### PR TITLE
Fix project load failure for projects with analyzers

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAnalyzerReference.xaml
@@ -7,7 +7,7 @@
     Description="Resolved Analyzer reference properties"
     xmlns="http://schemas.microsoft.com/build/2009/properties">
     <Rule.DataSource>
-        <DataSource Persistence="ResolvedReference" ItemType="Analyzer" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+        <DataSource Persistence="ProjectFile" ItemType="Analyzer" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
     </Rule.DataSource>
 
     <StringProperty Name="OriginalItemSpec" 


### PR DESCRIPTION
**Customer scenario**

A project that has analyzers will show a CPS fault dialog during load and the Dependencies node will be completely empty. 

**Bugs this fixes:** 
Opening the ProjectSystem solution with latest D15PreRel causes this error.

**Fix details**
The ResolvedAnalyzerReference rule was using the ResolvedReference provider which seems to be designed only for use with items returned by targets. However the ResolvedAnalyzerReference rule doesn't run any target and simply gets the analyzer items from the project file. A change last week added IsImplicitlyDefined metadata to the rule which causes the provider to go down a path that throws a NotImplementedException. Switching the provider to just the ProjectFile in this PR since we just need the Analyzer items from evaluation.

**Workarounds, if any**
None

**Risk**

Scoped to analyzers in dependencies node.

**Performance impact**

None. We are just changing the datasource

**Is this a regression from a previous update?**
No. Regression from last week.

**Root cause analysis:**

Need an integration test with analyzers.

**How was the bug found?**

Dogfooding.

@dotnet/project-system @abpiskunov 