### PR TITLE
Dont mix dataflow and querying live project in the ProjectAssetsFileWatcher

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectValueDataSourceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectValueDataSourceFactory.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading.Tasks.Dataflow;
 using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem
@@ -8,7 +9,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
     {
         public static IProjectValueDataSource<T> CreateInstance<T>()
         {
-            return Mock.Of<IProjectValueDataSource<T>>();
+            var mock = new Mock<IProjectValueDataSource<T>>();
+            mock.SetupGet(m => m.SourceBlock).Returns(Mock.Of<IReceivableSourceBlock<IProjectVersionedValue<T>>>());
+            return mock.Object;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
@@ -4,10 +4,9 @@ using System;
 using System.ComponentModel.Composition;
 using System.IO;
 using System.Threading.Tasks.Dataflow;
-using Microsoft.VisualStudio.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
-using TPL = System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
 {
@@ -19,6 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         private readonly IServiceProvider _serviceProvider;
         private readonly IUnconfiguredProjectCommonServices _projectServices;
         private readonly IProjectLockService _projectLockService;
+        private readonly IActiveConfiguredProjectSubscriptionService _activeConfiguredProjectSubscriptionService;
         private readonly IProjectTreeProvider _fileSystemTreeProvider;
         private IVsFileChangeEx _fileChangeService;
         private IDisposable _treeWatcher;
@@ -29,17 +29,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         public ProjectAssetFileWatcher([Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider,
                                       [Import(ContractNames.ProjectTreeProviders.FileSystemDirectoryTree)] IProjectTreeProvider fileSystemTreeProvider,
                                       IUnconfiguredProjectCommonServices projectServices,
-                                      IProjectLockService projectLockService)
+                                      IProjectLockService projectLockService,
+                                      IActiveConfiguredProjectSubscriptionService activeConfiguredProjectSubscriptionService)
         {
             Requires.NotNull(serviceProvider, nameof(serviceProvider));
             Requires.NotNull(fileSystemTreeProvider, nameof(fileSystemTreeProvider));
             Requires.NotNull(projectServices, nameof(projectServices));
             Requires.NotNull(projectLockService, nameof(projectLockService));
+            Requires.NotNull(activeConfiguredProjectSubscriptionService, nameof(activeConfiguredProjectSubscriptionService));
 
             _serviceProvider = serviceProvider;
             _fileSystemTreeProvider = fileSystemTreeProvider;
             _projectServices = projectServices;
             _projectLockService = projectLockService;
+            _activeConfiguredProjectSubscriptionService = activeConfiguredProjectSubscriptionService;
         }
 
         /// <summary>
@@ -58,15 +61,30 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         protected override void Initialize()
         {
             _fileChangeService = _serviceProvider.GetService<IVsFileChangeEx, SVsFileChangeEx>();
-            _treeWatcher = _fileSystemTreeProvider.Tree.LinkTo(new ActionBlock<IProjectVersionedValue<IProjectTreeSnapshot>>(new Action<IProjectVersionedValue<IProjectTreeSnapshot>>(ProjectTree_ChangedAsync)));
+
+            // The tree source to get changes to the tree so that we can identify when the assets file changes.
+            var treeSource = _fileSystemTreeProvider.Tree.SyncLinkOptions();
+
+            // The property source used to get the value of the $ProjectAssetsFile property so that we can identify the location of the assets file.
+            var sourceLinkOptions = new StandardRuleDataflowLinkOptions
+            {
+                RuleNames = Empty.OrdinalIgnoreCaseStringSet.Add(ConfigurationGeneral.SchemaName),
+                PropagateCompletion = true
+            };
+            var propertySource = _activeConfiguredProjectSubscriptionService.ProjectRuleSource.SourceBlock.SyncLinkOptions(sourceLinkOptions);
+            var target = new ActionBlock<IProjectVersionedValue<Tuple<IProjectTreeSnapshot, IProjectSubscriptionUpdate>>>(new Action<IProjectVersionedValue<Tuple<IProjectTreeSnapshot, IProjectSubscriptionUpdate>>>(DataFlow_Changed));
+
+            // Join the two sources so that we get synchronized versions of the data.
+            _treeWatcher = ProjectDataSources.SyncLinkTo(treeSource, propertySource, target);
         }
 
         /// <summary>
         /// Called on changes to the project tree.
         /// </summary>
-        internal async void ProjectTree_ChangedAsync(IProjectVersionedValue<IProjectTreeSnapshot> treeSnapshot)
+        internal void DataFlow_Changed(IProjectVersionedValue<Tuple<IProjectTreeSnapshot, IProjectSubscriptionUpdate>> dataFlowUpdate)
         {
-            var newTree = treeSnapshot.Value.Tree;
+            var treeSnapshot = dataFlowUpdate.Value.Item1;
+            var newTree = treeSnapshot.Tree;
             if (newTree == null)
             {
                 return;
@@ -79,7 +97,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             }
 
             // NOTE: Project lock file path may be null
-            var projectLockFilePath = await GetProjectLockFilePathAsync(newTree).ConfigureAwait(false);
+            var projectUpdate = dataFlowUpdate.Value.Item2;
+            var projectLockFilePath = GetProjectAssetsFilePath(newTree, projectUpdate);
 
             // project.json may have been renamed to {projectName}.project.json or in the case of the project.assets.json, 
             // the immediate path could have changed. In either case, change the file watcher.
@@ -90,40 +109,42 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             }
         }
 
-        private async TPL.Task<string> GetProjectLockFilePathAsync(IProjectTree newTree)
+        private string GetProjectAssetsFilePath(IProjectTree newTree, IProjectSubscriptionUpdate projectUpdate)
         {
+            var projectFilePath = projectUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildProjectFullPathProperty, null);
+
             // First check to see if the project has a project.json. 
-            IProjectTree projectJsonNode = FindProjectJsonNode(newTree);
+            IProjectTree projectJsonNode = FindProjectJsonNode(newTree, projectFilePath);
             if (projectJsonNode != null)
             {
-                var projectDirectory = Path.GetDirectoryName(_projectServices.Project.FullPath);
+                var projectDirectory = Path.GetDirectoryName(projectFilePath);
                 var projectLockJsonFilePath = Path.ChangeExtension(PathHelper.Combine(projectDirectory, projectJsonNode.Caption), ".lock.json");
                 return projectLockJsonFilePath;
             }
 
             // If there is no project.json then get the patch to obj\project.assets.json file which is generated for projects
             // with <PackageReference> items.
-            var configurationGeneral = await _projectServices.ActiveConfiguredProjectProperties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(false);
-            var objDirectory = (string) await configurationGeneral.BaseIntermediateOutputPath.GetValueAsync().ConfigureAwait(false);
-            if (objDirectory.Length == 0)
+            var objDirectory = projectUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.BaseIntermediateOutputPathProperty, null);
+
+            if (string.IsNullOrEmpty(objDirectory))
             {   // Don't have an intermdiate directory set, probably missing SDK attribute or Microsoft.Common.props
 
                 return null; 
             }
 
-            objDirectory = _projectServices.Project.MakeRooted(objDirectory);
+            objDirectory = PathHelper.MakeRooted(projectFilePath, objDirectory);
             var projectAssetsFilePath = PathHelper.Combine(objDirectory, "project.assets.json");
             return projectAssetsFilePath;
         }
 
