### PR TITLE
Add VB compile build events

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
@@ -100,4 +100,23 @@
   <BoolProperty Name="DefineDebug" DisplayName="Define Debug" Visible="False" />
   <BoolProperty Name="DefineTrace" DisplayName="Define Trace" Visible="False" />
 
+  <!-- VB Compile Build Event Page-->
+  <StringProperty Name="PreBuildEvent" DisplayName="Pre Build Event" Visible="False">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+  <StringProperty Name="PostBuildEvent" DisplayName="Post Build Event" Visible="False">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+  <EnumProperty Name="RunPostBuildEvent" DisplayName="Run Post-Build Event" Visible="False">
+    <EnumProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="RunPostBuildEvent" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+    </EnumProperty.DataSource>
+    <EnumValue Name="Always" DisplayName="Always" />
+    <EnumValue Name="OnBuildSuccess" DisplayName="On successful build"  IsDefault="True"/>
+    <EnumValue Name="OnOutputUpdated" DisplayName="When the build updates the project output" />
+  </EnumProperty>
 </Rule>


### PR DESCRIPTION
This is a follow up PR for #2004. Only the last commit is the new commit and the rest of the commits are part of #2004 and #2005.

**Customer scenario**

Enable VB Compile page - Build events page.

**Bugs this fixes:** 

#346 

**Workarounds, if any**

None

**Risk**

Low risk - since this just affects that page

**Performance impact**

None - since this is a new page, which just reflects the msbuild properties like any other page.

**Is this a regression from a previous update?** N/A

**Root cause analysis:** N/A

**How was the bug found?** N/A
