### PR TITLE
Creating a package to deploy the 1.x templates

### DIFF
--- a/build/Scripts/copyOutput.cmd
+++ b/build/Scripts/copyOutput.cmd
@@ -4,7 +4,7 @@ setlocal enabledelayedexpansion
 set BinariesDirectory=%1
 
 echo Copy the Modern Vsixes manifest into VsixV3
-robocopy %BinariesDirectory% %BinariesDirectory%VsixV3 Microsoft.VisualStudio.Editors.vsman Microsoft.VisualStudio.ProjectSystem.Managed.vsman Microsoft.VisualStudio.NetCore.ProjectTemplates.vsman /njh /njs /np /xx
+robocopy %BinariesDirectory% %BinariesDirectory%VsixV3 Microsoft.VisualStudio.Editors.vsman Microsoft.VisualStudio.ProjectSystem.Managed.vsman Microsoft.VisualStudio.NetCore.ProjectTemplates.vsman Microsoft.VisualStudio.NetCore.ProjectTemplates.1.x.vsman /njh /njs /np /xx
 
 echo Copy the Nugets to CoreXT Share
 robocopy %BinariesDirectory%NuGetPackages \\cpvsbuild\drops\dd\nuget /njh /njs /np /xx 

--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <ProjectDir>$(MSBuildThisFileDirectory)..\..\</ProjectDir>
+    <ProjectTemplateVersion>1.0.0-beta2-20170425-203</ProjectTemplateVersion>
     <NuGetToolPath Condition="">$(ProjectDir)build\bin\nuget.exe</NuGetToolPath>
     <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == ''">$(NUGET_PACKAGES)</NuGetPackageRoot> <!-- Respect environment variable if set -->
     <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == '' and

--- a/build/build.proj
+++ b/build/build.proj
@@ -16,6 +16,8 @@
     <VsManProjectFile Include="$(RepositoryRootDirectory)src\VsixV3\EditorsPackage\Microsoft.VisualStudio.Editors.vsmanproj" />
     <VsManProjectFile Include="$(RepositoryRootDirectory)src\VsixV3\ProjectSystemPackage\Microsoft.VisualStudio.ProjectSystem.Managed.vsmanproj" />
     <VsManProjectFile Include="$(RepositoryRootDirectory)src\VsixV3\ProjectTemplates\Microsoft.VisualStudio.NetCore.ProjectTemplates.vsmanproj" />
+    <VsManProjectFile Include="$(RepositoryRootDirectory)src\VsixV3\ProjectTemplates\Microsoft.VisualStudio.NetCore.ProjectTemplates.vsmanproj" />
+    <VsManProjectFile Include="$(RepositoryRootDirectory)src\VsixV3\ProjectTemplates1.x\Microsoft.VisualStudio.NetCore.ProjectTemplates.1.x.vsmanproj" />
   </ItemGroup>
 
   <Target Name="Restore">

--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -10,6 +10,7 @@
     <add key="myget.org nuget-build" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
     <add key="dotnet.myget.org roslyn-tools" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
     <add key="myget.org vs-devcore" value="http://www.myget.org/F/vs-devcore/api/v3/index.json" />
+    <add key="dotnet.myget.org templating" value="https://dotnet.myget.org/F/templating/api/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 

--- a/src/ProjectSystem.sln
+++ b/src/ProjectSystem.sln
@@ -101,6 +101,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.NetStandard.FShar
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.NetStandard.VB.ProjectTemplates.Vsix", "Templates\Microsoft.NetStandard.VB.ProjectTemplates.Vsix\Microsoft.NetStandard.VB.ProjectTemplates.Vsix.csproj", "{CC1FF91F-C0A9-4729-9863-45A688483F84}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DeployNupkgs", "Templates\DeployNupkgs\DeployNupkgs.csproj", "{AE328174-EBB5-49CF-B642-DBF6CEB2EA4B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -280,6 +282,10 @@ Global
 		{CC1FF91F-C0A9-4729-9863-45A688483F84}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CC1FF91F-C0A9-4729-9863-45A688483F84}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CC1FF91F-C0A9-4729-9863-45A688483F84}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AE328174-EBB5-49CF-B642-DBF6CEB2EA4B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AE328174-EBB5-49CF-B642-DBF6CEB2EA4B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AE328174-EBB5-49CF-B642-DBF6CEB2EA4B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AE328174-EBB5-49CF-B642-DBF6CEB2EA4B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -305,5 +311,6 @@ Global
 		{E5661DF5-A017-43D8-8874-E4B32E4650A4} = {7AC93D71-E528-4BDA-AEEF-47876EC5F5A0}
 		{8CE6132E-DD84-4137-A09C-0C4660DCC98F} = {7AC93D71-E528-4BDA-AEEF-47876EC5F5A0}
 		{CC1FF91F-C0A9-4729-9863-45A688483F84} = {7AC93D71-E528-4BDA-AEEF-47876EC5F5A0}
