### PR TITLE
Do not show Windows Application as an output type option for .Net Core and .Net Standard Application

### DIFF
--- a/src/Targets/Microsoft.Managed.DesignTime.targets
+++ b/src/Targets/Microsoft.Managed.DesignTime.targets
@@ -20,6 +20,7 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
 
     <!--This property sets the default output types supported by the project system.-->
+    <SupportedOutputTypes Condition="'$(SupportedOutputTypes)' == '' And '$(_IsNETCoreOrNETStandard)' == 'true'">Exe;Library</SupportedOutputTypes>
     <SupportedOutputTypes Condition="'$(SupportedOutputTypes)' == ''">Exe;WinExe;Library</SupportedOutputTypes>
   </PropertyGroup>
 


### PR DESCRIPTION
because 'Windows Application' does not mean anything in these worlds

Tagging @dotnet/project-system for review

**Customer scenario**

With this change the customer will not see the Windows Application output type for .Net Standard and .Net Core projects

**Bugs this fixes:** 

#2033 

**Workarounds, if any**

Set RunCommand property and other SDK related properties. Ideally, the customer should be having no knowledge about it.

**Risk**

Low. This is a targeted fix related output type for .Net Standard  and .Net Core projects. 

**Root cause analysis:**

Customer found issue. We are finding these issues as are onboarding Framework projects to the new project system and the SDK.

**How was the bug found?**

Customer reported
