### PR TITLE
Add supported output types property to get the VB application page to show up.

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBWinForms.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBWinForms.vb
@@ -993,7 +993,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             PopulateTargetFrameworkComboBox(TargetFrameworkComboBox)
 
             ' Hide the AssemblyInformation button if project supports Pack capability, and hence has a Package property page with assembly info properties.
-            EnableControl(AssemblyInfoButton, ProjectHierarchy.IsCapabilityMatch(Pack))
+            EnableControl(AssemblyInfoButton, Not ProjectHierarchy.IsCapabilityMatch(Pack))
         End Sub
 
         ''' <summary>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBWinForms.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBWinForms.vb
@@ -9,6 +9,7 @@ Imports Microsoft.VisualStudio.Shell.Interop
 Imports VSLangProj80
 Imports VslangProj90
 Imports VSLangProj110
+Imports Microsoft.VisualStudio.Shell
 
 Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
@@ -991,6 +992,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
             PopulateTargetFrameworkComboBox(TargetFrameworkComboBox)
 
+            ' Hide the AssemblyInformation button if project supports Pack capability, and hence has a Package property page with assembly info properties.
+            EnableControl(AssemblyInfoButton, ProjectHierarchy.IsCapabilityMatch(Pack))
         End Sub
 
         ''' <summary>

--- a/src/Targets/Microsoft.Managed.DesignTime.targets
+++ b/src/Targets/Microsoft.Managed.DesignTime.targets
@@ -18,6 +18,9 @@
     <DefineCommonManagedReferenceSchemas Condition=" '$(DefineCommonManagedReferenceSchemas)' == '' ">true</DefineCommonManagedReferenceSchemas>
 
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+
+    <!--This property sets the default output types supported by the project system.-->
+    <SupportedOutputTypes Condition="'$(SupportedOutputTypes)' == ''">Exe;WinExe;Library</SupportedOutputTypes>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
The VB app page makes a call to query the hierarchy for VSHPROPID_SupportedOutputTypes. CPS used to return nothing which is why the VB app page wasn't showing up at all. I've made a change to CPS to instead return the value of a property called `SupportedOutputTypes` . Setting that property in our design time targets to set the defaults to Exe;WinExe;Library. Note that the C# prop page also respects this property. 

Also making a change to disable the assemblyinfo button if the Pack capability is set since we'll show the package page.

Fixes #940 

(Note: I had originally planned to bring up the C# application for VB as well to keep it simple. However, it looks there code in the VB page that has some special handling for Root namespace - it strips that out of startup objects for eg and makes changes to app.settings etc. and it's quite spread out. So decided to not take that route).

@dotnet/project-system 

With the VB app page is mostly functional - The app.manifest button and startup pages don't work yet. I'll fix in them follow up PRs.