### PR TITLE
Don't use the AlwaysAvailable capability

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/UserFileInterceptedProjectPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/UserFileInterceptedProjectPropertiesProvider.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     [Export("UserFileWithInterception", typeof(IProjectInstancePropertiesProvider))]
     [Export(typeof(IProjectInstancePropertiesProvider))]
     [ExportMetadata("Name", "UserFileWithInterception")]
-    [AppliesTo(ProjectCapability.AlwaysAvailable)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     internal class UserFileInterceptedProjectPropertiesProvider : InterceptedProjectPropertiesProviderBase
     {
         private const string userSuffix = ".user";

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/UserFileWithXamlDefaultsInterceptedProjectPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/UserFileWithXamlDefaultsInterceptedProjectPropertiesProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     [Export("UserFileWithXamlDefaultsWithInterception", typeof(IProjectInstancePropertiesProvider))]
     [Export(typeof(IProjectInstancePropertiesProvider))]
     [ExportMetadata("Name", "UserFileWithXamlDefaultsWithInterception")]
-    [AppliesTo(ProjectCapability.AlwaysAvailable)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     internal sealed class UserFileWithXamlDefaultsInterceptedProjectPropertiesProvider : UserFileInterceptedProjectPropertiesProvider
     {
         [ImportingConstructor]


### PR DESCRIPTION
**Customer scenario**

Using the AlwaysAvailable capability might mean that these components could get loaded in non-C#\VB\F# scenarios. Changing it to be specific to C#\VB\F#

**Bugs this fixes:** 

Fixes https://github.com/dotnet/project-system/issues/1697

**Workarounds, if any**

N\A

**Risk**

None.

**Performance impact**

None 

**Is this a regression from a previous update?**
No

@dotnet/project-system @MattGertz for approval.
