### PR TITLE
Add support for properly theming the property page controls

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerView.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerView.vb
@@ -1240,7 +1240,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
 
         Protected Overrides Sub OnThemeChanged()
             Dim VsUIShell5 = VsUIShell5Service
-            BackColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell5, "Background", __THEMEDCOLORTYPE.TCT_Background, Drawing.SystemColors.ControlLight)
+            BackColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell5, "Background", __THEMEDCOLORTYPE.TCT_Background, Drawing.SystemColors.Window)
 
             MyBase.OnThemeChanged()
         End Sub

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerView.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerView.vb
@@ -53,7 +53,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             '
             SuspendLayout()
             AutoScroll = False
-            BackColor = Drawing.SystemColors.ControlLight
             Name = "ApplicationDesignerView"
             ResumeLayout(False)
             PerformLayout()
@@ -1237,6 +1236,13 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             If SelectedIndex <> _activePanelIndex Then
                 SelectedIndex = _activePanelIndex
             End If
+        End Sub
+
+        Protected Overrides Sub OnThemeChanged()
+            Dim VsUIShell5 = VsUIShell5Service
+            BackColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell5, "Background", __THEMEDCOLORTYPE.TCT_Background, Drawing.SystemColors.ControlLight)
+
+            MyBase.OnThemeChanged()
         End Sub
 
 

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerWindowPane.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerWindowPane.vb
@@ -118,7 +118,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
 
         Private Sub OnThemeChanged()
             Dim VsUIShell5 = VsUIShell5Service
-            _view.BackColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell5Service, "Background", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Control)
+            _view.BackColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell5Service, "Background", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Window)
         End Sub
 
         Private Sub OnBroadcastMessageEventsHelperBroadcastMessage(msg As UInteger, wParam As IntPtr, lParam As IntPtr) Handles _broadcastMessageEventsHelper.BroadcastMessage

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerWindowPane.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerWindowPane.vb
@@ -9,6 +9,7 @@ Imports Common = Microsoft.VisualStudio.Editors.AppDesCommon
 Imports Microsoft.VisualStudio.Shell.Design
 Imports System.Windows.Forms
 Imports System.ComponentModel.Design
+Imports System.Drawing
 Imports System.Reflection
 Imports IOleDataObject = Microsoft.VisualStudio.OLE.Interop.IDataObject
 
@@ -26,7 +27,11 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
 
         Private _host As IDesignerHost
         Private _viewHelper As CmdTargetHelper
+        Private _UIShellService As IVsUIShell
         Private _UIShell2Service As IVsUIShell2
