### PR TITLE
Add TFMs to top level package properties grid (partial fix for 587 for RTM)

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/NuGetDependenciesSubTreeProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/NuGetDependenciesSubTreeProviderTests.cs
@@ -66,6 +66,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                         ""Resolved"":""true"",
                         ""Dependencies"":""""
                     },
+                    ""tfm2/package1/1.0.2.0"": {
+                        ""Name"": ""package"",
+                        ""Version"": ""1.0.2.0"",
+                        ""Type"":""Package"",
+                        ""Path"":""SomePath"",
+                        ""Resolved"":""true"",
+                        ""Dependencies"":""""
+                    },
                     ""tfm1/PackageToRemove/1.0.0"": {
                         ""Name"": ""PackageToRemove"",
                         ""Version"": ""1.0.0"",
@@ -83,10 +91,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                         ""Dependencies"":""""
                     },
                     ""tfm2"": {
-                        ""RuntimeIdentifier"": ""net45"",
+                        ""RuntimeIdentifier"": ""net46"",
                         ""TargetFrameworkMoniker"": "".NetFramework,Version=v4.5"",
-                        ""FrameworkName"": ""net45"",
-                        ""FrameworkVersion"": ""4.5"",
+                        ""FrameworkName"": ""net46"",
+                        ""FrameworkVersion"": ""4.6"",
                         ""Dependencies"":""package1/1.0.2.0;ExistingUnresolvedPackage/2.0.0""
                     },
                     ""tfm1/package2/1.0.2.0"": {
@@ -117,7 +125,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 ""RuleName"": ""ResolvedPackageReference""
             },
             ""Difference"": {
-                ""AddedItems"": [ ""tfm1"", ""tfm1/package1/1.0.2.0"", ""tfm2"", ""tfm1/package2/1.0.2.0"", 
+                ""AddedItems"": [ ""tfm1"", ""tfm1/package1/1.0.2.0"", ""tfm2"", ""tfm1/package2/1.0.2.0"", ""tfm2/package1/1.0.2.0"",
                                   ""tfm1/ToBeOverridenByResolvedPackage/1.0.0"", ""tfm2/ExistingUnresolvedPackage/2.0.0"" ],
                 ""ChangedItems"": [ ""tfm1/PackageToChange/2.0.0"", ""tfm1/PackageToChange2/2.0.0"" ],
                 ""RemovedItems"": [ ""tfm1/PackageToRemove/1.0.0"" ],
@@ -255,6 +263,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     Assert.True(currentSnapshot.Any(x => x.Equals(addedNode.Id.ItemSpec, StringComparison.OrdinalIgnoreCase)));
                 }
             }
+
+            var node = provider.TestCreateDependencyNode("tfm1/package1/1.0.2.0");
+            Assert.Equal("net45 4.5;net46 4.6", node.Properties["TargetFramework"]);
         }
 
         [Theory]
@@ -1194,6 +1205,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 }
 
                 node.AddChild(childNode);
+            }
+
+            public IDependencyNode TestCreateDependencyNode(string itemSpec)
+            {
+                CurrentSnapshot.DependenciesWorld.TryGetValue(itemSpec, out DependencyMetadata dependencyMetadata);
+                return CreateDependencyNode(dependencyMetadata);
             }
 
             private class SnapshotModel

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
@@ -64,7 +64,7 @@
                     ReadOnly="True" />
 
     <StringProperty Name="TargetFramework" 
-                    Visible="False" 
+                    Visible="True" 
                     ReadOnly="True" />
 
     <StringProperty Name="FrameworkName" 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedPackageReference.xaml
@@ -46,7 +46,7 @@
                     ReadOnly="True" />
 
     <StringProperty Name="TargetFramework" 
-                    Visible="False" 
+                    Visible="True" 
                     ReadOnly="True" />
 
     <StringProperty Name="FrameworkName" 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/PackageReference.xaml
@@ -18,7 +18,7 @@
   <StringProperty Name="Path" Visible="False" ReadOnly="True" />
   <StringProperty Name="Type" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TargetFramework" Visible="True" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ResolvedPackageReference.xaml
@@ -11,7 +11,7 @@
   <StringProperty Name="Path" Visible="False" ReadOnly="True" />
   <StringProperty Name="Type" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TargetFramework" Visible="True" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/PackageReference.xaml
@@ -18,7 +18,7 @@
   <StringProperty Name="Path" Visible="False" ReadOnly="True" />
   <StringProperty Name="Type" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TargetFramework" Visible="True" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ResolvedPackageReference.xaml
@@ -11,7 +11,7 @@
   <StringProperty Name="Path" Visible="False" ReadOnly="True" />
   <StringProperty Name="Type" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TargetFramework" Visible="True" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/PackageReference.xaml
@@ -18,7 +18,7 @@
   <StringProperty Name="Path" Visible="False" ReadOnly="True" />
   <StringProperty Name="Type" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TargetFramework" Visible="True" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ResolvedPackageReference.xaml
@@ -11,7 +11,7 @@
   <StringProperty Name="Path" Visible="False" ReadOnly="True" />
   <StringProperty Name="Type" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TargetFramework" Visible="True" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/PackageReference.xaml
@@ -18,7 +18,7 @@
   <StringProperty Name="Path" Visible="False" ReadOnly="True" />
   <StringProperty Name="Type" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TargetFramework" Visible="True" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ResolvedPackageReference.xaml
@@ -11,7 +11,7 @@
   <StringProperty Name="Path" Visible="False" ReadOnly="True" />
   <StringProperty Name="Type" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TargetFramework" Visible="True" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/PackageReference.xaml
@@ -18,7 +18,7 @@
   <StringProperty Name="Path" Visible="False" ReadOnly="True" />
   <StringProperty Name="Type" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TargetFramework" Visible="True" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ResolvedPackageReference.xaml
@@ -11,7 +11,7 @@
   <StringProperty Name="Path" Visible="False" ReadOnly="True" />
   <StringProperty Name="Type" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TargetFramework" Visible="True" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/PackageReference.xaml
@@ -18,7 +18,7 @@
   <StringProperty Name="Path" Visible="False" ReadOnly="True" />
   <StringProperty Name="Type" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TargetFramework" Visible="True" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ResolvedPackageReference.xaml
@@ -11,7 +11,7 @@
   <StringProperty Name="Path" Visible="False" ReadOnly="True" />
   <StringProperty Name="Type" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TargetFramework" Visible="True" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/PackageReference.xaml
@@ -18,7 +18,7 @@
   <StringProperty Name="Path" Visible="False" ReadOnly="True" />
   <StringProperty Name="Type" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TargetFramework" Visible="True" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ResolvedPackageReference.xaml
@@ -11,7 +11,7 @@
   <StringProperty Name="Path" Visible="False" ReadOnly="True" />
   <StringProperty Name="Type" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TargetFramework" Visible="True" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/PackageReference.xaml
@@ -18,7 +18,7 @@
   <StringProperty Name="Path" Visible="False" ReadOnly="True" />
   <StringProperty Name="Type" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TargetFramework" Visible="True" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ResolvedPackageReference.xaml
@@ -11,7 +11,7 @@
   <StringProperty Name="Path" Visible="False" ReadOnly="True" />
   <StringProperty Name="Type" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TargetFramework" Visible="True" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/PackageReference.xaml
@@ -18,7 +18,7 @@
   <StringProperty Name="Path" Visible="False" ReadOnly="True" />
   <StringProperty Name="Type" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TargetFramework" Visible="True" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ResolvedPackageReference.xaml
@@ -11,7 +11,7 @@
   <StringProperty Name="Path" Visible="False" ReadOnly="True" />
   <StringProperty Name="Type" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TargetFramework" Visible="True" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/PackageReference.xaml
@@ -18,7 +18,7 @@
   <StringProperty Name="Path" Visible="False" ReadOnly="True" />
   <StringProperty Name="Type" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TargetFramework" Visible="True" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ResolvedPackageReference.xaml
@@ -11,7 +11,7 @@
   <StringProperty Name="Path" Visible="False" ReadOnly="True" />
   <StringProperty Name="Type" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TargetFramework" Visible="True" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/PackageReference.xaml
@@ -18,7 +18,7 @@
   <StringProperty Name="Path" Visible="False" ReadOnly="True" />
   <StringProperty Name="Type" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TargetFramework" Visible="True" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ResolvedPackageReference.xaml
@@ -11,7 +11,7 @@
   <StringProperty Name="Path" Visible="False" ReadOnly="True" />
   <StringProperty Name="Type" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TargetFramework" Visible="True" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/PackageReference.xaml
@@ -18,7 +18,7 @@
   <StringProperty Name="Path" Visible="False" ReadOnly="True" />
   <StringProperty Name="Type" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TargetFramework" Visible="True" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ResolvedPackageReference.xaml
@@ -11,7 +11,7 @@
   <StringProperty Name="Path" Visible="False" ReadOnly="True" />
   <StringProperty Name="Type" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TargetFramework" Visible="True" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/PackageReference.xaml
@@ -18,7 +18,7 @@
   <StringProperty Name="Path" Visible="False" ReadOnly="True" />
   <StringProperty Name="Type" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TargetFramework" Visible="True" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ResolvedPackageReference.xaml
@@ -11,7 +11,7 @@
   <StringProperty Name="Path" Visible="False" ReadOnly="True" />
   <StringProperty Name="Type" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TargetFramework" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TargetFramework" Visible="True" ReadOnly="True" />
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />


### PR DESCRIPTION
**Customer scenario**

Since we can not do full support for showing multiple TFMs in UI in RTM, we aggreed to show TFMs for top level packages in the properties grid separated by ';'

**Bugs this fixes:**

related to https://github.com/dotnet/roslyn-project-system/issues/587 

**Workarounds, if any**

N/A

**Risk**

Low

**Performance impact**

none

