### PR TITLE
[WIP] Fault tree provider

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Input/CommandGroup.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Input/CommandGroup.cs
@@ -10,5 +10,10 @@ namespace Microsoft.VisualStudio.Input
         public const string UIHierarchyWindow = VSConstants.CMDSETID.UIHierarchyWindowCommandSet_string;
         public const string VisualStudioStandard97 = VSConstants.CMDSETID.StandardCommandSet97_string;
         public const string VisualStudioStandard2k = VSConstants.CMDSETID.StandardCommandSet2K_string;
+        public const string VisualStudioStandard2010 = VSConstants.CMDSETID.StandardCommandSet2010_string;
+        public const string VisualStudioStandard11 = VSConstants.CMDSETID.StandardCommandSet11_string;
+        public const string VisualStudioStandard12 = VSConstants.CMDSETID.StandardCommandSet12_string;
+        public const string VisualStudioStandard14 = VSConstants.CMDSETID.StandardCommandSet14_string;
+        public const string VisualStudioStandard15 = VSConstants.CMDSETID.StandardCommandSet15_string;
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Input/VisualStudioStandard2kCommandId.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Input/VisualStudioStandard2kCommandId.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 namespace Microsoft.VisualStudio.Input
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Input/VisualStudioStandard97CommandId.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Input/VisualStudioStandard97CommandId.cs
@@ -10,5 +10,6 @@ namespace Microsoft.VisualStudio.Input
         public const long Open = (long)VSConstants.VSStd97CmdID.Open;
         public const long AddClass = (long)VSConstants.VSStd97CmdID.AddClass;
         public const long SaveProjectItem = (long)VSConstants.VSStd97CmdID.SaveProjectItem;
+        public const long UnloadProject = (long)VSConstants.VSStd97CmdID.UnloadProject;
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -50,6 +50,7 @@
     <Compile Include="ProjectSystem\VS\Editor\TempFileTextBufferManager.cs" />
     <Compile Include="ProjectSystem\VS\EditAndContinue\EditAndContinueProvider.cs" />
     <Compile Include="ProjectSystem\VS\ExportProjectNodeComServiceAttribute.cs" />
+    <Compile Include="ProjectSystem\VS\Input\Commands\FaultedTreeCommandGroupHandler.cs" />
     <Compile Include="ProjectSystem\VS\Input\Commands\GenerateNuGetPackageTopLevelBuildMenuCommand.cs" />
     <Compile Include="ProjectSystem\VS\Input\Commands\GenerateNuGetPackageProjectContextMenuCommand.cs" />
     <Compile Include="ProjectSystem\VS\Input\Commands\AbstractGenerateNuGetPackageCommand.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -165,6 +165,7 @@
     <Compile Include="ProjectSystem\VS\Tree\Dependencies\DependencyNodeResolvedStateComparer.cs" />
     <Compile Include="ProjectSystem\VS\Tree\Dependencies\IDependencyNodeExtensions.cs" />
     <Compile Include="ProjectSystem\VS\Tree\Dependencies\PackageAnalyzerAssemblyDependencyNode.cs" />
+    <Compile Include="ProjectSystem\VS\Tree\FaultedTreeProjectItemContextProvider.cs" />
     <Compile Include="ProjectSystem\VS\UI\DialogServices.cs" />
     <Compile Include="ProjectSystem\VS\UI\IDialogServices.cs" />
     <Compile Include="ProjectSystem\VS\UI\IVsShellUtilitiesHelper.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/FaultedTreeCommandGroupHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/FaultedTreeCommandGroupHandler.cs