+        Private _UIShell5Service As IVsUIShell5
+
+        Private WithEvents _broadcastMessageEventsHelper As Common.ShellUtil.BroadcastMessageEventsHelper
 
 
         ''' <summary>
@@ -43,9 +48,10 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             '
             _view = New ApplicationDesignerWindowPaneControl()
             AddHandler _view.GotFocus, AddressOf OnViewFocus
-            _view.BackColor = PropertyPages.PropPageUserControlBase.PropPageBackColor
+            OnThemeChanged()
 
             _host = TryCast(GetService(GetType(IDesignerHost)), IDesignerHost)
+            _broadcastMessageEventsHelper = New Common.ShellUtil.BroadcastMessageEventsHelper(Me)
 
             AddHandler surface.Unloaded, AddressOf OnSurfaceUnloaded
 
@@ -108,6 +114,18 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             Else
                 Common.Switches.TracePDFocus(TraceLevel.Warning, "  ... ignoring - m_View currently has no children")
             End If
+        End Sub
+
+        Private Sub OnThemeChanged()
+            Dim VsUIShell5 = VsUIShell5Service
+            _view.BackColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell5Service, "Background", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Control)
+        End Sub
+
+        Private Sub OnBroadcastMessageEventsHelperBroadcastMessage(msg As UInteger, wParam As IntPtr, lParam As IntPtr) Handles _broadcastMessageEventsHelper.BroadcastMessage
+            Select Case msg
+                Case win.WM_PALETTECHANGED, win.WM_SYSCOLORCHANGE, win.WM_THEMECHANGED
+                    OnThemeChanged()
+            End Select
         End Sub
 
         Public Overrides ReadOnly Property Window() As IWin32Window
@@ -442,6 +460,23 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             Return hr
         End Function
 
+        ''' <summary>
+        ''' Retrieves the IVsUIShell service
+        ''' </summary>
+        ''' <remarks></remarks>
+        Public ReadOnly Property VsUIShellService() As IVsUIShell
+            Get
+                If (_UIShellService Is Nothing) Then
+                    If Common.VBPackageInstance IsNot Nothing Then
+                        _UIShellService = TryCast(Common.VBPackageInstance.GetService(GetType(IVsUIShell)), IVsUIShell)
+                    Else
+                        _UIShellService = TryCast(GetService(GetType(IVsUIShell)), IVsUIShell)
+                    End If
+                End If
+
+                Return _UIShellService
+            End Get
+        End Property
 
         ''' <summary>
         ''' Retrieves the IVsUIShell2 service
@@ -450,15 +485,30 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         Public ReadOnly Property VsUIShell2Service() As IVsUIShell2
             Get
                 If (_UIShell2Service Is Nothing) Then
-                    If (Common.VBPackageInstance IsNot Nothing) Then
-                        Dim VsUiShell As IVsUIShell = CType(Common.VBPackageInstance.GetService(GetType(IVsUIShell)), IVsUIShell)
-                        If VsUiShell IsNot Nothing Then
-                            _UIShell2Service = TryCast(VsUiShell, IVsUIShell2)
-                        End If
+                    Dim VsUiShell As IVsUIShell = VsUIShellService
+                    If VsUiShell IsNot Nothing Then
+                        _UIShell2Service = TryCast(VsUiShell, IVsUIShell2)
                     End If
                 End If
-                Return _UIShell2Service
 
+                Return _UIShell2Service
+            End Get
+        End Property
+
+        ''' <summary>
+        ''' Retrieves the IVsUIShell5 service
+        ''' </summary>
+        ''' <remarks></remarks>
+        Public ReadOnly Property VsUIShell5Service() As IVsUIShell5
+            Get
+                If (_UIShell5Service Is Nothing) Then
+                    Dim VsUiShell As IVsUIShell = VsUIShellService
+                    If VsUiShell IsNot Nothing Then
+                        _UIShell5Service = TryCast(VsUiShell, IVsUIShell5)
+                    End If
+                End If
+
+                Return _UIShell5Service
             End Get
         End Property
 
@@ -529,11 +579,17 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                     ' disposedView.  After we're done calling base.Dispose()
                     ' will take care of our own stuff.
                     '
+                    _UIShellService = Nothing
                     _UIShell2Service = Nothing
+                    _UIShell5Service = Nothing
                     _view = Nothing
                     Dim DesSurface As DesignSurface = Surface
                     If (DesSurface IsNot Nothing) Then
                         RemoveHandler DesSurface.Unloaded, AddressOf OnSurfaceUnloaded
+                    End If
+                    If (_broadcastMessageEventsHelper IsNot Nothing) Then
+                        _broadcastMessageEventsHelper.Dispose()
+                        _broadcastMessageEventsHelper = Nothing
                     End If
                 End If
 

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabControl.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabControl.vb
@@ -44,7 +44,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <remarks></remarks>
         Private WithEvents _broadcastMessageEventsHelper As Common.ShellUtil.BroadcastMessageEventsHelper
 
-
+        Public Event ThemeChanged(sender As Object, args As EventArgs)
 
 #Region " Component Designer generated code "
 
@@ -238,6 +238,8 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
 
             'Force the renderer to recreate its GDI objects
             _renderer.CreateGDIObjects(True)
+
+            RaiseEvent ThemeChanged(Me, EventArgs.Empty)
         End Sub
 
 

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabControl.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabControl.vb
@@ -226,7 +226,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             End If
         End Sub
 
-        Private Sub OnThemeChanged()
+        Protected Overridable Sub OnThemeChanged()
             'Update our themed colors
             Dim VsUIShell5 = VsUIShell5Service
             _hostingPanel.BackColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell5Service, "Background", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Control)

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabControl.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabControl.vb
@@ -229,11 +229,11 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         Protected Overridable Sub OnThemeChanged()
             'Update our themed colors
             Dim VsUIShell5 = VsUIShell5Service
-            _hostingPanel.BackColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell5Service, "Background", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Control)
+            _hostingPanel.BackColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell5Service, "Background", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Window)
 
             'Update our system colors
             Dim VsUIShell2 = VsUIShell2Service
-            OverflowButton.FlatAppearance.BorderColor = Common.ShellUtil.GetColor(VsUIShell2, __VSSYSCOLOREX.VSCOLOR_COMMANDBAR_BORDER, SystemColors.MenuText)
+            OverflowButton.FlatAppearance.BorderColor = Common.ShellUtil.GetColor(VsUIShell2, __VSSYSCOLOREX.VSCOLOR_COMMANDBAR_BORDER, SystemColors.WindowFrame)
             OverflowButton.FlatAppearance.MouseOverBackColor = Common.ShellUtil.GetColor(VsUIShell2, __VSSYSCOLOREX.VSCOLOR_COMMANDBAR_HOVER, SystemColors.Highlight)
 
             'Force the renderer to recreate its GDI objects

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabControlRenderer.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabControlRenderer.vb
@@ -66,9 +66,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
 
 #End Region
 
-        ' Category guid for project designer theme colors 
-        Private Shared ReadOnly s_projectDesignerThemeCategory As New Guid("ef1a2d2c-5d16-4ddb-8d04-79d0f6c1c56e")
-
         'The left X position for all tab buttons
         Private _buttonsLocationX As Integer
         'The top Y position for the topmost button
@@ -228,16 +225,16 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                 '  do the right thing when not hosted inside Visual Studio, and change according to the theme.
 
 
-                _controlBackgroundColor = Common.ShellUtil.GetDesignerThemeColor(VsUIShell, s_projectDesignerThemeCategory, "Background", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Control)
+                _controlBackgroundColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell, "Background", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Control)
 
-                _buttonForegroundColor = Common.ShellUtil.GetDesignerThemeColor(VsUIShell, s_projectDesignerThemeCategory, "CategoryTab", __THEMEDCOLORTYPE.TCT_Foreground, SystemColors.ControlText)
-                _buttonBackgroundColor = Common.ShellUtil.GetDesignerThemeColor(VsUIShell, s_projectDesignerThemeCategory, "CategoryTab", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Control)
+                _buttonForegroundColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell, "CategoryTab", __THEMEDCOLORTYPE.TCT_Foreground, SystemColors.ControlText)
+                _buttonBackgroundColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell, "CategoryTab", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Control)
 
-                _selectedButtonForegroundColor = Common.ShellUtil.GetDesignerThemeColor(VsUIShell, s_projectDesignerThemeCategory, "SelectedCategoryTab", __THEMEDCOLORTYPE.TCT_Foreground, SystemColors.HighlightText)
-                _selectedButtonBackgroundColor = Common.ShellUtil.GetDesignerThemeColor(VsUIShell, s_projectDesignerThemeCategory, "SelectedCategoryTab", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Highlight)
+                _selectedButtonForegroundColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell, "SelectedCategoryTab", __THEMEDCOLORTYPE.TCT_Foreground, SystemColors.HighlightText)
+                _selectedButtonBackgroundColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell, "SelectedCategoryTab", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Highlight)
 
-                _hoverButtonForegroundColor = Common.ShellUtil.GetDesignerThemeColor(VsUIShell, s_projectDesignerThemeCategory, "MouseOverCategoryTab", __THEMEDCOLORTYPE.TCT_Foreground, SystemColors.HighlightText)
-                _hoverButtonBackgroundColor = Common.ShellUtil.GetDesignerThemeColor(VsUIShell, s_projectDesignerThemeCategory, "MouseOverCategoryTab", __THEMEDCOLORTYPE.TCT_Background, SystemColors.HotTrack)
+                _hoverButtonForegroundColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell, "MouseOverCategoryTab", __THEMEDCOLORTYPE.TCT_Foreground, SystemColors.HighlightText)
+                _hoverButtonBackgroundColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell, "MouseOverCategoryTab", __THEMEDCOLORTYPE.TCT_Background, SystemColors.HotTrack)
 
                 'Get GDI objects
                 _controlBackgroundBrush = New SolidBrush(_controlBackgroundColor)

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabControlRenderer.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabControlRenderer.vb
@@ -98,6 +98,9 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         'The service provider to use.  May be Nothing
         Private _serviceProvider As IServiceProvider
 
+        Private _UIShellService As IVsUIShell
+        Private _UIShell5Service As IVsUIShell5
+
         'Backs the PreferredButtonInSwitchableSlot property
         Private _preferredButtonForSwitchableSlot As ProjectDesignerTabButton
 
@@ -153,22 +156,40 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         End Property
 
         ''' <summary>
