### PR TITLE
Add IVsOptionalService

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/VsOptionalServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/VsOptionalServiceTests.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    [ProjectSystemTrait]
+    public class VsOptionalServiceTests
+    {
+        [Fact]
+        public void Constructor_NullAsServiceProvider_ThrowsArgumentNull()
+        {
+            var threadingService = IProjectThreadingServiceFactory.Create();
+
+            Assert.Throws<ArgumentNullException>("serviceProvider", () => {
+                return new VsService<string, string>((IServiceProvider)null, threadingService);
+            });
+        }
+
+        [Fact]
+        public void Constructor_NullAsThreadingService_ThrowsArgumentNull()
+        {
+            var serviceProvider = SVsServiceProviderFactory.Create();
+
+            Assert.Throws<ArgumentNullException>("threadingService", () => {
+                return new VsService<string, string>(serviceProvider, (IProjectThreadingService)null);
+            });
+        }
+
+        [Fact]
+        public void Value_MustBeCalledOnUIThread()
+        {
+            var threadingService = IProjectThreadingServiceFactory.ImplementVerifyOnUIThread(() => throw new InvalidOperationException());
+
+            var service = CreateInstance<string, string>(threadingService: threadingService);
+
+            Assert.Throws<InvalidOperationException>(() => {
+                var value = service.Value;
+            });
+        }
+
+        [Fact]
+        public void Value_WhenMissingService_ReturnsNull()
+        {
+            var threadingService = IProjectThreadingServiceFactory.ImplementVerifyOnUIThread(() => { });
+            var serviceProvider = IServiceProviderFactory.ImplementGetService(type => null);
+
+            var service = CreateInstance<string, string>(serviceProvider: serviceProvider, threadingService: threadingService);
+
+            var result = service.Value;
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Value_ReturnsGetService()
+        {
+            object input = new object();
+
+            var threadingService = IProjectThreadingServiceFactory.ImplementVerifyOnUIThread(() => { });
+            var serviceProvider = IServiceProviderFactory.ImplementGetService(type => {
+                if (type == typeof(string))
+                    return input;
+
+                return null;
+
+            });
+
+            var service = CreateInstance<string, object>(serviceProvider: serviceProvider, threadingService: threadingService);
+
+            var result = service.Value;
+
+            Assert.Same(input, result);
+        }
+
+        [Fact]
+        public void Value_DoesNotCache()
+        {
+            var threadingService = IProjectThreadingServiceFactory.ImplementVerifyOnUIThread(() => { });
+            var serviceProvider = IServiceProviderFactory.ImplementGetService(type => {
+                return new object();
+            });
+
+            var service = CreateInstance<string, object>(serviceProvider: serviceProvider, threadingService: threadingService);
+
+            var result1 = service.Value;
+            var result2 = service.Value;
+
+            Assert.NotSame(result1, result2);
+        }
+
+        private VsOptionalService<TService, TInterface> CreateInstance<TService, TInterface>(IServiceProvider serviceProvider = null, IProjectThreadingService threadingService = null)
+        {
+            serviceProvider = serviceProvider ?? SVsServiceProviderFactory.Create();
+            threadingService = threadingService ?? IProjectThreadingServiceFactory.Create();
+
+            return new VsOptionalService<TService, TInterface>(serviceProvider, threadingService);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsOptionalService`1.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsOptionalService`1.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Runtime.InteropServices;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    /// <summary>
+    ///     Provides access to an optional Visual Studio proffered service.
+    /// </summary>
+    /// <typeparam name="T">
+    ///     The type of the service to retrieve and return from <see cref="Value"/>.
+    /// </typeparam>
+    internal interface IVsOptionalService<T>
+    {
+        /// <summary>
+        ///     Gets the optional service object associated with <typeparamref name="T"/>.
+        /// </summary>
+        ///<exception cref="COMException">
+        ///     This property was not accessed from the UI thread.
+        /// </exception>
+        /// <value>
+        ///     The service <see cref="object"/> associated with <typeparamref name="T"/>;
+        ///     otherwise, <see langword="null"/> if it is not present.
+        /// </value>
+        T Value
+        {
+            get;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsOptionalService`2.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsOptionalService`2.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    /// <summary>
+    ///     Provides access to an optional Visual Studio proffered service.
+    /// </summary>
+    /// <typeparam name="TService">
+    ///     The type of the service to retrieve.
+    /// </typeparam>
+    /// <typeparam name="TInterface">
+    ///     The type of the service to return from <see cref="IVsService{T}.Value"/>
+    /// </typeparam>
+    internal interface IVsOptionalService<TService, TInterface> : IVsOptionalService<TInterface>
+    {
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsService`1.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsService`1.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
     /// <summary>
-    ///     Provides access to a Visual Studio proffered service.
+    ///     Provides access to a required Visual Studio proffered service.
     /// </summary>
     /// <typeparam name="T">
     ///     The type of the service to retrieve and return from <see cref="Value"/>.
@@ -13,10 +14,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     internal interface IVsService<T>
     {
         /// <summary>
-        ///     Gets the service object of associated with <typeparamref name="T"/>.
+        ///     Gets the required service object associated with <typeparamref name="T"/>.
         /// </summary>
         ///<exception cref="COMException">
         ///     This property was not accessed from the UI thread.
+        /// </exception>
+        /// <value>
+        ///     The service <see cref="object"/> associated with <typeparamref name="T"/>;
+        ///     otherwise, throws an exception if it is not present.
+        /// </value>
+        /// <exception cref="Exception">
+        ///     The service could not be found.
         /// </exception>
         T Value
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsService`2.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsService`2.cs
@@ -3,7 +3,7 @@
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
     /// <summary>
-    ///     Provides access to a Visual Studio proffered service.
+    ///     Provides access to a required Visual Studio proffered service.
     /// </summary>
     /// <typeparam name="TService">
     ///     The type of the service to retrieve.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsOptionalService`1.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsOptionalService`1.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    /// <summary>
+    ///     Provides an implementation of <see cref="IVsOptionalService{T}"/> that calls into Visual Studio's <see cref="SVsServiceProvider"/>.
+    /// </summary>
+    [Export(typeof(IVsOptionalService<>))]
+    internal class VsOptionalService<T> : IVsOptionalService<T>
+    {
+        private readonly IProjectThreadingService _threadingService;
+        private readonly IServiceProvider _serviceProvider;
+        private readonly Type _serviceType;
+
+        [ImportingConstructor]
+        public VsOptionalService([Import(typeof(SVsServiceProvider))]IServiceProvider serviceProvider, IProjectThreadingService threadingService)
+            : this(serviceProvider, threadingService, typeof(T))
+        {
+        }
+
+        protected VsOptionalService(IServiceProvider serviceProvider, IProjectThreadingService threadingService, Type serviceType)
+        {
+            Requires.NotNull(serviceProvider, nameof(serviceProvider));
+            Requires.NotNull(threadingService, nameof(threadingService));
+            Requires.NotNull(serviceType, nameof(serviceType));
+
+            _serviceProvider = serviceProvider;
+            _threadingService = threadingService;
+            _serviceType = serviceType;
+        }
+
+        public T Value
+        {
+            get
+            {
+                _threadingService.VerifyOnUIThread();
+
+                return (T)_serviceProvider.GetService(_serviceType);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsOptionalService`2.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsOptionalService`2.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    /// <summary>
+    ///     Provides an implementation of <see cref="IVsOptionalService{TInterfaceType, TServiceType}"/> that calls into Visual Studio's <see cref="SVsServiceProvider"/>.
+    /// </summary>
+    [Export(typeof(IVsOptionalService<,>))]
+    internal class VsOptionalService<TService, TInterface> : VsOptionalService<TInterface>, IVsOptionalService<TService, TInterface>
+    {
+        [ImportingConstructor]
+        public VsOptionalService([Import(typeof(SVsServiceProvider))]IServiceProvider serviceProvider, IProjectThreadingService threadingService)
+            : base(serviceProvider, threadingService, typeof(TService))
+        {
+        }
+    }
+}


### PR DESCRIPTION
Added IVsOptionalService where GetService returning null for a given service is expected and not a product bug.

I considered different approaches for this; such as returning a different property/methpd from IVsService that didn't throw - I ended up liking this approach from a consumption standpoint, this leaves it to look like Lazy<T>.Value.