@@ -1,0 +1,83 @@
+﻿using Microsoft.VisualStudio.Input;
+using Microsoft.VisualStudio.ProjectSystem.Input;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
+{
+    internal class FaultedTreeCommandGroupHandler : IAsyncCommandGroupHandler
+    {
+        [ExportCommandGroup(CommandGroup.VisualStudioStandard97)]
+        [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
+        [Order(int.MaxValue)] // We want to be ahead of the standard handlers
+        public static IAsyncCommandGroupHandler VisualStudioStandard97Handler =>
+            new FaultedTreeCommandGroupHandler(new List<long> { VisualStudioStandard97CommandId.UnloadProject });
+
+        [ExportCommandGroup(CommandGroup.VisualStudioStandard2k)]
+        [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
+        [Order(int.MaxValue)] // We want to be ahead of the standard handlers
+        public static IAsyncCommandGroupHandler VisualStudioStandard2kHandler =>
+            new FaultedTreeCommandGroupHandler(new List<long> { VisualStudioStandard2kCommandId.EditProjectFile });
+
+        [ExportCommandGroup(CommandGroup.VisualStudioStandard2010)]
+        [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
+        [Order(int.MaxValue)] // We want to be ahead of the standard handlers
+        public static IAsyncCommandGroupHandler VisualStudioStandard2010Handler => new FaultedTreeCommandGroupHandler(null);
+
+        [ExportCommandGroup(CommandGroup.VisualStudioStandard11)]
+        [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
+        [Order(int.MaxValue)] // We want to be ahead of the standard handlers
+        public static IAsyncCommandGroupHandler VisualStudioStandard11Handler => new FaultedTreeCommandGroupHandler(null);
+
+        [ExportCommandGroup(CommandGroup.VisualStudioStandard12)]
+        [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
+        [Order(int.MaxValue)] // We want to be ahead of the standard handlers
+        public static IAsyncCommandGroupHandler VisualStudioStandard12Handler => new FaultedTreeCommandGroupHandler(null);
+
+        [ExportCommandGroup(CommandGroup.VisualStudioStandard14)]
+        [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
+        [Order(int.MaxValue)] // We want to be ahead of the standard handlers
+        public static IAsyncCommandGroupHandler VisualStudioStandard14Handler => new FaultedTreeCommandGroupHandler(null);
+
+        [ExportCommandGroup(CommandGroup.VisualStudioStandard15)]
+        [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
+        [Order(100)] // We want to be ahead of the standard handlers
+        public static IAsyncCommandGroupHandler VisualStudioStandard15Handler => new FaultedTreeCommandGroupHandler(null);
+
+        private readonly IList<long> _allowedCommands;
+
+        private FaultedTreeCommandGroupHandler(IList<long> allowedCommands)
+        {
+            _allowedCommands = allowedCommands ?? new List<long>();
+        }
+
+        public Task<CommandStatusResult> GetCommandStatusAsync(IImmutableSet<IProjectTree> nodes, long commandId, bool focused, string commandText, CommandStatus progressiveStatus)
+        {
+            // Only handle if we've selected 1 node, and the tree is faulted
+            if (nodes.Count != 1 || !nodes.First().Flags.Contains("FaultTree"))
+            {
+                return GetCommandStatusResult.Unhandled;
+            }
+
+            // If the command is in the list of commands that we want to allow to show, return unhandled so the real handler can get it.
+            // Otherwise, return not supported
+            if (_allowedCommands.Contains(commandId))
+            {
+                return GetCommandStatusResult.Unhandled;
+            }
+            else
+            {
+                return GetCommandStatusResult.Handled(string.Empty, CommandStatus.Invisible);
+            }
+        }
+
+        public Task<bool> TryHandleCommandAsync(IImmutableSet<IProjectTree> nodes, long commandId, bool focused, long commandExecuteOptions, IntPtr variantArgIn, IntPtr variantArgOut)
+        {
+            // We don't handle any tasks.
+            return Task.FromResult(false);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/FaultedTreeProjectItemContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/FaultedTreeProjectItemContextProvider.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree
+{
+    [Export(typeof(IProjectItemContextMenuProvider))]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
+    [Order(1)] // Ahead of CPS provider
+    internal class FaultedTreeProjectItemContextProvider : IProjectItemContextMenuProvider
+    {
+        public bool TryGetContextMenu(IProjectTree projectItem, out Guid menuCommandGuid, out int menuCommandId)
+        {
+            // TODO: Switch to ProjectTreeFlags.AdditionalFlags.FaultTree when we take updated CPS bits.
+            // https://github.com/dotnet/roslyn-project-system/issues/1340
+            if (projectItem.Root.Flags.Contains("FaultTree"))
+            {
+                menuCommandGuid = VsMenus.guidSHLMainMenu;
+                menuCommandId = VsMenus.IDM_VS_CTXT_PROJNODE;
+                return true;
+            }
+            else
+            {
+                menuCommandGuid = Guid.Empty;
+                menuCommandId = 0;
+                return false;
+            }
+        }
+
+        public bool TryGetMixedItemsContextMenu(IEnumerable<IProjectTree> projectItems, out Guid menuCommandGuid, out int menuCommandId)
+        {
+            // For mixed items, we let the default implementation handle it.
+            menuCommandGuid = Guid.Empty;
+            menuCommandId = 0;
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
I'll add the escrow template when we've worked out what we need to do here. The gist of the change is this:

* We create an IProjectItemContextMenuProvider for trees with the "FaultTree" flag set. This sets the tree to use the standard project context menu.
* We create a handler for the standard commands that rejects all commands when the faulted tree is selected, except UnloadProject and EditProjectFile

There are a few issues with this implementation though:

1. There are a large number of standard commands that we don't want to reject. Things like exiting VS, closing the solution, view commands, etc. Way too many to create a viable whitelist
2. Conversely, creating a blacklist also creates a large number of commands we want to disable, although significantly smaller than the whitelist.
3. CPS does not have an extension point that allows us to get sent all commands from all groups. This means that we can't easily intercept things like the NuGet Package Manager, and other commands that have non-standard groups. This is what I was able to clear the menu down to with the code in this PR:
![image](https://cloud.githubusercontent.com/assets/2371880/22313911/d0c22fae-e313-11e6-88fa-3900389da4e4.png)

Given these issues, here's my proposal:
1. We create a stub menu, and add the Unload, Edit, and Delete commands to the menu. This is the context menu we provide.
2. Separately, we write a handler that has a blacklist of a few commands that should not be enabled, such as the build project commands, add item commands, set as startup commands, etc. This will block the user from being able to use these, and we won't have the issue of the context menu being cluttered by a bunch of commands that might come from extensions the user has installed.

Thoughts @davkean @jviau @lifengl? /cc @dotnet/project-system.