### PR TITLE
Fix memory leaks for dependencies nodes

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyFactory.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 using Moq;
 using Newtonsoft.Json.Linq;
@@ -33,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                                             ProjectTreeFlags? setPropertiesFlags = null,
                                             bool? equals = null,
                                             IImmutableList<string> setPropertiesDependencyIDs = null,
-                                            ITargetedDependenciesSnapshot snapshot = null,
+                                            ITargetFramework targetFramework = null,
                                             MockBehavior? mockBehavior = null)
         {
             var behavior = mockBehavior ?? MockBehavior.Strict;
@@ -94,9 +95,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 mock.Setup(x => x.Flags).Returns(flags.Value);
             }
 
-            if (snapshot != null)
+            if (targetFramework != null)
             {
-                mock.Setup(x => x.Snapshot).Returns(snapshot);
+                mock.Setup(x => x.TargetFramework).Returns(targetFramework);
             }
 
             if (setPropertiesCaption != null 
@@ -124,8 +125,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             ImageMoniker? unresolvedIcon = null,
             ImageMoniker? unresolvedExpandedIcon = null,
             Dictionary<string, string> properties = null,
-            IEnumerable<string> dependenciesIds = null,
-            IEnumerable<IDependency> dependencies = null)
+            IEnumerable<string> dependenciesIds = null)
         {
             if (string.IsNullOrEmpty(jsonString))
             {
@@ -168,11 +168,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             if (dependenciesIds != null)
             {
                 data.DependencyIDs = ImmutableList<string>.Empty.AddRange(dependenciesIds);
-            }
-
-            if (dependencies != null)
-            {
-                data.Dependencies = ImmutableList<IDependency>.Empty.AddRange(dependencies);
             }
 
             return data;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IMockDependenciesViewModelFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IMockDependenciesViewModelFactory.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 using Moq;
@@ -36,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                     mock.Setup(x => x.CreateRootViewModel(
                                         It.Is<string>((t) => string.Equals(t, d.ProviderType, System.StringComparison.OrdinalIgnoreCase)),
                                         false))
-                        .Returns(d.ToViewModel());
+                        .Returns(((IDependencyModel)d).ToViewModel(false));
                 }
             }
 
@@ -47,10 +48,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                     mock.Setup(x => x.CreateTargetViewModel(
                             It.Is<ITargetedDependenciesSnapshot>(
                                 (t) => string.Equals(t.TargetFramework.Moniker, d.Caption, System.StringComparison.OrdinalIgnoreCase))))
-                        .Returns(d.ToViewModel());
+                        .Returns(((IDependencyModel)d).ToViewModel(false));
                 }
             }
-            
+
             return mock.Object;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITargetedDependenciesSnapshotFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITargetedDependenciesSnapshotFactory.cs
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             var behavior = mockBehavior ?? MockBehavior.Default;
             var mock = new Mock<ITargetedDependenciesSnapshot>(behavior);
 
-            mock.Setup(x => x.CheckForUnresolvedDependencies(It.Is<IDependency>(y => y.Id.Equals(id))))
+            mock.Setup(x => x.CheckForUnresolvedDependencies(It.Is<IDependency>(y => y.Id.Equals(id, System.StringComparison.OrdinalIgnoreCase))))
                 .Returns(hasUnresolvedDependency);
 
             return mock.Object;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DuplicatedDependenciesSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DuplicatedDependenciesSnapshotFilterTests.cs
@@ -38,11 +38,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var filter = new DuplicatedDependenciesSnapshotFilter();
 
             var resultDependency = filter.BeforeAdd(
-                projectPath: null,
-                targetFramework: null,
-                dependency: dependency.Object,
-                worldBuilder: worldBuilder,
-                topLevelBuilder: topLevelBuilder);
+                null,
+                null,
+                dependency.Object,
+                worldBuilder,
+                topLevelBuilder,
+                out bool filterAnyChanges);
 
             Assert.False(worldBuilder.ContainsKey(otherDependency.Object.Id));
 
@@ -81,11 +82,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var filter = new DuplicatedDependenciesSnapshotFilter();
 
             var resultDependency = filter.BeforeAdd(
-                projectPath: null,
-                targetFramework: null,
-                dependency: dependency.Object,
-                worldBuilder: worldBuilder,
-                topLevelBuilder: topLevelBuilder);
+                null,
+                null,
+                dependency.Object,
+                worldBuilder,
+                topLevelBuilder,
+                out bool filterAnyChanges);
 
             Assert.True(worldBuilder.ContainsKey(otherDependency.Object.Id));
 
@@ -122,11 +124,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var filter = new DuplicatedDependenciesSnapshotFilter();
 
             var resultDependency = filter.BeforeAdd(
-                projectPath: null,
-                targetFramework: null,
-                dependency: dependency.Object,
-                worldBuilder: worldBuilder,
-                topLevelBuilder: topLevelBuilder);
+                null,
+                null,
+                dependency.Object,
+                worldBuilder,
+                topLevelBuilder,
+                out bool filterAnyChanges);
 
             Assert.False(worldBuilder.ContainsKey(otherDependency.Object.Id));
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/SdkAndPackagesDependenciesSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/SdkAndPackagesDependenciesSnapshotFilterTests.cs
@@ -28,11 +28,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var filter = new SdkAndPackagesDependenciesSnapshotFilter();
 
             var resultDependency = filter.BeforeAdd(
-                projectPath: null,
-                targetFramework: null,
-                dependency: dependency.Object,
-                worldBuilder: worldBuilder,
-                topLevelBuilder: null);
+                null,
+                null,
+                dependency.Object,
+                worldBuilder,
+                null,
+                out bool filterAnyChanges);
 
             dependency.VerifyAll();
         }
@@ -71,11 +72,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var filter = new SdkAndPackagesDependenciesSnapshotFilter();
 
             var resultDependency = filter.BeforeAdd(
-                projectPath: null,
-                targetFramework: mockTargetFramework,
-                dependency: sdkDependency.Object,
-                worldBuilder: worldBuilder,
-                topLevelBuilder: topLevelBuilder);
+                null,
+                mockTargetFramework,
+                sdkDependency.Object,
+                worldBuilder,
+                topLevelBuilder,
+                out bool filterAnyChanges);
 
             sdkDependency.VerifyAll();
             otherDependency.VerifyAll();
@@ -107,11 +109,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var filter = new SdkAndPackagesDependenciesSnapshotFilter();
 
             var resultDependency = filter.BeforeAdd(
-                projectPath: null,
-                targetFramework: mockTargetFramework,
-                dependency: dependency.Object,
-                worldBuilder: worldBuilder,
-                topLevelBuilder: null);
+                null,
+                mockTargetFramework,
+                dependency.Object,
+                worldBuilder,
+                null,
+                out bool filterAnyChanges);
 
             dependency.VerifyAll();
             otherDependency.VerifyAll();
