### PR TITLE
Use just built rules\targets in the RoslynDev hive

### DIFF
--- a/build/Targets/ProducesNoOutput.Imports.targets
+++ b/build/Targets/ProducesNoOutput.Imports.targets
@@ -7,9 +7,8 @@
     <TargetPath></TargetPath>    <!-- Prevent projects referencing this from trying to pass us to the compiler -->
   </PropertyGroup>
   
-  <!-- Return this back when up-to-date bug is fixed (projects are being build everytime) -->
-  <!-- <Target Name="CoreCompile" /> -->                               <!-- Prevent Csc from being called -->  
-  <!-- <Target Name="GenerateTargetFrameworkMonikerAttribute" /> -->  <!-- Don't generate TFM attribute -->    
+  <Target Name="CoreCompile" />                                <!-- Prevent Csc from being called -->  
+  <Target Name="GenerateTargetFrameworkMonikerAttribute" />  <!-- Don't generate TFM attribute -->    
   <Target Name="RuntimeImplementationProjectOutputGroup" />   <!-- Group always attempts resolve runtime, regardless of <CopyNuGetImplementations>-->
   
 </Project>

--- a/build/Targets/ProducesNoOutput.Settings.targets
+++ b/build/Targets/ProducesNoOutput.Settings.targets
@@ -3,14 +3,8 @@
 
   <PropertyGroup>
     <GenerateDependencyFile>false</GenerateDependencyFile>
-    <IsDeployment Condition="'$(IsDeployment)' == ''">true</IsDeployment>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(IsDeployment)' == 'false'">
-    <UseCommonOutputDirectory>true</UseCommonOutputDirectory>
-    <OutDir>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\..\bin\obj\Unused\$(Configuration)'))\</OutDir>
-  </PropertyGroup>
-  
   <Import Project="VSL.Settings.targets" />
 
   <PropertyGroup>

--- a/build/Targets/ProducesNoOutput.Settings.targets
+++ b/build/Targets/ProducesNoOutput.Settings.targets
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <GenerateDependencyFile>false</GenerateDependencyFile>
-    <IsDeployment Condition="'$(IsDeployment)' == ''">false</IsDeployment>
+    <IsDeployment Condition="'$(IsDeployment)' == ''">true</IsDeployment>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsDeployment)' == 'false'">
@@ -14,9 +14,8 @@
   <Import Project="VSL.Settings.targets" />
 
   <PropertyGroup>
-    <!-- Return this back when up-to-date bug is fixed (projects are being build everytime) -->
-    <!--<CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
-        <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>-->
+    <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
+    <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
     <OutputType>Library</OutputType>
   </PropertyGroup>
 </Project>

--- a/src/DeployTestDependencies/DeployTestDependencies.csproj
+++ b/src/DeployTestDependencies/DeployTestDependencies.csproj
@@ -1,11 +1,7 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project>
-  <PropertyGroup>
-    <IsDeployment>true</IsDeployment>
-  </PropertyGroup>
   <Import Project="..\..\build\Targets\ProducesNoOutput.Settings.targets" />
   <PropertyGroup>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFramework>net46</TargetFramework>
     <OutDir>$(OutDir)Tests\</OutDir>
     <ProjectSystemLayer>VisualStudioDesigner</ProjectSystemLayer>

--- a/src/ProjectSystem.sln
+++ b/src/ProjectSystem.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.4
+VisualStudioVersion = 15.0.26420.2
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeployTestDependencies", "DeployTestDependencies\DeployTestDependencies.csproj", "{37BA82E6-9ABD-4ACA-AA26-2DFD39A359A5}"
 EndProject
