### PR TITLE
Fix for 2002 to show properties for nodes that had their resolved sta…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyFactory.cs
@@ -34,6 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                                             ProjectTreeFlags? setPropertiesFlags = null,
                                             bool? equals = null,
                                             IImmutableList<string> setPropertiesDependencyIDs = null,
+                                            string setPropertiesSchemaName = null,
                                             ITargetFramework targetFramework = null,
                                             MockBehavior? mockBehavior = null)
         {
@@ -105,7 +106,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 || setPropertiesResolved != null
                 || setPropertiesFlags != null)
             {
-                mock.Setup(x => x.SetProperties(setPropertiesCaption, setPropertiesResolved, setPropertiesFlags, setPropertiesDependencyIDs))
+                mock.Setup(x => x.SetProperties(
+                            setPropertiesCaption, 
+                            setPropertiesResolved, 
+                            setPropertiesFlags,
+                            setPropertiesSchemaName, 
+                            setPropertiesDependencyIDs))
                     .Returns(mock.Object);
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/SdkAndPackagesDependenciesSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/SdkAndPackagesDependenciesSnapshotFilterTests.cs
@@ -55,6 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 topLevel: true,
                 setPropertiesDependencyIDs: dependencyIDs,
                 setPropertiesResolved:true,
+                setPropertiesSchemaName: ResolvedSdkReference.SchemaName,
                 setPropertiesFlags: flags);
 
             var otherDependency = IDependencyFactory.Implement(
@@ -128,8 +129,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var mockTargetFramework = ITargetFrameworkFactory.Implement(moniker: "tfm");
 
             var dependency = IDependencyFactory.Implement(
-                flags: DependencyTreeFlags.PackageNodeFlags,
                 id: "mydependency1id",
+                flags: DependencyTreeFlags.PackageNodeFlags,
                 name: "mydependency1",
                 topLevel: true,
                 resolved: true,
@@ -137,12 +138,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             var flags = DependencyTreeFlags.PackageNodeFlags
                                            .Union(DependencyTreeFlags.ResolvedFlags)
-                                            .Except(DependencyTreeFlags.UnresolvedFlags);
+                                           .Except(DependencyTreeFlags.UnresolvedFlags);
             var sdkDependency = IDependencyFactory.Implement(
                     id: $"tfm\\{SdkRuleHandler.ProviderTypeString}\\mydependency1",
+                    flags: DependencyTreeFlags.PackageNodeFlags.Union(DependencyTreeFlags.UnresolvedFlags), // to see if unresolved is fixed
                     setPropertiesResolved:true,
                     setPropertiesDependencyIDs: dependencyIDs,
                     setPropertiesFlags: flags,
+                    setPropertiesSchemaName: ResolvedSdkReference.SchemaName,
                     equals:true);
 
             var worldBuilder = new Dictionary<string, IDependency>()
@@ -187,8 +190,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                            .Except(DependencyTreeFlags.ResolvedFlags);
             var sdkDependency = IDependencyFactory.Implement(
                     id: $"tfm\\{SdkRuleHandler.ProviderTypeString}\\mydependency1",
+                    flags: DependencyTreeFlags.SdkSubTreeNodeFlags.Union(DependencyTreeFlags.ResolvedFlags), // to see if resolved is fixed
                     setPropertiesDependencyIDs: dependencyIDs,
                     setPropertiesResolved: false,
+                    setPropertiesSchemaName: SdkReference.SchemaName,
                     setPropertiesFlags: flags);
 
             var worldBuilder = new Dictionary<string, IDependency>()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependency.cs
@@ -42,6 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             string caption = null,
             bool? resolved = null,
             ProjectTreeFlags? flags = null,
+            string schemaName = null,
             IImmutableList<string> dependencyIDs = null)
         {
             return this;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnsupportedProjectsSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnsupportedProjectsSnapshotFilterTests.cs
@@ -108,6 +108,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     flags: DependencyTreeFlags.ProjectNodeFlags.Union(DependencyTreeFlags.ResolvedFlags),
                     originalItemSpec:@"c:\myproject2\project.csproj",
                     setPropertiesResolved:false,
+                    setPropertiesSchemaName:ProjectReference.SchemaName,
                     setPropertiesFlags: DependencyTreeFlags.ProjectNodeFlags.Union(DependencyTreeFlags.UnresolvedFlags));
 
             var filter = new UnsupportedProjectsSnapshotFilter(aggregateSnapshotProvider, targetFrameworkProvider);
@@ -136,6 +137,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     flags: DependencyTreeFlags.ProjectNodeFlags.Union(DependencyTreeFlags.ResolvedFlags),
                     originalItemSpec: @"c:\myproject2\project.csproj",
                     setPropertiesResolved: false,
+                    setPropertiesSchemaName: ProjectReference.SchemaName,
                     setPropertiesFlags: DependencyTreeFlags.ProjectNodeFlags.Union(DependencyTreeFlags.UnresolvedFlags));
 
             var filter = new UnsupportedProjectsSnapshotFilter(aggregateSnapshotProvider, null);
