### PR TITLE
Use file path where possible for dependency items

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/IDependencyModelExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/IDependencyModelExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             return new DependencyViewModel
             {
                 Caption = self.Caption,
-                FilePath = self.Id,
+                FilePath = self.Path ?? self.Id,
                 SchemaName = self.SchemaName,
                 SchemaItemType = self.SchemaItemType,
                 Priority = self.Priority,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             return new DependencyViewModel
             {
                 Caption = self.Caption,
-                FilePath = self.Id,
+                FilePath = self.Path ?? self.Id,
                 SchemaName = self.SchemaName,
                 SchemaItemType = self.SchemaItemType,
                 Priority = self.Priority,


### PR DESCRIPTION
**Customer scenario**

To create the Dependencies tree and its children, we start with IDependencyModel nodes, which are converted to IDependencyViewModel nodes, which are in turn converted to IProjectTree instances, which end up backing items in the IVsHierarchy. Currently the value of `IDependencyViewModel.FilePath` is exposed via the `IVsHierarchy` via `IVsHierarchy.GetCanonicalName`.

In general, when dealing with a hierarchy item that represents a file on disk `IVsHierarchy.GetCanonicalName` returns the full path to that file. However, we're currently returning the `IDependencyModel.Id`, which is our internal ID for the node and munges together things like the project name, target framework, and file path.

In practice this makes it impossible for the consumer of the `IVsHierarchy` to get the full path to an item. This commit updates our code so that if we have a path to an item we'll use that; otherwise we'll fallback to the ID.

**Bugs this fixes:** 

N/A

**Workarounds, if any**

No workaround

**Risk**

Low

**Performance impact**

None.

**Is this a regression from a previous update?**

N/A

**Root cause analysis:**

N/A

**How was the bug found?**

Ad hoc testing of support for analyzer nodes in Solution Explorer.
