### PR TITLE
Debug property page under LaunchProfiles capability

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Properties/CSharpProjectDesignerPageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Properties/CSharpProjectDesignerPageProvider.cs
@@ -35,7 +35,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
                 builder.Add(CSharpProjectDesignerPage.Package);
             }
 
-            builder.Add(CSharpProjectDesignerPage.Debug);
+            if (_capabilities.Contains(ProjectCapability.LaunchProfiles))
+            {
+                builder.Add(CSharpProjectDesignerPage.Debug);
+            }
+
             builder.Add(CSharpProjectDesignerPage.Signing);
 
             return Task.FromResult<IReadOnlyCollection<IPageMetadata>>(builder.ToImmutable());

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests/ProjectSystem/VS/Properties/FSharpProjectDesignerPageProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests/ProjectSystem/VS/Properties/FSharpProjectDesignerPageProviderTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -17,32 +18,39 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
-        public async Task GetPagesAsync_ReturnsPagesInOrder()
+        public async Task GetPagesAsync_WhenAllCapabiltiesPresent_ReturnsPagesInOrder()
         {
-            var provider = CreateInstance();
-            var pages = await provider.GetPagesAsync();
+            var provider = CreateInstance(ProjectCapability.LaunchProfiles, ProjectCapability.Pack);
+            var result = await provider.GetPagesAsync();
 
-            Assert.Equal(pages.Count(), 5);
-            Assert.Same(pages.ElementAt(0), FSharpProjectDesignerPage.Application);
-            Assert.Same(pages.ElementAt(1), FSharpProjectDesignerPage.Build);
-            Assert.Same(pages.ElementAt(2), FSharpProjectDesignerPage.BuildEvents);
-            Assert.Same(pages.ElementAt(3), FSharpProjectDesignerPage.Debug);
-            Assert.Same(pages.ElementAt(4), FSharpProjectDesignerPage.ReferencePaths);
+            var expected = ImmutableArray.Create<IPageMetadata>(
+               FSharpProjectDesignerPage.Application,
+               FSharpProjectDesignerPage.Build,
+               FSharpProjectDesignerPage.BuildEvents,
+               FSharpProjectDesignerPage.Debug,
+               FSharpProjectDesignerPage.Package,
+               FSharpProjectDesignerPage.ReferencePaths
+            );
+
+            Assert.Equal(expected, result);
         }
 
         [Fact]
-        public async Task GetPagesAsync_WithPackCapability()
+        public async Task GetPagesAsync_WhenNoLaunchProfilesCapability_DoesNotContainDebugPage()
         {
-            var provider = CreateInstance(ProjectCapability.Pack);
-            var pages = await provider.GetPagesAsync();
+            var provider = CreateInstance();
+            var result = await provider.GetPagesAsync();
 
-            Assert.Equal(pages.Count(), 6);
-            Assert.Same(pages.ElementAt(0), FSharpProjectDesignerPage.Application);
-            Assert.Same(pages.ElementAt(1), FSharpProjectDesignerPage.Build);
-            Assert.Same(pages.ElementAt(2), FSharpProjectDesignerPage.BuildEvents);
-            Assert.Same(pages.ElementAt(3), FSharpProjectDesignerPage.Debug);
-            Assert.Same(pages.ElementAt(4), FSharpProjectDesignerPage.Package);
-            Assert.Same(pages.ElementAt(5), FSharpProjectDesignerPage.ReferencePaths);
+            Assert.DoesNotContain(FSharpProjectDesignerPage.Debug, result);
+        }
+
+        [Fact]
+        public async Task GetPagesAsync_WhenNoPackCapability_DoesNotContainPackagePage()
+        {
+            var provider = CreateInstance();
+            var result = await provider.GetPagesAsync();
+
+            Assert.DoesNotContain(FSharpProjectDesignerPage.Package, result);
         }
 
         private static FSharpProjectDesignerPageProvider CreateInstance(params string[] capabilities)

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/ProjectSystem/VS/Properties/FSharpProjectDesignerPageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/ProjectSystem/VS/Properties/FSharpProjectDesignerPageProvider.cs
@@ -28,7 +28,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             builder.Add(FSharpProjectDesignerPage.Application);
             builder.Add(FSharpProjectDesignerPage.Build);
             builder.Add(FSharpProjectDesignerPage.BuildEvents);
