### PR TITLE
Fix for two related issues 1959 and 1250 where we need to read project xml to determine if dependency is implicit or not

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyFactory.cs
@@ -28,10 +28,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                                             IEnumerable<string> dependencyIDs = null,
                                             bool? resolved = null,
                                             bool? topLevel = null,
+                                            bool? isImplicit = null,
                                             ProjectTreeFlags? flags = null,
                                             string setPropertiesCaption = null,
                                             bool? setPropertiesResolved = null,
                                             ProjectTreeFlags? setPropertiesFlags = null,
+                                            bool? setPropertiesImplicit = null,
                                             bool? equals = null,
                                             IImmutableList<string> setPropertiesDependencyIDs = null,
                                             string setPropertiesSchemaName = null,
@@ -91,6 +93,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 mock.Setup(x => x.TopLevel).Returns(topLevel.Value);
             }
 
+            if (isImplicit != null && isImplicit.HasValue)
+            {
+                mock.Setup(x => x.Implicit).Returns(isImplicit.Value);
+            }
+
             if (flags != null && flags.HasValue)
             {
                 mock.Setup(x => x.Flags).Returns(flags.Value);
@@ -104,14 +111,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             if (setPropertiesCaption != null 
                 || setPropertiesDependencyIDs != null 
                 || setPropertiesResolved != null
-                || setPropertiesFlags != null)
+                || setPropertiesFlags != null
+                || setPropertiesImplicit != null)
             {
                 mock.Setup(x => x.SetProperties(
                             setPropertiesCaption, 
                             setPropertiesResolved, 
                             setPropertiesFlags,
                             setPropertiesSchemaName, 
-                            setPropertiesDependencyIDs))
+                            setPropertiesDependencyIDs,
+                            It.IsAny<ImageMoniker>(),
+                            setPropertiesImplicit))
                     .Returns(mock.Object);
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectDependenciesSubTreeProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectDependenciesSubTreeProviderFactory.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 using Moq;
@@ -33,5 +35,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             
             return mock.Object;
         }
+
+        public static IProjectDependenciesSubTreeProviderInternal ImplementInternal(
+            string providerType = null,
+            ImageMoniker icon = new ImageMoniker(),
+            MockBehavior? mockBehavior = null)
+        {
+            var behavior = mockBehavior ?? MockBehavior.Strict;
+            var mock = new Mock<IProjectDependenciesSubTreeProviderInternal>(behavior);
+
+            if (providerType != null)
+            {
+                mock.Setup(x => x.ProviderType).Returns(providerType);
+            }
+
+            if (icon.Id != 0 || icon.Guid != Guid.Empty)
+            {
+                mock.Setup(x => x.GetImplicitIcon()).Returns(icon);
+            }
+
+            return mock.Object;
+        }
+
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DuplicatedDependenciesSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DuplicatedDependenciesSnapshotFilterTests.cs
@@ -43,6 +43,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 dependency.Object,
                 worldBuilder,
                 topLevelBuilder,
+                null,
+                null,
                 out bool filterAnyChanges);
 
             Assert.False(worldBuilder.ContainsKey(otherDependency.Object.Id));
@@ -87,6 +89,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 dependency.Object,
                 worldBuilder,
                 topLevelBuilder,
+                null,
+                null,
                 out bool filterAnyChanges);
 
             Assert.True(worldBuilder.ContainsKey(otherDependency.Object.Id));
@@ -129,6 +133,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 dependency.Object,
                 worldBuilder,
                 topLevelBuilder,
+                null,
+                null,
                 out bool filterAnyChanges);
 
             Assert.False(worldBuilder.ContainsKey(otherDependency.Object.Id));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/ImplicitTopLevelDependenciesSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/ImplicitTopLevelDependenciesSnapshotFilterTests.cs
