### PR TITLE
Pass rule set to language service

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ICommandLineParserServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ICommandLineParserServiceFactory.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
+using Moq;
+
+namespace Microsoft.VisualStudio.Mocks
+{
+    internal static class ICommandLineParserServiceFactory
+    {
+        public static ICommandLineParserService Create()
+        {
+            return CreateFromOptions(new BuildOptions(
+                Enumerable.Empty<CommandLineSourceFile>(),
+                Enumerable.Empty<CommandLineSourceFile>(),
+                Enumerable.Empty<CommandLineReference>(),
+                Enumerable.Empty<CommandLineAnalyzerReference>()));
+        }
+
+        public static ICommandLineParserService CreateFromOptions(BuildOptions options)
+        {
+            var context = new Mock<ICommandLineParserService>();
+
+            context.Setup(c => c.Parse(It.IsAny<IEnumerable<string>>())).Returns(options);
+
+            return context.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectChangeDescriptionFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectChangeDescriptionFactory.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem
@@ -9,6 +10,28 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public static IProjectChangeDescription Create()
         {
             return Mock.Of<IProjectChangeDescription>();
+        }
+
+        public static IProjectChangeDescription CreateFromSnapshots(IProjectRuleSnapshot before = null, IProjectChangeDiff diff = null, IProjectRuleSnapshot after = null)
+        {
+            var mock = new Mock<IProjectChangeDescription>();
+
+            if (before != null)
+            {
+                mock.SetupGet(c => c.Before).Returns(before);
+            }
+
+            if (diff != null)
+            {
+                mock.SetupGet(c => c.Difference).Returns(diff);
+            }
+
+            if (after != null)
+            {
+                mock.SetupGet(c => c.After).Returns(after);
+            }
+
+            return mock.Object;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectChangeDiffFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectChangeDiffFactory.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.ProjectSystem;
+using Moq;
+
+namespace Microsoft.VisualStudio.Mocks
+{
+    internal static class IProjectChangeDiffFactory
+    {
+        public static IProjectChangeDiff Create()
+        {
+            return Mock.Of<IProjectChangeDiff>();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectRuleSnapshotFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectRuleSnapshotFactory.cs
@@ -6,28 +6,68 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 {
     internal static class IProjectRuleSnapshotFactory
     {
+        public static IProjectRuleSnapshot Create(string ruleName)
+        {
+            var mock = new Mock<IProjectRuleSnapshot>();
+            mock.SetupGet(r => r.RuleName)
+                .Returns(ruleName);
+
+            var properties = ImmutableDictionary<string, string>.Empty;
+
+            mock.SetupGet(r => r.Properties)
+                .Returns(properties);
+
+            var items = ImmutableDictionary<string, IImmutableDictionary<string, string>>.Empty;
+
+            mock.SetupGet(r => r.Items)
+                .Returns(items);
+
+            return mock.Object;
+        }
+
         public static IProjectRuleSnapshot Create(string ruleName, string propertyName, string propertyValue)
         {
             var mock = new Mock<IProjectRuleSnapshot>();
             mock.SetupGet(r => r.RuleName)
                 .Returns(ruleName);
 
-            var dictionary = ImmutableDictionary<string, string>.Empty.Add(propertyName, propertyValue);
+            var properties = ImmutableDictionary<string, string>.Empty.Add(propertyName, propertyValue);
 
             mock.SetupGet(r => r.Properties)
-                .Returns(dictionary);
+                .Returns(properties);
 
+            var items = ImmutableDictionary<string, IImmutableDictionary<string, string>>.Empty;
+
+            mock.SetupGet(r => r.Items)
+                .Returns(items);
 
             return mock.Object;
         }
 
-        public static IProjectRuleSnapshot Add(this IProjectRuleSnapshot snapshot, string propertyName, string propertyValue)
+        public static IProjectRuleSnapshot AddProperty(this IProjectRuleSnapshot snapshot, string propertyName, string propertyValue)
         {
             var mock = Mock.Get(snapshot);
 
             var dictionary = snapshot.Properties.Add(propertyName, propertyValue);
 
             mock.SetupGet(r => r.Properties)
+                .Returns(dictionary);
+
+            return mock.Object;
+        }
+
+        public static IProjectRuleSnapshot AddItem(this IProjectRuleSnapshot snapshot, string item, IImmutableDictionary<string, string> itemProperties = null)
+        {
+            var mock = Mock.Get(snapshot);
+
+            if (itemProperties == null)
+            {
+                itemProperties = ImmutableDictionary<string, string>.Empty;
+            }
+
+            var dictionary = snapshot.Items.Add(item, itemProperties);
+
+            mock.SetupGet(r => r.Items)
                 .Returns(dictionary);
 
             return mock.Object;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectRuleSnapshotsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectRuleSnapshotsFactory.cs
@@ -14,11 +14,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         {
             if (!snapshots.TryGetValue(ruleName, out IProjectRuleSnapshot snapshot))
             {
-                snapshot = IProjectRuleSnapshotFactory.Create(ruleName, propertyName, propertyValue);
+                snapshot = IProjectRuleSnapshotFactory.Create(ruleName)
+                    .AddProperty(propertyName, propertyValue);
                 return snapshots.Add(ruleName, snapshot);
             }
 
-            return snapshots.SetItem(ruleName, snapshot.Add(propertyName, propertyValue));
+            return snapshots.SetItem(ruleName, snapshot.AddProperty(propertyName, propertyValue));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IWorkspaceProjectContextFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IWorkspaceProjectContextFactory.cs
@@ -58,5 +58,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             return context.Object;
         }
+
+        public static IWorkspaceProjectContext CreateForCommandLineArguments(UnconfiguredProject project, Action<string> setOptions = null, Action<string> setRuleSetFile = null)
+        {
+            var context = new Mock<IWorkspaceProjectContext>();
+
+            context.SetupGet(c => c.ProjectFilePath)
+                .Returns(project.FullPath);
+
+            if (setOptions != null)
+            {
+                context.Setup(c => c.SetOptions(It.IsAny<string>()))
+                    .Callback<string>(p1 => setOptions(p1));
+            }
+
+            if (setRuleSetFile != null)
+            {
+                context.Setup(c => c.SetRuleSetFile(It.IsAny<string>()))
+                    .Callback<string>(p1 => setRuleSetFile(p1));
+            }
+
+            return context.Object;
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandlerTests.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.VisualStudio.Mocks;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
+{
+    [ProjectSystemTrait]
+    public class CommandLineItemHandlerTests
+    {
+        [Fact]
+        public void RuleSetPassedToLanguageService()
+        {
+            string options = null;
+            string ruleSetFile = null;
+
+            Action<string> onSetOptions = s => options = s;
+            Action<string> onSetRuleSetFile = s => ruleSetFile = s;
+
+            var project = UnconfiguredProjectFactory.Create(filePath: @"C:\Myproject\Myproject.csproj");
+            var context = IWorkspaceProjectContextFactory.CreateForCommandLineArguments(project, onSetOptions, onSetRuleSetFile);
+
+            var after = IProjectRuleSnapshotFactory.Create(CompilerCommandLineArgs.SchemaName)
+                .AddItem(@"/ruleset:MyRules.ruleset");
+            var change = IProjectChangeDescriptionFactory.CreateFromSnapshots(after: after, diff: IProjectChangeDiffFactory.Create());
+
+            var handler = new CommandLineItemHandler(project, ICommandLineParserServiceFactory.Create());
+            handler.Handle(change, context, isActiveContext: false);
+
+            Assert.Equal(expected: @"/ruleset:MyRules.ruleset", actual: options);
+            Assert.Equal(expected: @"C:\Myproject\MyRules.ruleset", actual: ruleSetFile);
+        }
+
+        [Fact]
+        public void EmptyStringPassedToLanguageServiceWhenNoRuleSetPresent()
+        {
+            string options = null;
+            string ruleSetFile = null;
+
+            Action<string> onSetOptions = s => options = s;
+            Action<string> onSetRuleSetFile = s => ruleSetFile = s;
+
+            var project = UnconfiguredProjectFactory.Create(filePath: @"C:\Myproject\Myproject.csproj");
+            var context = IWorkspaceProjectContextFactory.CreateForCommandLineArguments(project, onSetOptions, onSetRuleSetFile);
+
+            var after = IProjectRuleSnapshotFactory.Create(CompilerCommandLineArgs.SchemaName)
+                .AddItem(@"/reportanalyzer");
+            var change = IProjectChangeDescriptionFactory.CreateFromSnapshots(after: after, diff: IProjectChangeDiffFactory.Create());
+
+            var handler = new CommandLineItemHandler(project, ICommandLineParserServiceFactory.Create());
+            handler.Handle(change, context, isActiveContext: false);
+
+            Assert.Equal(expected: @"/reportanalyzer", actual: options);
+            Assert.Equal(expected: string.Empty, actual: ruleSetFile);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1923.

MSBuild translates the `<CodeAnalysisRuleSet>Foo.ruleset</CodeAnalysisRuleSet>` property into the `/ruleset:Foo.ruleset` option in the compiler command line options. The project system code forwards this along with all of the other options to the language service, where it is parsed into the appropriate `CommandLineArguments` structure and passed along to the workspace.

As part of this process, the contents of Foo.ruleset will be extracted and the settings for individual rules properly reflected in the arguments. However, the language service loses track of Foo.ruleset. If it subsequently changes on disk the LS won't see that, and won't know to update the options.

It turns out we already have an `IWorkspaceProjectContext.SetRuleSetFile` method to handle this. Calling the method will cause the language service to set up the proper file watchers and regenerate options on changes to the file. This change updates the project system to call this method, and adds a couple of unit tests (along with some unit testing infrastructure).