### PR TITLE
[Logging] Format the text *before* Forking

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowProjectLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowProjectLogger.cs
@@ -33,6 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
         {
             get { return _options.IsProjectOutputPaneEnabled; }
         }
+
         public void WriteLine(string text)
         {
             WriteLine(new FormatArray(text));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowProjectLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowProjectLogger.cs
@@ -63,6 +63,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
         {
             if (IsEnabled)
             {
+                string text = formatArray.Text + Environment.NewLine;
+
                 // Extremely naive implementation of a Windows Pane logger - the assumption here is that text is rarely written,
                 // so transitions to the UI thread are uncommon and are fire and forget. If we start writing to this a lot (such 
                 // as via build), then we'll need to implement a better queueing mechanism.
@@ -72,7 +74,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
                     IVsOutputWindowPane pane = await _outputWindowProvider.GetOutputWindowPaneAsync()
                                                                           .ConfigureAwait(true);
 
-                    pane.OutputStringNoPump(formatArray.Text + Environment.NewLine);
+                    pane.OutputStringNoPump(text);
 
                 }, options: ForkOptions.HideLocks | ForkOptions.StartOnMainThread);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/IProjectLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/IProjectLogger.cs
@@ -21,60 +21,73 @@ namespace Microsoft.VisualStudio.ProjectSystem.Logging
         }
 
         /// <summary>
-        ///     Writes the specified text, followed by the current line terminator, 
+        ///     If <see cref="IsEnabled"/> is <see langword="true"/>, writes 
+        ///     the specified text, followed by the current line terminator, 
         ///     to the log.
         /// </summary>
         void WriteLine(string text);
 
         /// <summary>
-        ///     Writes the text representation of the specified object, 
-        ///     followed by the current line terminator, to the log using the 
-        ///     specified format information.
+        ///     If <see cref="IsEnabled"/> is <see langword="true"/>, writes 
+        ///     the text representation of the specified object, followed by 
+        ///     the current line terminator, to the log using the specified 
+        ///     format information.
         /// </summary>
         /// <exception cref="ArgumentNullException">
-        ///     <paramref name="format"/> is <see langword="null"/>.
+        ///      <see cref="IsEnabled"/> is <see langword="true"/> and 
+        ///      <paramref name="format"/> is <see langword="null"/>.
         /// </exception>
         /// <exception cref="FormatException">
-        ///     The format specification in <paramref name="format"/> is invalid.
+        ///     <see cref="IsEnabled"/> is <see langword="true"/> and the format 
+        ///     specification in <paramref name="format"/> is invalid.
         /// </exception>
         void WriteLine(string format, object argument);
 
         /// <summary>
-        ///     Writes the text representation of the specified objects, 
-        ///     followed by the current line terminator, to the log using the 
-        ///     specified format information.
+        ///     If <see cref="IsEnabled"/> is <see langword="true"/>, writes 
+        ///     the text representation of the specified objects, followed by 
+        ///     the current line terminator, to the log using the specified 
+        ///     format information.
         /// </summary>
         /// <exception cref="ArgumentNullException">
-        ///     <paramref name="format"/> is <see langword="null"/>.
+        ///      <see cref="IsEnabled"/> is <see langword="true"/> and 
+        ///      <paramref name="format"/> is <see langword="null"/>.
         /// </exception>
         /// <exception cref="FormatException">
-        ///     The format specification in <paramref name="format"/> is invalid.
+        ///     <see cref="IsEnabled"/> is <see langword="true"/> and the format 
+        ///     specification in <paramref name="format"/> is invalid.
         /// </exception>
         void WriteLine(string format, object argument1, object argument2);
 
         /// <summary>
-        ///     Writes the text representation of the specified objects, 
-        ///     followed by the current line terminator, to the log using the 
-        ///     specified format information.
+        ///     If <see cref="IsEnabled"/> is <see langword="true"/>, writes 
+        ///     the text representation of the specified objects, followed by 
+        ///     the current line terminator, to the log using the specified 
+        ///     format information.
         /// </summary>
         /// <exception cref="ArgumentNullException">
-        ///     <paramref name="format"/> is <see langword="null"/>.
+        ///      <see cref="IsEnabled"/> is <see langword="true"/> and 
+        ///      <paramref name="format"/> is <see langword="null"/>.
         /// </exception>
         /// <exception cref="FormatException">
-        ///     The format specification in <paramref name="format"/> is invalid.
+        ///     <see cref="IsEnabled"/> is <see langword="true"/> and the format 
+        ///     specification in <paramref name="format"/> is invalid.
         /// </exception>
         void WriteLine(string format, object argument1, object argument2, object argument3);
 
         /// <summary>
-        ///     Writes the text representation of the specified array of objects, 
-        ///     followed by the current line terminator, to the log using the 
-        ///     specified format information.
+        ///     If <see cref="IsEnabled"/> is <see langword="true"/>, writes the 
+        ///     text representation of the specified array of objects, followed 
+        ///     by the current line terminator, to the log using the specified 
+        ///     format information.
         /// </summary>
         /// <exception cref="ArgumentNullException">
-        ///     <paramref name="format"/> is <see langword="null"/>.
+        ///      <see cref="IsEnabled"/> is <see langword="true"/> and 
+        ///      <paramref name="format"/> is <see langword="null"/>.
         /// </exception>
         /// <exception cref="FormatException">
-        ///     The format specification in <paramref name="format"/> is invalid.
+        ///     <see cref="IsEnabled"/> is <see langword="true"/> and the format 
+        ///     specification in <paramref name="format"/> is invalid.
         /// </exception>
         void WriteLine(string format, params object[] arguments);
     }


### PR DESCRIPTION
- Update xml docs for IProjectLogger to reflect IsEnabled changes
- Format the text *before* Forking, which avoids us throwing exceptions after we've forked and pushed to the UI thread
