### PR TITLE
[LanguageService] Stop sending duplicate references, additional files and analyzers to Roslyn

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ContextHandlerProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ContextHandlerProvider.cs
@@ -93,7 +93,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             // Command-line only
             ((project, context) => new MetadataReferenceItemHandler(project, context),      null),                              // <ProjectReference />, <Reference /> items
-            ((project, context) => new AnalyzerItemHandler(context),                        null),                              // <Analyzer /> item
+            ((project, context) => new AnalyzerItemHandler(project, context),               null),                              // <Analyzer /> item
             ((project, context) => new AdditionalFilesItemHandler(project, context),        null)                               // <AdditionalFiles /> item
             );
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ContextHandlerProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ContextHandlerProvider.cs
@@ -94,7 +94,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             // Command-line only
             ((project, context) => new MetadataReferenceItemHandler(project, context),      null),                              // <ProjectReference />, <Reference /> items
             ((project, context) => new AnalyzerItemHandler(context),                        null),                              // <Analyzer /> item
-            ((project, context) => new AdditionalFilesItemHandler(context),                 null)                               // <AdditionalFiles /> item
+            ((project, context) => new AdditionalFilesItemHandler(project, context),        null)                               // <AdditionalFiles /> item
             );
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
@@ -12,8 +12,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     /// </summary>
     internal class AdditionalFilesItemHandler : ICommandLineHandler
     {
-        // WORKAROUND: To avoid Roslyn throwing when we add duplicate references, we remember what 
-        // send to them and avoid sending on duplicates.
+        // WORKAROUND: To avoid Roslyn throwing when we add duplicate additonal files, we remember what 
+        // sent to them and avoid sending on duplicates.
         // See: https://github.com/dotnet/project-system/issues/2230
 
         private readonly UnconfiguredProject _project;
@@ -25,7 +25,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Requires.NotNull(project, nameof(project));
             Requires.NotNull(context, nameof(context));
 
-            _project = project;
             _project = project;
             _context = context;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
@@ -12,13 +13,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     /// </summary>
     internal class AnalyzerItemHandler : ICommandLineHandler
     {
+        // WORKAROUND: To avoid Roslyn throwing when we add duplicate analyzers, we remember what 
+        // sent to them and avoid sending on duplicates.
+
+        // See: https://github.com/dotnet/project-system/issues/2230
+        private readonly UnconfiguredProject _project;
         private readonly IWorkspaceProjectContext _context;
+        private readonly HashSet<string> _paths = new HashSet<string>(StringComparers.Paths);
 
         [ImportingConstructor]
-        public AnalyzerItemHandler(IWorkspaceProjectContext context)
+        public AnalyzerItemHandler(UnconfiguredProject project, IWorkspaceProjectContext context)
         {
+            Requires.NotNull(project, nameof(project));
             Requires.NotNull(context, nameof(context));
 
+            _project = project;
             _context = context;
         }
 
@@ -30,12 +39,36 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             foreach (CommandLineAnalyzerReference analyzer in removed.AnalyzerReferences)
             {
-                _context.RemoveAnalyzerReference(analyzer.FilePath);
+                var fullPath = _project.MakeRooted(analyzer.FilePath);
+
+                RemoveFromContextIfPresent(fullPath);
             }
 
             foreach (CommandLineAnalyzerReference analyzer in added.AnalyzerReferences)
             {
-                _context.AddAnalyzerReference(analyzer.FilePath);
+                var fullPath = _project.MakeRooted(analyzer.FilePath);
+
+                AddToContextIfNotPresent(fullPath);
+            }
+        }
+
+        private void AddToContextIfNotPresent(string fullPath)
+        {
+            if (!_paths.Contains(fullPath))
+            {
+                _context.AddAdditionalFile(fullPath);
+                bool added = _paths.Add(fullPath);
+                Assumes.True(added);
+            }
+        }
+
+        private void RemoveFromContextIfPresent(string fullPath)
+        {
+            if (_paths.Contains(fullPath))
+            {
+                _context.RemoveAdditionalFile(fullPath);
+                bool removed = _paths.Remove(fullPath);
+                Assumes.True(removed);
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     internal class MetadataReferenceItemHandler : ICommandLineHandler
     {
         // WORKAROUND: To avoid Roslyn throwing when we add duplicate references, we remember what 
-        // send to them and avoid sending on duplicates.
+        // sent to them and avoid sending on duplicates.
         // See: https://github.com/dotnet/project-system/issues/2230
 
         private readonly UnconfiguredProject _project;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
@@ -12,6 +12,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     /// </summary>
     internal class MetadataReferenceItemHandler : ICommandLineHandler
     {
+        // WORKAROUND: To avoid Roslyn throwing when we add duplicate references, we remember what 
+        // send to them and avoid sending on duplicates.
+        // See: https://github.com/dotnet/project-system/issues/2230
+
         private readonly UnconfiguredProject _project;
         private readonly IWorkspaceProjectContext _context;
         private readonly HashSet<string> _paths = new HashSet<string>(StringComparers.Paths);


### PR DESCRIPTION
This implements the same behavior as legacy project system, however this is short term behavior. Long term behavior will be determined by https://github.com/dotnet/project-system/issues/2230.

This stops Roslyn throwing when we attempt to add duplicates, long term I would like these to be errors the same as the command-line.