### PR TITLE
Dynamically populate the target framework dropdown

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageInternalBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageInternalBase.vb
@@ -128,7 +128,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 ' TODO: Remove IsTargetFrameworksDefined check after issue #800 is resolved.
                 If (TargetFrameworksDefined() = False And vsFrameworkMultiTargeting IsNot Nothing) Then
 
-                    Dim supportedFrameworks As IEnumerable(Of TargetFrameworkMoniker) = TargetFrameworkMoniker.GetSupportedTargetFrameworkMonikers(vsFrameworkMultiTargeting, DTEProject)
+                    Dim supportedTargetFrameworksDescriptor = GetPropertyDescriptor("SupportedTargetFrameworks")
+                    Dim supportedFrameworks As IEnumerable(Of TargetFrameworkMoniker) = TargetFrameworkMoniker.GetSupportedTargetFrameworkMonikers(vsFrameworkMultiTargeting, DTEProject, supportedTargetFrameworksDescriptor)
 
                     For Each supportedFramework As TargetFrameworkMoniker In supportedFrameworks
                         targetFrameworkComboBox.Items.Add(supportedFramework)

--- a/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworkMoniker.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworkMoniker.vb
@@ -3,6 +3,7 @@
 Imports EnvDTE
 Imports Microsoft.VisualStudio.Shell.Interop
 Imports System.Runtime.Versioning
+Imports System.ComponentModel
 
 Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
@@ -48,25 +49,25 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Function
 
         'TODO: Remove this hardcoded list (Refer Bug: #795)
-        Private Shared Function AddDotNetCoreFramework(prgSupportedFrameworks As Array) As Array
-            Dim supportedFrameworksList As List(Of String) = New List(Of String)
-            For Each moniker As String In prgSupportedFrameworks
-                supportedFrameworksList.Add(moniker)
-            Next
+        Private Shared Function AddDotNetCoreFramework(prgSupportedFrameworks As Array, supportedTargetFrameworksDescriptor As PropertyDescriptor) As Array
+            Dim _TypeConverter As TypeConverter = supportedTargetFrameworksDescriptor.Converter
+            If _TypeConverter IsNot Nothing Then
+                Dim supportedFrameworksList As List(Of String) = New List(Of String)
+                For Each moniker As String In prgSupportedFrameworks
+                    supportedFrameworksList.Add(moniker)
+                Next
 
-            supportedFrameworksList.Add(".NETCoreApp,Version=v1.0")
-            supportedFrameworksList.Add(".NETCoreApp,Version=v1.1")
-            supportedFrameworksList.Add(".NETCoreApp,Version=v2.0")
-            supportedFrameworksList.Add(".NETStandard,Version=v1.0")
-            supportedFrameworksList.Add(".NETStandard,Version=v1.1")
-            supportedFrameworksList.Add(".NETStandard,Version=v1.2")
-            supportedFrameworksList.Add(".NETStandard,Version=v1.3")
-            supportedFrameworksList.Add(".NETStandard,Version=v1.4")
-            supportedFrameworksList.Add(".NETStandard,Version=v1.5")
-            supportedFrameworksList.Add(".NETStandard,Version=v1.6")
-            supportedFrameworksList.Add(".NETStandard,Version=v2.0")
-            Return supportedFrameworksList.ToArray
+                For Each frameworkValue In _TypeConverter.GetStandardValues()
+                    Dim framework = CStr(frameworkValue)
+                    If framework IsNot Nothing Then
+                        supportedFrameworksList.Add(framework)
+                    End If
+                Next
 