@@ -152,11 +155,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var filter = new SdkAndPackagesDependenciesSnapshotFilter();
 
             var resultDependency = filter.BeforeAdd(
-                projectPath: null,
-                targetFramework: mockTargetFramework,
-                dependency: dependency.Object,
-                worldBuilder: worldBuilder,
-                topLevelBuilder: topLevelBuilder);
+                null,
+                mockTargetFramework,
+                dependency.Object,
+                worldBuilder,
+                topLevelBuilder,
+                out bool filterAnyChanges);
 
             dependency.VerifyAll();
             sdkDependency.VerifyAll();
@@ -199,11 +203,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var filter = new SdkAndPackagesDependenciesSnapshotFilter();
 
             filter.BeforeRemove(
-                projectPath: null,
-                targetFramework: mockTargetFramework,
-                dependency: dependency.Object,
-                worldBuilder: worldBuilder,
-                topLevelBuilder: topLevelBuilder);
+                null,
+                mockTargetFramework,
+                dependency.Object,
+                worldBuilder,
+                topLevelBuilder,
+                out bool filterAnyChanges);
 
             dependency.VerifyAll();
             sdkDependency.VerifyAll();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependency.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
@@ -35,10 +35,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         public IImmutableList<string> DependencyIDs { get; set; } = ImmutableList<string>.Empty;
         public ProjectTreeFlags Flags { get; set; } = ProjectTreeFlags.Empty;
         public string Id { get; set; }
-        public bool HasUnresolvedDependency { get; set; }
         public string Alias { get; set; }
-        public IEnumerable<IDependency> Dependencies { get; set; }
-        public ITargetedDependenciesSnapshot Snapshot { get; set; }
+        public ITargetFramework TargetFramework { get; set; }
 
         public IDependency SetProperties(
             string caption = null,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnresolvedDependenciesSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnresolvedDependenciesSnapshotFilterTests.cs
@@ -29,11 +29,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var filter = new UnresolvedDependenciesSnapshotFilter();
 
             var resultDependency = filter.BeforeAdd(
-                projectPath: null,
-                targetFramework: null,
-                dependency: dependency.Object,
-                worldBuilder: worldBuilder,
-                topLevelBuilder: null);
+                null,
+                null,
+                dependency.Object,
+                worldBuilder,
+                null,
+                out bool filterAnyChanges);
 
             Assert.Null(resultDependency);
 
@@ -55,11 +56,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var filter = new UnresolvedDependenciesSnapshotFilter();
 
             var resultDependency = filter.BeforeAdd(
-                projectPath: null,
-                targetFramework: null,
-                dependency: dependency.Object,
-                worldBuilder: worldBuilder,
-                topLevelBuilder: null);
+                null,
+                null,
+                dependency.Object,
+                worldBuilder,
+                null,
+                out bool filterAnyChanges);
 
             Assert.NotNull(resultDependency);
             Assert.Equal("mydependency2", resultDependency.Id);
@@ -77,11 +79,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var filter = new UnresolvedDependenciesSnapshotFilter();
 
             var resultDependency = filter.BeforeAdd(
-                projectPath: null,
-                targetFramework: null,
-                dependency: dependency.Object,
-                worldBuilder: null,
-                topLevelBuilder: null);
+                null,
+                null,
+                dependency.Object,
+                null,
+                null,
+                out bool filterAnyChanges);
 
             Assert.NotNull(resultDependency);
             Assert.Equal("mydependency2", resultDependency.Id);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnsupportedProjectsSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnsupportedProjectsSnapshotFilterTests.cs
@@ -51,32 +51,36 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var filter = new UnsupportedProjectsSnapshotFilter(aggregateSnapshotProvider, targetFRameworkProvider);
 
             var resultDependency = filter.BeforeAdd(
-                projectPath: null,
-                targetFramework: null,
-                dependency: dependency.Object,
-                worldBuilder: worldBuilder,
-                topLevelBuilder: null);
+                null,
+                null,
+                dependency.Object,
+                worldBuilder,
+                null,
+                out bool filterAnyChanges);
 
             resultDependency = filter.BeforeAdd(
-                projectPath: null,
-                targetFramework: null,
-                dependency: topLevelDependency.Object,
-                worldBuilder: worldBuilder,
-                topLevelBuilder: null);
+                null,
+                null,
+                topLevelDependency.Object,
+                worldBuilder,
+                null,
+                out bool filterAnyChanges2);
 
             resultDependency = filter.BeforeAdd(
-                projectPath: null,
-                targetFramework: null,
-                dependency: topLevelResolvedDependency.Object,
-                worldBuilder: worldBuilder,
-                topLevelBuilder: null);
+                null,
+                null,
+                topLevelResolvedDependency.Object,
+                worldBuilder,
+                null,
+                out bool filterAnyChanges3);
 
             resultDependency = filter.BeforeAdd(
-                projectPath: null,
-                targetFramework: null,
-                dependency: topLevelResolvedSharedProjectDependency.Object,
-                worldBuilder: worldBuilder,
-                topLevelBuilder: null);
+                null,
+                null,
+                topLevelResolvedSharedProjectDependency.Object,
+                worldBuilder,
+                null,
+                out bool filterAnyChanges4);
 
             dependency.VerifyAll();
             topLevelDependency.VerifyAll();
@@ -98,22 +102,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var targetFrameworkProvider = ITargetFrameworkProviderFactory.Implement(getNearestFramework: targetFramework);
 
             var dependency = IDependencyFactory.Implement(
+                    targetFramework: targetFramework,
                     topLevel: true,
                     resolved: true,
                     flags: DependencyTreeFlags.ProjectNodeFlags.Union(DependencyTreeFlags.ResolvedFlags),
                     originalItemSpec:@"c:\myproject2\project.csproj",
-                    snapshot: targetedSnapshot,
                     setPropertiesResolved:false,
                     setPropertiesFlags: DependencyTreeFlags.ProjectNodeFlags.Union(DependencyTreeFlags.UnresolvedFlags));
 
             var filter = new UnsupportedProjectsSnapshotFilter(aggregateSnapshotProvider, targetFrameworkProvider);
 
             var resultDependency = filter.BeforeAdd(
-                projectPath: null,
-                targetFramework: null,
-                dependency: dependency.Object,
-                worldBuilder: null,
-                topLevelBuilder: null);            
+                null,
+                null,
+                dependency.Object,
+                null,
+                null,
+                out bool filterAnyChanges);            
 
             dependency.VerifyAll();
         }
@@ -136,11 +141,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var filter = new UnsupportedProjectsSnapshotFilter(aggregateSnapshotProvider, null);
 
             var resultDependency = filter.BeforeAdd(
-                projectPath: null,
-                targetFramework: null,
-                dependency: dependency.Object,
-                worldBuilder: null,
-                topLevelBuilder: null);
+                null,
+                null,
+                dependency.Object,
+                null,
+                null,
+                out bool filterAnyChanges);
 
             dependency.VerifyAll();
         }
