### PR TITLE
Add logging to SourceItemHandler

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectLoggerFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectLoggerFactory.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Logging
+{
+    internal static class IProjectLoggerFactory
+    {
+        public static IProjectLogger Create()
+        {
+            return Mock.Of<IProjectLogger>();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemHandlerTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
+using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
@@ -21,11 +22,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         [Fact]
         public void Handle_NullAsProjectChange_ThrowsArgumentNull()
         {
-            var handler = CreateInstance();
+            var update = Mock.Of<IProjectVersionedValue<IProjectSubscriptionUpdate>>();
             var context = IWorkspaceProjectContextFactory.Create();
-
+            
+            var handler = CreateInstance();
+            
             Assert.Throws<ArgumentNullException>("projectChange", () => {
-                handler.Handle((IProjectChangeDescription)null, context, true);
+                handler.Handle(update, (IProjectChangeDescription)null, context, true);
             });
         }
 
@@ -33,11 +36,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         [Fact]
         public void Handle_NullAsContext_ThrowsArgumentNull()
         {
-            var handler = CreateInstance();
+            var update = Mock.Of<IProjectVersionedValue<IProjectSubscriptionUpdate>>();
             var projectChange = IProjectChangeDescriptionFactory.Create();
 
+            var handler = CreateInstance();
+
             Assert.Throws<ArgumentNullException>("context", () => {
-                handler.Handle(projectChange, (IWorkspaceProjectContext)null, true);
+                handler.Handle(update, projectChange, (IWorkspaceProjectContext)null, true);
             });
         }
 
@@ -59,6 +64,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Action<string> onSourceFileAdded = s => Assert.True(sourceFilesPushedToWorkspace.Add(s));
             Action<string> onSourceFileRemoved = s => sourceFilesPushedToWorkspace.Remove(s);
 
+            var update = Mock.Of<IProjectVersionedValue<IProjectSubscriptionUpdate>>();
+
             var project = UnconfiguredProjectFactory.Create(filePath: @"C:\Myproject.csproj");
             var context = IWorkspaceProjectContextFactory.CreateForSourceFiles(project, onSourceFileAdded, onSourceFileRemoved);
 
@@ -67,14 +74,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             var added = BuildOptions.FromCommonCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"C:\file1.cs", @"C:\file2.cs", @"C:\file1.cs" }, baseDirectory: projectDir, sdkDirectory: null));
             var empty = BuildOptions.FromCommonCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null));
 
-            handler.Handle(added: added, removed: empty, context: context, isActiveContext: true);
+            handler.Handle(update, added: added, removed: empty, context: context, isActiveContext: true);
 
             Assert.Equal(2, sourceFilesPushedToWorkspace.Count);
             Assert.Contains(@"C:\file1.cs", sourceFilesPushedToWorkspace);
             Assert.Contains(@"C:\file2.cs", sourceFilesPushedToWorkspace);
 
             var removed = BuildOptions.FromCommonCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"C:\file1.cs", @"C:\file1.cs" }, baseDirectory: projectDir, sdkDirectory: null));
-            handler.Handle(added: empty, removed: removed, context: context, isActiveContext: true);
+            handler.Handle(update, added: empty, removed: removed, context: context, isActiveContext: true);
 
             Assert.Equal(1, sourceFilesPushedToWorkspace.Count);
             Assert.Contains(@"C:\file2.cs", sourceFilesPushedToWorkspace);
@@ -87,6 +94,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Action<string> onSourceFileAdded = s => Assert.True(sourceFilesPushedToWorkspace.Add(s));
             Action<string> onSourceFileRemoved = s => sourceFilesPushedToWorkspace.Remove(s);
 
+            var update = Mock.Of<IProjectVersionedValue<IProjectSubscriptionUpdate>>();
             var project = UnconfiguredProjectFactory.Create(filePath: @"C:\ProjectFolder\Myproject.csproj");
             var context = IWorkspaceProjectContextFactory.CreateForSourceFiles(project, onSourceFileAdded, onSourceFileRemoved);
 
