### PR TITLE
Store TargetFrameworkMoniker in the ConfiguredProjectHostObject

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ConfiguredProjectHostObject.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ConfiguredProjectHostObject.cs
@@ -12,15 +12,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
     {
         private readonly UnconfiguredProjectHostObject _unconfiguredProjectHostObject;
         private readonly string _projectDisplayName;
+        private readonly string _targetFrameworkMoniker;
 
-        public ConfiguredProjectHostObject(UnconfiguredProjectHostObject unconfiguredProjectHostObject, string projectDisplayName)
+        public ConfiguredProjectHostObject(UnconfiguredProjectHostObject unconfiguredProjectHostObject, string projectDisplayName, string targetFrameworkMoniker)
             : base (innerHierarchy: unconfiguredProjectHostObject, innerVsProject: unconfiguredProjectHostObject)
         {
             Requires.NotNull(unconfiguredProjectHostObject, nameof(unconfiguredProjectHostObject));
             Requires.NotNullOrEmpty(projectDisplayName, nameof(projectDisplayName));
+            Requires.NotNull(targetFrameworkMoniker, nameof(targetFrameworkMoniker));
 
             _unconfiguredProjectHostObject = unconfiguredProjectHostObject;
             _projectDisplayName = projectDisplayName;
+            _targetFrameworkMoniker = targetFrameworkMoniker;
         }
 
         public string ProjectDisplayName => _projectDisplayName;
@@ -32,6 +35,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         {
             switch (propid)
             {
+                case (int)__VSHPROPID4.VSHPROPID_TargetFrameworkMoniker:
+                    pvar = _targetFrameworkMoniker;
+                    return VSConstants.S_OK;
+
                 case (int)__VSHPROPID7.VSHPROPID_IsSharedItem:
                     // In our world everything is shared
                     pvar = true;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ProjectHostProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ProjectHostProvider.cs
@@ -18,9 +18,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
 
         public IUnconfiguredProjectHostObject UnconfiguredProjectHostObject { get; }
 
-        public IConfiguredProjectHostObject GetConfiguredProjectHostObject(IUnconfiguredProjectHostObject unconfiguredProjectHostObject, string projectDisplayName)
+        public IConfiguredProjectHostObject GetConfiguredProjectHostObject(IUnconfiguredProjectHostObject unconfiguredProjectHostObject, string projectDisplayName, string targetFrameworkMoniker)
         {
-            return new ConfiguredProjectHostObject((UnconfiguredProjectHostObject)unconfiguredProjectHostObject, projectDisplayName);
+            return new ConfiguredProjectHostObject((UnconfiguredProjectHostObject)unconfiguredProjectHostObject, projectDisplayName, targetFrameworkMoniker);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IProjectHostProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IProjectHostProvider.cs
@@ -12,7 +12,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         /// </summary>
         /// <param name="unconfiguredProjectHostObject">Host object for the underlying unconfigured project.</param>
         /// <param name="projectDisplayName">Project display name for the configured cross-targeting project.</param>
-        IConfiguredProjectHostObject GetConfiguredProjectHostObject(IUnconfiguredProjectHostObject unconfiguredProjectHostObject, string projectDisplayName);
+        /// <param name="targetFramework">Target framework for the configured cross-targeting project.</param>
+        IConfiguredProjectHostObject GetConfiguredProjectHostObject(IUnconfiguredProjectHostObject unconfiguredProjectHostObject, string projectDisplayName, string targetFramework);
 
         /// <summary>
         /// Gets an <see cref="IUnconfiguredProjectHostObject"/> for the current unconfigured project.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/UnconfiguredProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/UnconfiguredProjectContextProvider.cs
@@ -187,7 +187,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         {
             string filePath = _commonServices.Project.FullPath;
 
-            return new ProjectData() {
+            return new ProjectData()
+            {
                 FullPath = filePath,
                 DisplayName = Path.GetFileNameWithoutExtension(filePath)
             };
@@ -225,7 +226,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             string languageName = await GetLanguageServiceName().ConfigureAwait(false);
             if (string.IsNullOrEmpty(languageName))
                 return null;
-            
+
             Guid projectGuid = await GetProjectGuidAsync().ConfigureAwait(false);
             string targetPath = await GetTargetPathAsync().ConfigureAwait(false);
             if (string.IsNullOrEmpty(targetPath))
@@ -235,12 +236,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             await _asyncLoadDashboard.ProjectLoadedInHost.ConfigureAwait(false);
 
             // TODO: https://github.com/dotnet/roslyn-project-system/issues/353
-            return await _taskScheduler.RunAsync(TaskSchedulerPriority.UIThreadBackgroundPriority, async () => 
+            return await _taskScheduler.RunAsync(TaskSchedulerPriority.UIThreadBackgroundPriority, async () =>
             {
                 await _commonServices.ThreadingService.SwitchToUIThread();
 
                 var projectData = GetProjectData();
-                
+
                 // Get the set of active configured projects ignoring target framework.
                 var configuredProjectsMap = await _activeConfiguredProjectsProvider.GetActiveConfiguredProjectsMapAsync().ConfigureAwait(true);
 
@@ -262,8 +263,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
                         var projectProperties = configuredProject.Services.ExportProvider.GetExportedValue<ProjectProperties>();
                         var configurationGeneralProperties = await projectProperties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(true);
                         targetPath = (string)await configurationGeneralProperties.TargetPath.GetValueAsync().ConfigureAwait(true);
+                        var targetFrameworkMoniker = (string)await configurationGeneralProperties.TargetFrameworkMoniker.GetValueAsync().ConfigureAwait(true);
                         var displayName = GetDisplayName(configuredProject, projectData, targetFramework);
-                        configuredProjectHostObject = _projectHostProvider.GetConfiguredProjectHostObject(_unconfiguredProjectHostObject, displayName);
+                        configuredProjectHostObject = _projectHostProvider.GetConfiguredProjectHostObject(_unconfiguredProjectHostObject, displayName, targetFrameworkMoniker);
 
                         // TODO: https://github.com/dotnet/roslyn-project-system/issues/353
                         await _commonServices.ThreadingService.SwitchToUIThread();
@@ -281,7 +283,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
                         // By default, set "LastDesignTimeBuildSucceeded = false" to turn off diagnostics until first design time build succeeds for this project.
                         workspaceProjectContext.LastDesignTimeBuildSucceeded = false;
 
-                        AddConfiguredProjectState(configuredProject, workspaceProjectContext, configuredProjectHostObject);                        
+                        AddConfiguredProjectState(configuredProject, workspaceProjectContext, configuredProjectHostObject);
                     }
 
                     innerProjectContextsBuilder.Add(targetFramework, workspaceProjectContext);


### PR DESCRIPTION
**Customer scenario**

Roslyn handles multi-targeting scenarios by creating multiple projects in the workspace, one for each target. In order to show the correct set of diagnostics on the correct set of analyzers in the Solution Explorer in these scenarios we need to be able to find the correct Roslyn project for a given target. 

When asking the Roslyn Language Service to create a project we pass it a `ConfiguredProjectHostObject` to represent the project hierarchy. This change updates the host object to be aware of its TargetFrameworkMoniker, and expose it through the `IVsHierarchy` interface via the `__VSHPROPID4.VSHPROPID_TargetFrameworkMoniker` property.

**Bugs this fixes:** 

Related to #88.

**Workarounds, if any**

N/A

**Risk**

Low

**Performance impact**

None

**Is this a regression from a previous update?**

N/A

**Root cause analysis:**

N/A

**How was the bug found?**

N/A