+        ''' Attempts to obtain the IVsUIShell interface.
+        ''' </summary>
+        ''' <value>The IVsUIShell service if found, otherwise null</value>
+        ''' <remarks>Uses the publicly-obtained ServiceProvider property, if it was set.</remarks>
+        Private ReadOnly Property VsUIShellService() As IVsUIShell
+            Get
+                If (_UIShellService Is Nothing) Then
+                    If Common.VBPackageInstance IsNot Nothing Then
+                        _UIShellService = TryCast(Common.VBPackageInstance.GetService(GetType(IVsUIShell)), IVsUIShell)
+                    ElseIf ServiceProvider IsNot Nothing Then
+                        _UIShellService = TryCast(ServiceProvider.GetService(GetType(IVsUIShell)), IVsUIShell)
+                    End If
+                End If
+
+                Return _UIShellService
+            End Get
+        End Property
+
+        ''' <summary>
         ''' Attempts to obtain the IVsUIShell5 interface.
         ''' </summary>
         ''' <value>The IVsUIShell5 service if found, otherwise null</value>
         ''' <remarks>Uses the publicly-obtained ServiceProvider property, if it was set.</remarks>
         Private ReadOnly Property VsUIShell5Service() As IVsUIShell5
             Get
-                Dim sp As IServiceProvider = ServiceProvider
-                If sp IsNot Nothing Then
-                    Dim vsUiShell As IVsUIShell = TryCast(sp.GetService(GetType(IVsUIShell)), IVsUIShell)
-                    If vsUiShell IsNot Nothing Then
-                        Dim uIShell2Service As IVsUIShell5 = TryCast(vsUiShell, IVsUIShell5)
-                        Return uIShell2Service
+                If (_UIShell5Service Is Nothing) Then
+                    Dim VsUIShell = VsUIShellService
+
+                    If (VsUIShell IsNot Nothing) Then
+                        _UIShell5Service = TryCast(VsUIShell, IVsUIShell5)
                     End If
                 End If
 
-                Return Nothing
+                Return _UIShell5Service
             End Get
         End Property
 

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabControlRenderer.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabControlRenderer.vb
@@ -246,10 +246,10 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                 '  do the right thing when not hosted inside Visual Studio, and change according to the theme.
 
 
-                _controlBackgroundColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell, "Background", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Control)
+                _controlBackgroundColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell, "Background", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Window)
 
-                _buttonForegroundColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell, "CategoryTab", __THEMEDCOLORTYPE.TCT_Foreground, SystemColors.ControlText)
-                _buttonBackgroundColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell, "CategoryTab", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Control)
+                _buttonForegroundColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell, "CategoryTab", __THEMEDCOLORTYPE.TCT_Foreground, SystemColors.WindowText)
+                _buttonBackgroundColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell, "CategoryTab", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Window)
 
                 _selectedButtonForegroundColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell, "SelectedCategoryTab", __THEMEDCOLORTYPE.TCT_Foreground, SystemColors.HighlightText)
                 _selectedButtonBackgroundColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell, "SelectedCategoryTab", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Highlight)

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/SpecialFileCustomViewProvider.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/SpecialFileCustomViewProvider.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
 
         Private _view As Control
         Private _linkText As String
-        Private _designerView As ApplicationDesignerView
+        Private WithEvents _designerView As ApplicationDesignerView
         Private _designerPanel As ApplicationDesignerPanel
         Private _specialFileId As Integer
 
@@ -115,6 +115,13 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             If _view IsNot Nothing Then
                 _view.Dispose()
                 _view = Nothing
+            End If
+        End Sub
+
+        Private Sub DesignerView_ThemeChanged(sender As Object, args As EventArgs) Handles _designerView.ThemeChanged
+            If _view IsNot Nothing Then
+                Dim View As SpecialFileCustomView = CType(_view, SpecialFileCustomView)
+                View.LinkLabel.SetThemedColor(_designerPanel.VsUIShell5)
             End If
         End Sub
 

--- a/src/Microsoft.VisualStudio.AppDesigner/Common/ShellUtil.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/Common/ShellUtil.vb
@@ -15,6 +15,9 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
     ''' <remarks></remarks>
     Friend NotInheritable Class ShellUtil
 
