### PR TITLE
Show all analyzers in Solution Explorer

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AnalyzerReference.xaml
@@ -7,7 +7,8 @@
     Description="Analyzer reference properties"
     xmlns="http://schemas.microsoft.com/build/2009/properties">
     <Rule.DataSource>
-        <DataSource Persistence="ProjectFile" ItemType="Analyzer" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+        <DataSource Persistence="ProjectFile" ItemType="Analyzer" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext"
+                    SourceType="TargetResults" MSBuildTarget="CollectAnalyzersDesignTime"/>
     </Rule.DataSource>
     <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAnalyzerReference.xaml
@@ -7,7 +7,8 @@
     Description="Resolved Analyzer reference properties"
     xmlns="http://schemas.microsoft.com/build/2009/properties">
     <Rule.DataSource>
-        <DataSource Persistence="ResolvedReference" ItemType="Analyzer" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+        <DataSource Persistence="ResolvedReference" ItemType="Analyzer" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext"
+                    SourceType="TargetResults" MSBuildTarget="CollectAnalyzersDesignTime"/>
     </Rule.DataSource>
 
     <StringProperty Name="OriginalItemSpec" 

--- a/src/Targets/Microsoft.Managed.DesignTime.targets
+++ b/src/Targets/Microsoft.Managed.DesignTime.targets
@@ -7,7 +7,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-  <!-- Turn off capabilities from Microsoft.Common.CurrentVersions.targets and explicitly include the ones we want. The list below
+    <!-- Turn off capabilities from Microsoft.Common.CurrentVersions.targets and explicitly include the ones we want. The list below
        currently matches what is in common targets, but removes BuildWindowsDesktopTarget -->
     <DefineCommonItemSchemas>false</DefineCommonItemSchemas>
     <DefineCommonCapabilities>false</DefineCommonCapabilities>
@@ -90,7 +90,7 @@
 
     <!-- Settings page capability -->
     <ProjectCapability Include="AppSettings" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'"/>
- </ItemGroup>
+  </ItemGroup>
 
   <!-- Common Project System rules that override rules defined in msbuild. These are exact copy of the rules defined in msbuild. -->
   <ItemGroup Condition="'$(DefineCommonManagedItemSchemas)' == 'true'">
@@ -264,5 +264,8 @@
            />
 
   </Target>
+
+  <!-- This target collects all Analyzers in the project. -->
+  <Target Name="CollectAnalyzersDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(Analyzer)" />
 
 </Project>


### PR DESCRIPTION
**Customer scenario**

Currently when expanding the "Analyzers" node in Solution Explorer you will only see analyzers that have been added directly to the project--analyzers from NuGet packages will not be shown. To get to those you would need to dig through the "NuGet" node and then the individual packages to find what you want.

A major reason we show analyzers in the Solution Explorer is to allow the user to expand them, see the diagnostics each one supports, and adjust the severity. Forcing the user to dig through the NuGet packages would make this effectively impossible as the user would need to know ahead of time which packages include which analyzers, or else they have to spend a lot of time clicking around until they find what they want.

To simplify this experience, we should just show all the analyzers that are going to be passed to the compiler in a flat list. We accomplish this by adding a new target, `CollectAnalyzersDesignTime`, and updating the `AnalyzerReference` and `ResolvedAnalyzerReference` rules to depend on that.

**Bugs this fixes:** 

Related to #88.

**Workarounds, if any**

None.

**Risk**

Low.

**Performance impact**

Expected to be low. The set of analyzers shown the Solution Explorer is now dependent on a design-time build, but we'll already be doing that design-time build for other reasons, anyway.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

N/A

**How was the bug found?**

While figuring out what a complete solution to #88 would look like.
