### PR TITLE
Add telemetry for configuration changes and project assets

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITelemetryServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITelemetryServiceFactory.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Telemetry
+{
+    internal static class ITelemetryServiceFactory
+    {
+        public static ITelemetryService Create() => Mock.Of<ITelemetryService>();
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Configuration/ConfigurationProjectConfigurationDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Configuration/ConfigurationProjectConfigurationDimensionProviderTests.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using Microsoft.VisualStudio.ProjectSystem.VS.Editor;
+using Microsoft.VisualStudio.ProjectSystem.VS.Telemetry;
 using Xunit;
-using System;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
 {
@@ -25,7 +26,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
                 IProjectXmlAccessor _projectXmlAccessor = IProjectXmlAccessorFactory.Create(projectFile.Project);
-                var provider = new ConfigurationProjectConfigurationDimensionProvider(_projectXmlAccessor);
+                ITelemetryService _telemetryService = ITelemetryServiceFactory.Create();
+                var provider = new ConfigurationProjectConfigurationDimensionProvider(_projectXmlAccessor, _telemetryService);
                 var unconfiguredProject = UnconfiguredProjectFactory.Create(filePath: projectFile.Filename);
                 var values = await provider.GetDefaultValuesForDimensionsAsync(unconfiguredProject);
                 Assert.Equal(1, values.Count());
@@ -41,7 +43,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
             using (var projectFile = new MsBuildProjectFile())
             {
                 IProjectXmlAccessor _projectXmlAccessor = IProjectXmlAccessorFactory.Create(projectFile.Project);
-                var provider = new ConfigurationProjectConfigurationDimensionProvider(_projectXmlAccessor);
+                ITelemetryService _telemetryService = ITelemetryServiceFactory.Create();
+                var provider = new ConfigurationProjectConfigurationDimensionProvider(_projectXmlAccessor, _telemetryService);
                 var unconfiguredProject = UnconfiguredProjectFactory.Create(filePath: projectFile.Filename);
                 var values = await provider.GetDefaultValuesForDimensionsAsync(unconfiguredProject);
                 Assert.Equal(0, values.Count());
@@ -54,7 +57,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
                 IProjectXmlAccessor _projectXmlAccessor = IProjectXmlAccessorFactory.Create(projectFile.Project);
-                var provider = new ConfigurationProjectConfigurationDimensionProvider(_projectXmlAccessor);
+                ITelemetryService _telemetryService = ITelemetryServiceFactory.Create();
+                var provider = new ConfigurationProjectConfigurationDimensionProvider(_projectXmlAccessor, _telemetryService);
                 var unconfiguredProject = UnconfiguredProjectFactory.Create(filePath: projectFile.Filename);
                 var values = await provider.GetProjectConfigurationDimensionsAsync(unconfiguredProject);
                 Assert.Equal(1, values.Count());
@@ -73,7 +77,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
             using (var projectFile = new MsBuildProjectFile())
             {
                 IProjectXmlAccessor _projectXmlAccessor = IProjectXmlAccessorFactory.Create(projectFile.Project);
-                var provider = new ConfigurationProjectConfigurationDimensionProvider(_projectXmlAccessor);
+                ITelemetryService _telemetryService = ITelemetryServiceFactory.Create();
+                var provider = new ConfigurationProjectConfigurationDimensionProvider(_projectXmlAccessor, _telemetryService);
                 var unconfiguredProject = UnconfiguredProjectFactory.Create(filePath: projectFile.Filename);
                 var values = await provider.GetProjectConfigurationDimensionsAsync(unconfiguredProject);
                 Assert.Equal(0, values.Count());
@@ -86,7 +91,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
                 IProjectXmlAccessor _projectXmlAccessor = IProjectXmlAccessorFactory.Create(projectFile.Project);
-                var provider = new ConfigurationProjectConfigurationDimensionProvider(_projectXmlAccessor);
+                ITelemetryService _telemetryService = ITelemetryServiceFactory.Create();
+                var provider = new ConfigurationProjectConfigurationDimensionProvider(_projectXmlAccessor, _telemetryService);
                 var unconfiguredProject = UnconfiguredProjectFactory.Create(filePath: projectFile.Filename);
 
                 // On ChangeEventStage.After nothing should be changed
@@ -121,7 +127,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
                 IProjectXmlAccessor _projectXmlAccessor = IProjectXmlAccessorFactory.Create(projectFile.Project);
-                var provider = new ConfigurationProjectConfigurationDimensionProvider(_projectXmlAccessor);
+                ITelemetryService _telemetryService = ITelemetryServiceFactory.Create();
+                var provider = new ConfigurationProjectConfigurationDimensionProvider(_projectXmlAccessor, _telemetryService);
                 var unconfiguredProject = UnconfiguredProjectFactory.Create(filePath: projectFile.Filename);
 
                 // On ChangeEventStage.After nothing should be changed
@@ -156,7 +163,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
                 IProjectXmlAccessor _projectXmlAccessor = IProjectXmlAccessorFactory.Create(projectFile.Project);
-                var provider = new ConfigurationProjectConfigurationDimensionProvider(_projectXmlAccessor);
+                ITelemetryService _telemetryService = ITelemetryServiceFactory.Create();
+                var provider = new ConfigurationProjectConfigurationDimensionProvider(_projectXmlAccessor, _telemetryService);
                 var unconfiguredProject = UnconfiguredProjectFactory.Create(filePath: projectFile.Filename);
 
                 ProjectConfigurationDimensionValueChangedEventArgs args = new ProjectConfigurationDimensionValueChangedEventArgs(
@@ -178,7 +186,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
                 IProjectXmlAccessor _projectXmlAccessor = IProjectXmlAccessorFactory.Create(projectFile.Project);
-                var provider = new ConfigurationProjectConfigurationDimensionProvider(_projectXmlAccessor);
+                ITelemetryService _telemetryService = ITelemetryServiceFactory.Create();
+                var provider = new ConfigurationProjectConfigurationDimensionProvider(_projectXmlAccessor, _telemetryService);
                 var unconfiguredProject = UnconfiguredProjectFactory.Create(filePath: projectFile.Filename);
 
                 // On ChangeEventStage.Before nothing should be changed
@@ -215,7 +224,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
                 IProjectXmlAccessor _projectXmlAccessor = IProjectXmlAccessorFactory.Create(projectFile.Project);
-                var provider = new ConfigurationProjectConfigurationDimensionProvider(_projectXmlAccessor);
+                ITelemetryService _telemetryService = ITelemetryServiceFactory.Create();
+                var provider = new ConfigurationProjectConfigurationDimensionProvider(_projectXmlAccessor, _telemetryService);
                 var unconfiguredProject = UnconfiguredProjectFactory.Create(filePath: projectFile.Filename);
 
                 ProjectConfigurationDimensionValueChangedEventArgs args = new ProjectConfigurationDimensionValueChangedEventArgs(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Configuration/PlatformProjectConfigurationDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Configuration/PlatformProjectConfigurationDimensionProviderTests.cs
@@ -2,6 +2,7 @@
 
 using System.Linq;
 using Microsoft.VisualStudio.ProjectSystem.VS.Editor;
+using Microsoft.VisualStudio.ProjectSystem.VS.Telemetry;
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
@@ -24,7 +25,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
                 IProjectXmlAccessor _projectXmlAccessor = IProjectXmlAccessorFactory.Create(projectFile.Project);
-                var provider = new PlatformProjectConfigurationDimensionProvider(_projectXmlAccessor);
+                ITelemetryService _telemetryService = ITelemetryServiceFactory.Create();
+                var provider = new PlatformProjectConfigurationDimensionProvider(_projectXmlAccessor, _telemetryService);
                 var unconfiguredProject = UnconfiguredProjectFactory.Create(filePath: projectFile.Filename);
                 var values = await provider.GetDefaultValuesForDimensionsAsync(unconfiguredProject);
                 Assert.Equal(1, values.Count());
@@ -40,7 +42,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
                 IProjectXmlAccessor _projectXmlAccessor = IProjectXmlAccessorFactory.Create(projectFile.Project);
-                var provider = new PlatformProjectConfigurationDimensionProvider(_projectXmlAccessor);
+                ITelemetryService _telemetryService = ITelemetryServiceFactory.Create();
+                var provider = new PlatformProjectConfigurationDimensionProvider(_projectXmlAccessor, _telemetryService);
                 var unconfiguredProject = UnconfiguredProjectFactory.Create(filePath: projectFile.Filename);
                 var values = await provider.GetProjectConfigurationDimensionsAsync(unconfiguredProject);
                 Assert.Equal(1, values.Count());
@@ -60,7 +63,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
                 IProjectXmlAccessor _projectXmlAccessor = IProjectXmlAccessorFactory.Create(projectFile.Project);
-                var provider = new PlatformProjectConfigurationDimensionProvider(_projectXmlAccessor);
+                ITelemetryService _telemetryService = ITelemetryServiceFactory.Create();
+                var provider = new PlatformProjectConfigurationDimensionProvider(_projectXmlAccessor, _telemetryService);
                 var unconfiguredProject = UnconfiguredProjectFactory.Create(filePath: projectFile.Filename);
 
                 // On ChangeEventStage.After nothing should be changed
@@ -95,7 +99,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
                 IProjectXmlAccessor _projectXmlAccessor = IProjectXmlAccessorFactory.Create(projectFile.Project);
-                var provider = new PlatformProjectConfigurationDimensionProvider(_projectXmlAccessor);
+                ITelemetryService _telemetryService = ITelemetryServiceFactory.Create();
+                var provider = new PlatformProjectConfigurationDimensionProvider(_projectXmlAccessor, _telemetryService);
                 var unconfiguredProject = UnconfiguredProjectFactory.Create(filePath: projectFile.Filename);
 
                 // On ChangeEventStage.After nothing should be changed
@@ -130,7 +135,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
                 IProjectXmlAccessor _projectXmlAccessor = IProjectXmlAccessorFactory.Create(projectFile.Project);
-                var provider = new PlatformProjectConfigurationDimensionProvider(_projectXmlAccessor);
+                ITelemetryService _telemetryService = ITelemetryServiceFactory.Create();
+                var provider = new PlatformProjectConfigurationDimensionProvider(_projectXmlAccessor, _telemetryService);
                 var unconfiguredProject = UnconfiguredProjectFactory.Create(filePath: projectFile.Filename);
 
                 // Nothing should happen on platform rename as it's unsupported

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Configuration/TargetFrameworkProjectConfigurationDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Configuration/TargetFrameworkProjectConfigurationDimensionProviderTests.cs
@@ -2,6 +2,7 @@
 
 using System.Linq;
 using Microsoft.VisualStudio.ProjectSystem.VS.Editor;
+using Microsoft.VisualStudio.ProjectSystem.VS.Telemetry;
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
@@ -29,7 +30,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
             using (var projectFile = new MsBuildProjectFile(projectXmlTFM))
             {
                 IProjectXmlAccessor _projectXmlAccessor = IProjectXmlAccessorFactory.Create(projectFile.Project);
-                var provider = new TargetFrameworkProjectConfigurationDimensionProvider(_projectXmlAccessor);
+                ITelemetryService _telemetryService = ITelemetryServiceFactory.Create();
+                var provider = new TargetFrameworkProjectConfigurationDimensionProvider(_projectXmlAccessor, _telemetryService);
                 var unconfiguredProject = UnconfiguredProjectFactory.Create(filePath: projectFile.Filename);
                 var values = await provider.GetDefaultValuesForDimensionsAsync(unconfiguredProject);
                 Assert.Equal(0, values.Count());
@@ -42,7 +44,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
             using (var projectFile = new MsBuildProjectFile(projectXmlTFMs))
             {
                 IProjectXmlAccessor _projectXmlAccessor = IProjectXmlAccessorFactory.Create(projectFile.Project);
-                var provider = new TargetFrameworkProjectConfigurationDimensionProvider(_projectXmlAccessor);
+                ITelemetryService _telemetryService = ITelemetryServiceFactory.Create();
+                var provider = new TargetFrameworkProjectConfigurationDimensionProvider(_projectXmlAccessor, _telemetryService);
                 var unconfiguredProject = UnconfiguredProjectFactory.Create(filePath: projectFile.Filename);
                 var values = await provider.GetDefaultValuesForDimensionsAsync(unconfiguredProject);
                 Assert.Equal(1, values.Count());
@@ -58,7 +61,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
             using (var projectFile = new MsBuildProjectFile(projectXmlTFM))
             {
                 IProjectXmlAccessor _projectXmlAccessor = IProjectXmlAccessorFactory.Create(projectFile.Project);
-                var provider = new TargetFrameworkProjectConfigurationDimensionProvider(_projectXmlAccessor);
+                ITelemetryService _telemetryService = ITelemetryServiceFactory.Create();
+                var provider = new TargetFrameworkProjectConfigurationDimensionProvider(_projectXmlAccessor, _telemetryService);
                 var unconfiguredProject = UnconfiguredProjectFactory.Create(filePath: projectFile.Filename);
                 var values = await provider.GetProjectConfigurationDimensionsAsync(unconfiguredProject);
                 Assert.Equal(0, values.Count());
@@ -71,7 +75,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
             using (var projectFile = new MsBuildProjectFile(projectXmlTFMs))
             {
                 IProjectXmlAccessor _projectXmlAccessor = IProjectXmlAccessorFactory.Create(projectFile.Project);
-                var provider = new TargetFrameworkProjectConfigurationDimensionProvider(_projectXmlAccessor);
+                ITelemetryService _telemetryService = ITelemetryServiceFactory.Create();
+                var provider = new TargetFrameworkProjectConfigurationDimensionProvider(_projectXmlAccessor, _telemetryService);
                 var unconfiguredProject = UnconfiguredProjectFactory.Create(filePath: projectFile.Filename);
                 var values = await provider.GetProjectConfigurationDimensionsAsync(unconfiguredProject);
                 Assert.Equal(1, values.Count());
@@ -97,7 +102,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
             using (var projectFile = new MsBuildProjectFile(projectXmlTFMs))
             {
                 IProjectXmlAccessor _projectXmlAccessor = IProjectXmlAccessorFactory.Create(projectFile.Project);
-                var provider = new TargetFrameworkProjectConfigurationDimensionProvider(_projectXmlAccessor);
+                ITelemetryService _telemetryService = ITelemetryServiceFactory.Create();
+                var provider = new TargetFrameworkProjectConfigurationDimensionProvider(_projectXmlAccessor, _telemetryService);
                 var unconfiguredProject = UnconfiguredProjectFactory.Create(filePath: projectFile.Filename);
                 var property = MsBuildUtilities.GetProperty(projectFile.Project, ConfigurationGeneral.TargetFrameworksProperty);
                 string expectedTFMs = property.Value;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Configuration/BaseProjectConfigurationDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Configuration/BaseProjectConfigurationDimensionProvider.cs
@@ -20,6 +20,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
         protected readonly ITelemetryService _telemetryService;
         protected readonly bool _valueContainsPii;
 
+        private const string TelemetryEventName = "DimensionChanged";
+
         /// <summary>
         /// Initializes a new instance of the <see cref="BaseProjectConfigurationDimensionProvider"/> class.
         /// </summary>
@@ -154,7 +156,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
                 MsBuildUtilities.AppendPropertyValue(msbuildProject, evaluatedPropertyValue, _propertyName, dimensionValue);
             }).ConfigureAwait(false);
 
-            _telemetryService.PostProperty($"DimensionChanged/{_dimensionName}/Add", "Value", HashValueIfNeeded(dimensionValue), unconfiguredProject);
+            _telemetryService.PostProperty($"{TelemetryEventName}/{_dimensionName}/Add", "Value", HashValueIfNeeded(dimensionValue), unconfiguredProject);
         }
 
         /// <summary>
@@ -171,7 +173,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
                 MsBuildUtilities.RemovePropertyValue(msbuildProject, evaluatedPropertyValue, _propertyName, dimensionValue);
             }).ConfigureAwait(false);
 
-            _telemetryService.PostProperty($"DimensionChanged/{_dimensionName}/Remove", "Value", HashValueIfNeeded(dimensionValue), unconfiguredProject);
+            _telemetryService.PostProperty($"{TelemetryEventName}/{_dimensionName}/Remove", "Value", HashValueIfNeeded(dimensionValue), unconfiguredProject);
         }
 
 
@@ -196,7 +198,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
                 ("NewValue", HashValueIfNeeded(newName)),
             };
 
-            _telemetryService.PostProperties($"DimensionChanged/{_dimensionName}/Rename", properties, unconfiguredProject);
+            _telemetryService.PostProperties($"{TelemetryEventName}/{_dimensionName}/Rename", properties, unconfiguredProject);
         }
 
         private string HashValueIfNeeded(string value)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Configuration/ConfigurationProjectConfigurationDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Configuration/ConfigurationProjectConfigurationDimensionProvider.cs
@@ -4,6 +4,7 @@ using System;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.VS.Editor;
+using Microsoft.VisualStudio.ProjectSystem.VS.Telemetry;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
 {
@@ -22,8 +23,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
     internal class ConfigurationProjectConfigurationDimensionProvider : BaseProjectConfigurationDimensionProvider
     {
         [ImportingConstructor]
-        public ConfigurationProjectConfigurationDimensionProvider(IProjectXmlAccessor projectXmlAccessor)
-            : base(projectXmlAccessor, ConfigurationGeneral.ConfigurationProperty, "Configurations")
+        public ConfigurationProjectConfigurationDimensionProvider(IProjectXmlAccessor projectXmlAccessor, ITelemetryService telemetryService)
+            : base(projectXmlAccessor, telemetryService, ConfigurationGeneral.ConfigurationProperty, "Configurations", valueContainsPii: true)
         {
         }
 
@@ -41,10 +42,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
                     switch (args.Change)
                     {
                         case ConfigurationDimensionChange.Add:
-                            await OnConfigurationAddedAsync(args.Project, args.DimensionValue).ConfigureAwait(true);
+                            await OnDimensionValueAddedAsync(args.Project, args.DimensionValue).ConfigureAwait(true);
                             break;
                         case ConfigurationDimensionChange.Delete:
-                            await OnConfigurationRemovedAsync(args.Project, args.DimensionValue).ConfigureAwait(true);
+                            await OnDimensionValueRemovedAsync(args.Project, args.DimensionValue).ConfigureAwait(true);
                             break;
                         case ConfigurationDimensionChange.Rename:
                             // Need to wait until the core rename changes happen before renaming the property.
@@ -57,56 +58,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
                     // of the core changes to rename existing conditions have executed.
                     if (args.Change == ConfigurationDimensionChange.Rename)
                     {
-                        await OnConfigurationRenamedAsync(args.Project, args.OldDimensionValue, args.DimensionValue).ConfigureAwait(true);
+                        await OnDimensionValueRenamedAsync(args.Project, args.OldDimensionValue, args.DimensionValue).ConfigureAwait(true);
                     }
                 }
             }
-        }
-
-        /// <summary>
-        /// Adds a configuration to the project.
-        /// </summary>
-        /// <param name="unconfiguredProject">Unconfigured project for which the configuration change.</param>
-        /// <param name="configurationName">Name of the new configuration.</param>
-        /// <returns>A task for the async operation.</returns>
-        private async Task OnConfigurationAddedAsync(UnconfiguredProject unconfiguredProject, string configurationName)
-        {
-            string evaluatedPropertyValue = await GetPropertyValue(unconfiguredProject).ConfigureAwait(false);
-            await _projectXmlAccessor.ExecuteInWriteLock(msbuildProject =>
-            {
-                MsBuildUtilities.AppendPropertyValue(msbuildProject, evaluatedPropertyValue, _propertyName, configurationName);
-            }).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Removes a configuration from the project.
-        /// </summary>
-        /// <param name="unconfiguredProject">Unconfigured project for which the configuration change.</param>
-        /// <param name="configurationName">Name of the deleted configuration.</param>
-        /// <returns>A task for the async operation.</returns>
-        private async Task OnConfigurationRemovedAsync(UnconfiguredProject unconfiguredProject, string configurationName)
-        {
-            string evaluatedPropertyValue = await GetPropertyValue(unconfiguredProject).ConfigureAwait(false);
-            await _projectXmlAccessor.ExecuteInWriteLock(msbuildProject =>
-            {
-                MsBuildUtilities.RemovePropertyValue(msbuildProject, evaluatedPropertyValue, _propertyName, configurationName);
-            }).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Renames an existing configuration in the project.
-        /// </summary>
-        /// <param name="unconfiguredProject">Unconfigured project for which the configuration change.</param>
-        /// <param name="oldName">Original name of the configuration.</param>
-        /// <param name="newName">New name of the configuration.</param>
-        /// <returns>A task for the async operation.</returns>
-        private async Task OnConfigurationRenamedAsync(UnconfiguredProject unconfiguredProject, string oldName, string newName)
-        {
-            string evaluatedPropertyValue = await GetPropertyValue(unconfiguredProject).ConfigureAwait(false);
-            await _projectXmlAccessor.ExecuteInWriteLock(msbuildProject =>
-            {
-                MsBuildUtilities.RenamePropertyValue(msbuildProject, evaluatedPropertyValue, _propertyName, oldName, newName);
-            }).ConfigureAwait(false);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Configuration/TargetFrameworkProjectConfigurationDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Configuration/TargetFrameworkProjectConfigurationDimensionProvider.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.VS.Editor;
+using Microsoft.VisualStudio.ProjectSystem.VS.Telemetry;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
 {
@@ -22,8 +23,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
     internal class TargetFrameworkProjectConfigurationDimensionProvider : BaseProjectConfigurationDimensionProvider
     {
         [ImportingConstructor]
-        public TargetFrameworkProjectConfigurationDimensionProvider(IProjectXmlAccessor projectXmlAccessor)
-            : base(projectXmlAccessor, ConfigurationGeneral.TargetFrameworkProperty, ConfigurationGeneral.TargetFrameworksProperty)
+        public TargetFrameworkProjectConfigurationDimensionProvider(IProjectXmlAccessor projectXmlAccessor, ITelemetryService telemetryService)
+            : base(projectXmlAccessor, telemetryService, ConfigurationGeneral.TargetFrameworkProperty, ConfigurationGeneral.TargetFrameworksProperty, valueContainsPii: false)
         {
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Telemetry/ITelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Telemetry/ITelemetryService.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using Microsoft.VisualStudio.Telemetry;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Telemetry

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Telemetry/ITelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Telemetry/ITelemetryService.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Telemetry;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Telemetry
+{
+    /// <summary>
+    /// Internal as we don't want anyone who depends on us to post events to our eventId.
+    /// </summary>
+    internal interface ITelemetryService
+    {
+        /// <summary>
+        /// Posts a given telemetry event path to the telemetry service session for the program.
+        /// </summary>
+        /// <param name="telemetryEvent">Name of the event to post.</param>
+        void PostEvent(string telemetryEvent);
+
+        /// <summary>
+        /// Posts a given telemetry operation to the telemetry service. <seealso cref="TelemetrySessionExtensions.PostOperation(TelemetrySession, string, TelemetryResult, string, TelemetryEventCorrelation[])"/>
+        /// </summary>
+        /// <param name="operationPath">Postfix on "vs/projectsystem/"</param>
+        /// <param name="result">The result of the operation</param>
+        /// <param name="resultSummary">Summary of the result</param>
+        /// <param name="correlatedWith">Events to correlate this event with</param>
+        /// <returns>Posted telemetry event.</returns>
+        TelemetryEventCorrelation PostOperation(string operationPath, TelemetryResult result, string resultSummary = null, TelemetryEventCorrelation[] correlatedWith = null);
+
+        /// <summary>
+        /// Reports a given non-fatal watson to the telemetry service. <seealso cref="TelemetrySessionExtensions.PostFault(TelemetrySession, string, string, Exception, Func{IFaultUtility, int}, TelemetryEventCorrelation[])"/>
+        /// </summary>
+        /// <param name="eventPostfix">Postfix on "vs/projectsystem/"</param>
+        /// <param name="description">Description to include with the NFW</param>
+        /// <param name="exception">Exception that caused the NFW</param>
+        /// <param name="callback">Gathers information for the NFW</param>
+        /// <returns>Posted telemetry event.</returns>
+        TelemetryEventCorrelation Report(string eventPostfix, string description, Exception exception, Func<IFaultUtility, int> callback = null);
+
+        /// <summary>
+        /// Posts an event with a single property.
+        /// </summary>
+        /// <param name="eventName">Name of the event.</param>
+        /// <param name="propertyName">Name of the property.</param>
+        /// <param name="propertyValue">Value of the property.</param>
+        /// <param name="unconfiguredProject">Correlated project asset for this event.</param>
+        void PostProperty(string eventName, string propertyName, string propertyValue, UnconfiguredProject unconfiguredProject = null);
+
+        /// <summary>
+        /// Posts an event with multiple properties.
+        /// </summary>
+        /// <param name="eventName">Name of the event.</param>
+        /// <param name="properties">Collection of property name and values.</param>
+        /// <param name="unconfiguredProject">Correlated project asset for this event.</param>
+        void PostProperties(string eventName, IEnumerable<(string propertyName, string propertyValue)> properties, UnconfiguredProject unconfiguredProject = null);
+
+        /// <summary>
+        /// Hashes personally identifiable information for telemetry consumption.
+        /// </summary>
+        /// <param name="value">Value to hashed.</param>
+        /// <returns>Hashed value.</returns>
+        string HashValue(string value);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Telemetry/VsTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Telemetry/VsTelemetryService.cs
@@ -1,0 +1,238 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Telemetry;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Telemetry
+{
+    [Export(typeof(ITelemetryService))]
+    [SuppressMessage("Microsoft.Cryptographic.Standard", "CA5350:MD5CannotBeUsed", Justification = "MD5 hash is not being used for security")]
+    internal class VsTelemetryService : ITelemetryService
+    {
+        /// <summary>
+        /// Prefix for events.
+        /// </summary>
+        private const string EventPrefix = "vs/projectsystem/managed/";
+
+        /// <summary>
+        /// Dictionary of known project assets.
+        /// </summary>
+        private Dictionary<string, TelemetryEventCorrelation> projectAssets = new Dictionary<string, TelemetryEventCorrelation>();
+
+        /// <summary>
+        /// Project lock service.
+        /// </summary>
+        private readonly IProjectLockService _projectLockService;
+
+        private readonly IUnconfiguredProjectVsServices _projectVsService;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VsTelemetryService"/> class.
+        /// </summary>
+        /// <param name="projectLockService">Project lock service.</param>
+        /// <param name="projectVsService"></param>
+        [ImportingConstructor]
+        public VsTelemetryService(IProjectLockService projectLockService, IUnconfiguredProjectVsServices projectVsService)
+        {
+            _projectLockService = projectLockService;
+            _projectVsService = projectVsService;
+        }
+
+        [ProjectAutoLoad(startAfter: ProjectLoadCheckpoint.ProjectFactoryCompleted)]
+        [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
+        internal async Task OnProjectFactoryCompletedAsync()
+        {
+            await CreateProjectAsset(_projectVsService.Project).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Posts a given telemetry event path to the telemetry service session for the program.
+        /// </summary>
+        /// <param name="telemetryEvent">Name of the event to post.</param>
+        public void PostEvent(string telemetryEvent)
+        {
+            TelemetryService.DefaultSession.PostEvent($"{EventPrefix}{telemetryEvent}");
+        }
+
+        /// <summary>
+        /// Posts a given telemetry operation to the telemetry service. <seealso cref="TelemetrySessionExtensions.PostOperation(TelemetrySession, string, TelemetryResult, string, TelemetryEventCorrelation[])"/>
+        /// </summary>
+        /// <param name="operationPath">Postfix on "vs/projectsystem/"</param>
+        /// <param name="result">The result of the operation</param>
+        /// <param name="resultSummary">Summary of the result</param>
+        /// <param name="correlatedWith">Events to correlate this event with</param>
+        /// <returns>Posted telemetry event.</returns>
+        public TelemetryEventCorrelation PostOperation(string operationPath, TelemetryResult result, string resultSummary = null, TelemetryEventCorrelation[] correlatedWith = null)
+        {
+            return TelemetryService.DefaultSession.PostOperation(
+                eventName: $"{EventPrefix}{operationPath}",
+                result: result,
+                resultSummary: resultSummary,
+                correlatedWith: correlatedWith);
+        }
+
+        /// <summary>
+        /// Reports a given non-fatal watson to the telemetry service. <seealso cref="TelemetrySessionExtensions.PostFault(TelemetrySession, string, string, Exception, Func{IFaultUtility, int}, TelemetryEventCorrelation[])"/>
+        /// </summary>
+        /// <param name="eventPostfix">Postfix on "vs/projectsystem/"</param>
+        /// <param name="description">Description to include with the NFW</param>
+        /// <param name="exception">Exception that caused the NFW</param>
+        /// <param name="callback">Gathers information for the NFW</param>
+        /// <returns>Posted telemetry event.</returns>
+        public TelemetryEventCorrelation Report(string eventPostfix, string description, Exception exception, Func<IFaultUtility, int> callback = null)
+        {
+            return TelemetryService.DefaultSession.PostFault(
+                eventName: $"{EventPrefix}{eventPostfix}",
+                description: description,
+                exceptionObject: exception,
+                gatherEventDetails: callback);
+        }
+
+        /// <summary>
+        /// Posts an event with a single property.
+        /// </summary>
+        /// <param name="eventName">Name of the event</param>
+        /// <param name="propertyName">Name of the property.</param>
+        /// <param name="propertyValue">Value of the property.</param>
+        /// <param name="unconfiguredProject">Correlated project asset for this event.</param>
+        public void PostProperty(string eventName, string propertyName, string propertyValue, UnconfiguredProject unconfiguredProject = null)
+        {
+            TelemetryEvent telemetryEvent = new TelemetryEvent(EventPrefix + eventName.ToLower());
+            telemetryEvent.Properties.Add(BuildPropertyName(eventName, propertyName), propertyValue);
+            TryCorrelateProject(unconfiguredProject, telemetryEvent);
+            TelemetryService.DefaultSession.PostEvent(telemetryEvent);
+        }
+
+        /// <summary>
+        /// Posts an event with multiple properties.
+        /// </summary>
+        /// <param name="eventName">Name of the event.</param>
+        /// <param name="properties">Collection of property name and values.</param>
+        /// <param name="unconfiguredProject">Correlated project asset for this event.</param>
+        public void PostProperties(string eventName, IEnumerable<(string propertyName, string propertyValue)> properties, UnconfiguredProject unconfiguredProject = null)
+        {
+            TelemetryEvent telemetryEvent = new TelemetryEvent(EventPrefix + eventName.ToLower());
+            foreach(var property in properties)
+            {
+                telemetryEvent.Properties.Add(BuildPropertyName(eventName, property.propertyName), property.propertyValue);
+            }
+
+            TryCorrelateProject(unconfiguredProject, telemetryEvent);
+            TelemetryService.DefaultSession.PostEvent(telemetryEvent);
+        }
+
+        /// <summary>
+        /// Hashes personally identifiable information for telemetry consumption.
+        /// </summary>
+        /// <param name="value">Value to hashed.</param>
+        /// <returns>Hashed value.</returns>
+        public string HashValue(string value)
+        {
+            using (var md5 = MD5.Create())
+            {
+                byte[] hash = md5.ComputeHash(Encoding.UTF8.GetBytes(value));
+                return BitConverter.ToString(hash);
+            }
+        }
+
+        /// <summary>
+        /// Creates a project asset.
+        /// </summary>
+        /// <param name="unconfiguredProject">Project to create the asset from.</param>
+        /// <returns>Telemetry event representing the project asset.</returns>
+        public async Task CreateProjectAsset(UnconfiguredProject unconfiguredProject)
+        {
+            string assetId = GetProjectId(unconfiguredProject);
+            if (!projectAssets.ContainsKey(assetId))
+            {
+                Dictionary<string, object> projectProperties = new Dictionary<string, object>();
+                string eventName = "Project";
+
+                using (var access = await _projectLockService.ReadLockAsync())
+                {
+                    var configuredProject = await unconfiguredProject.GetSuggestedConfiguredProjectAsync().ConfigureAwait(false);
+                    var properties = configuredProject.Services.ProjectPropertiesProvider.GetCommonProperties();
+
+                    List<string> propertyNames = new List<string>()
+                    {
+                        ConfigurationGeneral.TargetFrameworkProperty,
+                        ConfigurationGeneral.TargetFrameworksProperty,
+                        ConfigurationGeneral.OutputTypeProperty
+                    };
+
+                    foreach (var propertyName in propertyNames)
+                    {
+                        var propertyValue = await properties.GetEvaluatedPropertyValueAsync(propertyName).ConfigureAwait(false);
+                        if (!string.IsNullOrEmpty(propertyValue))
+                        {
+                            projectProperties[BuildPropertyName(eventName, propertyName)] = propertyValue;
+                        }
+                    }
+                }
+
+                var projectAsset = TelemetryService.DefaultSession.PostAsset(
+                    EventPrefix + eventName.ToLowerInvariant(),
+                    assetId,
+                    0,
+                    projectProperties);
+
+                projectAssets.Add(assetId, projectAsset);
+            }
+        }
+
+        /// <summary>
+        /// Build a fully qualified property name based on it's parent event and the property name
+        /// </summary>
+        /// <param name="eventName">Name of the parent event.</param>
+        /// <param name="propertyName">Name of the property.</param>
+        /// <returns>Fully qualified property name.</returns>
+        /// <remarks>
+        /// Properties are expected to be in the following format - EventName.PropertyName
+        /// with the the slashes from the vent name replaced by periods.
+        /// e.g. vs/myevent would translate to VS.MyEvent.MyProperty
+        /// </remarks>
+        private string BuildPropertyName(string eventName, string propertyName)
+        {
+            string name = "VS.ProjectSystem.Managed." + eventName.Replace('/', '.');
+
+            if (!name.EndsWith("."))
+            {
+                name += ".";
+            }
+
+            name += propertyName;
+
+            return name;
+        }
+
+        /// <summary>
+        /// Tries to correlate a project 
+        /// </summary>
+        /// <param name="unconfiguredProject">Correlated project asset for this event.</param>
+        /// <param name="telemetryEvent">Telemetry event to correlate the asset to.</param>
+        private void TryCorrelateProject(UnconfiguredProject unconfiguredProject, TelemetryEvent telemetryEvent)
+        {
+            if (unconfiguredProject != null && projectAssets.TryGetValue(GetProjectId(unconfiguredProject), out TelemetryEventCorrelation projectAsset))
+            {
+                telemetryEvent.Correlate(projectAsset);
+            }
+        }
+
+        /// <summary>
+        /// Gets an unique identifier for the unconfigured project.
+        /// </summary>
+        /// <param name="unconfiguredProject">Unconfigured project.</param>
+        /// <returns>Unique identifier for the project.</returns>
+        private string GetProjectId(UnconfiguredProject unconfiguredProject)
+        {
+            // TODO: This should really be the project GUID. For now use a hash of the filename
+            return HashValue(unconfiguredProject.FullPath.ToLowerInvariant());
+        }
+    }
+}


### PR DESCRIPTION
#1773 

This adds telemetry for add/remove/rename configs and telemetry for project so that we can correlate the events to an asset. For now I'm only adding OutputType and TargetFrameworks but I'm sure there's more data that should be logged which can be added later.

Config names can contain PII while platforms and frameworks don't so only hashing the config names.

Sample telemetry data:

vs/projectsystem/managed/project (<d6d821c7-480f-453a-a5b0-dbe8449f60c8>)
  Reserved.DataModel.CorrelationId = c13eeb3f-6199-4254-bdd5-bfab4a8d1e6c
  VS.ProjectSystem.Managed.Project.OutputType = Exe
  VS.ProjectSystem.Managed.Project.TargetFramework = netcoreapp1.1

vs/projectsystem/managed/project (<d6d821c7-480f-453a-a5b0-dbe8449f60c8>)
  Reserved.DataModel.CorrelationId = fba55dfe-ae2b-48a8-b7ed-cc3bb60ed179
  VS.ProjectSystem.Managed.Project.OutputType = Exe
  VS.ProjectSystem.Managed.Project.TargetFramework = netcoreapp1.0

vs/projectsystem/managed/dimensionchanged/platform/remove (<d6d821c7-480f-453a-a5b0-dbe8449f60c8>)
  Reserved.DataModel.Correlation.1 = c13eeb3f-6199-4254-bdd5-bfab4a8d1e6c,Asset,
  VS.ProjectSystem.Managed.DimensionChanged.Platform.Remove.Value = x64

vs/projectsystem/managed/dimensionchanged/platform/add (<d6d821c7-480f-453a-a5b0-dbe8449f60c8>)
  Reserved.DataModel.Correlation.1 = fba55dfe-ae2b-48a8-b7ed-cc3bb60ed179,Asset,
  VS.ProjectSystem.Managed.DimensionChanged.Platform.Add.Value = x86

vs/projectsystem/managed/dimensionchanged/configuration/rename (<d6d821c7-480f-453a-a5b0-dbe8449f60c8>)
  Reserved.DataModel.Correlation.1 = e382c8ae-7a68-48f9-a3c1-3f495e8f745c,Asset,
   VS.ProjectSystem.Managed.DimensionChanged.Configuration.Rename.NewValue = 0C-BC-66-11-F5-54-0B-D0-80-9A-38-8D-C9-5A-61-5B
   VS.ProjectSystem.Managed.DimensionChanged.Configuration.Rename.OldValue = B8-E7-B4-65-DF-7C-59-79-DC-73-1D-06-E8-4C-E2-CF