### PR TITLE
Add service to create/return "Project" Output Window pane

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsOptionalServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsOptionalServiceFactory.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    internal static class IVsOptionalServiceFactory
+    {
+        public static IVsOptionalService<T> Create<T>(T value)
+        {
+            var mock = new Mock<IVsOptionalService<T>>();
+            mock.SetupGet(s => s.Value)
+                .Returns(() => value);
+
+            return mock.Object;
+        }
+
+        public static IVsOptionalService<TService, TInterface> Create<TService, TInterface>(TInterface value)
+        {
+            var mock = new Mock<IVsOptionalService<TService, TInterface>>();
+            mock.SetupGet(s => s.Value)
+                .Returns(() => value);
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsOutputWindow2Factory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsOutputWindow2Factory.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.VisualStudio.Shell.Interop
+{
+    internal static class IVsOutputWindow2Factory
+    {
+        public static IVsOutputWindow CreateWithActivePane(IVsOutputWindowPane pane)
+        {
+            return new VsOutputWindowMock(pane);
+        }
+
+        private class VsOutputWindowMock : IVsOutputWindow, IVsOutputWindow2
+        {
+            private Guid _activePaneGuid = Guid.NewGuid();
+            private Dictionary<Guid, IVsOutputWindowPane> _panes = new Dictionary<Guid, IVsOutputWindowPane>();
+
+            public VsOutputWindowMock(IVsOutputWindowPane activePane)
+            {
+                _panes.Add(_activePaneGuid, activePane);
+            }
+
+            public int GetPane(ref Guid rguidPane, out IVsOutputWindowPane ppPane)
+            {
+                _panes.TryGetValue(rguidPane, out ppPane);
+
+                return 0;
+            }
+
+            public int CreatePane(ref Guid rguidPane, string pszPaneName, int fInitVisible, int fClearWithSolution)
+            {
+                _panes[rguidPane] = IVsOutputWindowPaneFactory.Create();
+
+                return 0;
+            }
+
+            public int DeletePane(ref Guid rguidPane)
+            {
+                throw new NotImplementedException();
+            }
+
+            public int GetActivePaneGUID(out Guid pguidPane)
+            {
+                pguidPane = _activePaneGuid;
+                return 0;
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsOutputWindowFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsOutputWindowFactory.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.VisualStudio.Shell.Interop
+{
+    internal static class IVsOutputWindowFactory
+    {
+        public static IVsOutputWindow Create()
+        {
+            return new VsOutputWindowMock();
+        }
+
+        private class VsOutputWindowMock : IVsOutputWindow
+        {
+            private Dictionary<Guid, IVsOutputWindowPane> _panes = new Dictionary<Guid, IVsOutputWindowPane>();
+
+            public int GetPane(ref Guid rguidPane, out IVsOutputWindowPane ppPane)
+            {
+                _panes.TryGetValue(rguidPane, out ppPane);
+
+                return 0;
+            }
+
+            public int CreatePane(ref Guid rguidPane, string pszPaneName, int fInitVisible, int fClearWithSolution)
+            {
+                _panes[rguidPane] = IVsOutputWindowPaneFactory.Create();
+
+                return 0;
+            }
+
+            public int DeletePane(ref Guid rguidPane)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsOutputWindowPaneFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsOutputWindowPaneFactory.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Moq;
+using System;
+
+namespace Microsoft.VisualStudio.Shell.Interop
+{
+    internal static class IVsOutputWindowPaneFactory
+    {
+        public static IVsOutputWindowPane Create()
+        {
+            var mock = new Mock<IVsOutputWindowPane>();
+            return mock.Object;
+        }
+
+        public static IVsOutputWindowPane ImplementActivate(Func<int> action)
+        {
+            var mock = new Mock<IVsOutputWindowPane>();
+            mock.Setup(p => p.Activate())
+                .Returns(action);
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Logging/ProjectOutputWindowPaneProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Logging/ProjectOutputWindowPaneProviderTests.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Shell.Interop;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
+{
+    [ProjectSystemTrait]
+    public class ProjectOutputWindowPaneProviderTests
+    {
+        [Fact]
+        public async Task GetOutputWindowPaneAsync_WhenNoIVsOutputWindow_ReturnsNull()
+        {
+            var provider = CreateInstance();
+
+            var result = await provider.GetOutputWindowPaneAsync();
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task GetOutputWindowPaneAsync_ReturnsResult()
+        {
+            var outputWindow = IVsOutputWindowFactory.Create();
+
+            var provider = CreateInstance(outputWindow: outputWindow);
+
+            var result = await provider.GetOutputWindowPaneAsync();
+
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public async Task GetOutputWindowPaneAsync_ReturnsCachedResult()
+        {
+            var outputWindow = IVsOutputWindowFactory.Create();
+
+            var provider = CreateInstance(outputWindow: outputWindow);
+
+            var result1 = await provider.GetOutputWindowPaneAsync();
+            var result2 = await provider.GetOutputWindowPaneAsync();
+
+            Assert.Same(result1, result2);
+        }
+
+        [Fact]
+        public async Task GetOutputWindowPaneAsync_ReactivatesPreviouslyActiveWindow()
+        {
+            int callCount = 0;
+            var pane = IVsOutputWindowPaneFactory.ImplementActivate(() => { callCount++; return 0; });
+
+            var outputWindow = IVsOutputWindow2Factory.CreateWithActivePane(pane);
+            var provider = CreateInstance(outputWindow: outputWindow);
+
+            await provider.GetOutputWindowPaneAsync();
+
+            Assert.Equal(1, callCount);
+        }
+
+        private static ProjectOutputWindowPaneProvider CreateInstance(IProjectThreadingService threadingService = null, IVsOutputWindow outputWindow = null)
+        {
+            threadingService = threadingService ?? IProjectThreadingServiceFactory.Create();
+
+            var outputWindowService = IVsOptionalServiceFactory.Create<SVsOutputWindow, IVsOutputWindow>(outputWindow);
+
+            return new ProjectOutputWindowPaneProvider(threadingService, outputWindowService);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/VsOptionalServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/VsOptionalServiceTests.cs
@@ -1,0 +1,101 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    [ProjectSystemTrait]
+    public class VsOptionalServiceTests
+    {
+        [Fact]
+        public void Constructor_NullAsServiceProvider_ThrowsArgumentNull()
+        {
+            var threadingService = IProjectThreadingServiceFactory.Create();
+
+            Assert.Throws<ArgumentNullException>("serviceProvider", () => {
+                return new VsService<string, string>((IServiceProvider)null, threadingService);
+            });
+        }
+
+        [Fact]
+        public void Constructor_NullAsThreadingService_ThrowsArgumentNull()
+        {
+            var serviceProvider = SVsServiceProviderFactory.Create();
+
+            Assert.Throws<ArgumentNullException>("threadingService", () => {
+                return new VsService<string, string>(serviceProvider, (IProjectThreadingService)null);
+            });
+        }
+
+        [Fact]
+        public void Value_MustBeCalledOnUIThread()
+        {
+            var threadingService = IProjectThreadingServiceFactory.ImplementVerifyOnUIThread(() => throw new InvalidOperationException());
+
+            var service = CreateInstance<string, string>(threadingService: threadingService);
+
+            Assert.Throws<InvalidOperationException>(() => {
+                var value = service.Value;
+            });
+        }
+
+        [Fact]
+        public void Value_WhenMissingService_ReturnsNull()
+        {
+            var threadingService = IProjectThreadingServiceFactory.ImplementVerifyOnUIThread(() => { });
+            var serviceProvider = IServiceProviderFactory.ImplementGetService(type => null);
+
+            var service = CreateInstance<string, string>(serviceProvider: serviceProvider, threadingService: threadingService);
+
+            var result = service.Value;
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Value_ReturnsGetService()
+        {
+            object input = new object();
+
+            var threadingService = IProjectThreadingServiceFactory.ImplementVerifyOnUIThread(() => { });
+            var serviceProvider = IServiceProviderFactory.ImplementGetService(type => {
+                if (type == typeof(string))
+                    return input;
+
+                return null;
+
+            });
+
+            var service = CreateInstance<string, object>(serviceProvider: serviceProvider, threadingService: threadingService);
+
+            var result = service.Value;
+
+            Assert.Same(input, result);
+        }
+
+        [Fact]
+        public void Value_DoesNotCache()
+        {
+            var threadingService = IProjectThreadingServiceFactory.ImplementVerifyOnUIThread(() => { });
+            var serviceProvider = IServiceProviderFactory.ImplementGetService(type => {
+                return new object();
+            });
+
+            var service = CreateInstance<string, object>(serviceProvider: serviceProvider, threadingService: threadingService);
+
+            var result1 = service.Value;
+            var result2 = service.Value;
+
+            Assert.NotSame(result1, result2);
+        }
+
+        private VsOptionalService<TService, TInterface> CreateInstance<TService, TInterface>(IServiceProvider serviceProvider = null, IProjectThreadingService threadingService = null)
+        {
+            serviceProvider = serviceProvider ?? SVsServiceProviderFactory.Create();
+            threadingService = threadingService ?? IProjectThreadingServiceFactory.Create();
+
+            return new VsOptionalService<TService, TInterface>(serviceProvider, threadingService);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsOptionalService`1.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsOptionalService`1.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Runtime.InteropServices;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    /// <summary>
+    ///     Provides access to an optional Visual Studio proffered service.
+    /// </summary>
+    /// <typeparam name="T">
+    ///     The type of the service to retrieve and return from <see cref="Value"/>.
+    /// </typeparam>
+    internal interface IVsOptionalService<T>
+    {
+        /// <summary>
+        ///     Gets the optional service object associated with <typeparamref name="T"/>.
+        /// </summary>
+        ///<exception cref="COMException">
+        ///     This property was not accessed from the UI thread.
+        /// </exception>
+        /// <value>
+        ///     The service <see cref="object"/> associated with <typeparamref name="T"/>;
+        ///     otherwise, <see langword="null"/> if it is not present.
+        /// </value>
+        T Value
+        {
+            get;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsOptionalService`2.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsOptionalService`2.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    /// <summary>
+    ///     Provides access to an optional Visual Studio proffered service.
+    /// </summary>
+    /// <typeparam name="TService">
+    ///     The type of the service to retrieve.
+    /// </typeparam>
+    /// <typeparam name="TInterface">
+    ///     The type of the service to return from <see cref="IVsService{T}.Value"/>
+    /// </typeparam>
+    internal interface IVsOptionalService<TService, TInterface> : IVsOptionalService<TInterface>
+    {
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsService`1.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsService`1.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
     /// <summary>
-    ///     Provides access to a Visual Studio proffered service.
+    ///     Provides access to a required Visual Studio proffered service.
     /// </summary>
     /// <typeparam name="T">
     ///     The type of the service to retrieve and return from <see cref="Value"/>.
@@ -13,10 +14,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     internal interface IVsService<T>
     {
         /// <summary>
-        ///     Gets the service object of associated with <typeparamref name="T"/>.
+        ///     Gets the required service object associated with <typeparamref name="T"/>.
         /// </summary>
         ///<exception cref="COMException">
         ///     This property was not accessed from the UI thread.
+        /// </exception>
+        /// <value>
+        ///     The service <see cref="object"/> associated with <typeparamref name="T"/>;
+        ///     otherwise, throws an exception if it is not present.
+        /// </value>
+        /// <exception cref="Exception">
+        ///     The service could not be found.
         /// </exception>
         T Value
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsService`2.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IVsService`2.cs
@@ -3,7 +3,7 @@
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
     /// <summary>
-    ///     Provides access to a Visual Studio proffered service.
+    ///     Provides access to a required Visual Studio proffered service.
     /// </summary>
     /// <typeparam name="TService">
     ///     The type of the service to retrieve.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/IProjectOutputWindowPaneProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/IProjectOutputWindowPaneProvider.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
+{
+    /// <summary>
+    ///     Provides access to the project output window pane.
+    /// </summary>
+    internal interface IProjectOutputWindowPaneProvider
+    {
+        /// <summary>
+        ///     Returns the project output window pane.
+        /// </summary>
+        /// <returns>
+        ///     The project <see cref="IVsOutputWindowPane"/> object, or <see langword="null"/> 
+        ///     if the <see cref="IVsOutputWindow"/> service is not present.
+        /// </returns>
+        Task<IVsOutputWindowPane> GetOutputWindowPaneAsync();
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowPaneProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowPaneProvider.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
+{
+    [Export(typeof(IProjectOutputWindowPaneProvider))]
+    internal class ProjectOutputWindowPaneProvider : IProjectOutputWindowPaneProvider
+    {
+        private static readonly Guid ProjectOutputWindowPaneGuid = new Guid("{A18568CC-CA90-4AEE-9D14-A7E9D753B544}");
+
+        private readonly IProjectThreadingService _threadingService;
+        private readonly IVsOptionalService<IVsOutputWindow> _outputWindow;
+        private readonly AsyncLazy<IVsOutputWindowPane> _outputWindowPane;
+
+        [ImportingConstructor]
+        public ProjectOutputWindowPaneProvider(IProjectThreadingService threadingService, IVsOptionalService<SVsOutputWindow, IVsOutputWindow> outputWindow)
+        {
+            Requires.NotNull(threadingService, nameof(threadingService));
+            Requires.NotNull(outputWindow, nameof(outputWindow));
+
+            _threadingService = threadingService;
+            _outputWindow = outputWindow;
+            _outputWindowPane = new AsyncLazy<IVsOutputWindowPane>(CreateOutputWindowPaneAsync, threadingService.JoinableTaskFactory);
+        }
+
+        public Task<IVsOutputWindowPane> GetOutputWindowPaneAsync()
+        {
+            return _outputWindowPane.GetValueAsync();
+        }
+
+        private async Task<IVsOutputWindowPane> CreateOutputWindowPaneAsync()
+        {
+            await _threadingService.SwitchToUIThread();
+
+            IVsOutputWindow outputWindow = _outputWindow.Value;
+            if (outputWindow == null)
+                return null;    // Command-line build
+
+            Guid activePane = outputWindow.GetActivePane();
+
+            IVsOutputWindowPane pane = CreateProjectOutputWindowPane(outputWindow);
+
+            // Creating a pane causes it to be "active", reset the active pane back to the previously active pane
+            if (activePane != Guid.Empty)
+                outputWindow.ActivatePane(activePane);
+
+            return pane;
+        }
+
+        private IVsOutputWindowPane CreateProjectOutputWindowPane(IVsOutputWindow outputWindow)
+        {
+            Guid paneGuid = ProjectOutputWindowPaneGuid;
+            HResult hr = outputWindow.CreatePane(ref paneGuid, VSResources.OutputWindowPaneTitle, fInitVisible: 1, fClearWithSolution: 0);
+            if (hr.Failed)
+                throw hr.Exception;
+
+            hr = outputWindow.GetPane(ref paneGuid, out IVsOutputWindowPane pane);
+            if (hr.Failed)
+                throw hr.Exception;
+
+            return pane;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsOptionalService`1.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsOptionalService`1.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    /// <summary>
+    ///     Provides an implementation of <see cref="IVsOptionalService{T}"/> that calls into Visual Studio's <see cref="SVsServiceProvider"/>.
+    /// </summary>
+    [Export(typeof(IVsOptionalService<>))]
+    internal class VsOptionalService<T> : IVsOptionalService<T>
+    {
+        private readonly IProjectThreadingService _threadingService;
+        private readonly IServiceProvider _serviceProvider;
+        private readonly Type _serviceType;
+
+        [ImportingConstructor]
+        public VsOptionalService([Import(typeof(SVsServiceProvider))]IServiceProvider serviceProvider, IProjectThreadingService threadingService)
+            : this(serviceProvider, threadingService, typeof(T))
+        {
+        }
+
+        protected VsOptionalService(IServiceProvider serviceProvider, IProjectThreadingService threadingService, Type serviceType)
+        {
+            Requires.NotNull(serviceProvider, nameof(serviceProvider));
+            Requires.NotNull(threadingService, nameof(threadingService));
+            Requires.NotNull(serviceType, nameof(serviceType));
+
+            _serviceProvider = serviceProvider;
+            _threadingService = threadingService;
+            _serviceType = serviceType;
+        }
+
+        public T Value
+        {
+            get
+            {
+                _threadingService.VerifyOnUIThread();
+
+                return (T)_serviceProvider.GetService(_serviceType);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsOptionalService`2.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsOptionalService`2.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    /// <summary>
+    ///     Provides an implementation of <see cref="IVsOptionalService{TInterfaceType, TServiceType}"/> that calls into Visual Studio's <see cref="SVsServiceProvider"/>.
+    /// </summary>
+    [Export(typeof(IVsOptionalService<,>))]
+    internal class VsOptionalService<TService, TInterface> : VsOptionalService<TInterface>, IVsOptionalService<TService, TInterface>
+    {
+        [ImportingConstructor]
+        public VsOptionalService([Import(typeof(SVsServiceProvider))]IServiceProvider serviceProvider, IProjectThreadingService threadingService)
+            : base(serviceProvider, threadingService, typeof(TService))
+        {
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/IVsOutputWindowExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/IVsOutputWindowExtensions.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.ProjectSystem.VS;
+
+namespace Microsoft.VisualStudio.Shell.Interop
+{
+    /// <summary>
+    ///     Provides extension methods for <see cref="IVsOutputWindow"/>.
+    /// </summary>
+    internal static class IVsOutputWindowExtensions
+    {
+        /// <summary>
+        ///     Actives the output window pane associated with the specified GUID. Does nothing if the pane cannot be found.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="outputWindow"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="paneGuid"/> is empty.
+        /// </exception>
+        public static void ActivatePane(this IVsOutputWindow outputWindow, Guid paneGuid)
+        {
+            Requires.NotNull(outputWindow, nameof(outputWindow));
+            Requires.NotEmpty(paneGuid, nameof(paneGuid));
+
+            HResult hr = outputWindow.GetPane(ref paneGuid, out IVsOutputWindowPane pane);
+            if (hr.IsOK) // Pane found
+            {
+                hr = pane.Activate();
+                if (hr.Failed)
+                    throw hr.Exception;
+            }
+        }
+
+        /// <summary>
+        ///     Returns the GUID associated with the active window pane, or <see cref="Guid.Empty"/> if no 
+        ///     active pane or the active pane is unknown.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="outputWindow"/> is <see langword="null"/>.
+        /// </exception>
+        public static Guid GetActivePane(this IVsOutputWindow outputWindow)
+        {
+            Requires.NotNull(outputWindow, nameof(outputWindow));
+
+            if (outputWindow is IVsOutputWindow2 outputWindow2)
+            {
+                HResult hr = outputWindow2.GetActivePaneGUID(out Guid activePaneGuid);
+                if (hr.Failed)
+                    throw hr.Exception;
+
+                return activePaneGuid;
+            }
+
+            return Guid.Empty;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
@@ -355,6 +355,15 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Project.
+        /// </summary>
+        internal static string OutputWindowPaneTitle {
+            get {
+                return ResourceManager.GetString("OutputWindowPaneTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to _Overwrite.
         /// </summary>
         internal static string Overwrite {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
@@ -279,4 +279,7 @@ In order to debug this project, add an executable project to this solution which
   <data name="DebugFrameworkMenuText" xml:space="preserve">
     <value>Framework ({0})</value>
   </data>
+  <data name="OutputWindowPaneTitle" xml:space="preserve">
+    <value>Project</value>
+  </data>
 </root>


### PR DESCRIPTION
This is 2 of 4 PRs for the new logging infrastructure. The PR's have been split up to reduce the amount of code to be reviewed.

This PR includes a new interface & implementation called IProjectOutputWindowPaneProvider/ProjectOutputWindowPaneProvider that provides access to the a new "Project" Output Window pane that we will be writing to via a logger. ProjectOutputWindowPaneProvider simply provides a access to a singleton IVsWindowOutputPane across the project system, it does not write it or hide it behind an option - that's coming in a future PR. 

The idea is that this pane will be turned on when we need to get more information from a customer's machine. I have a future PR where the language service writes to this to help chase down some the issues that are not repro'ing inside the debugger. 

Note this includes https://github.com/dotnet/project-system/pull/2111, so you should just look at the last two commits https://github.com/davkean/project-system/commit/77fe9c0893fc7d103b2685e034fd6cb9ba5e2992 and https://github.com/davkean/project-system/commit/40be1d86ef1e777b768b3b8847a9b9b9066ff139.
