### PR TITLE
[WIP] Stop resetting workspace context for single TFM changes

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -329,8 +329,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         private bool HasTargetFrameworksChanged(IProjectVersionedValue<IProjectSubscriptionUpdate> e)
         {
             return e.Value.ProjectChanges.TryGetValue(ConfigurationGeneral.SchemaName, out IProjectChangeDescription projectChange) &&
-                (projectChange.Difference.ChangedProperties.Contains(ConfigurationGeneral.TargetFrameworkProperty) ||
-                 projectChange.Difference.ChangedProperties.Contains(ConfigurationGeneral.TargetFrameworksProperty));
+                 projectChange.Difference.ChangedProperties.Contains(ConfigurationGeneral.TargetFrameworksProperty);
         }
 
         protected override async Task DisposeCoreAsync(bool initialized)


### PR DESCRIPTION
- Stop resetting workspace context for single TFM changes
- Pass 'removes' from failed design-time builds onto Roslyn

Partially fixes #2148 and refixes #1445.

We were making a couple of assumptions here;

1) **TFM changes are the only things that cause design-time builds errors (they aren't)**

The original fix of #1445 basically was a workaround, it attempted to reset the workspace context to avoid duplicate references/source files ending up in the workspace context. However, it was incomplete - design-time builds can break for any reason - so while we got a "fresh" start for TFM changes, other failed builds still caused us to be in an inconsistent state. Instead of doing this, and ignoring these design-time build results, we simply alway pass the results onto Roslyn - thereby removing all references, sources, etc. Then next time a successful build occurs, we'll be a consistent state because the diff contains the results from that failed build to the successful build.

2) **When we reset the workspace on TFM change, that we also reset the dataflow subscription - and hence get all the "current" evaluation data and design-time sent to the new context (we don't).**

When we threw away the workspace context and created another, we were making the assumption that we'd hook up the subscription again and get all previous results that didn't change. We don't - we avoid hooking up a [new subscription if the configuration didn't change](https://github.com/dotnet/project-system/blob/87311919d33adeb6178cd6798fa11e0b045a510d/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs#L260). This means we completely miss all of the evaluation and design-time build results that haven't changed from the previous build, and hence in the repro for #2148 Program.cs ends up in Misc. I need to confirm if this is still a problem with multi-TFM, hence the "partial".

**Note:** This is still a little work in progress, 1) still want to clean up some code in LanguageServiceHost around single TFM handling that I don't think is needed anymore and 2) this new behavior causes results that came through evaluation to be thrown away (in this case source files), they'll get readded later down the track during design-time build, but they'll be missing FolderNames.
