### PR TITLE
Return AbstractProject which implements ENC interface for EnC Service

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/EditAndContinue/EditAndContinueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/EditAndContinue/EditAndContinueProvider.cs
@@ -4,7 +4,6 @@ using System;
 using System.ComponentModel.Composition;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.TextManager.Interop;
 using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 using Microsoft.VisualStudio.ProjectSystem.VS;
 using EncInterop = Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue.Interop;
@@ -12,9 +11,9 @@ using EncInterop = Microsoft.VisualStudio.LanguageServices.Implementation.EditAn
 namespace Microsoft.VisualStudio.ProjectSystem.Managed.VS.EditAndContinue
 {
 
-    [ExportProjectNodeComService(typeof(IVsENCRebuildableProjectCfg), typeof(EncInterop.IVsENCRebuildableProjectCfg2), typeof(EncInterop.IVsENCRebuildableProjectCfg4))]
+    [ExportProjectNodeComService(typeof(IVsENCRebuildableProjectCfg))]
     [AppliesTo(ProjectCapability.EditAndContinue)]
-    internal class EditAndContinueProvider : IVsENCRebuildableProjectCfg, EncInterop.IVsENCRebuildableProjectCfg2, EncInterop.IVsENCRebuildableProjectCfg4
+    internal class EditAndContinueProvider : IVsENCRebuildableProjectCfg
     {
         private readonly ILanguageServiceHost _host;
 
@@ -24,81 +23,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Managed.VS.EditAndContinue
             _host = host;
         }
 
-        // Different methods return different VSConstants(instead of VSConstants.E_FAIL) when HostSpecificEditAndContinueService is null.
-        // The out parameters are assigned some default value in these methods. These are not random values.
-        // These are the same values returned by the language service if its EnC component, to which language service delegate Enc Calls,
-        // is null. We are retaining the same behavior here.
-        // Similarly for implementation of IVsENCRebuildableProjectCfg4 as well
-        public int BuildForEnc([In, MarshalAs(UnmanagedType.IUnknown)] object pUpdatePE)
+        // AbstractProject implements IVsENCRebuildableProjectCfg2 and IVsENCRebuildableProjectCfg4 only
+        [ExportProjectNodeComService(typeof(EncInterop.IVsENCRebuildableProjectCfg2), typeof(EncInterop.IVsENCRebuildableProjectCfg4))]
+        [AppliesTo(ProjectCapability.EditAndContinue)]
+        internal Object EditAndContinueService
         {
-            return ((EncInterop.IVsENCRebuildableProjectCfg2)_host.HostSpecificEditAndContinueService)?.BuildForEnc(pUpdatePE) ?? VSConstants.S_OK;
-        }
-
-        public int EncApplySucceeded([In] int hrApplyResult)
-        {
-            return ((EncInterop.IVsENCRebuildableProjectCfg2)_host.HostSpecificEditAndContinueService)?.EncApplySucceeded(hrApplyResult) ?? VSConstants.S_OK;
-        }
-
-        public int EnterBreakStateOnPE([In] EncInterop.ENC_BREAKSTATE_REASON encBreakReason, [In, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] ENC_ACTIVE_STATEMENT[] pActiveStatements, [In] uint cActiveStatements)
-        {
-            return ((EncInterop.IVsENCRebuildableProjectCfg2)_host.HostSpecificEditAndContinueService)?.EnterBreakStateOnPE(encBreakReason, pActiveStatements, cActiveStatements) ?? VSConstants.S_OK;
-        }
-
-        public int ExitBreakStateOnPE()
-        {
-            return ((EncInterop.IVsENCRebuildableProjectCfg2)_host.HostSpecificEditAndContinueService)?.ExitBreakStateOnPE() ?? VSConstants.S_OK;
-        }
-
-        public int GetCurrentActiveStatementPosition([In] uint id, [MarshalAs(UnmanagedType.LPArray), Out] TextSpan[] ptsNewPosition)
-        {
-            return ((EncInterop.IVsENCRebuildableProjectCfg2)_host.HostSpecificEditAndContinueService)?.GetCurrentActiveStatementPosition(id, ptsNewPosition) ?? VSConstants.E_FAIL;
-        }
-
-        public int GetCurrentExceptionSpanPosition([In] uint id, [MarshalAs(UnmanagedType.LPArray), Out] TextSpan[] ptsNewPosition)
-        {
-            return ((EncInterop.IVsENCRebuildableProjectCfg2)_host.HostSpecificEditAndContinueService)?.GetCurrentExceptionSpanPosition(id, ptsNewPosition) ?? VSConstants.E_FAIL;
-        }
-
-        public int GetENCBuildState([MarshalAs(UnmanagedType.LPArray), Out] ENC_BUILD_STATE[] pENCBuildState)
-        {
-            return ((EncInterop.IVsENCRebuildableProjectCfg2)_host.HostSpecificEditAndContinueService)?.GetENCBuildState(pENCBuildState) ?? VSConstants.E_FAIL;
-        }
-
-        public int GetExceptionSpanCount([Out] out uint pcExceptionSpan)
-        {
-            pcExceptionSpan = default(uint);
-            return ((EncInterop.IVsENCRebuildableProjectCfg2)_host.HostSpecificEditAndContinueService)?.GetExceptionSpanCount(out pcExceptionSpan) ?? VSConstants.E_FAIL;
-        }
-
-        public int GetExceptionSpans([In] uint celt, [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0), Out] ENC_EXCEPTION_SPAN[] rgelt, [In, Out] ref uint pceltFetched)
-        {
-            return ((EncInterop.IVsENCRebuildableProjectCfg2)_host.HostSpecificEditAndContinueService)?.GetExceptionSpans(celt, rgelt, ref pceltFetched) ?? VSConstants.E_FAIL;
-        }
-
-        public int GetPEBuildTimeStamp([MarshalAs(UnmanagedType.LPArray), Out] OLE.Interop.FILETIME[] pTimeStamp)
-        {
-            return ((EncInterop.IVsENCRebuildableProjectCfg2)_host.HostSpecificEditAndContinueService)?.GetPEBuildTimeStamp(pTimeStamp) ?? VSConstants.E_NOTIMPL;
-        }
-
-        public int GetPEidentity([MarshalAs(UnmanagedType.LPArray), Out] Guid[] pMVID, [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.BStr), Out] string[] pbstrPEName)
-        {
-            return ((EncInterop.IVsENCRebuildableProjectCfg2)_host.HostSpecificEditAndContinueService)?.GetPEidentity(pMVID, pbstrPEName) ?? VSConstants.E_FAIL;
-        }
-
-        public int StartDebuggingPE()
-        {
-            return ((EncInterop.IVsENCRebuildableProjectCfg2)_host.HostSpecificEditAndContinueService)?.StartDebuggingPE() ?? VSConstants.S_OK;
-        }
-
-        public int StopDebuggingPE()
-        {
-            return ((EncInterop.IVsENCRebuildableProjectCfg2)_host.HostSpecificEditAndContinueService)?.StopDebuggingPE() ?? VSConstants.S_OK;
-        }
-
-        public int HasCustomMetadataEmitter([MarshalAs(UnmanagedType.VariantBool)] out bool value)
-        {
-            value = true;
-            return ((EncInterop.IVsENCRebuildableProjectCfg4)_host.HostSpecificEditAndContinueService)?.HasCustomMetadataEmitter(out value) ?? VSConstants.S_OK;
+            get
+            {
+                return _host.HostSpecificEditAndContinueService;
+            }
         }
 
         // Managed ENC always uses IVsENCRebuildableProjectCfg2.


### PR DESCRIPTION
Instead of receiving the call for ENC and reforwarding the call to AbstractProject, MEF export the AbstractProject as EnC interface.

**Customer scenario**

None. This change removes a bunch of code which was unnecessary in the first place

**Bugs this fixes:** 

#1019

**Workarounds, if any**

N/A

**Risk**

None since no functional change

**Performance impact**

None

**Is this a regression from a previous update?** N/A

**Root cause analysis:** N/A

**How was the bug found?**
N/A

Tagging @dotnet/project-system for review