### PR TITLE
Updating the DesignerTabControl to allow keyboard navigation on the DesignerTabButton(s)

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerView.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerView.vb
@@ -824,8 +824,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             '  adding the AppicationDesignerPanels, so that the final size of the HostingPanel is
             '  known.
             For i As Integer = 0 To _designerPanels.GetUpperBound(0)
-                Dim iTab As Integer = AddTab(_designerPanels(i).TabTitle, _designerPanels(i).TabAutomationName)
-                GetTabButton(iTab).TabStop = False 'Keep from setting focus to the tabs when they're clicked so we don't fire OnItemGotFocus
+                AddTab(_designerPanels(i).TabTitle, _designerPanels(i).TabAutomationName)
             Next
 
             'Now that all the tab titles have been figured out, we can go ahead and add all the 
@@ -999,7 +998,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <param name="Index">Index of Designer panel to show</param>
         ''' <param name="ForceShow">Forces the Show code to go through, even if the current panel is the same as the one requested.</param>
         ''' <remarks></remarks>
-        Private Sub ShowTab(Index As Integer, Optional ForceShow As Boolean = False)
+        Private Sub ShowTab(Index As Integer, Optional ForceShow As Boolean = False, Optional ForceActivate As Boolean = False)
 
             Common.Switches.TracePDFocus(TraceLevel.Warning, "ApplicationDesignerView.ShowTab(" & Index & ")")
             If _inShowTab Then
@@ -1100,6 +1099,17 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                             End If
 
                         End With
+                    ElseIf ForceActivate Then
+                        ' We need to reactivate the page to ensure that focus returns to the first control, as the user
+                        ' may have been using keyboard navigation to access the page and would otherwise be on the final
+                        ' control in the form again (putting them right back in the DesignerTabControl on next Tab).
+                        Dim PropPageView As PropPageDesigner.PropPageDesignerView
+                        PropPageView = TryCast(NewCurrentPanel.DocView, PropPageDesigner.PropPageDesignerView)
+                        If PropPageView IsNot Nothing Then
+                            PropPageView.ActivatePage(PropPageView.PropPage)
+                        Else
+                            'Must have had error loading
+                        End If
                     End If
                 Catch ex As Exception When Common.ReportWithoutCrash(ex, NameOf(ShowTab), NameOf(ApplicationDesignerView))
                     ErrorMessage = Common.DebugMessageFromException(ex)
@@ -1228,9 +1238,13 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <param name="item"></param>
         ''' <remarks></remarks>
         Public Overrides Sub OnItemClick(item As ProjectDesignerTabButton)
+            OnItemClick(item, reactivatePage:=False)
+        End Sub
+
+        Public Overrides Sub OnItemClick(item As ProjectDesignerTabButton, reactivatePage As Boolean)
             Common.Switches.TracePDFocus(TraceLevel.Warning, "ApplicationDesignerView.OnItemClick")
-            MyBase.OnItemClick(item)
-            ShowTab(SelectedIndex, ForceShow:=True)
+            MyBase.OnItemClick(item, reactivatePage)
+            ShowTab(SelectedIndex, ForceShow:=True, ForceActivate:=reactivatePage)
 
             ' we need set back the tab, if we failed to switch...
             If SelectedIndex <> _activePanelIndex Then

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabControl.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabControl.vb
@@ -461,6 +461,10 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <param name="item">The tab button which has been clicked.</param>
         ''' <remarks></remarks>
         Public Overridable Sub OnItemClick(item As ProjectDesignerTabButton)
+            OnItemClick(item, reactivatePage:=False)
+        End Sub
+
+        Public Overridable Sub OnItemClick(item As ProjectDesignerTabButton, reactivatePage As Boolean)
             SelectedItem = item
         End Sub
 

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabControlRenderer.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabControlRenderer.vb
@@ -38,15 +38,18 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
 
         ' Tab button foreground/background 
         Private _buttonForegroundColor As Color
-        Private _buttonBackgroundColor as Color
+        Private _buttonBackgroundColor As Color
+        Private _buttonBorderColor As Color
 
         ' Tab button selected foreground/background 
         Private _selectedButtonForegroundColor As Color