+        Public Shared ReadOnly ProjectDesignerThemeCategory As New Guid("ef1a2d2c-5d16-4ddb-8d04-79d0f6c1c56e")
+
+        Public Shared ReadOnly EnvironmentThemeCategory As New Guid("624ed9c3-bdfd-41fa-96c3-7c824ea32e3d")
 
         ''' <summary>
         ''' Gets a color from the shell's color service.  If for some reason this fails, returns the supplied
@@ -69,6 +72,14 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
 
             Debug.Fail("Unable to get color from the shell, using a predetermined default color instead." & vbCrLf & "Color Category = " & themeCategory.ToString() & ", Color Name = " & themeColorName & ", Color Type = " & colorType & ", Default Color = &h" & Hex(defaultColor.ToArgb))
             Return defaultColor
+        End Function
+
+        Public Shared Function GetEnvironmentThemeColor(uiShellService As IVsUIShell5, themeColorName As String, colorType As __THEMEDCOLORTYPE, defaultColor As Color) As Color
+            Return GetDesignerThemeColor(uiShellService, EnvironmentThemeCategory, themeColorName, colorType, defaultColor)
+        End Function
+
+        Public Shared Function GetProjectDesignerThemeColor(uiShellService As IVsUIShell5, themeColorName As String, colorType As __THEMEDCOLORTYPE, defaultColor As Color) As Color
+            Return GetDesignerThemeColor(uiShellService, ProjectDesignerThemeCategory, themeColorName, colorType, defaultColor)
         End Function
 
         Private Shared Function RGBAToColor(rgbaValue As UInteger) As Color

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerView.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerView.vb
@@ -553,7 +553,12 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
 
         Private Sub OnThemeChanged()
             Dim VsUIShell5 = VsUIShell5Service