@@ -1,0 +1,217 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Filters;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
+{
+    [ProjectSystemTrait]
+    public class ImplicitTopLevelDependenciesSnapshotFilterTests
+    {
+        [Fact]
+        public void ImplicitTopLevelDependenciesSnapshotFilter_WhenNotTopLevel_ShouldDoNothing()
+        {
+            var dependency = IDependencyFactory.Implement(
+                id: "mydependency2",
+                topLevel: false);
+
+            var worldBuilder = new Dictionary<string, IDependency>()
+            {
+                { dependency.Object.Id, dependency.Object }
+            }.ToImmutableDictionary().ToBuilder();
+
+            var filter = new ImplicitTopLevelDependenciesSnapshotFilter();
+
+            var resultDependency = filter.BeforeAdd(
+                null,
+                null,
+                dependency.Object,
+                worldBuilder,
+                null,
+                null,
+                null,
+                out bool filterAnyChanges);
+
+            Assert.Equal(dependency.Object.Id, resultDependency.Id);
+            Assert.False(filterAnyChanges);
+
+            dependency.VerifyAll();
+        }
+
+        [Fact]
+        public void ImplicitTopLevelDependenciesSnapshotFilter_WhenImplicitAlready_ShouldDoNothing()
+        {
+            var dependency = IDependencyFactory.Implement(
+                id: "mydependency2",
+                topLevel: true,
+                isImplicit: true);
+
+            var worldBuilder = new Dictionary<string, IDependency>()
+            {
+                { dependency.Object.Id, dependency.Object }
+            }.ToImmutableDictionary().ToBuilder();
+
+            var filter = new ImplicitTopLevelDependenciesSnapshotFilter();
+
+            var resultDependency = filter.BeforeAdd(
+                null,
+                null,
+                dependency.Object,
+                worldBuilder,
+                null,
+                null,
+                null,
+                out bool filterAnyChanges);
+
+            Assert.Equal(dependency.Object.Id, resultDependency.Id);
+            Assert.False(filterAnyChanges);
+
+            dependency.VerifyAll();
+        }
+
+        [Fact]
+        public void ImplicitTopLevelDependenciesSnapshotFilter_WhenUnresolved_ShouldDoNothing()
+        {
+            var dependency = IDependencyFactory.Implement(
+                id: "mydependency2",
+                topLevel: true,
+                isImplicit: false,
+                resolved: false);
+
+            var worldBuilder = new Dictionary<string, IDependency>()
+            {
+                { dependency.Object.Id, dependency.Object }
+            }.ToImmutableDictionary().ToBuilder();
+           
+            var filter = new ImplicitTopLevelDependenciesSnapshotFilter();
+
+            var resultDependency = filter.BeforeAdd(
+                null,
+                null,
+                dependency.Object,
+                worldBuilder,
+                null,
+                null,
+                null,
+                out bool filterAnyChanges);
+
+            Assert.Equal(dependency.Object.Id, resultDependency.Id);
+            Assert.False(filterAnyChanges);
+
+            dependency.VerifyAll();
+        }
+
+        [Fact]
+        public void ImplicitTopLevelDependenciesSnapshotFilter_WhenNotGenericDependency_ShouldDoNothing()
+        {
+            var dependency = IDependencyFactory.Implement(
+                id: "mydependency2",
+                topLevel: true,
+                isImplicit: false,
+                resolved: true,
+                flags: DependencyTreeFlags.SubTreeRootNodeFlags);
+
+            var worldBuilder = new Dictionary<string, IDependency>()
+            {
+                { dependency.Object.Id, dependency.Object }
+            }.ToImmutableDictionary().ToBuilder();
+
+            var filter = new ImplicitTopLevelDependenciesSnapshotFilter();
+
+            var resultDependency = filter.BeforeAdd(
+                null,
+                null,
+                dependency.Object,
+                worldBuilder,
+                null,
+                null,
+                null,
+                out bool filterAnyChanges);
+
+            Assert.Equal(dependency.Object.Id, resultDependency.Id);
+            Assert.False(filterAnyChanges);
+
+            dependency.VerifyAll();
+        }
+
+        [Fact]
+        public void ImplicitTopLevelDependenciesSnapshotFilter_WhenCanApplyImplicitProjectContainsItem_ShouldDoNothing()
+        {
+            var dependency = IDependencyFactory.Implement(
+                id: "mydependency2",
+                topLevel: true,
+                isImplicit: false,
+                resolved: true,
+                flags: DependencyTreeFlags.GenericDependencyFlags,
+                originalItemSpec: "myprojectitem");
+
+            var worldBuilder = new Dictionary<string, IDependency>()
+            {
+                { dependency.Object.Id, dependency.Object }
+            }.ToImmutableDictionary().ToBuilder();
+
+            var filter = new ImplicitTopLevelDependenciesSnapshotFilter();
+
+            var resultDependency = filter.BeforeAdd(
+                null,
+                null,
+                dependency.Object,
+                worldBuilder,
+                null,
+                null,
+                new HashSet<string>(new[] { "myprojectitem" }),
+                out bool filterAnyChanges);
+
+            Assert.Equal(dependency.Object.Id, resultDependency.Id);
+            Assert.False(filterAnyChanges);
+
+            dependency.VerifyAll();
+        }
+
+        [Fact]
+        public void ImplicitTopLevelDependenciesSnapshotFilter_WhenNeedToApplyImplicit_ShouldSetProperties()
+        {
+            var dependency = IDependencyFactory.Implement(
+                id: "mydependency2",
+                providerType: "myProvider",
+                topLevel: true,
+                isImplicit: false,
+                resolved: true,
+                flags: DependencyTreeFlags.GenericDependencyFlags,
+                originalItemSpec: "myprojectitem",
+                setPropertiesImplicit: true);
+
+            var worldBuilder = new Dictionary<string, IDependency>()
+            {
+                { dependency.Object.Id, dependency.Object }
+            }.ToImmutableDictionary().ToBuilder();
+
+            var subTreeProvider = IProjectDependenciesSubTreeProviderFactory.ImplementInternal(
+                providerType: "myProvider",
+                icon: KnownMonikers.Abbreviation);
+
+            var filter = new ImplicitTopLevelDependenciesSnapshotFilter();
+            var resultDependency = filter.BeforeAdd(
+                null,
+                null,
+                dependency.Object,
+                worldBuilder,
+                null,
+                new Dictionary<string, IProjectDependenciesSubTreeProvider>
+                {
+                    { subTreeProvider.ProviderType, subTreeProvider }
+                },
+                new HashSet<string>(),
+                out bool filterAnyChanges);
+
+            Assert.Equal(dependency.Object.Id, resultDependency.Id);
+            Assert.True(filterAnyChanges);
+
+            dependency.VerifyAll();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/SdkAndPackagesDependenciesSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/SdkAndPackagesDependenciesSnapshotFilterTests.cs
@@ -33,6 +33,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 dependency.Object,
                 worldBuilder,
                 null,
+                null,
+                null,
                 out bool filterAnyChanges);
 
             dependency.VerifyAll();
@@ -78,6 +80,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 sdkDependency.Object,
                 worldBuilder,
                 topLevelBuilder,
+                null,
+                null,
                 out bool filterAnyChanges);
 
             sdkDependency.VerifyAll();
@@ -114,6 +118,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 mockTargetFramework,
                 dependency.Object,
                 worldBuilder,
+                null,
+                null,
                 null,
                 out bool filterAnyChanges);
 