+		{AE328174-EBB5-49CF-B642-DBF6CEB2EA4B} = {6DE4B49E-AC38-4E35-82CD-D52731503111}
 	EndGlobalSection
 EndGlobal

--- a/src/Templates/DeployNupkgs/DeployNupkgs.csproj
+++ b/src/Templates/DeployNupkgs/DeployNupkgs.csproj
@@ -1,0 +1,26 @@
+﻿<Project>
+  <Import Project="..\..\..\build\Targets\VSL.Settings.targets" />
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+    <OutputType>Library</OutputType>
+    <RestorePackages>true</RestorePackages>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFramework>net46</TargetFramework>
+    <UseCommonOutputDirectory>true</UseCommonOutputDirectory>
+    <ProjectSystemLayer>VisualStudio</ProjectSystemLayer>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Common.ProjectTemplates.1.x" Version="$(ProjectTemplateVersion)" />
+    <PackageReference Include="Microsoft.DotNet.Test.ProjectTemplates.1.x" Version="$(ProjectTemplateVersion)" />
+  </ItemGroup>
+
+  <Import Project="..\..\..\build\Targets\VSL.Imports.targets" />
+  <Target Name="AfterBuild">
+    <ItemGroup>
+      <NugetPackagesToCopy Include="$(NuGetPackageRoot)\microsoft.dotnet.common.projecttemplates.1.x\$(ProjectTemplateVersion)\microsoft.dotnet.common.projecttemplates.1.x.$(ProjectTemplateVersion).nupkg" />
+      <NugetPackagesToCopy Include="$(NuGetPackageRoot)\microsoft.dotnet.test.projecttemplates.1.x\$(ProjectTemplateVersion)\microsoft.dotnet.test.projecttemplates.1.x.$(ProjectTemplateVersion).nupkg" />
+    </ItemGroup>
+    <Copy SourceFiles="@(NugetPackagesToCopy)" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
+  </Target>
+</Project>

--- a/src/Templates/DeployNupkgs/DeployNupkgs.csproj
+++ b/src/Templates/DeployNupkgs/DeployNupkgs.csproj
@@ -21,6 +21,10 @@
       <NugetPackagesToCopy Include="$(NuGetPackageRoot)\microsoft.dotnet.common.projecttemplates.1.x\$(ProjectTemplateVersion)\microsoft.dotnet.common.projecttemplates.1.x.$(ProjectTemplateVersion).nupkg" />
       <NugetPackagesToCopy Include="$(NuGetPackageRoot)\microsoft.dotnet.test.projecttemplates.1.x\$(ProjectTemplateVersion)\microsoft.dotnet.test.projecttemplates.1.x.$(ProjectTemplateVersion).nupkg" />
     </ItemGroup>
-    <Copy SourceFiles="@(NugetPackagesToCopy)" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
+    <ItemGroup>
+      <NugetPackagesDestination Include="$(OutputPath)\microsoft.dotnet.common.projecttemplates.1.x.1.0.0.nupkg" />
+      <NugetPackagesDestination Include="$(OutputPath)\microsoft.dotnet.test.projecttemplates.1.x.1.0.0.nupkg" />
+    </ItemGroup>
+    <Copy SourceFiles="@(NugetPackagesToCopy)" DestinationFiles="@(NugetPackagesDestination)" ContinueOnError="true" />
   </Target>
 </Project>

--- a/src/Templates/Microsoft.NetCore.CSharp.ProjectTemplates/ClassLibrary-CSharp-NetCoreApp.vstemplate
+++ b/src/Templates/Microsoft.NetCore.CSharp.ProjectTemplates/ClassLibrary-CSharp-NetCoreApp.vstemplate
@@ -20,7 +20,7 @@
     <CustomParameters>
       <CustomParameter Name="$language$" Value="C#" />
       <CustomParameter Name="$uistyle$" Value="none" />
