### PR TITLE
Add logging to the language service 

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectLoggerContextFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectLoggerContextFactory.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Logging
+{
+    internal static class ProjectLoggerContextFactory
+    {
+        public static ProjectLoggerContext Create()
+        {
+            var mock = new Mock<IProjectLogger>();
+            return mock.Object.BeginContext("");
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandlerTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
+using Microsoft.VisualStudio.ProjectSystem.Logging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
@@ -25,20 +26,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             var project = UnconfiguredProjectFactory.Create(filePath: @"C:\Myproject.csproj");
             var context = IWorkspaceProjectContextFactory.CreateForMetadataReferences(project, onReferenceAdded, onReferenceRemoved);
+            var loggerContext = ProjectLoggerContextFactory.Create();
 
             var handler = new MetadataReferenceItemHandler(project);
             var projectDir = Path.GetDirectoryName(project.FullPath);
             var added = BuildOptions.FromCommonCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"/reference:C:\Assembly1.dll", @"/reference:C:\Assembly2.dll", @"/reference:C:\Assembly1.dll" }, baseDirectory: projectDir, sdkDirectory: null));
             var empty = BuildOptions.FromCommonCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null));
 
-            handler.Handle(added: added, removed: empty, context: context, isActiveContext: true);
+            handler.Handle(added: added, removed: empty, context: context, isActiveContext: true, loggerContext:loggerContext);
 
             Assert.Equal(2, referencesPushedToWorkspace.Count);
             Assert.Contains(@"C:\Assembly1.dll", referencesPushedToWorkspace);
             Assert.Contains(@"C:\Assembly2.dll", referencesPushedToWorkspace);
 
             var removed = BuildOptions.FromCommonCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"/reference:C:\Assembly1.dll", @"/reference:C:\Assembly1.dll" }, baseDirectory: projectDir, sdkDirectory: null));
-            handler.Handle(added: empty, removed: removed, context: context, isActiveContext: true);
+            handler.Handle(added: empty, removed: removed, context: context, isActiveContext: true, loggerContext: loggerContext);
 
             Assert.Equal(1, referencesPushedToWorkspace.Count);
             Assert.Contains(@"C:\Assembly2.dll", referencesPushedToWorkspace);
@@ -53,13 +55,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             var project = UnconfiguredProjectFactory.Create(filePath: @"C:\ProjectFolder\Myproject.csproj");
             var context = IWorkspaceProjectContextFactory.CreateForMetadataReferences(project, onReferenceAdded, onReferenceRemoved);
+            var loggerContext = ProjectLoggerContextFactory.Create();
 
             var handler = new MetadataReferenceItemHandler(project);
             var projectDir = Path.GetDirectoryName(project.FullPath);
             var added = BuildOptions.FromCommonCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"/reference:Assembly1.dll", @"/reference:C:\ProjectFolder\Assembly2.dll", @"/reference:..\ProjectFolder\Assembly3.dll" }, baseDirectory: projectDir, sdkDirectory: null));
             var removed = BuildOptions.FromCommonCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null));
 
-            handler.Handle(added: added, removed: removed, context: context, isActiveContext: true);
+            handler.Handle(added: added, removed: removed, context: context, isActiveContext: true, loggerContext: loggerContext);
 
             Assert.Equal(3, referencesPushedToWorkspace.Count);
             Assert.Contains(@"C:\ProjectFolder\Assembly1.dll", referencesPushedToWorkspace);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowProjectLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowProjectLogger.cs
@@ -35,30 +35,30 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
         }
         public void WriteLine(string text)
         {
-            WriteLineCore(new FormatArray(text));
+            WriteLine(new FormatArray(text));
         }
 
         public void WriteLine(string format, object argument)
         {
-            WriteLineCore(new FormatArray(format, argument));
+            WriteLine(new FormatArray(format, argument));
         }
 
         public void WriteLine(string format, object argument1, object argument2)
         {
-            WriteLineCore(new FormatArray(format, argument1, argument2));
+            WriteLine(new FormatArray(format, argument1, argument2));
         }
 
         public void WriteLine(string format, object argument1, object argument2, object argument3)
         {
-            WriteLineCore(new FormatArray(format, argument1, argument2, argument3));
+            WriteLine(new FormatArray(format, argument1, argument2, argument3));
         }
 
         public void WriteLine(string format, params object[] arguments)
         {
-            WriteLineCore(new FormatArray(format, arguments));
+            WriteLine(new FormatArray(format, arguments));
         }
 
