### PR TITLE
Make BuildOptions/IParseBuildOptions internal

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/BuildOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/BuildOptions.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
-    public class BuildOptions
+    internal class BuildOptions
     {
         public IEnumerable<CommandLineSourceFile> SourceFiles { get; }
         public IEnumerable<CommandLineSourceFile> AdditionalFiles { get; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IParseBuildOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IParseBuildOptions.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
-    public interface IParseBuildOptions
+    internal interface IParseBuildOptions
     {
         BuildOptions Parse(IEnumerable<string> args, string baseDirectory);
     }


### PR DESCRIPTION
These do not need to be public and are not part of our public API.