### PR TITLE
Enable VB Advanced Compile Options page

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
@@ -21,7 +21,7 @@
   <EnumProperty Name="PlatformTarget" DisplayName="Platform Target" Visible="False"/>
   <BoolProperty Name="Prefer32Bit" DisplayName="Prefer 32Bit" Visible="False"/>
   <BoolProperty Name="AllowUnsafeBlocks"  Default="False"  DisplayName="Allow unsafe code" Visible="False"/>
-  <StringProperty Name="Optimize" DisplayName="Optimize" Visible="False"/>
+  <BoolProperty Name="Optimize" DisplayName="Optimize" Visible="False"/>
   <StringProperty Name="NoWarn" DisplayName="Supress Warning" Visible="False"/>
   <BoolProperty Name="TreatWarningsAsErrors"  Default="False" Description="Treat warnings as errors" Visible="False"/>
   <StringProperty Name="TreatSpecificWarningsAsErrors"  Description="Treat specific warnings as errors" Visible="False" />
@@ -61,7 +61,6 @@
       <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectDirectory" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
-
   <DynamicEnumProperty Name="WarningLevel" DisplayName="Warning Level" EnumProvider="WarningLevelEnumProvider" Visible="False">
     <DynamicEnumProperty.DataSource>
       <DataSource Persistence="ProjectFile" HasConfigurationCondition="True" SourceOfDefaultValue="AfterContext" />
@@ -90,10 +89,15 @@
     <EnumValue Name="Off" DisplayName="Off" />
     <EnumValue Name="On" DisplayName="On" IsDefault="True" />
   </EnumProperty>
-
   <DynamicEnumProperty Name="OptionStrict" DisplayName="Option Strict" EnumProvider="OptionStrictEnumProvider" Visible="False">
     <DynamicEnumProperty.DataSource>
       <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
     </DynamicEnumProperty.DataSource>
   </DynamicEnumProperty>
+
+  <!-- VB Advanced Compile Options-->
+  <BoolProperty Name="RemoveIntegerChecks" DisplayName="Remove Integer Checks" Visible="False" />
+  <BoolProperty Name="DefineDebug" DisplayName="Define Debug" Visible="False" />
+  <BoolProperty Name="DefineTrace" DisplayName="Define Trace" Visible="False" />
+
 </Rule>


### PR DESCRIPTION
This is a follow up PR for #2004. Only the last commit is a new commit and the rest of the commits are part of 2004.

**Customer scenario**

Enable VB advanced compile options page. 

**Bugs this fixes:** 

#346 

**Workarounds, if any**

None

**Risk**

Low risk - since this just affects that page

**Performance impact**

None - since this is a new page, which just reflects the msbuild properties like any other page.

**Is this a regression from a previous update?** N/A

**Root cause analysis:** N/A

**How was the bug found?** N/A