-        private IProjectTree FindProjectJsonNode(IProjectTree newTree)
+        private IProjectTree FindProjectJsonNode(IProjectTree newTree, string projectFilePath)
         {
             if (newTree.TryFindImmediateChild("project.json", out IProjectTree projectJsonNode))
             {
                 return projectJsonNode;
             }
 
-            var projectName = Path.GetFileNameWithoutExtension(_projectServices.Project.FullPath);
+            var projectName = Path.GetFileNameWithoutExtension(projectFilePath);
             if (newTree.TryFindImmediateChild($"{projectName}.project.json", out projectJsonNode))
             {
                 return projectJsonNode;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -78,6 +78,7 @@
     <StringListProperty Name="AvailablePlatforms" Separator="," />
     <BoolProperty Name="Optimize" Description="Should compiler optimize output?" />
     <StringProperty Name="MSBuildProjectDirectory" Visible="false"/>
+    <StringProperty Name="MSBuildProjectFullPath" Visible="false" />
     <StringProperty Name="DefaultPlatform" Visible="false" />
     <StringProperty Name="PackageAction" Visible="false" Description="The MSBuild target to use when packaging a project." />
     <StringProperty Name="DefaultContentType" Visible="false" Description="The default content type name to use when adding files." />


### PR DESCRIPTION
**Customer scenario**

Today we get dataflow for some of the data but get other data by querying the project. This can lead to some race conditions and also causes us to load the catalog twice. This changes it to just query from dataflow. This will also fix the Watson crash where the project was unloaded when we were querying for the project data as we are not querying the project at all anymore

**Bugs this fixes:** 

Fixes #645, Fixes #1768 and VSO 296591

**Workarounds, if any**

None

**Risk**

Low 

**Performance impact**

Might improve perf since we won't compute catalogs twice.

**Is this a regression from a previous update?**
No

**Root cause analysis:**

Didn't understand that we couldn't mix dataflow and live project.

**How was the bug found?**

Code review.

@dotnet/project-system @natidea @davkean 

@lifengl can you please review as well?