### PR TITLE
Minor changes to dependencies 

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetSubscriptionHostBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetSubscriptionHostBase.cs
@@ -205,23 +205,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
                         {
                             return _currentAggregateProjectContext;
                         }
-
-                        previousContextToDispose = _currentAggregateProjectContext;
                     }
+
+                    previousContextToDispose = _currentAggregateProjectContext;
                 }
 
                 // Force refresh the CPS active project configuration (needs UI thread).
                 await _commonServices.ThreadingService.SwitchToUIThread();
                 await _activeProjectConfigurationRefreshService.RefreshActiveProjectConfigurationAsync().ConfigureAwait(false);
 
-                // Create new project context.
-                _currentAggregateProjectContext = await _contextProvider.Value.CreateProjectContextAsync().ConfigureAwait(false);
-
                 // Dispose the old project context, if one exists.
                 if (previousContextToDispose != null)
                 {
                     await DisposeAggregateProjectContextAsync(previousContextToDispose).ConfigureAwait(false);
                 }
+
+                // Create new project context.
+                _currentAggregateProjectContext = await _contextProvider.Value.CreateProjectContextAsync().ConfigureAwait(false);
 
                 OnAggregateContextChanged(previousContextToDispose, _currentAggregateProjectContext);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AnalyzerReference.xaml
@@ -9,4 +9,5 @@
     <Rule.DataSource>
         <DataSource Persistence="ProjectFile" ItemType="Analyzer" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
     </Rule.DataSource>
+    <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AssemblyReference.xaml
@@ -44,4 +44,5 @@
                     Description="The CLR runtime version targeted by this assembly."
                     Visible="False"
                     ReadOnly="True" />
+    <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ComReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ComReference.xaml
@@ -1,13 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="ComReference" DisplayName="COM Reference" PageTemplate="generic" Description="COM reference properties" xmlns="http://schemas.microsoft.com/build/2009/properties">
-  <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="COMReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-  </Rule.DataSource>
-  <StringProperty Name="Guid" DisplayName="CLSID" Description="The GUID of the COM server." />
-  <StringProperty Name="Lcid" DisplayName="Locale" Description="The LCID of the COM server." />
-  <IntProperty Name="VersionMajor" />
-  <IntProperty Name="VersionMinor" />
-  <BoolProperty Name="Isolated" />
-  <StringProperty Name="WrapperTool" />
+    <Rule.DataSource>
+        <DataSource Persistence="ProjectFile" ItemType="COMReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+    </Rule.DataSource>
+    <StringProperty Name="Guid" DisplayName="CLSID" Description="The GUID of the COM server." />
+    <StringProperty Name="Lcid" DisplayName="Locale" Description="The LCID of the COM server." />
+    <IntProperty Name="VersionMajor" />
+    <IntProperty Name="VersionMinor" />
+    <BoolProperty Name="Isolated" />
+    <StringProperty Name="WrapperTool" />
+    <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAnalyzerReference.xaml
@@ -18,4 +18,5 @@
             <DataSource Persistence="Intrinsic" ItemType="Analyzer" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
     </StringProperty>
+    <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAssemblyReference.xaml
@@ -119,4 +119,5 @@
     <StringProperty Name="FusionName" Visible="False" ReadOnly="True" Description="The full fusion name of the resolved assembly." />
     <StringProperty Name="ResolvedFrom" Visible="False" ReadOnly="True" Description="{}What repository held the reference that was used to resolve this.  (&quot;{GAC}&quot; if it was in the GAC)." />
     <StringProperty Name="FrameworkFile" Visible="False" ReadOnly="True" Description="Is this file a framework file. Ie Found in the target framework directory or in the redist list." />
+    <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedCOMReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedCOMReference.xaml
@@ -121,4 +121,5 @@
     <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" Description="The evaluated item name of the original reference item whose resolution resulted in this resolved reference item." />
     <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
     <StringProperty Name="Name" Visible="false" ReadOnly="True" />
+    <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedSdkReference.xaml
@@ -24,4 +24,5 @@
     <BoolProperty Name="ExpandContent" DisplayName="Expand Content" ReadOnly="True" />
     <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Expand Reference Assemblies" ReadOnly="True" />
     <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copy Local Expanded Reference Assemblies" ReadOnly="True" />
+    <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SdkReference.xaml
@@ -22,4 +22,5 @@
     <BoolProperty Name="ExpandContent" DisplayName="Expand Content" ReadOnly="True" />
     <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Expand Reference Assemblies" ReadOnly="True" />
     <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copy Local Expanded Reference Assemblies" ReadOnly="True" />
+    <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
 </Rule>


### PR DESCRIPTION
- add new IsImplicitlyDefined property to xaml rules files (sdk can send it, but we forgot to update schema)
- fix bad merge issue that messes up aggregate snapshot update in single target app (if user updates target in the single target app, it keeps old one too; change now handles that and allows new aggregate snapshot to be generated) 