### PR TITLE
[LanguageService] Stop boxing ImmutableArray<T> in BuildOptions

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp/ProjectSystem/LanguageServices/CSharpParseBuildOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp/ProjectSystem/LanguageServices/CSharpParseBuildOptions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     {
         public BuildOptions Parse(IEnumerable<string> args, string baseDirectory)
         {
-            return BuildOptions.FromCommonCommandLineArguments(
+            return BuildOptions.FromCommandLineArguments(
                 CSharpCommandLineParser.Default.Parse(args, baseDirectory, sdkDirectory: null, additionalReferenceDirectories: null));
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp/ProjectSystem/LanguageServices/FSharpParseBuildOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp/ProjectSystem/LanguageServices/FSharpParseBuildOptions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         public BuildOptions Parse(IEnumerable<string> args, string baseDirectory)
         {
             // TODO: replace with F# command line parser
-            return BuildOptions.FromCommonCommandLineArguments(
+            return BuildOptions.FromCommandLineArguments(
                 CSharpCommandLineParser.Default.Parse(args, baseDirectory, sdkDirectory: null, additionalReferenceDirectories: null));
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandlerTests.cs
@@ -28,8 +28,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             var handler = new MetadataReferenceItemHandler(project);
             var projectDir = Path.GetDirectoryName(project.FullPath);
-            var added = BuildOptions.FromCommonCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"/reference:C:\Assembly1.dll", @"/reference:C:\Assembly2.dll", @"/reference:C:\Assembly1.dll" }, baseDirectory: projectDir, sdkDirectory: null));
-            var empty = BuildOptions.FromCommonCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null));
+            var added = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"/reference:C:\Assembly1.dll", @"/reference:C:\Assembly2.dll", @"/reference:C:\Assembly1.dll" }, baseDirectory: projectDir, sdkDirectory: null));
+            var empty = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null));
 
             handler.Handle(added: added, removed: empty, context: context, isActiveContext: true);
 
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Assert.Contains(@"C:\Assembly1.dll", referencesPushedToWorkspace);
             Assert.Contains(@"C:\Assembly2.dll", referencesPushedToWorkspace);
 
-            var removed = BuildOptions.FromCommonCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"/reference:C:\Assembly1.dll", @"/reference:C:\Assembly1.dll" }, baseDirectory: projectDir, sdkDirectory: null));
+            var removed = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"/reference:C:\Assembly1.dll", @"/reference:C:\Assembly1.dll" }, baseDirectory: projectDir, sdkDirectory: null));
             handler.Handle(added: empty, removed: removed, context: context, isActiveContext: true);
 
             Assert.Equal(1, referencesPushedToWorkspace.Count);
@@ -56,8 +56,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             var handler = new MetadataReferenceItemHandler(project);
             var projectDir = Path.GetDirectoryName(project.FullPath);
-            var added = BuildOptions.FromCommonCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"/reference:Assembly1.dll", @"/reference:C:\ProjectFolder\Assembly2.dll", @"/reference:..\ProjectFolder\Assembly3.dll" }, baseDirectory: projectDir, sdkDirectory: null));
-            var removed = BuildOptions.FromCommonCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null));
+            var added = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"/reference:Assembly1.dll", @"/reference:C:\ProjectFolder\Assembly2.dll", @"/reference:..\ProjectFolder\Assembly3.dll" }, baseDirectory: projectDir, sdkDirectory: null));
+            var removed = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null));
 
             handler.Handle(added: added, removed: removed, context: context, isActiveContext: true);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemHandlerTests.cs
@@ -64,8 +64,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             var handler = new SourceItemHandler(project);
             var projectDir = Path.GetDirectoryName(project.FullPath);
-            var added = BuildOptions.FromCommonCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"C:\file1.cs", @"C:\file2.cs", @"C:\file1.cs" }, baseDirectory: projectDir, sdkDirectory: null));
-            var empty = BuildOptions.FromCommonCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null));
+            var added = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"C:\file1.cs", @"C:\file2.cs", @"C:\file1.cs" }, baseDirectory: projectDir, sdkDirectory: null));
+            var empty = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null));
 
             handler.Handle(added: added, removed: empty, context: context, isActiveContext: true);
 
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Assert.Contains(@"C:\file1.cs", sourceFilesPushedToWorkspace);
             Assert.Contains(@"C:\file2.cs", sourceFilesPushedToWorkspace);
 
-            var removed = BuildOptions.FromCommonCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"C:\file1.cs", @"C:\file1.cs" }, baseDirectory: projectDir, sdkDirectory: null));
+            var removed = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"C:\file1.cs", @"C:\file1.cs" }, baseDirectory: projectDir, sdkDirectory: null));
             handler.Handle(added: empty, removed: removed, context: context, isActiveContext: true);
 
             Assert.Equal(1, sourceFilesPushedToWorkspace.Count);
@@ -92,8 +92,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             var handler = new SourceItemHandler(project);
             var projectDir = Path.GetDirectoryName(project.FullPath);
-            var added = BuildOptions.FromCommonCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"file1.cs", @"..\ProjectFolder\file1.cs" }, baseDirectory: projectDir, sdkDirectory: null));
-            var removed = BuildOptions.FromCommonCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null));
+            var added = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"file1.cs", @"..\ProjectFolder\file1.cs" }, baseDirectory: projectDir, sdkDirectory: null));
+            var removed = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null));
 
             handler.Handle(added: added, removed: removed, context: context, isActiveContext: true);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/BuildOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/BuildOptions.cs
