### PR TITLE
Fix reference properties

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AssemblyReference.xaml
@@ -27,6 +27,24 @@
                   DisplayName="Embed Interop Types"
                   Description="Indicates whether types defined in this assembly will be embedded into the target assembly." />
 
+    <StringProperty Name="Identity"
+                    ReadOnly="True"
+                    DisplayName="Identity"
+                    Description="Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).">
+        <StringProperty.DataSource>
+            <DataSource PersistedName="{}{Identity}" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+
+    <StringProperty Name="ResolvedPath"
+                    ReadOnly="True"
+                    DisplayName="Path"
+                    Description="Location of the file being referenced.">
+        <StringProperty.DataSource>
+            <DataSource PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+    
     <BoolProperty Name="SpecificVersion" 
                   DisplayName="Specific Version"
                   Description="Indicates whether this assembly can be resolved without regard to multi-targeting rules for assembly resolution.">
@@ -34,6 +52,12 @@
             <DataSource Persistence="AssemblyReference" ItemType="Reference" HasConfigurationCondition="False"  SourceOfDefaultValue="AfterContext" />
         </BoolProperty.DataSource>
     </BoolProperty>
+
+    <StringProperty Name="Version"
+                    ReadOnly="True"
+                    DisplayName="Version"
+                    Description="Version of reference.">
+    </StringProperty>
 
     <StringProperty Name="RequiredTargetFramework" DisplayName="Required Target Framework" Visible="False" />
     <StringProperty Name="HintPath" Visible="false" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AssemblyReference.xaml
@@ -14,6 +14,8 @@
                     SourceOfDefaultValue="AfterContext" />
     </Rule.DataSource>
 
+    <!-- Visible properties -->
+
     <StringListProperty Name="Aliases"
                         DisplayName="Aliases"
                         Description="A comma-delimited list of aliases to this reference."
@@ -72,18 +74,25 @@
                     Description="Version of reference.">
     </StringProperty>
 
-    <StringProperty Name="RequiredTargetFramework"
-                    DisplayName="Required Target Framework"
-                    Visible="False" />
+    <!-- Hidden properties -->
+
     <StringProperty Name="HintPath" Visible="false" />
-    <StringProperty Name="SDKName" Visible="false" />
-    <BoolProperty Name="IsWinMDFile" Visible="false" />
+
     <StringProperty Name="ImageRuntime"
                     DisplayName="Runtime Version"
                     Description="The CLR runtime version targeted by this assembly."
                     Visible="False"
                     ReadOnly="True" />
+
     <StringProperty Name="IsImplicitlyDefined"
                     Visible="False"
                     ReadOnly="True" />
+
+    <BoolProperty Name="IsWinMDFile" Visible="false" />
+
+    <StringProperty Name="RequiredTargetFramework"
+                    DisplayName="Required Target Framework"
+                    Visible="False" />
+
+    <StringProperty Name="SDKName" Visible="false" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AssemblyReference.xaml
@@ -6,8 +6,12 @@
     PageTemplate="generic"
     Description="Reference Properties"
     xmlns="http://schemas.microsoft.com/build/2009/properties">
+
     <Rule.DataSource>
-        <DataSource Persistence="ProjectFile" ItemType="Reference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+        <DataSource Persistence="ProjectFile"
+                    ItemType="Reference"
+                    HasConfigurationCondition="False"
+                    SourceOfDefaultValue="AfterContext" />
     </Rule.DataSource>
 
     <StringListProperty Name="Aliases"
@@ -16,10 +20,14 @@
                         Separator="," />
 
     <BoolProperty Name="CopyLocal"
-                DisplayName="Copy Local"
-                Description="Indicates whether the reference will be copied to the output directory.">
+                  DisplayName="Copy Local"
+                  Description="Indicates whether the reference will be copied to the output directory.">
         <BoolProperty.DataSource>
-            <DataSource Persistence="ProjectFile" ItemType="Reference" HasConfigurationCondition="False" PersistedName="Private" SourceOfDefaultValue="AfterContext" />
+            <DataSource Persistence="ProjectFile"
+                        ItemType="Reference"
+                        HasConfigurationCondition="False"
+                        PersistedName="Private"
+                        SourceOfDefaultValue="AfterContext" />
         </BoolProperty.DataSource>
     </BoolProperty>
 
@@ -32,7 +40,8 @@
                     DisplayName="Identity"
                     Description="Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).">
         <StringProperty.DataSource>
-            <DataSource PersistedName="{}{Identity}" SourceOfDefaultValue="AfterContext" />
+            <DataSource PersistedName="{}{Identity}"
+                        SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
     </StringProperty>
 
@@ -41,15 +50,19 @@
                     DisplayName="Path"
                     Description="Location of the file being referenced.">
         <StringProperty.DataSource>
-            <DataSource PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
+            <DataSource PersistedName="Identity"
+                        SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
     </StringProperty>
-    
+
     <BoolProperty Name="SpecificVersion" 
                   DisplayName="Specific Version"
                   Description="Indicates whether this assembly can be resolved without regard to multi-targeting rules for assembly resolution.">
         <BoolProperty.DataSource>
-            <DataSource Persistence="AssemblyReference" ItemType="Reference" HasConfigurationCondition="False"  SourceOfDefaultValue="AfterContext" />
+            <DataSource Persistence="AssemblyReference"
+                        ItemType="Reference"
+                        HasConfigurationCondition="False"
+                        SourceOfDefaultValue="AfterContext" />
         </BoolProperty.DataSource>
     </BoolProperty>
 
@@ -59,7 +72,9 @@
                     Description="Version of reference.">
     </StringProperty>
 
