### PR TITLE
Make launch provider more robust

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Utilities/SequencialTaskExecutorTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Utilities/SequencialTaskExecutorTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 using System;
 using System.Collections.Generic;
-using Microsoft.VisualStudio.ProjectSystem.Utilities;
+using Microsoft.VisualStudio.Threading.Tasks;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Utilities/SequencialTaskExecutorTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Utilities/SequencialTaskExecutorTests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 {
                     Func<Task> func = async () =>
                     {
-                        await Task.Delay(2000).ConfigureAwait(false);
+                        await Task.Delay(100).ConfigureAwait(false);
                     };
                     await func().ConfigureAwait(false);
                 }));
@@ -108,10 +108,23 @@ namespace Microsoft.VisualStudio.ProjectSystem
             }
             catch (OperationCanceledException)
             {
+                bool mustBeCancelled = false;
                 for (int i = 0; i < NumberOfTasks; i++)
                 {
-                    Assert.True(tasks[i].IsCanceled);
+                    // The first task or two may already be running. So we skip completed tasks until we find 
+                    // one that is is cancelled
+                    if (mustBeCancelled)
+                    {
+                        Assert.True(tasks[i].IsCanceled);
+                    }
+                    else
+                    {
+                        // All remaining tasks should be cancelled
+                        mustBeCancelled = tasks[i].IsCanceled;
+                    }
                 }
+
+                Assert.True(mustBeCancelled);
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Utilities/SequencialTaskExecutorTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Utilities/SequencialTaskExecutorTests.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.ProjectSystem.Utilities;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+
+    [ProjectSystemTrait]
+    public class SequencialTaskExecutorTests
+    {
+        [Fact]
+        public async Task EnsureTasksAreRunInOrder()
+        {
+            const int NumberOfTasks = 25;
+            var sequencer = new SequencialTaskExecutor();
+
+            List<Task> tasks = new List<Task>();
+            List<int> sequences = new List<int>();
+            for (int i = 0; i < NumberOfTasks; i++)
+            {
+                int num = i;
+                tasks.Add(sequencer.ExecuteTask(async () =>
+                {
+                    Func<Task> func = async () =>
+                    {
+                        await Task.Delay(1).ConfigureAwait(false);
+                        sequences.Add(num);
+                    };
+                    await func().ConfigureAwait(false);
+                }));
+            }
+
+            await Task.WhenAll(tasks.ToArray());
+            for (int i = 0; i < NumberOfTasks; i++)
+            {
+                Assert.Equal(i, sequences[i]);
+            }
+        }
+
+        [Fact]
+        public async Task EnsureNestedCallsAreExcecutedDirectly()
+        {
+            const int NumberOfTasks = 10;
+            var sequencer = new SequencialTaskExecutor();
+
+            List<Task> tasks = new List<Task>();
+            List<int> sequences = new List<int>();
+            for (int i = 0; i < NumberOfTasks; i++)
+            {
+                int num = i;
+                tasks.Add(sequencer.ExecuteTask(async () =>
+                {
+                    Func<Task> func = async () =>
+                    {
+                        await sequencer.ExecuteTask(async () =>
+                        {
+                            await Task.Delay(1).ConfigureAwait(false);
+                            sequences.Add(num);
+                        });
+                    };
+                    await func().ConfigureAwait(false);
+                }));
+            }
+
+            await Task.WhenAll(tasks.ToArray());
+            for (int i = 0; i < NumberOfTasks; i++)
+            {
+                Assert.Equal(i, sequences[i]);
+            }
+        }
+
+        [Fact]
+        public void CalltoDisposedObjectShouldThrow()
+        {
+            var sequencer = new SequencialTaskExecutor();
+            sequencer.Dispose();
+            Assert.Throws<ObjectDisposedException>(() => { sequencer.ExecuteTask(() => Task.CompletedTask); });
+        }
+
+        [Fact]
+        public async Task EnsureTasksCancelledWhenDisposed()
+        {
+            const int NumberOfTasks = 10;
+            var sequencer = new SequencialTaskExecutor();
+
+            List<Task> tasks = new List<Task>();
+            for (int i = 0; i < NumberOfTasks; i++)
+            {
+                int num = i;
+                tasks.Add(sequencer.ExecuteTask(async () =>
+                {
+                    Func<Task> func = async () =>
+                    {
+                        await Task.Delay(2000).ConfigureAwait(false);
+                    };
+                    await func().ConfigureAwait(false);
+                }));
+            }
+            sequencer.Dispose();
+
+            try
+            {
+                await Task.WhenAll(tasks.ToArray());
+                Assert.False(true);
+            }
+            catch (OperationCanceledException)
+            {
+                for (int i = 0; i < NumberOfTasks; i++)
+                {
+                    Assert.True(tasks[i].IsCanceled);
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -10,14 +10,12 @@ using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
-using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using Microsoft.VisualStudio.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
-
     /// <summary>
     /// Manages the set of Debug profiles and web server settings and provides these as a dataflow source. Note 
     /// that many of the methods are protected so that unit tests can derive from this class and poke them as

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -97,6 +97,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
         protected IDisposable ProjectRuleSubscriptionLink { get; set; }
 
+        private SequencialTaskExecutor _sequentialTaskQueue = new SequencialTaskExecutor();
+
         /// <summary>
         /// Returns the full path to the launch settings file
         /// </summary>
@@ -229,7 +231,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 var snapshot = CurrentSnapshot;
                 if (snapshot == null || !LaunchProfile.IsSameProfileName(activeProfile, snapshot.ActiveProfile?.Name))
                 {
-                    await UpdateActiveProfileInSnapshotAsync(activeProfile).ConfigureAwait(false);
+                    // Updates need to be sequenced
+                    await _sequentialTaskQueue.ExecuteTask(async () =>
+                                    {
+                                        await UpdateActiveProfileInSnapshotAsync(activeProfile).ConfigureAwait(false);
+                                    }).ConfigureAwait(false);
                 }
             }
         }
@@ -578,8 +584,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                         {
                             return;
                         }
-
-                        await UpdateProfilesAsync(null).ConfigureAwait(false);
+                        
+                        // Updates need to be sequenced
+                        await _sequentialTaskQueue.ExecuteTask(async () =>
+                                        {
+                                            await UpdateProfilesAsync(null).ConfigureAwait(false);
+                                        }).ConfigureAwait(false);
                     });
                 }
             }
