### PR TITLE
Do not double-prefix telemetry events [master]

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
@@ -171,6 +171,7 @@
     <Compile Include="ProjectSystem\VS\Properties\ProjectDesignerServiceTests.cs" />
     <Compile Include="ProjectSystem\VS\Utilities\EnumMatchToBooleanConverterTests.cs" />
     <Compile Include="Shell\HierarchyIdTests.cs" />
+    <Compile Include="Telemetry\VsTelemetryServiceTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Telemetry/VsTelemetryServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Telemetry/VsTelemetryServiceTests.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Telemetry
+{
+    public class VsTelemetryServiceTests
+    {
+        [Fact]
+        public void PostEvent_NullAsEventName_ThrowArgumentNull()
+        {
+            var service = CreateInstance();
+
+            Assert.Throws<ArgumentNullException>("eventName", () => {
+                service.PostEvent((string)null);
+            });
+        }
+
+        [Fact]
+        public void PostEvent_EmptyAsEventName_ThrowArgument()
+        {
+            var service = CreateInstance();
+
+            Assert.Throws<ArgumentException>("eventName", () => {
+                service.PostEvent(string.Empty);
+            });
+        }
+
+        [Fact]
+        public void PostOperation_NullAsEventName_ThrowArgumentNull()
+        {
+            var service = CreateInstance();
+
+            Assert.Throws<ArgumentNullException>("eventName", () => {
+                service.PostOperation((string)null, TelemetryResult.Failure, resultSummary:"resultSummary", correlatedWith:null);
+            });
+        }
+
+        [Fact]
+        public void PostOperation_EmptyAsEventName_ThrowArgument()
+        {
+            var service = CreateInstance();
+
+            Assert.Throws<ArgumentException>("eventName", () => {
+                service.PostOperation(string.Empty, TelemetryResult.Failure, resultSummary: "resultSummary", correlatedWith: null);
+            });
+        }
+
+        [Fact]
+        public void Report_NullAsEventName_ThrowArgumentNull()
+        {
+            var service = CreateInstance();
+
+            Assert.Throws<ArgumentNullException>("eventName", () => {
+                service.Report((string)null, "description", new Exception(), null);
+            });
+        }
+
+        [Fact]
+        public void Report_EmptyAsEventName_ThrowArgumentNull()
+        {
+            var service = CreateInstance();
+
+            Assert.Throws<ArgumentException>("eventName", () => {
+                service.Report(string.Empty, "description", new Exception(), null);
+            });
+        }
+
+        [Fact]
+        public void Report_NullAsException_ThrowArgumentNull()
+        {
+            var service = CreateInstance();
+
+            Assert.Throws<ArgumentNullException>("exception", () => {
+                service.Report("EventName", "description", (Exception)null, null);
+            });
+        }
+
+        private static VsTelemetryService CreateInstance()
+        {
+            return new VsTelemetryService();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/ITelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/ITelemetryService.cs
@@ -12,25 +12,25 @@ namespace Microsoft.VisualStudio.Telemetry
         /// <summary>
         /// Posts a given telemetry event path to the telemetry service session for the program.
         /// </summary>
-        void PostEvent(string telemetryEvent);
+        void PostEvent(string eventName);
 
         /// <summary>
         /// Posts a given telemetry operation to the telemetry service. <seealso cref="TelemetrySessionExtensions.PostOperation(TelemetrySession, string, TelemetryResult, string, TelemetryEventCorrelation[])"/>
         /// </summary>
-        /// <param name="operationPath">Postfix on "vs/projectsystem/"</param>
+        /// <param name="eventName">Name of the event.</param>
         /// <param name="Result">The result of the operation</param>
         /// <param name="resultSummary">Summary of the result</param>
         /// <param name="correlatedWith">Events to correlate this event with</param>
         /// <returns></returns>
-        TelemetryEventCorrelation PostOperation(string operationPath, TelemetryResult Result, string resultSummary = null, TelemetryEventCorrelation[] correlatedWith = null);
+        TelemetryEventCorrelation PostOperation(string eventName, TelemetryResult Result, string resultSummary = null, TelemetryEventCorrelation[] correlatedWith = null);
 
         /// <summary>
         /// Reports a given non-fatal watson to the telemetry service. <seealso cref="TelemetrySessionExtensions.PostFault(TelemetrySession, string, string, Exception, Func{IFaultUtility, int}, TelemetryEventCorrelation[])"/>
         /// </summary>
-        /// <param name="eventPostfix">Postfix on "vs/projectsystem/"</param>
+        /// <param name="eventName">Name of the event.</param>
         /// <param name="description">Description to include with the NFW</param>
         /// <param name="exception">Exception that caused the NFW</param>
         /// <param name="callback">Gathers information for the NFW</param>
-        TelemetryEventCorrelation Report(string eventPostfix, string description, Exception exception, Func<IFaultUtility, int> callback = null);
+        TelemetryEventCorrelation Report(string eventName, string description, Exception exception, Func<IFaultUtility, int> callback = null);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/VsTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/VsTelemetryService.cs
@@ -8,26 +8,24 @@ namespace Microsoft.VisualStudio.Telemetry
     [Export(typeof(ITelemetryService))]
     internal class VsTelemetryService : ITelemetryService
     {
-        const string EventPrefix = "vs/projectsystem/";
-
-        public void PostEvent(string telemetryEvent)
+        public void PostEvent(string eventName)
         {
-            TelemetryService.DefaultSession.PostEvent($"{EventPrefix}{telemetryEvent}");
+            TelemetryService.DefaultSession.PostEvent(eventName);
         }
 
-        public TelemetryEventCorrelation PostOperation(string operationPath, TelemetryResult result, string resultSummary = null, TelemetryEventCorrelation[] correlatedWith = null)
+        public TelemetryEventCorrelation PostOperation(string eventName, TelemetryResult result, string resultSummary = null, TelemetryEventCorrelation[] correlatedWith = null)
         {
             return TelemetryService.DefaultSession.PostOperation(
-                eventName: $"{EventPrefix}{operationPath}",
+                eventName: eventName,
                 result: result,
                 resultSummary: resultSummary,
                 correlatedWith: correlatedWith);
         }
 
-        public TelemetryEventCorrelation Report(string eventPostfix, string description, Exception exception, Func<IFaultUtility, int> callback = null)
+        public TelemetryEventCorrelation Report(string eventName, string description, Exception exception, Func<IFaultUtility, int> callback = null)
         {
             return TelemetryService.DefaultSession.PostFault(
-                eventName: $"{EventPrefix}{eventPostfix}",
+                eventName: eventName,
                 description: description,
                 exceptionObject: exception,
                 gatherEventDetails: callback);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/VsTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/VsTelemetryService.cs
@@ -10,11 +10,17 @@ namespace Microsoft.VisualStudio.Telemetry
     {
         public void PostEvent(string eventName)
         {
+            Requires.NotNullOrEmpty(eventName, nameof(eventName));
+
             TelemetryService.DefaultSession.PostEvent(eventName);
         }
 
         public TelemetryEventCorrelation PostOperation(string eventName, TelemetryResult result, string resultSummary = null, TelemetryEventCorrelation[] correlatedWith = null)
         {
+            Requires.NotNullOrEmpty(eventName, nameof(eventName));
+            if (result == TelemetryResult.None)
+                throw new ArgumentException(null, nameof(result));
+
             return TelemetryService.DefaultSession.PostOperation(
                 eventName: eventName,
                 result: result,
@@ -24,6 +30,9 @@ namespace Microsoft.VisualStudio.Telemetry
 
         public TelemetryEventCorrelation Report(string eventName, string description, Exception exception, Func<IFaultUtility, int> callback = null)
         {
+            Requires.NotNullOrEmpty(eventName, nameof(eventName));
+            Requires.NotNull(exception, nameof(exception));
+
             return TelemetryService.DefaultSession.PostFault(
                 eventName: eventName,
                 description: description,


### PR DESCRIPTION
Telemetry events were being double-prefixed, one from the event name being passed to the service, and one within the service itself.