### PR TITLE
Ap/u3/encoding

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyFactory.cs
@@ -141,7 +141,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             ImageMoniker? unresolvedIcon = null,
             ImageMoniker? unresolvedExpandedIcon = null,
             Dictionary<string, string> properties = null,
-            IEnumerable<string> dependenciesIds = null)
+            IEnumerable<string> dependenciesIds = null,
+            ITargetFramework targetFramework = null)
         {
             if (string.IsNullOrEmpty(jsonString))
             {
@@ -184,6 +185,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             if (dependenciesIds != null)
             {
                 data.DependencyIDs = ImmutableList<string>.Empty.AddRange(dependenciesIds);
+            }
+
+            if (targetFramework != null)
+            {
+                data.TargetFramework = targetFramework;
             }
 
             return data;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyExtensionsTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyExtensionsTests.cs
@@ -221,5 +221,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             Assert.Equal(@"c:\somepath\someproject\subfolder\xxx", dependency3.GetActualPath(projectPath));
         }
+
+        [Fact]
+        public void DependencyExtensionsTests_GetTopLevelId()
+        {
+            var dependency1 = IDependencyFactory.FromJson(@"
+{
+    ""Id"":""id1"",
+    ""ProviderType"": ""ProjectDependency""
+}");
+
+            Assert.Equal("id1", dependency1.GetTopLevelId());
+
+            var dependency2 = IDependencyFactory.FromJson(@"
+{
+    ""Id"":""id1"",
+    ""Path"":""xxxxxxx"",
+    ""ProviderType"": ""MyProvider""
+}", targetFramework: ITargetFrameworkFactory.Implement("tfm1"));
+
+            Assert.Equal("tfm1\\MyProvider\\xxxxxxx", dependency2.GetTopLevelId());
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyTests.cs
@@ -122,8 +122,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Theory]
-        [InlineData(@"../../somepath", @"tfm1\xxx\__\__\somepath")]
-        [InlineData(@"__\somepath..\", @"tfm1\xxx\__\somepath__\")]
+        [InlineData(@"../../somepath", @"tfm1\xxx\..\..\somepath")]
+        [InlineData(@"__\somepath..\", @"tfm1\xxx\__\somepath..")]
         [InlineData(@"somepath", @"tfm1\xxx\somepath")]
         public void Dependency_Id_NoSnapsotTargetFramework(string modelId, string expectedId)
         {
@@ -137,8 +137,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Theory]
-        [InlineData(@"../../somepath", @"tfm\providerType\__\__\somepath")]
-        [InlineData(@"__\somepath..\", @"tfm\providerType\__\somepath__\")]
+        [InlineData(@"../../somepath", @"tfm\providerType\..\..\somepath")]
+        [InlineData(@"__\somepath..\", @"tfm\providerType\__\somepath..")]
         [InlineData(@"somepath", @"tfm\providerType\somepath")]
         public void Dependency_Id(string modelId, string expectedId)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/GroupedByTargetTreeViewProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/GroupedByTargetTreeViewProviderTests.cs
@@ -46,6 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         [Fact]
         public void GrouppedByTargetTreeViewProvider_WhenOneTargetSnapshotWithExistingDependencies_ShouldApplyChanges()
         {
+            var tfm1 = ITargetFrameworkFactory.Implement(moniker: "tfm1");
             var dependencyRootXxx = IDependencyFactory.FromJson(@"
 {
     ""ProviderType"": ""Xxx"",
@@ -60,10 +61,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     ""ProviderType"": ""Xxx"",
     ""Id"": ""tfm1\\xxx\\dependency1"",
     ""Name"":""dependency1"",
+    ""Path"":""dependencyXxxpath"",
     ""Caption"":""Dependency1"",
     ""SchemaItemType"":""Xxx"",
     ""Resolved"":""true""
-}", icon:KnownMonikers.Uninstall, expandedIcon:KnownMonikers.Uninstall);
+}", icon:KnownMonikers.Uninstall, expandedIcon:KnownMonikers.Uninstall, targetFramework: tfm1);
 
             var dependencyRootYyy = IDependencyFactory.FromJson(@"
 {
@@ -78,20 +80,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     ""ProviderType"": ""Yyy"",
     ""Id"": ""tfm1\\yyy\\dependency1"",
     ""Name"":""dependency1"",
+    ""Path"":""dependencyYyypath"",
     ""Caption"":""Dependency1"",
     ""SchemaItemType"":""Yyy"",
     ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall, targetFramework: tfm1);
 
             var dependencyYyyExisting = IDependencyFactory.FromJson(@"
 {
     ""ProviderType"": ""Yyy"",
     ""Id"": ""tfm1\\yyy\\dependencyExisting"",
     ""Name"":""dependencyExisting"",
+    ""Path"":""dependencyExistingPath"",
     ""Caption"":""DependencyExisting"",
     ""SchemaItemType"":""Yyy"",
     ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall, targetFramework: tfm1);
 
             var dependencies = new List<IDependency>
             {
@@ -134,7 +138,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             var testData = new Dictionary<ITargetFramework, List<IDependency>>
             {
-                { ITargetFrameworkFactory.Implement(moniker: "tfm1"), dependencies }
+                { tfm1, dependencies }
             };
 
             var project = UnconfiguredProjectFactory.Create(filePath: @"c:\somefodler\someproject.csproj");
@@ -153,9 +157,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 @"Caption=MyDependencies, FilePath=, IconHash=325248080, ExpandedIconHash=325248080, Rule=, IsProjectItem=False, CustomTag=
 Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
 Caption=DependencyExisting, FilePath=tfm1\yyy\dependencyExisting, IconHash=325249260, ExpandedIconHash=325249260, Rule=, IsProjectItem=False, CustomTag=
-Caption=Dependency1, FilePath=tfm1\yyy\dependency1, IconHash=325249260, ExpandedIconHash=325249260, Rule=, IsProjectItem=True, CustomTag=
+Caption=Dependency1, FilePath=tfm1\Yyy\dependencyYyypath, IconHash=325249260, ExpandedIconHash=325249260, Rule=, IsProjectItem=True, CustomTag=
 Caption=XxxDependencyRoot, FilePath=XxxDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
-Caption=Dependency1, FilePath=tfm1\xxx\dependency1, IconHash=325249260, ExpandedIconHash=325249260, Rule=, IsProjectItem=True, CustomTag=
+Caption=Dependency1, FilePath=tfm1\Xxx\dependencyXxxpath, IconHash=325249260, ExpandedIconHash=325249260, Rule=, IsProjectItem=True, CustomTag=
 ";
             Assert.Equal(expectedFlatHierarchy, ((TestProjectTree)resultTree).FlatHierarchy);
         }
@@ -163,6 +167,7 @@ Caption=Dependency1, FilePath=tfm1\xxx\dependency1, IconHash=325249260, Expanded
         [Fact]
         public void GrouppedByTargetTreeViewProvider_WhenOneTargetSnapshotAndDependencySupportsHierarchyAndIsResolved_ShouldReadd()
         {
+            var tfm1 = ITargetFrameworkFactory.Implement(moniker: "tfm1");
             var dependencyRootYyy = IDependencyFactory.FromJson(@"
 {
     ""ProviderType"": ""Yyy"",
@@ -176,12 +181,14 @@ Caption=Dependency1, FilePath=tfm1\xxx\dependency1, IconHash=325249260, Expanded
     ""ProviderType"": ""Yyy"",
     ""Id"": ""tfm1\\yyy\\dependencyExisting"",
     ""Name"":""dependencyExisting"",
+    ""Path"":""dependencyExistingpath"",
     ""Caption"":""DependencyExisting"",
     ""SchemaItemType"":""Yyy"",
     ""Resolved"":""true""
 }", icon: KnownMonikers.Uninstall, 
     expandedIcon: KnownMonikers.Uninstall, 
-    flags: DependencyTreeFlags.SupportsHierarchy);
+    flags: DependencyTreeFlags.SupportsHierarchy,
+    targetFramework: tfm1);
 
             var dependencies = new List<IDependency>
             {
@@ -217,7 +224,7 @@ Caption=Dependency1, FilePath=tfm1\xxx\dependency1, IconHash=325249260, Expanded
 
             var testData = new Dictionary<ITargetFramework, List<IDependency>>
             {
-                { ITargetFrameworkFactory.Implement(moniker: "tfm1"), dependencies }
+                { tfm1, dependencies }
             };
 
             var project = UnconfiguredProjectFactory.Create(filePath: @"c:\somefodler\someproject.csproj");
@@ -235,7 +242,7 @@ Caption=Dependency1, FilePath=tfm1\xxx\dependency1, IconHash=325249260, Expanded
             var expectedFlatHierarchy =
 @"Caption=MyDependencies, FilePath=, IconHash=325248080, ExpandedIconHash=325248080, Rule=, IsProjectItem=False, CustomTag=
 Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
-Caption=DependencyExisting, FilePath=tfm1\yyy\dependencyExisting, IconHash=325249260, ExpandedIconHash=325249260, Rule=, IsProjectItem=True, CustomTag=
+Caption=DependencyExisting, FilePath=tfm1\Yyy\dependencyExistingpath, IconHash=325249260, ExpandedIconHash=325249260, Rule=, IsProjectItem=True, CustomTag=
 ";
             Assert.Equal(expectedFlatHierarchy, ((TestProjectTree)resultTree).FlatHierarchy);
         }
@@ -539,6 +546,10 @@ Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconH
         [Fact]
         public void GrouppedByTargetTreeViewProvider_WhenMultipleTargetSnapshotsWithExistingDependencies_ShouldApplyChanges()
         {
+            var tfm1 = ITargetFrameworkFactory.Implement(moniker: "tfm1");
+            var tfm2 = ITargetFrameworkFactory.Implement(moniker: "tfm2");
+            var tfmAny = ITargetFrameworkFactory.Implement(moniker: "any");
+
             var dependencyRootXxx = IDependencyFactory.FromJson(@"
 {
     ""ProviderType"": ""Xxx"",
@@ -552,11 +563,12 @@ Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconH
 {
     ""ProviderType"": ""Xxx"",
     ""Id"": ""xxx\\dependency1"",
+    ""Path"": ""dependencyxxxpath"",
     ""Name"":""dependency1"",
     ""Caption"":""Dependency1"",
     ""SchemaItemType"":""Xxx"",
     ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall, targetFramework: tfm1);
 
             var dependencyRootYyy = IDependencyFactory.FromJson(@"
 {
@@ -570,21 +582,23 @@ Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconH
 {
     ""ProviderType"": ""Yyy"",
     ""Id"": ""yyy\\dependency1"",
+    ""Path"": ""dependencyyyypath"",
     ""Name"":""dependency1"",
     ""Caption"":""Dependency1"",
     ""SchemaItemType"":""Yyy"",
     ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall, targetFramework: tfm1);
 
             var dependencyYyyExisting = IDependencyFactory.FromJson(@"
 {
     ""ProviderType"": ""Yyy"",
     ""Id"": ""yyy\\dependencyExisting"",
+    ""Path"": ""dependencyyyyExistingpath"",
     ""Name"":""dependencyExisting"",
     ""Caption"":""DependencyExisting"",
     ""SchemaItemType"":""Yyy"",
     ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall, targetFramework: tfm1);
 
             var dependencyRootZzz = IDependencyFactory.FromJson(@"
 {
@@ -598,9 +612,10 @@ Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconH
 {
     ""ProviderType"": ""Zzz"",
     ""Id"": ""ZzzDependencyAny1"",
+    ""Path"": ""ZzzDependencyAny1path"",
     ""Name"":""ZzzDependencyAny1"",
     ""Caption"":""ZzzDependencyAny1""
-}");
+}", targetFramework:tfmAny);
 
             var dependencies = new List<IDependency>
             {
@@ -668,9 +683,9 @@ Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconH
 
             var testData = new Dictionary<ITargetFramework, List<IDependency>>
             {
-                { ITargetFrameworkFactory.Implement(moniker: "tfm1"), dependencies },
-                { ITargetFrameworkFactory.Implement(moniker: "tfm2"), dependencies },
-                { ITargetFrameworkFactory.Implement(moniker: "any"), dependenciesAny }
+                { tfm1, dependencies },
+                { tfm2, dependencies },
+                { tfmAny, dependenciesAny }
             };
 
             var project = UnconfiguredProjectFactory.Create(filePath: @"c:\somefodler\someproject.csproj");
@@ -689,18 +704,18 @@ Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconH
 @"Caption=MyDependencies, FilePath=, IconHash=325248080, ExpandedIconHash=325248080, Rule=, IsProjectItem=False, CustomTag=
 Caption=tfm2, FilePath=tfm2, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=, BubbleUpFlag=True
 Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
-Caption=Dependency1, FilePath=yyy\dependency1, IconHash=325249260, ExpandedIconHash=325249260, Rule=, IsProjectItem=False, CustomTag=
-Caption=DependencyExisting, FilePath=yyy\dependencyExisting, IconHash=325249260, ExpandedIconHash=325249260, Rule=, IsProjectItem=False, CustomTag=
+Caption=Dependency1, FilePath=tfm1\Yyy\dependencyyyypath, IconHash=325249260, ExpandedIconHash=325249260, Rule=, IsProjectItem=False, CustomTag=
+Caption=DependencyExisting, FilePath=tfm1\Yyy\dependencyyyyExistingpath, IconHash=325249260, ExpandedIconHash=325249260, Rule=, IsProjectItem=False, CustomTag=
 Caption=XxxDependencyRoot, FilePath=XxxDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
-Caption=Dependency1, FilePath=xxx\dependency1, IconHash=325249260, ExpandedIconHash=325249260, Rule=, IsProjectItem=False, CustomTag=
+Caption=Dependency1, FilePath=tfm1\Xxx\dependencyxxxpath, IconHash=325249260, ExpandedIconHash=325249260, Rule=, IsProjectItem=False, CustomTag=
 Caption=ZzzDependencyRoot, FilePath=ZzzDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
 Caption=ZzzDependencyAny1, FilePath=ZzzDependencyAny1, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
 Caption=tfm1, FilePath=tfm1, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=, BubbleUpFlag=True
 Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
-Caption=Dependency1, FilePath=yyy\dependency1, IconHash=325249260, ExpandedIconHash=325249260, Rule=, IsProjectItem=True, CustomTag=
-Caption=DependencyExisting, FilePath=yyy\dependencyExisting, IconHash=325249260, ExpandedIconHash=325249260, Rule=, IsProjectItem=True, CustomTag=
+Caption=Dependency1, FilePath=tfm1\Yyy\dependencyyyypath, IconHash=325249260, ExpandedIconHash=325249260, Rule=, IsProjectItem=True, CustomTag=
+Caption=DependencyExisting, FilePath=tfm1\Yyy\dependencyyyyExistingpath, IconHash=325249260, ExpandedIconHash=325249260, Rule=, IsProjectItem=True, CustomTag=
 Caption=XxxDependencyRoot, FilePath=XxxDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
-Caption=Dependency1, FilePath=xxx\dependency1, IconHash=325249260, ExpandedIconHash=325249260, Rule=, IsProjectItem=True, CustomTag=
+Caption=Dependency1, FilePath=tfm1\Xxx\dependencyxxxpath, IconHash=325249260, ExpandedIconHash=325249260, Rule=, IsProjectItem=True, CustomTag=
 ";
             Assert.Equal(expectedFlatHierarchy, ((TestProjectTree)resultTree).FlatHierarchy);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -157,7 +157,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     continue;
                 }
 
-                var dependency = snapshot.FindDependency(filePath);
+                var dependency = snapshot.FindDependency(filePath, topLevel:true);
                 if (dependency == null || dependency.Implicit)
                 {
                     canRemove = false;
@@ -249,7 +249,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                         continue;
                     }
 
-                    var sharedProjectDependency = snapshot.FindDependency(sharedFilePath);
+                    var sharedProjectDependency = snapshot.FindDependency(sharedFilePath, topLevel:true);
                     if (sharedProjectDependency != null)
                     {
                         sharedFilePath = sharedProjectDependency.Path;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/GraphActionHandlerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/GraphActionHandlerBase.cs
@@ -64,20 +64,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
             var id = inputGraphNode.GetValue<string>(DependenciesGraphSchema.DependencyIdProperty);
             if (id == null)
             {
+                // this is top level node and it contains full path 
                 id = inputGraphNode.Id.GetValue(CodeGraphNodeIdName.File);
                 if (id.StartsWith(projectFolder, StringComparison.OrdinalIgnoreCase))
                 {
                     id = id.Substring(projectFolder.Length).TrimStart('\\');
                 }
-            }
 
-            if (id == null)
+                return GetTopLevelDependency(projectPath, id, out snapshot);
+            }
+            else
             {
-                return null;
+                return GetDependency(projectPath, id, out snapshot);
             }
-
-            // always refresh
-            return GetDependency(projectPath, id, out snapshot);
         }
 
         protected IDependency GetDependency(
@@ -87,6 +86,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
         {
             snapshot = GetSnapshot(projectPath);
             return snapshot?.FindDependency(dependencyId);
+        }
+
+        protected IDependency GetTopLevelDependency(
+            string projectPath,
+            string dependencyId,
+            out IDependenciesSnapshot snapshot)
+        {
+            snapshot = GetSnapshot(projectPath);
+            return snapshot?.FindDependency(dependencyId, topLevel:true);
         }
 
         protected IDependenciesSnapshot GetSnapshot(string projectPath)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
@@ -321,7 +321,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
             string projectPath,
             IDependencyViewModel viewModel)
         {
-            var newNodeId = GetTopLevelGraphNodeId(projectPath, viewModel.OriginalModel.Id);
+            var newNodeId = GetTopLevelGraphNodeId(projectPath, viewModel.OriginalModel.GetTopLevelId());
             return DoAddGraphNode(newNodeId, graphContext, projectPath, parentNode: null, viewModel:viewModel);
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GroupedByTargetTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GroupedByTargetTreeViewProvider.cs
@@ -390,10 +390,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 var flags = FilterFlags(viewModel.Flags.Except(DependencyTreeFlags.BaseReferenceFlags),
                                         additionalFlags,
                                         excludedFlags);
+                var filePath = (viewModel.OriginalModel != null && viewModel.OriginalModel.TopLevel && viewModel.OriginalModel.Resolved)
+                                ? viewModel.OriginalModel.GetTopLevelId() 
+                                : viewModel.FilePath;
 
                 node = TreeServices.CreateTree(
                     caption: viewModel.Caption,
-                    filePath: viewModel.FilePath,
+                    filePath: filePath,
                     visible: true,
                     browseObjectProperties: rule,
                     flags: flags,
@@ -421,12 +424,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             if (node == null)
             {
                 var flags = FilterFlags(viewModel.Flags, additionalFlags, excludedFlags);
+                var filePath = (viewModel.OriginalModel != null && viewModel.OriginalModel.TopLevel && viewModel.OriginalModel.Resolved) 
+                                    ? viewModel.OriginalModel.GetTopLevelId()
+                                    : viewModel.FilePath;
 
                 var itemContext = ProjectPropertiesContext.GetContext(
                     CommonServices.Project,
-                    file: viewModel.FilePath,
+                    file: filePath,
                     itemType: viewModel.SchemaItemType,
-                    itemName: viewModel.FilePath);
+                    itemName: filePath);
 
                 node = TreeServices.CreateTree(
                     caption: viewModel.Caption,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -63,8 +63,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             }
         }
 
-        public IDependency FindDependency(string id)
+        public IDependency FindDependency(string id, bool topLevel = false)
         {
+            if (string.IsNullOrEmpty(id))
+            {
+                return null;
+            }
+
+            if (topLevel)
+            {
+                // if top level first try to find by top level id with full path,
+                // if found - return, if not - try regular Id in the DependenciesWorld
+                foreach (var target in Targets)
+                {
+                    var dependency = target.Value.TopLevelDependencies.FirstOrDefault(
+                        x => x.GetTopLevelId().Equals(id, StringComparison.OrdinalIgnoreCase));
+                    if (dependency != null)
+                    {
+                        return dependency;
+                    }
+                }
+            }
+
             foreach (var target in Targets)
             {
                 if (target.Value.DependenciesWorld.TryGetValue(id, out IDependency dependency))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
@@ -266,7 +266,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
         private static string Normalize(string id)
         {
-            return id.Replace('.', '_').Replace('/', '\\');
+            return id.Replace('/', '\\');
         }
 
         public static string GetID(ITargetFramework targetFramework, string providerType, string modelId)
@@ -275,8 +275,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             Requires.NotNullOrEmpty(providerType, nameof(providerType));
             Requires.NotNullOrEmpty(modelId, nameof(modelId));
 
-            var normalizedModelId = modelId.Replace('.', '_');
-            return $"{targetFramework.ShortName}/{providerType}/{normalizedModelId}".TrimEnd('/').Replace('/', '\\');
+            return $"{targetFramework.ShortName}\\{providerType}\\{Normalize(modelId)}".TrimEnd('\\');
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependenciesSnapshot.cs
@@ -36,7 +36,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         /// Finds dependency for given id accross all target frameworks.
         /// </summary>
         /// <param name="id">Unique id for dependency to be found.</param>
+        /// <param name="topLevel">Suggests that id is specified for top level dependency and 
+        /// different logic should be used, while searching for it.
+        /// </param>
         /// <returns>IDependency object if given id was found, otherwise null.</returns>
-        IDependency FindDependency(string id);
+        IDependency FindDependency(string id, bool topLevel = false);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
@@ -52,6 +52,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         }
 
         /// <summary>
+        /// Returns id having full path instead of OriginalItemSpec
+        /// </summary>
+        public static string GetTopLevelId(this IDependency self)
+        {
+            return string.IsNullOrEmpty(self.Path)
+                ? self.Id
+                : Dependency.GetID(self.TargetFramework, self.ProviderType, self.Path);
+        }
+
+        /// <summary>
         /// Returns all icons specified for given dependency.
         /// </summary>
         public static IEnumerable<ImageMoniker> GetIcons(this IDependency self)


### PR DESCRIPTION
**Customer scenario**

This is to unblock individual Anallyzers workitem by @tmeschter . Analyzers nodes implementation is base on iVsHierarchies and to keep one implementation we need to adjust for them. Change is to send full paths wihtou encoding for top level dependencies to IProjectTree. GrpahNodes logic knows how to determine if node is top level and find it in the snapshot.

**Bugs this fixes:** 

Related to #2062.

**Workarounds, if any**

N/A

**Risk**

Small

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

**Is this a regression from a previous update?**

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

(E.g. customer reported it vs. ad hoc testing)