-        private void WriteLineCore(FormatArray formatArray)
+        private void WriteLine(FormatArray formatArray)
         {
             if (IsEnabled)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowProjectLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowProjectLogger.cs
@@ -30,9 +30,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
             _outputWindowProvider = outputWindowProvider;
         }
 
+        public bool IsEnabled
+        {
+            get { return _options.IsProjectOutputPaneEnabled; }
+        }
+
         public void WriteLine(string format, params object[] arguments)
         {
-            if (_options.IsProjectOutputPaneEnabled)
+            if (IsEnabled)
             {
                 // Only allocate if the pane is actually enabled
                 string text = string.Format(CultureInfo.CurrentCulture, format, arguments);
@@ -43,7 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
 
         public void WriteLine(string text)
         {
-            if (_options.IsProjectOutputPaneEnabled)
+            if (IsEnabled)
             {
                 WriteLineCore(text);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowProjectLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowProjectLogger.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.ComponentModel.Composition;
-using System.Globalization;
 using Microsoft.VisualStudio.ProjectSystem.Logging;
 using Microsoft.VisualStudio.Shell.Interop;
 
@@ -36,49 +35,30 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
         }
         public void WriteLine(string text)
         {
-            if (IsEnabled)
-            {
-                WriteLineCore(text);
-            }
+            WriteLineCore(new FormatArray(text));
         }
 
         public void WriteLine(string format, object argument)
         {
-            if (IsEnabled)
-            {
-                // Only allocate if the pane is actually enabled, making sure we call through the non-params array version
-                WriteLineCore(string.Format(CultureInfo.CurrentCulture, format, argument));
-            }
+            WriteLineCore(new FormatArray(format, argument));
         }
 
         public void WriteLine(string format, object argument1, object argument2)
         {
-            if (IsEnabled)
-            {
-                // Only allocate if the pane is actually enabled, making sure we call through the non-params array version
-                WriteLineCore(string.Format(CultureInfo.CurrentCulture, format, argument1, argument2));
-            }
+            WriteLineCore(new FormatArray(format, argument1, argument2));
         }
 
         public void WriteLine(string format, object argument1, object argument2, object argument3)
         {
-            if (IsEnabled)
-            {
-                // Only allocate if the pane is actually enabled, making sure we call through the non-params array version
-                WriteLineCore(string.Format(CultureInfo.CurrentCulture, format, argument1, argument2, argument3));
-            }
+            WriteLineCore(new FormatArray(format, argument1, argument2, argument3));
         }
 
         public void WriteLine(string format, params object[] arguments)
         {
-            if (IsEnabled)
-            {
-                // Only allocate if the pane is actually enabled
-                WriteLineCore(string.Format(CultureInfo.CurrentCulture, format, arguments));
-            }
+            WriteLineCore(new FormatArray(format, arguments));
         }
 
-        private void WriteLineCore(string text)
+        private void WriteLineCore(FormatArray formatArray)
         {
             if (IsEnabled)
             {
@@ -91,7 +71,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
                     IVsOutputWindowPane pane = await _outputWindowProvider.GetOutputWindowPaneAsync()
                                                                           .ConfigureAwait(true);
 
-                    pane.OutputStringNoPump(text + Environment.NewLine);
+                    pane.OutputStringNoPump(formatArray.Text + Environment.NewLine);
 
                 }, options: ForkOptions.HideLocks | ForkOptions.StartOnMainThread);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractLanguageServiceRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractLanguageServiceRuleHandler.cs
@@ -2,6 +2,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Logging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
@@ -13,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
         public virtual bool ReceiveUpdatesWithEmptyProjectChange => false;
 
-        public virtual void Handle(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
+        public virtual void Handle(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext, ProjectLoggerContext loggerContext)
         {
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
@@ -26,11 +26,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             foreach (CommandLineSourceFile additionalFile in removed.AdditionalFiles)
             {
+                loggerContext.WriteLine("Removing additional file {0}", additionalFile.Path);
+
                 context.RemoveAdditionalFile(additionalFile.Path);
             }
 
             foreach (CommandLineSourceFile additionalFile in added.AdditionalFiles)
             {
+                loggerContext.WriteLine("Adding additional file {0}", additionalFile.Path);
+
                 context.AddAdditionalFile(additionalFile.Path, isInCurrentContext: isActiveContext);
             }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
@@ -3,6 +3,7 @@
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Logging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
@@ -18,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         {
         }
 
-        public void Handle(BuildOptions added, BuildOptions removed, IWorkspaceProjectContext context, bool isActiveContext)
+        public void Handle(BuildOptions added, BuildOptions removed, IWorkspaceProjectContext context, bool isActiveContext, ProjectLoggerContext loggerContext)
         {
             Requires.NotNull(added, nameof(added));
             Requires.NotNull(removed, nameof(removed));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
@@ -3,6 +3,7 @@
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Logging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
@@ -18,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         {
         }
 
-        public void Handle(BuildOptions added, BuildOptions removed, IWorkspaceProjectContext context, bool isActiveContext)
+        public void Handle(BuildOptions added, BuildOptions removed, IWorkspaceProjectContext context, bool isActiveContext, ProjectLoggerContext loggerContext)
         {
             Requires.NotNull(added, nameof(added));
             Requires.NotNull(removed, nameof(removed));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
@@ -26,11 +26,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             foreach (CommandLineAnalyzerReference analyzer in removed.AnalyzerReferences)
             {
+                loggerContext.WriteLine("Removing analyzer {0}", analyzer.FilePath);
+
                 context.RemoveAnalyzerReference(analyzer.FilePath);
             }
 
             foreach (CommandLineAnalyzerReference analyzer in added.AnalyzerReferences)
             {
+                loggerContext.WriteLine("Adding analyzer {0}", analyzer.FilePath);
+
                 context.AddAnalyzerReference(analyzer.FilePath);
             }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandler.cs
@@ -62,8 +62,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             // case and we should ignore the results.
 
             bool designTimeBuildSuceeeded = projectChange.After.Items.Count != 0;
-            loggerContext.WriteLine("Setting 'last design time build succeeded' to {0}", designTimeBuildSuceeeded);
-            context.LastDesignTimeBuildSucceeded = designTimeBuildSuceeeded;
+
+            if (context.LastDesignTimeBuildSucceeded != designTimeBuildSuceeeded)
+            {
+                loggerContext.WriteLine("Setting 'last design time build succeeded' to {0}", designTimeBuildSuceeeded);
+                context.LastDesignTimeBuildSucceeded = designTimeBuildSuceeeded;
+            }
+
             return !designTimeBuildSuceeeded;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandler.cs
@@ -61,10 +61,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             // Check if the design-time build failed, if we have no arguments, then that is likely the 
             // case and we should ignore the results.
 
-            bool designTimeBuildFailed = projectChange.After.Items.Count == 0;
-            loggerContext.WriteLine("Setting 'last design time build succeeded' to {0}", designTimeBuildFailed);
-            context.LastDesignTimeBuildSucceeded = !designTimeBuildFailed;
-            return designTimeBuildFailed;
+            bool designTimeBuildSuceeeded = projectChange.After.Items.Count != 0;
+            loggerContext.WriteLine("Setting 'last design time build succeeded' to {0}", designTimeBuildSuceeeded);
+            context.LastDesignTimeBuildSucceeded = designTimeBuildSuceeeded;
+            return !designTimeBuildSuceeeded;
         }
 
         private static void ProcessOptions(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, ProjectLoggerContext loggerContext)
@@ -74,9 +74,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             string commandLine = string.Join(" ", commandlineArguments);
 
-            loggerContext.WriteLine("Setting options {0}", commandLine);
+            loggerContext.WriteLine("Setting options to {0}", commandLine);
             context.SetOptions(commandLine);
-        }
+        }   
 
         private void ProcessItems(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext, ProjectLoggerContext loggerContext)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandler.cs
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             if (context.LastDesignTimeBuildSucceeded != designTimeBuildSuceeeded)
             {
-                loggerContext.WriteLine("Setting 'last design time build succeeded' to {0}", designTimeBuildSuceeeded);
+                loggerContext.WriteLine("Setting 'last design time build succeeded' to {0} because we were sent no command-line arguments from the last design-time build.", designTimeBuildSuceeeded);
                 context.LastDesignTimeBuildSucceeded = designTimeBuildSuceeeded;
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandler.cs
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             if (context.LastDesignTimeBuildSucceeded != designTimeBuildSuceeeded)
             {
-                loggerContext.WriteLine("Setting 'last design time build succeeded' to {0} because we were sent no command-line arguments from the last design-time build.", designTimeBuildSuceeeded);
+                loggerContext.WriteLine("Setting 'last design time build succeeded' to {0}.", designTimeBuildSuceeeded);
                 context.LastDesignTimeBuildSucceeded = designTimeBuildSuceeeded;
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandler.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Logging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
@@ -43,14 +44,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         // Broken design time builds generates updates with no changes.
         public override bool ReceiveUpdatesWithEmptyProjectChange => true;
 
-        public override void Handle(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
+        public override void Handle(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext, ProjectLoggerContext loggerContext)
         {
             Requires.NotNull(projectChange, nameof(projectChange));
 
             if (!ProcessDesignTimeBuildFailure(projectChange, context))
             {
                 ProcessOptions(projectChange, context);
-                ProcessItems(projectChange, context, isActiveContext);
+                ProcessItems(projectChange, context, isActiveContext, loggerContext);
             }
         }
 
@@ -72,14 +73,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             context.SetOptions(string.Join(" ", commandlineArguments));
         }
 
-        private void ProcessItems(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
+        private void ProcessItems(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext, ProjectLoggerContext loggerContext)
         {
             BuildOptions addedItems = _commandLineParser.Parse(projectChange.Difference.AddedItems);
             BuildOptions removedItems = _commandLineParser.Parse(projectChange.Difference.RemovedItems);
 
             foreach (var handler in Handlers)
             {
-                handler.Value.Handle(addedItems, removedItems, context, isActiveContext);
+                handler.Value.Handle(addedItems, removedItems, context, isActiveContext, loggerContext);
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
@@ -3,6 +3,7 @@
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Logging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
@@ -23,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             _unconfiguredProject = project;
         }
 
-        public void Handle(BuildOptions added, BuildOptions removed, IWorkspaceProjectContext context, bool isActiveContext)
+        public void Handle(BuildOptions added, BuildOptions removed, IWorkspaceProjectContext context, bool isActiveContext, ProjectLoggerContext loggerContext)
         {
             Requires.NotNull(added, nameof(added));
             Requires.NotNull(removed, nameof(removed));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
@@ -32,12 +32,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             foreach (CommandLineReference reference in removed.MetadataReferences)
             {
                 var fullPath = _unconfiguredProject.MakeRooted(reference.Reference);
+
+                loggerContext.WriteLine("Removing reference {0}", fullPath);
+
                 context.RemoveMetadataReference(fullPath);
             }
 
             foreach (CommandLineReference reference in added.MetadataReferences)
             {
                 var fullPath = _unconfiguredProject.MakeRooted(reference.Reference);
+
+                loggerContext.WriteLine("Adding reference {0}", fullPath);
+
                 context.AddMetadataReference(fullPath, reference.Properties);
             }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
@@ -37,6 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             {
                 if (Guid.TryParse(projectChange.After.Properties[ConfigurationGeneral.ProjectGuidProperty], out Guid result))
                 {
+                    loggerContext.WriteLine("Setting project GUID to {0}", result);
                     context.Guid = result;
                 }
             }
@@ -53,6 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
                 var newBinOutputPath = projectChange.After.Properties[ConfigurationGeneral.TargetPathProperty];
                 if (!string.IsNullOrEmpty(newBinOutputPath))
                 {
+                    loggerContext.WriteLine("Setting 'bin output path' to {0}", newBinOutputPath);
                     context.BinOutputPath = newBinOutputPath;
                 }
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
@@ -3,6 +3,7 @@
 using System;
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Logging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
@@ -28,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             get { return ConfigurationGeneral.SchemaName; }
         }
 
-        public override void Handle(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
+        public override void Handle(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext, ProjectLoggerContext loggerContext)
         {
             Requires.NotNull(projectChange, nameof(projectChange));
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -54,12 +54,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             foreach (CommandLineSourceFile sourceFile in removed.SourceFiles)
             {
-                RemoveSourceFile(sourceFile.Path, context);
+                RemoveSourceFile(sourceFile.Path, context, loggerContext);
             }
 
             foreach (CommandLineSourceFile sourceFile in added.SourceFiles)
             {
-                AddSourceFile(sourceFile.Path, null, context, isActiveContext);
+                AddSourceFile(sourceFile.Path, null, context, isActiveContext, loggerContext);
             }
         }
 
@@ -72,12 +72,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             foreach (string filePath in diff.RemovedItems)
             {
-                RemoveSourceFile(filePath, context);
+                RemoveSourceFile(filePath, context, loggerContext);
             }
 
             foreach (string filePath in diff.AddedItems)
             {
-                AddSourceFile(filePath, GetFolders(filePath, projectChange), context, isActiveContext);
+                AddSourceFile(filePath, GetFolders(filePath, projectChange), context, isActiveContext, loggerContext);
             }
 
             foreach (KeyValuePair<string, string> filePaths in diff.RenamedItems)
@@ -85,15 +85,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
                 string removeFilePath = filePaths.Key;
                 string addFilePath = filePaths.Value;
 
-                RemoveSourceFile(removeFilePath, context);
-                AddSourceFile(addFilePath, GetFolders(addFilePath, projectChange), context, isActiveContext);
+                RemoveSourceFile(removeFilePath, context, loggerContext);
+                AddSourceFile(addFilePath, GetFolders(addFilePath, projectChange), context, isActiveContext, loggerContext);
             }
 
             foreach (string filePath in diff.ChangedItems)
             {
                 // We add and then remove ChangedItems to handle Linked metadata changes
-                RemoveSourceFile(filePath, context);
-                AddSourceFile(filePath, GetFolders(filePath, projectChange), context, isActiveContext);
+                RemoveSourceFile(filePath, context, loggerContext);
+                AddSourceFile(filePath, GetFolders(filePath, projectChange), context, isActiveContext, loggerContext);
             }
         }
 
@@ -105,17 +105,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             return Task.CompletedTask;
         }
 
-        private void RemoveSourceFile(string filePath, IWorkspaceProjectContext context)
+        private void RemoveSourceFile(string filePath, IWorkspaceProjectContext context, ProjectLoggerContext loggerContext)
         {
             string fullPath = _project.MakeRooted(filePath);
 
             if (_sourceFilesByContext.TryGetValue(context, out HashSet<string> sourceFiles) && sourceFiles.Remove(fullPath))
             {
+                loggerContext.WriteLine("Removing source file {0}", fullPath);
                 context.RemoveSourceFile(fullPath);
             }
         }
 
-        private void AddSourceFile(string filePath, string[] folderNames, IWorkspaceProjectContext context, bool isActiveContext)
+        private void AddSourceFile(string filePath, string[] folderNames, IWorkspaceProjectContext context, bool isActiveContext, ProjectLoggerContext loggerContext)
         {
             string fullPath = _project.MakeRooted(filePath);
 
@@ -129,6 +130,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
                 return;
             }
 
+            loggerContext.WriteLine("Adding source file {0}", fullPath);
             sourceFiles.Add(fullPath);
             context.AddSourceFile(fullPath, folderNames: folderNames, isInCurrentContext: isActiveContext);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Logging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
@@ -46,7 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             get { return RuleHandlerType.Evaluation; }
         }
 
-        public void Handle(BuildOptions added, BuildOptions removed, IWorkspaceProjectContext context, bool isActiveContext)
+        public void Handle(BuildOptions added, BuildOptions removed, IWorkspaceProjectContext context, bool isActiveContext, ProjectLoggerContext loggerContext)
         {
             Requires.NotNull(added, nameof(added));
             Requires.NotNull(removed, nameof(removed));
@@ -62,7 +63,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             }
         }
 
-        public override void Handle(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext)
+        public override void Handle(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext, ProjectLoggerContext loggerContext)
         {
             Requires.NotNull(projectChange, nameof(projectChange));
             Requires.NotNull(context, nameof(context));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ILanguageServiceCommandLineHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ILanguageServiceCommandLineHandler.cs
@@ -2,6 +2,7 @@
 
 using System;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Logging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
@@ -27,6 +28,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         /// <param name="isActiveContext">
         ///     Flag indicating if the given <paramref name="context"/> is the active project context.
         /// </param>
+        /// <param name="loggerContext">
+        ///     The <see cref="ProjectLoggerContext"/> context for logging to the log.
+        /// </param>
         /// <exception cref="ArgumentNullException">
         ///     <paramref name="added"/> is <see langword="null"/>.
         ///     <para>
@@ -34,6 +38,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ///     </para>
         ///     <paramref name="removed"/> is <see langword="null"/>.
         /// </exception>
-        void Handle(BuildOptions added, BuildOptions removed, IWorkspaceProjectContext context, bool isActiveContext);
+        void Handle(BuildOptions added, BuildOptions removed, IWorkspaceProjectContext context, bool isActiveContext, ProjectLoggerContext loggerContext);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ILanguageServiceRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ILanguageServiceRuleHandler.cs
@@ -3,6 +3,7 @@
 using System;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Logging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
@@ -58,10 +59,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         /// <param name="isActiveContext">
         ///     Flag indicating if the given <paramref name="context"/> is the active project context.
         /// </param>
+        /// <param name="loggerContext">
+        ///     The <see cref="ProjectLoggerContext"/> context for logging to the log.
+        /// </param>
         /// <exception cref="ArgumentNullException">
         ///     <paramref name="projectChange"/> is <see langword="null"/>.
         /// </exception>
-        void Handle(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext);
+        void Handle(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext, ProjectLoggerContext loggerContext);
 
         /// <summary>
         /// Handles clearing any state specific to the given context being released.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -299,19 +299,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                     return;
                 }
 
+                ProjectLoggerContext loggerContext = BeginLoggingContext(update, handlerType, isActiveContext);
+
                 // Broken design time builds sometimes cause updates with no project changes and sometimes cause updates with a project change that has no difference.
                 // We handle the former case here, and the latter case is handled in the CommandLineItemHandler.
                 if (update.Value.ProjectChanges.Count == 0)
                 {
                     if (handlerType == RuleHandlerType.DesignTimeBuild)
                     {
+                        loggerContext.WriteLine("Setting 'last design time build succeeded' to False because we were sent no project changes from the last design-time build.");
                         projectContextToUpdate.LastDesignTimeBuildSucceeded = false;
                     }
 
                     return;
                 }
-
-                ProjectLoggerContext loggerContext = BeginLoggingContext(update, handlerType, isActiveContext);
 
                 foreach (var handler in handlers)
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -299,6 +299,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                     return;
                 }
 
+                _logger.WriteLine("Processing rule changes for {0}", _commonServices.Project.FullPath);
+
                 ProjectLoggerContext loggerContext = BeginLoggingContext(update, handlerType, isActiveContext);
 
                 // Broken design time builds sometimes cause updates with no project changes and sometimes cause updates with a project change that has no difference.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -329,7 +329,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             string version = GetConfiguredProjectVersion(update);
             string configuration = update.Value.ProjectConfiguration.Name;
 
-            return _logger.BeginContext("[Rule: {0}, Config: {1}, ConfiguredProjectVersion: {2}, IsActiveContext: {3}]", handlerType, configuration, version, isActiveContext);
+            return _logger.BeginContext("[{0}, {1}, Version: {2}, IsActiveContext: {3}]", handlerType, configuration, version, isActiveContext);
         }
 
         private string GetConfiguredProjectVersion(IProjectVersionedValue<IProjectSubscriptionUpdate> update)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/FormatArray.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/FormatArray.cs
@@ -68,27 +68,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.Logging
             _arguments = arguments;
         }
 
-        public int Length
-        {
-            get { return _arguments.Length; }
-        }
-
         public string Text
         {
             get
             {
+                int length = _arguments.Length;
+
                 // Making sure we call through the non-params array version of String.Format 
                 // where possible to avoid "params" array allocation.
-                if (Length == 0)
+                if (length == 0)
                     return _format;
 
-                if (Length == 1)
+                if (length == 1)
                     return string.Format(CultureInfo.CurrentCulture, _format, _argument1);
 
-                if (Length == 2)
+                if (length == 2)
                     return string.Format(CultureInfo.CurrentCulture, _format, _argument1, _argument2);
 
-                if (Length == 3)
+                if (length == 3)
                     return string.Format(CultureInfo.CurrentCulture, _format, _argument1, _argument2, _argument3);
 
                 return string.Format(CultureInfo.CurrentCulture, _format, _arguments);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/FormatArray.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/FormatArray.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Logging
+{
+    /// <summary>
+    ///     Provides an object that allows a common way to format a set of objects, only allocating if needed.
+    /// </summary>
+    internal struct FormatArray
+    {
+        // Sentinel fixed-length arrays eliminate the need for a "count" field keeping this
+        // struct down to just 4 fields. These are only used for their "Length" property,
+        // that is, their elements are never set or referenced.
+        private static readonly object[] ZeroArgumentArray = Array.Empty<object>();
+        private static readonly object[] OneArgumentArray = new object[1];
+        private static readonly object[] TwoArgumentArray = new object[2];
+        private static readonly object[] ThreeArgumentArray = new object[3];
+        private readonly string _format;
+        private readonly object _argument1;
+        private readonly object _argument2;
+        private readonly object _argument3;
+        private readonly object[] _arguments;
+
+        public FormatArray(string text)
+        {
+            _format = text;
+            _argument1 = null;
+            _argument2 = null;
+            _argument3 = null;
+            _arguments = ZeroArgumentArray;
+        }
+
+        public FormatArray(string format, object argument)
+        {
+            _format = format;
+            _argument1 = argument;
+            _argument2 = null;
+            _argument3 = null;
+            _arguments = OneArgumentArray;
+        }
+
+        public FormatArray(string format, object argument1, object argument2)
+        {
+            _format = format;
+            _argument1 = argument1;
+            _argument2 = argument2;
+            _argument3 = null;
+            _arguments = TwoArgumentArray;
+        }
+
+        public FormatArray(string format, object argument1, object argument2, object argument3)
+        {
+            _format = format;
+            _argument1 = argument1;
+            _argument2 = argument2;
+            _argument3 = argument3;
+            _arguments = ThreeArgumentArray;
+        }
+
+        public FormatArray(string format, object[] arguments)
+        {
+            _format = format;
+            _argument1 = null;
+            _argument2 = null;
+            _argument3 = null;
+            _arguments = arguments;
+        }
+
+        public int Length
+        {
+            get { return _arguments.Length; }
+        }
+
+        public string Text
+        {
+            get
+            {
+                // Making sure we call through the non-params array version of String.Format 
+                // where possible to avoid "params" array allocation.
+                if (Length == 0)
+                    return _format;
+
+                if (Length == 1)
+                    return string.Format(CultureInfo.CurrentCulture, _format, _argument1);
+
+                if (Length == 2)
+                    return string.Format(CultureInfo.CurrentCulture, _format, _argument1, _argument2);
+
+                if (Length == 3)
+                    return string.Format(CultureInfo.CurrentCulture, _format, _argument1, _argument2, _argument3);
+
+                return string.Format(CultureInfo.CurrentCulture, _format, _arguments);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/IProjectLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/IProjectLogger.cs
@@ -27,6 +27,45 @@ namespace Microsoft.VisualStudio.ProjectSystem.Logging
         void WriteLine(string text);
 
         /// <summary>
+        ///     Writes the text representation of the specified object, 
+        ///     followed by the current line terminator, to the log using the 
+        ///     specified format information.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="format"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///     The format specification in <paramref name="format"/> is invalid.
+        /// </exception>
+        void WriteLine(string format, object argument);
+
+        /// <summary>
+        ///     Writes the text representation of the specified objects, 
+        ///     followed by the current line terminator, to the log using the 
+        ///     specified format information.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="format"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///     The format specification in <paramref name="format"/> is invalid.
+        /// </exception>
+        void WriteLine(string format, object argument1, object argument2);
+
+        /// <summary>
+        ///     Writes the text representation of the specified objects, 
+        ///     followed by the current line terminator, to the log using the 
+        ///     specified format information.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="format"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///     The format specification in <paramref name="format"/> is invalid.
+        /// </exception>
+        void WriteLine(string format, object argument1, object argument2, object argument3);
+
+        /// <summary>
         ///     Writes the text representation of the specified array of objects, 
         ///     followed by the current line terminator, to the log using the 
         ///     specified format information.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/IProjectLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/IProjectLogger.cs
@@ -10,6 +10,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Logging
     internal interface IProjectLogger
     {
         /// <summary>
+        ///     Gets a value indicating if the logger is enabled.
+        /// </summary>
+        /// <value>
+        ///     <see langword="true"/> if the <see cref="IProjectLogger"/> is enabled and logging to the log; otherwise, <see langword="false"/>.
+        /// </value>
+        bool IsEnabled
+        {
+            get;
+        }
+
+        /// <summary>
         ///     Writes the specified text, followed by the current line terminator, 
         ///     to the log.
         /// </summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/ProjectLoggerContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/ProjectLoggerContext.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Logging
+{
+    /// <summary>
+    ///     Provides additional context to log messages when they are logged to the log.
+    /// </summary>
+    internal struct ProjectLoggerContext
+    {
+        private readonly IProjectLogger _logger;
+        private readonly FormatArray _formatArray;
+
+        internal ProjectLoggerContext(IProjectLogger logger, FormatArray formatArray)
+        {
+            _logger = logger;
+            _formatArray = formatArray;
+        }
+
+        /// <summary>
+        ///     Writes the specified text, followed by the current line terminator, 
+        ///     to the log.
+        /// </summary>
+        public void WriteLine(string text)
+        {
+            if (_logger.IsEnabled)
+            {
+                _logger.WriteLine(_formatArray.Text + " " + text);
+            }
+        }
+
+        /// <summary>
+        ///     Writes the text representation of the specified object, 
+        ///     followed by the current line terminator, to the log using the 
+        ///     specified format information.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="format"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///     The format specification in <paramref name="format"/> is invalid.
+        /// </exception>
+        public void WriteLine(string format, object argument)
+        {
+            if (_logger.IsEnabled)
+            {
+                _logger.WriteLine(_formatArray.Text + " " + format, argument);
+            }
+        }
+
+        /// <summary>
+        ///     Writes the text representation of the specified objects, 
+        ///     followed by the current line terminator, to the log using the 
+        ///     specified format information.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="format"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///     The format specification in <paramref name="format"/> is invalid.
+        /// </exception>
+        public void WriteLine(string format, object argument1, object argument2)
+        {
+            if (_logger.IsEnabled)
+            {
+                _logger.WriteLine(_formatArray.Text + " " + format, argument1, argument2);
+            }
+        }
+
+        /// <summary>
+        ///     Writes the text representation of the specified objects, 
+        ///     followed by the current line terminator, to the log using the 
+        ///     specified format information.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="format"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///     The format specification in <paramref name="format"/> is invalid.
+        /// </exception>
+        public void WriteLine(string format, object argument1, object argument2, object argument3)
+        {
+            if (_logger.IsEnabled)
+            {
+                _logger.WriteLine(_formatArray.Text + " " + format, argument1, argument2, argument3);
+            }
+        }
+
+        /// <summary>
+        ///     Writes the text representation of the specified array of objects, 
+        ///     followed by the current line terminator, to the log using the 
+        ///     specified format information.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="format"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///     The format specification in <paramref name="format"/> is invalid.
+        /// </exception>
+        public void WriteLine(string format, params object[] arguments)
+        {
+            if (_logger.IsEnabled)
+            {
+                _logger.WriteLine(_formatArray.Text + " " + format, arguments);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/ProjectLoggerExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/ProjectLoggerExtensions.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.Logging
+{
+    /// <summary>
+    ///     Provides static extension methods for <see cref="IProjectLogger"/> instances.
+    /// </summary>
+    internal static class ProjectLoggerExtensions
+    {
+        /// <summary>
+        ///     Begins a logger context the specified text.
+        /// </summary>
+        public static ProjectLoggerContext BeginContext(this IProjectLogger logger, string text)
+        {
+            Requires.NotNull(logger, nameof(logger));
+
+            return new ProjectLoggerContext(logger, new FormatArray(text));
+        }
+
+        /// <summary>
+        ///     Begins a logger context with the specified object and format information.
+        /// </summary>
+        public static ProjectLoggerContext BeginContext(this IProjectLogger logger, string format, object argument)
+        {
+            Requires.NotNull(logger, nameof(logger));
+
+            return new ProjectLoggerContext(logger, new FormatArray(format, argument));
+        }
+
+        /// <summary>
+        ///     Begins a logger context with the specified objects and format information.
+        /// </summary>
+        public static ProjectLoggerContext BeginContext(this IProjectLogger logger, string format, object argument1, object argument2)
+        {
+            Requires.NotNull(logger, nameof(logger));
+
+            return new ProjectLoggerContext(logger, new FormatArray(format, argument1, argument2));
+        }
+
+        /// <summary>
+        ///     Begins a logger context with the specified objects and format information.
+        /// </summary>
+        public static ProjectLoggerContext BeginContext(this IProjectLogger logger, string format, object argument1, object argument2, object argument3)
+        {
+            Requires.NotNull(logger, nameof(logger));
+
+            return new ProjectLoggerContext(logger, new FormatArray(format, argument1, argument2, argument3));
+        }
+
+        /// <summary>
+        ///     Begins a logger context with the specified array of objects and format information.
+        /// </summary>
+        public static ProjectLoggerContext BeginContext(this IProjectLogger logger, string format, params object[] arguments)
+        {
+            Requires.NotNull(logger, nameof(logger));
+
+            return new ProjectLoggerContext(logger, new FormatArray(format, arguments));
+        }
+    }
+}


### PR DESCRIPTION
Starts logging from the language service to the output window.

This includes https://github.com/dotnet/project-system/pull/2144, https://github.com/dotnet/project-system/pull/2143 and https://github.com/dotnet/project-system/pull/2142, so read from https://github.com/davkean/project-system/commit/d54033e4adc1b12b5b9014341a677ef903f18d2e onwwards.