-    <StringProperty Name="RequiredTargetFramework" DisplayName="Required Target Framework" Visible="False" />
+    <StringProperty Name="RequiredTargetFramework"
+                    DisplayName="Required Target Framework"
+                    Visible="False" />
     <StringProperty Name="HintPath" Visible="false" />
     <StringProperty Name="SDKName" Visible="false" />
     <BoolProperty Name="IsWinMDFile" Visible="false" />
@@ -68,5 +83,7 @@
                     Description="The CLR runtime version targeted by this assembly."
                     Visible="False"
                     ReadOnly="True" />
-    <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+    <StringProperty Name="IsImplicitlyDefined"
+                    Visible="False"
+                    ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.xaml
@@ -8,7 +8,10 @@
     xmlns="http://schemas.microsoft.com/build/2009/properties">
 
     <Rule.DataSource>
-        <DataSource Persistence="ProjectFile" ItemType="ProjectReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+        <DataSource Persistence="ProjectFile" 
+                    ItemType="ProjectReference" 
+                    HasConfigurationCondition="False" 
+                    SourceOfDefaultValue="AfterContext" />
     </Rule.DataSource>
 
     <StringListProperty Name="Aliases"
@@ -22,7 +25,7 @@
                         SourceOfDefaultValue="AfterContext" />
         </StringListProperty.DataSource>
     </StringListProperty>
-    
+
     <BoolProperty Name="ReferenceOutputAssembly"
                   DisplayName="Reference Output Assembly"
                   Description="A value indicating whether the compiler should include a reference to the target project's primary output assembly." />
@@ -31,15 +34,19 @@
                   DisplayName="Copy Local Satellite Assemblies"
                   Description="Indicates whether the satellite assemblies of the reference target should be copied into this project's output directory." />
 
-    <BoolProperty Name="LinkLibraryDependencies" Visible="False" />
+    <BoolProperty Name="LinkLibraryDependencies"
+                  Visible="False" />
 
-    <BoolProperty Name="UseLibraryDependencyInputs" Visible="False" />
+    <BoolProperty Name="UseLibraryDependencyInputs"
+                  Visible="False" />
 
     <StringProperty Name="Project" 
                     Visible="False"
                     Description="the Guid the solution tracks an individual project reference target with" />
 
-    <StringProperty Name="ReferencedProjectIdentifier" Visible="False" Description="The old (VS2010 beta) way to store the Guid the solution tracks an individual project reference target with" />
+    <StringProperty Name="ReferencedProjectIdentifier"
+                    Visible="False"
+                    Description="The old (VS2010 beta) way to store the Guid the solution tracks an individual project reference target with" />
 
     <BoolProperty Name="CopyLocal"
                   DisplayName="Copy Local"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.xaml
@@ -11,6 +11,18 @@
         <DataSource Persistence="ProjectFile" ItemType="ProjectReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
     </Rule.DataSource>
 
+    <StringListProperty Name="Aliases"
+                        DisplayName="Aliases"
+                        Description="A comma-delimited list of aliases to this reference."
+                        Separator=",">
+        <StringListProperty.DataSource>
+            <DataSource Persistence="ProjectFile"
+                        ItemType="ProjectReference"
+                        HasConfigurationCondition="False"
+                        SourceOfDefaultValue="AfterContext" />
+        </StringListProperty.DataSource>
+    </StringListProperty>
+    
     <BoolProperty Name="ReferenceOutputAssembly"
                   DisplayName="Reference Output Assembly"
                   Description="A value indicating whether the compiler should include a reference to the target project's primary output assembly." />
@@ -40,6 +52,55 @@
                         SourceOfDefaultValue="AfterContext" />
         </BoolProperty.DataSource>
     </BoolProperty>
+
+    <StringProperty Name="Culture" 
+                    ReadOnly="True"
+                    DisplayName="Culture" 
+                    Description="The value of the culture field from the assembly metadata.">
+    </StringProperty>
+
+    <StringProperty Name="Description" 
+                    ReadOnly="True" 
+                    DisplayName="Description" 
+                    Description="The value of the Title field from the assembly metadata.">
+    </StringProperty>
+
+    <BoolProperty Name="EmbedInteropTypes"
+                  DisplayName="Embed Interop Types"
+                  Description="Indicates whether types defined in this assembly will be embedded into the target assembly.">
+        <BoolProperty.DataSource>
+            <DataSource Persistence="ProjectFile"
+                        ItemType="ProjectReference"
+                        HasConfigurationCondition="False"
+                        SourceOfDefaultValue="AfterContext" />
+        </BoolProperty.DataSource>
+    </BoolProperty>
+
+    <StringProperty Name="Identity"
+                    ReadOnly="True"
+                    DisplayName="Identity"
+                    Description="Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).">
+        <StringProperty.DataSource>
+            <DataSource PersistedName="{}{Identity}"
+                        SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+
+    <StringProperty Name="ResolvedPath"
+                    ReadOnly="True"
+                    DisplayName="Path"
+                    Description="Location of the file being referenced.">
+        <StringProperty.DataSource>
+            <DataSource PersistedName="Identity"
+                        SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+
+    <StringProperty Name="Version"
+                    ReadOnly="True"
+                    DisplayName="Version"
+                    Description="Version of reference.">
+    </StringProperty>
 
     <StringProperty Name="IncludeAssets" 
                     Visible="True"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.xaml
@@ -14,6 +14,8 @@
                     SourceOfDefaultValue="AfterContext" />
     </Rule.DataSource>
 
+    <!-- Visible properties -->
+
     <StringListProperty Name="Aliases"
                         DisplayName="Aliases"
                         Description="A comma-delimited list of aliases to this reference."
