### PR TITLE
Add CSharp and VB Project Configuration Properties for Automation

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Properties/CSharpProjectConfigurationPropertiesTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Properties/CSharpProjectConfigurationPropertiesTests.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
+{
+    [ProjectSystemTrait]
+    public class CSharpProjectConfigurationPropertiesTests
+    {
+        [Fact]
+        public void Constructor_NullAsProjectProperties_ThrowsArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>("projectProperties", () => {
+                new CSharpProjectConfigurationProperties(null, null);
+            });
+        }
+
+        [Fact]
+        public void Constructor_NullAsThreadingService_ThrowsArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>("threadingService", () =>
+            {
+                new CSharpProjectConfigurationProperties(ProjectPropertiesFactory.CreateEmpty(), null);
+            });
+        }
+
+        [Fact]
+        public void CSharpProjectConfigurationProperties_CodeAnalysisRuleSet()
+        {
+            var setValues = new List<object>();
+            var project = UnconfiguredProjectFactory.Create();
+            var data = new PropertyPageData()
+            {
+                Category = ConfiguredBrowseObject.SchemaName,
+                PropertyName = ConfiguredBrowseObject.CodeAnalysisRuleSetProperty,
+                Value = "Blah",
+                SetValues = setValues
+            };
+
+            var projectProperties = ProjectPropertiesFactory.Create(project, data);
+
+            var vsLangProjectProperties = CreateInstance(projectProperties, IProjectThreadingServiceFactory.Create());
+            Assert.Equal(vsLangProjectProperties.CodeAnalysisRuleSet, "Blah");
+
+            var testValue = "Testing";
+            vsLangProjectProperties.CodeAnalysisRuleSet = testValue;
+            Assert.Equal(setValues.Single(), testValue);
+        }
+
+        [Fact]
+        public void CSharpProjectConfigurationProperties_LangVersion()
+        {
+            var setValues = new List<object>();
+            var project = UnconfiguredProjectFactory.Create();
+            var data = new PropertyPageData()
+            {
+                Category = ConfiguredBrowseObject.SchemaName,
+                PropertyName = ConfiguredBrowseObject.LangVersionProperty,
+                Value = "6",
+                SetValues = setValues
+            };
+
+            var projectProperties = ProjectPropertiesFactory.Create(project, data);
+
+            var vsLangProjectProperties = CreateInstance(projectProperties, IProjectThreadingServiceFactory.Create());
+            Assert.Equal(vsLangProjectProperties.LanguageVersion, "6");
+
+            var testValue = "7.1";
+            vsLangProjectProperties.LanguageVersion = testValue;
+            Assert.Equal(setValues.Single(), testValue);
+        }
+
+        private CSharpProjectConfigurationProperties CreateInstance(ProjectProperties projectProperties, IProjectThreadingService projectThreadingService)
+        {
+            return new CSharpProjectConfigurationProperties(projectProperties, projectThreadingService);
+        }
+    }
+}
+

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Properties/CSharpProjectConfigurationProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Properties/CSharpProjectConfigurationProperties.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+using VSLangProj110;
+using VSLangProj80;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
+{
+    [Export(ExportContractNames.VsTypes.ConfiguredProjectPropertiesAutomationObject)]
+    [Order(Order.Default)]
+    [AppliesTo(ProjectCapability.CSharp)]
+    public class CSharpProjectConfigurationProperties : AbstractProjectConfigurationProperties,
+        CSharpProjectConfigurationProperties3,
+        CSharpProjectConfigurationProperties6
+    {
+        [ImportingConstructor]
+        internal CSharpProjectConfigurationProperties(
+            ProjectProperties projectProperties,
+            IProjectThreadingService threadingService)
+            : base(projectProperties, threadingService)
+        {
+        }
+
+        public string ErrorReport { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AbstractProjectConfigurationProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AbstractProjectConfigurationProperties.cs
@@ -1,0 +1,130 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using VSLangProj;
+using VSLangProj80;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
+{
+    public abstract class AbstractProjectConfigurationProperties : ProjectConfigurationProperties3
+    {
+        private readonly ProjectProperties _projectProperties;
+        private readonly IProjectThreadingService _threadingService;
+
+        internal AbstractProjectConfigurationProperties(
+            ProjectProperties projectProperties,
+            IProjectThreadingService threadingService)
+        {
+            Requires.NotNull(projectProperties, nameof(projectProperties));
+            Requires.NotNull(threadingService, nameof(threadingService));
+
+            _projectProperties = projectProperties;
+            _threadingService = threadingService;
+        }
+
+        public string LanguageVersion
+        {
+            get
+            {
+                return _threadingService.ExecuteSynchronously(async () =>
+                {
+                    var browseObjectProperties = await _projectProperties.GetConfiguredBrowseObjectPropertiesAsync().ConfigureAwait(true);
+                    return await browseObjectProperties.LangVersion.GetEvaluatedValueAtEndAsync().ConfigureAwait(true);
+                });
+            }
+
+            set
+            {
+                _threadingService.ExecuteSynchronously(async () =>
+                {
+                    var browseObjectProperties = await _projectProperties.GetConfiguredBrowseObjectPropertiesAsync().ConfigureAwait(true);
+                    await browseObjectProperties.LangVersion.SetValueAsync(value).ConfigureAwait(true);
+                });
+            }
+        }
+
+        public string CodeAnalysisRuleSet
+        {
+            get
+            {
+                return _threadingService.ExecuteSynchronously(async () =>
+                {
+                    var browseObjectProperties = await _projectProperties.GetConfiguredBrowseObjectPropertiesAsync().ConfigureAwait(true);
+                    return await browseObjectProperties.CodeAnalysisRuleSet.GetEvaluatedValueAtEndAsync().ConfigureAwait(true);
+                });
+            }
+
+            set
+            {
+                _threadingService.ExecuteSynchronously(async () =>
+                {
+                    var browseObjectProperties = await _projectProperties.GetConfiguredBrowseObjectPropertiesAsync().ConfigureAwait(true);
+                    await browseObjectProperties.CodeAnalysisRuleSet.SetValueAsync(value).ConfigureAwait(true);
+                });
+            }
+        }
+
+        public object ExtenderNames => null;
+        public string __id => throw new System.NotImplementedException();
+        public bool DebugSymbols { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public bool DefineDebug { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public bool DefineTrace { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public string OutputPath { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public string IntermediatePath { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public string DefineConstants { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public bool RemoveIntegerChecks { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public uint BaseAddress { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public bool AllowUnsafeBlocks { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public bool CheckForOverflowUnderflow { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public string DocumentationFile { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public bool Optimize { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public bool IncrementalBuild { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public string StartProgram { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public string StartWorkingDirectory { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public string StartURL { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public string StartPage { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public string StartArguments { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public bool StartWithIE { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public bool EnableASPDebugging { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public bool EnableASPXDebugging { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public bool EnableUnmanagedDebugging { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public prjStartAction StartAction { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public object get_Extender(string arg)
+        {
+            throw new System.NotImplementedException();
+        }
+        public string ExtenderCATID => throw new System.NotImplementedException();
+        public prjWarningLevel WarningLevel { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public bool TreatWarningsAsErrors { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public bool EnableSQLServerDebugging { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public uint FileAlignment { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public bool RegisterForComInterop { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public string ConfigurationOverrideFile { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public bool RemoteDebugEnabled { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public string RemoteDebugMachine { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public string NoWarn { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public bool NoStdLib { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public string DebugInfo { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public string PlatformTarget { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public string TreatSpecificWarningsAsErrors { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public bool RunCodeAnalysis { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public string CodeAnalysisLogFile { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public string CodeAnalysisRuleAssemblies { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public string CodeAnalysisInputAssembly { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public string CodeAnalysisRules { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public string CodeAnalysisSpellCheckLanguages { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public bool CodeAnalysisUseTypeNameInSuppression { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public string CodeAnalysisModuleSuppressionsFile { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public bool UseVSHostingProcess { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public sgenGenerationOption GenerateSerializationAssemblies { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public bool CodeAnalysisIgnoreGeneratedCode { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public bool CodeAnalysisOverrideRuleVisibilities { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public string CodeAnalysisDictionaries { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public string CodeAnalysisCulture { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public string CodeAnalysisRuleSetDirectories { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public bool CodeAnalysisIgnoreBuiltInRuleSets { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public string CodeAnalysisRuleDirectories { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public bool CodeAnalysisIgnoreBuiltInRules { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public bool CodeAnalysisFailOnMissingRules { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+        public bool Prefer32Bit { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
@@ -119,4 +119,9 @@
     <EnumValue Name="OnBuildSuccess" DisplayName="On successful build"  IsDefault="True"/>
     <EnumValue Name="OnOutputUpdated" DisplayName="When the build updates the project output" />
   </EnumProperty>
+
+  <!-- CSharp Project Configuration Properties-->
+  <StringProperty Name="LangVersion" DisplayName="CSharp Language Version" Visible="False"/>
+  <StringProperty Name="CodeAnalysisRuleSet" DisplayName=" Code Analysis Rule set" Visible="False"/>
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Properties/VisualBasicProjectConfigurationPropertiesTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Properties/VisualBasicProjectConfigurationPropertiesTests.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
+{
+    [ProjectSystemTrait]
+    public class VisualBasicProjectConfigurationPropertiesTests
+    {
+        [Fact]
+        public void Constructor_NullAsProjectProperties_ThrowsArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>("projectProperties", () => {
+                new VisualBasicProjectConfigurationProperties(null, null);
+            });
+        }
+
+        [Fact]
+        public void Constructor_NullAsThreadingService_ThrowsArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>("threadingService", () =>
+            {
+                new VisualBasicProjectConfigurationProperties(ProjectPropertiesFactory.CreateEmpty(), null);
+            });
+        }
+
+        [Fact]
+        public void VisualBasicProjectConfigurationProperties_CodeAnalysisRuleSet()
+        {
+            var setValues = new List<object>();
+            var project = UnconfiguredProjectFactory.Create();
+            var data = new PropertyPageData()
+            {
+                Category = ConfiguredBrowseObject.SchemaName,
+                PropertyName = ConfiguredBrowseObject.CodeAnalysisRuleSetProperty,
+                Value = "Blah",
+                SetValues = setValues
+            };
+
+            var projectProperties = ProjectPropertiesFactory.Create(project, data);
+
+            var vsLangProjectProperties = CreateInstance(projectProperties, IProjectThreadingServiceFactory.Create());
+            Assert.Equal(vsLangProjectProperties.CodeAnalysisRuleSet, "Blah");
+
+            var testValue = "Testing";
+            vsLangProjectProperties.CodeAnalysisRuleSet = testValue;
+            Assert.Equal(setValues.Single(), testValue);
+        }
+
+        [Fact]
+        public void VisualBasicProjectConfigurationProperties_LangVersion()
+        {
+            var setValues = new List<object>();
+            var project = UnconfiguredProjectFactory.Create();
+            var data = new PropertyPageData()
+            {
+                Category = ConfiguredBrowseObject.SchemaName,
+                PropertyName = ConfiguredBrowseObject.LangVersionProperty,
+                Value = "9",
+                SetValues = setValues
+            };
+
+            var projectProperties = ProjectPropertiesFactory.Create(project, data);
+
+            var vsLangProjectProperties = CreateInstance(projectProperties, IProjectThreadingServiceFactory.Create());
+            Assert.Equal(vsLangProjectProperties.LanguageVersion, "9");
+
+            var testValue = "10";
+            vsLangProjectProperties.LanguageVersion = testValue;
+            Assert.Equal(setValues.Single(), testValue);
+        }
+
+        private VisualBasicProjectConfigurationProperties CreateInstance(ProjectProperties projectProperties, IProjectThreadingService projectThreadingService)
+        {
+            return new VisualBasicProjectConfigurationProperties(projectProperties, projectThreadingService);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Properties/VisualBasicProjectConfigurationProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Properties/VisualBasicProjectConfigurationProperties.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+using VSLangProj110;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
+{
+    [Export(ExportContractNames.VsTypes.ConfiguredProjectPropertiesAutomationObject)]
+    [Order(Order.Default)]
+    [AppliesTo(ProjectCapability.VisualBasic)]
+    public class VisualBasicProjectConfigurationProperties : AbstractProjectConfigurationProperties,
+        VBProjectConfigurationProperties6
+    {
+        [ImportingConstructor]
+        internal VisualBasicProjectConfigurationProperties(
+            ProjectProperties projectProperties,
+            IProjectThreadingService threadingService)
+            : base(projectProperties, threadingService)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Tagging @srivatsn @tmeschter @davkean @dotnet/project-system for review

**Customer scenario**

Add CSharp and VB Project Configuration Properties. These are the Project Configuration Properties which backs the Automation Objects obtained through DTE. We need this change to support 2 scenarios(As of now, we have 2. There will be more.)

1. Enable Codefixer to change the Language Version of a C# version to newer version = #2137 
2. Enable changing the severity of an analyzer rule from the Analyzer Node - #2114 

**Bugs this fixes:** 

Fixes #2137 Fixes #2114 Fixes #1919 

**Workarounds, if any**

None

**Risk**

Low - we are enabling a feature which did not work previously.

**Performance impact**

Low - since the new code does not deal with allocations or any of the known hot paths

**Is this a regression from a previous update?**

**Root cause analysis:**

This is a parity work to bring the new project system on par with the old project system and support back compat

**How was the bug found?**

Ad hoc testing