### PR TITLE
Stop publishing tree just to get folder names for the language service

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectChangeDescriptionFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectChangeDescriptionFactory.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class IProjectChangeDescriptionFactory
+    {
+        public static IProjectChangeDescription Create()
+        {
+            return Mock.Of<IProjectChangeDescription>();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IWorkspaceProjectContextFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IWorkspaceProjectContextFactory.cs
@@ -10,6 +10,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
     internal static class IWorkspaceProjectContextFactory
     {
+        public static IWorkspaceProjectContext Create()
+        {
+            return Mock.Of<IWorkspaceProjectContext>();
+        }
+
         public static IWorkspaceProjectContext CreateForSourceFiles(UnconfiguredProject project, Action<string> addSourceFile = null, Action<string> removeSourceFile = null)
         {
             var context = new Mock<IWorkspaceProjectContext>();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemHandlerTests.cs
@@ -12,9 +12,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         [Fact]
         public void Constructor()
         {
-            Assert.Throws<ArgumentNullException>(() => new SourceItemHandler(UnconfiguredProjectFactory.Create(), null));
-            Assert.Throws<ArgumentNullException>(() => new SourceItemHandler(null, IPhysicalProjectTreeFactory.Create()));
-            new SourceItemHandler(UnconfiguredProjectFactory.Create(), IPhysicalProjectTreeFactory.Create());
+            Assert.Throws<ArgumentNullException>(() => new SourceItemHandler(null));
+            new SourceItemHandler(UnconfiguredProjectFactory.Create());
         }
 
         [Fact]
@@ -27,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             var project = UnconfiguredProjectFactory.Create(filePath: @"C:\Myproject.csproj");
             var context = IWorkspaceProjectContextFactory.CreateForSourceFiles(project, onSourceFileAdded, onSourceFileRemoved);
 
-            var handler = new SourceItemHandler(project, IPhysicalProjectTreeFactory.Create());
+            var handler = new SourceItemHandler(project);
             var projectDir = Path.GetDirectoryName(project.FullPath);
             var added = CSharpCommandLineParser.Default.Parse(args: new[] { @"C:\file1.cs", @"C:\file2.cs", @"C:\file1.cs" }, baseDirectory: projectDir, sdkDirectory: null);
             var empty = CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null);
@@ -55,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             var project = UnconfiguredProjectFactory.Create(filePath: @"C:\ProjectFolder\Myproject.csproj");
             var context = IWorkspaceProjectContextFactory.CreateForSourceFiles(project, onSourceFileAdded, onSourceFileRemoved);
 
-            var handler = new SourceItemHandler(project, IPhysicalProjectTreeFactory.Create());
+            var handler = new SourceItemHandler(project);
             var projectDir = Path.GetDirectoryName(project.FullPath);
             var added = CSharpCommandLineParser.Default.Parse(args: new[] { @"file1.cs", @"..\ProjectFolder\file1.cs" }, baseDirectory: projectDir, sdkDirectory: null);
             var removed = CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemHandlerTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
@@ -10,10 +11,45 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     public class SourceItemHandlerTests
     {
         [Fact]
-        public void Constructor()
+        public void Constructor_NullAsProject_ThrowsArgumentNull()
         {
-            Assert.Throws<ArgumentNullException>(() => new SourceItemHandler(null));
-            new SourceItemHandler(UnconfiguredProjectFactory.Create());
+            Assert.Throws<ArgumentNullException>("project", () => {
+                new SourceItemHandler((UnconfiguredProject)null);
+            });
+        }
+
+        [Fact]
+        public void Handle_NullAsProjectChange_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var context = IWorkspaceProjectContextFactory.Create();
+
+            Assert.Throws<ArgumentNullException>("projectChange", () => {
+                handler.Handle((IProjectChangeDescription)null, context, true);
+            });
+        }
+
+
+        [Fact]
+        public void Handle_NullAsContext_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var projectChange = IProjectChangeDescriptionFactory.Create();
+
+            Assert.Throws<ArgumentNullException>("context", () => {
+                handler.Handle(projectChange, (IWorkspaceProjectContext)null, true);
+            });
+        }
+
+        [Fact]
+        public void OnContextReleasedAsync_NullAsContext_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var context = IProjectChangeDescriptionFactory.Create();
+
+            Assert.Throws<ArgumentNullException>("context", () => {
+                handler.OnContextReleasedAsync((IWorkspaceProjectContext)null);
+            });
         }
 
         [Fact]
@@ -63,6 +99,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             Assert.Equal(1, sourceFilesPushedToWorkspace.Count);
             Assert.Contains(@"C:\ProjectFolder\file1.cs", sourceFilesPushedToWorkspace);
+        }
+
+        private SourceItemHandler CreateInstance(UnconfiguredProject project = null)
+        {
+            project = project ?? UnconfiguredProjectFactory.Create();
+
+            return new SourceItemHandler(project);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/FileItemServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/FileItemServices.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.IO;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class FileItemServices
+    {
+        public static readonly char[] PathSeparatorCharacters = { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
+
+        public static string GetLinkFilePath(IImmutableDictionary<string, string> metadata)
+        {
+            Requires.NotNull(metadata, nameof(metadata));
+
+            // This mimic's CPS's handling of Link metadata
+            if (metadata.TryGetValue(ConfigurationGeneralFile.LinkProperty, out string linkFilePath) && !string.IsNullOrWhiteSpace(linkFilePath))
+            {
+                return linkFilePath.TrimEnd(PathSeparatorCharacters);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractLanguageServiceRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractLanguageServiceRuleHandler.cs
@@ -13,9 +13,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
         public virtual bool ReceiveUpdatesWithEmptyProjectChange => false;
 
-        public virtual Task HandleAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> e, IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
+        public virtual void Handle(IProjectVersionedValue<IProjectSubscriptionUpdate> e, IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
         {
-            return Task.CompletedTask;
         }
 
         public virtual Task OnContextReleasedAsync(IWorkspaceProjectContext context)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractLanguageServiceRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractLanguageServiceRuleHandler.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
         public virtual bool ReceiveUpdatesWithEmptyProjectChange => false;
 
-        public virtual void Handle(IProjectVersionedValue<IProjectSubscriptionUpdate> e, IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
+        public virtual void Handle(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
         {
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandler.cs
@@ -44,9 +44,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         // Broken design time builds generates updates with no changes.
         public override bool ReceiveUpdatesWithEmptyProjectChange => true;
 
-        public override void Handle(IProjectVersionedValue<IProjectSubscriptionUpdate> e, IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
+        public override void Handle(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
         {
-            Requires.NotNull(e, nameof(e));
             Requires.NotNull(projectChange, nameof(projectChange));
 
             if (!ProcessDesignTimeBuildFailure(projectChange, context))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandler.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 
@@ -45,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         // Broken design time builds generates updates with no changes.
         public override bool ReceiveUpdatesWithEmptyProjectChange => true;
 
-        public override Task HandleAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> e, IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
+        public override void Handle(IProjectVersionedValue<IProjectSubscriptionUpdate> e, IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
         {
             Requires.NotNull(e, nameof(e));
             Requires.NotNull(projectChange, nameof(projectChange));
@@ -55,8 +54,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
                 ProcessOptions(projectChange, context);
                 ProcessItems(projectChange, context, isActiveContext);
             }
-
-            return Task.CompletedTask;
         }
 
         private static bool ProcessDesignTimeBuildFailure(IProjectChangeDescription projectChange, IWorkspaceProjectContext context)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
@@ -28,9 +28,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             get { return ConfigurationGeneral.SchemaName; }
         }
 
-        public override void Handle(IProjectVersionedValue<IProjectSubscriptionUpdate> e, IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
+        public override void Handle(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
         {
-            Requires.NotNull(e, nameof(e));
             Requires.NotNull(projectChange, nameof(projectChange));
 
             if (projectChange.Difference.ChangedProperties.Contains(ConfigurationGeneral.ProjectGuidProperty))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.ComponentModel.Composition;
-using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
@@ -29,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             get { return ConfigurationGeneral.SchemaName; }
         }
 
-        public override Task HandleAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> e, IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
+        public override void Handle(IProjectVersionedValue<IProjectSubscriptionUpdate> e, IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
         {
             Requires.NotNull(e, nameof(e));
             Requires.NotNull(projectChange, nameof(projectChange));
@@ -57,8 +56,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
                     context.BinOutputPath = newBinOutputPath;
                 }
             }
-
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -75,25 +75,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
                 RemoveSourceFile(filePath, context);
             }
 
-            if (diff.AddedItems.Count > 0 || diff.RenamedItems.Count > 0 || diff.ChangedItems.Count > 0)
+            foreach (string filePath in diff.AddedItems)
             {
-                foreach (string filePath in diff.AddedItems)
-                {
-                    AddSourceFile(filePath, GetFolders(filePath, projectChange), context, isActiveContext);
-                }
+                AddSourceFile(filePath, GetFolders(filePath, projectChange), context, isActiveContext);
+            }
 
-                foreach (KeyValuePair<string, string> filePaths in diff.RenamedItems)
-                {
-                    RemoveSourceFile(filePaths.Key, context);
-                    AddSourceFile(filePaths.Value, GetFolders(filePaths.Value, projectChange), context, isActiveContext);
-                }
+            foreach (KeyValuePair<string, string> filePaths in diff.RenamedItems)
+            {
+                RemoveSourceFile(filePaths.Key, context);
+                AddSourceFile(filePaths.Value, GetFolders(filePaths.Value, projectChange), context, isActiveContext);
+            }
 
-                foreach (string filePath in diff.ChangedItems)
-                {
-                    // We add and then remove ChangedItems to handle Linked metadata changes
-                    RemoveSourceFile(filePath, context);
-                    AddSourceFile(filePath, GetFolders(filePath, projectChange), context, isActiveContext);
-                }
+            foreach (string filePath in diff.ChangedItems)
+            {
+                // We add and then remove ChangedItems to handle Linked metadata changes
+                RemoveSourceFile(filePath, context);
+                AddSourceFile(filePath, GetFolders(filePath, projectChange), context, isActiveContext);
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -145,8 +145,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             if (parentFolder == null)
                 parentFolder = GetParentFolder(filePath);
 
-            // We now have a folder in the form of `Folder1\Folder2` relative to the project directory 
-            // split it up and break it up into individual path components
+            // We now have a folder in the form of `Folder1\Folder2` relative to the
+            // project directory  split it up into individual path components
             if (parentFolder.Length > 0)
             {
                 return parentFolder.Split(FileItemServices.PathSeparatorCharacters);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -27,16 +27,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         // IntelliSense.
         private readonly UnconfiguredProject _project;
         private readonly Dictionary<IWorkspaceProjectContext, HashSet<string>> _sourceFilesByContext = new Dictionary<IWorkspaceProjectContext, HashSet<string>>();
-        private readonly IPhysicalProjectTree _projectTree;
 
         [ImportingConstructor]
-        public SourceItemHandler(UnconfiguredProject project, IPhysicalProjectTree projectTree)
+        public SourceItemHandler(UnconfiguredProject project)
         {
             Requires.NotNull(project, nameof(project));
-            Requires.NotNull(projectTree, nameof(projectTree));
 
             _project = project;
-            _projectTree = projectTree;
         }
 
         public override string RuleName

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -83,8 +83,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             foreach (KeyValuePair<string, string> filePaths in diff.RenamedItems)
             {
-                RemoveSourceFile(filePaths.Key, context);
-                AddSourceFile(filePaths.Value, GetFolders(filePaths.Value, projectChange), context, isActiveContext);
+                string removeFilePath = filePaths.Key;
+                string addFilePath = filePaths.Value;
+
+                RemoveSourceFile(removeFilePath, context);
+                AddSourceFile(addFilePath, GetFolders(addFilePath, projectChange), context, isActiveContext);
             }
 
             foreach (string filePath in diff.ChangedItems)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -64,9 +64,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             }
         }
 
-        public override void Handle(IProjectVersionedValue<IProjectSubscriptionUpdate> e, IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
+        public override void Handle(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
         {
-            Requires.NotNull(e, nameof(e));
             Requires.NotNull(projectChange, nameof(projectChange));
 
             IProjectChangeDiff diff = projectChange.Difference;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             }
         }
 
-        public override Task HandleAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> e, IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
+        public override void Handle(IProjectVersionedValue<IProjectSubscriptionUpdate> e, IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
         {
             Requires.NotNull(e, nameof(e));
             Requires.NotNull(projectChange, nameof(projectChange));
@@ -96,8 +96,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
                     AddSourceFile(filePath, GetFolders(filePath, projectChange), context, isActiveContext);
                 }
             }
-
-            return Task.CompletedTask;
         }
 
         public override Task OnContextReleasedAsync(IWorkspaceProjectContext context)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -65,6 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         public override void Handle(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
         {
             Requires.NotNull(projectChange, nameof(projectChange));
+            Requires.NotNull(context, nameof(context));
 
             IProjectChangeDiff diff = projectChange.Difference;
 
@@ -97,6 +98,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
         public override Task OnContextReleasedAsync(IWorkspaceProjectContext context)
         {
+            Requires.NotNull(context, nameof(context));
+
             _sourceFilesByContext.Remove(context);
             return Task.CompletedTask;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -112,9 +112,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             return Task.CompletedTask;
         }
 
-        private void RemoveSourceFile(string fullPath, IWorkspaceProjectContext context)
+        private void RemoveSourceFile(string filePath, IWorkspaceProjectContext context)
         {
-            fullPath = _project.MakeRooted(fullPath);
+            string fullPath = _project.MakeRooted(filePath);
 
             if (_sourceFilesByContext.TryGetValue(context, out HashSet<string> sourceFiles) && sourceFiles.Remove(fullPath))
             {
@@ -122,9 +122,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             }
         }
 
-        private void AddSourceFile(string fullPath, IWorkspaceProjectContext context, bool isActiveContext, IProjectTreeServiceState state = null)
+        private void AddSourceFile(string filePath, IWorkspaceProjectContext context, bool isActiveContext, IProjectTreeServiceState state = null)
         {
-            fullPath = _project.MakeRooted(fullPath);
+            string fullPath = _project.MakeRooted(filePath);
 
             if (!_sourceFilesByContext.TryGetValue(context, out HashSet<string> sourceFiles))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ILanguageServiceRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ILanguageServiceRuleHandler.cs
@@ -48,10 +48,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ///     Handles the specified set of changes to a rule, and applies them
         ///     to the given <see cref="IWorkspaceProjectContext"/>.
         /// </summary>
-        /// <param name="e">
-        ///     A <see cref="IProjectVersionedValue{IProjectSubscriptionService}"/> representing 
-        ///     the overall changes to the project.
-        /// </param>
         /// <param name="projectChange">
         ///     A <see cref="IProjectChangeDescription"/> representing the set of 
         ///     changes made to the project.
@@ -63,13 +59,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ///     Flag indicating if the given <paramref name="context"/> is the active project context.
         /// </param>
         /// <exception cref="ArgumentNullException">
-        ///     <paramref name="e"/> is <see langword="null"/>.
-        ///     <para>
-        ///         -or-
-        ///     </para>
         ///     <paramref name="projectChange"/> is <see langword="null"/>.
         /// </exception>
-        void Handle(IProjectVersionedValue<IProjectSubscriptionUpdate> e, IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext);
+        void Handle(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext);
 
         /// <summary>
         /// Handles clearing any state specific to the given context being released.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ILanguageServiceRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ILanguageServiceRuleHandler.cs
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ///     </para>
         ///     <paramref name="projectChange"/> is <see langword="null"/>.
         /// </exception>
-        Task HandleAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> e, IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext);
+        void Handle(IProjectVersionedValue<IProjectSubscriptionUpdate> e, IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext);
 
         /// <summary>
         /// Handles clearing any state specific to the given context being released.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -312,7 +312,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                     IProjectChangeDescription projectChange = update.Value.ProjectChanges[handler.RuleName];
                     if (handler.ReceiveUpdatesWithEmptyProjectChange || projectChange.Difference.AnyChanges)
                     {
-                        handler.Handle(update, projectChange, projectContextToUpdate, isActiveContext);
+                        handler.Handle(projectChange, projectContextToUpdate, isActiveContext);
                     }
                 }
             });

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -312,7 +312,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                     IProjectChangeDescription projectChange = update.Value.ProjectChanges[handler.RuleName];
                     if (handler.ReceiveUpdatesWithEmptyProjectChange || projectChange.Difference.AnyChanges)
                     {
-                        await handler.HandleAsync(update, projectChange, projectContextToUpdate, isActiveContext).ConfigureAwait(true);
+                        handler.Handle(update, projectChange, projectContextToUpdate, isActiveContext);
                     }
                 }
             });


### PR DESCRIPTION
We used to publish and look up the project tree to find the effective path of a `<Compile/>` to pass to Roslyn. Originally I did this to handle that fact that some trees _might_ result in different view of the files (think Venus Web Sites where all files end up in App_Code). This ended up being quite complex, slow and due active configurations changing, or multi-targeting, could result in incorrect data being passed to Roslyn. For example, in multi-targeting projects, if a file was conditioned out of the current configuration the folder names for that file would never be found because it would never show be shown in the "Active" tree.

Instead we just get the folder names from the item itself, looking at Link metadata if specified, here's some examples:

```
<Compile Include="File.cs" />                         --> {}
<Compile Include="Foo\File.cs" />                     --> {Foo}
<Compile Include="Foo\Bar\File.cs" />                 --> {Foo, Bar}
<Compile Include="..\Foo\Bar.cs" Link="Bar.cs" />     --> {}
<Compile Include="..\Foo\Bar.cs" Link="Foo\Bar.cs" /> --> {Foo}

```

Fixes: https://github.com/dotnet/roslyn-project-system/issues/1760, https://github.com/dotnet/roslyn-project-system/issues/1655

Tests are coming.