@@ -26,28 +28,6 @@
         </StringListProperty.DataSource>
     </StringListProperty>
 
-    <BoolProperty Name="ReferenceOutputAssembly"
-                  DisplayName="Reference Output Assembly"
-                  Description="A value indicating whether the compiler should include a reference to the target project's primary output assembly." />
-
-    <BoolProperty Name="CopyLocalSatelliteAssemblies"
-                  DisplayName="Copy Local Satellite Assemblies"
-                  Description="Indicates whether the satellite assemblies of the reference target should be copied into this project's output directory." />
-
-    <BoolProperty Name="LinkLibraryDependencies"
-                  Visible="False" />
-
-    <BoolProperty Name="UseLibraryDependencyInputs"
-                  Visible="False" />
-
-    <StringProperty Name="Project" 
-                    Visible="False"
-                    Description="the Guid the solution tracks an individual project reference target with" />
-
-    <StringProperty Name="ReferencedProjectIdentifier"
-                    Visible="False"
-                    Description="The old (VS2010 beta) way to store the Guid the solution tracks an individual project reference target with" />
-
     <BoolProperty Name="CopyLocal"
                   DisplayName="Copy Local"
                   Description="Indicates whether the reference will be copied to the output directory.">
@@ -59,6 +39,10 @@
                         SourceOfDefaultValue="AfterContext" />
         </BoolProperty.DataSource>
     </BoolProperty>
+
+    <BoolProperty Name="CopyLocalSatelliteAssemblies"
+                  DisplayName="Copy Local Satellite Assemblies"
+                  Description="Indicates whether the satellite assemblies of the reference target should be copied into this project's output directory." />
 
     <StringProperty Name="Culture" 
                     ReadOnly="True"
@@ -83,6 +67,11 @@
         </BoolProperty.DataSource>
     </BoolProperty>
 
+    <StringProperty Name="ExcludeAssets" 
+                    Visible="True"
+                    DisplayName="ExcludeAssets"
+                    Description="Assets to exclude from this reference" />
+
     <StringProperty Name="Identity"
                     ReadOnly="True"
                     DisplayName="Identity"
@@ -92,6 +81,20 @@
                         SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
     </StringProperty>
+
+    <StringProperty Name="IncludeAssets" 
+                    Visible="True"
+                    DisplayName="IncludeAssets"
+                    Description="Assets to include from this reference" />
+
+    <BoolProperty Name="ReferenceOutputAssembly"
+                  DisplayName="Reference Output Assembly"
+                  Description="A value indicating whether the compiler should include a reference to the target project's primary output assembly." />
+
+    <StringProperty Name="PrivateAssets" 
+                    Visible="True"
+                    DisplayName="PrivateAssets"
+                    Description="Assets that are private in this reference" />
 
     <StringProperty Name="ResolvedPath"
                     ReadOnly="True"
@@ -109,18 +112,19 @@
                     Description="Version of reference.">
     </StringProperty>
 
-    <StringProperty Name="IncludeAssets" 
-                    Visible="True"
-                    DisplayName="IncludeAssets"
-                    Description="Assets to include from this reference" />
+    <!-- Hidden properties -->
+    <BoolProperty Name="LinkLibraryDependencies"
+                  Visible="False" />
 
-    <StringProperty Name="ExcludeAssets" 
-                    Visible="True"
-                    DisplayName="ExcludeAssets"
-                    Description="Assets to exclude from this reference" />
+    <StringProperty Name="Project" 
+                    Visible="False"
+                    Description="the Guid the solution tracks an individual project reference target with" />
 
-    <StringProperty Name="PrivateAssets" 
-                    Visible="True"
-                    DisplayName="PrivateAssets"
-                    Description="Assets that are private in this reference" />
+    <StringProperty Name="ReferencedProjectIdentifier"
+                    Visible="False"
+                    Description="The old (VS2010 beta) way to store the Guid the solution tracks an individual project reference target with" />
+
+    <BoolProperty Name="UseLibraryDependencyInputs"
+                  Visible="False" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.xaml
@@ -69,7 +69,7 @@
 
     <StringProperty Name="ExcludeAssets" 
                     Visible="True"
-                    DisplayName="ExcludeAssets"
+                    DisplayName="Exclude Assets"
                     Description="Assets to exclude from this reference" />
 
     <StringProperty Name="Identity"
@@ -84,7 +84,7 @@
 
     <StringProperty Name="IncludeAssets" 
                     Visible="True"
-                    DisplayName="IncludeAssets"
+                    DisplayName="Include Assets"
                     Description="Assets to include from this reference" />
 
     <BoolProperty Name="ReferenceOutputAssembly"
@@ -93,7 +93,7 @@
 
     <StringProperty Name="PrivateAssets" 
                     Visible="True"
-                    DisplayName="PrivateAssets"
+                    DisplayName="Private Assets"
                     Description="Assets that are private in this reference" />
 
     <StringProperty Name="ResolvedPath"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAssemblyReference.xaml
@@ -16,6 +16,8 @@
                     SourceOfDefaultValue="AfterContext" />
     </Rule.DataSource>
 
+    <!-- Visible properties -->
+
     <StringListProperty Name="Aliases"
                         DisplayName="Aliases"
                         Description="A comma-delimited list of aliases to this reference."
@@ -40,18 +42,6 @@
         </BoolProperty.DataSource>
     </BoolProperty>
 
-    <StringProperty Name="Culture" 
-                    ReadOnly="True"
-                    Visible="False"
-                    DisplayName="Culture" 
-                    Description="The value of the culture field from the assembly metadata." />
-
-    <StringProperty Name="Description" 
-                    ReadOnly="True" 
-                    Visible="False"
-                    DisplayName="Description" 
-                    Description="The value of the Title field from the assembly metadata." />
-
     <BoolProperty Name="EmbedInteropTypes"
                   DisplayName="Embed Interop Types"
                   Description="Indicates whether types defined in this assembly will be embedded into the target assembly.">
