### PR TITLE
Dynamically populate Target Framework dropdown from SDK

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageInternalBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageInternalBase.vb
@@ -128,7 +128,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 ' TODO: Remove IsTargetFrameworksDefined check after issue #800 is resolved.
                 If (TargetFrameworksDefined() = False And vsFrameworkMultiTargeting IsNot Nothing) Then
 
-                    Dim supportedFrameworks As IEnumerable(Of TargetFrameworkMoniker) = TargetFrameworkMoniker.GetSupportedTargetFrameworkMonikers(vsFrameworkMultiTargeting, DTEProject)
+                    Dim supportedTargetFrameworksDescriptor = GetPropertyDescriptor("SupportedTargetFrameworks")
+                    Dim supportedFrameworks As IEnumerable(Of TargetFrameworkMoniker) = TargetFrameworkMoniker.GetSupportedTargetFrameworkMonikers(vsFrameworkMultiTargeting, DTEProject, supportedTargetFrameworksDescriptor)
 
                     For Each supportedFramework As TargetFrameworkMoniker In supportedFrameworks
                         targetFrameworkComboBox.Items.Add(supportedFramework)

--- a/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworkMoniker.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworkMoniker.vb
@@ -81,7 +81,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
             Dim supportedFrameworksArray As Array = Nothing
             VSErrorHandler.ThrowOnFailure(vsFrameworkMultiTargeting.GetSupportedFrameworks(supportedFrameworksArray))
-            supportedFrameworksArray = AddDotNetCoreFramework(supportedFrameworksArray, supportedTargetFrameworksDescriptor)
+            If supportedTargetFrameworksDescriptor IsNot Nothing Then
+                supportedFrameworksArray = AddDotNetCoreFramework(supportedFrameworksArray, supportedTargetFrameworksDescriptor)
+            End If
 
             Dim targetFrameworkMonikerProperty As [Property] = currentProject.Properties.Item(ApplicationPropPage.Const_TargetFrameworkMoniker)
             Dim currentTargetFrameworkMoniker As String = CStr(targetFrameworkMonikerProperty.Value)

--- a/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworkMoniker.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworkMoniker.vb
@@ -3,6 +3,7 @@
 Imports EnvDTE
 Imports Microsoft.VisualStudio.Shell.Interop
 Imports System.Runtime.Versioning
+Imports System.ComponentModel
 
 Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
@@ -48,25 +49,25 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Function
 
         'TODO: Remove this hardcoded list (Refer Bug: #795)
-        Private Shared Function AddDotNetCoreFramework(prgSupportedFrameworks As Array) As Array
-            Dim supportedFrameworksList As List(Of String) = New List(Of String)
-            For Each moniker As String In prgSupportedFrameworks
-                supportedFrameworksList.Add(moniker)
-            Next
+        Private Shared Function AddDotNetCoreFramework(prgSupportedFrameworks As Array, supportedTargetFrameworksDescriptor As PropertyDescriptor) As Array
+            Dim _TypeConverter As TypeConverter = supportedTargetFrameworksDescriptor.Converter
+            If _TypeConverter IsNot Nothing Then
+                Dim supportedFrameworksList As List(Of String) = New List(Of String)
+                For Each moniker As String In prgSupportedFrameworks
+                    supportedFrameworksList.Add(moniker)
+                Next
 
-            supportedFrameworksList.Add(".NETCoreApp,Version=v1.0")
-            supportedFrameworksList.Add(".NETCoreApp,Version=v1.1")
-            supportedFrameworksList.Add(".NETCoreApp,Version=v2.0")
-            supportedFrameworksList.Add(".NETStandard,Version=v1.0")
-            supportedFrameworksList.Add(".NETStandard,Version=v1.1")
-            supportedFrameworksList.Add(".NETStandard,Version=v1.2")
-            supportedFrameworksList.Add(".NETStandard,Version=v1.3")
-            supportedFrameworksList.Add(".NETStandard,Version=v1.4")
-            supportedFrameworksList.Add(".NETStandard,Version=v1.5")
-            supportedFrameworksList.Add(".NETStandard,Version=v1.6")
-            supportedFrameworksList.Add(".NETStandard,Version=v2.0")
-            Return supportedFrameworksList.ToArray
+                For Each frameworkValue In _TypeConverter.GetStandardValues()
+                    Dim framework = CStr(frameworkValue)
+                    If framework IsNot Nothing Then
+                        supportedFrameworksList.Add(framework)
+                    End If
+                Next
 
