### PR TITLE
Implement special file handler for app.manifest. 

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectTreeProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectTreeProviderFactory.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return mock.Object;
         }
 
-        public static IProjectTreeProvider Create(string addNewItemDirectoryReturn = null)
+        public static IProjectTreeProvider Create(string addNewItemDirectoryReturn = null, Func<IProjectTree, string, IProjectTree> findByPathAction = null)
         {
             var mock = new Mock<IProjectTreeProvider>();
 
@@ -64,6 +64,10 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 });
 
             mock.Setup(t => t.GetAddNewItemDirectory(It.IsAny<IProjectTree>())).Returns(addNewItemDirectoryReturn);
+
+            mock.Setup(p => p.FindByPath(It.IsAny<IProjectTree>(), It.IsAny<string>()))
+                .Returns(findByPathAction);
+
             return mock.Object;
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviderTests.cs
@@ -342,7 +342,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.csproj""
 
 
         [Theory]
-        // Property specified and not in the tree
+        // Property specified and in the tree
         [InlineData(@"
 Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.csproj""
     Properties (flags: {Folder AppDesignerFolder}), FilePath: ""C:\Foo\Properties""
@@ -362,7 +362,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.csproj""
 Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.csproj""
     Properties (flags: {Folder AppDesignerFolder}), FilePath: ""C:\Foo\Properties""
     myapp.manifest, FilePath: ""C:\Foo\myapp.manifest""
-", "Default", @"C:\Foo\Properties\app.manifest")]
+", "DefaultManifest", @"C:\Foo\Properties\app.manifest")]
         [InlineData(@"
 Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.csproj""
     Properties (flags: {Folder AppDesignerFolder}), FilePath: ""C:\Foo\Properties""

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractSpecialFileProvider.cs
@@ -15,7 +15,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
     /// </summary>
     internal abstract class AbstractSpecialFileProvider : ISpecialFileProvider
     {
-        private readonly IPhysicalProjectTree _projectTree;
         private readonly IProjectItemProvider _sourceItemsProvider;
         private readonly IFileSystem _fileSystem;
         private readonly ISpecialFilesManager _specialFilesManager;
@@ -26,6 +25,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         /// a file.
         /// </summary>
         private readonly Lazy<ICreateFileFromTemplateService> _templateFileCreationService;
+
+        protected readonly IPhysicalProjectTree _projectTree;
 
         public AbstractSpecialFileProvider(IPhysicalProjectTree projectTree,
                                            [Import(ExportContractNames.ProjectItemProviders.SourceFiles)] IProjectItemProvider sourceItemsProvider,
@@ -114,7 +115,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         ///       Look under the appdesigner folder for files that normally live there.
         ///       Look under the project root for all files.
         /// </summary>
-        private async Task<IProjectTree> FindFileAsync(string specialFileName)
+        protected virtual async Task<IProjectTree> FindFileAsync(string specialFileName)
         {
             IProjectTree rootNode = _projectTree.CurrentTree;
             IProjectTree specialFileNode;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppManifestSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppManifestSpecialFileProvider.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.IO;
+
+namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
+{
+    [ExportSpecialFileProvider(SpecialFiles.AppManifest)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
+    class AppManifestSpecialFileProvider : AbstractSpecialFileProvider
+    {
+        private readonly ProjectProperties _projectProperties;
+        private const string NoManifestValue = "NoManifest";
+        private const string DefaultManifestValue = "DefaultManifest";
+
+        [ImportingConstructor]
+        public AppManifestSpecialFileProvider(IPhysicalProjectTree projectTree,
+                                              [Import(ExportContractNames.ProjectItemProviders.SourceFiles)] IProjectItemProvider sourceItemsProvider,
+                                              [Import(AllowDefault = true)] Lazy<ICreateFileFromTemplateService> templateFileCreationService,
+                                              IFileSystem fileSystem,
+                                              ISpecialFilesManager specialFilesManager,
+                                              ProjectProperties projectProperties) 
+            : base(projectTree, sourceItemsProvider, templateFileCreationService, fileSystem, specialFilesManager)
+        {
+            _projectProperties = projectProperties;
+        }
+
+        protected override string Name => "app.manifest";
+
+        protected override string TemplateName => "AppManifestInternal.zip";
+
+        protected override async Task<IProjectTree> FindFileAsync(string specialFileName)
+        {
+            // If the ApplicationManifest property is defined then we should just use that - otherwise fall back to the default logic to find app.manifest.
+            var configurationGeneral = await _projectProperties.GetConfigurationGeneralBrowseObjectPropertiesAsync().ConfigureAwait(false);
+            var appManifestProperty = await configurationGeneral.ApplicationManifest.GetValueAsync().ConfigureAwait(false) as string;
+
+            if (!string.IsNullOrEmpty(appManifestProperty) && 
+                !appManifestProperty.Equals(DefaultManifestValue, StringComparison.InvariantCultureIgnoreCase) && 
+                !appManifestProperty.Equals(NoManifestValue, StringComparison.InvariantCultureIgnoreCase))
+            {
+                return _projectTree.TreeProvider.FindByPath(_projectTree.CurrentTree, appManifestProperty);
+            }
+
+            return await base.FindFileAsync(specialFileName).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppManifestSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppManifestSpecialFileProvider.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
 {
     [ExportSpecialFileProvider(SpecialFiles.AppManifest)]
     [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
-    class AppManifestSpecialFileProvider : AbstractSpecialFileProvider
+    internal class AppManifestSpecialFileProvider : AbstractSpecialFileProvider
     {
         private readonly ProjectProperties _projectProperties;
         private const string NoManifestValue = "NoManifest";
@@ -24,6 +24,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
                                               ProjectProperties projectProperties) 
             : base(projectTree, sourceItemsProvider, templateFileCreationService, fileSystem, specialFilesManager)
         {
+            Requires.NotNull(projectProperties, nameof(projectProperties));
+
             _projectProperties = projectProperties;
         }
 
@@ -35,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         {
             // If the ApplicationManifest property is defined then we should just use that - otherwise fall back to the default logic to find app.manifest.
             var configurationGeneral = await _projectProperties.GetConfigurationGeneralBrowseObjectPropertiesAsync().ConfigureAwait(false);
-            var appManifestProperty = await configurationGeneral.ApplicationManifest.GetValueAsync().ConfigureAwait(false) as string;
+            var appManifestProperty = await configurationGeneral.ApplicationManifest.GetEvaluatedValueAtEndAsync().ConfigureAwait(false) as string;
 
             if (!string.IsNullOrEmpty(appManifestProperty) && 
                 !appManifestProperty.Equals(DefaultManifestValue, StringComparison.InvariantCultureIgnoreCase) && 


### PR DESCRIPTION
This is needed by the VB application page - it has a button to bring up the app,manifest file which queries the special file handler for it.

This is basically a straightforward handler except if the ApplicationManifest property is specified - in that case, the path specified by that property is used. If that file is not found, we fall back to the regular logic of finding a special file including creating in default location (Verified the behavior with legacy ps).

Fixes #83 