### PR TITLE
[LanguageService] Move logic for updating "handlers" into a separate component

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemHandlerTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             var context = IProjectChangeDescriptionFactory.Create();
 
             Assert.Throws<ArgumentNullException>("context", () => {
-                handler.OnContextReleasedAsync((IWorkspaceProjectContext)null);
+                handler.OnContextReleased((IWorkspaceProjectContext)null);
             });
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractLanguageServiceRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractLanguageServiceRuleHandler.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
@@ -17,9 +16,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         {
         }
 
-        public virtual Task OnContextReleasedAsync(IWorkspaceProjectContext context)
+        public virtual void OnContextReleasedAsync(IWorkspaceProjectContext context)
         {
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractLanguageServiceRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractLanguageServiceRuleHandler.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
-    internal abstract class AbstractLanguageServiceRuleHandler : ILanguageServiceRuleHandler
+    internal abstract class AbstractLanguageServiceRuleHandler : IEvaluationHandler
     {
         public abstract RuleHandlerType HandlerType { get; }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractLanguageServiceRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractLanguageServiceRuleHandler.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         {
         }
 
-        public virtual void OnContextReleasedAsync(IWorkspaceProjectContext context)
+        public virtual void OnContextReleased(IWorkspaceProjectContext context)
         {
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractLanguageServiceRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractLanguageServiceRuleHandler.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     {
         public abstract RuleHandlerType HandlerType { get; }
 
-        public abstract string RuleName { get; }
+        public abstract string EvaluationRuleName { get; }
 
         public virtual bool ReceiveUpdatesWithEmptyProjectChange => false;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
@@ -9,9 +9,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     /// <summary>
     ///     Handles changes to the  &lt;AdditionalFiles/&gt; item during design-time builds.
     /// </summary>
-    [Export(typeof(ILanguageServiceCommandLineHandler))]
+    [Export(typeof(ICommandLineHandler))]
     [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharpLanguageService)]
-    internal class AdditionalFilesItemHandler : ILanguageServiceCommandLineHandler
+    internal class AdditionalFilesItemHandler : ICommandLineHandler
     {
         [ImportingConstructor]
         public AdditionalFilesItemHandler(UnconfiguredProject project)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
@@ -9,9 +9,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     /// <summary>
     ///     Handles changes to the  &lt;Analyzer/&gt; item during design-time builds.
     /// </summary>
-    [Export(typeof(ILanguageServiceCommandLineHandler))]
+    [Export(typeof(ICommandLineHandler))]
     [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharpLanguageService)]
-    internal class AnalyzerItemHandler : ILanguageServiceCommandLineHandler
+    internal class AnalyzerItemHandler : ICommandLineHandler
     {
         [ImportingConstructor]
         public AnalyzerItemHandler(UnconfiguredProject project)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandler.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     /// <summary>
     ///     Handles changes to the command-line arguments that are passed to the compiler during design-time builds.
     /// </summary>
-    [Export(typeof(ILanguageServiceRuleHandler))]
+    [Export(typeof(IEvaluationHandler))]
     [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharpLanguageService)]
     internal class CommandLineItemHandler : AbstractLanguageServiceRuleHandler
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandler.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             get;
         }
 
-        public override string RuleName
+        public override string EvaluationRuleName
         {
             get { return CompilerCommandLineArgs.SchemaName; }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineItemHandler.cs
@@ -21,11 +21,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Requires.NotNull(commandLineParser, nameof(commandLineParser));
 
             _commandLineParser = commandLineParser;
-            Handlers = new OrderPrecedenceImportCollection<ILanguageServiceCommandLineHandler>(projectCapabilityCheckProvider: project);
+            Handlers = new OrderPrecedenceImportCollection<ICommandLineHandler>(projectCapabilityCheckProvider: project);
         }
 
         [ImportMany]
-        public OrderPrecedenceImportCollection<ILanguageServiceCommandLineHandler> Handlers
+        public OrderPrecedenceImportCollection<ICommandLineHandler> Handlers
         {
             get;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
@@ -9,9 +9,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     /// <summary>
     ///     Handles changes to references that are passed to the compiler during design-time builds.
     /// </summary>
-    [Export(typeof(ILanguageServiceCommandLineHandler))]
+    [Export(typeof(ICommandLineHandler))]
     [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharpLanguageService)]
-    internal class MetadataReferenceItemHandler : ILanguageServiceCommandLineHandler
+    internal class MetadataReferenceItemHandler : ICommandLineHandler
     {
         private readonly UnconfiguredProject _unconfiguredProject;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             get { return RuleHandlerType.Evaluation; }
         }
 
-        public override string RuleName
+        public override string EvaluationRuleName
         {
             get { return ConfigurationGeneral.SchemaName; }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     /// <summary>
     ///     Handles changes to the project and makes sure the language service is aware of them.
     /// </summary>
-    [Export(typeof(ILanguageServiceRuleHandler))]
+    [Export(typeof(IEvaluationHandler))]
     [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharpLanguageService)]
     internal class ProjectPropertiesItemHandler : AbstractLanguageServiceRuleHandler
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     ///     to the compiler during design-time builds.
     /// </summary>
     [Export(typeof(ILanguageServiceCommandLineHandler))]
-    [Export(typeof(ILanguageServiceRuleHandler))]
+    [Export(typeof(IEvaluationHandler))]
     [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharpLanguageService)]
     internal class SourceItemHandler : AbstractLanguageServiceRuleHandler, ILanguageServiceCommandLineHandler
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -13,10 +13,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     ///     Handles changes to sources files during project evaluations and changes to source files that are passed
     ///     to the compiler during design-time builds.
     /// </summary>
-    [Export(typeof(ILanguageServiceCommandLineHandler))]
+    [Export(typeof(ICommandLineHandler))]
     [Export(typeof(IEvaluationHandler))]
     [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharpLanguageService)]
