### PR TITLE
[Infrastructure] Stop copying unchanged files

### DIFF
--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -500,7 +500,13 @@
     <!-- Copy manifests to be picked up by NuGet insertion packages -->
     <Copy SourceFiles="source.extension.vsixmanifest" 
           DestinationFolder="$(OutDir)\Manifests\$(MSBuildProjectName)"
-          Condition="'$(CreateVsixContainer)' == 'true'">
+          SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
+          OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+          Retries="$(CopyRetryCount)"
+          RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+          UseHardlinksIfPossible="$(CreateHardLinksForCopyFilesToOutputDirectoryIfPossible)"
+          Condition="'$(CreateVsixContainer)' == 'true'"
+          >
       
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>
     </Copy>
@@ -514,7 +520,13 @@
 
     <!-- Copy rule files for testing and setup authoring purposes -->
     <Copy SourceFiles="@(_XamlPropertyRuleToCopy)"
-          DestinationFiles="@(_XamlPropertyRuleToCopy->'$(OutDir)\Rules\%(RecursiveDir)%(Filename)%(Extension)')">
+          DestinationFiles="@(_XamlPropertyRuleToCopy->'$(OutDir)\Rules\%(RecursiveDir)%(Filename)%(Extension)')"
+          SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
+          OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+          Retries="$(CopyRetryCount)"
+          RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+          UseHardlinksIfPossible="$(CreateHardLinksForCopyFilesToOutputDirectoryIfPossible)"
+          >
       
       <Output TaskParameter="DestinationFiles" ItemName="FileWrites"/>      
     </Copy>


### PR DESCRIPTION
Every build of ProjectSystem.Managed and VSIX projects were unnecessarily copying extra files. Prevent that to speed up-to-date builds.

Also respected the same properties that we use in CopyFilesToOutputDirectory.

Note: I attempted to replace this target with the default copying that MSBuild does for `<None/>` without success. Spent over an hour debugging it and could not figure out why it wouldn't copy these items and gave up.