### PR TITLE
fix incorrect ID on VB NetCore project template

### DIFF
--- a/src/Templates/Microsoft.NetCore.VB.ProjectTemplates/ClassLibrary.vstemplate
+++ b/src/Templates/Microsoft.NetCore.VB.ProjectTemplates/ClassLibrary.vstemplate
@@ -2,7 +2,7 @@
 <VSTemplate Version="3.0.0" Type="ProjectGroup" xmlns="http://schemas.microsoft.com/developer/vstemplate/2005" xmlns:sdk="http://schemas.microsoft.com/developer/vstemplate-sdkextension/2010">
   <TemplateData>
     <Name Package="{860A27C0-B665-47F3-BC12-637E16A1050A}" ID="9"/>
-    <Description Package="{860A27C0-B665-47F3-BC12-637E16A1050A}" ID="6"/>
+    <Description Package="{860A27C0-B665-47F3-BC12-637E16A1050A}" ID="10"/>
     <Icon Package="{164B10B9-B200-11D0-8C61-00A0C91E29D5}" ID="4500" />
     <ProjectType>VisualBasic</ProjectType>
     <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>


### PR DESCRIPTION
**Customer scenario**

Customer is unable to determine difference between Vb Net Core class Library and VB netstandard class library as both have identical descriptions

**Bugs this fixes:** 

https://github.com/dotnet/project-system/issues/2222

**Workarounds, if any**

None

**Risk**

None

**Performance impact**

None

**Is this a regression from a previous update?**

Yes

**Root cause analysis:**

Copy/Paste error

**How was the bug found?**

ad hoc testing
