### PR TITLE
Make IActiveConfiguredProjectsProvider public

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredObjects.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredObjects.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
     /// <typeparam name="T">
     ///     The type of the active configured objects.
     /// </typeparam>
-    internal class ActiveConfiguredObjects<T>
+    public class ActiveConfiguredObjects<T>
     {
         /// <summary>
         ///     Initializes a new instance of <see cref="ActiveConfiguredObjects{T}"/> with the specified objects and configurations 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IActiveConfiguredProjectsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IActiveConfiguredProjectsProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
     ///         Debug | AnyCPU | net45
     ///         Debug | AnyCPU | net46
     /// </summary>
-    internal interface IActiveConfiguredProjectsProvider
+    public interface IActiveConfiguredProjectsProvider
     {
         /// <summary>
         /// Gets all the active configured projects by TargetFramework dimension for the current unconfigured project.


### PR DESCRIPTION
VSTest would like to consumer this interface, make it public.