### PR TITLE
Add Runtime assemblies for VB Framework projects

### DIFF
--- a/src/Targets/Microsoft.VisualBasic.DesignTime.targets
+++ b/src/Targets/Microsoft.VisualBasic.DesignTime.targets
@@ -43,14 +43,19 @@
         >
 
     <!-- VB Framework projects needs core library references. In the case of Command line scenario, the vbc injects this reference. -->
-    <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-      <MSCorlibPath>$(FrameworkPathOverride)\mscorlib.dll</MSCorlibPath>
-      <MSVBPath>$(FrameworkPathOverride)\Microsoft.VisualBasic.dll</MSVBPath>
+    <PropertyGroup Condition="'$(FrameworkPathOverride)' != ''">
+      <MSCorlibPath Condition=" '$(MSCorlibPath)' == '' ">$(FrameworkPathOverride)\mscorlib.dll</MSCorlibPath>
+      <MSVBRuntimeFileOrPath Condition=" '$(MSVBRuntimeFileOrPath)' == '' And '$(VBRuntimePath)' == '$(VBRuntime)'">$(VBRuntimePath)</MSVBRuntimeFileOrPath>
+      <MSVBRuntimeFileOrPath Condition=" '$(MSVBRuntimeFileOrPath)' == '' And '$(VBRuntime)' == 'DEFAULT'">$(FrameworkPathOverride)\Microsoft.VisualBasic.dll</MSVBRuntimeFileOrPath>
+      <MSVBRuntimeFileOrPath Condition=" '$(MSVBRuntimeFileOrPath)' == '' And '$(VBRuntime)' != '' And'$(VBRuntime)' != 'None' And '$(VBRuntime)' != 'Embed'">$(VBRuntime)</MSVBRuntimeFileOrPath>
     </PropertyGroup>
 
     <ItemGroup>
       <VbcCommandLineArgs Condition="Exists('$(MSCorlibPath)')" Include="/reference:$(MSCorlibPath)"/>
-      <VbcCommandLineArgs Condition="Exists('$(MSVBPath)')" Include="/reference:$(MSVBPath)"/>
+
+      <!-- MSVBRuntimeFileOrPath could either be the filename relative to sdkpath or the actual path to the runtime-->
+      <VbcCommandLineArgs Condition="Exists('$(MSVBRuntimeFileOrPath)')" Include="/reference:$(MSVBRuntimeFileOrPath)"/>
+      <VbcCommandLineArgs Condition="'$(MSVBRuntimeFileOrPath)' != '' And Exists('$(FrameworkPathOverride)\$(MSVBRuntimeFileOrPath)')" Include="/reference:$(FrameworkPathOverride)\$(MSVBRuntimeFileOrPath)"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Targets/Microsoft.VisualBasic.DesignTime.targets
+++ b/src/Targets/Microsoft.VisualBasic.DesignTime.targets
@@ -22,7 +22,7 @@
     <DefineVisualBasicItemSchemas>false</DefineVisualBasicItemSchemas>
   </PropertyGroup>
 
-    <ItemGroup>
+  <ItemGroup>
      <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)VisualBasic.ProjectItemsSchema.xaml;"/>
 
       <!-- Namespace Import List-->
@@ -31,21 +31,32 @@
       </PropertyPageSchema>
 
      <ProjectCapability Include="VB;Managed"/>
+  </ItemGroup>
+
+  <!-- Targets -->
+
+  <!-- Returns Vbc command-line arguments for the language service -->
+  <Target Name="CompileDesignTime"
+          Returns="@(_CompilerCommandLineArgs)"
+          DependsOnTargets="_CheckCompileDesignTimePrerequisite;Compile"
+          Condition="'$(IsCrossTargetingBuild)' != 'true'"
+        >
+
+    <!-- VB Framework projects needs core library references. In the case of Command line scenario, the vbc injects this reference. -->
+    <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+      <MSCorlibPath>$(FrameworkPathOverride)\mscorlib.dll</MSCorlibPath>
+      <MSVBPath>$(FrameworkPathOverride)\Microsoft.VisualBasic.dll</MSVBPath>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <VbcCommandLineArgs Condition="Exists('$(MSCorlibPath)')" Include="/reference:$(MSCorlibPath)"/>
+      <VbcCommandLineArgs Condition="Exists('$(MSVBPath)')" Include="/reference:$(MSVBPath)"/>
     </ItemGroup>
 
-    <!-- Targets -->
-    
-    <!-- Returns Vbc command-line arguments for the language service -->
-    <Target Name="CompileDesignTime"
-            Returns="@(_CompilerCommandLineArgs)"
-            DependsOnTargets="_CheckCompileDesignTimePrerequisite;Compile"
-            Condition="'$(IsCrossTargetingBuild)' != 'true'"
-          >
+    <ItemGroup>
+      <_CompilerCommandLineArgs Include="@(VbcCommandLineArgs)"/>
+    </ItemGroup>
 
-      <ItemGroup>
-        <_CompilerCommandLineArgs Include="@(VbcCommandLineArgs)"/>
-      </ItemGroup>
-        
   </Target>
 
 </Project>


### PR DESCRIPTION
VB Framework projects needs references to the Core libraries, without which Object and all the essential types will be missing. This reference was added by VisualBasic Project in the legacy world. This change will perform a similar functionality.

Tagging @srivatsn @dotnet/project-system for review

**Customer scenario**

Without this change, the language service for all of VB framework projects is broken

**Bugs this fixes:** 

#1961 

**Workarounds, if any**

None

**Risk**

Low. This change is only for VB framework projects.

**Performance impact**

None. There is no complex computation. 

**Is this a regression from a previous update?**

No. This scenario could not have worked before unless the Core libraries were added by mistake.

**Root cause analysis:**

This is parity behavior of the VB Legacy Project which is one of the many things that VB does.

**How was the bug found?**

Ad-hoc testing