-      <CustomParameter Name="groupid" Value="Microsoft.Common.Library" />
+      <CustomParameter Name="$groupid$" Value="Microsoft.Common.Library" />
       <CustomParameter Name="$set:baseline$" Value="app" />
     </CustomParameters>
   </TemplateContent>

--- a/src/Templates/Microsoft.NetCore.FSharp.ProjectTemplates/ClassLibrary-FSharp-NetCoreApp.vstemplate
+++ b/src/Templates/Microsoft.NetCore.FSharp.ProjectTemplates/ClassLibrary-FSharp-NetCoreApp.vstemplate
@@ -20,7 +20,7 @@
     <CustomParameters>
       <CustomParameter Name="$language$" Value="F#" />
       <CustomParameter Name="$uistyle$" Value="none" />
-      <CustomParameter Name="groupid" Value="Microsoft.Common.Library" />
+      <CustomParameter Name="$groupid$" Value="Microsoft.Common.Library" />
       <CustomParameter Name="$set:baseline$" Value="app" />
     </CustomParameters>
   </TemplateContent>

--- a/src/Templates/Microsoft.NetCore.VB.ProjectTemplates/ClassLibrary-VB-NetCoreApp.vstemplate
+++ b/src/Templates/Microsoft.NetCore.VB.ProjectTemplates/ClassLibrary-VB-NetCoreApp.vstemplate
@@ -20,7 +20,7 @@
     <CustomParameters>
       <CustomParameter Name="$language$" Value="VB" />
       <CustomParameter Name="$uistyle$" Value="none" />
-      <CustomParameter Name="groupid" Value="Microsoft.Common.Library" />
+      <CustomParameter Name="$groupid$" Value="Microsoft.Common.Library" />
       <CustomParameter Name="$set:baseline$" Value="app" />
     </CustomParameters>
   </TemplateContent>

--- a/src/VsixV3/ProjectTemplates1.x/Microsoft.VisualStudio.NetCore.ProjectTemplates.1.x.swixproj
+++ b/src/VsixV3/ProjectTemplates1.x/Microsoft.VisualStudio.NetCore.ProjectTemplates.1.x.swixproj
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\build\Targets\VSL.Settings.targets" />
+
+  <PropertyGroup>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <OutputArchitecture>neutral</OutputArchitecture>
+    <OutputLocalized>false</OutputLocalized>
+    <OutputType>vsix</OutputType>
+    <IsPackage>true</IsPackage>
+    <OutputName>Microsoft.VisualStudio.NetCore.ProjectTemplates.1.x</OutputName>
+  </PropertyGroup>
+
+  <Import Project="$(NuGetPackageRoot)\MicroBuild.Core\$(MicroBuildVersion)\build\MicroBuild.Core.props" />
+
+  <PropertyGroup>
+    <PackagePreprocessorDefinitions>$(PackagePreprocessorDefinitions);Version=$(BuildVersion);OutputPath=$(OutDir);SourcePath=$(OutDir)..\..\src;ProjectTemplateVersion=$(ProjectTemplateVersion);LicenseUri=http://www.microsoft.com</PackagePreprocessorDefinitions>
+    <OutputPath>$(OutDir)\VsixV3</OutputPath>
+    <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Package Include="Microsoft.VisualStudio.NetCore.ProjectTemplates.1.x.swr" />
+  </ItemGroup>
+
+  <Import Project="$(NuGetPackageRoot)\MicroBuild.Core\$(MicroBuildVersion)\build\MicroBuild.Core.targets" />
+</Project>

--- a/src/VsixV3/ProjectTemplates1.x/Microsoft.VisualStudio.NetCore.ProjectTemplates.1.x.swr
+++ b/src/VsixV3/ProjectTemplates1.x/Microsoft.VisualStudio.NetCore.ProjectTemplates.1.x.swr
@@ -1,0 +1,16 @@
+use vs
+
+package name=Microsoft.VisualStudio.NetCore.ProjectTemplates.1.x
+        version=$(Version)
+
+vs.localizedResources
+  vs.localizedResource language=en-us
+                       title="Microsoft VisualStudio Managed Project Templates NetCore 1.x"
+                       description="Microsoft VisualStudio Managed Project Templates for NetCore 1.x Projects"
+
+folder "InstallDir:Common7\IDE\Extensions\Microsoft\Dotnet"
+  file source="$(SourcePath)\VsixV3\ProjectTemplates1.x\Templates.pkgdef"
+  
+folder "InstallDir:Common7\IDE\Extensions\Microsoft\Dotnet\Templates\NetCore\1.x"
+  file source="$(OutputPath)\microsoft.dotnet.common.projecttemplates.1.x.$(ProjectTemplateVersion).nupkg"
+  file source="$(OutputPath)\microsoft.dotnet.test.projecttemplates.1.x.$(ProjectTemplateVersion).nupkg"