-            BackColor = ShellUtil.GetProjectDesignerThemeColor(VsUIShell5Service, "Background", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Control)
+            If TypeOf PropPage Is PropPageBase AndAlso CType(PropPage, PropPageBase).SupportsTheming Then
+                BackColor = ShellUtil.GetProjectDesignerThemeColor(VsUIShell5Service, "Background", __THEMEDCOLORTYPE.TCT_Background, SystemColors.ControlLight)
+            Else
+                BackColor = SystemColors.Control
+            End If
+
             ConfigurationPanel.BackColor = BackColor
             PropertyPagePanel.BackColor = BackColor
         End Sub
@@ -625,6 +630,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                     End If
 
                     _isPageActivated = True
+                    OnThemeChanged()
 
                     'Is the control hosted natively via SetParent?
                     If PropertyPagePanel.Controls.Count > 0 Then

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerView.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerView.vb
@@ -554,9 +554,9 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         Private Sub OnThemeChanged()
             Dim VsUIShell5 = VsUIShell5Service
             If TypeOf PropPage Is PropPageBase AndAlso CType(PropPage, PropPageBase).SupportsTheming Then
-                BackColor = ShellUtil.GetProjectDesignerThemeColor(VsUIShell5Service, "Background", __THEMEDCOLORTYPE.TCT_Background, SystemColors.ControlLight)
+                BackColor = ShellUtil.GetProjectDesignerThemeColor(VsUIShell5Service, "Background", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Window)
             Else
-                BackColor = SystemColors.Control
+                BackColor = SystemColors.Window
             End If
 
             ConfigurationPanel.BackColor = BackColor

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPage.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPage.vb
@@ -271,6 +271,12 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End Get
         End Property
 
