### PR TITLE
Add ProjectLoggerContext

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowProjectLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowProjectLogger.cs
@@ -35,30 +35,30 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
         }
         public void WriteLine(string text)
         {
-            WriteLineCore(new FormatArray(text));
+            WriteLine(new FormatArray(text));
         }
 
         public void WriteLine(string format, object argument)
         {
-            WriteLineCore(new FormatArray(format, argument));
+            WriteLine(new FormatArray(format, argument));
         }
 
         public void WriteLine(string format, object argument1, object argument2)
         {
-            WriteLineCore(new FormatArray(format, argument1, argument2));
+            WriteLine(new FormatArray(format, argument1, argument2));
         }
 
         public void WriteLine(string format, object argument1, object argument2, object argument3)
         {
-            WriteLineCore(new FormatArray(format, argument1, argument2, argument3));
+            WriteLine(new FormatArray(format, argument1, argument2, argument3));
         }
 
         public void WriteLine(string format, params object[] arguments)
         {
-            WriteLineCore(new FormatArray(format, arguments));
+            WriteLine(new FormatArray(format, arguments));
         }
 
-        private void WriteLineCore(FormatArray formatArray)
+        private void WriteLine(FormatArray formatArray)
         {
             if (IsEnabled)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowProjectLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowProjectLogger.cs
@@ -30,9 +30,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
             _outputWindowProvider = outputWindowProvider;
         }
 