@@ -95,7 +103,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             var added = BuildOptions.FromCommonCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"file1.cs", @"..\ProjectFolder\file1.cs" }, baseDirectory: projectDir, sdkDirectory: null));
             var removed = BuildOptions.FromCommonCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null));
 
-            handler.Handle(added: added, removed: removed, context: context, isActiveContext: true);
+            handler.Handle(update, added: added, removed: removed, context: context, isActiveContext: true);
 
             Assert.Equal(1, sourceFilesPushedToWorkspace.Count);
             Assert.Contains(@"C:\ProjectFolder\file1.cs", sourceFilesPushedToWorkspace);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowProjectLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowProjectLogger.cs
@@ -30,9 +30,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
             _outputWindowProvider = outputWindowProvider;
         }
 
+        public bool IsEnabled
+        {
+            get { return _options.IsProjectOutputPaneEnabled; }
+        }
+
         public void WriteLine(string format, params object[] arguments)
         {
-            if (_options.IsProjectOutputPaneEnabled)
+            if (IsEnabled)
             {
                 // Only allocate if the pane is actually enabled
                 string text = string.Format(CultureInfo.CurrentCulture, format, arguments);
@@ -43,7 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
 
         public void WriteLine(string text)
         {
-            if (_options.IsProjectOutputPaneEnabled)
+            if (IsEnabled)
             {
                 WriteLineCore(text);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractLanguageServiceRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractLanguageServiceRuleHandler.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
         public virtual bool ReceiveUpdatesWithEmptyProjectChange => false;
 
-        public virtual void Handle(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
+        public virtual void Handle(IProjectVersionedValue<IProjectSubscriptionUpdate> update, IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
         {
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         {
         }
 
-        public void Handle(BuildOptions added, BuildOptions removed, IWorkspaceProjectContext context, bool isActiveContext)
+        public void Handle(IProjectVersionedValue<IProjectSubscriptionUpdate> update, BuildOptions added, BuildOptions removed, IWorkspaceProjectContext context, bool isActiveContext)
         {
             Requires.NotNull(added, nameof(added));
             Requires.NotNull(removed, nameof(removed));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         {
         }
 
-        public void Handle(BuildOptions added, BuildOptions removed, IWorkspaceProjectContext context, bool isActiveContext)
+        public void Handle(IProjectVersionedValue<IProjectSubscriptionUpdate> update, BuildOptions added, BuildOptions removed, IWorkspaceProjectContext context, bool isActiveContext)
         {
             Requires.NotNull(added, nameof(added));
             Requires.NotNull(removed, nameof(removed));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandler.cs
@@ -43,14 +43,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         // Broken design time builds generates updates with no changes.
         public override bool ReceiveUpdatesWithEmptyProjectChange => true;
 
-        public override void Handle(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
+        public override void Handle(IProjectVersionedValue<IProjectSubscriptionUpdate> update, IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
         {
             Requires.NotNull(projectChange, nameof(projectChange));
 
             if (!ProcessDesignTimeBuildFailure(projectChange, context))
             {
                 ProcessOptions(projectChange, context);
-                ProcessItems(projectChange, context, isActiveContext);
+                ProcessItems(update, projectChange, context, isActiveContext);
             }
         }
 
@@ -72,14 +72,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             context.SetOptions(string.Join(" ", commandlineArguments));
         }
 
-        private void ProcessItems(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
+        private void ProcessItems(IProjectVersionedValue<IProjectSubscriptionUpdate> update, IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
         {
             BuildOptions addedItems = _commandLineParser.Parse(projectChange.Difference.AddedItems);
             BuildOptions removedItems = _commandLineParser.Parse(projectChange.Difference.RemovedItems);
 
             foreach (var handler in Handlers)
             {
-                handler.Value.Handle(addedItems, removedItems, context, isActiveContext);
+                handler.Value.Handle(update, addedItems, removedItems, context, isActiveContext);
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             _unconfiguredProject = project;
         }
 
-        public void Handle(BuildOptions added, BuildOptions removed, IWorkspaceProjectContext context, bool isActiveContext)
+        public void Handle(IProjectVersionedValue<IProjectSubscriptionUpdate> update, BuildOptions added, BuildOptions removed, IWorkspaceProjectContext context, bool isActiveContext)
         {
             Requires.NotNull(added, nameof(added));
             Requires.NotNull(removed, nameof(removed));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             get { return ConfigurationGeneral.SchemaName; }
         }
 
-        public override void Handle(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
+        public override void Handle(IProjectVersionedValue<IProjectSubscriptionUpdate> update, IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
         {
             Requires.NotNull(projectChange, nameof(projectChange));
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             get { return RuleHandlerType.Evaluation; }
         }
 
-        public void Handle(BuildOptions added, BuildOptions removed, IWorkspaceProjectContext context, bool isActiveContext)
+        public void Handle(IProjectVersionedValue<IProjectSubscriptionUpdate> update, BuildOptions added, BuildOptions removed, IWorkspaceProjectContext context, bool isActiveContext)
         {
             Requires.NotNull(added, nameof(added));
             Requires.NotNull(removed, nameof(removed));
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             }
         }
 
-        public override void Handle(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
+        public override void Handle(IProjectVersionedValue<IProjectSubscriptionUpdate> update, IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
         {
             Requires.NotNull(projectChange, nameof(projectChange));
             Requires.NotNull(context, nameof(context));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -123,13 +123,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
                 sourceFiles = new HashSet<string>(StringComparers.Paths);
                 _sourceFilesByContext.Add(context, sourceFiles);
             }
-            else if (sourceFiles.Contains(fullPath))
-            {
-                return;
-            }
 
-            sourceFiles.Add(fullPath);
-            context.AddSourceFile(fullPath, folderNames: folderNames, isInCurrentContext: isActiveContext);
+            if (sourceFiles.Add(fullPath))
+            {
+                context.AddSourceFile(fullPath, folderNames: folderNames, isInCurrentContext: isActiveContext);
+            }
         }
 
         private string[] GetFolders(string filePath, IProjectChangeDescription projectChange)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -6,6 +6,8 @@ using System.IO;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Logging;
+using System;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
@@ -26,14 +28,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         // a file is added to the project, we don't need to wait for a slow design-time build just to get useful 
         // IntelliSense.
         private readonly UnconfiguredProject _project;
+        private readonly IProjectLogger _logger;
         private readonly Dictionary<IWorkspaceProjectContext, HashSet<string>> _sourceFilesByContext = new Dictionary<IWorkspaceProjectContext, HashSet<string>>();
 
         [ImportingConstructor]
-        public SourceItemHandler(UnconfiguredProject project)
+        public SourceItemHandler(UnconfiguredProject project, IProjectLogger logger)
         {
             Requires.NotNull(project, nameof(project));
+            Requires.NotNull(logger, nameof(logger));
 
             _project = project;
+            _logger = logger;
         }
 
         public override string RuleName
@@ -51,14 +56,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Requires.NotNull(added, nameof(added));
             Requires.NotNull(removed, nameof(removed));
 
+            string version = GetConfiguredProjectVersion(update);
+            string configuration = update.Value.ProjectConfiguration.Name;
+
             foreach (CommandLineSourceFile sourceFile in removed.SourceFiles)
             {
-                RemoveSourceFile(sourceFile.Path, context);
+                RemoveSourceFile(version, configuration, sourceFile.Path, context, evaluation: false);
             }
 
             foreach (CommandLineSourceFile sourceFile in added.SourceFiles)
             {
-                AddSourceFile(sourceFile.Path, null, context, isActiveContext);
+                AddSourceFile(version, configuration, sourceFile.Path, null, context, isActiveContext, evaluation: false);
             }
         }
 
@@ -67,16 +75,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Requires.NotNull(projectChange, nameof(projectChange));
             Requires.NotNull(context, nameof(context));
 
+            string version = GetConfiguredProjectVersion(update);
+            string configuration = update.Value.ProjectConfiguration.Name;
+
             IProjectChangeDiff diff = projectChange.Difference;
 
             foreach (string filePath in diff.RemovedItems)
             {
-                RemoveSourceFile(filePath, context);
+                RemoveSourceFile(version, configuration, filePath, context, evaluation: true);
             }
 
             foreach (string filePath in diff.AddedItems)
             {
-                AddSourceFile(filePath, GetFolders(filePath, projectChange), context, isActiveContext);
+                AddSourceFile(version, configuration, filePath, GetFolders(filePath, projectChange), context, isActiveContext, evaluation: true);
             }
 
             foreach (KeyValuePair<string, string> filePaths in diff.RenamedItems)
@@ -84,15 +95,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
                 string removeFilePath = filePaths.Key;
                 string addFilePath = filePaths.Value;
 
-                RemoveSourceFile(removeFilePath, context);
-                AddSourceFile(addFilePath, GetFolders(addFilePath, projectChange), context, isActiveContext);
+                RemoveSourceFile(version, configuration, removeFilePath, context, evaluation: true);
+                AddSourceFile(version, configuration, addFilePath, GetFolders(addFilePath, projectChange), context, isActiveContext, evaluation: true);
             }
 
             foreach (string filePath in diff.ChangedItems)
             {
                 // We add and then remove ChangedItems to handle Linked metadata changes
-                RemoveSourceFile(filePath, context);
-                AddSourceFile(filePath, GetFolders(filePath, projectChange), context, isActiveContext);
+                RemoveSourceFile(version, configuration, filePath, context, evaluation: true);
+                AddSourceFile(version, configuration, filePath, GetFolders(filePath, projectChange), context, isActiveContext, evaluation: true);
             }
         }
 
@@ -104,17 +115,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             return Task.CompletedTask;
         }
 
-        private void RemoveSourceFile(string filePath, IWorkspaceProjectContext context)
+        private void RemoveSourceFile(string version, string configuration, string filePath, IWorkspaceProjectContext context, bool evaluation)
         {
             string fullPath = _project.MakeRooted(filePath);
 
             if (_sourceFilesByContext.TryGetValue(context, out HashSet<string> sourceFiles) && sourceFiles.Remove(fullPath))
             {
+                LogRemove(version, configuration, fullPath, evaluation);
                 context.RemoveSourceFile(fullPath);
             }
         }
 
-        private void AddSourceFile(string filePath, string[] folderNames, IWorkspaceProjectContext context, bool isActiveContext)
+        private void AddSourceFile(string version, string configuration, string filePath, string[] folderNames, IWorkspaceProjectContext context, bool isActiveContext, bool evaluation)
         {
             string fullPath = _project.MakeRooted(filePath);
 
@@ -126,6 +138,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             if (sourceFiles.Add(fullPath))
             {
+                LogAdd(version, configuration, fullPath, evaluation, isActiveContext);
                 context.AddSourceFile(fullPath, folderNames: folderNames, isInCurrentContext: isActiveContext);
             }
         }
@@ -167,6 +180,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         private string GetParentFolder(string filePath)
         {
             return Path.GetDirectoryName(_project.MakeRelative(filePath));
+        }
+
+        private void LogAdd(string version, string configuration, string fullPath, bool evaluation, bool isActiveContext)
+        {
+            _logger.WriteLine(this, "[Rule: {0}, Config:{1}, Version:{2}] Adding {3} (IsActiveContext: {4})", evaluation ? "Evaluation" : "DesignTime", configuration, version, fullPath, isActiveContext);
+        }
+
+        private void LogRemove(string version, string configuration, string fullPath, bool evaluation)
+        {
+            _logger.WriteLine(this, "[Rule: {0}, Config:{1}, Version:{2}] Removing {3}", evaluation ? "Evaluation" : "DesignTime", configuration, version, fullPath);
+        }
+
+        private string GetConfiguredProjectVersion(IProjectVersionedValue<IProjectSubscriptionUpdate> update)
+        {
+            if (update.DataSourceVersions.TryGetValue(ProjectDataSources.ConfiguredProjectVersion, out IComparable value))
+            {
+                return value.ToString();
+            }
+
+            return null;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ILanguageServiceCommandLineHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ILanguageServiceCommandLineHandler.cs
@@ -15,6 +15,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ///     Handles the specified added and removed command-line arguments, and applies 
         ///     them to the given <see cref="IWorkspaceProjectContext"/>.
         /// </summary>
+        /// <param name="update">
+        ///     A <see cref="IProjectVersionedValue{T}"/> of <see cref="IProjectSubscriptionUpdate"/> 
+        ///     representing the overall set of changes made to the project.
+        /// </param>
         /// <param name="added">
         ///     A <see cref="BuildOptions"/> representing the added arguments.
         /// </param>
@@ -34,6 +38,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ///     </para>
         ///     <paramref name="removed"/> is <see langword="null"/>.
         /// </exception>
-        void Handle(BuildOptions added, BuildOptions removed, IWorkspaceProjectContext context, bool isActiveContext);
+        void Handle(IProjectVersionedValue<IProjectSubscriptionUpdate> update, BuildOptions added, BuildOptions removed, IWorkspaceProjectContext context, bool isActiveContext);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ILanguageServiceRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ILanguageServiceRuleHandler.cs
@@ -48,6 +48,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ///     Handles the specified set of changes to a rule, and applies them
         ///     to the given <see cref="IWorkspaceProjectContext"/>.
         /// </summary>
+        /// <param name="update">
+        ///     A <see cref="IProjectVersionedValue{T}"/> of <see cref="IProjectSubscriptionUpdate"/> 
+        ///     representing the overall set of changes made to the project.
+        /// </param>
         /// <param name="projectChange">
         ///     A <see cref="IProjectChangeDescription"/> representing the set of 
         ///     changes made to the project.
@@ -61,7 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         /// <exception cref="ArgumentNullException">
         ///     <paramref name="projectChange"/> is <see langword="null"/>.
         /// </exception>
-        void Handle(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext);
+        void Handle(IProjectVersionedValue<IProjectSubscriptionUpdate> update, IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext);
 
         /// <summary>
         /// Handles clearing any state specific to the given context being released.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -312,7 +312,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                     IProjectChangeDescription projectChange = update.Value.ProjectChanges[handler.RuleName];
                     if (handler.ReceiveUpdatesWithEmptyProjectChange || projectChange.Difference.AnyChanges)
                     {
-                        handler.Handle(projectChange, projectContextToUpdate, isActiveContext);
+                        handler.Handle(update, projectChange, projectContextToUpdate, isActiveContext);
                     }
                 }
             });

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/IProjectLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/IProjectLogger.cs
@@ -10,6 +10,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Logging
     internal interface IProjectLogger
     {
         /// <summary>
+        ///     Gets a value indicating if the logger is enabled.
+        /// </summary>
+        /// <value>
+        ///     <see langword="true"/> if the <see cref="IProjectLogger"/> is enabled and logging to the log; otherwise, <see langword="false"/>.
+        /// </value>
+        bool IsEnabled
+        {
+            get;
+        }
+
+        /// <summary>
         ///     Writes the specified text, followed by the current line terminator, 
         ///     to the log.
         /// </summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/ProjectLoggerExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/ProjectLoggerExtensions.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Logging
+{
+    /// <summary>
+    ///     Provides static extension methods for <see cref="IProjectLogger"/> instances.
+    /// </summary>
+    internal static class ProjectLoggerExtensions
+    {
+        /// <summary>
+        ///     Writes the sender and text representation of the specified array of objects,
+        ///     followed by the current line terminator, to the log using the 
+        ///     specified format information.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="logger"/> is <see langword="null"/>.
+        ///     <para>
+        ///         -or-
+        ///     </para>
+        ///     <paramref name="sender"/> is <see langword="null"/>.
+        ///     <para>
+        ///         -or-
+        ///     </para>
+        ///     <paramref name="format"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///     The format specification in <paramref name="format"/> is invalid.
+        /// </exception>
+        public static void WriteLine(this IProjectLogger logger, object sender, string format, params object[] arguments)
+        {
+            Requires.NotNull(logger, nameof(logger));
+            Requires.NotNull(sender, nameof(sender));
+
+            if (logger.IsEnabled)
+            {
+                logger.WriteLine($"{sender.GetType().Name}: {format}", arguments);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add first set of logging to SourceItemHandler, more coming through.

Not overly happy with the how much data needs to be passed through, so got changes to logger to "init" a context so that stuff such as the type name, version, configuration, etc is automatically appended to all writes for a given context.