### PR TITLE
Updating the property page set parent logic so accessibility keys work.

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/Common/switches.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/Common/switches.vb
@@ -280,13 +280,6 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         Public Shared PDCmdTarget As New TraceSwitch("PDCmdTarget", "Trace command routing (CmdTargetHelper, etc.) in the project designer")
 
         ''' <summary>
-        ''' Always use native ::SetParent() instead of setting the WinForms Parent property for property page hosting.
-        ''' This is useful for testing the hosting of pages as it would occur for non-native pages.
-        ''' </summary>
-        ''' <remarks></remarks>
-        Public Shared PDAlwaysUseSetParent As New BooleanSwitch("PDAlwaysUseSetParent", "Always use native ::SetParent() instead of setting the WinForms Parent property for property page hosting")
-
-        ''' <summary>
         ''' Traces message routing in the project designer and its property pages
         ''' </summary>
         ''' <remarks></remarks>

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPage.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPage.vb
@@ -340,13 +340,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             If Not _propPage Is Nothing Then
 
                 _propPage.SuspendLayout() 'No need for more layouts...
-                If _propPage.Parent IsNot Nothing AndAlso Not _hostedInNative Then
-                    'We sited ourselves by setting the Windows Forms Parent property
-                    _propPage.Parent = Nothing
-                ElseIf _wasSetParentCalled Then
-                    'We sited ourselves via a native SetParent call
-                    NativeMethods.SetParent(_propPage.Handle, _prevParent)
-                End If
+                NativeMethods.SetParent(_propPage.Handle, _prevParent)
 
                 _propPage.Dispose()
                 _propPage = Nothing
@@ -422,7 +416,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             ' we need to adjust the size of the page if it's autosize or if we're native (in which
             ' case we're going to adjust the size of our secret usercontrol instead) See the Create
             ' for more info about the panel
-            If _propPage IsNot Nothing AndAlso pRect IsNot Nothing AndAlso pRect.Length <> 0 AndAlso (_propPage.AutoSize OrElse _hostedInNative) Then
+            If _propPage IsNot Nothing AndAlso pRect IsNot Nothing AndAlso pRect.Length <> 0 Then
                 Dim minSize As Drawing.Size = _propPage.MinimumSize
 
                 ' we have to preserve these to set the size of our scrolling panel
@@ -441,11 +435,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 End If
 
                 _propPage.Bounds = New Rectangle(pRect(0).left, pRect(0).top, minRespectingWidth, minRespectingHeight)
-                ' if we're in native, set our scrolling panel to be the exact size that we were
+                ' set our scrolling panel to be the exact size that we were
                 ' passed so if we need scroll bars, they show up properly
-                If _hostedInNative Then
-                    _propPage.Parent.Size = New Drawing.Size(width, height)
-                End If
+                _propPage.Parent.Size = New Drawing.Size(width, height)
 
             End If
 
@@ -498,15 +490,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             ' if we're in native, show/hide our secret scrolling panel too
             ' See Create(hWnd) for more info on where that comes from
             If nCmdShow <> s_SW_HIDE Then
-                If _hostedInNative Then
-                    _propPage.Parent.Show()
-                End If
+                _propPage.Parent.Show()
                 _propPage.Show()
                 SetHelpContext()
             Else
-                If _hostedInNative Then
-                    _propPage.Parent.Hide()
-                End If
+                _propPage.Parent.Hide()
                 _propPage.Hide()
             End If
 
@@ -631,29 +619,18 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
                 Common.Switches.TracePDPerf("PropPage.Create: Setting the property page's parent")
 
-                Dim ParentControl As Control = Control.FromHandle(hWndParent)
-                Dim AlwaysUseSetParent As Boolean = False
-#If DEBUG Then
-                AlwaysUseSetParent = Common.Switches.PDAlwaysUseSetParent.Enabled
-#End If
-                If ParentControl IsNot Nothing AndAlso Not AlwaysUseSetParent Then
-                    _propPage.Parent = ParentControl
-                    Debug.Assert(_propPage.Parent IsNot Nothing, "Huh?  Deactivate() logic depends on this.")
-                Else
-                    'Not a managed window, use the win32 api method
-                    _hostedInNative = True
-                    ' in order to have scroll bars properly appear in large fonts, wrap
-                    ' the page in a usercontrol (since it supports AutoScroll) that won't
-                    ' scale with fonts. Move(rect) will set the proper size.
-                    Dim sizingParent As New UserControl()
-                    sizingParent.AutoScaleMode = AutoScaleMode.None
-                    sizingParent.AutoScroll = True
-                    sizingParent.Text = "SizingParent" 'For debugging purposes (Spy++)
-                    _propPage.Parent = sizingParent
-                    NativeMethods.SetParent(sizingParent.Handle, hWndParent)
-                    _wasSetParentCalled = True
-                    Debug.Assert(_propPage.Parent Is Nothing OrElse AlwaysUseSetParent, "Huh?  Deactivate() logic depends on this.")
-                End If
+                ' in order to have scroll bars properly appear in large fonts, wrap
+                ' the page in a usercontrol (since it supports AutoScroll) that won't
+                ' scale with fonts. Move(rect) will set the proper size. This is also required
+                ' so existing accessibility keys (such as Alt+Down, for ComboBoxes) continue
+                ' working.
+                Dim sizingParent As New UserControl()
+                sizingParent.AutoScaleMode = AutoScaleMode.None
+                sizingParent.AutoScroll = True
+                sizingParent.Text = "SizingParent" 'For debugging purposes (Spy++)
+                _propPage.Parent = sizingParent
+
+                NativeMethods.SetParent(sizingParent.Handle, hWndParent)
 
                 'Site the undo manager if we have one and the page supports it
                 If (_propPageUndoSite IsNot Nothing) AndAlso (TypeOf _propPage Is IVsProjectDesignerPage) Then

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPage.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPage.vb
@@ -112,8 +112,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Private _objects As Object()
         Private _prevParent As IntPtr
         Private _dispidFocus As Integer
-        Private _hostedInNative As Boolean = False
-        Private _wasSetParentCalled As Boolean
 
         Protected Sub New()
         End Sub
@@ -487,7 +485,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 Throw New InvalidOperationException("Form not created")
             End If
 
-            ' if we're in native, show/hide our secret scrolling panel too
+            ' show/hide our secret scrolling panel too
             ' See Create(hWnd) for more info on where that comes from
             If nCmdShow <> s_SW_HIDE Then
                 _propPage.Parent.Show()


### PR DESCRIPTION
This resolves VSO Bug 409664.

This modifies the properties page to always use `SetParent`. Previously, this was only used for hosting native pages (or activated via a debug switch). However, enabling it globally allows accessibility keys (such as Alt+Down, for ComboBoxes) to work as expected.