### PR TITLE
only use ProjectGroup when defining templates

### DIFF
--- a/src/Templates/Microsoft.NetCore.CSharp.ProjectTemplates.Test/MSTest-CSharp-NetCoreApp.vstemplate
+++ b/src/Templates/Microsoft.NetCore.CSharp.ProjectTemplates.Test/MSTest-CSharp-NetCoreApp.vstemplate
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<VSTemplate Version="3.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
+<VSTemplate Version="3.0.0" Type="ProjectGroup" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
     <Name Package="{52CBD135-1F97-2580-011F-C7CD052E44DE}" ID="521"/>
     <Description Package="{52CBD135-1F97-2580-011F-C7CD052E44DE}" ID="522"/>

--- a/src/Templates/Microsoft.NetCore.CSharp.ProjectTemplates.Test/XUnitTest-CSharp-NetCoreApp.vstemplate
+++ b/src/Templates/Microsoft.NetCore.CSharp.ProjectTemplates.Test/XUnitTest-CSharp-NetCoreApp.vstemplate
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<VSTemplate Version="3.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
+<VSTemplate Version="3.0.0" Type="ProjectGroup" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
     <Name Package="{860A27C0-B665-47F3-BC12-637E16A1050A}" ID="11" />
     <Description Package="{860A27C0-B665-47F3-BC12-637E16A1050A}" ID="12" />

--- a/src/Templates/Microsoft.NetCore.FSharp.ProjectTemplates.Test/MSTest-FSharp-NetCoreApp.vstemplate
+++ b/src/Templates/Microsoft.NetCore.FSharp.ProjectTemplates.Test/MSTest-FSharp-NetCoreApp.vstemplate
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<VSTemplate Version="3.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
+<VSTemplate Version="3.0.0" Type="ProjectGroup" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
     <Name Package="{52CBD135-1F97-2580-011F-C7CD052E44DE}" ID="521"/>
     <Description Package="{52CBD135-1F97-2580-011F-C7CD052E44DE}" ID="522"/>

--- a/src/Templates/Microsoft.NetCore.FSharp.ProjectTemplates.Test/XUnitTest-FSharp-NetCoreApp.vstemplate
+++ b/src/Templates/Microsoft.NetCore.FSharp.ProjectTemplates.Test/XUnitTest-FSharp-NetCoreApp.vstemplate
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<VSTemplate Version="3.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
+<VSTemplate Version="3.0.0" Type="ProjectGroup" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
     <Name Package="{860A27C0-B665-47F3-BC12-637E16A1050A}" ID="11" />
     <Description Package="{860A27C0-B665-47F3-BC12-637E16A1050A}" ID="12" />

--- a/src/Templates/Microsoft.NetCore.VB.ProjectTemplates.Test/MSTest-VB-NetCoreApp.vstemplate
+++ b/src/Templates/Microsoft.NetCore.VB.ProjectTemplates.Test/MSTest-VB-NetCoreApp.vstemplate
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<VSTemplate Version="3.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
+<VSTemplate Version="3.0.0" Type="ProjectGroup" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
     <Name Package="{52CBD135-1F97-2580-011F-C7CD052E44DE}" ID="521"/>
     <Description Package="{52CBD135-1F97-2580-011F-C7CD052E44DE}" ID="522"/>

--- a/src/Templates/Microsoft.NetCore.VB.ProjectTemplates.Test/XUnitTest-VB-NetCoreApp.vstemplate
+++ b/src/Templates/Microsoft.NetCore.VB.ProjectTemplates.Test/XUnitTest-VB-NetCoreApp.vstemplate
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<VSTemplate Version="3.0.0" Type="Project" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
+<VSTemplate Version="3.0.0" Type="ProjectGroup" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
     <Name Package="{860A27C0-B665-47F3-BC12-637E16A1050A}" ID="11" />
     <Description Package="{860A27C0-B665-47F3-BC12-637E16A1050A}" ID="12" />


### PR DESCRIPTION
**Customer scenario**

This enables the VSTemplates to be created with the new template engine

**Workarounds, if any**

None

**Risk**

Low, this is just an update to the metadata in the vstemplate files, it is well isolated from other components.

**Root cause analysis:**

Churn in the new template engine 