### PR TITLE
Do not rollup .Net Core class library templates

### DIFF
--- a/src/Templates/Microsoft.NetCore.CSharp.ProjectTemplates/ClassLibrary.vstemplate
+++ b/src/Templates/Microsoft.NetCore.CSharp.ProjectTemplates/ClassLibrary.vstemplate
@@ -7,7 +7,7 @@
     <ProjectType>CSharp</ProjectType>
     <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
     <SortOrder>14</SortOrder>
-    <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
+    <NumberOfParentCategoriesToRollUp>0</NumberOfParentCategoriesToRollUp>
     <TemplateID>Microsoft.CSharp.NetCore.ClassLibrary</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <CreateInPlace>true</CreateInPlace>

--- a/src/Templates/Microsoft.NetCore.FSharp.ProjectTemplates/ClassLibrary.vstemplate
+++ b/src/Templates/Microsoft.NetCore.FSharp.ProjectTemplates/ClassLibrary.vstemplate
@@ -7,7 +7,7 @@
     <ProjectType>FSharp</ProjectType>
     <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
     <SortOrder>14</SortOrder>
-    <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
+    <NumberOfParentCategoriesToRollUp>0</NumberOfParentCategoriesToRollUp>
     <TemplateID>Microsoft.FSharp.NetCore.ClassLibrary</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <CreateInPlace>true</CreateInPlace>

--- a/src/Templates/Microsoft.NetCore.VB.ProjectTemplates/ClassLibrary.vstemplate
+++ b/src/Templates/Microsoft.NetCore.VB.ProjectTemplates/ClassLibrary.vstemplate
@@ -7,7 +7,7 @@
     <ProjectType>VisualBasic</ProjectType>
     <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
     <SortOrder>14</SortOrder>
-    <NumberOfParentCategoriesToRollUp>1</NumberOfParentCategoriesToRollUp>
+    <NumberOfParentCategoriesToRollUp>0</NumberOfParentCategoriesToRollUp>
     <TemplateID>Microsoft.VisualBasic.NetCore.ClassLibrary</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>
     <CreateInPlace>true</CreateInPlace>


### PR DESCRIPTION
Fixes #2146

**Customer scenario**

Project creation rolls up .NET Core class libraries, causing 3 types of class libraries to be presented to the user

**Bugs this fixes:** 

https://github.com/dotnet/project-system/issues/2146

**Workarounds, if any**

None

**Risk**

this change does not effect other parts of the project system.

**Performance impact**

None

**Is this a regression from a previous update?**

Yes

**Root cause analysis:**

Previously the VB project templates were rolled up a level and the C# ones were not.  The VB templates never got inserted into VS but were the implementation consulted when moving the templates to the project system repo

**How was the bug found?**

ad hoc testing