+        Public Overridable ReadOnly Property SupportsTheming() As Boolean
+            Get
+                Return False
+            End Get
+        End Property
+
 
         Private Sub IPropertyPage2_Activate(hWndParent As IntPtr, pRect() As RECT, bModal As Integer) Implements IPropertyPage2.Activate, IPropertyPage.Activate
 

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
@@ -51,7 +51,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             'This call is required by the Windows Form Designer.
             InitializeComponent()
 
-            BackColor = PropPageBackColor
+            'Ensure we set out colors based on the current theme
+            OnThemeChanged()
 
             'Add any initialization after the InitializeComponent() call
             AddToRunningTable()
@@ -3839,8 +3840,15 @@ NextControl:
                     m_ScalingCompleted = False
                     SetDialogFont(PageRequiresScaling)
                 End If
+            ElseIf msg = Interop.win.WM_PALETTECHANGED OrElse msg = Interop.win.WM_SYSCOLORCHANGE OrElse msg = Interop.win.WM_THEMECHANGED Then
+                OnThemeChanged()
             End If
         End Function
+
+        Private Sub OnThemeChanged()
+            Dim VsUIShell5 = VsUIShell5Service
+            BackColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell5, "Background", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Control)
+        End Sub
 
         ''' <summary>
         ''' Set font and scale page accordingly

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
@@ -315,6 +315,16 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End Get
         End Property
 
+        ''' <summary>
+        '''  Return a boolean value that indicates whether or not the control supports the color theming service
+        ''' </summary>
+        ''' <returns></returns>
+        Public Overridable ReadOnly Property SupportsTheming() As Boolean
+            Get
+                Return False
+            End Get
+        End Property
+
         Public ReadOnly Property ProjectHierarchy() As IVsHierarchy
             Get
                 Return _projectHierarchy
@@ -3847,8 +3857,12 @@ NextControl:
         End Function
 
         Private Sub OnThemeChanged()