@@ -62,16 +52,6 @@
                         SourceOfDefaultValue="AfterContext" />
         </BoolProperty.DataSource>
     </BoolProperty>
-
-    <EnumProperty Name="FileType"
-                  ReadOnly="True"
-                  Visible="False"
-                  DisplayName="File Type"
-                  Description="The file type of the reference.">
-        <EnumValue Name="Assembly" DisplayName=".NET assembly" />
-        <EnumValue Name="ActiveX" DisplayName="COM type library" />
-        <EnumValue Name="Native Assembly" DisplayName="Native Assembly" />
-    </EnumProperty>
 
     <StringProperty Name="Identity"
                     ReadOnly="True"
@@ -93,13 +73,6 @@
         </StringProperty.DataSource>
     </StringProperty>
 
-    <StringProperty Name="RuntimeVersion"
-                    ReadOnly="True"
-                    Visible="False"
-                    DisplayName="Runtime Version"
-                    Description="Version of the .NET runtime this assembly was compiled against.">
-    </StringProperty>
-
     <BoolProperty Name="SpecificVersion" 
                   DisplayName="Specific Version"
                   Description="Indicates whether this assembly can be resolved without regard to multi-targeting rules for assembly resolution.">
@@ -111,6 +84,51 @@
         </BoolProperty.DataSource>
     </BoolProperty>
 
+    <StringProperty Name="Version"
+                    ReadOnly="True"
+                    DisplayName="Version"
+                    Description="Version of reference.">
+    </StringProperty>
+
+    <!-- Hidden properties -->
+
+    <StringProperty Name="Culture" 
+                    ReadOnly="True"
+                    Visible="False"
+                    DisplayName="Culture" 
+                    Description="The value of the culture field from the assembly metadata." />
+
+    <StringProperty Name="Description" 
+                    ReadOnly="True" 
+                    Visible="False"
+                    DisplayName="Description" 
+                    Description="The value of the Title field from the assembly metadata." />
+
+    <EnumProperty Name="FileType"
+                  ReadOnly="True"
+                  Visible="False"
+                  DisplayName="File Type"
+                  Description="The file type of the reference.">
+        <EnumValue Name="Assembly" DisplayName=".NET assembly" />
+        <EnumValue Name="ActiveX" DisplayName="COM type library" />
+        <EnumValue Name="Native Assembly" DisplayName="Native Assembly" />
+    </EnumProperty>
+
+    <StringProperty Name="HintPath" Visible="false" />
+
+    <StringProperty Name="RequiredTargetFramework" 
+                    DisplayName="Required Target Framework" 
+                    Visible="False" />
+
+    <StringProperty Name="RuntimeVersion"
+                    ReadOnly="True"
+                    Visible="False"
+                    DisplayName="Runtime Version"
+                    Description="Version of the .NET runtime this assembly was compiled against.">
+    </StringProperty>
+
+    <StringProperty Name="SDKIdentity" Visible="false" />
+
     <BoolProperty Name="StrongName"
                   ReadOnly="True"
                   Visible="False"
@@ -118,52 +136,48 @@
                   Description="True indicates that the reference has been signed with a key-pair.">
     </BoolProperty>
 
-    <StringProperty Name="Version"
-                    ReadOnly="True"
-                    DisplayName="Version"
-                    Description="Version of reference.">
-    </StringProperty>
-
-    <StringProperty Name="RequiredTargetFramework" 
-                    DisplayName="Required Target Framework" 
-                    Visible="False" />
-    <StringProperty Name="HintPath" Visible="false" />
-    <StringProperty Name="SDKIdentity" Visible="false" />
-
     <!-- This is the metadata we store on the reference item when we add it. -->
     <BoolProperty Name="IsWinMDFile" 
                   Visible="false" 
                   Description="Indicates whether the project system ascertained that this is a WinMD (as opposed to an assembly)" />
 
     <!-- These are metadata added to the resolved item by MSBuild that we don't show to the user but use internally. -->
-    <BoolProperty Name="WinMDFile" 
-                  Visible="false"
-                  ReadOnly="True" 
-                  Description="Indicates whether the build system ascertained that this is a WinMD (as opposed to an assembly)" />
-    <StringProperty Name="Name"
-                    Visible="false"
-                    ReadOnly="True" />
-    <StringProperty Name="OriginalItemSpec"
-                    Visible="False" 
-                    ReadOnly="True"
-                    Description="The evaluated item name of the original reference item whose resolution resulted in this resolved reference item." />
-    <StringProperty Name="ReferenceFromSDK"
-                    Visible="False"
-                    ReadOnly="True" 
-                    Description="The SDK that this reference came from when using the expand SDK target." />
-    <StringProperty Name="FusionName" 
-                    Visible="False" 
-                    ReadOnly="True" 
-                    Description="The full fusion name of the resolved assembly." />
-    <StringProperty Name="ResolvedFrom"
-                    Visible="False"
-                    ReadOnly="True" 
-                    Description="{}What repository held the reference that was used to resolve this.  (&quot;{GAC}&quot; if it was in the GAC)." />
+
     <StringProperty Name="FrameworkFile" 
                     Visible="False" 
                     ReadOnly="True" 
                     Description="Is this file a framework file. Ie Found in the target framework directory or in the redist list." />
