### PR TITLE
Fix crash caused by project unload while ProjectAssetsFileWatcher.ProjectTree_ChangedAsync is running 

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ILoadedProjectContextServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ILoadedProjectContextServiceFactory.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    internal static class ILoadedProjectContextServiceFactory
+    {
+        public static ILoadedProjectContextService Create(Func<IProjectThreadingService> threadingServiceCreator = null)
+        {
+            var threadingService = threadingServiceCreator == null ? IProjectThreadingServiceFactory.Create() : threadingServiceCreator();
+
+            var loadedProjectService = new Mock<ILoadedProjectContextService>();
+
+            loadedProjectService
+                .Setup(u => u.LoadedProjectAsync(It.IsAny<Func<Task>>()))
+                .Returns((Func<Task> asyncAction) => threadingService.JoinableTaskFactory.RunAsync(asyncAction));
+
+            return loadedProjectService.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/NuGet/ProjectAssetFileWatcherTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/NuGet/ProjectAssetFileWatcherTests.cs
@@ -31,6 +31,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\foo.proj""
                                                      IProjectTreeProviderFactory.Create(),
                                                      IUnconfiguredProjectCommonServicesFactory.Create(unconfiguredProject,
                                                                                                       projectProperties: ProjectPropertiesFactory.Create(unconfiguredProject, new[] { propertyData })),
+                                                     ILoadedProjectContextServiceFactory.Create(),
                                                      IProjectLockServiceFactory.Create());
 
             var tree = ProjectTreeParser.Parse(inputTree);
@@ -87,6 +88,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\foo.proj""
                                                      IProjectTreeProviderFactory.Create(),
                                                      IUnconfiguredProjectCommonServicesFactory.Create(unconfiguredProject,
                                                                                                       projectProperties: ProjectPropertiesFactory.Create(unconfiguredProject, new[] { propertyData })),
+                                                     ILoadedProjectContextServiceFactory.Create(),
                                                      IProjectLockServiceFactory.Create());
             watcher.Load();
 
@@ -117,6 +119,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\foo.proj""
                                                      IProjectTreeProviderFactory.Create(),
                                                      IUnconfiguredProjectCommonServicesFactory.Create(unconfiguredProject,
                                                                                                       projectProperties: ProjectPropertiesFactory.Create(unconfiguredProject, new[] { propertyData })),
+                                                     ILoadedProjectContextServiceFactory.Create(),
                                                      IProjectLockServiceFactory.Create());
 
             var tree = ProjectTreeParser.Parse(@"Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\foo.proj""");

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ILoadedProjectContextService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ILoadedProjectContextService.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    /// <summary>
+    /// Abstraction over IProjectAsynchronousTasksService.LoadedProjectAsync(). 
+    /// This simplifies unit testing of components that use LoadedProjectAsync
+    /// </summary>
+    internal interface ILoadedProjectContextService
+    {
+        /// <summary>
+        /// Provides protection for some operation that the project will not close before 
+        /// the completion of some task.
+        /// </summary>
+        JoinableTask LoadedProjectAsync(Func<Task> action);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LoadedProjectContextService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LoadedProjectContextService.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    /// <summary>
+    /// Abstraction over IProjectAsynchronousTasksService.LoadedProjectAsync(). 
+    /// This simplifies unit testing of components that use LoadedProjectAsync
+    /// </summary>
+    [Export(typeof(ILoadedProjectContextService))]
+    internal class LoadedProjectContextService : ILoadedProjectContextService
+    {
+        private readonly IProjectAsynchronousTasksService _tasksService;
+
+        [ImportingConstructor]
+        public LoadedProjectContextService(
+            [Import(ExportContractNames.Scopes.UnconfiguredProject)]IProjectAsynchronousTasksService tasksService)
+        {
+            _tasksService = tasksService;
+        }
+
+        /// <summary>
+        /// Provides protection for some operation that the project will not close before 
+        /// the completion of some task.
+        /// </summary>
+        public JoinableTask LoadedProjectAsync(Func<Task> action) =>
+            _tasksService.LoadedProjectAsync(action);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
@@ -20,6 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         private readonly IUnconfiguredProjectCommonServices _projectServices;
         private readonly IProjectLockService _projectLockService;
         private readonly IProjectTreeProvider _fileSystemTreeProvider;
+        private readonly ILoadedProjectContextService _loadedProjectService;
         private IVsFileChangeEx _fileChangeService;
         private IDisposable _treeWatcher;
         private uint _filechangeCookie;
@@ -29,16 +30,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         public ProjectAssetFileWatcher([Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider,
                                       [Import(ContractNames.ProjectTreeProviders.FileSystemDirectoryTree)] IProjectTreeProvider fileSystemTreeProvider,
                                       IUnconfiguredProjectCommonServices projectServices,
+                                      ILoadedProjectContextService loadedProjectService,
                                       IProjectLockService projectLockService)
         {
             Requires.NotNull(serviceProvider, nameof(serviceProvider));
             Requires.NotNull(fileSystemTreeProvider, nameof(fileSystemTreeProvider));
             Requires.NotNull(projectServices, nameof(projectServices));
+            Requires.NotNull(loadedProjectService, nameof(loadedProjectService));
             Requires.NotNull(projectLockService, nameof(projectLockService));
 
             _serviceProvider = serviceProvider;
             _fileSystemTreeProvider = fileSystemTreeProvider;
             _projectServices = projectServices;
+            _loadedProjectService = loadedProjectService;
             _projectLockService = projectLockService;
         }
 
@@ -80,7 +84,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
 
             try
             {
-                await _projectServices.Project.Services.ProjectAsynchronousTasks.LoadedProjectAsync(async () =>
+                // Operations to get project lock file access the Project and hence should be guarded
+                // by LoadedProjectAsync to prevent the project from being unloaded
+                await _loadedProjectService.LoadedProjectAsync(async () =>
                 {
                     // NOTE: Project lock file path may be null
                     var projectLockFilePath = await GetProjectLockFilePathAsync(newTree).ConfigureAwait(false);
@@ -184,7 +190,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             {
                 try
                 {
-                    await _projectServices.Project.Services.ProjectAsynchronousTasks.LoadedProjectAsync(async () =>
+                    await _loadedProjectService.LoadedProjectAsync(async () =>
                     {
                         using (var access = await _projectLockService.WriteLockAsync())
                         {


### PR DESCRIPTION
**Customer scenario**

A Watson is reported when project is unloaded while project system is computing the lock file path in response to changes in the project file tree. 

This change wraps these operations in a `LoadedProjectAsync()` context (as was done in an earlier fix #874) because these operations access the Project itself which may be unloaded. 

**Bugs this fixes:** 

Fixes #1768 and [#296591](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/296591)

**Workarounds, if any**

N/A

**Risk**

Low, fix wraps operations in `ProjectTree_ChangedAsync` in a LoadedProjectAsync context as recommended by CPS team, and further wraps that in a Try-Catch.

**Performance impact**

Low

**Is this a regression from a previous update?**

No

**Root cause analysis:**

#874 fixes this in `FilesChanged` but we did not notice that `ProjectTree_ChangedAsync` is also susceptible. However we continued to receive Watsons leading to further investigation and guidance from CPS team.

**How was the bug found?**

Watson, Dogfooding

/cc @dotnet/project-system 
/cc @lifengl