### PR TITLE
Use ShouldSignBuild instead of RunningInMicroBuild

### DIFF
--- a/build/Targets/GenerateAssemblyInfo.targets
+++ b/build/Targets/GenerateAssemblyInfo.targets
@@ -1,6 +1,6 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Choose>
-    <When Condition="'$(RunningInMicroBuild)' != 'true'">
+    <When Condition="'$(ShouldSignBuild)' != 'true'">
       <!-- On non-official builds we don't burn in a git sha.  In large part because it 
            hurts our determinism efforts as binaries which should be the same between
            builds will not (due to developers building against different HEAD 


### PR DESCRIPTION
@srivatsn @davkean @dotnet/project-system for review

**Customer scenario**
![image](https://cloud.githubusercontent.com/assets/10550513/26082548/6be98690-3985-11e7-92cf-88a5ee648113.png)

In the image above, we should see the commit ID in the Product version field.

**Risk**

Low, since this does not affect the production code

**Performance impact**

None - This is infra change

**Is this a regression from a previous update?**

**How was the bug found?**

Ad-hoc