### PR TITLE
Update property descriptions

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AdditionalFiles.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AdditionalFiles.xaml
@@ -4,7 +4,7 @@
   Name="AdditionalFiles"
   DisplayName="Additional File"
   PageTemplate="generic"
-  Description="Additional file items"
+  Description="File Properties"
   xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="AdditionalFiles" SourceOfDefaultValue="AfterContext" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AnalyzerReference.xaml
@@ -4,7 +4,7 @@
     Name="AnalyzerReference"
     DisplayName="Analyzer Reference"
     PageTemplate="generic"
-    Description="Analyzer reference properties"
+    Description="Analyzer Properties"
     xmlns="http://schemas.microsoft.com/build/2009/properties">
     <Rule.DataSource>
         <DataSource Persistence="ProjectFile" ItemType="Analyzer" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AssemblyReference.xaml
@@ -4,7 +4,7 @@
     Name="AssemblyReference"
     DisplayName="Assembly Reference"
     PageTemplate="generic"
-    Description="Assembly reference properties"
+    Description="Reference Properties"
     xmlns="http://schemas.microsoft.com/build/2009/properties">
     <Rule.DataSource>
         <DataSource Persistence="ProjectFile" ItemType="Reference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ComReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ComReference.xaml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Rule Name="ComReference" DisplayName="COM Reference" PageTemplate="generic" Description="COM reference properties" xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="ComReference" DisplayName="COM Reference" PageTemplate="generic" Description="COM Reference Properties" xmlns="http://schemas.microsoft.com/build/2009/properties">
     <Rule.DataSource>
         <DataSource Persistence="ProjectFile" ItemType="COMReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
     </Rule.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Compile.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Compile.xaml
@@ -1,64 +1,64 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule
-	Name="Compile"
-	DisplayName="File Properties"
-	PageTemplate="generic"
-	Description="File Properties"
-	xmlns="http://schemas.microsoft.com/build/2009/properties">
-  <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" Label="Configuration" ItemType="Compile" HasConfigurationCondition="false" SourceOfDefaultValue="AfterContext" />
-  </Rule.DataSource>
-  <Rule.Categories>
-    <Category Name="Advanced" DisplayName="Advanced" />
-    <Category Name="Misc" DisplayName="Misc" />
-  </Rule.Categories>
+    Name="Compile"
+    DisplayName="File Properties"
+    PageTemplate="generic"
+    Description="File Properties"
+    xmlns="http://schemas.microsoft.com/build/2009/properties">
+    <Rule.DataSource>
+        <DataSource Persistence="ProjectFile" Label="Configuration" ItemType="Compile" HasConfigurationCondition="false" SourceOfDefaultValue="AfterContext" />
+    </Rule.DataSource>
+    <Rule.Categories>
+        <Category Name="Advanced" DisplayName="Advanced" />
+        <Category Name="Misc" DisplayName="Misc" />
+    </Rule.Categories>
 
-  <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Build Action"  Category="Advanced"
+    <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Build Action"  Category="Advanced"
                    Description="How the file relates to the build and deployment processes."
                    EnumProvider="ItemTypes" />
-  <EnumProperty
+    <EnumProperty
       Name="CopyToOutputDirectory"
       DisplayName="Copy to Output Directory"
       Category="Advanced"
       Description="Specifies the source file will be copied to the output directory.">
-    <EnumValue Name="Never" DisplayName="Do not copy" />
-    <EnumValue Name="Always" DisplayName="Copy always" />
-    <EnumValue Name="PreserveNewest" DisplayName="Copy if newer" />
-  </EnumProperty>
+        <EnumValue Name="Never" DisplayName="Do not copy" />
+        <EnumValue Name="Always" DisplayName="Copy always" />
+        <EnumValue Name="PreserveNewest" DisplayName="Copy if newer" />
+    </EnumProperty>
 
-  <StringProperty
+    <StringProperty
       Name="Generator"
       Category="Advanced"
       DisplayName="Custom Tool"
       Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
-  <StringProperty
+    <StringProperty
       Name="CustomToolNamespace"
       Category="Advanced"
       DisplayName="Custom Tool Namespace"
       Description="The namespace into which the output of the custom tool is placed." />
 
