### PR TITLE
Ap/u3/properties

### DIFF
--- a/src/Targets/Microsoft.Managed.DesignTime.targets
+++ b/src/Targets/Microsoft.Managed.DesignTime.targets
@@ -169,7 +169,7 @@
   <ItemGroup Condition="'$(DefineCommonManagedReferenceSchemas)' == 'true'">
     <!-- Assembly references -->
     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)AssemblyReference.xaml">
-      <Context>;BrowseObject</Context>
+      <Context>Project;BrowseObject</Context>
     </PropertyPageSchema>
 
     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)ResolvedAssemblyReference.xaml">
@@ -178,7 +178,7 @@
 
     <!-- COM references -->
     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)COMReference.xaml">
-      <Context>;BrowseObject</Context>
+      <Context>Project;BrowseObject</Context>
     </PropertyPageSchema>
 
     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)ResolvedCOMReference.xaml">
@@ -187,7 +187,7 @@
 
     <!-- Project references -->
     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)ProjectReference.xaml">
-      <Context>;BrowseObject</Context>
+      <Context>Project;BrowseObject</Context>
     </PropertyPageSchema>
 
     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)ResolvedProjectReference.xaml">


### PR DESCRIPTION
**Customer scenario**

Showing correct tool window instead of a dialog for browse properties for dependencies

**Bugs this fixes:** 

https://github.com/dotnet/project-system/issues/397

**Workarounds, if any**


**Risk**

Minimal

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

**Is this a regression from a previous update?**

**Root cause analysis:**

We inherrited File context for all properties since we hade ";" in front of xaml rules registrations, and for files CPS by default shows that dialog with properties. 

**How was the bug found?**

(E.g. customer reported it vs. ad hoc testing)