+
+    <StringProperty Name="FusionName" 
+                    Visible="False" 
+                    ReadOnly="True" 
+                    Description="The full fusion name of the resolved assembly." />
+
     <StringProperty Name="IsImplicitlyDefined" 
                     Visible="False" 
                     ReadOnly="True" />
+
+    <StringProperty Name="Name"
+                    Visible="false"
+                    ReadOnly="True" />
+
+    <StringProperty Name="OriginalItemSpec"
+                    Visible="False" 
+                    ReadOnly="True"
+                    Description="The evaluated item name of the original reference item whose resolution resulted in this resolved reference item." />
+
+    <StringProperty Name="ReferenceFromSDK"
+                    Visible="False"
+                    ReadOnly="True" 
+                    Description="The SDK that this reference came from when using the expand SDK target." />
+
+    <StringProperty Name="ResolvedFrom"
+                    Visible="False"
+                    ReadOnly="True" 
+                    Description="{}What repository held the reference that was used to resolve this.  (&quot;{GAC}&quot; if it was in the GAC)." />
+
+    <BoolProperty Name="WinMDFile" 
+                  Visible="false"
+                  ReadOnly="True" 
+                  Description="Indicates whether the build system ascertained that this is a WinMD (as opposed to an assembly)" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAssemblyReference.xaml
@@ -6,9 +6,14 @@
     PageTemplate="generic"
     Description="Reference Properties"
     xmlns="http://schemas.microsoft.com/build/2009/properties">
+
     <Rule.DataSource>
-        <DataSource Persistence="ResolvedReference" ItemType="Reference" HasConfigurationCondition="False" 
-                    SourceType="TargetResults" MSBuildTarget="ResolveAssemblyReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
+        <DataSource Persistence="ResolvedReference"
+                    ItemType="Reference"
+                    HasConfigurationCondition="False" 
+                    SourceType="TargetResults"
+                    MSBuildTarget="ResolveAssemblyReferencesDesignTime"
+                    SourceOfDefaultValue="AfterContext" />
     </Rule.DataSource>
 
     <StringListProperty Name="Aliases"
@@ -16,7 +21,10 @@
                         Description="A comma-delimited list of aliases to this reference."
                         Separator=",">
         <StringListProperty.DataSource>
-            <DataSource Persistence="ProjectFile" ItemType="Reference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+            <DataSource Persistence="ProjectFile"
+                        ItemType="Reference" 
+                        HasConfigurationCondition="False" 
+                        SourceOfDefaultValue="AfterContext" />
         </StringListProperty.DataSource>
     </StringListProperty>
 
@@ -24,7 +32,11 @@
                   DisplayName="Copy Local"
                   Description="Indicates whether the reference will be copied to the output directory.">
         <BoolProperty.DataSource>
-            <DataSource Persistence="ProjectFile" ItemType="Reference" HasConfigurationCondition="False" PersistedName="Private" SourceOfDefaultValue="AfterContext" />
+            <DataSource Persistence="ProjectFile" 
+                        ItemType="Reference" 
+                        HasConfigurationCondition="False" 
+                        PersistedName="Private" 
+                        SourceOfDefaultValue="AfterContext" />
         </BoolProperty.DataSource>
     </BoolProperty>
 
@@ -44,7 +56,10 @@
                   DisplayName="Embed Interop Types"
                   Description="Indicates whether types defined in this assembly will be embedded into the target assembly.">
         <BoolProperty.DataSource>
-            <DataSource Persistence="ProjectFile" ItemType="Reference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+            <DataSource Persistence="ProjectFile" 
+                        ItemType="Reference"
+                        HasConfigurationCondition="False"
+                        SourceOfDefaultValue="AfterContext" />
         </BoolProperty.DataSource>
     </BoolProperty>
 
@@ -63,7 +78,8 @@
                     DisplayName="Identity"
                     Description="Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).">
         <StringProperty.DataSource>
-            <DataSource PersistedName="{}{Identity}" SourceOfDefaultValue="AfterContext" />
+            <DataSource PersistedName="{}{Identity}" 
+                        SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
     </StringProperty>
 
@@ -72,7 +88,8 @@
                     DisplayName="Path"
                     Description="Location of the file being referenced.">
         <StringProperty.DataSource>
-            <DataSource PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
+            <DataSource PersistedName="Identity" 
+                        SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
     </StringProperty>
 
@@ -87,7 +104,10 @@
                   DisplayName="Specific Version"
                   Description="Indicates whether this assembly can be resolved without regard to multi-targeting rules for assembly resolution.">
         <BoolProperty.DataSource>
-            <DataSource Persistence="AssemblyReference" ItemType="Reference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+            <DataSource Persistence="AssemblyReference" 
+                        ItemType="Reference" 
+                        HasConfigurationCondition="False" 
+                        SourceOfDefaultValue="AfterContext" />
         </BoolProperty.DataSource>
     </BoolProperty>
 
@@ -104,20 +124,46 @@
                     Description="Version of reference.">
     </StringProperty>
 
-    <StringProperty Name="RequiredTargetFramework" DisplayName="Required Target Framework" Visible="False" />
+    <StringProperty Name="RequiredTargetFramework" 
+                    DisplayName="Required Target Framework" 
+                    Visible="False" />
     <StringProperty Name="HintPath" Visible="false" />
     <StringProperty Name="SDKIdentity" Visible="false" />
 
     <!-- This is the metadata we store on the reference item when we add it. -->
-    <BoolProperty Name="IsWinMDFile" Visible="false" Description="Indicates whether the project system ascertained that this is a WinMD (as opposed to an assembly)" />
+    <BoolProperty Name="IsWinMDFile" 
+                  Visible="false" 
+                  Description="Indicates whether the project system ascertained that this is a WinMD (as opposed to an assembly)" />
 
     <!-- These are metadata added to the resolved item by MSBuild that we don't show to the user but use internally. -->