@@ -163,6 +169,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 dependency.Object,
                 worldBuilder,
                 topLevelBuilder,
+                null,
+                null,
                 out bool filterAnyChanges);
 
             dependency.VerifyAll();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
@@ -77,6 +77,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 changes,
                 catalogs,
                 snapshotFilters,
+                null,
+                null,
                 out bool anyChanges);
 
             Assert.NotNull(snapshot.TargetFramework);
@@ -136,6 +138,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 changes,
                 catalogs,
                 snapshotFilters,
+                null,
+                null,
                 out bool anyChanges);
 
             Assert.NotNull(snapshot.TargetFramework);
@@ -196,6 +200,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 changes,
                 catalogs,
                 new[] { snapshotFilter },
+                null,
+                null,
                 out bool anyChanges);
 
             Assert.NotNull(snapshot.TargetFramework);
@@ -267,6 +273,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 changes,
                 catalogs,
                 new[] { snapshotFilter },
+                null,
+                null,
                 out bool anyChanges);
 
             Assert.NotNull(snapshot.TargetFramework);
@@ -336,6 +344,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 changes,
                 catalogs,
                 new[] { snapshotFilter },
+                null,
+                null,
                 out bool anyChanges);
 
             Assert.NotNull(snapshot.TargetFramework);
@@ -406,6 +416,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 changes,
                 catalogs,
                 new[] { snapshotFilter },
