### PR TITLE
Fix Ctrl F5 for "Run Executable"

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
@@ -222,11 +222,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
             activeProfile.EnvironmentVariables = new Dictionary<string, string>() { { "var1", "Value1" } }.ToImmutableDictionary();
             var targets = await debugger.QueryDebugTargetsAsync(DebugLaunchOptions.NoDebug, activeProfile);
             Assert.Equal(1, targets.Count);
-            Assert.True(targets[0].Executable.EndsWith(@"\cmd.exe", StringComparison.OrdinalIgnoreCase));
+            Assert.Equal(activeProfile.ExecutablePath, targets[0].Executable);
             Assert.Equal(DebugLaunchOperation.CreateProcess, targets[0].LaunchOperation);
             Assert.Equal((DebugLaunchOptions.NoDebug | DebugLaunchOptions.StopDebuggingOnEnd | DebugLaunchOptions.MergeEnvironment), targets[0].LaunchOptions);
             Assert.Equal(DebuggerEngines.ManagedCoreEngine, targets[0].LaunchDebugEngineGuid);
-            Assert.Equal("/c \"\"" + activeProfile.ExecutablePath + "\" --someArgs & pause\"", targets[0].Arguments);
+            Assert.Equal("--someArgs", targets[0].Arguments);
         }
 
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
@@ -59,9 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// </summary>
         public bool SupportsProfile(ILaunchProfile profile)
         {
-            return string.IsNullOrWhiteSpace(profile.CommandName) ||
-                profile.CommandName.Equals(LaunchSettingsProvider.RunProjectCommandName, StringComparison.OrdinalIgnoreCase) ||
-                profile.CommandName.Equals(LaunchSettingsProvider.RunExecutableCommandName, StringComparison.OrdinalIgnoreCase);
+            return string.IsNullOrWhiteSpace(profile.CommandName) || IsRunProjectCommand(profile) || IsRunExecutableCommand(profile);
         }
 
         /// <summary>
@@ -152,6 +150,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             }
         }
 
+        private static bool IsRunExecutableCommand(ILaunchProfile profile)
+        {
+            return string.Equals(profile.CommandName, LaunchSettingsProvider.RunExecutableCommandName, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsRunProjectCommand(ILaunchProfile profile)
+        {
+            return string.Equals(profile.CommandName, LaunchSettingsProvider.RunProjectCommandName, StringComparison.OrdinalIgnoreCase);
+        }
+
         /// <summary>
         /// This is called on F5 to return the list of debug targets. What we return depends on the type
         /// of project.
@@ -171,7 +179,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             string defaultWorkingDir = projectFolder;
 
             // Is this profile just running the project? If so we ignore the exe
-            if (string.Equals(resolvedProfile.CommandName, LaunchSettingsProvider.RunProjectCommandName, StringComparison.OrdinalIgnoreCase))
+            if (IsRunProjectCommand(resolvedProfile))
             {
                 // Can't run a class library directly
                 if (await GetIsClassLibraryAsync().ConfigureAwait(false))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
@@ -102,8 +102,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         {
             List<DebugLaunchSettings> launchSettings = new List<DebugLaunchSettings>();
 
-            var settings = new DebugLaunchSettings(launchOptions);
-
             // Resolve the tokens in the profile
             ILaunchProfile resolvedProfile = await TokenReplacer.ReplaceTokensInProfileAsync(activeProfile).ConfigureAwait(true);
 
@@ -164,7 +162,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             var settings = new DebugLaunchSettings(launchOptions);
 
             string executable, arguments;
-            string commandLineArguments = resolvedProfile.CommandLineArgs;
 
             string projectFolder = Path.GetDirectoryName(UnconfiguredProject.FullPath);
             var configuredProject = await GetConfiguredProjectForDebugAsync().ConfigureAwait(false);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
@@ -103,8 +103,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             // Resolve the tokens in the profile
             ILaunchProfile resolvedProfile = await TokenReplacer.ReplaceTokensInProfileAsync(activeProfile).ConfigureAwait(true);
 
-            // We want to launch the process via the command shell when not debugging, except when this debug session is being launched for profiling.
-            bool useCmdShell = (launchOptions & (DebugLaunchOptions.NoDebug | DebugLaunchOptions.Profiling)) == DebugLaunchOptions.NoDebug;
+            // For "run project", we want to launch the process via the command shell when not debugging, except when this debug session is being
+            // launched for profiling.
+            bool useCmdShell =
+                    IsRunProjectCommand(resolvedProfile) &&
+                    (launchOptions & (DebugLaunchOptions.NoDebug | DebugLaunchOptions.Profiling)) == DebugLaunchOptions.NoDebug;
+
             var consoleTarget = await GetConsoleTargetForProfile(resolvedProfile, launchOptions, useCmdShell).ConfigureAwait(true);
 
             launchSettings.Add(consoleTarget);


### PR DESCRIPTION
**Customer scenario**

See #1831.

**Bugs this fixes:** 

See #1831.

**Risk**

_Non fully qualified_ executable paths (e.g. "notepad") don't work ("The system cannot find the file specified") because previously it worked via PATH-expansion in cmd.exe. But: Exactly the same is true for F5 (with debugger) because here also happens no PATH-expansion. Therefore I think if this is a problem (for non fully qualified paths), it should be handled in a new bug and PR.

**Performance impact**

Almost none.

**Is this a regression from a previous update?**

It is a regression from the old project system.

**How was the bug found?**

Customer reported it.
