### PR TITLE
Move the Get Suggested Configured Project out of lock

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/MSBuildXmlAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/MSBuildXmlAccessor.cs
@@ -58,9 +58,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
         public async Task<string> GetEvaluatedPropertyValue(UnconfiguredProject unconfiguredProject, string propertyName)
         {
+            var configuredProject = await unconfiguredProject.GetSuggestedConfiguredProjectAsync().ConfigureAwait(false);
             using (var access = await _projectLockService.ReadLockAsync())
             {
-                var configuredProject = await unconfiguredProject.GetSuggestedConfiguredProjectAsync().ConfigureAwait(false);
                 var evaluatedProject = await access.GetProjectAsync(configuredProject).ConfigureAwait(false);
                 return evaluatedProject.GetProperty(propertyName)?.EvaluatedValue;
             }


### PR DESCRIPTION
In the case where no prior configured project is created, calling `GetSuggestedConfiguredProjectAsync` ends up taking the path to create a Configured Project. No lock is expected to be held during the process of Configured Project creation, to publish data without any deadlock.

This fix is part of fixing #1878 and the [rest of the change is on CPS side](https://mseng.visualstudio.com/VSIDEProj/_git/VSIDEProj.CPS/pullrequest/202562?path=%2Fsrc%2FMicrosoft.VisualStudio.ProjectSystem.Implementation&_a=overview)

@srivatsn @davkean @dotnet/project-system for review