### PR TITLE
Make VSProject public

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsProject.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsProject.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.ComponentModel.Composition;
+using System.Runtime.InteropServices;
 using EnvDTE;
 using VSLangProj;
 
@@ -19,14 +20,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
     [Export(ExportContractNames.VsTypes.VSProject, typeof(VSLangProj.VSProject))]
     [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
     [Order(10)]
-    internal partial class VSProject : VSLangProj.VSProject
+    public partial class VSProject : VSLangProj.VSProject
     {
         private readonly VSLangProj.VSProject _vsProject;
         private readonly IProjectThreadingService _threadingService;
         private readonly ActiveConfiguredProject<ProjectProperties> _projectProperties;
 
         [ImportingConstructor]
-        public VSProject(
+        internal VSProject(
             [Import(ExportContractNames.VsTypes.CpsVSProject)] VSLangProj.VSProject vsProject,
             IProjectThreadingService threadingService,
             ActiveConfiguredProject<ProjectProperties> projectProperties)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsProject_VsLangProjectProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsProject_VsLangProjectProperties.cs
@@ -5,7 +5,7 @@ using VSLangProj110;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
 {
-    internal partial class VSProject : VSLangProj.ProjectProperties
+    public partial class VSProject : VSLangProj.ProjectProperties
     {
 
         private ProjectProperties ProjectProperties


### PR DESCRIPTION
With VSProject being internal, InvalidCast exception was thrown if the object was tried to be marshalled to other processes

Fix #1901 

Tag @dotnet/project-system @srivatsn @davkean @tmeschter @natidea for review. I tested this change and it works.

FYI, @abpiskunov @BillHiebert 