-        Private _selectedButtonBackgroundColor as Color
+        Private _selectedButtonBackgroundColor As Color
+        Private _selectedButtonBorderColor As Color
 
         ' Tab button hover foreground/background
         Private _hoverButtonForegroundColor As Color
-        Private _hoverButtonBackgroundColor as Color
+        Private _hoverButtonBackgroundColor As Color
+        Private _hoverButtonBorderColor As Color
 
 #End Region
 
@@ -56,13 +59,16 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         Private _controlBackgroundBrush As SolidBrush
 
         ' Tab button foreground/background 
-        Private _buttonBackgroundBrush as Brush
+        Private _buttonBackgroundBrush As Brush
+        Private _buttonBorderPen As Pen
 
         ' Tab button selected foreground/background 
-        Private _selectedButtonBackgroundBrush as Brush
+        Private _selectedButtonBackgroundBrush As Brush
+        Private _selectedButtonBorderPen As Pen
 
         ' Tab button hover foreground/background
-        Private _hoverButtonBackgroundBrush as Brush
+        Private _hoverButtonBackgroundBrush As Brush
+        Private _hoverButtonBorderPen As Pen
 
 #End Region
 
@@ -250,18 +256,34 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
 
                 _buttonForegroundColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell, "CategoryTab", __THEMEDCOLORTYPE.TCT_Foreground, SystemColors.WindowText)
                 _buttonBackgroundColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell, "CategoryTab", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Window)
+                _buttonBorderColor = _buttonForegroundColor
 
                 _selectedButtonForegroundColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell, "SelectedCategoryTab", __THEMEDCOLORTYPE.TCT_Foreground, SystemColors.HighlightText)
                 _selectedButtonBackgroundColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell, "SelectedCategoryTab", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Highlight)
+                _selectedButtonBorderColor = _selectedButtonForegroundColor
 
                 _hoverButtonForegroundColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell, "MouseOverCategoryTab", __THEMEDCOLORTYPE.TCT_Foreground, SystemColors.HighlightText)
                 _hoverButtonBackgroundColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell, "MouseOverCategoryTab", __THEMEDCOLORTYPE.TCT_Background, SystemColors.HotTrack)
+                _hoverButtonBorderColor = _hoverButtonForegroundColor
 
                 'Get GDI objects
                 _controlBackgroundBrush = New SolidBrush(_controlBackgroundColor)
+
                 _buttonBackgroundBrush = New SolidBrush(_buttonBackgroundColor)
+                _buttonBorderPen = New Pen(_buttonBorderColor) With {
+                    .DashStyle = DashStyle.Dash
+                }
+
                 _selectedButtonBackgroundBrush = New SolidBrush(_selectedButtonBackgroundColor)
+                _selectedButtonBorderPen = New Pen(_selectedButtonBorderColor) With {
+                    .DashStyle = DashStyle.Dash
+                }
+
                 _hoverButtonBackgroundBrush = New SolidBrush(_hoverButtonBackgroundColor)
+                _hoverButtonBorderPen = New Pen(_buttonBorderColor) With {
+                    .DashStyle = DashStyle.Dash
+                }
+
 
                 If ForceUpdate Then
                     'Colors may have changed, need to update state.  Also, the gradient brushes are
@@ -534,13 +556,16 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
 
             Dim backgroundBrush As Brush = _buttonBackgroundBrush
             Dim foregroundColor As Color = _buttonForegroundColor ' TextRenderer.DrawText takes a color over a brush 
+            Dim borderPen As Pen = _buttonBorderPen
 
             If IsSelected Then
                 backgroundBrush = _selectedButtonBackgroundBrush
                 foregroundColor = _selectedButtonForegroundColor
-            Else If IsHovered Then
+                borderPen = _selectedButtonBorderPen
+            ElseIf IsHovered Then
                 backgroundBrush = _hoverButtonBackgroundBrush
                 foregroundColor = _hoverButtonForegroundColor
+                borderPen = _hoverButtonBorderPen
             End If
 
             Const TriangleWidth As Integer = 6