@@ -7,11 +7,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
     internal class BuildOptions
     {
-        public IEnumerable<CommandLineSourceFile> SourceFiles { get; }
-        public IEnumerable<CommandLineSourceFile> AdditionalFiles { get; }
-        public IEnumerable<CommandLineReference> MetadataReferences { get; }
-        public IEnumerable<CommandLineAnalyzerReference> AnalyzerReferences { get; }
-
         public BuildOptions(IEnumerable<CommandLineSourceFile> sourceFiles, IEnumerable<CommandLineSourceFile> additionalFiles, IEnumerable<CommandLineReference> metadataReferences, IEnumerable<CommandLineAnalyzerReference> analyzerReferences)
         {
             Requires.NotNull(sourceFiles, nameof(sourceFiles));
@@ -23,6 +18,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             AdditionalFiles = additionalFiles;
             MetadataReferences = metadataReferences;
             AnalyzerReferences = analyzerReferences;
+        }
+
+        public IEnumerable<CommandLineSourceFile> SourceFiles
+        {
+            get;
+        }
+
+        public IEnumerable<CommandLineSourceFile> AdditionalFiles
+        {
+            get;
+        }
+
+        public IEnumerable<CommandLineReference> MetadataReferences
+        {
+            get;
+        }
+
+        public IEnumerable<CommandLineAnalyzerReference> AnalyzerReferences
+        {
+            get;
         }
 
         public static BuildOptions FromCommonCommandLineArguments(CommandLineArguments commonCommandLineArguments)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/BuildOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/BuildOptions.cs
@@ -1,41 +1,36 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
+using System.Collections.Immutable;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
     internal class BuildOptions
     {
-        public BuildOptions(IEnumerable<CommandLineSourceFile> sourceFiles, IEnumerable<CommandLineSourceFile> additionalFiles, IEnumerable<CommandLineReference> metadataReferences, IEnumerable<CommandLineAnalyzerReference> analyzerReferences)
+        public BuildOptions(ImmutableArray<CommandLineSourceFile> sourceFiles, ImmutableArray<CommandLineSourceFile> additionalFiles, ImmutableArray<CommandLineReference> metadataReferences, ImmutableArray<CommandLineAnalyzerReference> analyzerReferences)
         {
-            Requires.NotNull(sourceFiles, nameof(sourceFiles));
-            Requires.NotNull(additionalFiles, nameof(additionalFiles));
-            Requires.NotNull(metadataReferences, nameof(metadataReferences));
-            Requires.NotNull(analyzerReferences, nameof(analyzerReferences));
-
             SourceFiles = sourceFiles;
             AdditionalFiles = additionalFiles;
             MetadataReferences = metadataReferences;
             AnalyzerReferences = analyzerReferences;
         }
 
-        public IEnumerable<CommandLineSourceFile> SourceFiles
+        public ImmutableArray<CommandLineSourceFile> SourceFiles
         {
             get;
         }
 
-        public IEnumerable<CommandLineSourceFile> AdditionalFiles
+        public ImmutableArray<CommandLineSourceFile> AdditionalFiles
         {
             get;
         }
 
-        public IEnumerable<CommandLineReference> MetadataReferences
+        public ImmutableArray<CommandLineReference> MetadataReferences
         {
             get;
         }
 
-        public IEnumerable<CommandLineAnalyzerReference> AnalyzerReferences
+        public ImmutableArray<CommandLineAnalyzerReference> AnalyzerReferences
         {
             get;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/BuildOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/BuildOptions.cs
@@ -35,15 +35,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             get;
         }
 
-        public static BuildOptions FromCommonCommandLineArguments(CommandLineArguments commonCommandLineArguments)
+        public static BuildOptions FromCommandLineArguments(CommandLineArguments commandLineArguments)
         {
-            Requires.NotNull(commonCommandLineArguments, nameof(commonCommandLineArguments));
+            Requires.NotNull(commandLineArguments, nameof(commandLineArguments));
 
             return new BuildOptions(
-                commonCommandLineArguments.SourceFiles,
-                commonCommandLineArguments.AdditionalFiles,
-                commonCommandLineArguments.MetadataReferences,
-                commonCommandLineArguments.AnalyzerReferences);
+                commandLineArguments.SourceFiles,
+                commandLineArguments.AdditionalFiles,
+                commandLineArguments.MetadataReferences,
+                commandLineArguments.AnalyzerReferences);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic/ProjectSystem/LanguageServices/VisualBasicParseBuildOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic/ProjectSystem/LanguageServices/VisualBasicParseBuildOptions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     {
         public BuildOptions Parse(IEnumerable<string> args, string baseDirectory)
         {
-            return BuildOptions.FromCommonCommandLineArguments(
+            return BuildOptions.FromCommandLineArguments(
                 VisualBasicCommandLineParser.Default.Parse(args, baseDirectory, sdkDirectory: null, additionalReferenceDirectories: null));
         }
     }


### PR DESCRIPTION
- Move properties below constructor
- Replace IEnumerable<T> -> ImmutableArray<T>
   - We were boxing the ImmutableArray<T> unnecessarily.
- Remove "Common" from BuildOptions
   - This was left over the original review.