-  <BoolProperty Name="ExcludedFromBuild" DisplayName="Excluded From Build">
-    <BoolProperty.DataSource>
-      <DataSource Persistence="ProjectFile" Label="Configuration" ItemType="Compile" HasConfigurationCondition="true" SourceOfDefaultValue="AfterContext" />
-    </BoolProperty.DataSource>
-  </BoolProperty>
-  <BoolProperty Name="Visible" Visible="false" />
-  <StringProperty Name="DependentUpon" Visible="false">
-    <StringProperty.Metadata>
-      <NameValuePair Name="DoNotCopyAcrossProjects" Value="true" />
-    </StringProperty.Metadata>
-  </StringProperty>
-  <StringProperty Name="Link" Visible="false">
-    <StringProperty.DataSource>
-      <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-    <StringProperty.Metadata>
-      <NameValuePair Name="DoNotCopyAcrossProjects" Value="true" />
-    </StringProperty.Metadata>
-  </StringProperty>
-  <StringProperty Name="SubType" Visible="false" />
-  <StringProperty Name="LastGenOutput" Visible="false" Description="The filename of the last file generated as a result of the SFG." />
-  <BoolProperty Name="DesignTime" Visible="false" Description="A value indicating whether this file has a designer." />
-  <BoolProperty Name="AutoGen" Visible="false" Description="A value indicating whether this is a generated file." />
+    <BoolProperty Name="ExcludedFromBuild" DisplayName="Excluded From Build">
+        <BoolProperty.DataSource>
+            <DataSource Persistence="ProjectFile" Label="Configuration" ItemType="Compile" HasConfigurationCondition="true" SourceOfDefaultValue="AfterContext" />
+        </BoolProperty.DataSource>
+    </BoolProperty>
+    <BoolProperty Name="Visible" Visible="false" />
+    <StringProperty Name="DependentUpon" Visible="false">
+        <StringProperty.Metadata>
+            <NameValuePair Name="DoNotCopyAcrossProjects" Value="true" />
+        </StringProperty.Metadata>
+    </StringProperty>
+    <StringProperty Name="Link" Visible="false">
+        <StringProperty.DataSource>
+            <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+        <StringProperty.Metadata>
+            <NameValuePair Name="DoNotCopyAcrossProjects" Value="true" />
+        </StringProperty.Metadata>
+    </StringProperty>
+    <StringProperty Name="SubType" Visible="false" />
+    <StringProperty Name="LastGenOutput" Visible="false" Description="The filename of the last file generated as a result of the SFG." />
+    <BoolProperty Name="DesignTime" Visible="false" Description="A value indicating whether this file has a designer." />
+    <BoolProperty Name="AutoGen" Visible="false" Description="A value indicating whether this is a generated file." />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/EmbeddedResource.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/EmbeddedResource.xaml
@@ -1,99 +1,99 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
 <Rule
-	Name="EmbeddedResource"
-	DisplayName="Embedded Resource"
-	PageTemplate="generic"
-	Description="Embedded resources"
-	xmlns="http://schemas.microsoft.com/build/2009/properties">
-  <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="EmbeddedResource" SourceOfDefaultValue="AfterContext" />
-  </Rule.DataSource>
-  <Rule.Categories>
-    <Category Name="Advanced" DisplayName="Advanced" />
-    <Category Name="Misc" DisplayName="Misc" />
-  </Rule.Categories>
+    Name="EmbeddedResource"
+    DisplayName="Embedded Resource"
+    PageTemplate="generic"
+    Description="File Properties"
+    xmlns="http://schemas.microsoft.com/build/2009/properties">
+    <Rule.DataSource>
+        <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="EmbeddedResource" SourceOfDefaultValue="AfterContext" />
+    </Rule.DataSource>
+    <Rule.Categories>
+        <Category Name="Advanced" DisplayName="Advanced" />
+        <Category Name="Misc" DisplayName="Misc" />
+    </Rule.Categories>
 
-  <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Build Action"  Category="Advanced"
+    <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Build Action"  Category="Advanced"
                      Description="How the file relates to the build and deployment processes."
                      EnumProvider="ItemTypes" />
-  <EnumProperty
+    <EnumProperty
       Name="CopyToOutputDirectory"
       DisplayName="Copy to Output Directory"
       Category="Advanced"
       Description="Specifies the source file will be copied to the output directory.">
-    <EnumValue Name="Never" DisplayName="Do not copy" />
-    <EnumValue Name="Always" DisplayName="Copy always" />
-    <EnumValue Name="PreserveNewest" DisplayName="Copy if newer" />
-  </EnumProperty>
+        <EnumValue Name="Never" DisplayName="Do not copy" />
+        <EnumValue Name="Always" DisplayName="Copy always" />
+        <EnumValue Name="PreserveNewest" DisplayName="Copy if newer" />
+    </EnumProperty>
 
-  <StringProperty
+    <StringProperty
       Name="Generator"
       Category="Advanced"
       DisplayName="Custom Tool"
       Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
-  <StringProperty
+    <StringProperty
       Name="CustomToolNamespace"
       Category="Advanced"
       DisplayName="Custom Tool Namespace"
       Description="The namespace into which the output of the custom tool is placed." />
 
