### PR TITLE
Update NuGetMoniker to beta2 for master

### DIFF
--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -73,7 +73,7 @@
 
   <!-- NuGet version -->
   <PropertyGroup>
-    <CommonNuGetMoniker>beta1</CommonNuGetMoniker>
+    <CommonNuGetMoniker>beta2</CommonNuGetMoniker>
     <VSSemanticVersion>15.3</VSSemanticVersion>    
     <RoslynNuGetReleaseVersion>$(RoslynSemanticVersion.Substring(0, $(RoslynSemanticVersion.LastIndexOf('.'))))</RoslynNuGetReleaseVersion>
     <RoslynNuGetPerBuildVersion Condition="'$(BuildNumberFiveDigitDateStamp)' != '' AND '$(BuildNumberBuildOfTheDayPadded)' != ''">$(RoslynNuGetReleaseVersion).0-$(CommonNuGetMoniker)-$(BuildNumberFiveDigitDateStamp.Trim())$(BuildNumberBuildOfTheDayPadded.Trim())</RoslynNuGetPerBuildVersion>


### PR DESCRIPTION
Infrastructure change only to set distinguishing versions for NuGet packages when we publish them.

/cc @basoundr @srivatsn 