### PR TITLE
Add new project property "TargetFrameworkMonikers" that lists all specified target monikers in the project.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -53,6 +53,7 @@
     <Compile Include="ProjectSystem\VS\Input\Commands\GenerateNuGetPackageProjectContextMenuCommand.cs" />
     <Compile Include="ProjectSystem\VS\Input\Commands\AbstractGenerateNuGetPackageCommand.cs" />
     <Compile Include="ProjectSystem\VS\Properties\InterceptedProjectProperties\OutputTypeExValueProvider.cs" />
+    <Compile Include="ProjectSystem\VS\Properties\InterceptedProjectProperties\TargetFrameworkMonikersValueProvider.cs" />
     <Compile Include="ProjectSystem\VS\PropertyPages\BuildMacroInfo.cs" />
     <Compile Include="ProjectSystem\VS\Generators\SingleFileGeneratorFactoryAggregator.cs" />
     <Compile Include="ProjectSystem\VS\NuGet\ProjectProperties.cs" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikerValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikerValueProvider.cs
@@ -14,11 +14,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
     [ExportInterceptingPropertyValueProvider("TargetFrameworkMoniker", ExportInterceptingPropertyValueProviderFile.ProjectFile)]
     internal sealed class TargetFrameworkMonikerValueProvider : InterceptingPropertyValueProviderBase
     {
-        private IUnconfiguredProjectVsServices _unconfiguredProjectVsServices;
+        private readonly IUnconfiguredProjectVsServices _unconfiguredProjectVsServices;
         private readonly ProjectProperties _properties;
         private readonly IVsFrameworkParser _frameworkParser;
         private const string _targetFrameworkProperty = "TargetFramework";
-        private const string _targetFrameworksProperty = "TargetFrameworks";
 
         [ImportingConstructor]
         public TargetFrameworkMonikerValueProvider(IUnconfiguredProjectVsServices unconfiguredProjectVsServices, ProjectProperties properties, IVsFrameworkParser frameworkParser)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikersValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikersValueProvider.cs
@@ -4,48 +4,33 @@ using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
-using static Microsoft.VisualStudio.ProjectSystem.Build.TargetFrameworkProjectConfigurationDimensionProvider;
-using System.Linq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectProperties
 {
     [ExportInterceptingPropertyValueProvider("TargetFrameworkMonikers", ExportInterceptingPropertyValueProviderFile.ProjectFile)]
-    internal sealed class TargetFrameworkMonikersValueProvider : InterceptingPropertyValueProviderBase
+    internal class TargetFrameworkMonikersValueProvider : InterceptingPropertyValueProviderBase
     {
         private readonly ActiveConfiguredProjectsProvider _projectProvider;
-        private readonly ProjectProperties _properties;
 
         [ImportingConstructor]
-        public TargetFrameworkMonikersValueProvider(ActiveConfiguredProjectsProvider projectProvider, ProjectProperties properties)
+        public TargetFrameworkMonikersValueProvider(ActiveConfiguredProjectsProvider projectProvider)
         {
             _projectProvider = projectProvider;
-            _properties = properties;
         }
 
         public override async Task<string> OnGetEvaluatedPropertyValueAsync(string evaluatedPropertyValue, IProjectProperties defaultProperties)
         {
-            var activeProjectConfigurations = await _projectProvider.GetActiveProjectConfigurationsAsync().ConfigureAwait(false);
-            var isCrossTarging = activeProjectConfigurations.All(c => c.IsCrossTargeting());
-            if (isCrossTarging)
+            var configuredProjects = await _projectProvider.GetActiveConfiguredProjectsAsync().ConfigureAwait(true);
+            var builder = ImmutableArray.CreateBuilder<string>();
+            foreach (var configuredProject in configuredProjects)
             {
-                var builder = ImmutableArray.CreateBuilder<string>();
-                foreach (var activeProjectConfiguration in activeProjectConfigurations)
-                {
-                    if (activeProjectConfiguration.Dimensions.TryGetValue(TargetFrameworkPropertyName, out var tfm))
-                    {
-                        builder.Add(tfm);
-                    }
-                }
+                var projectProperties = configuredProject.Services.ExportProvider.GetExportedValue<ProjectProperties>();
+                var configuration = await projectProperties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(true);
+                var currentTargetFrameworkMoniker = (string)await configuration.TargetFrameworkMoniker.GetValueAsync().ConfigureAwait(true);
+                builder.Add(currentTargetFrameworkMoniker);
+            }
 
-                builder.Sort();
-                return string.Join(";", builder.ToArray());
-            }
-            else
-            {
-                var configuration = await _properties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(true);
-                var currentTargetFrameworkMoniker = (string)await configuration.TargetFrameworkMoniker.GetValueAsync().ConfigureAwait(false);
-                return currentTargetFrameworkMoniker;
-            }
+            return string.Join(";", builder.ToArray());
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikersValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikersValueProvider.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using static Microsoft.VisualStudio.ProjectSystem.Build.TargetFrameworkProjectConfigurationDimensionProvider;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectProperties
+{
+    [ExportInterceptingPropertyValueProvider("TargetFrameworkMonikers", ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+    internal sealed class TargetFrameworkMonikersValueProvider : InterceptingPropertyValueProviderBase
+    {
+        private readonly ProjectProperties _properties;
+
+        [ImportingConstructor]
+        public TargetFrameworkMonikersValueProvider(ProjectProperties properties)
+        {
+            _properties = properties;
+        }
+
+        public override async Task<string> OnGetEvaluatedPropertyValueAsync(string evaluatedPropertyValue, IProjectProperties defaultProperties)
+        {
+            var configuration = await _properties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(true);
+            var currentTargetFramework = (string)await configuration.TargetFramework.GetValueAsync().ConfigureAwait(true);
+            var currentTargetFrameworks = (string)await configuration.TargetFrameworks.GetValueAsync().ConfigureAwait(true);
+            if (!string.IsNullOrEmpty(currentTargetFrameworks))
+            {
+                // sorting the target frameworks so projects that specify the same set of frameworks return the same string
+                return string.Join(";", ParseTargetFrameworks(currentTargetFrameworks).Sort());
+            }
+            else if (!string.IsNullOrEmpty(currentTargetFramework))
+            {
+                return currentTargetFramework;
+            }
+
+            return string.Empty;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -50,9 +50,9 @@
             <DataSource Persistence="ProjectFileWithInterception" PersistedName="TargetFrameworkMoniker" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
     </StringProperty>
-    <StringProperty Name="TargetFrameworkMonikers" DisplayName="Target Framework Monikers">
+    <StringProperty Name="TargetFrameworkMonikers" DisplayName="Target Framework Monikers" ReadOnly="True">
         <StringProperty.DataSource>
-            <DataSource Persistence="ImplicitProjectFile" PersistedName="TargetFrameworkMonikers" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+            <DataSource Persistence="ProjectFileWithInterception" PersistedName="TargetFrameworkMonikers" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext"/>
         </StringProperty.DataSource>
     </StringProperty>
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -52,7 +52,7 @@
     </StringProperty>
     <StringProperty Name="TargetFrameworkMonikers" DisplayName="Target Framework Monikers">
         <StringProperty.DataSource>
-            <DataSource Persistence="ProjectFileWithInterception" PersistedName="TargetFrameworkMonikers" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+            <DataSource Persistence="ImplicitProjectFile" PersistedName="TargetFrameworkMonikers" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
     </StringProperty>
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -50,6 +50,11 @@
             <DataSource Persistence="ProjectFileWithInterception" PersistedName="TargetFrameworkMoniker" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
     </StringProperty>
+    <StringProperty Name="TargetFrameworkMonikers" DisplayName="Target Framework Monikers">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFileWithInterception" PersistedName="TargetFrameworkMonikers" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
 
     <StringProperty Name="TargetPath" />
     <StringProperty Name="DocumentationFile" DisplayName="XML doc comments file" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -8,152 +8,157 @@
   OverrideMode= "Replace"
   xmlns="http://schemas.microsoft.com/build/2009/properties">
 
-  <Rule.Categories>
-    <Category Name="General" DisplayName="General" Description="General" />
-  </Rule.Categories>
+    <Rule.Categories>
+        <Category Name="General" DisplayName="General" Description="General" />
+    </Rule.Categories>
 
-  <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-  </Rule.DataSource>
+    <Rule.DataSource>
+        <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+    </Rule.DataSource>
 
-  <StringProperty Name="ApplicationIcon" DisplayName="Application Icon" Visible="False" />
-  <StringProperty Name="TargetFrameworkMoniker" DisplayName="Target Framework Moniker" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileWithInterception" PersistedName="TargetFrameworkMoniker" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="AssemblyName" DisplayName="Assembly Name" Visible="False"/>
-  <StringProperty Name="Name" Visible="False" />
-  <StringProperty Name="RootNamespace" DisplayName="Root namespace" Visible="False"/>
-  <StringProperty Name="DefaultNamespace" DisplayName="Default namespace" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource PersistedName="RootNamespace" Persistence="ProjectFile" HasConfigurationCondition="false" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="TargetFrameworks" DisplayName="Target Frameworks" Visible="False">
+    <StringProperty Name="ApplicationIcon" DisplayName="Application Icon" Visible="False" />
+    <StringProperty Name="TargetFrameworkMoniker" DisplayName="Target Framework Moniker" Visible="False">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFileWithInterception" PersistedName="TargetFrameworkMoniker" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+    <StringProperty Name="TargetFrameworkMonikers" DisplayName="Target Framework Monikers" Visible="False" ReadOnly="True">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFileWithInterception" PersistedName="TargetFrameworkMonikers" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext"/>
+        </StringProperty.DataSource>
+    </StringProperty>
+    <StringProperty Name="AssemblyName" DisplayName="Assembly Name" Visible="False"/>
+    <StringProperty Name="Name" Visible="False" />
+    <StringProperty Name="RootNamespace" DisplayName="Root namespace" Visible="False"/>
+    <StringProperty Name="DefaultNamespace" DisplayName="Default namespace" Visible="False">
+        <StringProperty.DataSource>
+            <DataSource PersistedName="RootNamespace" Persistence="ProjectFile" HasConfigurationCondition="false" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+    <StringProperty Name="TargetFrameworks" DisplayName="Target Frameworks" Visible="False">
         <StringProperty.DataSource>
             <DataSource Persistence="ProjectFile" PersistedName="TargetFrameworks" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
-  </StringProperty>
+    </StringProperty>
     <IntProperty Name="TargetFramework" ReadOnly="True" Visible="False">
-    <IntProperty.DataSource>
-      <DataSource Persistence="ProjectFileWithInterception" PersistedName="TargetFramework" SourceOfDefaultValue="AfterContext" />
-    </IntProperty.DataSource>
-  </IntProperty>
-  <StringProperty Name="OutputName" Visible="False" />
-  <DynamicEnumProperty Name="OutputType" DisplayName="Output Type" EnumProvider="OutputTypeEnumProvider" Visible="False"/>
-  <EnumProperty Name="OutputTypeEx" DisplayName="Output Type" Visible="False">
-    <EnumValue Name="winexe" DisplayName="0" />
-    <EnumValue Name="exe" DisplayName="1" />
-    <EnumValue Name="library" DisplayName="2" />
-    <EnumValue Name="appcontainerexe" DisplayName="3" />
-    <EnumValue Name="winmdobj" DisplayName="4" />
-    <EnumProperty.DataSource>
-      <DataSource Persistence="ProjectFileWithInterception" PersistedName="OutputTypeEx" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </EnumProperty.DataSource>
-  </EnumProperty>
-  <StringProperty Name="StartupObject" DisplayName="Type that contains the entry point" Visible="False"/>
-  <StringProperty Name="ApplicationManifest" DisplayName="Application Manifest" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileWithInterception" PersistedName="ApplicationManifest" HasConfigurationCondition="false" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="Win32ResourceFile" DisplayName="Win32 Resource File" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="Win32Resource" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="PreBuildEvent" DisplayName="Pre Build Event" Visible="False"/>
-  <StringProperty Name="PostBuildEvent" DisplayName="Post Build Event" Visible="False"/>
-  <EnumProperty Name="RunPostBuildEvent" DisplayName="Run Post Build Event" Visible="False">
-    <EnumValue Name="Always" DisplayName="Always" />
-    <EnumValue Name="OnBuildSuccess" DisplayName="On successful build"  IsDefault="True" />
-    <EnumValue Name="OnOutputUpdated" DisplayName="When the build updates the project output" />
-  </EnumProperty>
-  <StringProperty Name="ReferencePath" DisplayName="Reference Path" Visible="False"/>
-  <StringProperty Name="FileName" DisplayName="Project File" ReadOnly="True">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectFile" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="FullPath" DisplayName="Project Folder" ReadOnly="True">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectDirectory" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="LocalPath" ReadOnly="True" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectDirectory" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+        <IntProperty.DataSource>
+            <DataSource Persistence="ProjectFileWithInterception" PersistedName="TargetFramework" SourceOfDefaultValue="AfterContext" />
+        </IntProperty.DataSource>
+    </IntProperty>
+    <StringProperty Name="OutputName" Visible="False" />
+    <DynamicEnumProperty Name="OutputType" DisplayName="Output Type" EnumProvider="OutputTypeEnumProvider" Visible="False"/>
+    <EnumProperty Name="OutputTypeEx" DisplayName="Output Type" Visible="False">
+        <EnumValue Name="winexe" DisplayName="0" />
+        <EnumValue Name="exe" DisplayName="1" />
+        <EnumValue Name="library" DisplayName="2" />
+        <EnumValue Name="appcontainerexe" DisplayName="3" />
+        <EnumValue Name="winmdobj" DisplayName="4" />
+        <EnumProperty.DataSource>
+            <DataSource Persistence="ProjectFileWithInterception" PersistedName="OutputTypeEx" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+        </EnumProperty.DataSource>
+    </EnumProperty>
+    <StringProperty Name="StartupObject" DisplayName="Type that contains the entry point" Visible="False"/>
+    <StringProperty Name="ApplicationManifest" DisplayName="Application Manifest" Visible="False">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFileWithInterception" PersistedName="ApplicationManifest" HasConfigurationCondition="false" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+    <StringProperty Name="Win32ResourceFile" DisplayName="Win32 Resource File" Visible="False">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFile" PersistedName="Win32Resource" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+    <StringProperty Name="PreBuildEvent" DisplayName="Pre Build Event" Visible="False"/>
+    <StringProperty Name="PostBuildEvent" DisplayName="Post Build Event" Visible="False"/>
+    <EnumProperty Name="RunPostBuildEvent" DisplayName="Run Post Build Event" Visible="False">
+        <EnumValue Name="Always" DisplayName="Always" />
+        <EnumValue Name="OnBuildSuccess" DisplayName="On successful build"  IsDefault="True" />
+        <EnumValue Name="OnOutputUpdated" DisplayName="When the build updates the project output" />
+    </EnumProperty>
+    <StringProperty Name="ReferencePath" DisplayName="Reference Path" Visible="False"/>
+    <StringProperty Name="FileName" DisplayName="Project File" ReadOnly="True">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectFile" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+    <StringProperty Name="FullPath" DisplayName="Project Folder" ReadOnly="True">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectDirectory" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+    <StringProperty Name="LocalPath" ReadOnly="True" Visible="False">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectDirectory" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
 
-  <!-- Package properties -->
-  <BoolProperty Name="GeneratePackageOnBuild" DisplayName="Generate Package On Build" Default="False" Visible="False"/>
-  <StringProperty Name="PackageId" DisplayName="Package Id" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileWithInterception" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="Version" DisplayName="Package Version" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileOrAssemblyInfo" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="Authors" DisplayName="Authors" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileWithInterception" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <BoolProperty Name="PackageRequireLicenseAcceptance" DisplayName="Package Require License Acceptance" Default="False" Visible="False"/>
-  <StringProperty Name="PackageLicenseUrl" DisplayName="Package License Url" Visible="False"/>
-  <StringProperty Name="PackageProjectUrl" DisplayName="Package Project Url" Visible="False"/>
-  <StringProperty Name="PackageIconUrl" DisplayName="Package Icon Url" Visible="False"/>
-  <StringProperty Name="PackageTags" DisplayName="Package Tags" Visible="False"/>
-  <StringProperty Name="PackageReleaseNotes" DisplayName="Release Notes" Visible="False"/>
-  <StringProperty Name="RepositoryUrl" DisplayName="Repository Url" Visible="False"/>
-  <StringProperty Name="RepositoryType" DisplayName="Repository Type" Visible="False"/>
+    <!-- Package properties -->
+    <BoolProperty Name="GeneratePackageOnBuild" DisplayName="Generate Package On Build" Default="False" Visible="False"/>
+    <StringProperty Name="PackageId" DisplayName="Package Id" Visible="False">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFileWithInterception" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+    <StringProperty Name="Version" DisplayName="Package Version" Visible="False">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFileOrAssemblyInfo" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+    <StringProperty Name="Authors" DisplayName="Authors" Visible="False">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFileWithInterception" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+    <BoolProperty Name="PackageRequireLicenseAcceptance" DisplayName="Package Require License Acceptance" Default="False" Visible="False"/>
+    <StringProperty Name="PackageLicenseUrl" DisplayName="Package License Url" Visible="False"/>
+    <StringProperty Name="PackageProjectUrl" DisplayName="Package Project Url" Visible="False"/>
+    <StringProperty Name="PackageIconUrl" DisplayName="Package Icon Url" Visible="False"/>
+    <StringProperty Name="PackageTags" DisplayName="Package Tags" Visible="False"/>
+    <StringProperty Name="PackageReleaseNotes" DisplayName="Release Notes" Visible="False"/>
+    <StringProperty Name="RepositoryUrl" DisplayName="Repository Url" Visible="False"/>
+    <StringProperty Name="RepositoryType" DisplayName="Repository Type" Visible="False"/>
 
-  <!--AssemblyInfo properties-->
-  <StringProperty Name="Description" DisplayName="Assembly Description" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileOrAssemblyInfo" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="Company" DisplayName="Assembly Company" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileOrAssemblyInfo" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="Product" DisplayName="Product" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileOrAssemblyInfo" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="Copyright" DisplayName="Copyright" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileOrAssemblyInfo" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="AssemblyVersion" DisplayName="Assembly Version" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileOrAssemblyInfo" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+    <!--AssemblyInfo properties-->
+    <StringProperty Name="Description" DisplayName="Assembly Description" Visible="False">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFileOrAssemblyInfo" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+    <StringProperty Name="Company" DisplayName="Assembly Company" Visible="False">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFileOrAssemblyInfo" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+    <StringProperty Name="Product" DisplayName="Product" Visible="False">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFileOrAssemblyInfo" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+    <StringProperty Name="Copyright" DisplayName="Copyright" Visible="False">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFileOrAssemblyInfo" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+    <StringProperty Name="AssemblyVersion" DisplayName="Assembly Version" Visible="False">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFileOrAssemblyInfo" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
     <StringProperty Name="FileVersion" DisplayName="Assembly File Version" Visible="False">
         <StringProperty.DataSource>
             <DataSource Persistence="ProjectFileOrAssemblyInfo" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
     </StringProperty>
     <StringProperty Name="NeutralLanguage" DisplayName="Neutral Resources Language" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileOrAssemblyInfo" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <BoolProperty Name="SignAssembly" DisplayName="Sign the assembly" Visible="False"/>
-  <BoolProperty Name="DelaySign" DisplayName="Delay sign only" Visible="False"/>
-  <StringProperty Name="AssemblyOriginatorKeyFile" DisplayName="Strong name key file" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileWithInterception" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFileOrAssemblyInfo" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+    <BoolProperty Name="SignAssembly" DisplayName="Sign the assembly" Visible="False"/>
+    <BoolProperty Name="DelaySign" DisplayName="Delay sign only" Visible="False"/>
+    <StringProperty Name="AssemblyOriginatorKeyFile" DisplayName="Strong name key file" Visible="False">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFileWithInterception" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
 </Rule>


### PR DESCRIPTION
**Customer scenario**

.NET Core projects have added a new concept of being able to target multiple frameworks in a single project. We have asks from some MVPs to invest more in that feature and we need to make decisions on investment based on this data.

**Bugs this fixes:** 

https://github.com/dotnet/project-system/issues/1764

**Workarounds, if any**

None

**Risk**

Low.  This exposes a property that CPS will log telemetry on

**Performance impact**

Low. This exposes a property that CPS will log telemetry on

**Is this a regression from a previous update?**

No
