### PR TITLE
Pass EmitAssetsLogMessages to NuGet

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -86,4 +86,8 @@
                     Visible="False" 
                     ReadOnly="True" />
 
+    <StringProperty Name="EmitAssetsLogMessages" 
+                    Visible="False" 
+                    ReadOnly="True" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -90,4 +90,16 @@
                     Visible="False" 
                     ReadOnly="True" />
 
+    <StringProperty Name="RestoreSources" 
+                    Visible="False" 
+                    ReadOnly="True" />
+
+    <StringProperty Name="RestoreFallbackFolders" 
+                    Visible="False" 
+                    ReadOnly="True" />
+
+    <StringProperty Name="RestorePackagesPath" 
+                    Visible="False" 
+                    ReadOnly="True" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/NuGetRestore.xaml
@@ -46,4 +46,7 @@
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
   <StringProperty Name="EmitAssetsLogMessages" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/NuGetRestore.xaml
@@ -45,4 +45,5 @@
   <StringProperty Name="Version" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
+  <StringProperty Name="EmitAssetsLogMessages" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/NuGetRestore.xaml
@@ -46,4 +46,7 @@
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
   <StringProperty Name="EmitAssetsLogMessages" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/NuGetRestore.xaml
@@ -45,4 +45,5 @@
   <StringProperty Name="Version" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
+  <StringProperty Name="EmitAssetsLogMessages" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/NuGetRestore.xaml
@@ -46,4 +46,7 @@
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
   <StringProperty Name="EmitAssetsLogMessages" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/NuGetRestore.xaml
@@ -45,4 +45,5 @@
   <StringProperty Name="Version" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
+  <StringProperty Name="EmitAssetsLogMessages" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/NuGetRestore.xaml
@@ -46,4 +46,7 @@
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
   <StringProperty Name="EmitAssetsLogMessages" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/NuGetRestore.xaml
@@ -45,4 +45,5 @@
   <StringProperty Name="Version" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
+  <StringProperty Name="EmitAssetsLogMessages" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/NuGetRestore.xaml
@@ -46,4 +46,7 @@
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
   <StringProperty Name="EmitAssetsLogMessages" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/NuGetRestore.xaml
@@ -45,4 +45,5 @@
   <StringProperty Name="Version" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
+  <StringProperty Name="EmitAssetsLogMessages" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/NuGetRestore.xaml
@@ -46,4 +46,7 @@
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
   <StringProperty Name="EmitAssetsLogMessages" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/NuGetRestore.xaml
@@ -45,4 +45,5 @@
   <StringProperty Name="Version" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
+  <StringProperty Name="EmitAssetsLogMessages" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/NuGetRestore.xaml
@@ -46,4 +46,7 @@
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
   <StringProperty Name="EmitAssetsLogMessages" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/NuGetRestore.xaml
@@ -45,4 +45,5 @@
   <StringProperty Name="Version" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
+  <StringProperty Name="EmitAssetsLogMessages" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/NuGetRestore.xaml
@@ -46,4 +46,7 @@
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
   <StringProperty Name="EmitAssetsLogMessages" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/NuGetRestore.xaml
@@ -45,4 +45,5 @@
   <StringProperty Name="Version" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
+  <StringProperty Name="EmitAssetsLogMessages" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/NuGetRestore.xaml
@@ -46,4 +46,7 @@
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
   <StringProperty Name="EmitAssetsLogMessages" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/NuGetRestore.xaml
@@ -45,4 +45,5 @@
   <StringProperty Name="Version" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
+  <StringProperty Name="EmitAssetsLogMessages" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/NuGetRestore.xaml
@@ -46,4 +46,7 @@
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
   <StringProperty Name="EmitAssetsLogMessages" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/NuGetRestore.xaml
@@ -45,4 +45,5 @@
   <StringProperty Name="Version" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
+  <StringProperty Name="EmitAssetsLogMessages" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/NuGetRestore.xaml
@@ -46,4 +46,7 @@
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
   <StringProperty Name="EmitAssetsLogMessages" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/NuGetRestore.xaml
@@ -45,4 +45,5 @@
   <StringProperty Name="Version" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
+  <StringProperty Name="EmitAssetsLogMessages" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/NuGetRestore.xaml
@@ -46,4 +46,7 @@
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
   <StringProperty Name="EmitAssetsLogMessages" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/NuGetRestore.xaml
@@ -45,4 +45,5 @@
   <StringProperty Name="Version" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
+  <StringProperty Name="EmitAssetsLogMessages" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/NuGetRestore.xaml
@@ -46,4 +46,7 @@
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
   <StringProperty Name="EmitAssetsLogMessages" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/NuGetRestore.xaml
@@ -45,4 +45,5 @@
   <StringProperty Name="Version" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionPrefix" Visible="False" ReadOnly="True" />
   <StringProperty Name="VersionSuffix" Visible="False" ReadOnly="True" />
+  <StringProperty Name="EmitAssetsLogMessages" Visible="False" ReadOnly="True" />
 </Rule>


### PR DESCRIPTION
Pass the property `EmitAssetsLogMessages` to NuGet to indicate that diagnostics will be emitted to error list through an SDK-based task, instead of through NuGet

**Customer scenario**

When the changes in https://github.com/dotnet/sdk/pull/1228 are merged, SDK-based projects will see NuGet warnings repeated twice: once from the new task in that PR and once from NuGet's existing logger. We recently decided the mechanism to turn off the NuGet logging is to pass this flag which is set by the SDK. Legacy (none SDK) projects will continue to use existing NuGet logging.

**Bugs this fixes:** 

Part of https://github.com/dotnet/project-system/issues/1660
Fixes https://github.com/dotnet/project-system/issues/2225

**Workarounds, if any**

Users can filter out warnings without an Error code to hide the NuGet logger diagnostics, but this is not a good experience

**Risk**

Low, this change only updates a Rule file to pass an additional property

**Performance impact**

Low, this change only updates a Rule file to pass an additional property

**Is this a regression from a previous update?**

No

**Root cause analysis:**

Known work item, we just reached agreement with NuGet on the mechanism

**How was the bug found?**

Known work item

/cc @dotnet/project-system 
/cc @emgarten 

(Note: we still need to run xliff converter over the 15.3.x branch. I included only the changes to NuGetRestore.xaml to simplify this PR)