### PR TITLE
Turn off rules coming from CSharp\VB targets in MSBuild.

### DIFF
--- a/src/Targets/Microsoft.CSharp.DesignTime.targets
+++ b/src/Targets/Microsoft.CSharp.DesignTime.targets
@@ -17,6 +17,9 @@
     <LanguageServiceId Condition="'$(LanguageServiceId)'==''">{694DD9B6-B865-4C5B-AD85-86356E9C88DC}</LanguageServiceId>
     <TemplateLanguage Condition="'$(TemplateLanguage)' == ''">CSharp</TemplateLanguage>
     <AddItemTemplatesGuid Condition="'$(AddItemTemplatesGuid)' == ''">{FAE04EC0-301F-11d3-BF4B-00C04F79EFBC}</AddItemTemplatesGuid>
+  
+    <!-- Turn off rules and capabilities that are defined in MSBuild so that we can import our own below -->
+    <DefineCSharpItemSchemas>false</DefineCSharpItemSchemas>
   </PropertyGroup>
 
     <ItemGroup>

--- a/src/Targets/Microsoft.VisualBasic.DesignTime.targets
+++ b/src/Targets/Microsoft.VisualBasic.DesignTime.targets
@@ -17,6 +17,9 @@
     <LanguageServiceId Condition="'$(LanguageServiceId)'==''">{E34ACDC0-BAAE-11D0-88BF-00A0C9110049}</LanguageServiceId>
     <TemplateLanguage Condition="'$(TemplateLanguage)' == ''">VisualBasic</TemplateLanguage>
     <AddItemTemplatesGuid Condition="'$(AddItemTemplatesGuid)' == ''">{F184B08F-C81C-45F6-A57F-5ABD9991F28F}</AddItemTemplatesGuid>
+
+    <!-- Turn off rules and capabilities that are defined in MSBuild so that we can import our own below -->
+    <DefineVisualBasicItemSchemas>false</DefineVisualBasicItemSchemas>
   </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
We have our own copy of rules that are also being imported by MSBuild. I'm adding a flag to msbuild to disable importing these rules and setting that here. See https://github.com/Microsoft/msbuild/pull/1938 for the MSBuild change.

@dotnet/project-system 