### PR TITLE
Updating the VSThemedLinkLabel to use SystemColors.HotTrack for pages that aren't themed.

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/VSThemedLinkLabel.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/VSThemedLinkLabel.vb
@@ -20,12 +20,20 @@ Public Class VSThemedLinkLabel
     End Sub
 
     Public Sub SetThemedColor(vsUIShell5 As IVsUIShell5)
+        SetThemedColor(vsUIShell5, supportsTheming:=True)
+    End Sub
 
-        ' The default value is the actual value of DiagReportLinkTextHover and DiagReportLinkText defined by Dev11
-        _vsThemedLinkColorHover = ShellUtil.GetEnvironmentThemeColor(vsUIShell5, "PanelHyperlinkHover", __THEMEDCOLORTYPE.TCT_Background, SystemColors.HotTrack)
-        _vsThemedLinkColor = ShellUtil.GetEnvironmentThemeColor(vsUIShell5, "PanelHyperlink", __THEMEDCOLORTYPE.TCT_Background, SystemColors.HotTrack)
+    Public Sub SetThemedColor(vsUIShell5 As IVsUIShell5, supportsTheming As Boolean)
+        If supportsTheming Then
+            _vsThemedLinkColorHover = ShellUtil.GetEnvironmentThemeColor(vsUIShell5, "PanelHyperlinkHover", __THEMEDCOLORTYPE.TCT_Background, SystemColors.HotTrack)
+            _vsThemedLinkColor = ShellUtil.GetEnvironmentThemeColor(vsUIShell5, "PanelHyperlink", __THEMEDCOLORTYPE.TCT_Background, SystemColors.HotTrack)
+            ActiveLinkColor = ShellUtil.GetEnvironmentThemeColor(vsUIShell5, "PanelHyperlinkPressed", __THEMEDCOLORTYPE.TCT_Background, SystemColors.HotTrack)
+        Else
+            _vsThemedLinkColorHover = SystemColors.HotTrack
+            _vsThemedLinkColor = SystemColors.HotTrack
+            ActiveLinkColor = SystemColors.HotTrack
+        End If
 
-        ActiveLinkColor = ShellUtil.GetEnvironmentThemeColor(vsUIShell5, "PanelHyperlinkPressed", __THEMEDCOLORTYPE.TCT_Background, SystemColors.HotTrack)
         LinkColor = _vsThemedLinkColor
         LinkBehavior = LinkBehavior.HoverUnderline
     End Sub

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityPropPage.vb
@@ -98,7 +98,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             'Opt out of page scaling since we're using AutoScaleMode
             PageRequiresScaling = False
 
-            linkLabelHelp.SetThemedColor(VsUIShell5Service)
+            linkLabelHelp.SetThemedColor(VsUIShell5Service, SupportsTheming)
         End Sub
 
 #Region "Event handlers"

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ServicesPropPage.Designer.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ServicesPropPage.Designer.vb
@@ -56,7 +56,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Me.TableLayoutPanel1.SetColumnSpan(Me.HelpLabel, 2)
             Me.HelpLabel.Name = "HelpLabel"
             Me.HelpLabel.TabStop = True
-            Me.HelpLabel.SetThemedColor(VsUIShell5Service)
+            Me.HelpLabel.SetThemedColor(VsUIShell5Service, SupportsTheming)
             '
             'TableLayoutPanel1
             '

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
@@ -435,7 +435,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             _toolbarPanel.SetToolbar(VsUIShell, Constants.MenuConstants.GUID_SETTINGSDESIGNER_MenuGroup, Constants.MenuConstants.IDM_VS_TOOLBAR_Settings)
             _toolbarPanel.BringToFront()
 
-            _descriptionLinkLabel.SetThemedColor(TryCast(VsUIShell, IVsUIShell5))
+            _descriptionLinkLabel.SetThemedColor(TryCast(VsUIShell, IVsUIShell5), supportsTheming:=False)
 
         End Sub
 


### PR DESCRIPTION
**Customer scenario**

Customers with certain vision impairments may not be able to properly read the text.

**Bugs this fixes:** 

https://devdiv.visualstudio.com/DevDiv/_workitems?id=391644

**Workarounds, if any**

None

**Risk**

Minimal, this just changes the color used by the link label controls to ensure they are accessibile.

**Performance impact**

Minimal to None

**Is this a regression from a previous update?**

No

**Root cause analysis:**

The VSThemedLinkLabel control assumed that the background color was itself themed. This was not the case for the majority of our property pages.

How did we miss it?  What tests are we adding to guard against it in the future?

Known accessibility issue

**How was the bug found?**

Accessibility Tenant