--- a/src/VsixV3/ProjectTemplates1.x/Microsoft.VisualStudio.NetCore.ProjectTemplates.1.x.swr
+++ b/src/VsixV3/ProjectTemplates1.x/Microsoft.VisualStudio.NetCore.ProjectTemplates.1.x.swr
@@ -12,5 +12,5 @@ folder "InstallDir:Common7\IDE\Extensions\Microsoft\Dotnet"
   file source="$(SourcePath)\VsixV3\ProjectTemplates1.x\Templates.pkgdef"
   
 folder "InstallDir:Common7\IDE\Extensions\Microsoft\Dotnet\Templates\NetCore\1.x"
-  file source="$(OutputPath)\microsoft.dotnet.common.projecttemplates.1.x.$(ProjectTemplateVersion).nupkg"
-  file source="$(OutputPath)\microsoft.dotnet.test.projecttemplates.1.x.$(ProjectTemplateVersion).nupkg"
+  file source="$(OutputPath)\microsoft.dotnet.common.projecttemplates.1.x.1.0.0.nupkg"
+  file source="$(OutputPath)\microsoft.dotnet.test.projecttemplates.1.x.1.0.0.nupkg"

--- a/src/VsixV3/ProjectTemplates1.x/Microsoft.VisualStudio.NetCore.ProjectTemplates.1.x.vsmanproj
+++ b/src/VsixV3/ProjectTemplates1.x/Microsoft.VisualStudio.NetCore.ProjectTemplates.1.x.vsmanproj
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  
+  <PropertyGroup>
+    <UseVisualStudioVersion>true</UseVisualStudioVersion>
+  </PropertyGroup>
+  
+  <Import Project="..\..\..\build\Targets\VSL.Settings.targets" />
+
+  <PropertyGroup>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FinalizeManifest>true</FinalizeManifest>
+    <FinalizeSkipLayout>true</FinalizeSkipLayout>
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <OutputPath>$(OutDir)\VsixV3</OutputPath>
+    <IsPackage>true</IsPackage>
+    <FinalizeValidate>false</FinalizeValidate>
+    <ValidateManifest>false</ValidateManifest>
+  </PropertyGroup>
+
+  <Import Project="$(NuGetPackageRoot)\MicroBuild.Core\$(MicroBuildVersion)\build\MicroBuild.Core.props" />
+  <Import Project="$(NuGetPackageRoot)\MicroBuild.Core\$(MicroBuildVersion)\build\MicroBuild.Core.targets" />
+
+  <Target Name="BeforeBuild">
+    <MSBuild Projects="Microsoft.VisualStudio.NetCore.ProjectTemplates.1.x.swixproj" Targets="Build" />
+  </Target>
+
+  <ItemGroup>
+    <MergeManifest Include="$(OutputPath)\Microsoft.VisualStudio.NetCore.ProjectTemplates.1.x.json" />
+  </ItemGroup>
+
+  <Target Name="ValidateManifest" />
+</Project>

--- a/src/VsixV3/ProjectTemplates1.x/Templates.pkgdef
+++ b/src/VsixV3/ProjectTemplates1.x/Templates.pkgdef
@@ -1,0 +1,2 @@
+[$RootKey$\TemplateEngine\Templates\NetCore\1.x]
+"InstalledPath"="$RootFolder$\Common7\IDE\Extensions\Microsoft\Dotnet\Templates\NetCore\1.x"


### PR DESCRIPTION
**Customer scenario**

Customer installs Visual Studio but does not install dotnet CLI tools, without this change no netcore templates will be installed

**Bugs this fixes:** 

related to https://github.com/dotnet/project-system/pull/2053

**Workarounds, if any**

none

**Risk**

Low

