### PR TITLE
Use UnconfiguredProject instead of IUnconfiguredProjectCommonServices

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsProviderTests.cs
@@ -132,23 +132,21 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var configurationsService = IProjectConfigurationsServiceFactory.ImplementGetKnownProjectConfigurationsAsync(configs);
             var activeConfiguredProjectProvider = IActiveConfiguredProjectProviderFactory.ImplementActiveProjectConfiguration(() => activeConfig);
             var services = IUnconfiguredProjectServicesFactory.Create(activeConfiguredProjectProvider: activeConfiguredProjectProvider, projectConfigurationsService: configurationsService);
-            var configuredProject = UnconfiguredProjectFactory.ImplementLoadConfiguredProjectAsync((projectConfiguration) => {
+            var project = UnconfiguredProjectFactory.ImplementLoadConfiguredProjectAsync((projectConfiguration) => {
                 return Task.FromResult(ConfiguredProjectFactory.ImplementProjectConfiguration(projectConfiguration));
             });
 
             var dimensionProviders = dimensionNames.Select(name => IActiveConfiguredProjectsDimensionProviderFactory.ImplementDimensionName(name));
 
-            var commonServices = IUnconfiguredProjectCommonServicesFactory.ImplementProject(configuredProject);
-
-            return CreateInstance(services: services, commonServices: commonServices, dimensionProviders: dimensionProviders);
+            return CreateInstance(services: services, project: project, dimensionProviders: dimensionProviders);
         }
 
-        private ActiveConfiguredProjectsProvider CreateInstance(IUnconfiguredProjectServices services = null, IUnconfiguredProjectCommonServices commonServices = null, IEnumerable<IActiveConfiguredProjectsDimensionProvider> dimensionProviders = null)
+        private ActiveConfiguredProjectsProvider CreateInstance(IUnconfiguredProjectServices services = null, UnconfiguredProject project = null, IEnumerable<IActiveConfiguredProjectsDimensionProvider> dimensionProviders = null)
         {
             services = services ?? IUnconfiguredProjectServicesFactory.Create();
-            commonServices = commonServices ?? IUnconfiguredProjectCommonServicesFactory.Create();
+            project = project ?? UnconfiguredProjectFactory.Create();
 
-            var provider = new ActiveConfiguredProjectsProvider(services, commonServices);
+            var provider = new ActiveConfiguredProjectsProvider(services, project);
 
             if (dimensionProviders != null)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
@@ -54,18 +54,18 @@ namespace Microsoft.VisualStudio.ProjectSystem
         //                  Debug |   AnyCPU
 
         private readonly IUnconfiguredProjectServices _services;
-        private readonly IUnconfiguredProjectCommonServices _commonServices;
+        private readonly UnconfiguredProject _project;
 
         [ImportingConstructor]
-        public ActiveConfiguredProjectsProvider(IUnconfiguredProjectServices services, IUnconfiguredProjectCommonServices commonServices)
+        public ActiveConfiguredProjectsProvider(IUnconfiguredProjectServices services, UnconfiguredProject project)
         {
             Requires.NotNull(services, nameof(services));
-            Requires.NotNull(commonServices, nameof(commonServices));
+            Requires.NotNull(project, nameof(project));
 
             _services = services;
-            _commonServices = commonServices;
+            _project = project;
 
-            DimensionProviders = new OrderPrecedenceImportCollection<IActiveConfiguredProjectsDimensionProvider>(projectCapabilityCheckProvider: commonServices.Project);
+            DimensionProviders = new OrderPrecedenceImportCollection<IActiveConfiguredProjectsDimensionProvider>(projectCapabilityCheckProvider: project);
         }
 
         [ImportMany]
@@ -107,8 +107,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             foreach (ProjectConfiguration configuration in configurations.Objects)
             {
-                ConfiguredProject project = await _commonServices.Project.LoadConfiguredProjectAsync(configuration)
-                                                                         .ConfigureAwait(false);
+                ConfiguredProject project = await _project.LoadConfiguredProjectAsync(configuration)
+                                                          .ConfigureAwait(false);
 
                 builder.Add(project);
             }


### PR DESCRIPTION
ActiveConfiguredProjectsProvider doesn't need IUnconfiguredProjectCommonServices and I'm changing IUnconfiguredProjectCommonServices to use IActiveConfiguredProjectsProvider.