@@ -165,18 +171,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     resolved: true,
                     flags: DependencyTreeFlags.ProjectNodeFlags.Union(DependencyTreeFlags.ResolvedFlags),
                     originalItemSpec: @"c:\myproject2\project.csproj",
-                    snapshot: targetedSnapshot,
+                    targetFramework: targetFramework,
                     setPropertiesResolved: false,
                     setPropertiesFlags: DependencyTreeFlags.ProjectNodeFlags.Union(DependencyTreeFlags.UnresolvedFlags));
 
             var filter = new UnsupportedProjectsSnapshotFilter(aggregateSnapshotProvider, targetFrameworkProvider);
 
             var resultDependency = filter.BeforeAdd(
-                projectPath: null,
-                targetFramework: null,
-                dependency: dependency.Object,
-                worldBuilder: null,
-                topLevelBuilder: null);
+                null,
+                null,
+                dependency.Object,
+                null,
+                null,
+                out bool filterAnyChanges);
 
             dependency.VerifyAll();
         }
@@ -201,16 +208,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     resolved: true,
                     flags: DependencyTreeFlags.ProjectNodeFlags.Union(DependencyTreeFlags.ResolvedFlags),
                     originalItemSpec: @"c:\myproject2\project.csproj",
-                    snapshot:targetedSnapshot);
+                    targetFramework: targetFramework
+                 );
 
             var filter = new UnsupportedProjectsSnapshotFilter(aggregateSnapshotProvider, targetFrameworkProvider);
 
             var resultDependency = filter.BeforeAdd(
-                projectPath: null,
-                targetFramework: null,
-                dependency: dependency.Object,
-                worldBuilder: null,
-                topLevelBuilder: null);
+                null,
+                null,
+                dependency.Object,
+                null,
+                null,
+                out bool filterAnyChanges);
 
             dependency.VerifyAll();
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -539,7 +539,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Requires.NotNull(dependency, nameof(dependency));
 
             ConfiguredProject project = null;
-            if (dependency.Snapshot.TargetFramework.Equals(TargetFramework.Any))
+            if (dependency.TargetFramework.Equals(TargetFramework.Any))
             {
                 project = ActiveConfiguredProject;
             }
@@ -547,7 +547,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             {
                 ThreadHelper.JoinableTaskFactory.Run(async () =>
                 {
-                    project = await DependenciesHost.GetConfiguredProject(dependency.Snapshot.TargetFramework)
+                    project = await DependenciesHost.GetConfiguredProject(dependency.TargetFramework)
                                                     .ConfigureAwait(false) ?? ActiveConfiguredProject;
                 });
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/CheckChildrenGraphActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/CheckChildrenGraphActionHandler.cs
@@ -30,12 +30,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
 
         public override bool HandleRequest(IGraphContext graphContext)
         {
-            var trackChanges = false;
             foreach (var inputGraphNode in graphContext.InputNodes)
             {
                 if (graphContext.CancelToken.IsCancellationRequested)
                 {
-                    return trackChanges;
+                    return false;
                 }
 
                 var projectPath = inputGraphNode.Id.GetValue(CodeGraphNodeIdName.Assembly);
@@ -70,7 +69,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
                 }
             }
 
-            return trackChanges;
+            return false;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/CheckChildrenGraphActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/CheckChildrenGraphActionHandler.cs
@@ -44,8 +44,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
                     continue;
                 }
 
-                var dependency = GetDependency(graphContext, inputGraphNode);
-                if (dependency == null)
+                var dependency = GetDependency(graphContext, inputGraphNode, out IDependenciesSnapshot snapshot);
+                if (dependency == null || snapshot == null)
                 {
                     continue;
                 }
@@ -56,14 +56,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
                     continue;
                 }
 
-                if (dependency.Flags.Contains(DependencyTreeFlags.SupportsHierarchy))
-                {
-                    trackChanges = true;
-                }
-
                 using (var scope = new GraphTransactionScope())
                 {
-                    inputGraphNode.SetValue(DependenciesGraphSchema.DependencyProperty, dependency);
+                    inputGraphNode.SetValue(DependenciesGraphSchema.DependencyIdProperty, dependency.Id);
+                    inputGraphNode.SetValue(DependenciesGraphSchema.ResolvedProperty, dependency.Resolved);
 
                     if (viewProvider.Value.HasChildren(projectPath, dependency))
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/GetChildrenGraphActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/GetChildrenGraphActionHandler.cs
@@ -43,8 +43,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
                     continue;
                 }
 
-                var dependency = GetDependency(graphContext, inputGraphNode);
-                if (dependency == null)
+                var dependency = GetDependency(graphContext, inputGraphNode, out IDependenciesSnapshot snapshot);
+                if (dependency == null || snapshot == null)
                 {
                     continue;
                 }