-    internal class SourceItemHandler : AbstractLanguageServiceRuleHandler, ILanguageServiceCommandLineHandler
+    internal class SourceItemHandler : AbstractLanguageServiceRuleHandler, ICommandLineHandler
     {
         // When a source file has been added/removed from a project, we'll receive notifications for it twice; once
         // during project evaluation, and once during a design-time build. To prevent us from adding duplicate items 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -3,7 +3,6 @@
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.IO;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 
@@ -96,12 +95,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             }
         }
 
-        public override Task OnContextReleasedAsync(IWorkspaceProjectContext context)
+        public override void OnContextReleasedAsync(IWorkspaceProjectContext context)
         {
             Requires.NotNull(context, nameof(context));
 
             _sourceFilesByContext.Remove(context);
-            return Task.CompletedTask;
         }
 
         private void RemoveSourceFile(string filePath, IWorkspaceProjectContext context)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             }
         }
 
-        public override void OnContextReleasedAsync(IWorkspaceProjectContext context)
+        public override void OnContextReleased(IWorkspaceProjectContext context)
         {
             Requires.NotNull(context, nameof(context));
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             _project = project;
         }
 
-        public override string RuleName
+        public override string EvaluationRuleName
         {
             get { return Compile.SchemaName; }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ICommandLineHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ICommandLineHandler.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     ///     Handles changes within the command-line, and applies them to a <see cref="IWorkspaceProjectContext"/> 
     ///     instance.
     /// </summary>
-    internal interface ILanguageServiceCommandLineHandler
+    internal interface ICommandLineHandler
     {
         /// <summary>
         ///     Handles the specified added and removed command-line arguments, and applies 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IEvaluationHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IEvaluationHandler.cs
@@ -13,13 +13,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     internal interface IEvaluationHandler
     {
         /// <summary>
-        ///     Gets the rule this handler handles.
+        ///     Gets the evaluation rule this handler handles.
         /// </summary>
         /// <value>
-        ///     A <see cref="string"/> containing the rule that this <see cref="IEvaluationHandler"/> 
+        ///     A <see cref="string"/> containing the evaluation rule that this <see cref="IEvaluationHandler"/> 
         ///     handles.
         /// </value>
-        string RuleName
+        string EvaluationRuleName
         {
             get;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IEvaluationHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IEvaluationHandler.cs
@@ -68,6 +68,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         /// <param name="context">
         ///     A <see cref="IWorkspaceProjectContext"/> being released.
         /// </param>
-        void OnContextReleasedAsync(IWorkspaceProjectContext context);
+        void OnContextReleased(IWorkspaceProjectContext context);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IEvaluationHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IEvaluationHandler.cs
@@ -2,7 +2,6 @@
 
 using System;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
-using System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
@@ -69,6 +68,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         /// <param name="context">
         ///     A <see cref="IWorkspaceProjectContext"/> being released.
         /// </param>
-        Task OnContextReleasedAsync(IWorkspaceProjectContext context);
+        void OnContextReleasedAsync(IWorkspaceProjectContext context);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IEvaluationHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IEvaluationHandler.cs
@@ -10,13 +10,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     ///     Handles changes to a language service rule,  and applies them to a 
     ///     <see cref="IWorkspaceProjectContext"/> instance.
     /// </summary>
-    internal interface ILanguageServiceRuleHandler
+    internal interface IEvaluationHandler
     {
         /// <summary>
         ///     Gets the rule this handler handles.
         /// </summary>
         /// <value>
-        ///     A <see cref="string"/> containing the rule that this <see cref="ILanguageServiceRuleHandler"/> 
+        ///     A <see cref="string"/> containing the rule that this <see cref="IEvaluationHandler"/> 
         ///     handles.
         /// </value>
         string RuleName
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         /// </summary>
         /// <value>
         ///     One of the <see cref="RuleHandlerType"/> values indicate the type of change the 
-        ///     <see cref="ILanguageServiceRuleHandler"/> handles.
+        ///     <see cref="IEvaluationHandler"/> handles.
         /// </value>
         RuleHandlerType HandlerType
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHandlerManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHandlerManager.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
+{
+    [Export]
+    internal class LanguageServiceHandlerManager
+    {
+        [ImportingConstructor]
+        public LanguageServiceHandlerManager(UnconfiguredProject project)
+        {
+            Requires.NotNull(project, nameof(project));
+
+            Handlers = new OrderPrecedenceImportCollection<IEvaluationHandler>(projectCapabilityCheckProvider: project);
+        }
+
+        [ImportMany]
+        public OrderPrecedenceImportCollection<IEvaluationHandler> Handlers
+        {
+            get;
+        }
+
+        public void Handle(IProjectVersionedValue<IProjectSubscriptionUpdate> update, RuleHandlerType handlerType, IWorkspaceProjectContext context, bool isActiveContext)
+        {
+            Requires.NotNull(update, nameof(update));
+
+            var handlers = Handlers.Select(h => h.Value)
+                                   .Where(h => h.HandlerType == handlerType);
+
+            foreach (var handler in handlers)
+            {
+                IProjectChangeDescription projectChange = update.Value.ProjectChanges[handler.EvaluationRuleName];
+                if (handler.ReceiveUpdatesWithEmptyProjectChange || projectChange.Difference.AnyChanges)
+                {
+                    handler.Handle(projectChange, context, isActiveContext);
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Handles clearing any state specific to the given context being released.
+        /// </summary>
+        /// <param name="context">
+        ///     A <see cref="IWorkspaceProjectContext"/> being released.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="context"/> is <see langword="null"/>.
+        /// </exception>
+        public async Task OnContextReleasedAsync(IWorkspaceProjectContext context)
+        {
+            Requires.NotNull(context, nameof(context));
+
+            foreach (var handler in Handlers)
+            {
+                await handler.Value.OnContextReleasedAsync(context)
+                                   .ConfigureAwait(false);
+            }
+        }
+
+        public IEnumerable<string> GetWatchedRules(RuleHandlerType handlerType)
+        {
+            return Handlers.Where(h => h.Value.HandlerType == handlerType)
+                           .Select(h => h.Value.EvaluationRuleName)
+                           .Distinct(StringComparers.RuleNames)
+                           .ToArray();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHandlerManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHandlerManager.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
@@ -52,14 +51,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         /// <exception cref="ArgumentNullException">
         ///     <paramref name="context"/> is <see langword="null"/>.
         /// </exception>
-        public async Task OnContextReleasedAsync(IWorkspaceProjectContext context)
+        public void OnContextReleasedAsync(IWorkspaceProjectContext context)
         {
             Requires.NotNull(context, nameof(context));
 
             foreach (var handler in Handlers)
             {
-                await handler.Value.OnContextReleasedAsync(context)
-                                   .ConfigureAwait(false);
+                handler.Value.OnContextReleasedAsync(context);
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHandlerManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHandlerManager.cs
@@ -51,13 +51,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         /// <exception cref="ArgumentNullException">
         ///     <paramref name="context"/> is <see langword="null"/>.
         /// </exception>
-        public void OnContextReleasedAsync(IWorkspaceProjectContext context)
+        public void OnContextReleased(IWorkspaceProjectContext context)
         {
             Requires.NotNull(context, nameof(context));
 
             foreach (var handler in Handlers)
             {
-                handler.Value.OnContextReleasedAsync(context);
+                handler.Value.OnContextReleased(context);
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -234,8 +234,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             foreach (var innerContext in projectContext.DisposedInnerProjectContexts)
             {
-                await _languageServiceHandlerManager.OnContextReleasedAsync(innerContext)
-                                                    .ConfigureAwait(false);
+                _languageServiceHandlerManager.OnContextReleasedAsync(innerContext);
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -309,7 +309,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
                 foreach (var handler in handlers)
                 {
-                    IProjectChangeDescription projectChange = update.Value.ProjectChanges[handler.RuleName];
+                    IProjectChangeDescription projectChange = update.Value.ProjectChanges[handler.EvaluationRuleName];
                     if (handler.ReceiveUpdatesWithEmptyProjectChange || projectChange.Difference.AnyChanges)
                     {
                         handler.Handle(projectChange, projectContextToUpdate, isActiveContext);
@@ -321,7 +321,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         private IEnumerable<string> GetWatchedRules(RuleHandlerType handlerType)
         {
             return Handlers.Where(h => h.Value.HandlerType == handlerType)
-                           .Select(h => h.Value.RuleName)
+                           .Select(h => h.Value.EvaluationRuleName)
                            .Distinct(StringComparers.RuleNames)
                            .ToArray();
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             _activeConfiguredProjectSubscriptionService = activeConfiguredProjectSubscriptionService;
             _activeProjectConfigurationRefreshService = activeProjectConfigurationRefreshService;
 
-            Handlers = new OrderPrecedenceImportCollection<ILanguageServiceRuleHandler>(projectCapabilityCheckProvider: commonServices.Project);
+            Handlers = new OrderPrecedenceImportCollection<IEvaluationHandler>(projectCapabilityCheckProvider: commonServices.Project);
             _evaluationSubscriptionLinks = new List<IDisposable>();
             _designTimeBuildSubscriptionLinks = new List<IDisposable>();
             _projectConfigurationsWithSubscriptions = new HashSet<ProjectConfiguration>();
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         public object HostSpecificEditAndContinueService => _currentAggregateProjectContext?.ENCProjectConfig;
 
         [ImportMany]
-        public OrderPrecedenceImportCollection<ILanguageServiceRuleHandler> Handlers
+        public OrderPrecedenceImportCollection<IEvaluationHandler> Handlers
         {
             get;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -234,7 +234,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             foreach (var innerContext in projectContext.DisposedInnerProjectContexts)
             {
-                _languageServiceHandlerManager.OnContextReleasedAsync(innerContext);
+                _languageServiceHandlerManager.OnContextReleased(innerContext);
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/RuleHandlerType.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/RuleHandlerType.cs
@@ -6,13 +6,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     internal enum RuleHandlerType
     {
         /// <summary>
-        ///     The <see cref="ILanguageServiceRuleHandler"/> handles changes 
+        ///     The <see cref="IEvaluationHandler"/> handles changes 
         ///     to evaluation rules.
         /// </summary>
         Evaluation,
 
         /// <summary>
-        ///     The <see cref="ILanguageServiceRuleHandler"/> handles changes 
+        ///     The <see cref="IEvaluationHandler"/> handles changes 
         ///     to design-time build rules.
         /// </summary>
         DesignTimeBuild,


### PR DESCRIPTION
Moved the logic for updating language service handlers into separate component.

A future PR will move from each handler handling *all* contexts, to handling a single context.

Note: This change includes the handler renames - they make much more sense in a future PR where the command-line handling is merged into this new LanguageServiceHandlerManager component.