+                Return supportedFrameworksList.ToArray
+            End If
+
+            Return prgSupportedFrameworks
         End Function
 
         ''' <summary>
@@ -75,11 +76,12 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="vsFrameworkMultiTargeting"></param>
         Public Shared Function GetSupportedTargetFrameworkMonikers(
             vsFrameworkMultiTargeting As IVsFrameworkMultiTargeting,
-            currentProject As Project) As IEnumerable(Of TargetFrameworkMoniker)
+            currentProject As Project,
+            supportedTargetFrameworksDescriptor As PropertyDescriptor) As IEnumerable(Of TargetFrameworkMoniker)
 
             Dim supportedFrameworksArray As Array = Nothing
             VSErrorHandler.ThrowOnFailure(vsFrameworkMultiTargeting.GetSupportedFrameworks(supportedFrameworksArray))
-            supportedFrameworksArray = AddDotNetCoreFramework(supportedFrameworksArray)
+            supportedFrameworksArray = AddDotNetCoreFramework(supportedFrameworksArray, supportedTargetFrameworksDescriptor)
 
             Dim targetFrameworkMonikerProperty As [Property] = currentProject.Properties.Item(ApplicationPropPage.Const_TargetFrameworkMoniker)
             Dim currentTargetFrameworkMoniker As String = CStr(targetFrameworkMonikerProperty.Value)
@@ -127,10 +129,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
                         ' Use DTAR to get the display name corresponding to the moniker
                         Dim displayName As String = ""
-                        If String.Compare(frameworkName.Identifier, ".NETStandard", StringComparison.Ordinal) = 0 Then
-                            displayName = $".NET Standard {frameworkName.Version}"
-                        Else If String.Compare(frameworkName.Identifier, ".NETCoreApp", StringComparison.Ordinal) = 0 Then
-                            displayName = $".NET Core {frameworkName.Version}"
+                        If String.Compare(frameworkName.Identifier, ".NETStandard", StringComparison.Ordinal) = 0 OrElse
+                           String.Compare(frameworkName.Identifier, ".NETCoreApp", StringComparison.Ordinal) = 0 Then
+                            displayName = CStr(supportedTargetFrameworksDescriptor.Converter?.ConvertTo(moniker, GetType(String)))
                         Else
                             VSErrorHandler.ThrowOnFailure(vsFrameworkMultiTargeting.GetDisplayNameForTargetFx(moniker, displayName))
                         End If

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/SupportedTargetFrameworksEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/SupportedTargetFrameworksEnumProvider.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
+using System.Linq;
+using System;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties
+{
+    [ExportDynamicEnumValuesProvider("SupportedTargetFrameworksEnumProvider")]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
+    internal class SupportedTargetFrameworksEnumProvider : IDynamicEnumValuesProvider
+    {
+        private readonly IProjectLockService _projectLockService;
+        private readonly ConfiguredProject _configuredProject;
+
+        [ImportingConstructor]
+        public SupportedTargetFrameworksEnumProvider(IProjectLockService projectLockService, ConfiguredProject configuredProject)
+        {
+            _projectLockService = projectLockService;
+            _configuredProject = configuredProject;
+        }
+
+        public Task<IDynamicEnumValuesGenerator> GetProviderAsync(IList<NameValuePair> options)
+        {
+            return Task.FromResult<IDynamicEnumValuesGenerator>(new SupportedTargetFrameworksEnumValuesGenerator(_projectLockService, _configuredProject));
+        }
+
+        internal class SupportedTargetFrameworksEnumValuesGenerator : IDynamicEnumValuesGenerator
+        {
+            private const string SupportedTargetFrameworkItemName = "SupportedTargetFramework";
+            private const string DisplayNameMetadataName = "DisplayName";
+
+            private readonly IProjectLockService _projectLockService;
+            private readonly ConfiguredProject _configuredProject;
+
+            public SupportedTargetFrameworksEnumValuesGenerator(IProjectLockService projectLockService, ConfiguredProject configuredProject)
+            {
+                _projectLockService = projectLockService;
+                _configuredProject = configuredProject;
+            }
+
+            public bool AllowCustomValues => false;
+
+            public async Task<ICollection<IEnumValue>> GetListedValuesAsync()
+            {
+                var enumValues = new List<IEnumValue>();
+                using (var access = await _projectLockService.ReadLockAsync())
+                {
+                    var project = await access.GetProjectAsync(_configuredProject);
+                    var items = project.GetItems(itemType: SupportedTargetFrameworkItemName);
+
+                    foreach (var item in items)
+                    {
+                        var val = new PageEnumValue(new EnumValue { Name = item.EvaluatedInclude, DisplayName = item.GetMetadataValue(DisplayNameMetadataName) });
+                        enumValues.Add(val);
+                    }
+                }
+
+                return enumValues;
+            }
+
+            public Task<IEnumValue> TryCreateEnumValueAsync(string userSuppliedValue)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -161,4 +161,6 @@
             <DataSource Persistence="ProjectFileWithInterception" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
     </StringProperty>
+
+    <DynamicEnumProperty Name="SupportedTargetFrameworks" DisplayName="Supported TargetFrameworks" EnumProvider="SupportedTargetFrameworksEnumProvider" Visible="False"/>
 </Rule>


### PR DESCRIPTION
**Customer scenario**

The customer does not have the .NET Core 2.0 installed. They open a .NET Core 1.1 project and open the application property page. The target framework dropdown will contain a hardcoded entry for .NET Core 2.0 (even though .NET Core 2.0 is not installed). If they choose that, their project will no longer build and they will get errors about missing framework types. There will be no indication as to what went wrong, they will just thing .NET Core 2.0 is busted.

**Bugs this fixes:** 

#1516 

**Workarounds, if any**

The only workaround is to know that you haven't installed .NET Core 2.0 and not choose the .NET Core 2.0 entry in the dropdown.

**Risk**

Low. The code is isolated to just this single dropdown in the application designer.

**Performance impact**

Low. The code is isolated to just this single dropdown in the application designer. The code only reads entries from the project file, something the project system does everywhere.

**Is this a regression from a previous update?**

Yes, because .NET Core 2.0 will not be installed by default.

**Root cause analysis:**

This is a known issue with making .NET Core 2.0 not installed by default.

**How was the bug found?**

This is a known issue with making .NET Core 2.0 not installed by default.
