### PR TITLE
Move Xunit to 2.2.0 version from 2.1.0

### DIFF
--- a/build/Targets/References.targets
+++ b/build/Targets/References.targets
@@ -221,7 +221,7 @@
       <ItemGroup>
 
         <PackageReference Include="Moq" Version="4.2.1402.2112" />
-        <PackageReference Include="xunit" Version="2.1.0" />
+        <PackageReference Include="xunit" Version="2.2.0" />
 
       </ItemGroup>
     </When>

--- a/build/Targets/Roslyn.Toolsets.Xunit.targets
+++ b/build/Targets/Roslyn.Toolsets.Xunit.targets
@@ -2,7 +2,7 @@
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <XUnitPath>$(NuGetPackageRoot)\xunit.runner.console\2.1.0\tools\xunit.console.x86.exe</XUnitPath>
+    <XUnitPath>$(NuGetPackageRoot)\xunit.runner.console\2.2.0\tools\xunit.console.x86.exe</XUnitPath>
     <XUnitTestResultsDirectory>$(OutDir)\xUnitResults</XUnitTestResultsDirectory>
     <XUnitArguments>"$(OutDir)\$(AssemblyName).dll" -html "$(XUnitTestResultsDirectory)\$(AssemblyName).html" -noshadow</XUnitArguments>
   </PropertyGroup>

--- a/build/build.proj
+++ b/build/build.proj
@@ -88,7 +88,7 @@
 
     <Message Text="Running tests for %(SolutionFile.Filename) [$(Configuration)]" Importance="high" />
 
-    <Exec Command="&quot;$(NUGET_PACKAGES)\xunit.runner.console\2.1.0\tools\xunit.console.x86.exe&quot; &quot;@(TestAssembly, '&quot; &quot;')&quot; -quiet -nologo -noshadow -parallel all -xml &quot;@(XmlTestFile)&quot; -html &quot;@(HtmlTestFile)&quot;"
+    <Exec Command="&quot;$(NUGET_PACKAGES)\xunit.runner.console\2.2.0\tools\xunit.console.x86.exe&quot; &quot;@(TestAssembly, '&quot; &quot;')&quot; -quiet -nologo -noshadow -parallel all -xml &quot;@(XmlTestFile)&quot; -html &quot;@(HtmlTestFile)&quot;"
           LogStandardErrorAsError="true"
           IgnoreExitCode="true"
           >

--- a/src/DeployTestDependencies/DeployTestDependencies.csproj
+++ b/src/DeployTestDependencies/DeployTestDependencies.csproj
@@ -30,8 +30,8 @@
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.VisualBasic\Microsoft.VisualStudio.ProjectSystem.VisualBasic.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.1.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.1.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.console" Version="2.2.0" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
VS Test explorer needs XUnit version greater than or equal to 2.2.0 version to work.

Tagging @dotnet/project-system  for review