-  <StringProperty
+    <StringProperty
       Name="Identity"
       Visible="false"
       ReadOnly="true"
       Category="Misc"
       Description="The item specified in the Include attribute.">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="EmbeddedResource" PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+        <StringProperty.DataSource>
+            <DataSource Persistence="Intrinsic" ItemType="EmbeddedResource" PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
 
-  <StringProperty
+    <StringProperty
       Name="FullPath"
       DisplayName="Full Path"
       ReadOnly="true"
       Category="Misc"
       Description="Location of the file.">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="EmbeddedResource" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+        <StringProperty.DataSource>
+            <DataSource Persistence="Intrinsic" ItemType="EmbeddedResource" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
 
-  <StringProperty
+    <StringProperty
       Name="FileNameAndExtension"
       DisplayName="File Name"
       ReadOnly="true"
       Category="Misc"
       Description="Name of the file or folder.">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="EmbeddedResource" PersistedName="FileNameAndExtension" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+        <StringProperty.DataSource>
+            <DataSource Persistence="Intrinsic" ItemType="EmbeddedResource" PersistedName="FileNameAndExtension" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
 
-  <StringProperty Name="URL" ReadOnly="true" Visible="false">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="EmbeddedResource" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <BoolProperty Name="Visible" Visible="false" />
-  <StringProperty Name="DependentUpon" Visible="false" />
-  <StringProperty Name="Link" Visible="false">
-    <StringProperty.DataSource>
-      <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="Extension" Visible="False" ReadOnly="true">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="EmbeddedResource" PersistedName="Extension" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="LastGenOutput" Visible="false" Description="The filename of the last file generated as a result of the SFG." />
-  <BoolProperty Name="DesignTime" Visible="false" Description="A value indicating whether this file has a designer." />
-  <BoolProperty Name="AutoGen" Visible="false" Description="A value indicating whether this is a generated file." />
-  <StringProperty Name="CustomTool" Visible="false" Description="DTE Property for accessing the Generator property.">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" ItemType="EmbeddedResource" PersistedName="Generator" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+    <StringProperty Name="URL" ReadOnly="true" Visible="false">
+        <StringProperty.DataSource>
+            <DataSource Persistence="Intrinsic" ItemType="EmbeddedResource" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+    <BoolProperty Name="Visible" Visible="false" />
+    <StringProperty Name="DependentUpon" Visible="false" />
+    <StringProperty Name="Link" Visible="false">
+        <StringProperty.DataSource>
+            <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+    <StringProperty Name="Extension" Visible="False" ReadOnly="true">
+        <StringProperty.DataSource>
+            <DataSource Persistence="Intrinsic" ItemType="EmbeddedResource" PersistedName="Extension" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+    <StringProperty Name="LastGenOutput" Visible="false" Description="The filename of the last file generated as a result of the SFG." />
+    <BoolProperty Name="DesignTime" Visible="false" Description="A value indicating whether this file has a designer." />
+    <BoolProperty Name="AutoGen" Visible="false" Description="A value indicating whether this is a generated file." />
+    <StringProperty Name="CustomTool" Visible="false" Description="DTE Property for accessing the Generator property.">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFile" ItemType="EmbeddedResource" PersistedName="Generator" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/None.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/None.xaml
@@ -4,7 +4,7 @@
   Name="None"
   DisplayName="General"
   PageTemplate="generic"
-  Description="Non-build items"
+  Description="File Properties"
   xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="None" SourceOfDefaultValue="AfterContext" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
@@ -4,7 +4,7 @@
     Name="PackageReference"
     DisplayName="Package"
     PageTemplate="generic"
-    Description="Package"
+    Description="Package Properties"
     xmlns="http://schemas.microsoft.com/build/2009/properties">
     
     <Rule.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.xaml
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule
-	Name="ProjectReference"
-	DisplayName="Project Reference"
-	PageTemplate="generic"
-	Description="Project reference properties"
-	xmlns="http://schemas.microsoft.com/build/2009/properties">
+    Name="ProjectReference"
+    DisplayName="Project Reference"
+    PageTemplate="generic"
+    Description="Reference Properties"
+    xmlns="http://schemas.microsoft.com/build/2009/properties">
 
     <Rule.DataSource>
         <DataSource Persistence="ProjectFile" ItemType="ProjectReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
@@ -13,11 +13,11 @@
 
     <BoolProperty Name="ReferenceOutputAssembly"
                   DisplayName="Reference Output Assembly"
