### PR TITLE
Refactor ActiveConfiguredProjectsProvider

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ConfiguredProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ConfiguredProjectFactory.cs
@@ -14,5 +14,10 @@ namespace Microsoft.VisualStudio.ProjectSystem
             mock.Setup(c => c.Services).Returns(services);
             return mock.Object;
         }
+
+        public static ConfiguredProject ImplementProjectConfiguration(ProjectConfiguration projectConfiguration)
+        {
+            return Create(projectConfiguration: projectConfiguration);
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IActiveConfiguredProjectProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IActiveConfiguredProjectProviderFactory.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class IActiveConfiguredProjectProviderFactory
+    {
+        public static IActiveConfiguredProjectProvider ImplementActiveProjectConfiguration(Func<ProjectConfiguration> action)
+        {
+            var mock = new Mock<IActiveConfiguredProjectProvider>();
+            mock.SetupGet(p => p.ActiveProjectConfiguration)
+                .Returns(action);
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectConfigurationsServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectConfigurationsServiceFactory.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class IProjectConfigurationsServiceFactory
+    {
+        public static IProjectConfigurationsService ImplementGetKnownProjectConfigurationsAsync(IImmutableSet<ProjectConfiguration> action)
+        {
+            var mock = new Mock<IProjectConfigurationsService>();
+            mock.Setup(p => p.GetKnownProjectConfigurationsAsync())
+                .ReturnsAsync(action);
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IUnconfiguredProjectCommonServicesFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IUnconfiguredProjectCommonServicesFactory.cs
@@ -45,5 +45,10 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             return mock.Object;
         }
+
+        public static IUnconfiguredProjectCommonServices ImplementProject(UnconfiguredProject project)
+        {
+            return Create(project: project);
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IUnconfiguredProjectServicesFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IUnconfiguredProjectServicesFactory.cs
@@ -6,13 +6,26 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal static class IUnconfiguredProjectServicesFactory
     {
-        public static IUnconfiguredProjectServices Create(IProjectAsynchronousTasksService asyncTaskService = null)
+        public static IUnconfiguredProjectServices Create(IProjectAsynchronousTasksService asyncTaskService = null, IActiveConfiguredProjectProvider activeConfiguredProjectProvider = null, IProjectConfigurationsService projectConfigurationsService = null)
         {
             var mock = new Mock<IUnconfiguredProjectServices>();
 
             if (asyncTaskService != null)
             {
-                mock.Setup(s => s.ProjectAsynchronousTasks).Returns(asyncTaskService);
+                mock.Setup(s => s.ProjectAsynchronousTasks)
+                    .Returns(asyncTaskService);
+            }
+
+            if (activeConfiguredProjectProvider != null)
+            {
+                mock.Setup(s => s.ActiveConfiguredProjectProvider)
+                    .Returns(activeConfiguredProjectProvider);
+            }
+
+            if (projectConfigurationsService != null)
+            {
+                mock.Setup(s => s.ProjectConfigurationsService)
+                    .Returns(projectConfigurationsService);
             }
 
             return mock.Object;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectConfigurationFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectConfigurationFactory.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class ProjectConfigurationFactory
+    {
+
+
+        public static ProjectConfiguration Create(string name, IImmutableDictionary<string, string> dimensions)
+        {
+            return new StandardProjectConfiguration(name, dimensions);
+        }
+
+        public static ProjectConfiguration Create(string configuration)
+        {
+            var dimensionsBuilder = ImmutableDictionary.CreateBuilder<string, string>();
+
+            string[] dimensions = configuration.Split('|');
+
+            for (int i = 0; i < dimensions.Length; i++)
+            {
+                dimensionsBuilder.Add(GetDimensionName(i), dimensions[i]);
+            }
+
+            return Create(configuration, dimensionsBuilder.ToImmutable());
+        }
+
+        public static IImmutableSet<ProjectConfiguration> CreateMany(params string[] configurations)
+        {
+            var configurationsBuilder = ImmutableHashSet.CreateBuilder<ProjectConfiguration>();
+
+            foreach (string configuration in configurations)
+            {
+                ProjectConfiguration config = Create(configuration);
+                configurationsBuilder.Add(config);
+            }
+
+            return configurationsBuilder.ToImmutable();
+        }
+
+
+        private static string GetDimensionName(int ordinal)
+        {
+            switch (ordinal)
+            {
+                case 0:
+                    return "Configuration";
+
+                case 1:
+                    return "Platform";
+
+                case 2:
+                    return "TargetFramework";
+
+                default:
+                    throw new InvalidOperationException();
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/UnconfiguredProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/UnconfiguredProjectFactory.cs
@@ -55,5 +55,14 @@ namespace Microsoft.VisualStudio.ProjectSystem
             mock.Setup(u => u.GetFileEncodingAsync()).Returns(encoding);
             return mock.Object;
         }
+
+        public static UnconfiguredProject ImplementLoadConfiguredProjectAsync(Func<ProjectConfiguration, Task<ConfiguredProject>> action)
+        {
+            var mock = new Mock<UnconfiguredProject>();
+            mock.Setup(p => p.LoadConfiguredProjectAsync(It.IsAny<ProjectConfiguration>()))
+                .Returns(action);
+
+            return mock.Object;
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsProviderTests.cs
@@ -69,6 +69,39 @@ namespace Microsoft.VisualStudio.ProjectSystem
             Assert.Equal(activeConfigs, result);
         }
 
+        [Theory] // ActiveConfiguration                 Configurations
+        [InlineData("Debug|AnyCPU",                     "Debug|AnyCPU")]
+        [InlineData("Debug|AnyCPU",                     "Debug|AnyCPU;Release|AnyCPU")]
+        [InlineData("Debug|AnyCPU",                     "Release|AnyCPU;Debug|AnyCPU")]
+        [InlineData("Debug|AnyCPU",                     "Debug|AnyCPU;Release|AnyCPU;Debug|x86")]
+        [InlineData("Debug|AnyCPU",                     "Debug|AnyCPU;Release|AnyCPU;Debug|x86;Release|x86")]
+        [InlineData("Debug|AnyCPU",                     "Release|AnyCPU;Debug|x86;Release|x86;Debug|AnyCPU")]
+        [InlineData("Release|AnyCPU",                   "Debug|AnyCPU;Release|AnyCPU")]
+        [InlineData("Release|AnyCPU",                   "Release|AnyCPU;Debug|AnyCPU")]
+        [InlineData("Debug|x86",                        "Debug|AnyCPU;Release|AnyCPU;Debug|x86")]
+        [InlineData("Release|x86",                      "Debug|AnyCPU;Release|AnyCPU;Debug|x86;Release|x86")]
+        [InlineData("Release|x86",                      "Release|AnyCPU;Debug|x86;Release|x86;Debug|AnyCPU")]
+        public async Task GetActiveConfiguredProjects_LoadsAndReturnsConfiguredProject(string activeConfiguration, string configurations)
+        {
+            var activeConfig = ProjectConfigurationFactory.Create(activeConfiguration);
+            var configs = ProjectConfigurationFactory.CreateMany(configurations.Split(';'));
+            var configurationsService = IProjectConfigurationsServiceFactory.ImplementGetKnownProjectConfigurationsAsync(configs);
+            var activeConfiguredProjectProvider = IActiveConfiguredProjectProviderFactory.ImplementActiveProjectConfiguration(() => activeConfig);
+            var services = IUnconfiguredProjectServicesFactory.Create(activeConfiguredProjectProvider: activeConfiguredProjectProvider, projectConfigurationsService: configurationsService);
+            var configuredProject = UnconfiguredProjectFactory.ImplementLoadConfiguredProjectAsync((projectConfiguration) => {
+                return Task.FromResult(ConfiguredProjectFactory.ImplementProjectConfiguration(projectConfiguration));
+            });
+
+            var commonServices = IUnconfiguredProjectCommonServicesFactory.ImplementProject(configuredProject);
+
+            var provider = CreateInstance(services: services, commonServices:commonServices);
+
+            var result = await provider.GetActiveConfiguredProjectsAsync();
+
+            Assert.Equal(1, result.Length);
+            Assert.Equal(activeConfiguration, result[0].ProjectConfiguration.Name);
+        }
+
         private ActiveConfiguredProjectsProvider CreateInstance(IUnconfiguredProjectServices services = null, IUnconfiguredProjectCommonServices commonServices = null)
         {
             services = services ?? IUnconfiguredProjectServicesFactory.Create();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsProviderTests.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    public class ActiveConfiguredProjectsProviderTests
+    {
+        [Fact]
+        public async Task GetActiveProjectConfigurationsAsync_WhenNoActiveConfiguration_ReturnsEmpty()
+        {
+            var activeConfiguredProjectProvider = IActiveConfiguredProjectProviderFactory.ImplementActiveProjectConfiguration(() => null);
+            var services = IUnconfiguredProjectServicesFactory.Create(activeConfiguredProjectProvider: activeConfiguredProjectProvider);
+
+            var provider = CreateInstance(services: services);
+
+            var result = await provider.GetActiveProjectConfigurationsAsync();
+
+            Assert.Empty(result);
+        }
+
+        [Theory] // ActiveConfiguration                 Configurations
+        [InlineData("Debug|AnyCPU",                     "Debug|AnyCPU")]
+        [InlineData("Debug|AnyCPU",                     "Debug|AnyCPU;Release|AnyCPU")]
+        [InlineData("Debug|AnyCPU",                     "Release|AnyCPU;Debug|AnyCPU")]
+        [InlineData("Debug|AnyCPU",                     "Debug|AnyCPU;Release|AnyCPU;Debug|x86")]
+        [InlineData("Debug|AnyCPU",                     "Debug|AnyCPU;Release|AnyCPU;Debug|x86;Release|x86")]
+        [InlineData("Debug|AnyCPU",                     "Release|AnyCPU;Debug|x86;Release|x86;Debug|AnyCPU")]
+        [InlineData("Release|AnyCPU",                   "Debug|AnyCPU;Release|AnyCPU")]
+        [InlineData("Release|AnyCPU",                   "Release|AnyCPU;Debug|AnyCPU")]
+        [InlineData("Debug|x86",                        "Debug|AnyCPU;Release|AnyCPU;Debug|x86")]
+        [InlineData("Release|x86",                      "Debug|AnyCPU;Release|AnyCPU;Debug|x86;Release|x86")]
+        [InlineData("Release|x86",                      "Release|AnyCPU;Debug|x86;Release|x86;Debug|AnyCPU")]
+        public async Task GetActiveProjectConfigurationsAsync_ConfigurationsWithNoTargetFramework_ReturnsActiveProjectConfiguration(string activeConfiguration, string configurations)
+        {
+            var activeConfig = ProjectConfigurationFactory.Create(activeConfiguration);
+            var configs = ProjectConfigurationFactory.CreateMany(configurations.Split(';'));
+            var configurationsService = IProjectConfigurationsServiceFactory.ImplementGetKnownProjectConfigurationsAsync(configs);
+            var activeConfiguredProjectProvider = IActiveConfiguredProjectProviderFactory.ImplementActiveProjectConfiguration(() => activeConfig);
+            var services = IUnconfiguredProjectServicesFactory.Create(activeConfiguredProjectProvider: activeConfiguredProjectProvider, projectConfigurationsService: configurationsService);
+
+            var provider = CreateInstance(services: services);
+
+            var result = await provider.GetActiveProjectConfigurationsAsync();
+
+            Assert.Equal(1, result.Length);
+            Assert.Equal(activeConfiguration, result[0].Name);
+        }
+
+        [Theory] // ActiveConfiguration                 Configurations                                            Expected Active Configurations
+        [InlineData("Debug|AnyCPU|net45",               "Debug|AnyCPU|net45",                                     "Debug|AnyCPU|net45")]
+        [InlineData("Debug|AnyCPU|net45",               "Debug|AnyCPU|net45;Release|AnyCPU|net45",                "Debug|AnyCPU|net45")]
+        [InlineData("Debug|AnyCPU|net45",               "Debug|AnyCPU|net45;Debug|AnyCPU|net46",                  "Debug|AnyCPU|net45;Debug|AnyCPU|net46")]
+        [InlineData("Debug|AnyCPU|net46",               "Debug|AnyCPU|net45;Debug|AnyCPU|net46",                  "Debug|AnyCPU|net45;Debug|AnyCPU|net46")]
+        public async Task GetActiveProjectConfigurationsAsync_ConfigurationsWithTargetFramework_ReturnsConfigsThatMatchConfigurationAndPlatformFromActiveConfiguration(string activeConfiguration, string configurations, string expected)
+        {
+            var activeConfig = ProjectConfigurationFactory.Create(activeConfiguration);
+            var configs = ProjectConfigurationFactory.CreateMany(configurations.Split(';'));
+            var configurationsService = IProjectConfigurationsServiceFactory.ImplementGetKnownProjectConfigurationsAsync(configs);
+            var activeConfiguredProjectProvider = IActiveConfiguredProjectProviderFactory.ImplementActiveProjectConfiguration(() => activeConfig);
+            var services = IUnconfiguredProjectServicesFactory.Create(activeConfiguredProjectProvider: activeConfiguredProjectProvider, projectConfigurationsService: configurationsService);
+
+            var provider = CreateInstance(services: services);
+
+            var result = await provider.GetActiveProjectConfigurationsAsync();
+
+            var activeConfigs = ProjectConfigurationFactory.CreateMany(expected.Split(';'));
+            Assert.Equal(activeConfigs, result);
+        }
+
+        private ActiveConfiguredProjectsProvider CreateInstance(IUnconfiguredProjectServices services = null, IUnconfiguredProjectCommonServices commonServices = null)
+        {
+            services = services ?? IUnconfiguredProjectServicesFactory.Create();
+            commonServices = commonServices ?? IUnconfiguredProjectCommonServicesFactory.Create();
+
+            return new ActiveConfiguredProjectsProvider(services, commonServices);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [Export(typeof(IActiveConfiguredProjectsProvider))]
-    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     internal class ActiveConfiguredProjectsProvider : IActiveConfiguredProjectsProvider
     {
         private readonly IUnconfiguredProjectServices _services;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
@@ -7,9 +7,6 @@ using System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    /// <summary>
-    ///<see cref="IActiveConfiguredProjectsProvider"/>
-    /// </summary>
     [Export(typeof(IActiveConfiguredProjectsProvider))]
     [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     internal class ActiveConfiguredProjectsProvider : IActiveConfiguredProjectsProvider
@@ -27,9 +24,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
             _commonServices = commonServices;
         }
 
-        /// <summary>
-        /// <see cref="IActiveConfiguredProjectsProvider.GetActiveConfiguredProjectsMapAsync"/> 
-        /// </summary>
         public async Task<ImmutableDictionary<string, ConfiguredProject>> GetActiveConfiguredProjectsMapAsync()
         {
             var builder = ImmutableDictionary.CreateBuilder<string, ConfiguredProject>();
@@ -57,18 +51,12 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return builder.ToImmutableDictionary();
         }
 
-        /// <summary>
-        /// <see cref="IActiveConfiguredProjectsProvider.GetActiveConfiguredProjectsAsync"/> 
-        /// </summary>
         public async Task<ImmutableArray<ConfiguredProject>> GetActiveConfiguredProjectsAsync()
         {
             var projectMap = await GetActiveConfiguredProjectsMapAsync().ConfigureAwait(false);
             return projectMap.Values.ToImmutableArray();
         }
 
-        /// <summary>
-        /// <see cref="IActiveConfiguredProjectsProvider.GetActiveProjectConfigurationsAsync"/> 
-        /// </summary>
         public async Task<ImmutableArray<ProjectConfiguration>> GetActiveProjectConfigurationsAsync()
         {
             var projectMap = await GetActiveConfiguredProjectsMapAsync().ConfigureAwait(false);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
@@ -50,7 +50,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             var builder = ImmutableArray.CreateBuilder<ConfiguredProject>();
 
-            foreach (ProjectConfiguration configuration in await GetActiveProjectConfigurationsAsync())
+            ImmutableArray<ProjectConfiguration> configurations = await GetActiveProjectConfigurationsAsync().ConfigureAwait(false);
+            foreach (ProjectConfiguration configuration in configurations)
             {
                 var project = await _commonServices.Project.LoadConfiguredProjectAsync(configuration)
                                                            .ConfigureAwait(false);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
@@ -52,8 +52,17 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public async Task<ImmutableArray<ConfiguredProject>> GetActiveConfiguredProjectsAsync()
         {
-            var projectMap = await GetActiveConfiguredProjectsMapAsync().ConfigureAwait(false);
-            return projectMap.Values.ToImmutableArray();
+            var builder = ImmutableArray.CreateBuilder<ConfiguredProject>();
+
+            foreach (ProjectConfiguration configuration in await GetActiveProjectConfigurationsAsync())
+            {
+                var project = await _commonServices.Project.LoadConfiguredProjectAsync(configuration)
+                                                           .ConfigureAwait(false);
+
+                builder.Add(project);
+            }
+
+            return builder.ToImmutable();
         }
 
         public async Task<ImmutableArray<ProjectConfiguration>> GetActiveProjectConfigurationsAsync()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IActiveConfiguredProjectsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IActiveConfiguredProjectsProvider.cs
@@ -23,7 +23,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
     /// </summary>
     internal interface IActiveConfiguredProjectsProvider
     {
-
         /// <summary>
         /// Gets all the active configured projects by TargetFramework dimension for the current unconfigured project.
         /// If the current project is not a cross-targeting project, then it returns a singleton key-value pair with an ignorable key and single active configured project as value.
@@ -32,15 +31,30 @@ namespace Microsoft.VisualStudio.ProjectSystem
         Task<ImmutableDictionary<string, ConfiguredProject>> GetActiveConfiguredProjectsMapAsync();
 
         /// <summary>
-        /// Gets all the active configured projects for the current unconfigured project.
+        ///     Returns the ordered list of configured projects that are active for the current project, 
+        ///     loading them if needed.
         /// </summary>
-        /// <returns>Set of active configured projects.</returns>
+        /// <returns>
+        ///     An <see cref="ImmutableArray{T}"/> containing ordered set of <see cref="ConfiguredProject"/> 
+        ///     objects, or empty if there are no active configured projects.
+        /// </returns>
+        /// <remarks>
+        ///     The order in the returned <see cref="ImmutableArray{T}"/> matches the declared ordered within 
+        ///     the project file.
+        /// </remarks>
         Task<ImmutableArray<ConfiguredProject>> GetActiveConfiguredProjectsAsync();
 
         /// <summary>
-        /// Gets all the active project configurations for the current unconfigured project.
+        ///     Returns the ordered list of project configurations that are active for the current project.
         /// </summary>
-        /// <returns>Set of active project configurations.</returns>
+        /// <returns>
+        ///     An <see cref="ImmutableArray{T}"/> containing ordered set of <see cref="ProjectConfiguration"/> 
+        ///     objects, or empty if there are no active project configurations.
+        /// </returns>
+        /// <remarks>
+        ///     The order in the returned <see cref="ImmutableArray{T}"/> matches the declared ordered within 
+        ///     the project file.
+        /// </remarks>
         Task<ImmutableArray<ProjectConfiguration>> GetActiveProjectConfigurationsAsync();
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IActiveConfiguredProjectsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IActiveConfiguredProjectsProvider.cs
@@ -31,15 +31,15 @@ namespace Microsoft.VisualStudio.ProjectSystem
         Task<ImmutableDictionary<string, ConfiguredProject>> GetActiveConfiguredProjectsMapAsync();
 
         /// <summary>
-        ///     Returns the ordered list of configured projects that are active for the current project, 
+        ///     Returns the ordered list of configured projects that are active for the current project,
         ///     loading them if needed.
         /// </summary>
         /// <returns>
-        ///     An <see cref="ImmutableArray{T}"/> containing ordered set of <see cref="ConfiguredProject"/> 
+        ///     An <see cref="ImmutableArray{T}"/> containing ordered set of <see cref="ConfiguredProject"/>
         ///     objects, or empty if there are no active configured projects.
         /// </returns>
         /// <remarks>
-        ///     The order in the returned <see cref="ImmutableArray{T}"/> matches the declared ordered within 
+        ///     The order in the returned <see cref="ImmutableArray{T}"/> matches the declared ordered within
         ///     the project file.
         /// </remarks>
         Task<ImmutableArray<ConfiguredProject>> GetActiveConfiguredProjectsAsync();
@@ -48,11 +48,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
         ///     Returns the ordered list of project configurations that are active for the current project.
         /// </summary>
         /// <returns>
-        ///     An <see cref="ImmutableArray{T}"/> containing ordered set of <see cref="ProjectConfiguration"/> 
+        ///     An <see cref="ImmutableArray{T}"/> containing ordered set of <see cref="ProjectConfiguration"/>
         ///     objects, or empty if there are no active project configurations.
         /// </returns>
         /// <remarks>
-        ///     The order in the returned <see cref="ImmutableArray{T}"/> matches the declared ordered within 
+        ///     The order in the returned <see cref="ImmutableArray{T}"/> matches the declared ordered within
         ///     the project file.
         /// </remarks>
         Task<ImmutableArray<ProjectConfiguration>> GetActiveProjectConfigurationsAsync();


### PR DESCRIPTION
As a future change, I'm changing TargetFrameworkProjectConfigurationDimensionProvider to be the only component that understands that `<TargetFramework>` contributes to our how we determine configurations. This will remove ActiveConfiguredProjectsProvider, LanguageSevice, NuGetRestorer and debugging understanding of the `<TargetFramework>` property. To reduce churn and review time when I do that, I'm putting out my refactoring of the ActiveConfiguredProjectsProvider class which I did to prepare for that change.

Changes in this PR:

- Previously GetActiveConfiguredProjectsAsync/GetActiveProjectConfigurationsAsync would delegate onto GetActiveConfiguredProjectsMapAsync. However, this was the wrong dependency and meant that to get just the "active configurations" you needed to load all the active configured projects, put them in a data structure ("the map"), which was immediately thrown away.  Instead, I've reversed the dependency, so that GetActiveConfiguredProjectsMapAsync calls GetActiveConfiguredProjectsAsync, which in turn calls GetActiveProjectConfigurationsAsync, each method gets only enough data to do it's job.
- Wrote unit tests for GetActiveProjectConfigurationsAsync/GetActiveProjectConfigurationsAsync. Note, GetActiveConfiguredProjectsMapAsync in its current form will be going away - so I've skipped tests for it.