+                null,
+                null,
                 out bool anyChanges);
 
             Assert.NotNull(snapshot.TargetFramework);
@@ -540,6 +552,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 changes,
                 catalogs,
                 new[] { snapshotFilter },
+                null,
+                null,
                 out bool anyChanges);
 
             Assert.NotNull(snapshot.TargetFramework);
@@ -613,6 +627,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 IDependency dependency,
                 ImmutableDictionary<string, IDependency>.Builder worldBuilder,
                 ImmutableHashSet<IDependency>.Builder topLevelBuilder,
+                Dictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
+                HashSet<string> projectItemSpecs,
                 out bool filterAnyChanges)
             {
                 filterAnyChanges = _filterAnyChanges;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependency.cs
@@ -43,7 +43,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             bool? resolved = null,
             ProjectTreeFlags? flags = null,
             string schemaName = null,
-            IImmutableList<string> dependencyIDs = null)
+            IImmutableList<string> dependencyIDs = null,
+            ImageMoniker icon = new ImageMoniker(),
+            bool? isImplicit = null)
         {
             return this;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnresolvedDependenciesSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnresolvedDependenciesSnapshotFilterTests.cs
@@ -34,6 +34,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 dependency.Object,
                 worldBuilder,
                 null,
+                null,
+                null,
                 out bool filterAnyChanges);
 
             Assert.Null(resultDependency);
@@ -61,6 +63,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 dependency.Object,
                 worldBuilder,
                 null,
+                null,
+                null,
                 out bool filterAnyChanges);
 
             Assert.NotNull(resultDependency);
@@ -82,6 +86,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 null,
                 null,
                 dependency.Object,
+                null,
+                null,
                 null,
                 null,
                 out bool filterAnyChanges);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnsupportedProjectsSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnsupportedProjectsSnapshotFilterTests.cs
@@ -56,6 +56,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 dependency.Object,
                 worldBuilder,
                 null,
+                null,
+                null,
                 out bool filterAnyChanges);
 
             resultDependency = filter.BeforeAdd(
@@ -63,6 +65,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 null,
                 topLevelDependency.Object,
                 worldBuilder,
+                null,
+                null,
                 null,
                 out bool filterAnyChanges2);
 
@@ -72,6 +76,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 topLevelResolvedDependency.Object,
                 worldBuilder,
                 null,
+                null,
+                null,
                 out bool filterAnyChanges3);
 
             resultDependency = filter.BeforeAdd(
@@ -79,6 +85,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 null,
                 topLevelResolvedSharedProjectDependency.Object,
                 worldBuilder,
+                null,
+                null,
                 null,
                 out bool filterAnyChanges4);
 
@@ -119,6 +127,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 dependency.Object,
                 null,
                 null,
+                null,
+                null,
                 out bool filterAnyChanges);            
 
             dependency.VerifyAll();
@@ -146,6 +156,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 null,
                 null,
                 dependency.Object,
+                null,
+                null,
                 null,
                 null,
                 out bool filterAnyChanges);
@@ -186,6 +198,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 dependency.Object,
                 null,
                 null,
+                null,
+                null,
                 out bool filterAnyChanges);
 
             dependency.VerifyAll();
@@ -220,6 +234,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 null,
                 null,
                 dependency.Object,