-				  Description="A value indicating whether the compiler should include a reference to the target project's primary output assembly." />
+                  Description="A value indicating whether the compiler should include a reference to the target project's primary output assembly." />
 
     <BoolProperty Name="CopyLocalSatelliteAssemblies"
                   DisplayName="Copy Local Satellite Assemblies"
-				  Description="Indicates whether the satellite assemblies of the reference target should be copied into this project's output directory." />
+                  Description="Indicates whether the satellite assemblies of the reference target should be copied into this project's output directory." />
 
     <BoolProperty Name="LinkLibraryDependencies" Visible="False" />
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAnalyzerReference.xaml
@@ -4,7 +4,7 @@
     Name="ResolvedAnalyzerReference"
     DisplayName="Resolved Analyzer Reference"
     PageTemplate="generic"
-    Description="Resolved Analyzer reference properties"
+    Description="Analyzer Properties"
     xmlns="http://schemas.microsoft.com/build/2009/properties">
     <Rule.DataSource>
         <DataSource Persistence="ResolvedReference" ItemType="Analyzer" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext"
@@ -20,4 +20,13 @@
         </StringProperty.DataSource>
     </StringProperty>
     <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+
+    <StringProperty Name="ResolvedPath"
+                    ReadOnly="True"
+                    DisplayName="Path"
+                    Description="Location of the analyzer assembly.">
+        <StringProperty.DataSource>
+            <DataSource PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAssemblyReference.xaml
@@ -4,7 +4,7 @@
     Name="ResolvedAssemblyReference"
     DisplayName="Resolved Assembly Reference"
     PageTemplate="generic"
-    Description="Resolved reference"
+    Description="Reference Properties"
     xmlns="http://schemas.microsoft.com/build/2009/properties">
     <Rule.DataSource>
         <DataSource Persistence="ResolvedReference" ItemType="Reference" HasConfigurationCondition="False" 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedCOMReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedCOMReference.xaml
@@ -4,7 +4,7 @@
     Name="ResolvedCOMReference"
     DisplayName="Resolved COM Reference"
     PageTemplate="generic"
-    Description="Resolved reference"
+    Description="COM Reference Properties"
     xmlns="http://schemas.microsoft.com/build/2009/properties">
     <Rule.DataSource>
         <DataSource Persistence="ResolvedReference" ItemType="COMReference" HasConfigurationCondition="False" 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedPackageReference.xaml
@@ -4,7 +4,7 @@
     Name="ResolvedPackageReference"
     DisplayName="Package"
     PageTemplate="generic"
-    Description="Package"
+    Description="Package Properties"
     xmlns="http://schemas.microsoft.com/build/2009/properties">
    
     <Rule.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedProjectReference.xaml
@@ -4,7 +4,7 @@
     Name="ResolvedProjectReference"
     DisplayName="Resolved Project Reference"
     PageTemplate="generic"
-    Description="Resolved reference"
+    Description="Reference Properties"
     xmlns="http://schemas.microsoft.com/build/2009/properties">
     <Rule.DataSource>
         <DataSource Persistence="ResolvedReference" ItemType="ProjectReference" HasConfigurationCondition="False" 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedSdkReference.xaml
@@ -4,7 +4,7 @@
     Name="ResolvedSdkReference"
     DisplayName="Resolved SDK Reference"
     PageTemplate="generic"
-    Description="Resolved SDK reference"
+    Description="SDK Reference Properties"
     xmlns="http://schemas.microsoft.com/build/2009/properties">
     <Rule.DataSource>
         <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SdkReference.xaml
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule
-	Name="SdkReference"
-	DisplayName="SDK Reference"
-	PageTemplate="generic"
-	Description="SDK reference properties"
-	xmlns="http://schemas.microsoft.com/build/2009/properties">
+    Name="SdkReference"
+    DisplayName="SDK Reference"
+    PageTemplate="generic"
+    Description="SDK Reference Properties"
+    xmlns="http://schemas.microsoft.com/build/2009/properties">
     <Rule.DataSource>
         <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False"
-                    SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />        
+                    SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
     </Rule.DataSource>
     <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" ReadOnly="True" />
     <StringProperty Name="AppXLocation" DisplayName="App Package Location" ReadOnly="True" />


### PR DESCRIPTION
Update a bunch of property descriptions that are obviously different from those used in the old project system. We're not going for absolute consistency here, but unless what we have is clearly better we should just stick with the descriptions used in the old system.

**Customer scenario**

Customers using the new project system will see text in the Properties Window that is arbitrarily different from what we had in the old project system.

**Bugs this fixes:** 

Fixes #59.

**Workarounds, if any**

N/A

**Risk**

Low.

**Performance impact**

None; these are simply string changes.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

N/A

**How was the bug found?**

Dogfooding