### PR TITLE
Remove workarounds for Configurations in DesignTime Targets

### DIFF
--- a/src/Targets/Microsoft.Managed.DesignTime.targets
+++ b/src/Targets/Microsoft.Managed.DesignTime.targets
@@ -232,12 +232,6 @@
     </PropertyPageSchema>
   </ItemGroup>
 
-  <!-- Workaround: Need to remove this once an insertion containing this changes goes in https://github.com/dotnet/sdk/pull/949 -->
-  <PropertyGroup>
-    <Configurations Condition=" '$(Configurations)' == '' ">Debug;Release</Configurations>
-    <Platforms Condition=" '$(Platforms)' == '' ">AnyCPU</Platforms>
-  </PropertyGroup>
-
   <!-- Targets -->
 
   <!-- For a newly created project with no packages restored, Design time build complains that there is no ResolvePackageDependenciesDesignTime

--- a/src/Targets/Microsoft.Managed.DesignTime.targets
+++ b/src/Targets/Microsoft.Managed.DesignTime.targets
@@ -232,11 +232,6 @@
     </PropertyPageSchema>
   </ItemGroup>
 
-  <!-- Workaround: https://github.com/Microsoft/msbuild/pull/1879 -->
-  <ItemGroup>
-    <ProjectCapability Remove="ProjectConfigurationsInferredFromUsage" />
-  </ItemGroup>
-
   <!-- Workaround: Need to remove this once an insertion containing this changes goes in https://github.com/dotnet/sdk/pull/949 -->
   <PropertyGroup>
     <Configurations Condition=" '$(Configurations)' == '' ">Debug;Release</Configurations>


### PR DESCRIPTION
Tagging @srivatsn @RaulPerez1 @dotnet/project-system for review

**Customer scenario**

This change does not affect any customer scenario. This change removes a hack that was placed in the product until the actual fix flowed from SDK and msbuild into the product.

**Bugs this fixes:** 

Fixes #1772 

**Workarounds, if any**

None

**Risk**

None. Just removing redundant code.

**Performance impact**

None. Nothing related to perf.