-            Dim VsUIShell5 = VsUIShell5Service
-            BackColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell5, "Background", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Control)
+            If SupportsTheming Then
+                Dim VsUIShell5 = VsUIShell5Service
+                BackColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell5, "Background", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Control)
+            Else
+                BackColor = SystemColors.Control
+            End If
         End Sub
 
         ''' <summary>

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
@@ -252,6 +252,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Private _manualPageScaling As Boolean = False
 
         'Backcolor for all property pages
+        <Obsolete("Colors should be retrieved directly from the theming service")>
         Public Shared ReadOnly PropPageBackColor As Color = SystemColors.Control
 
         Private _activated As Boolean = True

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
@@ -3856,12 +3856,12 @@ NextControl:
             End If
         End Function
 
-        Private Sub OnThemeChanged()
+        Protected Overridable Sub OnThemeChanged()
             If SupportsTheming Then
                 Dim VsUIShell5 = VsUIShell5Service
-                BackColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell5, "Background", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Control)
+                BackColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell5, "Background", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Window)
             Else
-                BackColor = SystemColors.Control
+                BackColor = SystemColors.Window
             End If
         End Sub
 

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/VSThemedLinkLabel.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/VSThemedLinkLabel.vb
@@ -22,10 +22,10 @@ Public Class VSThemedLinkLabel
     Public Sub SetThemedColor(vsUIShell5 As IVsUIShell5)
 
         ' The default value is the actual value of DiagReportLinkTextHover and DiagReportLinkText defined by Dev11
-        _vsThemedLinkColorHover = ShellUtil.GetEnvironmentThemeColor(vsUIShell5, "PanelHyperlinkHover", __THEMEDCOLORTYPE.TCT_Background, Color.FromArgb(&HFF1382CE))
-        _vsThemedLinkColor = ShellUtil.GetEnvironmentThemeColor(vsUIShell5, "PanelHyperlink", __THEMEDCOLORTYPE.TCT_Background, Color.FromArgb(&HFF1382CE))
+        _vsThemedLinkColorHover = ShellUtil.GetEnvironmentThemeColor(vsUIShell5, "PanelHyperlinkHover", __THEMEDCOLORTYPE.TCT_Background, SystemColors.HotTrack)
+        _vsThemedLinkColor = ShellUtil.GetEnvironmentThemeColor(vsUIShell5, "PanelHyperlink", __THEMEDCOLORTYPE.TCT_Background, SystemColors.HotTrack)
 
-        ActiveLinkColor = ShellUtil.GetEnvironmentThemeColor(vsUIShell5, "PanelHyperlinkPressed", __THEMEDCOLORTYPE.TCT_Background, Color.FromArgb(&HFF1382CE))
+        ActiveLinkColor = ShellUtil.GetEnvironmentThemeColor(vsUIShell5, "PanelHyperlinkPressed", __THEMEDCOLORTYPE.TCT_Background, SystemColors.HotTrack)
         LinkColor = _vsThemedLinkColor
         LinkBehavior = LinkBehavior.HoverUnderline
     End Sub

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/VSThemedLinkLabel.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/VSThemedLinkLabel.vb
@@ -21,13 +21,11 @@ Public Class VSThemedLinkLabel
 
     Public Sub SetThemedColor(vsUIShell5 As IVsUIShell5)
 
-        Dim environmentThemeCategory As Guid = New Guid("624ed9c3-bdfd-41fa-96c3-7c824ea32e3d")
-
         ' The default value is the actual value of DiagReportLinkTextHover and DiagReportLinkText defined by Dev11
-        _vsThemedLinkColorHover = ShellUtil.GetDesignerThemeColor(vsUIShell5, environmentThemeCategory, "PanelHyperlinkHover", __THEMEDCOLORTYPE.TCT_Background, Color.FromArgb(&HFF1382CE))
-        _vsThemedLinkColor = ShellUtil.GetDesignerThemeColor(vsUIShell5, environmentThemeCategory, "PanelHyperlink", __THEMEDCOLORTYPE.TCT_Background, Color.FromArgb(&HFF1382CE))
+        _vsThemedLinkColorHover = ShellUtil.GetEnvironmentThemeColor(vsUIShell5, "PanelHyperlinkHover", __THEMEDCOLORTYPE.TCT_Background, Color.FromArgb(&HFF1382CE))
+        _vsThemedLinkColor = ShellUtil.GetEnvironmentThemeColor(vsUIShell5, "PanelHyperlink", __THEMEDCOLORTYPE.TCT_Background, Color.FromArgb(&HFF1382CE))
 
-        ActiveLinkColor = ShellUtil.GetDesignerThemeColor(vsUIShell5, environmentThemeCategory, "PanelHyperlinkPressed", __THEMEDCOLORTYPE.TCT_Background, Color.FromArgb(&HFF1382CE))
+        ActiveLinkColor = ShellUtil.GetEnvironmentThemeColor(vsUIShell5, "PanelHyperlinkPressed", __THEMEDCOLORTYPE.TCT_Background, Color.FromArgb(&HFF1382CE))
         LinkColor = _vsThemedLinkColor
         LinkBehavior = LinkBehavior.HoverUnderline
     End Sub


### PR DESCRIPTION
This updates the ApplicationDesigner to support "themed" property pages. This, or something similar, will be required to ensure we meet the accessibility requirements around color contrast ratios.

A relevant comment that was in "PropPageDesignerView" was:
> 'We used to use a lighter color than SystemColors.Control (and we would get it from the color service).
>            '  But that causes issues because a) we can't control disabled control colors, b) we have problems when our
>            '  pages are hosted in another property page frame with different colors (e.g., C++), and c) we have problems
>            '  when hosting a native property page over which we have no color control.
>            'So now we simply use SystemColors.Control all the time (constant on PropPageUserControlBase).
>            'Me.BackColor = GetPropertyPageBackColor(System.Drawing.SystemColors.ControlLight)

The side effect being that hosted controls which are not "themed" will result in the pages being "unviewable" under the dark (or high contrast) themes. I worked around this issue by exposing a new property on `PropPageBase` and `PropPageUserControlBase` called `SupportsTheming`. This property is overridable and defaults to `false`. If the property returns `false`, then we continue with the previous logic (just using `SystemColors.Control`); otherwise, we pull our colors from the theming service.

This results in non-themed controls appearing as follows:
![image](https://cloud.githubusercontent.com/assets/10487869/25961460/3e24b38c-362f-11e7-8933-5b642306f569.png)

A future PR will update our property pages to return `SupportsTheming=True` and to pull the colors from the theming service.

