### PR TITLE
Change the way we identify multi-targeting projects to create configurations

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/TargetFrameworkProjectConfigurationDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/TargetFrameworkProjectConfigurationDimensionProviderTests.cs
@@ -9,24 +9,32 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
     [ProjectSystemTrait]
     public class TargetFrameworkProjectConfigurationDimensionProviderTests
     {
-        private string projectXmlTFM =
+        private const string ProjectXmlTFM =
 @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <TargetFramework>netcoreapp1.0</TargetFramework>
   </PropertyGroup>
 </Project>";
 
-        private string projectXmlTFMs =
+        private const string ProjectXmlTFMs =
 @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp1.0;net45</TargetFrameworks>
   </PropertyGroup>
 </Project>";
 
+        private const string ProjectXmlTFMAndTFMs =
+@"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp1.0;net45</TargetFrameworks>
+    <TargetFramework>netcoreapp1.0</TargetFramework>
+  </PropertyGroup>
+</Project>";
+
         [Fact]
         public async void TargetFrameworkProjectConfigurationDimensionProvider_GetDefaultValuesForDimensionsAsync_TFM()
         {
-            using (var projectFile = new MsBuildProjectFile(projectXmlTFM))
+            using (var projectFile = new MsBuildProjectFile(ProjectXmlTFM))
             {
                 IProjectXmlAccessor _projectXmlAccessor = IProjectXmlAccessorFactory.Create(projectFile.Project);
                 var provider = new TargetFrameworkProjectConfigurationDimensionProvider(_projectXmlAccessor);
@@ -36,10 +44,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
             }
         }
 
-        [Fact]
-        public async void TargetFrameworkProjectConfigurationDimensionProvider_GetDefaultValuesForDimensionsAsync_TFMs()
+        [Theory]
+        [InlineData(ProjectXmlTFMs)]
+        [InlineData(ProjectXmlTFMAndTFMs)]
+        public async void TargetFrameworkProjectConfigurationDimensionProvider_GetDefaultValuesForDimensionsAsync_TFMs(string projectXml)
         {
-            using (var projectFile = new MsBuildProjectFile(projectXmlTFMs))
+            using (var projectFile = new MsBuildProjectFile(projectXml))
             {
                 IProjectXmlAccessor _projectXmlAccessor = IProjectXmlAccessorFactory.Create(projectFile.Project);
                 var provider = new TargetFrameworkProjectConfigurationDimensionProvider(_projectXmlAccessor);
@@ -55,7 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
         [Fact]
         public async void TargetFrameworkProjectConfigurationDimensionProvider_GetProjectConfigurationDimensionsAsync_TFM()
         {
-            using (var projectFile = new MsBuildProjectFile(projectXmlTFM))
+            using (var projectFile = new MsBuildProjectFile(ProjectXmlTFM))
             {
                 IProjectXmlAccessor _projectXmlAccessor = IProjectXmlAccessorFactory.Create(projectFile.Project);
                 var provider = new TargetFrameworkProjectConfigurationDimensionProvider(_projectXmlAccessor);
@@ -65,10 +75,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
             }
         }
 
-        [Fact]
-        public async void TargetFrameworkProjectConfigurationDimensionProvider_GetProjectConfigurationDimensionsAsync_TFMs()
+        [Theory]
+        [InlineData(ProjectXmlTFMs)]
+        [InlineData(ProjectXmlTFMAndTFMs)]
+        public async void TargetFrameworkProjectConfigurationDimensionProvider_GetProjectConfigurationDimensionsAsync_TFMs(string projectXml)
         {
-            using (var projectFile = new MsBuildProjectFile(projectXmlTFMs))
+            using (var projectFile = new MsBuildProjectFile(projectXml))
             {
                 IProjectXmlAccessor _projectXmlAccessor = IProjectXmlAccessorFactory.Create(projectFile.Project);
                 var provider = new TargetFrameworkProjectConfigurationDimensionProvider(_projectXmlAccessor);
@@ -94,7 +106,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
         public async void TargetFrameworkProjectConfigurationDimensionProvider_OnDimensionValueChanged(ConfigurationDimensionChange change, ChangeEventStage stage)
         {
             // No changes should happen for TFM so verify that the property is the same before and after
-            using (var projectFile = new MsBuildProjectFile(projectXmlTFMs))
+            using (var projectFile = new MsBuildProjectFile(ProjectXmlTFMs))
             {
                 IProjectXmlAccessor _projectXmlAccessor = IProjectXmlAccessorFactory.Create(projectFile.Project);
                 var provider = new TargetFrameworkProjectConfigurationDimensionProvider(_projectXmlAccessor);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/TargetFrameworkProjectConfigurationDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/TargetFrameworkProjectConfigurationDimensionProvider.cs
@@ -31,16 +31,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Configuration
         {
             Requires.NotNull(project, nameof(project));
 
-            string targetFrameworkProperty = await _projectXmlAccessor.GetEvaluatedPropertyValue(project, ConfigurationGeneral.TargetFrameworkProperty).ConfigureAwait(true);
-            if (targetFrameworkProperty != null)
+            string targetFrameworksProperty = await _projectXmlAccessor.GetEvaluatedPropertyValue(project, ConfigurationGeneral.TargetFrameworksProperty).ConfigureAwait(true);
+            if (targetFrameworksProperty != null)
             {
-                // If the project already defines a specific "TargetFramework" to target, then this is not a cross-targeting project and we don't need a target framework dimension.
-                return ImmutableArray<string>.Empty;
+                return BuildUtilities.GetPropertyValues(targetFrameworksProperty);
             }
             else
             {
-                string targetFrameworksProperty = await _projectXmlAccessor.GetEvaluatedPropertyValue(project, ConfigurationGeneral.TargetFrameworksProperty).ConfigureAwait(true);
-                return BuildUtilities.GetPropertyValues(targetFrameworksProperty);
+                // If the project doesn't have a "TargetFrameworks" property, then this is not a cross-targeting project and we don't need a target framework dimension.
+                return ImmutableArray<string>.Empty;
             }
         }
 


### PR DESCRIPTION
We were using the absence of the TargetFramework as indicating a multi-targeting project - but that's not true. TargetFramework will be set in the inner builds. So just look for the presence of TargetFrameworks.

@dotnet/project-system @RaulPerez1 @natidea 