### PR TITLE
Unify dependencies on LanguageServices

### DIFF
--- a/build/Targets/References.targets
+++ b/build/Targets/References.targets
@@ -70,7 +70,7 @@
         <PackageReference Include="System.ValueTuple" Version="4.3.0" />
         <PackageReference Include="Microsoft.Composition" Version="1.0.27" />
         <PackageReference Include="Newtonsoft.Json" Version="8.0.3" />
-        <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="2.3.0-beta1-61703-10" />
+        <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="2.3.0-beta2-61711-06" />
         <PackageReference Include="Microsoft.Build" Version="15.1.0-preview-000516-03" />
         <PackageReference Include="Microsoft.Build.Framework" Version="15.1.0-preview-000516-03" />
         <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.0-preview-000516-03" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests.csproj
@@ -12,11 +12,7 @@
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EnvDTE" Version="8.0.1" />
-    <PackageReference Include="EnvDTE80" Version="8.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.IntegrationTest.Utilities" Version="$(MicrosoftVisualStudioIntegrationTestUtilitiesVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="[$(MicrosoftVisualStudioLanguageServicesVersion)]" />
-    <PackageReference Include="System.Reflection.Metadata" Version="[$(SystemReflectionMetadataVersion)]" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests\Properties\AssemblyAttributes.cs">


### PR DESCRIPTION
This gets rid of the NuGet restore downgrade warnings.