-    <BoolProperty Name="WinMDFile" Visible="false" ReadOnly="True" Description="Indicates whether the build system ascertained that this is a WinMD (as opposed to an assembly)" />
-    <StringProperty Name="Name" Visible="false" ReadOnly="True" />
-    <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" Description="The evaluated item name of the original reference item whose resolution resulted in this resolved reference item." />
-    <StringProperty Name="ReferenceFromSDK" Visible="False" ReadOnly="True" Description="The SDK that this reference came from when using the expand SDK target." />
-    <StringProperty Name="FusionName" Visible="False" ReadOnly="True" Description="The full fusion name of the resolved assembly." />
-    <StringProperty Name="ResolvedFrom" Visible="False" ReadOnly="True" Description="{}What repository held the reference that was used to resolve this.  (&quot;{GAC}&quot; if it was in the GAC)." />
-    <StringProperty Name="FrameworkFile" Visible="False" ReadOnly="True" Description="Is this file a framework file. Ie Found in the target framework directory or in the redist list." />
-    <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+    <BoolProperty Name="WinMDFile" 
+                  Visible="false"
+                  ReadOnly="True" 
+                  Description="Indicates whether the build system ascertained that this is a WinMD (as opposed to an assembly)" />
+    <StringProperty Name="Name"
+                    Visible="false"
+                    ReadOnly="True" />
+    <StringProperty Name="OriginalItemSpec"
+                    Visible="False" 
+                    ReadOnly="True"
+                    Description="The evaluated item name of the original reference item whose resolution resulted in this resolved reference item." />
+    <StringProperty Name="ReferenceFromSDK"
+                    Visible="False"
+                    ReadOnly="True" 
+                    Description="The SDK that this reference came from when using the expand SDK target." />
+    <StringProperty Name="FusionName" 
+                    Visible="False" 
+                    ReadOnly="True" 
+                    Description="The full fusion name of the resolved assembly." />
+    <StringProperty Name="ResolvedFrom"
+                    Visible="False"
+                    ReadOnly="True" 
+                    Description="{}What repository held the reference that was used to resolve this.  (&quot;{GAC}&quot; if it was in the GAC)." />
+    <StringProperty Name="FrameworkFile" 
+                    Visible="False" 
+                    ReadOnly="True" 
+                    Description="Is this file a framework file. Ie Found in the target framework directory or in the redist list." />
+    <StringProperty Name="IsImplicitlyDefined" 
+                    Visible="False" 
+                    ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedProjectReference.xaml
@@ -6,6 +6,7 @@
     PageTemplate="generic"
     Description="Reference Properties"
     xmlns="http://schemas.microsoft.com/build/2009/properties">
+
     <Rule.DataSource>
         <DataSource Persistence="ResolvedReference" ItemType="ProjectReference" HasConfigurationCondition="False" 
                     SourceType="TargetResults" MSBuildTarget="ResolveProjectReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
@@ -16,17 +17,32 @@
                         Description="A comma-delimited list of aliases to this reference."
                         Separator=",">
         <StringListProperty.DataSource>
-            <DataSource Persistence="ProjectFile" ItemType="ProjectReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+            <DataSource Persistence="ProjectFile"
+                        ItemType="ProjectReference"
+                        HasConfigurationCondition="False"
+                        SourceOfDefaultValue="AfterContext" />
         </StringListProperty.DataSource>
     </StringListProperty>
+
+    <BoolProperty Name="ReferenceOutputAssembly"
+                  DisplayName="Reference Output Assembly"
+                  Description="A value indicating whether the compiler should include a reference to the target project's primary output assembly." />
 
     <BoolProperty Name="CopyLocal"
                   DisplayName="Copy Local"
                   Description="Indicates whether the reference will be copied to the output directory.">
         <BoolProperty.DataSource>
-            <DataSource Persistence="ProjectFile" ItemType="ProjectReference" HasConfigurationCondition="False" PersistedName="Private" SourceOfDefaultValue="AfterContext" />
+            <DataSource Persistence="ProjectFile"
+                        ItemType="ProjectReference"
+                        HasConfigurationCondition="False"
+                        PersistedName="Private"
+                        SourceOfDefaultValue="AfterContext" />
         </BoolProperty.DataSource>
     </BoolProperty>
+
+    <BoolProperty Name="CopyLocalSatelliteAssemblies"
+                  DisplayName="Copy Local Satellite Assemblies"
+                  Description="Indicates whether the satellite assemblies of the reference target should be copied into this project's output directory." />
 
     <StringProperty Name="Culture" 
                     ReadOnly="True"
@@ -101,6 +117,21 @@
                     Description="Version of reference.">
     </StringProperty>
 
+    <StringProperty Name="IncludeAssets" 
+                    Visible="True"
+                    DisplayName="IncludeAssets"
+                    Description="Assets to include from this reference" />
+
+    <StringProperty Name="ExcludeAssets" 
+                    Visible="True"
+                    DisplayName="ExcludeAssets"
+                    Description="Assets to exclude from this reference" />
+
+    <StringProperty Name="PrivateAssets" 
+                    Visible="True"
+                    DisplayName="PrivateAssets"
+                    Description="Assets that are private in this reference" />
+    
     <StringProperty Name="RequiredTargetFramework" DisplayName="Required Target Framework" Visible="False" />
     <StringProperty Name="HintPath" Visible="false" />
     <StringProperty Name="SDKIdentity" Visible="false" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedProjectReference.xaml
@@ -71,7 +71,7 @@
 
     <StringProperty Name="ExcludeAssets" 
                     Visible="True"