+                null,
+                null,
                 null,
                 null,
                 out bool filterAnyChanges);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -136,7 +136,36 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 return false;
             }
 
-            return nodes.All(node => node.Flags.Contains(DependencyTreeFlags.SupportsRemove));
+            var snapshot = DependenciesSnapshotProvider.CurrentSnapshot;
+            if (snapshot == null)
+            {
+                return false;
+            }
+
+            bool canRemove = true;
+            foreach (var node in nodes)
+            {
+                if (!node.Flags.Contains(DependencyTreeFlags.SupportsRemove))
+                {
+                    canRemove = false;
+                    break;
+                }
+
+                var filePath = UnconfiguredProject.GetRelativePath(node.FilePath);
+                if (string.IsNullOrEmpty(filePath))
+                {
+                    continue;
+                }
+
+                var dependency = snapshot.FindDependency(filePath);
+                if (dependency == null || dependency.Implicit)
+                {
+                    canRemove = false;
+                    break;
+                }
+            }
+
+            return canRemove;
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -329,7 +329,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             {
                 return;
             }
-            
+
             lock (_treeUpdateLock)
             {
                 if (_treeUpdateQueueTask == null || _treeUpdateQueueTask.IsCompleted)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IProjectDependenciesSubTreeProviderInternal.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IProjectDependenciesSubTreeProviderInternal.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Imaging.Interop;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
+{
+    /// <summary>
+    /// Internal extension of <see cref="IProjectDependenciesSubTreeProvider"/> contract,
+    /// to support generic dependencies modifications.
+    /// </summary>
+    internal interface IProjectDependenciesSubTreeProviderInternal : IProjectDependenciesSubTreeProvider
+    {
+        ImageMoniker GetImplicitIcon();
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -79,7 +79,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         private bool MergeChanges(
             ImmutableDictionary<ITargetFramework, IDependenciesChanges> changes,
             IProjectCatalogSnapshot catalogs,
-            IEnumerable<IDependenciesSnapshotFilter> snapshotFilters)
+            IEnumerable<IDependenciesSnapshotFilter> snapshotFilters,
+            IEnumerable<IProjectDependenciesSubTreeProvider> subTreeProviders,
+            HashSet<string> projectItemSpecs)
         {
             var anyChanges = false;
             var builder = _targets.ToBuilder();
@@ -93,6 +95,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                                             change.Value,
                                             catalogs,
                                             snapshotFilters,
+                                            subTreeProviders,
+                                            projectItemSpecs,
                                             out bool anyTfmChanges);
                 builder[change.Key] = newTargetedSnapshot;
 
@@ -139,10 +143,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             IProjectCatalogSnapshot catalogs,
             ITargetFramework activeTargetFramework,
             IEnumerable<IDependenciesSnapshotFilter> snapshotFilters,
+            IEnumerable<IProjectDependenciesSubTreeProvider> subTreeProviders,
+            HashSet<string> projectItemSpecs,
             out bool anyChanges)
         {
             var newSnapshot = new DependenciesSnapshot(projectPath, activeTargetFramework, previousSnapshot);
-            anyChanges = newSnapshot.MergeChanges(changes, catalogs, snapshotFilters);
+            anyChanges = newSnapshot.MergeChanges(changes, catalogs, snapshotFilters, subTreeProviders, projectItemSpecs);
             return newSnapshot;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
@@ -143,9 +143,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         public string Version { get; }
         public bool Resolved { get; private set; }
         public bool TopLevel { get; }
-        public bool Implicit { get; }
+        public bool Implicit { get; private set; }
         public bool Visible { get; }
-        public ImageMoniker Icon { get; }
+        public ImageMoniker Icon { get; private set; }
         public ImageMoniker ExpandedIcon { get; }
         public ImageMoniker UnresolvedIcon { get; }
         public ImageMoniker UnresolvedExpandedIcon { get; }
@@ -167,7 +167,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             bool? resolved = null,
             ProjectTreeFlags? flags = null,
             string schemaName = null,
-            IImmutableList<string> dependencyIDs = null)
+            IImmutableList<string> dependencyIDs = null,
+            ImageMoniker icon = new ImageMoniker(),
+            bool? isImplicit = null)
         {
             var clone = new Dependency(this, _modelId);
 
@@ -194,6 +196,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             if (dependencyIDs != null)
             {
                 clone.DependencyIDs = dependencyIDs;
+            }
+
+            if (icon.Id != 0 && icon.Guid != Guid.Empty)
+            {
+                clone.Icon = icon;
+            }
+
+            if (isImplicit != null)
+            {
+                clone.Implicit = isImplicit.Value;
             }
 
             return clone;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DependenciesSnapshotFilterBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DependenciesSnapshotFilterBase.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 
@@ -16,6 +17,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             IDependency dependency, 
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
             ImmutableHashSet<IDependency>.Builder topLevelBuilder,
+            Dictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
+            HashSet<string> projectItemSpecs,
             out bool filterAnyChanges)
         {
             filterAnyChanges = false;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DuplicatedDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DuplicatedDependenciesSnapshotFilter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Globalization;
@@ -27,6 +28,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             IDependency dependency, 
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
             ImmutableHashSet<IDependency>.Builder topLevelBuilder,
+            Dictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
+            HashSet<string> projectItemSpecs,
             out bool filterAnyChanges)
         {
             filterAnyChanges = false;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/IDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/IDependenciesSnapshotFilter.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 
@@ -25,6 +26,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
         /// <param name="dependency">The dependency to which filter should be applied.</param>
         /// <param name="worldBuilder">Builder for immutable world dictionary of updating snapshot.</param>
         /// <param name="topLevelBuilder">Top level dependencies list builder of updating snapshot.</param>
+        /// <param name="subTreeProviders">All known subtree providers</param>
+        /// <param name="projectItemSpecs">List of all items contained in project's xml at given moment</param>
         /// <param name="filterAnyChanges">True if filter did any changes in the snapshot</param>
         /// <returns>Dependency to be added if addition is approved, null if dependency should not be added to snapshot</returns>
         IDependency BeforeAdd(
@@ -33,6 +36,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             IDependency dependency, 
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
             ImmutableHashSet<IDependency>.Builder topLevelBuilder,
+            Dictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
+            HashSet<string> projectItemSpecs,
             out bool filterAnyChanges);
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/ImplicitTopLevelDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/ImplicitTopLevelDependenciesSnapshotFilter.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Collections.Generic;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Filters
+{
+    /// <summary>
+    /// Changes resolved top level project dependencies to unresolved if:
+    ///     - dependent project does not have targets supporting given target framework in current project
+    ///     - dependent project has any unresolved dependencies in a snapshot for given target framework
+    /// This helps to bubble up error status (yellow icon) for project dependencies.
+    /// </summary>
+    [Export(typeof(IDependenciesSnapshotFilter))]
+    [AppliesTo(ProjectCapability.DependenciesTree)]
+    [Order(Order)]
+    internal class ImplicitTopLevelDependenciesSnapshotFilter : DependenciesSnapshotFilterBase
+    {
+        public const int Order = 130;
+
+        private IAggregateDependenciesSnapshotProvider AggregateSnapshotProvider { get; }
+        private ITargetFrameworkProvider TargetFrameworkProvider { get; }
+
+        public override IDependency BeforeAdd(
+            string projectPath,
+            ITargetFramework targetFramework,
+            IDependency dependency, 
+            ImmutableDictionary<string, IDependency>.Builder worldBuilder,
+            ImmutableHashSet<IDependency>.Builder topLevelBuilder,
+            Dictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
+            HashSet<string> projectItemSpecs,
+            out bool filterAnyChanges)
+        {
+            filterAnyChanges = false;
+            IDependency resultDependency = dependency;
+
+            if (!resultDependency.TopLevel
+                || resultDependency.Implicit                
+                || !resultDependency.Resolved
+                || !resultDependency.Flags.Contains(DependencyTreeFlags.GenericDependencyFlags))
+            {
+                return resultDependency;
+            }
+
+            if (!projectItemSpecs.Contains(resultDependency.OriginalItemSpec))
+            {
+                // it is an implicit dependency
+                if (!subTreeProviders.TryGetValue(resultDependency.ProviderType, out IProjectDependenciesSubTreeProvider provider))
+                {
+                    return resultDependency;
+                }
+
+                var internalProvider = provider as IProjectDependenciesSubTreeProviderInternal;
+                if (internalProvider == null)
+                {
+                    return resultDependency;
+                }
+
+                resultDependency = resultDependency.SetProperties(
+                    icon: internalProvider.GetImplicitIcon(),
+                    isImplicit: true);
+                filterAnyChanges = true;
+            }
+
+            return resultDependency;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/SdkAndPackagesDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/SdkAndPackagesDependenciesSnapshotFilter.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
@@ -27,6 +28,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             IDependency dependency, 
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
             ImmutableHashSet<IDependency>.Builder topLevelBuilder,
+            Dictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
+            HashSet<string> projectItemSpecs,
             out bool filterAnyChanges)
         {
             filterAnyChanges = false;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/UnresolvedDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/UnresolvedDependenciesSnapshotFilter.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Linq;
@@ -25,6 +26,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             IDependency dependency, 
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
             ImmutableHashSet<IDependency>.Builder topLevelBuilder,
+            Dictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
+            HashSet<string> projectItemSpecs,
             out bool filterAnyChanges)
         {
             filterAnyChanges = false;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/UnsupportedProjectsSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/UnsupportedProjectsSnapshotFilter.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 using System.Collections.Immutable;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Filters
 {
@@ -38,6 +38,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             IDependency dependency, 
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
             ImmutableHashSet<IDependency>.Builder topLevelBuilder,
+            Dictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
+            HashSet<string> projectItemSpecs,
             out bool filterAnyChanges)
         {
             filterAnyChanges = false;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependency.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Immutable;
+using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
@@ -33,6 +34,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             bool? resolved = null,
             ProjectTreeFlags? flags = null,
             string schemaName = null,
-            IImmutableList<string> dependencyIDs = null);
+            IImmutableList<string> dependencyIDs = null,
+            ImageMoniker icon = new ImageMoniker(),
+            bool? isImplicit = null);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/AnalyzerRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/AnalyzerRuleHandler.cs
@@ -3,6 +3,7 @@
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models;
 
@@ -46,6 +47,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 resolved,
                 isImplicit,
                 properties);
+        }
+
+        public override ImageMoniker GetImplicitIcon()
+        {
+            return ManagedImageMonikers.CodeInformationPrivate;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/AssemblyRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/AssemblyRuleHandler.cs
@@ -3,6 +3,7 @@
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models;
 
@@ -46,6 +47,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 resolved,
                 isImplicit,
                 properties);
+        }
+
+        public override ImageMoniker GetImplicitIcon()
+        {
+            return ManagedImageMonikers.ReferencePrivate;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ComRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ComRuleHandler.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models;
 
@@ -45,6 +46,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 resolved,
                 isImplicit,
                 properties);
