### PR TITLE
Updating the PropPageDesignerView to ensure the ConfigurationPanel gains focus first for config pages.

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerView.resx
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerView.resx
@@ -142,7 +142,7 @@
     <value xml:space="preserve">ConfigurationTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;ConfigurationComboBox.ZOrder">
-    <value xml:space="preserve">0</value>
+    <value xml:space="preserve">1</value>
   </data>
   <data name="PlatformLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -160,7 +160,7 @@
     <value>48, 13</value>
   </data>
   <data name="PlatformLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
+    <value>0</value>
   </data>
   <data name="PlatformLabel.Text">
     <value xml:space="preserve">Platfor&amp;m:</value>
@@ -190,7 +190,7 @@
     <value>159, 21</value>
   </data>
   <data name="PlatformComboBox.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>1</value>
   </data>
   <data name="&gt;&gt;PlatformComboBox.Name">
     <value xml:space="preserve">PlatformComboBox</value>
@@ -217,7 +217,7 @@
     <value>863, 1</value>
   </data>
   <data name="ConfigDividerLine.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>1</value>
   </data>
   <data name="&gt;&gt;ConfigDividerLine.Name">
     <value xml:space="preserve">ConfigDividerLine</value>
@@ -229,7 +229,7 @@
     <value xml:space="preserve">ConfigurationPanel</value>
   </data>
   <data name="&gt;&gt;ConfigDividerLine.ZOrder">
-    <value xml:space="preserve">0</value>
+    <value xml:space="preserve">1</value>
   </data>
   <data name="ConfigurationLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -262,7 +262,7 @@
     <value xml:space="preserve">ConfigurationTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;ConfigurationLabel.ZOrder">
-    <value xml:space="preserve">1</value>
+    <value xml:space="preserve">0</value>
   </data>
   <data name="PropertyPagePanel.AccessibleName">
     <value xml:space="preserve">Property Page Panel</value>
@@ -283,7 +283,7 @@
     <value>863, 474</value>
   </data>
   <data name="PropertyPagePanel.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="PropertyPagePanel.Text">
     <value xml:space="preserve">PropertyPagePanel</value>
@@ -364,7 +364,7 @@
     <value>216, 27</value>
   </data>
   <data name="PLatformTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>1</value>
   </data>
   <data name="&gt;&gt;PLatformTableLayoutPanel.Name">
     <value xml:space="preserve">PLatformTableLayoutPanel</value>
@@ -403,7 +403,7 @@
     <value xml:space="preserve">ConfigurationPanel</value>
   </data>
   <data name="&gt;&gt;ConfigurationFlowLayoutPanel.ZOrder">
-    <value xml:space="preserve">1</value>
+    <value xml:space="preserve">0</value>
   </data>
   <data name="ConfigurationPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -421,7 +421,7 @@
     <value>863, 43</value>
   </data>
   <data name="ConfigurationPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>0</value>
   </data>
   <data name="&gt;&gt;ConfigurationPanel.Name">
     <value xml:space="preserve">ConfigurationPanel</value>
@@ -454,7 +454,7 @@
     <value>891, 568</value>
   </data>
   <data name="PropPageDesignerViewLayoutPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>0</value>
   </data>
   <data name="&gt;&gt;PropPageDesignerViewLayoutPanel.Name">
     <value xml:space="preserve">PropPageDesignerViewLayoutPanel</value>

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerView.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerView.vb
@@ -644,6 +644,13 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                         FocusFirstOrLastPropertyPageControl(True)
                     End If
 
+                    ' For configuration pages, we need to ensure the configuration panel recieves focus
+                    ' and not the property page itself. This allows a screen reader to give the page context
+                    ' before reading the values of any properties themselves.
+                    If _isConfigPage Then
+                        SelectNextControl(ConfigurationPanel, forward:=True, tabStopOnly:=True, nested:=True, wrap:=True)
+                    End If
+
                     SetUndoRedoCleanState()
 
                 Catch ex As Exception When ReportWithoutCrash(ex, NameOf(ActivatePage), NameOf(PropPageDesignerView))


### PR DESCRIPTION
**Customer scenario**

For configuration pages, we need to ensure the configuration panel receives focus and not the property page itself. This allows a screen reader to give the page context before reading the values of any properties themselves. 

**Bugs this fixes:** 

https://devdiv.visualstudio.com/DevDiv/_workitems?id=382395

**Workarounds, if any**

User can first tab through the entire page.

**Risk**

Minimal. This just changes which control gets focus first.

**Performance impact**

Minimal to none.

**Is this a regression from a previous update?**

No

**Root cause analysis:**

Known accessibility issue.

**How was the bug found?**

Accessibility tenant.