-                    DisplayName="ExcludeAssets"
+                    DisplayName="Exclude Assets"
                     Description="Assets to exclude from this reference" />
 
     <StringProperty Name="Identity"
@@ -86,7 +86,7 @@
 
     <StringProperty Name="IncludeAssets" 
                     Visible="True"
-                    DisplayName="IncludeAssets"
+                    DisplayName="Include Assets"
                     Description="Assets to include from this reference" />
 
     <BoolProperty Name="ReferenceOutputAssembly"
@@ -95,7 +95,7 @@
 
     <StringProperty Name="PrivateAssets" 
                     Visible="True"
-                    DisplayName="PrivateAssets"
+                    DisplayName="Private Assets"
                     Description="Assets that are private in this reference" />
 
     <StringProperty Name="ResolvedPath"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedProjectReference.xaml
@@ -16,6 +16,8 @@
                     SourceOfDefaultValue="AfterContext" />
     </Rule.DataSource>
 
+    <!-- Visible properties -->
+
     <StringListProperty Name="Aliases"
                         DisplayName="Aliases"
                         Description="A comma-delimited list of aliases to this reference."
@@ -27,10 +29,6 @@
                         SourceOfDefaultValue="AfterContext" />
         </StringListProperty.DataSource>
     </StringListProperty>
-
-    <BoolProperty Name="ReferenceOutputAssembly"
-                  DisplayName="Reference Output Assembly"
-                  Description="A value indicating whether the compiler should include a reference to the target project's primary output assembly." />
 
     <BoolProperty Name="CopyLocal"
                   DisplayName="Copy Local"
@@ -71,15 +69,10 @@
         </BoolProperty.DataSource>
     </BoolProperty>
 
-    <EnumProperty Name="FileType"
-                  ReadOnly="True"
-                  Visible="False"
-                  DisplayName="File Type"
-                  Description="The file type of the reference.">
-        <EnumValue Name="Assembly" DisplayName=".NET assembly" />
-        <EnumValue Name="ActiveX" DisplayName="COM type library" />
-        <EnumValue Name="Native Assembly" DisplayName="Native Assembly" />
-    </EnumProperty>
+    <StringProperty Name="ExcludeAssets" 
+                    Visible="True"
+                    DisplayName="ExcludeAssets"
+                    Description="Assets to exclude from this reference" />
 
     <StringProperty Name="Identity"
                     ReadOnly="True"
@@ -91,6 +84,20 @@
         </StringProperty.DataSource>
     </StringProperty>
 
+    <StringProperty Name="IncludeAssets" 
+                    Visible="True"
+                    DisplayName="IncludeAssets"
+                    Description="Assets to include from this reference" />
+
+    <BoolProperty Name="ReferenceOutputAssembly"
+                  DisplayName="Reference Output Assembly"
+                  Description="A value indicating whether the compiler should include a reference to the target project's primary output assembly." />
+
+    <StringProperty Name="PrivateAssets" 
+                    Visible="True"
+                    DisplayName="PrivateAssets"
+                    Description="Assets that are private in this reference" />
+
     <StringProperty Name="ResolvedPath"
                     ReadOnly="True"
                     DisplayName="Path"
@@ -101,12 +108,40 @@
         </StringProperty.DataSource>
     </StringProperty>
 
+    <StringProperty Name="Version"
+                    ReadOnly="True"
+                    DisplayName="Version"
+                    Description="Version of reference.">
+    </StringProperty>
+
+    <!-- Hidden properties -->
+
+    <EnumProperty Name="FileType"
+                  ReadOnly="True"
+                  Visible="False"
+                  DisplayName="File Type"
+                  Description="The file type of the reference.">
+        <EnumValue Name="Assembly" DisplayName=".NET assembly" />
+        <EnumValue Name="ActiveX" DisplayName="COM type library" />
+        <EnumValue Name="Native Assembly" DisplayName="Native Assembly" />
+    </EnumProperty>
+
+    <StringProperty Name="HintPath"
+                    Visible="false" />
+
+    <StringProperty Name="RequiredTargetFramework"
+                    DisplayName="Required Target Framework"
+                    Visible="False" />
+
     <StringProperty Name="RuntimeVersion"
                     ReadOnly="True"
                     Visible="False"
                     DisplayName="Runtime Version"
                     Description="Version of the .NET runtime this assembly was compiled against.">
     </StringProperty>
+
+    <StringProperty Name="SDKIdentity"
+                    Visible="false" />
 
     <BoolProperty Name="SpecificVersion" 
                   DisplayName="Specific Version"
@@ -120,51 +155,32 @@
                   Description="True indicates that the reference has been signed with a key-pair.">
     </BoolProperty>
 
-    <StringProperty Name="Version"
-                    ReadOnly="True"
-                    DisplayName="Version"
-                    Description="Version of reference.">
-    </StringProperty>
-
-    <StringProperty Name="IncludeAssets" 
-                    Visible="True"
-                    DisplayName="IncludeAssets"
-                    Description="Assets to include from this reference" />
-
-    <StringProperty Name="ExcludeAssets" 
-                    Visible="True"
-                    DisplayName="ExcludeAssets"
-                    Description="Assets to exclude from this reference" />
-
-    <StringProperty Name="PrivateAssets" 
-                    Visible="True"
-                    DisplayName="PrivateAssets"
-                    Description="Assets that are private in this reference" />
-
-    <StringProperty Name="RequiredTargetFramework" DisplayName="Required Target Framework" Visible="False" />
-    <StringProperty Name="HintPath" Visible="false" />
-    <StringProperty Name="SDKIdentity" Visible="false" />
-
     <!-- This is the metadata we store on the reference item when we add it. -->