+        public bool IsEnabled
+        {
+            get { return _options.IsProjectOutputPaneEnabled; }
+        }
+
         public void WriteLine(string format, params object[] arguments)
         {
-            if (_options.IsProjectOutputPaneEnabled)
+            if (IsEnabled)
             {
                 // Only allocate if the pane is actually enabled
                 string text = string.Format(CultureInfo.CurrentCulture, format, arguments);
@@ -43,7 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
 
         public void WriteLine(string text)
         {
-            if (_options.IsProjectOutputPaneEnabled)
+            if (IsEnabled)
             {
                 WriteLineCore(text);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowProjectLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowProjectLogger.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.ComponentModel.Composition;
-using System.Globalization;
 using Microsoft.VisualStudio.ProjectSystem.Logging;
 using Microsoft.VisualStudio.Shell.Interop;
 
@@ -36,49 +35,30 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
         }
         public void WriteLine(string text)
         {
-            if (IsEnabled)
-            {
-                WriteLineCore(text);
-            }
+            WriteLineCore(new FormatArray(text));
         }
 
         public void WriteLine(string format, object argument)
         {
-            if (IsEnabled)
-            {
-                // Only allocate if the pane is actually enabled, making sure we call through the non-params array version
-                WriteLineCore(string.Format(CultureInfo.CurrentCulture, format, argument));
-            }
+            WriteLineCore(new FormatArray(format, argument));
         }
 
         public void WriteLine(string format, object argument1, object argument2)
         {
-            if (IsEnabled)
-            {
-                // Only allocate if the pane is actually enabled, making sure we call through the non-params array version
-                WriteLineCore(string.Format(CultureInfo.CurrentCulture, format, argument1, argument2));
-            }
+            WriteLineCore(new FormatArray(format, argument1, argument2));
         }
 
         public void WriteLine(string format, object argument1, object argument2, object argument3)
         {
-            if (IsEnabled)
-            {
-                // Only allocate if the pane is actually enabled, making sure we call through the non-params array version
-                WriteLineCore(string.Format(CultureInfo.CurrentCulture, format, argument1, argument2, argument3));
-            }
+            WriteLineCore(new FormatArray(format, argument1, argument2, argument3));
         }
 
         public void WriteLine(string format, params object[] arguments)
         {
-            if (IsEnabled)
-            {
-                // Only allocate if the pane is actually enabled
-                WriteLineCore(string.Format(CultureInfo.CurrentCulture, format, arguments));
-            }
+            WriteLineCore(new FormatArray(format, arguments));
         }
 
-        private void WriteLineCore(string text)
+        private void WriteLineCore(FormatArray formatArray)
         {
             if (IsEnabled)
             {
@@ -91,7 +71,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
                     IVsOutputWindowPane pane = await _outputWindowProvider.GetOutputWindowPaneAsync()
                                                                           .ConfigureAwait(true);
 
-                    pane.OutputStringNoPump(text + Environment.NewLine);
+                    pane.OutputStringNoPump(formatArray.Text + Environment.NewLine);
 
                 }, options: ForkOptions.HideLocks | ForkOptions.StartOnMainThread);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/FormatArray.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/FormatArray.cs
@@ -68,27 +68,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.Logging
             _arguments = arguments;
         }
 
-        public int Length
-        {
-            get { return _arguments.Length; }
-        }
-
         public string Text
         {
             get
             {
+                int length = _arguments.Length;
+
                 // Making sure we call through the non-params array version of String.Format 
                 // where possible to avoid "params" array allocation.
-                if (Length == 0)
+                if (length == 0)
                     return _format;
 
-                if (Length == 1)
+                if (length == 1)
                     return string.Format(CultureInfo.CurrentCulture, _format, _argument1);
 
-                if (Length == 2)
+                if (length == 2)
                     return string.Format(CultureInfo.CurrentCulture, _format, _argument1, _argument2);
 
-                if (Length == 3)
+                if (length == 3)
                     return string.Format(CultureInfo.CurrentCulture, _format, _argument1, _argument2, _argument3);
 
                 return string.Format(CultureInfo.CurrentCulture, _format, _arguments);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/FormatArray.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/FormatArray.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Logging
+{
+    /// <summary>
+    ///     Provides an object that allows a common way to format a set of objects, only allocating if needed.
+    /// </summary>
+    internal struct FormatArray
+    {
+        // Sentinel fixed-length arrays eliminate the need for a "count" field keeping this
+        // struct down to just 4 fields. These are only used for their "Length" property,
+        // that is, their elements are never set or referenced.
+        private static readonly object[] ZeroArgumentArray = Array.Empty<object>();
+        private static readonly object[] OneArgumentArray = new object[1];
+        private static readonly object[] TwoArgumentArray = new object[2];
+        private static readonly object[] ThreeArgumentArray = new object[3];
+        private readonly string _format;
+        private readonly object _argument1;
+        private readonly object _argument2;
+        private readonly object _argument3;
+        private readonly object[] _arguments;
+
+        public FormatArray(string text)
+        {
+            _format = text;
+            _argument1 = null;
+            _argument2 = null;
+            _argument3 = null;
+            _arguments = ZeroArgumentArray;
+        }
+
+        public FormatArray(string format, object argument)
+        {
+            _format = format;
+            _argument1 = argument;
+            _argument2 = null;
+            _argument3 = null;
+            _arguments = OneArgumentArray;
+        }
+
+        public FormatArray(string format, object argument1, object argument2)
+        {
+            _format = format;
+            _argument1 = argument1;
+            _argument2 = argument2;
+            _argument3 = null;
+            _arguments = TwoArgumentArray;
+        }
+
+        public FormatArray(string format, object argument1, object argument2, object argument3)
+        {
+            _format = format;
+            _argument1 = argument1;
+            _argument2 = argument2;
+            _argument3 = argument3;
+            _arguments = ThreeArgumentArray;
+        }
+
+        public FormatArray(string format, object[] arguments)
+        {
+            _format = format;
+            _argument1 = null;
+            _argument2 = null;
+            _argument3 = null;
+            _arguments = arguments;
+        }
+
+        public int Length
+        {
+            get { return _arguments.Length; }
+        }
+
+        public string Text
+        {
+            get
+            {
+                // Making sure we call through the non-params array version of String.Format 
+                // where possible to avoid "params" array allocation.
+                if (Length == 0)
+                    return _format;
+
+                if (Length == 1)
+                    return string.Format(CultureInfo.CurrentCulture, _format, _argument1);
+
+                if (Length == 2)
+                    return string.Format(CultureInfo.CurrentCulture, _format, _argument1, _argument2);
+
+                if (Length == 3)
+                    return string.Format(CultureInfo.CurrentCulture, _format, _argument1, _argument2, _argument3);
+
+                return string.Format(CultureInfo.CurrentCulture, _format, _arguments);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/IProjectLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/IProjectLogger.cs
@@ -27,6 +27,45 @@ namespace Microsoft.VisualStudio.ProjectSystem.Logging
         void WriteLine(string text);
 
         /// <summary>
+        ///     Writes the text representation of the specified object, 
+        ///     followed by the current line terminator, to the log using the 
+        ///     specified format information.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="format"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///     The format specification in <paramref name="format"/> is invalid.
+        /// </exception>
+        void WriteLine(string format, object argument);
+
+        /// <summary>
+        ///     Writes the text representation of the specified objects, 
+        ///     followed by the current line terminator, to the log using the 
+        ///     specified format information.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="format"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///     The format specification in <paramref name="format"/> is invalid.
+        /// </exception>
+        void WriteLine(string format, object argument1, object argument2);
+
+        /// <summary>
+        ///     Writes the text representation of the specified objects, 
+        ///     followed by the current line terminator, to the log using the 
+        ///     specified format information.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="format"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///     The format specification in <paramref name="format"/> is invalid.
+        /// </exception>
+        void WriteLine(string format, object argument1, object argument2, object argument3);
+
+        /// <summary>
         ///     Writes the text representation of the specified array of objects, 
         ///     followed by the current line terminator, to the log using the 
         ///     specified format information.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/IProjectLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/IProjectLogger.cs
@@ -10,6 +10,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Logging
     internal interface IProjectLogger
     {
         /// <summary>
+        ///     Gets a value indicating if the logger is enabled.
+        /// </summary>
+        /// <value>
+        ///     <see langword="true"/> if the <see cref="IProjectLogger"/> is enabled and logging to the log; otherwise, <see langword="false"/>.
+        /// </value>
+        bool IsEnabled
+        {
+            get;
+        }
+
+        /// <summary>
         ///     Writes the specified text, followed by the current line terminator, 
         ///     to the log.
         /// </summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/ProjectLoggerContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/ProjectLoggerContext.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Logging
+{
+    /// <summary>
+    ///     Provides additional context to log messages when they are logged to the log.
+    /// </summary>
+    internal struct ProjectLoggerContext
+    {
+        private readonly IProjectLogger _logger;
+        private readonly FormatArray _formatArray;
+
+        internal ProjectLoggerContext(IProjectLogger logger, FormatArray formatArray)
+        {
+            _logger = logger;
+            _formatArray = formatArray;
+        }
+
+        /// <summary>
+        ///     Writes the specified text, followed by the current line terminator, 
+        ///     to the log.
+        /// </summary>
+        public void WriteLine(string text)
+        {
+            if (_logger.IsEnabled)
+            {
+                _logger.WriteLine(_formatArray.Text + " " + text);
+            }
+        }
+
+        /// <summary>
+        ///     Writes the text representation of the specified object, 
+        ///     followed by the current line terminator, to the log using the 
+        ///     specified format information.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="format"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///     The format specification in <paramref name="format"/> is invalid.
+        /// </exception>
+        public void WriteLine(string format, object argument)
+        {
+            if (_logger.IsEnabled)
+            {
+                _logger.WriteLine(_formatArray.Text + " " + format, argument);
+            }
+        }
+
+        /// <summary>
+        ///     Writes the text representation of the specified objects, 
+        ///     followed by the current line terminator, to the log using the 
+        ///     specified format information.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="format"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///     The format specification in <paramref name="format"/> is invalid.
+        /// </exception>
+        public void WriteLine(string format, object argument1, object argument2)
+        {
+            if (_logger.IsEnabled)
+            {
+                _logger.WriteLine(_formatArray.Text + " " + format, argument1, argument2);
+            }
+        }
+
+        /// <summary>
+        ///     Writes the text representation of the specified objects, 
+        ///     followed by the current line terminator, to the log using the 
+        ///     specified format information.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="format"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///     The format specification in <paramref name="format"/> is invalid.
+        /// </exception>
+        public void WriteLine(string format, object argument1, object argument2, object argument3)
+        {
+            if (_logger.IsEnabled)
+            {
+                _logger.WriteLine(_formatArray.Text + " " + format, argument1, argument2, argument3);
+            }
+        }
+
+        /// <summary>
+        ///     Writes the text representation of the specified array of objects, 
+        ///     followed by the current line terminator, to the log using the 
+        ///     specified format information.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="format"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///     The format specification in <paramref name="format"/> is invalid.
+        /// </exception>
+        public void WriteLine(string format, params object[] arguments)
+        {
+            if (_logger.IsEnabled)
+            {
+                _logger.WriteLine(_formatArray.Text + " " + format, arguments);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/ProjectLoggerExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/ProjectLoggerExtensions.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.Logging
+{
+    /// <summary>
+    ///     Provides static extension methods for <see cref="IProjectLogger"/> instances.
+    /// </summary>
+    internal static class ProjectLoggerExtensions
+    {
+        /// <summary>
+        ///     Begins a logger context the specified text.
+        /// </summary>
+        public static ProjectLoggerContext BeginContext(this IProjectLogger logger, string text)
+        {
+            Requires.NotNull(logger, nameof(logger));
+
+            return new ProjectLoggerContext(logger, new FormatArray(text));
+        }
+
+        /// <summary>
+        ///     Begins a logger context with the specified object and format information.
+        /// </summary>
+        public static ProjectLoggerContext BeginContext(this IProjectLogger logger, string format, object argument)
+        {
+            Requires.NotNull(logger, nameof(logger));
+
+            return new ProjectLoggerContext(logger, new FormatArray(format, argument));
+        }
+
+        /// <summary>
+        ///     Begins a logger context with the specified objects and format information.
+        /// </summary>
+        public static ProjectLoggerContext BeginContext(this IProjectLogger logger, string format, object argument1, object argument2)
+        {
+            Requires.NotNull(logger, nameof(logger));
+
+            return new ProjectLoggerContext(logger, new FormatArray(format, argument1, argument2));
+        }
+
+        /// <summary>
+        ///     Begins a logger context with the specified objects and format information.
+        /// </summary>
+        public static ProjectLoggerContext BeginContext(this IProjectLogger logger, string format, object argument1, object argument2, object argument3)
+        {
+            Requires.NotNull(logger, nameof(logger));
+
+            return new ProjectLoggerContext(logger, new FormatArray(format, argument1, argument2, argument3));
+        }
+
+        /// <summary>
+        ///     Begins a logger context with the specified array of objects and format information.
+        /// </summary>
+        public static ProjectLoggerContext BeginContext(this IProjectLogger logger, string format, params object[] arguments)
+        {
+            Requires.NotNull(logger, nameof(logger));
+
+            return new ProjectLoggerContext(logger, new FormatArray(format, arguments));
+        }
+    }
+}


### PR DESCRIPTION
This lets a higher level component prepend additional information to a logged message, meaning that less information needs to be passed down the lower components.

This simplifies logger significantly in the language service; the LanguageServiceHost begins a context and then passes it down to the handlers which simply log just what they are doing and don't need to include information about the configured project version or configuration, etc.

Note this includes: https://github.com/dotnet/project-system/pull/2142,k so just look at last 3 commits.