### PR TITLE
Add non-allocation logger paths

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowProjectLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowProjectLogger.cs
@@ -30,9 +30,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
             _outputWindowProvider = outputWindowProvider;
         }
 
+        public bool IsEnabled
+        {
+            get { return _options.IsProjectOutputPaneEnabled; }
+        }
+
         public void WriteLine(string format, params object[] arguments)
         {
-            if (_options.IsProjectOutputPaneEnabled)
+            if (IsEnabled)
             {
                 // Only allocate if the pane is actually enabled
                 string text = string.Format(CultureInfo.CurrentCulture, format, arguments);
@@ -43,7 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
 
         public void WriteLine(string text)
         {
-            if (_options.IsProjectOutputPaneEnabled)
+            if (IsEnabled)
             {
                 WriteLineCore(text);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/IProjectLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/IProjectLogger.cs
@@ -27,6 +27,45 @@ namespace Microsoft.VisualStudio.ProjectSystem.Logging
         void WriteLine(string text);
 
         /// <summary>
+        ///     Writes the text representation of the specified object, 
+        ///     followed by the current line terminator, to the log using the 
+        ///     specified format information.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="format"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///     The format specification in <paramref name="format"/> is invalid.
+        /// </exception>
+        void WriteLine(string format, object argument);
+
+        /// <summary>
+        ///     Writes the text representation of the specified objects, 
+        ///     followed by the current line terminator, to the log using the 
+        ///     specified format information.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="format"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///     The format specification in <paramref name="format"/> is invalid.
+        /// </exception>
+        void WriteLine(string format, object argument1, object argument2);
+
+        /// <summary>
+        ///     Writes the text representation of the specified objects, 
+        ///     followed by the current line terminator, to the log using the 
+        ///     specified format information.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="format"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///     The format specification in <paramref name="format"/> is invalid.
+        /// </exception>
+        void WriteLine(string format, object argument1, object argument2, object argument3);
+
+        /// <summary>
         ///     Writes the text representation of the specified array of objects, 
         ///     followed by the current line terminator, to the log using the 
         ///     specified format information.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/IProjectLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/IProjectLogger.cs
@@ -10,6 +10,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Logging
     internal interface IProjectLogger
     {
         /// <summary>
+        ///     Gets a value indicating if the logger is enabled.
+        /// </summary>
+        /// <value>
+        ///     <see langword="true"/> if the <see cref="IProjectLogger"/> is enabled and logging to the log; otherwise, <see langword="false"/>.
+        /// </value>
+        bool IsEnabled
+        {
+            get;
+        }
+
+        /// <summary>
         ///     Writes the specified text, followed by the current line terminator, 
         ///     to the log.
         /// </summary>


### PR DESCRIPTION
We were allocating params array even when logging was disabled. Avoid that, and call non-params array allocation versions of string.Format.