@@ -173,6 +175,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     originalItemSpec: @"c:\myproject2\project.csproj",
                     targetFramework: targetFramework,
                     setPropertiesResolved: false,
+                    setPropertiesSchemaName: ProjectReference.SchemaName,
                     setPropertiesFlags: DependencyTreeFlags.ProjectNodeFlags.Union(DependencyTreeFlags.UnresolvedFlags));
 
             var filter = new UnsupportedProjectsSnapshotFilter(aggregateSnapshotProvider, targetFrameworkProvider);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
@@ -163,9 +163,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         public string Alias => GetAlias(this);
 
         public IDependency SetProperties(
-            string caption = null, 
+            string caption = null,
             bool? resolved = null,
             ProjectTreeFlags? flags = null,
+            string schemaName = null,
             IImmutableList<string> dependencyIDs = null)
         {
             var clone = new Dependency(this, _modelId);
@@ -183,6 +184,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             if (flags != null)
             {
                 clone.Flags = flags.Value;
+            }
+
+            if (schemaName != null)
+            {
+                clone.SchemaName = schemaName;
             }
 
             if (dependencyIDs != null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/SdkAndPackagesDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/SdkAndPackagesDependenciesSnapshotFilter.cs
@@ -46,11 +46,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
                 if (worldBuilder.TryGetValue(packageId, out IDependency package) && package.Resolved)
                 {
                     filterAnyChanges = true;
-                    resultDependency = dependency.SetProperties(
-                        dependencyIDs:package.DependencyIDs, 
-                        resolved:true,
-                        flags:dependency.Flags.Union(DependencyTreeFlags.ResolvedFlags)
-                                              .Except(DependencyTreeFlags.UnresolvedFlags));
+                    resultDependency = dependency.ToResolved(
+                        schemaName: ResolvedSdkReference.SchemaName,
+                        dependencyIDs:package.DependencyIDs);
                 }
             }
             else if (dependency.Flags.Contains(DependencyTreeFlags.PackageNodeFlags) && dependency.Resolved)
@@ -62,11 +60,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
                 if (worldBuilder.TryGetValue(sdkId, out IDependency sdk))
                 {
                     filterAnyChanges = true;
-                    sdk = sdk.SetProperties(
-                        dependencyIDs:dependency.DependencyIDs, 
-                        resolved:true,
-                        flags: dependency.Flags.Union(DependencyTreeFlags.ResolvedFlags)
-                                               .Except(DependencyTreeFlags.UnresolvedFlags));
+                    sdk = sdk.ToResolved(
+                        schemaName: ResolvedSdkReference.SchemaName,
+                        dependencyIDs: dependency.DependencyIDs);
 
                     worldBuilder.Remove(sdk.Id);
                     worldBuilder.Add(sdk.Id, sdk);
@@ -102,12 +98,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
                 {
                     filterAnyChanges = true;
                     // clean up sdk when corresponding package is removing
-                    sdk = sdk.SetProperties(
-                        dependencyIDs:ImmutableList<string>.Empty, 
-                        resolved:false,
-                        flags: DependencyTreeFlags.SdkSubTreeNodeFlags
-                                                  .Union(DependencyTreeFlags.UnresolvedFlags)
-                                                  .Except(DependencyTreeFlags.ResolvedFlags));
+                    sdk = sdk.ToUnresolved(
+                        schemaName: SdkReference.SchemaName,
+                        dependencyIDs:ImmutableList<string>.Empty);
+
                     worldBuilder.Remove(sdk.Id);
                     worldBuilder.Add(sdk.Id, sdk);
                     topLevelBuilder.Remove(sdk);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/UnsupportedProjectsSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/UnsupportedProjectsSnapshotFilter.cs
@@ -3,6 +3,7 @@
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Filters
 {
@@ -51,9 +52,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
                 if (snapshot == null || snapshot.HasUnresolvedDependency)
                 {
                     filterAnyChanges = true;
-                    var unresolvedFlags = dependency.Flags.Union(DependencyTreeFlags.UnresolvedFlags)
-                                                          .Except(DependencyTreeFlags.ResolvedFlags);
-                    resultDependency = resultDependency.SetProperties(resolved: false, flags: unresolvedFlags);
+                    resultDependency = resultDependency.ToUnresolved(ProjectReference.SchemaName);
                 }
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependency.cs
@@ -32,6 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             string caption = null,
             bool? resolved = null,
             ProjectTreeFlags? flags = null,
+            string schemaName = null,
             IImmutableList<string> dependencyIDs = null);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models;
@@ -106,6 +107,40 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             }
 
             return dependencyProjectPath;
+        }
+        
+        public static IDependency ToResolved(this IDependency dependency,
+                                             string schemaName = null,
+                                             IImmutableList<string> dependencyIDs = null)
+        {
+            return dependency.SetProperties(
+                resolved: true,
+                flags: dependency.GetResolvedFlags(),
+                schemaName: schemaName,
+                dependencyIDs:dependencyIDs);
+        }
+
+        public static IDependency ToUnresolved(this IDependency dependency,
+                                               string schemaName = null,
+                                               IImmutableList<string> dependencyIDs = null)
+        {
+            return dependency.SetProperties(
+                resolved: false,
+                flags: dependency.GetUnresolvedFlags(),
+                schemaName: schemaName,
+                dependencyIDs: dependencyIDs);
+        }
+
+        public static ProjectTreeFlags GetResolvedFlags(this IDependency dependency)
+        {
+            return dependency.Flags.Union(DependencyTreeFlags.ResolvedFlags)
+                                   .Except(DependencyTreeFlags.UnresolvedFlags);
+        }
+
+        public static ProjectTreeFlags GetUnresolvedFlags(this IDependency dependency)
+        {
+            return dependency.Flags.Union(DependencyTreeFlags.UnresolvedFlags)
+                                   .Except(DependencyTreeFlags.ResolvedFlags);
         }
     }
 }


### PR DESCRIPTION
Sdk nodes (we always set their state programmatically and project node references that have some unsupported dependencies which we mark as unresolved , don't show properties. Fix is easy - we forgot to change IRule schema name when were changing resolved state.

For customers properties tool window would not be displayed for such nodes.

**Bugs this fixes:** 

https://github.com/dotnet/project-system/issues/2002

**Workarounds, if any**

None

**Risk**

Minimal/none

**Performance impact**

None

**Is this a regression from a previous update?**
Yes

**Root cause analysis:**

Small regression, after dependencies logic refactoring

**How was the bug found?**

(E.g. customer reported it vs. ad hoc testing)
