### PR TITLE
Obsolete IActiveConfiguredProjectsProvider.GetActiveConfiguredProjectsMapAsync

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IActiveConfiguredProjectsProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IActiveConfiguredProjectsProviderFactory.cs
@@ -23,7 +23,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
         public IActiveConfiguredProjectsProviderFactory ImplementGetActiveConfiguredProjectsMapAsync(ImmutableDictionary<string, ConfiguredProject> configuredProjects) 
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             _mock.Setup(x => x.GetActiveConfiguredProjectsMapAsync())
+#pragma warning restore CS0618 // Type or member is obsolete
                               .Returns(Task.FromResult(configuredProjects));
             return this;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
@@ -207,9 +207,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             return await _taskScheduler.RunAsync(TaskSchedulerPriority.UIThreadBackgroundPriority, async () => 
             {
                 var projectData = GetProjectData();
-                
+
                 // Get the set of active configured projects ignoring target framework.
+#pragma warning disable CS0618 // Type or member is obsolete
                 var configuredProjectsMap = await _activeConfiguredProjectsProvider.GetActiveConfiguredProjectsMapAsync().ConfigureAwait(true);
+#pragma warning restore CS0618 // Type or member is obsolete
                 var activeProjectConfiguration = _commonServices.ActiveConfiguredProject.ProjectConfiguration;
                 var innerProjectContextsBuilder = ImmutableDictionary.CreateBuilder<ITargetFramework, ITargetedProjectContext>();
                 var activeTargetFramework = TargetFramework.Empty;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ActiveDebugFrameworkServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ActiveDebugFrameworkServices.cs
@@ -67,7 +67,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </summary>
         public async Task<ConfiguredProject> GetConfiguredProjectForActiveFrameworkAsync()
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             var configProjects = await _activeConfiguredProjectsProvider.GetActiveConfiguredProjectsMapAsync().ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             // If there is only one we are done
             if (configProjects.Count == 1)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IActiveConfiguredProjectsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IActiveConfiguredProjectsProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 
@@ -28,6 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// If the current project is not a cross-targeting project, then it returns a singleton key-value pair with an ignorable key and single active configured project as value.
         /// </summary>
         /// <returns>Map from TargetFramework dimension to active configured project.</returns>
+        [Obsolete("This method will be removed in a future build.")]
         Task<ImmutableDictionary<string, ConfiguredProject>> GetActiveConfiguredProjectsMapAsync();
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/UnconfiguredProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/UnconfiguredProjectContextProvider.cs
@@ -240,9 +240,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
                 await _commonServices.ThreadingService.SwitchToUIThread();
 
                 var projectData = GetProjectData();
-                
+
                 // Get the set of active configured projects ignoring target framework.
+#pragma warning disable CS0618 // Type or member is obsolete
                 var configuredProjectsMap = await _activeConfiguredProjectsProvider.GetActiveConfiguredProjectsMapAsync().ConfigureAwait(true);
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 // Get the unconfigured project host object (shared host object).
                 var configuredProjectsToRemove = new HashSet<ConfiguredProject>(_configuredProjectHostObjectsMap.Keys);


### PR DESCRIPTION
(Preparing to make IActiveConfiguredProjectsProvider public for the VSTest guys)

This method will be removed in a future PR, want to avoid any new dependencies on it.