+        }
+
+        public override ImageMoniker GetImplicitIcon()
+        {
+            return ManagedImageMonikers.ComponentPrivate;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependenciesRuleHandlerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependenciesRuleHandlerBase.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
@@ -10,8 +11,8 @@ using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions
 {
     internal abstract class DependenciesRuleHandlerBase : 
-        ICrossTargetRuleHandler<DependenciesRuleChangeContext>, 
-        IProjectDependenciesSubTreeProvider
+        ICrossTargetRuleHandler<DependenciesRuleChangeContext>,
+        IProjectDependenciesSubTreeProviderInternal
     {
         #region ICrossTargetRuleHandler
 
@@ -33,6 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
         protected abstract string UnresolvedRuleName { get; }
         protected abstract string ResolvedRuleName { get; }
+        public abstract ImageMoniker GetImplicitIcon();
 
         /// <summary>
         /// If any standard provider has different OriginalItemSpec property name, 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/PackageRuleHandler.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models;
@@ -33,6 +34,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
         protected override string UnresolvedRuleName { get; } = PackageReference.SchemaName;
         protected override string ResolvedRuleName { get; } = ResolvedPackageReference.SchemaName;
         public override string ProviderType { get; } = ProviderTypeString;
+
+        public override ImageMoniker GetImplicitIcon()
+        {
+            return ManagedImageMonikers.NuGetGreyPrivate;
+        }
 
         public override Task HandleAsync(
             IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectCatalogSnapshot>> e,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ProjectRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ProjectRuleHandler.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
@@ -70,7 +71,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 isImplicit,
                 properties);
         }
-        
+
+        public override ImageMoniker GetImplicitIcon()
+        {
+            return ManagedImageMonikers.ApplicationPrivate;
+        }
+
         private void OnSnapshotChanged(object sender, SnapshotChangedEventArgs e)
         {
             OnOtherProjectDependenciesChanged(e.Snapshot, shouldBeResolved: true);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/SdkRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/SdkRuleHandler.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models;
 
@@ -47,6 +48,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 resolved && !isImplicit, 
                 isImplicit,
                 properties);
+        }
+
+        public override ImageMoniker GetImplicitIcon()
+        {
+            return ManagedImageMonikers.SdkPrivate;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectXmlAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectXmlAccessor.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Build.Construction;
 
@@ -38,5 +39,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// <param name="action">Operation to execute</param>
         /// <returns>A task for the async operation.</returns>
         Task ExecuteInWriteLock(Action<ProjectRootElement> action);
+
+        /// <summary>
+        /// Returns a hash set of all project items contained in project's xml at given moment
+        /// </summary>
+        /// <returns></returns>
+        Task<HashSet<string>> GetProjectItems();
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/MSBuildXmlAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/MSBuildXmlAccessor.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.IO;
 using Microsoft.Build.Construction;
+using Microsoft.VisualStudio.IO;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
@@ -56,6 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 _fileSystem.WriteAllText(_unconfiguredProject.FullPath, toSave, encoding);
             }
         }
