### PR TITLE
Fix project display name for multi-targeting

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/UnconfiguredProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/UnconfiguredProjectContextProvider.cs
@@ -306,7 +306,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             //   (a) The display name is used in the editor project context combo box when opening source files that used by more than one inner projects.
             //   (b) Language service requires each active workspace project context in the current workspace to have a unique value for {ProjectFilePath, DisplayName}.
             return configuredProject.ProjectConfiguration.IsCrossTargeting() ?
-                $"{projectData.DisplayName}({targetFramework})" :
+                $"{projectData.DisplayName} ({targetFramework})" :
                 projectData.DisplayName;
         }
 


### PR DESCRIPTION
**Customer scenario**

When a project has multiple targets we differentiate between them by
appending the specific target to the display name, like so:

> MyProject(netstandard1.4)
> MyProject(net45)

Note the lack of space between the project name and the target. This
commit adds the space back in:

> MyProject (netstandard1.4)
> MyProject (net45)

**Bugs this fixes:** 

N/A

**Workarounds, if any**

None

**Risk**

Low

**Performance impact**

None; just a string change.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

N/A

**How was the bug found?**

Ad hoc testing
