### PR TITLE
Fix for Dependencies tree stability issues

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependenciesChangesFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependenciesChangesFactory.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    internal class IDependenciesChangesFactory
+    {
+        public static IDependenciesChanges Create()
+        {
+            return Mock.Of<IDependenciesChanges>();
+        }
+
+        public static IDependenciesChanges Implement(
+            IEnumerable<IDependencyModel> addedNodes = null,
+            IEnumerable<IDependencyModel> removedNodes = null,
+            MockBehavior? mockBehavior = null)
+        {
+            var behavior = mockBehavior ?? MockBehavior.Strict;
+            var mock = new Mock<IDependenciesChanges>(behavior);
+
+            if (addedNodes != null)
+            {
+                mock.Setup(x => x.AddedNodes).Returns(ImmutableList<IDependencyModel>.Empty.AddRange(addedNodes));
+            }
+
+            if (removedNodes != null)
+            {
+                mock.Setup(x => x.RemovedNodes).Returns(ImmutableList<IDependencyModel>.Empty.AddRange(removedNodes));
+            }
+
+            return mock.Object;
+        }        
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
@@ -1,9 +1,14 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Filters;
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
@@ -28,7 +33,329 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         [Fact]
         public void TargetedDependenciesSnapshot_Constructor()
         {
-           
+            const string projectPath = @"c:\somefolder\someproject\a.csproj";
+            var targetFramework = ITargetFrameworkFactory.Implement("tfm1");
+            var previousSnapshot = ITargetedDependenciesSnapshotFactory.Implement(
+                dependenciesWorld:new Dictionary<string, IDependency>(),
+                topLevelDependencies:new List<IDependency>());
+
+            var catalogs = IProjectCatalogSnapshotFactory.Create();
+            var snapshot = new TestableTargetedDependenciesSnapshot(
+                projectPath,
+                targetFramework,
+                previousSnapshot,
+                catalogs);
+
+            Assert.NotNull(snapshot.TargetFramework);
+            Assert.Equal("tfm1", snapshot.TargetFramework.Moniker);
+            Assert.Equal(projectPath, snapshot.ProjectPath);
+            Assert.Equal(catalogs, snapshot.Catalogs);
+            Assert.Equal(previousSnapshot.TopLevelDependencies, snapshot.TopLevelDependencies);
+            Assert.Equal(previousSnapshot.DependenciesWorld, snapshot.DependenciesWorld);
+        }
+
+        [Fact]
+        public void TargetedDependenciesSnapshot_FromChanges_Empty()
+        {
+            const string projectPath = @"c:\somefolder\someproject\a.csproj";
+            var targetFramework = ITargetFrameworkFactory.Implement("tfm1");
+            var previousSnapshot = ITargetedDependenciesSnapshotFactory.Implement(
+                dependenciesWorld: new Dictionary<string, IDependency>(),
+                topLevelDependencies: new List<IDependency>());
+
+            var addedNodes = new List<IDependencyModel>();
+            var removedNodes = new List<IDependencyModel>();
+            var changes = IDependenciesChangesFactory.Implement(addedNodes: addedNodes, removedNodes: removedNodes);
+
+            IEnumerable<IDependenciesSnapshotFilter> snapshotFilters = null;
+
+            var catalogs = IProjectCatalogSnapshotFactory.Create();
+            var snapshot = TargetedDependenciesSnapshot.FromChanges(
+                projectPath,
+                targetFramework,
+                previousSnapshot,
+                changes,
+                catalogs,
+                snapshotFilters,
+                out bool anyChanges);
+
+            Assert.NotNull(snapshot.TargetFramework);
+            Assert.Equal("tfm1", snapshot.TargetFramework.Moniker);
+            Assert.Equal(projectPath, snapshot.ProjectPath);
+            Assert.Equal(catalogs, snapshot.Catalogs);
+            Assert.False(anyChanges);
+            Assert.Equal(0, snapshot.TopLevelDependencies.Count);
+            Assert.Equal(0, snapshot.DependenciesWorld.Count);
+        }
+
+        [Fact]
+        public void TargetedDependenciesSnapshot_FromChanges_NoChanges()
+        {
+            const string projectPath = @"c:\somefolder\someproject\a.csproj";
+            var targetFramework = ITargetFrameworkFactory.Implement("tfm1");
+
+            var dependencyModelTop1 = IDependencyFactory.FromJson(@"
+{
+    ""ProviderType"": ""Xxx"",
+    ""Id"": ""tfm1\\xxx\\topdependency1"",
+    ""Name"":""TopDependency1"",
+    ""Caption"":""TopDependency1"",
+    ""SchemaItemType"":""Xxx"",
+    ""Resolved"":""true""
+}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+
+            var dependencyModelChild1 = IDependencyFactory.FromJson(@"
+{
+    ""ProviderType"": ""Xxx"",
+    ""Id"": ""tfm1\\xxx\\childdependency1"",
+    ""Name"":""ChildDependency1"",
+    ""Caption"":""ChildDependency1"",
+    ""SchemaItemType"":""Xxx"",
+    ""Resolved"":""true""
+}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+
+            var previousSnapshot = ITargetedDependenciesSnapshotFactory.Implement(
+                dependenciesWorld: new Dictionary<string, IDependency>()
+                {
+                    { dependencyModelTop1.Id, dependencyModelTop1 },
+                    { dependencyModelChild1.Id, dependencyModelChild1 },
+                },
+                topLevelDependencies: new List<IDependency>() { dependencyModelTop1 });
+
+            var addedNodes = new List<IDependencyModel>();
+            var removedNodes = new List<IDependencyModel>();
+            var changes = IDependenciesChangesFactory.Implement(addedNodes: addedNodes, removedNodes: removedNodes);
+
+            IEnumerable<IDependenciesSnapshotFilter> snapshotFilters = null;
+
+            var catalogs = IProjectCatalogSnapshotFactory.Create();
+            var snapshot = TargetedDependenciesSnapshot.FromChanges(
+                projectPath,
+                targetFramework,
+                previousSnapshot,
+                changes,
+                catalogs,
+                snapshotFilters,
+                out bool anyChanges);
+
+            Assert.NotNull(snapshot.TargetFramework);
+            Assert.Equal("tfm1", snapshot.TargetFramework.Moniker);
+            Assert.Equal(projectPath, snapshot.ProjectPath);
+            Assert.Equal(catalogs, snapshot.Catalogs);
+            Assert.False(anyChanges);
+            Assert.Equal(1, snapshot.TopLevelDependencies.Count);
+            Assert.Equal(2, snapshot.DependenciesWorld.Count);
+        }
+
+        [Fact]
+        public void TargetedDependenciesSnapshot_FromChanges_NoChangesAfterFilterDeclinedChange()
+        {
+            const string projectPath = @"c:\somefolder\someproject\a.csproj";
+            var targetFramework = ITargetFrameworkFactory.Implement("tfm1");
+
+            var dependencyModelTop1 = IDependencyFactory.FromJson(@"
+{
+    ""ProviderType"": ""Xxx"",
+    ""Id"": ""tfm1\\xxx\\topdependency1"",
+    ""Name"":""TopDependency1"",
+    ""Caption"":""TopDependency1"",
+    ""SchemaItemType"":""Xxx"",
+    ""Resolved"":""true""
+}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+
+            var dependencyModelChild1 = IDependencyFactory.FromJson(@"
+{
+    ""ProviderType"": ""Xxx"",
+    ""Id"": ""tfm1\\xxx\\childdependency1"",
+    ""Name"":""ChildDependency1"",
+    ""Caption"":""ChildDependency1"",
+    ""SchemaItemType"":""Xxx"",
+    ""Resolved"":""true""
+}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+
+            var dependencyModelNew1 = IDependencyFactory.FromJson(@"
+{
+    ""ProviderType"": ""Xxx"",
+    ""Id"": ""newdependency1"",
+    ""Name"":""NewDependency1"",
+    ""Caption"":""NewDependency1"",
+    ""SchemaItemType"":""Xxx"",
+    ""Resolved"":""true""
+}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+            var previousSnapshot = ITargetedDependenciesSnapshotFactory.Implement(
+                dependenciesWorld: new Dictionary<string, IDependency>()
+                {
+                    { dependencyModelTop1.Id, dependencyModelTop1 },
+                    { dependencyModelChild1.Id, dependencyModelChild1 },
+                },
+                topLevelDependencies: new List<IDependency>() { dependencyModelTop1 });
+
+            var addedNodes = new List<IDependencyModel> { dependencyModelNew1 };
+            var removedNodes = new List<IDependencyModel>();
+            var changes = IDependenciesChangesFactory.Implement(addedNodes: addedNodes, removedNodes: removedNodes);
+
+            var snapshotFilter = new TestDependenciesSnapshotFilter()
+                    .ImplementBeforeAddResult(@"tfm1\xxx\newdependency1", null);
+
+            var catalogs = IProjectCatalogSnapshotFactory.Create();
+            var snapshot = TargetedDependenciesSnapshot.FromChanges(
+                projectPath,
+                targetFramework,
+                previousSnapshot,
+                changes,
+                catalogs,
+                new[] { snapshotFilter },
+                out bool anyChanges);
+
+            Assert.NotNull(snapshot.TargetFramework);
+            Assert.Equal("tfm1", snapshot.TargetFramework.Moniker);
+            Assert.Equal(projectPath, snapshot.ProjectPath);
+            Assert.Equal(catalogs, snapshot.Catalogs);
+            Assert.False(anyChanges);
+            Assert.Equal(1, snapshot.TopLevelDependencies.Count);
+            Assert.Equal(2, snapshot.DependenciesWorld.Count);
+        }
+
+        [Fact]
+        public void TargetedDependenciesSnapshot_FromChanges_RemovedAndAddedChanges()
+        {
+            const string projectPath = @"c:\somefolder\someproject\a.csproj";
+            var targetFramework = ITargetFrameworkFactory.Implement("tfm1");
+
+            var dependencyModelTop1 = IDependencyFactory.FromJson(@"
+{
+    ""ProviderType"": ""Xxx"",
+    ""Id"": ""topdependency1"",
+    ""Name"":""TopDependency1"",
+    ""Caption"":""TopDependency1"",
+    ""SchemaItemType"":""Xxx"",
+    ""Resolved"":""true""
+}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+
+            var dependencyModelChild1 = IDependencyFactory.FromJson(@"
+{
+    ""ProviderType"": ""Xxx"",
+    ""Id"": ""childdependency1"",
+    ""Name"":""ChildDependency1"",
+    ""Caption"":""ChildDependency1"",
+    ""SchemaItemType"":""Xxx"",
+    ""Resolved"":""true""
+}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+
+            var dependencyModelAdded1 = IDependencyFactory.FromJson(@"
+{
+    ""ProviderType"": ""Xxx"",
+    ""Id"": ""addeddependency1"",
+    ""Name"":""AddedDependency1"",
+    ""Caption"":""AddedDependency1"",
+    ""SchemaItemType"":""Xxx"",
+    ""Resolved"":""true""
+}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+
+            var dependencyModelAdded2 = IDependencyFactory.FromJson(@"
+{
+    ""ProviderType"": ""Xxx"",
+    ""Id"": ""addeddependency2"",
+    ""Name"":""AddedDependency2"",
+    ""Caption"":""AddedDependency2"",
+    ""SchemaItemType"":""Xxx"",
+    ""Resolved"":""true""
+}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+
+            var dependencyModelAdded3 = IDependencyFactory.FromJson(@"
+{
+    ""ProviderType"": ""Xxx"",
+    ""Id"": ""addeddependency3"",
+    ""Name"":""AddedDependency3"",
+    ""Caption"":""AddedDependency3"",
+    ""SchemaItemType"":""Xxx"",
+    ""Resolved"":""true"",
+    ""TopLevel"":""false""
+}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+
+            var dependencyAdded2Changed = IDependencyFactory.FromJson(@"
+{
+    ""ProviderType"": ""Xxx"",
+    ""Id"": ""tfm1\\xxx\\addeddependency2"",
+    ""Name"":""AddedDependency2Changed"",
+    ""Caption"":""AddedDependency2Changed"",
+    ""SchemaItemType"":""Xxx"",
+    ""Resolved"":""true""
+}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+
+            var dependencyRemoved1 = IDependencyFactory.FromJson(@"
+{
+    ""ProviderType"": ""Xxx"",
+    ""Id"": ""tfm1\\xxx\\Removeddependency1"",
+    ""Name"":""RemovedDependency1"",
+    ""Caption"":""RemovedDependency1"",
+    ""SchemaItemType"":""Xxx"",
+    ""Resolved"":""true""
+}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+
+            var dependencyModelRemoved1 = IDependencyFactory.FromJson(@"
+{
+    ""ProviderType"": ""Xxx"",
+    ""Id"": ""Removeddependency1"",
+    ""Name"":""RemovedDependency1"",
+    ""Caption"":""RemovedDependency1"",
+    ""SchemaItemType"":""Xxx"",
+    ""Resolved"":""true""
+}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+
+            var dependencyInsteadRemoved1 = IDependencyFactory.FromJson(@"
+{
+    ""ProviderType"": ""Xxx"",
+    ""Id"": ""tfm1\\xxx\\InsteadRemoveddependency1"",
+    ""Name"":""InsteadRemovedDependency1"",
+    ""Caption"":""InsteadRemovedDependency1"",
+    ""SchemaItemType"":""Xxx"",
+    ""Resolved"":""true""
+}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+
+            var previousSnapshot = ITargetedDependenciesSnapshotFactory.Implement(
+                dependenciesWorld: new Dictionary<string, IDependency>()
+                {
+                    { @"tfm1\xxx\topdependency1", dependencyModelTop1 },
+                    { @"tfm1\xxx\childdependency1", dependencyModelChild1 },
+                    { @"tfm1\xxx\Removeddependency1", dependencyRemoved1 },
+                },
+                topLevelDependencies: new List<IDependency>() { dependencyModelTop1 });
+
+            var addedNodes = new List<IDependencyModel> { dependencyModelAdded1, dependencyModelAdded2, dependencyModelAdded3 };
+            var removedNodes = new List<IDependencyModel> { dependencyModelRemoved1 };
+            var changes = IDependenciesChangesFactory.Implement(addedNodes: addedNodes, removedNodes: removedNodes);
+
+            var snapshotFilter = new TestDependenciesSnapshotFilter()
+                                        .ImplementBeforeAddResult(@"tfm1\xxx\addeddependency1", null)
+                                        .ImplementBeforeAddResult(@"tfm1\xxx\addeddependency2", dependencyAdded2Changed)
+                                        .ImplementBeforeRemoveResult(@"tfm1\xxx\Removeddependency1", dependencyInsteadRemoved1);
+
+            var catalogs = IProjectCatalogSnapshotFactory.Create();
+            var snapshot = TargetedDependenciesSnapshot.FromChanges(
+                projectPath,
+                targetFramework,
+                previousSnapshot,
+                changes,
+                catalogs,
+                new[] { snapshotFilter },
+                out bool anyChanges);
+
+            Assert.NotNull(snapshot.TargetFramework);
+            Assert.Equal("tfm1", snapshot.TargetFramework.Moniker);
+            Assert.Equal(projectPath, snapshot.ProjectPath);
+            Assert.Equal(catalogs, snapshot.Catalogs);
+            Assert.True(anyChanges);
+            Assert.Equal(3, snapshot.TopLevelDependencies.Count);
+            Assert.True(snapshot.TopLevelDependencies.Any(x => x.Id.Equals(@"topdependency1")));
+            Assert.True(snapshot.TopLevelDependencies.Any(x => x.Id.Equals(@"tfm1\xxx\InsteadRemoveddependency1")));
+            Assert.True(snapshot.TopLevelDependencies.Any(x => x.Id.Equals(@"tfm1\xxx\addeddependency2") && x.Caption.Equals("AddedDependency2Changed")));
+            Assert.Equal(5, snapshot.DependenciesWorld.Count);
+            Assert.True(snapshot.DependenciesWorld.ContainsKey(@"tfm1\xxx\topdependency1"));
+            Assert.True(snapshot.DependenciesWorld.ContainsKey(@"tfm1\xxx\childdependency1"));
+            Assert.True(snapshot.DependenciesWorld.ContainsKey(@"tfm1\xxx\addeddependency2"));
+            Assert.True(snapshot.DependenciesWorld.ContainsKey(@"tfm1\xxx\InsteadRemoveddependency1"));
+            Assert.True(snapshot.DependenciesWorld.ContainsKey(@"tfm1\xxx\addeddependency3"));
         }
 
         private class TestableTargetedDependenciesSnapshot : TargetedDependenciesSnapshot
@@ -43,5 +370,56 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             }
         }
 
+        internal class TestDependenciesSnapshotFilter : IDependenciesSnapshotFilter
+        {
+            public TestDependenciesSnapshotFilter ImplementBeforeAddResult(string id, IDependency dependency)
+            {
+                _beforeAdd.Add(id, dependency);
+
+                return this;
+            }
+
+            private Dictionary<string, IDependency> _beforeAdd 
+                = new Dictionary<string, IDependency>(StringComparer.OrdinalIgnoreCase);
+
+            public TestDependenciesSnapshotFilter ImplementBeforeRemoveResult(string id, IDependency dependency)
+            {
+                _beforeRemove.Add(id, dependency);
+
+                return this;
+            }
+
+            private Dictionary<string, IDependency> _beforeRemove
+                = new Dictionary<string, IDependency>(StringComparer.OrdinalIgnoreCase);
+
+            public IDependency BeforeAdd(
+                string projectPath,
+                ITargetFramework targetFramework,
+                IDependency dependency,
+                ImmutableDictionary<string, IDependency>.Builder worldBuilder,
+                ImmutableHashSet<IDependency>.Builder topLevelBuilder)
+            {
+                if (_beforeAdd.TryGetValue(dependency.Id, out IDependency newDependency))
+                {
+                    return newDependency;
+                }
+
+                return dependency;
+            }
+
+            public void BeforeRemove(
+                string projectPath,
+                ITargetFramework targetFramework,
+                IDependency dependency,
+                ImmutableDictionary<string, IDependency>.Builder worldBuilder,
+                ImmutableHashSet<IDependency>.Builder topLevelBuilder)
+            {
+                if (_beforeRemove.TryGetValue(dependency.Id, out IDependency newDependency))
+                {
+                    worldBuilder[newDependency.Id] = newDependency;
+                    topLevelBuilder.Add(newDependency);
+                }
+            }
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetSubscriptionHostBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetSubscriptionHostBase.cs
@@ -152,7 +152,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 
         private async Task UpdateProjectContextAndSubscriptionsAsync()
         {
-            var previousProjectContext = _currentAggregateProjectContext;
+            var previousProjectContext = await ExecuteWithinLockAsync(() =>
+            {
+                return Task.FromResult(_currentAggregateProjectContext);
+            });
+
             var newProjectContext = await UpdateProjectContextAsync().ConfigureAwait(false);
             if (previousProjectContext != newProjectContext)
             {
@@ -189,9 +193,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
                         {
                             return _currentAggregateProjectContext;
                         }
-
-                        // Dispose the old workspace project context for the previous target framework.
-                        await DisposeAggregateProjectContextAsync(_currentAggregateProjectContext).ConfigureAwait(false);
                     }
                     else
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/GraphActionHandlerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/GraphActionHandlerBase.cs
@@ -60,7 +60,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
             var id = dependency?.Id;
             if (id == null)
             {
-                // now check node file path if it is a DependencyNodeId 
                 id = inputGraphNode.Id.GetValue(CodeGraphNodeIdName.File);
                 if (id.StartsWith(projectFolder, StringComparison.OrdinalIgnoreCase))
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/GraphViewProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/GraphViewProviderBase.cs
@@ -76,6 +76,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
 
             foreach (var nodeToAdd in nodesToAdd)
             {
+                if (!nodeToAdd.Visible)
+                {
+                    continue;
+                }
+
                 Builder.AddGraphNode(graphContext, projectPath, dependencyGraphNode, nodeToAdd);
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/ProjectGraphViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/ProjectGraphViewProvider.cs
@@ -124,6 +124,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
 
             foreach (var nodeToAdd in nodesToAdd)
             {
+                if (!nodeToAdd.Visible)
+                {
+                    continue;
+                }
+
                 Builder.AddGraphNode(graphContext, dependencyProjectPath, dependencyGraphNode, nodeToAdd);
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySubscriptionsHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySubscriptionsHost.cs
@@ -43,7 +43,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 projectCapabilityCheckProvider: commonServices.Project);
 
             SnapshotFilters = new OrderPrecedenceImportCollection<IDependenciesSnapshotFilter>(
-                projectCapabilityCheckProvider: commonServices.Project);
+                projectCapabilityCheckProvider: commonServices.Project, 
+                orderingStyle:ImportOrderPrecedenceComparer.PreferenceOrder.PreferredComesLast);
 
             SubTreeProviders = new OrderPrecedenceImportCollection<IProjectDependenciesSubTreeProvider>(
                 ImportOrderPrecedenceComparer.PreferenceOrder.PreferredComesLast,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ProjectRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ProjectRuleHandler.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
@@ -89,7 +90,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
         /// </summary>
         /// <param name="otherProjectSnapshot"></param>
         /// <param name="shouldBeResolved">
-        /// Specifies if top-level project depencies resolved status. When other project just had it's dependencies
+        /// Specifies if top-level project dependencies resolved status. When other project just had it's dependencies
         /// changed, it is resolved=true (we check target's support when we add projec dependencies). However when 
         /// other project is unloaded, we should mark top-level dependencies as unresolved.
         /// </param>
@@ -136,7 +137,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                                 dependency.Properties);
 
                 var changes = new DependenciesChanges();
-                changes.IncludeRemovedChange(model);
+
+                // avoid unnecessary removing since, add would upgrade dependency in snapshot anyway,
+                // but remove would require removing item from the tree instead of in-place upgrade.
+                if (!shouldBeResolved)
+                {
+                    changes.IncludeRemovedChange(model);
+                }
+
                 changes.IncludeAddedChange(model);
 
                 FireDependenciesChanged(


### PR DESCRIPTION

Customer scenario

Random or stale dependency nodes in the tree. 

Bugs this fixes:

Fixes https://github.com/dotnet/project-system/issues/1980

Workarounds, if any

No

Risk

Small 

Performance impact

Low

Is this a regression from a previous update?

Yes

Root cause analysis:

New changes were pushed to support crosstargeting for dependencies tree and there are some adjustments needed.
After testing merged changes i saw several tree update quirks:

- when target changes old flow events still sent to dependencies rules subscribers and might end up in some old nodes be displayed in the tree
- avoid unnecessary closing project and sdk nodes
- when tracking change in graph nodes, skip all invisible dependencies to avoid showing them in lower level hierarchies

How was the bug found?

Testing new build