### PR TITLE
Fix for 1965 Attempting to show properties of certain references disp…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -560,7 +560,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var schema = browseObjectsCatalog.GetSchema(dependency.SchemaName);
             var itemSpec = string.IsNullOrEmpty(dependency.OriginalItemSpec) ? dependency.Path : dependency.OriginalItemSpec;
             var context = ProjectPropertiesContext.GetContext(UnconfiguredProject,
-                file: itemSpec,
                 itemType: dependency.SchemaItemType,
                 itemName: itemSpec);
 


### PR DESCRIPTION
**Customer scenario**

When user has non elevated VS selecting properties generates exceptions "file access violation" 

**Bugs this fixes:** 

https://github.com/dotnet/project-system/issues/1965

**Workarounds, if any**

No

**Risk**

Small

**Performance impact**

N/A

**Is this a regression from a previous update?**

**Root cause analysis:**

Potential CPS issue, however we should provide different property context anyway

**How was the bug found?**

(E.g. customer reported it vs. ad hoc testing)
