### PR TITLE
remove hack around CreateProjectContext for F#

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/UnconfiguredProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/UnconfiguredProjectContextProvider.cs
@@ -271,16 +271,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
 
                         // TODO: https://github.com/dotnet/roslyn-project-system/issues/353
                         await _commonServices.ThreadingService.SwitchToUIThread();
-
-                        // HACK HACK: Roslyn's CreateProjectContext only supports C# and VB and for F#, a new overload was added. Instead, that should be removed and the main overload should just take an optional error prefix.
-                        if (languageName == "F#")
-                        {
-                            workspaceProjectContext = _contextFactory.Value.CreateProjectContext(languageName, displayName, projectData.FullPath, projectGuid, configuredProjectHostObject, targetPath, null);
-                        }
-                        else
-                        {
-                            workspaceProjectContext = _contextFactory.Value.CreateProjectContext(languageName, displayName, projectData.FullPath, projectGuid, configuredProjectHostObject, targetPath);
-                        }
+                        workspaceProjectContext = _contextFactory.Value.CreateProjectContext(languageName, displayName, projectData.FullPath, projectGuid, configuredProjectHostObject, targetPath);
 
                         // By default, set "LastDesignTimeBuildSucceeded = false" to turn off diagnostics until first design time build succeeds for this project.
                         workspaceProjectContext.LastDesignTimeBuildSucceeded = false;


### PR DESCRIPTION
This removes a [previous hack](https://github.com/dotnet/project-system/blob/360a009390105ad50695ae595ddb62dbd56b87b3/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/UnconfiguredProjectContextProvider.cs#L278) that enabled a project context to be created for F#.

**NOTE:** This PR is dependent upon dotnet/roslyn#19667 being merged _and_ inserted into official VS builds.

@srivatsn @KevinRansom