@@ -62,7 +62,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
 
                 using (var scope = new GraphTransactionScope())
                 {
-                    viewProvider.Value.BuildGraph(graphContext, projectPath, dependency, inputGraphNode);
+                    viewProvider.Value.BuildGraph(
+                        graphContext, 
+                        projectPath, 
+                        dependency, 
+                        inputGraphNode, 
+                        snapshot.Targets[dependency.TargetFramework]);
 
                     scope.Complete();
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphSchema.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphSchema.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.VisualStudio.GraphModel;
-using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
 {
@@ -13,16 +12,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
         public static readonly GraphSchema Schema = new GraphSchema("Microsoft.VisualStudio.ProjectSystem.VS.Tree.DependenciesSchema");
         public static readonly GraphCategory CategoryDependency = Schema.Categories.AddNewCategory(VSResources.GraphNodeCategoryDependency);
 
-        private static readonly string DependencyPropertyId = "Microsoft.VisualStudio.ProjectSystem.VS.Tree.DependencyPropertyId";
-        public static readonly GraphProperty DependencyProperty;
+        private static readonly string DependencyIdPropertyId = "Dependency.Id";
+        public static readonly GraphProperty DependencyIdProperty;
 
-        private static readonly string IsFrameworkAssemblyFolderPropertyId = "Microsoft.VisualStudio.ProjectSystem.VS.Tree.IsFrameworkAssembly";
+        private static readonly string ResolvedPropertyId = "Dependency.Resolved";
+        public static readonly GraphProperty ResolvedProperty;
+
+        private static readonly string IsFrameworkAssemblyFolderPropertyId = "Dependency.IsFrameworkAssembly";
         public static readonly GraphProperty IsFrameworkAssemblyFolderProperty;
 
         static DependenciesGraphSchema()
         {
+            ResolvedProperty = Schema.Properties.AddNewProperty(ResolvedPropertyId, typeof(bool));
+            DependencyIdProperty = Schema.Properties.AddNewProperty(DependencyIdPropertyId, typeof(string));
             IsFrameworkAssemblyFolderProperty = Schema.Properties.AddNewProperty(IsFrameworkAssemblyFolderPropertyId, typeof(bool));
-            DependencyProperty = Schema.Properties.AddNewProperty(DependencyPropertyId, typeof(IDependency));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependencyNodeInfo.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependencyNodeInfo.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
+{
+    internal struct DependencyNodeInfo : IEquatable<DependencyNodeInfo>
+    {
+        public string Id;
+        public string Caption;
+        public bool Resolved;
+
+        public override int GetHashCode()
+        {
+            return unchecked(Id.ToLowerInvariant().GetHashCode());
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is DependencyNodeInfo other)
+            {
+                return Equals(other);
+            }
+
+            return false;
+        }
+
+        public bool Equals(DependencyNodeInfo other)
+        {
+            return other.GetHashCode() == GetHashCode();
+        }
+
+        public static DependencyNodeInfo FromDependency(IDependency dependency)
+        {
+            Requires.NotNull(dependency, nameof(dependency));
+
+            return new DependencyNodeInfo
+            {
+                Id = dependency.Id,
+                Caption = dependency.Caption,
+                Resolved = dependency.Resolved
+            };
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/IDependenciesGraphBuilder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/IDependenciesGraphBuilder.cs
@@ -2,7 +2,6 @@
 
 using Microsoft.VisualStudio.GraphModel;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models;
-using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
 {
@@ -12,23 +11,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
             IGraphContext graphContext, 
             string projectPath, 
             GraphNode parentNode, 
-            IDependency dependency);
-
-        GraphNode AddGraphNode(
-            IGraphContext graphContext, 
-            string projectPath, 
-            GraphNode parentNode, 
             IDependencyViewModel viewModel);
 
         GraphNode AddTopLevelGraphNode(
             IGraphContext graphContext,
             string projectPath,
-            IDependency dependency);
+            IDependencyViewModel viewModel);
 
         void RemoveGraphNode(
             IGraphContext graphContext,
             string projectPath,
-            IDependency dependency,
+            string modelId,
             GraphNode parentNode);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/GenericGraphViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/GenericGraphViewProvider.cs
@@ -19,22 +19,35 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
         {
         }
 
-        public override void BuildGraph(IGraphContext graphContext,
-                                           string projectPath,
-                                           IDependency dependency,
-                                           GraphNode dependencyGraphNode)
+        public override void BuildGraph(
+            IGraphContext graphContext,
+            string projectPath,
+            IDependency dependency,
+            GraphNode dependencyGraphNode,
+            ITargetedDependenciesSnapshot targetedSnapshot)
         {
-            // store refreshed dependency
-            dependencyGraphNode.SetValue(DependenciesGraphSchema.DependencyProperty, dependency);
+            // store refreshed dependency info
+            dependencyGraphNode.SetValue(DependenciesGraphSchema.DependencyIdProperty, dependency.Id);
+            dependencyGraphNode.SetValue(DependenciesGraphSchema.ResolvedProperty, dependency.Resolved);
 
-            foreach (var childDependency in dependency.Dependencies)
+            var children = targetedSnapshot.GetDependencyChildren(dependency);
+            if (children == null)
+            {
+                return;
+            }
+
+            foreach (var childDependency in children)
             {
                 if (!childDependency.Visible)
                 {
                     continue;
                 }
 
-                Builder.AddGraphNode(graphContext, projectPath, dependencyGraphNode, childDependency);
+                Builder.AddGraphNode(
+                    graphContext, 
+                    projectPath, 
+                    dependencyGraphNode, 
+                    childDependency.ToViewModel(targetedSnapshot));
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/GraphViewProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/GraphViewProviderBase.cs
@@ -28,21 +28,35 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
             return dependency.DependencyIDs.Count > 0;
         }
 
-        public virtual void BuildGraph(IGraphContext graphContext, 
-                                          string projectPath, 
-                                          IDependency dependency, 
-                                          GraphNode dependencyGraphNode)
+        public virtual void BuildGraph(
+            IGraphContext graphContext, 
+            string projectPath, 
+            IDependency dependency, 
+            GraphNode dependencyGraphNode,
+            ITargetedDependenciesSnapshot targetedSnapshot)
         {
-            // store refreshed dependency
-            dependencyGraphNode.SetValue(DependenciesGraphSchema.DependencyProperty, dependency);
-            foreach (var childDependency in dependency.Dependencies)
+            // store refreshed dependency info
+            dependencyGraphNode.SetValue(DependenciesGraphSchema.DependencyIdProperty, dependency.Id);
+            dependencyGraphNode.SetValue(DependenciesGraphSchema.ResolvedProperty, dependency.Resolved);
+            
+            var children = targetedSnapshot.GetDependencyChildren(dependency);
+            if (children == null)
+            {
+                return;
+            }
+
+            foreach (var childDependency in children)
             {
                 if (!childDependency.Visible)
                 {
                     continue;
                 }
 
-                Builder.AddGraphNode(graphContext, projectPath, dependencyGraphNode, childDependency);
+                Builder.AddGraphNode(
+                    graphContext, 
+                    projectPath, 
+                    dependencyGraphNode, 
+                    childDependency.ToViewModel(targetedSnapshot));
             }
         }
 
@@ -54,16 +68,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
         public virtual bool TrackChanges(
             IGraphContext graphContext,
             string projectPath,
-            IDependency existingDependency,
             IDependency updatedDependency,
-            GraphNode dependencyGraphNode)
+            GraphNode dependencyGraphNode,
+            ITargetedDependenciesSnapshot targetedSnapshot)
         {
             if (!AnyChanges(projectPath,
-                            existingDependency, 
+                            targetedSnapshot,
                             updatedDependency,
                             dependencyGraphNode,
-                            out IEnumerable<IDependency> nodesToAdd,
-                            out IEnumerable<IDependency> nodesToRemove,
+                            out IEnumerable<DependencyNodeInfo> nodesToAdd,
+                            out IEnumerable<DependencyNodeInfo> nodesToRemove,
                             out string dependencyProjectPath))
             {
                 return false;
@@ -71,21 +85,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
 
             foreach (var nodeToRemove in nodesToRemove)
             {
-                Builder.RemoveGraphNode(graphContext, projectPath, nodeToRemove, dependencyGraphNode);
+                Builder.RemoveGraphNode(graphContext, projectPath, nodeToRemove.Id, dependencyGraphNode);
             }
 
             foreach (var nodeToAdd in nodesToAdd)
             {
-                if (!nodeToAdd.Visible)
+                if (!targetedSnapshot.DependenciesWorld.TryGetValue(nodeToAdd.Id, out IDependency dependency)
+                    || dependency == null
+                    || !dependency.Visible)
                 {
                     continue;
                 }
 
-                Builder.AddGraphNode(graphContext, projectPath, dependencyGraphNode, nodeToAdd);
+                Builder.AddGraphNode(
+                    graphContext, 
+                    projectPath, 
+                    dependencyGraphNode,
+                    dependency.ToViewModel(targetedSnapshot));
             }
 
             // Update the node info saved on the 'inputNode'
-            dependencyGraphNode.SetValue(DependenciesGraphSchema.DependencyProperty, updatedDependency);
+            dependencyGraphNode.SetValue(DependenciesGraphSchema.DependencyIdProperty, updatedDependency.Id);
+            dependencyGraphNode.SetValue(DependenciesGraphSchema.ResolvedProperty, updatedDependency.Resolved);
 
             return true;
         }
@@ -102,32 +123,57 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
 
         protected virtual bool AnyChanges(
             string projectPath,
-            IDependency existingDependency,
+            ITargetedDependenciesSnapshot targetedSnapshot,
             IDependency updatedDependency,
             GraphNode dependencyGraphNode,
-            out IEnumerable<IDependency> nodesToAdd,
-            out IEnumerable<IDependency> nodesToRemove,
+            out IEnumerable<DependencyNodeInfo> nodesToAdd,
+            out IEnumerable<DependencyNodeInfo> nodesToRemove,
             out string dependencyProjectPath)
         {
             dependencyProjectPath = projectPath;
 
-            var existingChildren = existingDependency.Dependencies;
-            var updatedChildren = updatedDependency.Dependencies;
+            var existingChildrenInfo = GetExistingChildren(dependencyGraphNode);
+            var updatedChildren = targetedSnapshot.GetDependencyChildren(updatedDependency)
+                ?? Enumerable.Empty<IDependency>();
+            var updatedChildrenInfo = updatedChildren.Select(x => DependencyNodeInfo.FromDependency(x));
 
-            return AnyChanges(existingChildren, updatedChildren, out nodesToAdd, out nodesToRemove);
+            return AnyChanges(existingChildrenInfo, updatedChildrenInfo, out nodesToAdd, out nodesToRemove);
         }
 
-        protected bool AnyChanges(
-            IEnumerable<IDependency> existingChildren,
-            IEnumerable<IDependency> updatedChildren,
-            out IEnumerable<IDependency> nodesToAdd,
-            out IEnumerable<IDependency> nodesToRemove)
+        protected static bool AnyChanges(
+            IEnumerable<DependencyNodeInfo> existingChildren,
+            IEnumerable<DependencyNodeInfo> updatedChildren,
+            out IEnumerable<DependencyNodeInfo> nodesToAdd,
+            out IEnumerable<DependencyNodeInfo> nodesToRemove)
         {
-
             var comparer = new DependencyResolvedStateComparer();
-            nodesToRemove = existingChildren.Except(updatedChildren, comparer).ToList();
-            nodesToAdd = updatedChildren.Except(existingChildren, comparer).ToList();
+            nodesToRemove = existingChildren.Except(updatedChildren).ToList();
+            nodesToAdd = updatedChildren.Except(existingChildren).ToList();
             return nodesToAdd.Any() || nodesToRemove.Any();
+        }
+
+        protected static IEnumerable<DependencyNodeInfo> GetExistingChildren(GraphNode inputGraphNode)
+        {
+            var children = new List<DependencyNodeInfo>();
+            foreach (var childNode in inputGraphNode.FindDescendants())
+            {
+                var id = childNode.GetValue<string>(DependenciesGraphSchema.DependencyIdProperty);
+                if (string.IsNullOrEmpty(id))
+                {
+                    continue;
+                }
+
+                var dependencyInfo = new DependencyNodeInfo
+                {
+                    Id = id,
+                    Caption = childNode.Label,
+                    Resolved = childNode.GetValue<bool>(DependenciesGraphSchema.ResolvedProperty)
+                };
+
+                children.Add(dependencyInfo);
+            }
+
+            return children;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/IDependenciesGraphViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/IDependenciesGraphViewProvider.cs
@@ -16,16 +16,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
             IGraphContext graphContext, 
             string projectPath, 
             IDependency dependency, 
-            GraphNode dependencyGraphNode);
+            GraphNode dependencyGraphNode,
+            ITargetedDependenciesSnapshot targetedSnapshot);
 
         bool ShouldTrackChanges(string projectPath, string updatedProjectPath, IDependency dependency);
 
         bool TrackChanges(
             IGraphContext graphContext,
             string projectPath,
-            IDependency existingDependency,
             IDependency updatedDependency,
-            GraphNode dependencyGraphNode);
+            GraphNode dependencyGraphNode,
+            ITargetedDependenciesSnapshot targetedSnapshot);
 
         bool MatchSearchResults(
             string projectPath,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GroupedByTargetTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GroupedByTargetTreeViewProvider.cs
@@ -234,8 +234,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     excludedFlags = ProjectTreeFlags.Create(ProjectTreeFlags.Common.BubbleUp);
                 }
 
-                subTreeNode = CreateOrUpdateNode(subTreeNode, subTreeViewModel, rule:null, isProjectItem:false, excludedFlags: excludedFlags);
-                subTreeNode = BuildSubTree(subTreeNode, dependencyGroup.Value, catalogs, isActiveTarget, shouldCleanup:!isNewSubTreeNode);
+                subTreeNode = CreateOrUpdateNode(
+                    subTreeNode, 
+                    subTreeViewModel, 
+                    rule:null, 
+                    isProjectItem:false, 
+                    excludedFlags:excludedFlags);
+
+                subTreeNode = BuildSubTree(
+                    subTreeNode, 
+                    targetedSnapshot, 
+                    dependencyGroup.Value, 
+                    catalogs, 
+                    isActiveTarget, 
+                    shouldCleanup:!isNewSubTreeNode);
                 
                 currentNodes.Add(subTreeNode);
 
@@ -257,6 +269,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// </summary>
         private IProjectTree BuildSubTree(
             IProjectTree rootNode,
+            ITargetedDependenciesSnapshot targetedSnapshot,
             IEnumerable<IDependency> dependencies,
             IProjectCatalogSnapshot catalogs,
             bool isActiveTarget,
@@ -282,7 +295,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     }
                 }
 
-                dependencyNode = CreateOrUpdateNode(dependencyNode, dependency, catalogs, isActiveTarget);
+                dependencyNode = CreateOrUpdateNode(dependencyNode, dependency, targetedSnapshot, catalogs, isActiveTarget);
                 currentNodes.Add(dependencyNode);
 
                 if (isNewDependencyNode)
@@ -322,6 +335,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         private IProjectTree CreateOrUpdateNode(
             IProjectTree node,
             IDependency dependency,
+            ITargetedDependenciesSnapshot targetedSnapshot,
             IProjectCatalogSnapshot catalogs,
             bool isProjectItem,
             ProjectTreeFlags? additionalFlags = null,
@@ -333,7 +347,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 rule = TreeServices.GetRule(dependency, catalogs);
             }
 
-            return CreateOrUpdateNode(node, dependency.ToViewModel(), rule, isProjectItem, additionalFlags, excludedFlags);
+            return CreateOrUpdateNode(
+                node, 
+                dependency.ToViewModel(targetedSnapshot), 
+                rule, 
+                isProjectItem, 
+                additionalFlags, 
+                excludedFlags);
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DependencyViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DependencyViewModel.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Immutable;
 using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
@@ -16,5 +17,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
         public ImageMoniker ExpandedIcon { get; set; }
         public IImmutableDictionary<string, string> Properties { get; set; }
         public ProjectTreeFlags Flags { get; set; }
+        public IDependency OriginalModel { get; set; }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/IDependencyViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/IDependencyViewModel.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Immutable;
 using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
@@ -16,5 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
         ImageMoniker ExpandedIcon { get; }
         IImmutableDictionary<string, string> Properties { get; }
         ProjectTreeFlags Flags { get; }
+        IDependency OriginalModel { get; }
+
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
@@ -255,6 +255,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         {
             Requires.NotNull(targetFramework, nameof(targetFramework));
             Requires.NotNullOrEmpty(providerType, nameof(providerType));
+            Requires.NotNullOrEmpty(modelId, nameof(modelId));
 
             var normalizedModelId = modelId.Replace('.', '_');
             return $"{targetFramework.ShortName}/{providerType}/{normalizedModelId}".TrimEnd('/').Replace('/', '\\');

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
@@ -25,14 +25,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         public const int ComNodePriority = 170;
         public const int SdkNodePriority = 180;
 
-        public Dependency(IDependencyModel dependencyModel, ITargetedDependenciesSnapshot snapshot)
+        public Dependency(IDependencyModel dependencyModel, ITargetFramework targetFramework)
         {
             Requires.NotNull(dependencyModel, nameof(dependencyModel));
-            Requires.NotNull(snapshot, nameof(snapshot));
             Requires.NotNullOrEmpty(dependencyModel.ProviderType, nameof(dependencyModel.ProviderType));
             Requires.NotNullOrEmpty(dependencyModel.Id, nameof(dependencyModel.Id));
+            Requires.NotNull(targetFramework, nameof(targetFramework));
 
-            Snapshot = snapshot;
+            TargetFramework = targetFramework;
+
             _modelId = dependencyModel.Id;
             ProviderType = dependencyModel.ProviderType;
             Name = dependencyModel.Name ?? string.Empty;
@@ -79,7 +80,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 var normalizedDependencyIDs = new List<string>();
                 foreach (var id in dependencyModel.DependencyIDs)
                 {
-                    normalizedDependencyIDs.Add(GetID(Snapshot.TargetFramework, ProviderType, id));
+                    normalizedDependencyIDs.Add(GetID(TargetFramework, ProviderType, id));
                 }
 
                 DependencyIDs = ImmutableList.CreateRange(normalizedDependencyIDs);
@@ -87,7 +88,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         }
 
         private Dependency(IDependency model, string modelId)
-            : this(model, model.Snapshot)
+            : this(model, model.TargetFramework)
         {
             _modelId = modelId;
         }
@@ -99,6 +100,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         /// to get a unique id for the whole snapshot.
         /// </summary>
         private string _modelId;
+
         private string _id;
         public string Id
         {
@@ -106,13 +108,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             {
                 if (_id == null)
                 {
-                    // we need to replace .. in model id with something else, since IProjectItemTree 
-                    // alters it using Uri and .. symbols are gone (it tries to get full path). However
-                    // we do need ids to stay original and unique.
-                    _id = (Snapshot.TargetFramework == null
-                                ? Normalize(_modelId)
-                                : GetID(Snapshot.TargetFramework, ProviderType, _modelId));
-
+                    _id = GetID(TargetFramework, ProviderType, _modelId);
                 }
 
                 return _id;
@@ -162,68 +158,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
         #endregion
 
-        private bool? _hasUnresolvedDependency;
-        public bool HasUnresolvedDependency
-        {
-            get
-            {
-                if (_hasUnresolvedDependency == null)
-                {
-                    // CheckForUnresolvedDependencies does dependency tree traversal efficiently,
-                    // call it instead of going reqursively through Dependencies property.
-                    _hasUnresolvedDependency = Snapshot.CheckForUnresolvedDependencies(this);
-                }
+        public ITargetFramework TargetFramework { get; }
 
-                return _hasUnresolvedDependency.Value;
-            }
-        }
-
-        private IEnumerable<IDependency> _dependencies;
-        public IEnumerable<IDependency> Dependencies
-        {
-            get
-            {
-                if (_dependencies == null)
-                {
-                    var dependencies = new List<IDependency>();
-                    foreach(var id in DependencyIDs)
-                    {
-                        if (Snapshot.DependenciesWorld.TryGetValue(id, out IDependency child))
-                        {
-                            dependencies.Add(child);
-                        }                        
-                    }
-
-                    _dependencies = dependencies;
-                }
-
-                return _dependencies;
-            }
-        }
-
-        public ITargetedDependenciesSnapshot Snapshot { get; }
-
-        private string _alias = string.Empty;
-        public string Alias
-        {
-            get
-            {
-                if (string.IsNullOrEmpty(_alias))
-                {
-                    var path = OriginalItemSpec ?? Path;
-                    if (string.IsNullOrEmpty(path) || path.Equals(Caption, StringComparison.OrdinalIgnoreCase))
-                    {
-                        _alias = Caption;
-                    }
-                    else
-                    {
-                        _alias = string.Format(CultureInfo.CurrentCulture, "{0} ({1})", Caption, path);
-                    }
-                }
-
-                return _alias;
-            }
-        }
+        public string Alias => GetAlias(this);
 
         public IDependency SetProperties(
             string caption = null, 
@@ -296,6 +233,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             return Id;
         }
 
+        private static string GetAlias(IDependency dependency)
+        {
+            var path = dependency.OriginalItemSpec ?? dependency.Path;
+            if (string.IsNullOrEmpty(path) || path.Equals(dependency.Caption, StringComparison.OrdinalIgnoreCase))
+            {
+                return dependency.Caption;
+            }
+            else
+            {
+                return string.Format(CultureInfo.CurrentCulture, "{0} ({1})", dependency.Caption, path);
+            }
+        }
+
         private static string Normalize(string id)
         {
             return id.Replace('.', '_').Replace('/', '\\');
@@ -303,6 +253,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
         public static string GetID(ITargetFramework targetFramework, string providerType, string modelId)
         {
+            Requires.NotNull(targetFramework, nameof(targetFramework));
             Requires.NotNullOrEmpty(providerType, nameof(providerType));
 
             var normalizedModelId = modelId.Replace('.', '_');

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DependenciesSnapshotFilterBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DependenciesSnapshotFilterBase.cs
@@ -15,18 +15,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             ITargetFramework targetFramework,
             IDependency dependency, 
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
-            ImmutableHashSet<IDependency>.Builder topLevelBuilder)
+            ImmutableHashSet<IDependency>.Builder topLevelBuilder,
+            out bool filterAnyChanges)
         {
+            filterAnyChanges = false;
             return dependency;
         }
 
-        public virtual void BeforeRemove(
+        public virtual IDependency BeforeRemove(
             string projectPath,
             ITargetFramework targetFramework,
             IDependency dependency, 
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
-            ImmutableHashSet<IDependency>.Builder topLevelBuilder)
+            ImmutableHashSet<IDependency>.Builder topLevelBuilder,
+            out bool filterAnyChanges)
         {
+            filterAnyChanges = false;
+            return dependency;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DuplicatedDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DuplicatedDependenciesSnapshotFilter.cs
@@ -26,8 +26,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             ITargetFramework targetFramework,
             IDependency dependency, 
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
-            ImmutableHashSet<IDependency>.Builder topLevelBuilder)
+            ImmutableHashSet<IDependency>.Builder topLevelBuilder,
+            out bool filterAnyChanges)
         {
+            filterAnyChanges = false;
             IDependency resultDependency = dependency;
 
             var matchingDependency = topLevelBuilder.FirstOrDefault(
@@ -47,11 +49,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
 
             if (shouldApplyAlias)
             {
+                filterAnyChanges = true;
                 if (matchingDependency != null)
                 {
                     matchingDependency = matchingDependency.SetProperties(caption: matchingDependency.Alias);
+                    worldBuilder.Remove(matchingDependency.Id);
+                    worldBuilder.Add(matchingDependency.Id, matchingDependency);
+                    topLevelBuilder.Remove(matchingDependency);
                     topLevelBuilder.Add(matchingDependency);
-                    worldBuilder[matchingDependency.Id] = matchingDependency;
                 }
 
                 resultDependency = resultDependency.SetProperties(caption: dependency.Alias);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/IDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/IDependenciesSnapshotFilter.cs
@@ -20,12 +20,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
         ///     Returns original or modified dependency depending on filter's logic. 
         ///     If returns null, snapshot does not do any updates for this dependency.
         /// </returns>
+        /// <param name="projectPath">Path to current project.</param>
+        /// <param name="targetFramework">Target framework for which dependency was resolved.</param>
+        /// <param name="dependency">The dependency to which filter should be applied.</param>
+        /// <param name="worldBuilder">Builder for immutable world dictionary of updating snapshot.</param>
+        /// <param name="topLevelBuilder">Top level dependencies list builder of updating snapshot.</param>
+        /// <param name="filterAnyChanges">True if filter did any changes in the snapshot</param>
+        /// <returns>Dependency to be added if addition is approved, null if dependency should not be added to snapshot</returns>
         IDependency BeforeAdd(
             string projectPath,
             ITargetFramework targetFramework,
             IDependency dependency, 
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
-            ImmutableHashSet<IDependency>.Builder topLevelBuilder);
+            ImmutableHashSet<IDependency>.Builder topLevelBuilder,
+            out bool filterAnyChanges);
 
         /// <summary>
         /// Is called before removing a given dependecy.
@@ -35,11 +43,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
         /// <param name="dependency">The dependency to which filter should be applied.</param>
         /// <param name="worldBuilder">Builder for immutable world dictionary of updating snapshot.</param>
         /// <param name="topLevelBuilder">Top level dependencies list builder of updating snapshot.</param>
-        void BeforeRemove(
+        /// <param name="filterAnyChanges">True if filter did any changes in the snapshot</param>
+        /// <returns>Dependency itself if removal is approved, null if dependency should not be removed</returns>
+        IDependency BeforeRemove(
             string projectPath,
             ITargetFramework targetFramework,
             IDependency dependency, 
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
-            ImmutableHashSet<IDependency>.Builder topLevelBuilder);
+            ImmutableHashSet<IDependency>.Builder topLevelBuilder,
+            out bool filterAnyChanges);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/UnresolvedDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/UnresolvedDependenciesSnapshotFilter.cs
@@ -24,8 +24,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             ITargetFramework targetFramework,
             IDependency dependency, 
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
-            ImmutableHashSet<IDependency>.Builder topLevelBuilder)
+            ImmutableHashSet<IDependency>.Builder topLevelBuilder,
+            out bool filterAnyChanges)
         {
+            filterAnyChanges = false;
+
             if (dependency.Resolved == false && worldBuilder.Keys.Contains(dependency.Id))
             {
                 return null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependency.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 {
@@ -13,19 +13,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
     internal interface IDependency : IEquatable<IDependency>, IComparable<IDependency>, IDependencyModel
     {
         /// <summary>
-        /// Specifies if there is unresolved child somwhere in the dependency graph
+        /// Target framework of the snapshot dependency belongs to
         /// </summary>
-        bool HasUnresolvedDependency { get; }
-
-        /// <summary>
-        /// A list of direct child dependencies
-        /// </summary>
-        IEnumerable<IDependency> Dependencies { get; }
-
-        /// <summary>
-        /// Targeted snapshot dependnecy belong to.
-        /// </summary>
-        ITargetedDependenciesSnapshot Snapshot { get; }
+        ITargetFramework TargetFramework { get; }
 
         /// <summary>
         /// Alias is used to de-dupe tree nodes in the CPS tree. If there are seberal nodes in the same

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/ITargetedDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/ITargetedDependenciesSnapshot.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
@@ -56,5 +57,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         /// <param name="providerType">Provider type to check</param>
         /// <returns>Returns true if there is at least one unresolved dependency with given providerType.</returns>
         bool CheckForUnresolvedDependencies(string providerType);
+
+        /// <summary>
+        /// Returns a list of direct child nodes for given dependency
+        /// </summary>
+        /// <param name="dependency"></param>
+        /// <returns></returns>
+        IEnumerable<IDependency> GetDependencyChildren(IDependency dependency);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
@@ -32,12 +32,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         }
 
         public string ProjectPath { get; }
+
         public ITargetFramework TargetFramework { get; }
+
         public IProjectCatalogSnapshot Catalogs { get; }
+
         public ImmutableHashSet<IDependency> TopLevelDependencies { get; private set; } 
             = ImmutableHashSet<IDependency>.Empty;
+
         public ImmutableDictionary<string, IDependency> DependenciesWorld { get; private set; }
             = ImmutableDictionary<string, IDependency>.Empty;
+
+        private readonly object _snapshotLock = new object();
+
+        private Dictionary<string, IDependency> _topLevelDependenciesByPathMap
+            = new Dictionary<string, IDependency>(StringComparer.OrdinalIgnoreCase);
+
+        private Dictionary<string, IList<IDependency>> _dependenciesChildrenMap
+            = new Dictionary<string, IList<IDependency>>(StringComparer.OrdinalIgnoreCase);
+
+        private Dictionary<string, bool> _unresolvedDescendantsMap 
+            = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
 
         private bool? _hasUresolvedDependency;
         public bool HasUnresolvedDependency
@@ -57,8 +72,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             }
         }
 
-        private Dictionary<string, bool> _unresolvedDescendantsMap 
-            = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
         public bool CheckForUnresolvedDependencies(IDependency dependency)
         {
             if (_unresolvedDescendantsMap.TryGetValue(dependency.Id, out bool hasUnresolvedDescendants))
@@ -75,12 +88,34 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                     x => x.ProviderType.Equals(providerType, StringComparison.OrdinalIgnoreCase) && !x.Resolved);
         }
 
+        public IEnumerable<IDependency> GetDependencyChildren(IDependency dependency)
+        {
+            lock (_snapshotLock)
+            {
+                if (!_dependenciesChildrenMap.TryGetValue(dependency.Id, out IList<IDependency> children))
+                {
+                    children = new List<IDependency>();
+                    foreach (var id in dependency.DependencyIDs)
+                    {
+                        if (TryToFindDependency(id, out IDependency child))
+                        {
+                            children.Add(child);
+                        }
+                    }
+
+                    _dependenciesChildrenMap.Add(dependency.Id, children);
+                }
+
+                return children;
+            }
+        }
+
         private bool FindUnresolvedDependenciesRecursive(IDependency dependency)
         {
             var result = false;
             if (dependency.DependencyIDs.Count > 0)
             {
-                foreach (var child in dependency.Dependencies)
+                foreach (var child in GetDependencyChildren(dependency))
                 {
                     if (!child.Resolved)
                     {
@@ -105,14 +140,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             return result;
         }
 
+        private bool TryToFindDependency(string id, out IDependency dependency)
+        {
+            if (DependenciesWorld.TryGetValue(id, out dependency))
+            {
+                return true;
+            }
+
+            return _topLevelDependenciesByPathMap.TryGetValue(id, out dependency);
+        }
+
         private bool MergeChanges(
             IDependenciesChanges changes, 
             IEnumerable<IDependenciesSnapshotFilter> snapshotFilters)
         {
-            var topLevelBuilder = TopLevelDependencies.ToBuilder();
             var worldBuilder = ImmutableDictionary.CreateBuilder<string, IDependency>(
                                     StringComparer.OrdinalIgnoreCase);
             worldBuilder.AddRange(DependenciesWorld);
+            var topLevelBuilder = ImmutableHashSet.CreateBuilder<IDependency>();
+            topLevelBuilder.AddRange(TopLevelDependencies);
+
             var anyChanges = false;
 
             foreach (var removed in changes.RemovedNodes)
@@ -123,25 +170,50 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                     continue;
                 }
 
-                snapshotFilters.ForEach(
-                    filter => filter.BeforeRemove(ProjectPath, TargetFramework, dependency, worldBuilder, topLevelBuilder));
+                if (snapshotFilters != null)
+                {
+                    foreach (var filter in snapshotFilters)
+                    {
+                        dependency = filter.BeforeRemove(
+                            ProjectPath, TargetFramework, dependency, worldBuilder, topLevelBuilder, out bool filterAnyChanges);
+
+                        anyChanges |= filterAnyChanges;
+
+                        if (dependency == null)
+                        {
+                            break;
+                        }
+                    }
+                }
+
+                if (dependency == null)
+                {
+                    continue;
+                }
 
                 anyChanges = true;
 
                 worldBuilder.Remove(targetedId);
-                topLevelBuilder.Remove(dependency);             
+                topLevelBuilder.Remove(dependency);
             }
 
             foreach (var added in changes.AddedNodes)
             {
-                IDependency newDependency = new Dependency(added, this);
-                
-                foreach(var filter in snapshotFilters)
+                IDependency newDependency = new Dependency(added, TargetFramework);
+
+                if (snapshotFilters != null)
                 {
-                    newDependency = filter.BeforeAdd(ProjectPath, TargetFramework, newDependency, worldBuilder, topLevelBuilder);
-                    if (newDependency == null)
+                    foreach (var filter in snapshotFilters)
                     {
-                        break;
+                        newDependency = filter.BeforeAdd(
+                            ProjectPath, TargetFramework, newDependency, worldBuilder, topLevelBuilder, out bool filterAnyChanges);
+
+                        anyChanges |= filterAnyChanges;
+
+                        if (newDependency == null)
+                        {
+                            break;
+                        }
                     }
                 }
 
@@ -164,7 +236,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             DependenciesWorld = worldBuilder.ToImmutable();
             TopLevelDependencies = topLevelBuilder.ToImmutable();
 
+            ConstructTopLevelDependenciesByPathMap();
+
             return anyChanges;
+        }
+
+        private void ConstructTopLevelDependenciesByPathMap()
+        {
+            foreach (var topLevelDependency in TopLevelDependencies)
+            {
+                if (!string.IsNullOrEmpty(topLevelDependency.Path))
+                {
+                    _topLevelDependenciesByPathMap.Add(
+                        Dependency.GetID(TargetFramework, topLevelDependency.ProviderType, topLevelDependency.Path),
+                        topLevelDependency);
+                }
+            }
         }
 
         public static TargetedDependenciesSnapshot FromChanges(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ProjectRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ProjectRuleHandler.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
@@ -34,7 +33,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             SnapshotProvider = snapshotProvider;
             CommonServices = commonServices;
 
-            // TODO unsubscribe
             AggregateSnapshotProvider.SnapshotChanged += OnSnapshotChanged;
             AggregateSnapshotProvider.SnapshotProviderUnloading += OnSnapshotProviderUnloading;
 
@@ -150,7 +148,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 FireDependenciesChanged(
                     new DependenciesChangedEventArgs(
                         this, 
-                        dependency.Snapshot.TargetFramework.Moniker, 
+                        dependency.TargetFramework.Moniker, 
                         changes, 
                         catalogs:null, 
                         dataSourceVersions:null));


### PR DESCRIPTION
**Customer scenario**

Leaking and rapid memory growth when dependencies nodes hierarchies were opened and/or user added new dependencies.

**Bugs this fixes:** 

https://github.com/dotnet/project-system/issues/1979

Even though there might be many changes, but no panic :), essentially what they do is:

- remove Snapshot property from IDependency and fixing all corresponding code paths
- for GraphNodes we avoid to store IDependency objects complettely, since graph nodes logic is gready and keeps lots of objects in memory and IDependency is pretty fat. To avoid that we keep minimum info in graph nodes.
- Fix memory leak in DependenciesSubscriptionHost - forgot to unsubscribe from event.
- updated unit tests

**Workarounds, if any**

None

**Risk**

Medium

**Performance impact**

Improved performance and memory consumption

**Is this a regression from a previous update?**

No

**Root cause analysis:**



**How was the bug found?**

Memory analysis
