### PR TITLE
simple F# command line parser

### DIFF
--- a/build/Targets/References.targets
+++ b/build/Targets/References.targets
@@ -66,11 +66,11 @@
 
         <!-- NuGet Dependencies -->
         <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
-        <PackageReference Include="System.Reflection.Metadata" Version="1.4.1-beta-24430-01" />
+        <PackageReference Include="System.Reflection.Metadata" Version="1.4.2" />
         <PackageReference Include="System.ValueTuple" Version="4.3.0" />
         <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
         <PackageReference Include="Newtonsoft.Json" Version="8.0.3" />
-        <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="2.0.0-rc2" />
+        <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="2.3.0-beta1-61703-10" />
         <PackageReference Include="Microsoft.Build" Version="15.1.0-preview-000516-03" />
         <PackageReference Include="Microsoft.Build.Framework" Version="15.1.0-preview-000516-03" />
         <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.0-preview-000516-03" />

--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -4,6 +4,7 @@
 <configuration>
   <packageSources>
     <clear />
+    <add key="myget.org roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
     <add key="myget.org dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="myget.org roslyn-master-nightly" value="https://dotnet.myget.org/F/roslyn-master-nightly/api/v3/index.json" />
     <add key="myget.org msbuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />


### PR DESCRIPTION
This enables simple F# command line parsing.  There are only 4 different things that can be parsed which makes this parser very small:

1.  Metadata references.  For fsc.exe these all start with `-r:` or `--reference:`.
2.  Analyzer references.  F# doesn't support these so it's always an empty collection.
3.  Source files.  Non-option arguments (e.g., no leading `-`) that end in `.fs`, `.fsi`, etc.
4.  Additional files.  F# doesn't support these so it's always an empty collection.

This required updating the Roslyn references to bring in the newly exposed constructors in `CommandLineSourceFile` and `CommandLineReference`.

@KevinRansom @davkean @srivatsn 

Edit: I've verified these changes locally along with dotnet/roslyn#19566.