+
     <BoolProperty Name="IsWinMDFile"
                   Visible="false"
                   Description="Indicates whether the project system ascertained that this is a WinMD (as opposed to an assembly)" />
+
     <StringProperty Name="Project" 
                     Visible="False"
                     Description="the Guid the solution tracks an individual project reference target with" />
 
     <!-- These are metadata added to the resolved item by MSBuild that we don't show to the user but use internally. -->
+
     <BoolProperty Name="WinMDFile"
                   Visible="false"
                   ReadOnly="True"
                   Description="Indicates whether the build system ascertained that this is a WinMD (as opposed to an assembly)" />
+
     <StringProperty Name="OriginalItemSpec"
                     Visible="False"
                     ReadOnly="True"
                     Description="The evaluated item name of the original reference item whose resolution resulted in this resolved reference item." />
+
     <StringProperty Name="FusionName"
                     Visible="False"
                     ReadOnly="True" />
+
     <StringProperty Name="Name"
                     Visible="false"
                     ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedProjectReference.xaml
@@ -8,8 +8,12 @@
     xmlns="http://schemas.microsoft.com/build/2009/properties">
 
     <Rule.DataSource>
-        <DataSource Persistence="ResolvedReference" ItemType="ProjectReference" HasConfigurationCondition="False" 
-                    SourceType="TargetResults" MSBuildTarget="ResolveProjectReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
+        <DataSource Persistence="ResolvedReference"
+                    ItemType="ProjectReference"
+                    HasConfigurationCondition="False" 
+                    SourceType="TargetResults"
+                    MSBuildTarget="ResolveProjectReferencesDesignTime"
+                    SourceOfDefaultValue="AfterContext" />
     </Rule.DataSource>
 
     <StringListProperty Name="Aliases"
@@ -60,7 +64,10 @@
                   DisplayName="Embed Interop Types"
                   Description="Indicates whether types defined in this assembly will be embedded into the target assembly.">
         <BoolProperty.DataSource>
-            <DataSource Persistence="ProjectFile" ItemType="ProjectReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+            <DataSource Persistence="ProjectFile"
+                        ItemType="ProjectReference"
+                        HasConfigurationCondition="False"
+                        SourceOfDefaultValue="AfterContext" />
         </BoolProperty.DataSource>
     </BoolProperty>
 
@@ -79,7 +86,8 @@
                     DisplayName="Identity"
                     Description="Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).">
         <StringProperty.DataSource>
-            <DataSource PersistedName="{}{Identity}" SourceOfDefaultValue="AfterContext" />
+            <DataSource PersistedName="{}{Identity}"
+                        SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
     </StringProperty>
 
@@ -88,7 +96,8 @@
                     DisplayName="Path"
                     Description="Location of the file being referenced.">
         <StringProperty.DataSource>
-            <DataSource PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
+            <DataSource PersistedName="Identity"
+                        SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
     </StringProperty>
 
@@ -131,20 +140,32 @@
                     Visible="True"
                     DisplayName="PrivateAssets"
                     Description="Assets that are private in this reference" />
-    
+
     <StringProperty Name="RequiredTargetFramework" DisplayName="Required Target Framework" Visible="False" />
     <StringProperty Name="HintPath" Visible="false" />
     <StringProperty Name="SDKIdentity" Visible="false" />
 
     <!-- This is the metadata we store on the reference item when we add it. -->
-    <BoolProperty Name="IsWinMDFile" Visible="false" Description="Indicates whether the project system ascertained that this is a WinMD (as opposed to an assembly)" />
+    <BoolProperty Name="IsWinMDFile"
+                  Visible="false"
+                  Description="Indicates whether the project system ascertained that this is a WinMD (as opposed to an assembly)" />
     <StringProperty Name="Project" 
                     Visible="False"
                     Description="the Guid the solution tracks an individual project reference target with" />
 
     <!-- These are metadata added to the resolved item by MSBuild that we don't show to the user but use internally. -->
-    <BoolProperty Name="WinMDFile" Visible="false" ReadOnly="True" Description="Indicates whether the build system ascertained that this is a WinMD (as opposed to an assembly)" />
-    <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" Description="The evaluated item name of the original reference item whose resolution resulted in this resolved reference item." />
-    <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
-    <StringProperty Name="Name" Visible="false" ReadOnly="True" />
+    <BoolProperty Name="WinMDFile"
+                  Visible="false"
+                  ReadOnly="True"
+                  Description="Indicates whether the build system ascertained that this is a WinMD (as opposed to an assembly)" />
+    <StringProperty Name="OriginalItemSpec"
+                    Visible="False"
+                    ReadOnly="True"
+                    Description="The evaluated item name of the original reference item whose resolution resulted in this resolved reference item." />
+    <StringProperty Name="FusionName"
+                    Visible="False"
+                    ReadOnly="True" />
+    <StringProperty Name="Name"
+                    Visible="false"
+                    ReadOnly="True" />
 </Rule>


### PR DESCRIPTION
Make sure we show the same set of properties for resolved and unresolved assembly references, and for resolved and unresolved project references.

**Customer scenario**

In a .NET Standard or .NET Core project, if a customer clicks on an unresolved assembly or project reference they will see a different set of properties in the Properties window than they would on a resolved assembly or project reference. In some cases this prevents editing a property, because it just isn't there.

**Bugs this fixes:** 

#1480 

**Workarounds, if any**

Opening and editing the *proj file directly.

**Risk**

Low.

**Performance impact**

Little to no impact.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

Not clear. I imagine we've been more focused on just adding the properties needed to make the project system work right, and less concerned about the UI implications.

**How was the bug found?**

Ad hoc testing