@@ -554,15 +579,14 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
 
             g.FillRectangle(backgroundBrush, New Rectangle(0, 0, triangleHorizontalStart, button.Height))
 
-
             ' Draw the "arrow" part of the tab button if the item is selected for hovered 
             If IsSelected Then
 
                 ' Create an array of points which describes the path of the triangle
                 Dim trainglePoints() As PointF =
                 {
-                    New PointF(triangleHorizontalStart - 1, triangleVerticalStart), _
-                    New PointF(button.Width, CSng(triangleVerticalStart) + CSng(TriangleHeight) / 2), _
+                    New PointF(triangleHorizontalStart - 1, triangleVerticalStart),
+                    New PointF(button.Width, CSng(triangleVerticalStart) + CSng(TriangleHeight) / 2),
                     New PointF(triangleHorizontalStart - 1, triangleVerticalStart + TriangleHeight)
                 }
 
@@ -582,6 +606,10 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                     g.SmoothingMode = previousSmoothingMode
 
                 End Using
+            End If
+
+            If button.DrawFocusCues Then
+                g.DrawRectangle(borderPen, New Rectangle(0, 0, triangleHorizontalStart, button.Height - 1))
             End If
 
             Dim textRect As New Rectangle(s_buttonTextLeftOffset, 0, button.Width - s_buttonTextLeftOffset, button.Height)

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/PropertyPageSite.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/PropertyPageSite.vb
@@ -93,6 +93,12 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             End Set
         End Property
 
+        Friend ReadOnly Property Owner() As IPropertyPageSiteOwner
+            Get
+                Return _appDesView
+            End Get
+        End Property
+
 
 #Region " IPropertyPageSite"
         Public Const PROPPAGESTATUS_DIRTY As Integer = 1

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerView.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerView.vb
@@ -642,12 +642,12 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                     If _isNativeHostedPropertyPage Then
                         'Try to set initial focus to the property page, not the configuration panel
                         FocusFirstOrLastPropertyPageControl(True)
-                    End If
-
-                    ' For configuration pages, we need to ensure the configuration panel recieves focus
-                    ' and not the property page itself. This allows a screen reader to give the page context
-                    ' before reading the values of any properties themselves.
-                    If _isConfigPage Then
+                    Else
+                        ' Select the configuration panel to ensure it gains focus. For configuration pages, this
+                        ' ensures that the configuration panel receives focus and allows a screen reader to give
+                        ' the page context before reading the values of any properties themselves. For other pages
+                        ' this ensures that the first control of the page receives focus, which allows tab navigation
+                        ' to work in a reliable and predicable manner for users who can only use the keyboard.
                         SelectNextControl(ConfigurationPanel, forward:=True, tabStopOnly:=True, nested:=True, wrap:=True)
                     End If
 
@@ -1554,8 +1554,12 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                     Return True
                 End If
             Else
-                If (SelectNextControl(ActiveControl, forward, True, True, True)) Then
+                If (SelectNextControl(ActiveControl, forward, tabStopOnly:=True, nested:=True, wrap:=False)) Then
                     Return True
+                Else
+                    Dim appDesView As ApplicationDesignerView = CType(_loadedPageSite.Owner, ApplicationDesignerView)
+                    appDesView.SelectedItem.Focus()
+                    appDesView.SelectedItem.FocusedFromKeyboardNav = True
                 End If
             End If
 


### PR DESCRIPTION
**Customer scenario**

Customers who rely on keyboard navigation will not be able to navigate through the available property pages.

**Bugs this fixes:** 

https://devdiv.visualstudio.com/DevDiv/_workitems?id=409661

**Workarounds, if any**

None

**Risk**

Low, this adds the DesignerTabControl to the list of tab stops, but it requires some manual focus invocations to get it functioning with the existing codebase.

**Performance impact**

Low, this only adds a couple of additional checks on the existing code paths to determine if the keyboard based navigation is being used.

**Is this a regression from a previous update?**

No

**Root cause analysis:**

Known accessibility issue

**How was the bug found?**

Accessibility Tenant