-            builder.Add(FSharpProjectDesignerPage.Debug);
+
+            if (_capabilities.Contains(ProjectCapability.LaunchProfiles))
+            {
+                builder.Add(FSharpProjectDesignerPage.Debug);
+            }
 
             if (_capabilities.Contains(ProjectCapability.Pack))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Properties/VisualBasicProjectDesignerPageProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Properties/VisualBasicProjectDesignerPageProviderTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -17,30 +18,38 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
-        public async Task GetPagesAsync_ReturnsPagesInOrder()
+        public async Task GetPagesAsync_WhenAllCapabiltiesPresent_ReturnsPagesInOrder()
         {
-            var provider = CreateInstance();
-            var pages = await provider.GetPagesAsync();
+            var provider = CreateInstance(ProjectCapability.LaunchProfiles, ProjectCapability.Pack);
+            var result = await provider.GetPagesAsync();
 
-            Assert.Equal(pages.Count(), 4);
-            Assert.Same(pages.ElementAt(0), VisualBasicProjectDesignerPage.Application);
-            Assert.Same(pages.ElementAt(1), VisualBasicProjectDesignerPage.Compile);
-            Assert.Same(pages.ElementAt(2), VisualBasicProjectDesignerPage.References);
-            Assert.Same(pages.ElementAt(3), VisualBasicProjectDesignerPage.Debug);
+            var expected = ImmutableArray.Create<IPageMetadata>(
+               VisualBasicProjectDesignerPage.Application,
+               VisualBasicProjectDesignerPage.Compile,
+               VisualBasicProjectDesignerPage.Package,
+               VisualBasicProjectDesignerPage.References,
+               VisualBasicProjectDesignerPage.Debug               
+            );
+
+            Assert.Equal(expected, result);
         }
 
         [Fact]
-        public async Task GetPagesAsync_WithPackCapability()
+        public async Task GetPagesAsync_WhenNoLaunchProfilesCapability_DoesNotContainDebugPage()
         {
-            var provider = CreateInstance(ProjectCapability.Pack);
-            var pages = await provider.GetPagesAsync();
+            var provider = CreateInstance();
+            var result = await provider.GetPagesAsync();
 
-            Assert.Equal(pages.Count(), 5);
-            Assert.Same(pages.ElementAt(0), VisualBasicProjectDesignerPage.Application);
-            Assert.Same(pages.ElementAt(1), VisualBasicProjectDesignerPage.Compile);
-            Assert.Same(pages.ElementAt(2), VisualBasicProjectDesignerPage.Package);
-            Assert.Same(pages.ElementAt(3), VisualBasicProjectDesignerPage.References);
-            Assert.Same(pages.ElementAt(4), VisualBasicProjectDesignerPage.Debug);
+            Assert.DoesNotContain(VisualBasicProjectDesignerPage.Debug, result);
+        }
+
+        [Fact]
+        public async Task GetPagesAsync_WhenNoPackCapability_DoesNotContainPackagePage()
+        {
+            var provider = CreateInstance();
+            var result = await provider.GetPagesAsync();
+
+            Assert.DoesNotContain(VisualBasicProjectDesignerPage.Package, result);
         }
 
         private static VisualBasicProjectDesignerPageProvider CreateInstance(params string[] capabilities)

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Properties/VisualBasicProjectDesignerPageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Properties/VisualBasicProjectDesignerPageProvider.cs
@@ -34,7 +34,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             }
 
             builder.Add(VisualBasicProjectDesignerPage.References);
-            builder.Add(VisualBasicProjectDesignerPage.Debug);
+
+            if (_capabilities.Contains(ProjectCapability.LaunchProfiles))
+            {
+                builder.Add(VisualBasicProjectDesignerPage.Debug);
+            }
 
             return Task.FromResult<IReadOnlyCollection<IPageMetadata>>(builder.ToImmutable());
         }


### PR DESCRIPTION
Xamarin folks do not define LaunchProfiles and want to hide the Debug property page when it is not present.