### PR TITLE
Fix missing TargetFrameworks telemetry that was broken due to a mismerge

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikersValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikersValueProvider.cs
@@ -10,10 +10,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
     [ExportInterceptingPropertyValueProvider("TargetFrameworkMonikers", ExportInterceptingPropertyValueProviderFile.ProjectFile)]
     internal class TargetFrameworkMonikersValueProvider : InterceptingPropertyValueProviderBase
     {
-        private readonly ActiveConfiguredProjectsProvider _projectProvider;
+        private readonly IActiveConfiguredProjectsProvider _projectProvider;
 
         [ImportingConstructor]
-        public TargetFrameworkMonikersValueProvider(ActiveConfiguredProjectsProvider projectProvider)
+        public TargetFrameworkMonikersValueProvider(IActiveConfiguredProjectsProvider projectProvider)
         {
             _projectProvider = projectProvider;
         }


### PR DESCRIPTION
**Customer scenario**

We added telemetry data in 15.2 to identify multi-tfm projects and the frameworks being targeted by them. When this code merged into the 15.3 branch it broke. This change adds back that telemetry point.

**Bugs this fixes:** 

[VSO 430121](https://devdiv.visualstudio.com/DevDiv/_workitems?id=430121&fullScreen=false&_a=edit)

**Workarounds, if any**

None

**Risk**

Low

**Performance impact**

Low

**Is this a regression from a previous update?**

Yes from 15.2

**Root cause analysis:**

We were MEF importing a type that was being exported as a concrete type in 15.2 but through an interface in 15.3. When the merge happened there was no conflict because they were in different files and we didn't get any error.

**How was the bug found?**

Looking at MEF composition errors in 15.3

@dotnet/project-system @jmarolf 