+
         public async Task<string> GetEvaluatedPropertyValue(UnconfiguredProject unconfiguredProject, string propertyName)
         {
             var configuredProject = await unconfiguredProject.GetSuggestedConfiguredProjectAsync().ConfigureAwait(false);
@@ -73,6 +76,15 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 await access.CheckoutAsync(_unconfiguredProject.FullPath).ConfigureAwait(true);
                 var msbuildProject = await access.GetProjectXmlAsync(_unconfiguredProject.FullPath).ConfigureAwait(false);
                 action.Invoke(msbuildProject);
+            }
+        }
+
+        public async Task<HashSet<string>> GetProjectItems()
+        {
+            using (var access = await _projectLockService.ReadLockAsync())
+            {
+                var projectXml = await access.GetProjectXmlAsync(_unconfiguredProject.FullPath).ConfigureAwait(true);
+                return new HashSet<string>(projectXml.Items.Select(x => x.Include), StringComparer.OrdinalIgnoreCase);
             }
         }
     }


### PR DESCRIPTION
**Customer scenario**

We don't visually distinguish implicit dependencies vs ones that come directly from project xml. This also prevents us to block Remove operation (and right click command) , which result in bad error dialog when users attempts to delete an implicit dependency.

**Bugs this fixes:** 

https://github.com/dotnet/project-system/issues/1959
https://github.com/dotnet/project-system/issues/1250


**Workarounds, if any**

None

**Risk**

Small

**Performance impact**

Some might be - we have to read project's xml everytime we update dependencies snapshot. However, I did not see noticeable effects for now, in Roslyn project system dogfooding solution. 

**Is this a regression from a previous update?**

No

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

(E.g. customer reported it vs. ad hoc testing)