@@ -47,14 +47,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.VisualStudio.Proj
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests", "Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests.csproj", "{369DCA0F-A079-4D0C-8B32-53879199B681}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Targets", "Targets", "{573BCEB9-1EC1-49E0-8332-E8436304DFFA}"
-	ProjectSection(SolutionItems) = preProject
-		Targets\Microsoft.CSharp.DesignTime.targets = Targets\Microsoft.CSharp.DesignTime.targets
-		Targets\Microsoft.FSharp.DesignTime.targets = Targets\Microsoft.FSharp.DesignTime.targets
-		Targets\Microsoft.Managed.DesignTime.targets = Targets\Microsoft.Managed.DesignTime.targets
-		Targets\Microsoft.VisualBasic.DesignTime.targets = Targets\Microsoft.VisualBasic.DesignTime.targets
-	EndProjectSection
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.VisualStudio.Editors.UnitTests", "Microsoft.VisualStudio.Editor.UnitTests\Microsoft.VisualStudio.Editors.UnitTests.csproj", "{991DBD0C-6DB5-48B8-B41E-E1092445240D}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.ProjectSystem.FSharp", "Microsoft.VisualStudio.ProjectSystem.FSharp\Microsoft.VisualStudio.ProjectSystem.FSharp.csproj", "{7CDAA9BE-513D-421F-9A72-46764449C503}"
@@ -64,6 +56,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.ProjectSystem.FSharp.UnitTests", "Microsoft.VisualStudio.ProjectSystem.FSharp.UnitTests\Microsoft.VisualStudio.ProjectSystem.FSharp.UnitTests.csproj", "{2E6BC62C-D52B-47EC-B0F6-B9A68C057217}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests", "Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests\Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests.csproj", "{B70FA177-894C-4964-B6A7-937A361321BF}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Targets", "Targets\Targets.csproj", "{CE750338-2BB0-4911-98EA-0AC5D2794FAC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -152,10 +146,6 @@ Global
 		{991DBD0C-6DB5-48B8-B41E-E1092445240D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{991DBD0C-6DB5-48B8-B41E-E1092445240D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{991DBD0C-6DB5-48B8-B41E-E1092445240D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F9522F27-B9AC-4D6F-8F54-6A8BD4D33574}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F9522F27-B9AC-4D6F-8F54-6A8BD4D33574}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F9522F27-B9AC-4D6F-8F54-6A8BD4D33574}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F9522F27-B9AC-4D6F-8F54-6A8BD4D33574}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7CDAA9BE-513D-421F-9A72-46764449C503}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7CDAA9BE-513D-421F-9A72-46764449C503}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7CDAA9BE-513D-421F-9A72-46764449C503}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -172,6 +162,10 @@ Global
 		{B70FA177-894C-4964-B6A7-937A361321BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B70FA177-894C-4964-B6A7-937A361321BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B70FA177-894C-4964-B6A7-937A361321BF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CE750338-2BB0-4911-98EA-0AC5D2794FAC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CE750338-2BB0-4911-98EA-0AC5D2794FAC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CE750338-2BB0-4911-98EA-0AC5D2794FAC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CE750338-2BB0-4911-98EA-0AC5D2794FAC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ProjectSystemSetup/Properties/launchSettings.json
+++ b/src/ProjectSystemSetup/Properties/launchSettings.json
@@ -3,7 +3,12 @@
     "ProjectSystemSetup": {
       "commandName": "Executable",
       "executablePath": "$(DevEnvDir)devenv.exe",
-      "commandLineArgs": "/rootsuffix RoslynDev /log"
+      "commandLineArgs": "/rootsuffix RoslynDev /log",
+      "environmentVariables": {
+        "VisualBasicDesignTimeTargetsPath": "$(OutDir)Rules\\Microsoft.VisualBasic.DesignTime.targets",
+        "FSharpDesignTimeTargetsPath": "$(OutDir)Rules\\Microsoft.FSharp.DesignTime.targets",
+        "CSharpDesignTimeTargetsPath": "$(OutDir)Rules\\Microsoft.CSharp.DesignTime.targets"
+      }
     }
   }
 }

--- a/src/Targets/Targets.csproj
+++ b/src/Targets/Targets.csproj
@@ -1,0 +1,20 @@
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
+  <Import Project="..\..\build\Targets\ProducesNoOutput.Settings.targets" />
+
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+    <Nonshipping>true</Nonshipping>
+    <OutDir>$(OutDir)Rules\</OutDir>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="Microsoft.CSharp.DesignTime.targets" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="Microsoft.FSharp.DesignTime.targets" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="Microsoft.Managed.DesignTime.targets" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="Microsoft.VisualBasic.DesignTime.targets" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+  
+  <Import Project="..\..\build\Targets\ProducesNoOutput.Imports.targets" />
+
+</Project>

--- a/src/VsixV3/ProjectSystemPackage/Microsoft.VisualStudio.ProjectSystem.Managed.CommonFiles.swr
+++ b/src/VsixV3/ProjectSystemPackage/Microsoft.VisualStudio.ProjectSystem.Managed.CommonFiles.swr
@@ -9,10 +9,10 @@ vs.localizedResources
                        description="Microsoft VisualStudio ProjectSystem for C#/VB(Managed) Projects"
 
 folder "InstallDir:MSBuild\Microsoft\VisualStudio\Managed"
-  file source="$(SourcePath)\Targets\Microsoft.CSharp.DesignTime.targets"
-  file source="$(SourcePath)\Targets\Microsoft.VisualBasic.DesignTime.targets"
-  file source="$(SourcePath)\Targets\Microsoft.FSharp.DesignTime.targets"
-  file source="$(SourcePath)\Targets\Microsoft.Managed.DesignTime.targets"
+  file source="$(OutputPath)Rules\Microsoft.CSharp.DesignTime.targets"
+  file source="$(OutputPath)Rules\Microsoft.VisualBasic.DesignTime.targets"
+  file source="$(OutputPath)Rules\Microsoft.FSharp.DesignTime.targets"
+  file source="$(OutputPath)Rules\Microsoft.Managed.DesignTime.targets"
 
 folder "InstallDir:MSBuild\Microsoft\VisualStudio\Managed"
   file source="$(OutputPath)Rules\AdditionalFiles.xaml"


### PR DESCRIPTION
Changing rules\targets is a pain today because we have to change the actual copy in msbuild and we often forget to test with that leading to bugs. This change deploys all the targets and rules into a directory under the output directory and then sets env variables to make msbuild pick up these targets\rules in the RoslynDev instance instead of the copy in msbuild.

With this now, one can change a rule, F5 and the new instance will have the changed rule\target take effect.

@dotnet/project-system - looking at this commit by commit might be easier.