@@ -646,6 +656,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                     FileChangeScheduler = null;
                 }
 
+                if(_sequentialTaskQueue != null)
+                {
+                    _sequentialTaskQueue.Dispose();
+                    _sequentialTaskQueue = null;
+                }
+
                 if (_broadcastBlock != null)
                 {
                     _broadcastBlock.Complete();
@@ -667,13 +683,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </summary>
         public async Task UpdateAndSaveSettingsAsync(ILaunchSettings newSettings)
         {
+            // Updates need to be sequenced. Do not call this version from within an ExecuteTask as it
+            // will deadlock
+            await _sequentialTaskQueue.ExecuteTask(async () =>
+            {
+                await UpdateAndSaveSettingsInternalAsync(newSettings).ConfigureAwait(false);
+            }).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Replaces the current set of profiles with the contents of profiles. If changes were
+        /// made, the file will be checked out and saved. Note it ignores the value of the active profile
+        /// as this setting is controlled by a user property.
+        /// </summary>
+        private async Task UpdateAndSaveSettingsInternalAsync(ILaunchSettings newSettings)
+        {
+            await CheckoutSettingsFileAsync().ConfigureAwait(false);
+
             // Make sure the profiles are copied. We don't want them to mutate.
             var activeProfileName = ActiveProfile?.Name;
 
             ILaunchSettings newSnapshot = new LaunchSettings(newSettings.Profiles, newSettings.GlobalSettings, activeProfileName);
-
-            await CheckoutSettingsFileAsync().ConfigureAwait(false);
-
             SaveSettingsToDisk(newSettings);
 
             FinishUpdate(newSnapshot);
@@ -703,42 +733,46 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </summary>
         public async Task AddOrUpdateProfileAsync(ILaunchProfile profile, bool addToFront)
         {
-            var currentSettings = await GetSnapshotThrowIfErrors().ConfigureAwait(false);
-            ILaunchProfile existingProfile = null;
-            int insertionIndex = 0;
-            foreach (var p in currentSettings.Profiles)
+            // Updates need to be sequenced
+            await _sequentialTaskQueue.ExecuteTask(async () =>
             {
-                if (LaunchProfile.IsSameProfileName(p.Name, profile.Name))
+                var currentSettings = await GetSnapshotThrowIfErrors().ConfigureAwait(false);
+                ILaunchProfile existingProfile = null;
+                int insertionIndex = 0;
+                foreach (var p in currentSettings.Profiles)
                 {
-                    existingProfile = p;
-                    break;
+                    if (LaunchProfile.IsSameProfileName(p.Name, profile.Name))
+                    {
+                        existingProfile = p;
+                        break;
+                    }
+                    insertionIndex++;
                 }
-                insertionIndex++;
-            }
 
-            ImmutableList<ILaunchProfile> profiles;
-            if (existingProfile != null)
-            {
-                profiles = currentSettings.Profiles.Remove(existingProfile);
-            }
-            else
-            {
-                profiles = currentSettings.Profiles;
-            }
+                ImmutableList<ILaunchProfile> profiles;
+                if (existingProfile != null)
+                {
+                    profiles = currentSettings.Profiles.Remove(existingProfile);
+                }
+                else
+                {
+                    profiles = currentSettings.Profiles;
+                }
 
-            if (addToFront)
-            {
-                profiles = profiles.Insert(0, new LaunchProfile(profile));
-            }
-            else
-            {
-                // Insertion index will be set to the current count (end of list) if an existing item was not found otherwise
-                // it will point to where the previous one was found
-                profiles = profiles.Insert(insertionIndex, new LaunchProfile(profile));
-            }
+                if (addToFront)
+                {
+                    profiles = profiles.Insert(0, new LaunchProfile(profile));
+                }
+                else
+                {
+                    // Insertion index will be set to the current count (end of list) if an existing item was not found otherwise
+                    // it will point to where the previous one was found
+                    profiles = profiles.Insert(insertionIndex, new LaunchProfile(profile));
+                }
 
-            var newSnapshot = new LaunchSettings(profiles, currentSettings?.GlobalSettings, currentSettings?.ActiveProfile?.Name);
-            await UpdateAndSaveSettingsAsync(newSnapshot).ConfigureAwait(false);
+                var newSnapshot = new LaunchSettings(profiles, currentSettings?.GlobalSettings, currentSettings?.ActiveProfile?.Name);
+                await UpdateAndSaveSettingsInternalAsync(newSnapshot).ConfigureAwait(false);
+            }).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -746,14 +780,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </summary>
         public async Task RemoveProfileAsync(string profileName)
         {
-            var currentSettings = await GetSnapshotThrowIfErrors().ConfigureAwait(false);
-            var existingProfile = currentSettings.Profiles.FirstOrDefault(p => LaunchProfile.IsSameProfileName(p.Name, profileName));
-            if (existingProfile != null)
+            // Updates need to be sequenced
+            await _sequentialTaskQueue.ExecuteTask(async () =>
             {
-                var profiles = currentSettings.Profiles.Remove(existingProfile);
-                var newSnapshot = new LaunchSettings(profiles, currentSettings.GlobalSettings, currentSettings.ActiveProfile?.Name);
-                await UpdateAndSaveSettingsAsync(newSnapshot).ConfigureAwait(false);
-            }
+                var currentSettings = await GetSnapshotThrowIfErrors().ConfigureAwait(false);
+                var existingProfile = currentSettings.Profiles.FirstOrDefault(p => LaunchProfile.IsSameProfileName(p.Name, profileName));
+                if (existingProfile != null)
+                {
+                    var profiles = currentSettings.Profiles.Remove(existingProfile);
+                    var newSnapshot = new LaunchSettings(profiles, currentSettings.GlobalSettings, currentSettings.ActiveProfile?.Name);
+                    await UpdateAndSaveSettingsInternalAsync(newSnapshot).ConfigureAwait(false);
+                }
+            }).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -762,19 +800,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </summary>
         public async Task AddOrUpdateGlobalSettingAsync(string settingName, object settingContent)
         {
-            var currentSettings = await GetSnapshotThrowIfErrors().ConfigureAwait(false);
-            ImmutableDictionary<string, object> globalSettings = ImmutableDictionary<string, object>.Empty;
-            if (currentSettings.GlobalSettings.TryGetValue(settingName, out object currentValue))
+            // Updates need to be sequenced
+            await _sequentialTaskQueue.ExecuteTask(async () =>
             {
-                globalSettings = currentSettings.GlobalSettings.Remove(settingName);
-            }
-            else
-            {
-                globalSettings = currentSettings.GlobalSettings;
-            }
+                var currentSettings = await GetSnapshotThrowIfErrors().ConfigureAwait(false);
+                ImmutableDictionary<string, object> globalSettings = ImmutableDictionary<string, object>.Empty;
+                if (currentSettings.GlobalSettings.TryGetValue(settingName, out object currentValue))
+                {
+                    globalSettings = currentSettings.GlobalSettings.Remove(settingName);
+                }
+                else
+                {
+                    globalSettings = currentSettings.GlobalSettings;
+                }
 
-            var newSnapshot = new LaunchSettings(currentSettings.Profiles, globalSettings.Add(settingName, settingContent), currentSettings.ActiveProfile?.Name);
-            await UpdateAndSaveSettingsAsync(newSnapshot).ConfigureAwait(false);
+                var newSnapshot = new LaunchSettings(currentSettings.Profiles, globalSettings.Add(settingName, settingContent), currentSettings.ActiveProfile?.Name);
+                await UpdateAndSaveSettingsInternalAsync(newSnapshot).ConfigureAwait(false);
+            }).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -782,13 +824,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </summary>
         public async Task RemoveGlobalSettingAsync(string settingName)
         {
-            var currentSettings = await GetSnapshotThrowIfErrors().ConfigureAwait(false);
-            if (currentSettings.GlobalSettings.TryGetValue(settingName, out object currentValue))
+            // Updates need to be sequenced
+            await _sequentialTaskQueue.ExecuteTask(async () =>
             {
-                var globalSettings = currentSettings.GlobalSettings.Remove(settingName);
-                var newSnapshot = new LaunchSettings(currentSettings.Profiles, globalSettings, currentSettings.ActiveProfile?.Name);
-                await UpdateAndSaveSettingsAsync(newSnapshot).ConfigureAwait(false);
-            }
+                var currentSettings = await GetSnapshotThrowIfErrors().ConfigureAwait(false);
+                if (currentSettings.GlobalSettings.TryGetValue(settingName, out object currentValue))
+                {
+                    var globalSettings = currentSettings.GlobalSettings.Remove(settingName);
+                    var newSnapshot = new LaunchSettings(currentSettings.Profiles, globalSettings, currentSettings.ActiveProfile?.Name);
+                    await UpdateAndSaveSettingsInternalAsync(newSnapshot).ConfigureAwait(false);
+                }
+            }).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/SequencialTaskExecutor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/SequencialTaskExecutor.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
 {
     /// <summary>
     /// Runs tasks in the sequence they are added. This is done by starting with a completed task, and leveraging ContinueWith\Unwrap to 
-    /// "schedule" subsequent tasks to start after the previous one is completed. The Task continaing the callers function is returned so that
+    /// "schedule" subsequent tasks to start after the previous one is completed. The Task containing the callers function is returned so that
     /// the caller can await for their specific task to complete. When disposed unprocessed tasks are cancelled.
     /// </summary>
     internal class SequencialTaskExecutor : IDisposable 
@@ -37,6 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
 
             lock(SyncObject)
             {
+                // If we are on the same exceution chain, run the task directly
                 if (_executingTask.Value)
                 {
                     return asyncFunction();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/SequencialTaskExecutor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/SequencialTaskExecutor.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Utilities
+{
+    /// <summary>
+    /// Runs tasks in the sequence they are added. This is done by starting with a completed task, and leveraging ContinueWith\Unwrap to 
+    /// "schedule" subsequent tasks to start after the previous one is completed. The Task continaing the callers function is returned so that
+    /// the caller can await for their specific task to complete. When disposed unprocessed tasks are cancelled.
+    /// </summary>
+    internal class SequencialTaskExecutor : IDisposable 
+    {
+        private bool Disposed;
+        private Task TaskAdded = Task.CompletedTask;
+        private object SyncObject = new object();
+        private CancellationTokenSource DisposedCancelTokenSource = new CancellationTokenSource();
+
+        /// <summary>
+        /// Adds a new task to the continuation chain and returns it so that it can be awaited. 
+        /// Note that deadlocks will occur if a task returned from this function, awaits a task which also calls this function as that task will not 
+        /// start until this one ccompletes. 
+        /// </summary>
+        public Task ExecuteTask(Func<Task> asyncFunction)
+        {
+            if(Disposed)
+            {
+                throw new ObjectDisposedException(nameof(SequencialTaskExecutor));
+            }
+
+            lock(SyncObject)
+            {
+                TaskAdded = TaskAdded.ContinueWith(async (t) => 
+                { 
+                    DisposedCancelTokenSource.Token.ThrowIfCancellationRequested();
+                    await asyncFunction().ConfigureAwait(false);
+                },TaskScheduler.Default).Unwrap();
+            }
+            return TaskAdded;
+        }
+
+        /// <summary>
+        /// Dispose cancels outstanding tasks
+        /// </summary>
+        public void Dispose()
+        {
+            if(!Disposed)
+            {
+                DisposedCancelTokenSource.Cancel();
+                Disposed = true;
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/SequencialTaskExecutor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/SequencialTaskExecutor.cs
@@ -4,38 +4,38 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.VisualStudio.ProjectSystem.Utilities
+namespace Microsoft.VisualStudio.Threading.Tasks
 {
     /// <summary>
     /// Runs tasks in the sequence they are added. This is done by starting with a completed task, and leveraging ContinueWith\Unwrap to 
     /// "schedule" subsequent tasks to start after the previous one is completed. The Task containing the callers function is returned so that
     /// the caller can await for their specific task to complete. When disposed unprocessed tasks are cancelled.
     /// </summary>
-    internal class SequencialTaskExecutor : IDisposable 
+    internal class SequencialTaskExecutor : IDisposable
     {
-        private bool Disposed;
-        private Task TaskAdded = Task.CompletedTask;
-        private object SyncObject = new object();
-        private CancellationTokenSource DisposedCancelTokenSource = new CancellationTokenSource();
+        private bool _disposed;
+        private Task _taskAdded = Task.CompletedTask;
+        private readonly object _syncObject = new object();
+        private CancellationTokenSource _disposedCancelTokenSource = new CancellationTokenSource();
 
         /// <summary>
         /// Deadlocks will occur if a task returned from ExecuteTask , awaits a task which also calls ExcecuteTask. The 2nd one will never get started since
         /// it will be backed up behind the first one completing. The AysncLocal is used to detect when a task is being executed, and if a downstream one gets 
         /// added, it will be executed directly, rather than get queued
         /// </summary>
-        private AsyncLocal<bool> _executingTask = new AsyncLocal<bool>();
+        private System.Threading.AsyncLocal<bool> _executingTask = new System.Threading.AsyncLocal<bool>();
 
         /// <summary>
         /// Adds a new task to the continuation chain and returns it so that it can be awaited. 
         /// </summary>
         public Task ExecuteTask(Func<Task> asyncFunction)
         {
-            if(Disposed)
+            if (_disposed)
             {
                 throw new ObjectDisposedException(nameof(SequencialTaskExecutor));
             }
 
-            lock(SyncObject)
+            lock (_syncObject)
             {
                 // If we are on the same exceution chain, run the task directly
                 if (_executingTask.Value)
@@ -43,9 +43,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
                     return asyncFunction();
                 }
 
-                TaskAdded = TaskAdded.ContinueWith(async (t) => 
-                { 
-                    DisposedCancelTokenSource.Token.ThrowIfCancellationRequested();
+                _taskAdded = _taskAdded.ContinueWith(async (t) =>
+                {
+                    _disposedCancelTokenSource.Token.ThrowIfCancellationRequested();
                     try
                     {
                         _executingTask.Value = true;
@@ -55,9 +55,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
                     {
                         _executingTask.Value = false;
                     }
-                },TaskScheduler.Default).Unwrap();
+                }, TaskScheduler.Default).Unwrap();
             }
-            return TaskAdded;
+            return _taskAdded;
         }
 
         /// <summary>
@@ -65,10 +65,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
         /// </summary>
         public void Dispose()
         {
-            if(!Disposed)
+            if (!_disposed)
             {
-                DisposedCancelTokenSource.Cancel();
-                Disposed = true;
+                _disposedCancelTokenSource.Cancel();
+                _disposed = true;
             }
         }
     }


### PR DESCRIPTION
Addresses https://github.com/dotnet/roslyn-project-system/issues/495
Addresses VS feedback bug https://vsfeedback/comment/803555
Added a task executer which guarantees scheduled tasks are run in sequence. 
Changed the saving code in launchsettingsprovider.cs to use this scheduler.