+                Return supportedFrameworksList.ToArray
+            End If
+
+            Return prgSupportedFrameworks
         End Function
 
         ''' <summary>
@@ -75,11 +76,12 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="vsFrameworkMultiTargeting"></param>
         Public Shared Function GetSupportedTargetFrameworkMonikers(
             vsFrameworkMultiTargeting As IVsFrameworkMultiTargeting,
-            currentProject As Project) As IEnumerable(Of TargetFrameworkMoniker)
+            currentProject As Project,
+            supportedTargetFrameworksDescriptor As PropertyDescriptor) As IEnumerable(Of TargetFrameworkMoniker)
 
             Dim supportedFrameworksArray As Array = Nothing
             VSErrorHandler.ThrowOnFailure(vsFrameworkMultiTargeting.GetSupportedFrameworks(supportedFrameworksArray))
-            supportedFrameworksArray = AddDotNetCoreFramework(supportedFrameworksArray)
+            supportedFrameworksArray = AddDotNetCoreFramework(supportedFrameworksArray, supportedTargetFrameworksDescriptor)
 
             Dim targetFrameworkMonikerProperty As [Property] = currentProject.Properties.Item(ApplicationPropPage.Const_TargetFrameworkMoniker)
             Dim currentTargetFrameworkMoniker As String = CStr(targetFrameworkMonikerProperty.Value)
@@ -127,10 +129,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
                         ' Use DTAR to get the display name corresponding to the moniker
                         Dim displayName As String = ""
-                        If String.Compare(frameworkName.Identifier, ".NETStandard", StringComparison.Ordinal) = 0 Then
-                            displayName = $".NET Standard {frameworkName.Version}"
-                        Else If String.Compare(frameworkName.Identifier, ".NETCoreApp", StringComparison.Ordinal) = 0 Then
-                            displayName = $".NET Core {frameworkName.Version}"
+                        If String.Compare(frameworkName.Identifier, ".NETStandard", StringComparison.Ordinal) = 0 OrElse
+                           String.Compare(frameworkName.Identifier, ".NETCoreApp", StringComparison.Ordinal) = 0 Then
+                            displayName = CStr(supportedTargetFrameworksDescriptor.Converter?.ConvertTo(moniker, GetType(String)))
                         Else
                             VSErrorHandler.ThrowOnFailure(vsFrameworkMultiTargeting.GetDisplayNameForTargetFx(moniker, displayName))
                         End If

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/GlobalJsonRemoverTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/GlobalJsonRemoverTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
             UnitTestHelper.IsRunningUnitTests = true;
             var globalJsonPath = Path.Combine(Directory, "global.json");
             var solution = IVsSolutionFactory.CreateWithSolutionDirectory(DirectoryInfoCallback);
-            var projectItem = ProjectItemFactory.Create();
+            var projectItem = EnvDTE.ProjectItemFactory.Create();
             var dteSolution = SolutionFactory.ImplementFindProjectItem(path =>
             {
                 Assert.Equal(globalJsonPath, path);
@@ -108,7 +108,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
             UnitTestHelper.IsRunningUnitTests = true;
             var globalJsonPath = Path.Combine(Directory, "global.json");
             var solution = IVsSolutionFactory.CreateWithSolutionDirectory(DirectoryInfoCallback);
-            var projectItem = ProjectItemFactory.Create();
+            var projectItem = EnvDTE.ProjectItemFactory.Create();
             var dteSolution = SolutionFactory.ImplementFindProjectItem(path =>
             {
                 Assert.Equal(globalJsonPath, path);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectLockServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectLockServiceFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Moq;
+using System.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
@@ -8,7 +9,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
     {
         public static IProjectLockService Create()
         {
-            return Mock.Of<IProjectLockService>();
+            var mock = new Mock<IProjectLockService>();
+
+            mock.Setup(t => t.ReadLockAsync(It.IsAny<CancellationToken>())).Returns();
+
+            return mock.Object;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectLockServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectLockServiceFactory.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Moq;
-using System.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
@@ -9,11 +8,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
     {
         public static IProjectLockService Create()
         {
-            var mock = new Mock<IProjectLockService>();
-
-            mock.Setup(t => t.ReadLockAsync(It.IsAny<CancellationToken>())).Returns();
-
-            return mock.Object;
+            return Mock.Of<IProjectLockService>();
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectXmlAccessorFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectXmlAccessorFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Build.Construction;
@@ -48,5 +49,22 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             return mock.Object;
         }
+
+        public static IProjectXmlAccessor WithItems(string itemType, string metadataName, ICollection<(string name, string metadataValue)> items)
+        {
+            var mock = new Mock<IProjectXmlAccessor>();
+
+            mock.Setup(m => m.GetItems(
+                It.IsAny<ConfiguredProject>(), 
+                It.Is<string>((t) => string.Equals(t, itemType)),
+                It.Is<string>((t) => string.Equals(t, metadataName))))
+                .Returns<ConfiguredProject, string, string>((configuredProject, innerItemType, innerMetadataName) =>
+                {
+                    return Task.FromResult(items);
+                });
+
+            return mock.Object;
+        }
+
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectItemFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectItemFactory.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Moq;
+using Microsoft.Build.Evaluation;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class ProjectItemFactory
+    {
+        public static ProjectItem WithValue(string evaluatedInclude, (string name, string value) metadata)
+        {
+            var mock = new Mock<ProjectItem>();
+
+            mock.SetupGet(p => p.EvaluatedInclude)
+                .Returns(evaluatedInclude);
+
+            mock.Setup(p => p.GetMetadataValue(It.Is<string>((t) => string.Equals(t, metadata.name))))
+                .Returns(metadata.value);
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/SupportedTargetFrameworksEnumProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/SupportedTargetFrameworksEnumProviderTests.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties
+{
+    [ProjectSystemTrait]
+    public class SupportedTargetFrameworksEnumProviderTests
+    {
+        [Fact]
+        public void Constructor_NullProjectLockService_ThrowsArgumentNullException()
+        {
+            var configuredProject = ConfiguredProjectFactory.Create();
+            Assert.Throws<ArgumentNullException>("projectLockService", () =>
+            {
+                new SupportedTargetFrameworksEnumProvider(null, configuredProject);
+            });
+        }
+
+        [Fact]
+        public void Constructor_NullConfiguredProject_ThrowsArgumentNullException()
+        {
+            var projectLockService = IProjectLockServiceFactory.Create();
+
+            Assert.Throws<ArgumentNullException>("configuredProject", () =>
+            {
+                new SupportedTargetFrameworksEnumProvider(projectLockService, null);
+            });
+        }
+
+        [Fact]
+        public async Task Constructor()
+        {
+            var projectLockService = IProjectLockServiceFactory.Create();
+            var configuredProject = ConfiguredProjectFactory.Create();
+
+            var provider = new SupportedTargetFrameworksEnumProvider(projectLockService, configuredProject);
+            var generator = await provider.GetProviderAsync(null);
+
+            Assert.NotNull(generator);
+        }
+
+        [Fact]
+        public async Task GetListedValues()
+        {
+            var projectLockService = IProjectLockServiceFactory.Create();
+            var configuredProject = ConfiguredProjectFactory.Create();
+
+            var provider = new SupportedTargetFrameworksEnumProvider(projectLockService, configuredProject);
+            var generator = await provider.GetProviderAsync(null);
+            var values = await generator.GetListedValuesAsync();
+
+            //Assert.Equal(3, values.Count);
+            //Assert.Equal(new List<string> { "0", "1", "2" }, values.Select(v => v.DisplayName));
+        }
+
+        [Fact]
+        public async Task TryCreateEnumValue()
+        {
+            var projectLockService = IProjectLockServiceFactory.Create();
+            var configuredProject = ConfiguredProjectFactory.Create();
+
+            var provider = new SupportedTargetFrameworksEnumProvider(projectLockService, configuredProject);
+            var generator = await provider.GetProviderAsync(null);
+
+            Assert.Throws<NotImplementedException>(() =>
+            {
+                generator.TryCreateEnumValueAsync("foo");
+            });
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/SupportedTargetFrameworksEnumProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/SupportedTargetFrameworksEnumProviderTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -10,10 +12,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     public class SupportedTargetFrameworksEnumProviderTests
     {
         [Fact]
-        public void Constructor_NullProjectLockService_ThrowsArgumentNullException()
+        public void Constructor_NullProjectXmlAccessor_ThrowsArgumentNullException()
         {
             var configuredProject = ConfiguredProjectFactory.Create();
-            Assert.Throws<ArgumentNullException>("projectLockService", () =>
+            Assert.Throws<ArgumentNullException>("projectXmlAccessor", () =>
             {
                 new SupportedTargetFrameworksEnumProvider(null, configuredProject);
             });
@@ -22,21 +24,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [Fact]
         public void Constructor_NullConfiguredProject_ThrowsArgumentNullException()
         {
-            var projectLockService = IProjectLockServiceFactory.Create();
+            var projectXmlAccessor = IProjectXmlAccessorFactory.Create();
 
             Assert.Throws<ArgumentNullException>("configuredProject", () =>
             {
-                new SupportedTargetFrameworksEnumProvider(projectLockService, null);
+                new SupportedTargetFrameworksEnumProvider(projectXmlAccessor, null);
             });
         }
 
         [Fact]
         public async Task Constructor()
         {
-            var projectLockService = IProjectLockServiceFactory.Create();
+            var projectXmlAccessor = IProjectXmlAccessorFactory.Create();
             var configuredProject = ConfiguredProjectFactory.Create();
 
-            var provider = new SupportedTargetFrameworksEnumProvider(projectLockService, configuredProject);
+            var provider = new SupportedTargetFrameworksEnumProvider(projectXmlAccessor, configuredProject);
             var generator = await provider.GetProviderAsync(null);
 
             Assert.NotNull(generator);
@@ -45,24 +47,29 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [Fact]
         public async Task GetListedValues()
         {
-            var projectLockService = IProjectLockServiceFactory.Create();
+            var projectXmlAccessor = IProjectXmlAccessorFactory.WithItems("SupportedTargetFramework", "DisplayName", new[] {
+                (name: ".NETCoreApp,Version=v1.0", metadataValue: ".NET Core 1.0"),
+                (name: ".NETCoreApp,Version=v1.1", metadataValue: ".NET Core 1.1"),
+                (name: ".NETCoreApp,Version=v2.0", metadataValue: ".NET Core 2.0"),
+            });
             var configuredProject = ConfiguredProjectFactory.Create();
 
-            var provider = new SupportedTargetFrameworksEnumProvider(projectLockService, configuredProject);
+            var provider = new SupportedTargetFrameworksEnumProvider(projectXmlAccessor, configuredProject);
             var generator = await provider.GetProviderAsync(null);
             var values = await generator.GetListedValuesAsync();
 
-            //Assert.Equal(3, values.Count);
-            //Assert.Equal(new List<string> { "0", "1", "2" }, values.Select(v => v.DisplayName));
+            Assert.Equal(3, values.Count);
+            Assert.Equal(new List<string> { ".NETCoreApp,Version=v1.0", ".NETCoreApp,Version=v1.1", ".NETCoreApp,Version=v2.0" }, values.Select(v => v.Name));
+            Assert.Equal(new List<string> { ".NET Core 1.0", ".NET Core 1.1", ".NET Core 2.0" }, values.Select(v => v.DisplayName));
         }
 
         [Fact]
         public async Task TryCreateEnumValue()
         {
-            var projectLockService = IProjectLockServiceFactory.Create();
+            var projectXmlAccessor = IProjectXmlAccessorFactory.Create();
             var configuredProject = ConfiguredProjectFactory.Create();
 
-            var provider = new SupportedTargetFrameworksEnumProvider(projectLockService, configuredProject);
+            var provider = new SupportedTargetFrameworksEnumProvider(projectXmlAccessor, configuredProject);
             var generator = await provider.GetProviderAsync(null);
 
             Assert.Throws<NotImplementedException>(() =>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectXmlAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectXmlAccessor.cs
@@ -45,5 +45,14 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// </summary>
         /// <returns></returns>
         Task<HashSet<string>> GetProjectItems();
+
+        /// <summary>
+        /// Returns a collection of items.
+        /// </summary>
+        /// <param name="configuredProject">The configured project.</param>
+        /// <param name="itemType">The type of the items to get.</param>
+        /// <param name="metadataName">The name of the metadata to get.</param>
+        /// <returns></returns>
+        Task<ICollection<(string evaluatedInclude, string metadataValue)>> GetItems(ConfiguredProject configuredProject, string itemType, string metadataName);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/MSBuildXmlAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/MSBuildXmlAccessor.cs
@@ -87,5 +87,14 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 return new HashSet<string>(projectXml.Items.Select(x => x.Include), StringComparer.OrdinalIgnoreCase);
             }
         }
+
+        public async Task<ICollection<(string evaluatedInclude, string metadataValue)>> GetItems(ConfiguredProject configuredProject, string itemType, string metadataName)
+        {
+            using (var access = await _projectLockService.ReadLockAsync())
+            {
+                var project = await access.GetProjectAsync(configuredProject);
+                return project.GetItems(itemType: itemType).Select(i => (i.EvaluatedInclude, i.GetMetadataValue(metadataName))).ToArray();
+            }
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/SupportedTargetFrameworksEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/SupportedTargetFrameworksEnumProvider.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
+using System.Linq;
+using System;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties
+{
+    [ExportDynamicEnumValuesProvider("SupportedTargetFrameworksEnumProvider")]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
+    internal class SupportedTargetFrameworksEnumProvider : IDynamicEnumValuesProvider
+    {
+        private readonly IProjectLockService _projectLockService;
+        private readonly ConfiguredProject _configuredProject;
+
+        [ImportingConstructor]
+        public SupportedTargetFrameworksEnumProvider(IProjectLockService projectLockService, ConfiguredProject configuredProject)
+        {
+            _projectLockService = projectLockService;
+            _configuredProject = configuredProject;
+        }
+
+        public Task<IDynamicEnumValuesGenerator> GetProviderAsync(IList<NameValuePair> options)
+        {
+            return Task.FromResult<IDynamicEnumValuesGenerator>(new SupportedTargetFrameworksEnumValuesGenerator(_projectLockService, _configuredProject));
+        }
+
+        internal class SupportedTargetFrameworksEnumValuesGenerator : IDynamicEnumValuesGenerator
+        {
+            private const string SupportedTargetFrameworkItemName = "SupportedTargetFramework";
+            private const string DisplayNameMetadataName = "DisplayName";
+
+            private readonly IProjectLockService _projectLockService;
+            private readonly ConfiguredProject _configuredProject;
+
+            public SupportedTargetFrameworksEnumValuesGenerator(IProjectLockService projectLockService, ConfiguredProject configuredProject)
+            {
+                _projectLockService = projectLockService;
+                _configuredProject = configuredProject;
+            }
+
+            public bool AllowCustomValues => false;
+
+            public async Task<ICollection<IEnumValue>> GetListedValuesAsync()
+            {
+                var enumValues = new List<IEnumValue>();
+                using (var access = await _projectLockService.ReadLockAsync())
+                {
+                    var project = await access.GetProjectAsync(_configuredProject);
+                    var items = project.GetItems(itemType: SupportedTargetFrameworkItemName);
+
+                    foreach (var item in items)
+                    {
+                        var val = new PageEnumValue(new EnumValue { Name = item.EvaluatedInclude, DisplayName = item.GetMetadataValue(DisplayNameMetadataName) });
+                        enumValues.Add(val);
+                    }
+                }
+
+                return enumValues;
+            }
+
+            public Task<IEnumValue> TryCreateEnumValueAsync(string userSuppliedValue)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/SupportedTargetFrameworksEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/SupportedTargetFrameworksEnumProvider.cs
@@ -2,7 +2,6 @@
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework.XamlTypes;
-using System.Linq;
 using System;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Properties
@@ -17,6 +16,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [ImportingConstructor]
         public SupportedTargetFrameworksEnumProvider(IProjectLockService projectLockService, ConfiguredProject configuredProject)
         {
+            Requires.NotNull(projectLockService, nameof(projectLockService));
+            Requires.NotNull(configuredProject, nameof(configuredProject));
             _projectLockService = projectLockService;
             _configuredProject = configuredProject;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -161,4 +161,6 @@
             <DataSource Persistence="ProjectFileWithInterception" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
     </StringProperty>
+
+    <DynamicEnumProperty Name="SupportedTargetFrameworks" DisplayName="Supported TargetFrameworks" EnumProvider="SupportedTargetFrameworksEnumProvider" Visible="False"/>
 </Rule>


### PR DESCRIPTION
**Customer scenario**

The customer does not have the .NET Core 2.0 installed. They open a .NET Core 1.1 project and open the application property page. The target framework dropdown will contain a hardcoded entry for .NET Core 2.0 (even though .NET Core 2.0 is not installed). If they choose that, their project will no longer build and they will get errors about missing framework types. There will be no indication as to what went wrong, they will just thing .NET Core 2.0 is busted.

**Bugs this fixes:**

#1516 
VSO - https://devdiv.visualstudio.com/DevDiv/_workitems/edit/428151

**Workarounds, if any**

The only workaround is to know that you haven't installed .NET Core 2.0 and not choose the .NET Core 2.0 entry in the dropdown.

**Risk**

Low. The code is isolated to just this single dropdown in the application designer.

**Performance impact**

Low. The code is isolated to just this single dropdown in the application designer. The code only reads entries from the project file, something the project system does everywhere.

**Is this a regression from a previous update?**

Yes, because .NET Core 2.0 will not be installed by default.

**Root cause analysis:**

This is a known issue with making .NET Core 2.0 not installed by default.

**How was the bug found?**

This is a known issue with making .NET Core 2.0 not installed by default.