### PR TITLE
sdk-templates are no longer present in SDK. Modify groovy script to reflect that change.

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -103,8 +103,6 @@ pushd %WORKSPACE%\\sdk
 echo *** Build SDK
 call build.cmd -Configuration release -SkipTests || goto :BuildFailed "SDK"
 
-"%MSBUILDEXE%" /m /v:m /p:DeployExtension=True;VSSDKTargetPlatformRegRootSuffix=RoslynDev;Configuration=Release sdk-templates.sln
-
 exit /b 0
 
 :BuildFailed


### PR DESCRIPTION
The templates have been moved to Project system. Remove the explicit step to build the templates from the SDK.

The VSI tests still try to build the SDK templates from SDK and have been [failing](https://ci.dot.net/job/dotnet_project-system/view/Official%20Builds/job/master/job/vsi/). Remove that step. This is just infra change.

@jmarolf  @srivatsn @davkean @dotnet/project-system to make sure I am not missing anything else.