### PR TITLE
pulling down optprof data and using it in our build

### DIFF
--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -426,19 +426,26 @@
        ==================================================================================== -->
 
   <PropertyGroup>
-    <OptimizationDataFolderPath>$(MSBuildThisFileDirectory)..\..\..\Closed\OptimizationData</OptimizationDataFolderPath>
+    <OptimizationDataFolderPath>$(NuGetPackageRoot)\RoslynDependencies.OptimizationData\$(RoslynDependenciesOptimizationDataVersion)\content\OptimizationData</OptimizationDataFolderPath>
     <OptimizationDataFile>$([System.IO.Path]::GetFullPath('$(OptimizationDataFolderPath)\$(TargetName).pgo'))</OptimizationDataFile>
-    <IbcMergePath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\..\Closed\Tools\ibcmerge\ibcmerge.exe'))</IbcMergePath>
+    <IbcMergePath>$(NuGetPackageRoot)\Microsoft.DotNet.IBCMerge\$(MicrosoftDotNetIBCMergeVersion)\lib\net45\ibcmerge.exe</IbcMergePath>
   </PropertyGroup>
 
   <Target Name="ApplyOptimizations"
           Condition="'$(Configuration)' == 'Release' AND '$(NonShipping)' != 'true' AND '$(SkipApplyOptimizations)' != 'true' AND Exists('$(OptimizationDataFile)')"
           Inputs="@(IntermediateAssembly)"
           Outputs="@(IntermediateAssembly);$(PostCompileBinaryModificationSentinelFile)">
+    <Message Text="Adding optimization data to @(IntermediateAssembly)" />
 
-    <Message Text="Adding optimization data to @(IntermediateAssembly)"/>
-    <Exec Command="&quot;$(IbcMergePath)&quot; -q -f -partialNGEN -minify -mo &quot;@(IntermediateAssembly)&quot; -incremental &quot;$(OptimizationDataFile)&quot;" />
+    <Error Text="IBCMerge not found at $(IbcMergePath). Local developer builds should pass /p:SkipApplyOptimizations=true to avoid this"
+             Condition="!Exists('$(IbcMergePath)')" />
+    <Exec Command="&quot;$(IbcMergePath)&quot; -q -f -partialNGEN -minify -mo &quot;@(IntermediateAssembly)&quot; -incremental &quot;$(OptimizationDataFile)&quot;"
+            ConsoleToMSBuild="true"
+            Condition="Exists('$(IbcMergePath)')">
+      <Output TaskParameter="ConsoleOutput" PropertyName="IbcMergeOutput" />
+    </Exec>
 
+    <Message Text="$(IbcMergeOutput)" />
   </Target>
 
   <!-- ====================================================================================

--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -432,7 +432,7 @@
   </PropertyGroup>
 
   <Target Name="ApplyOptimizations"
-          Condition="'$(Configuration)' == 'Release' AND '$(NonShipping)' != 'true' AND '$(SkipApplyOptimizations)' != 'true' AND Exists('$(OptimizationDataFile)')"
+          Condition="'$(Configuration)' == 'Release' AND '$(NonShipping)' != 'true' AND '$(ShouldSignBuild)' == 'true' AND Exists('$(OptimizationDataFile)')"
           Inputs="@(IntermediateAssembly)"
           Outputs="@(IntermediateAssembly);$(PostCompileBinaryModificationSentinelFile)">
     <Message Text="Adding optimization data to @(IntermediateAssembly)" />

--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <RoslynDependenciesOptimizationDataVersion>2.0.0-rc-61101-16</RoslynDependenciesOptimizationDataVersion>
+    <RoslynDependenciesOptimizationDataVersion>2.0.0-rc-61101-17</RoslynDependenciesOptimizationDataVersion>
     <ProjectSystemSDKVersion>15.3.93-pre-g57d342093d</ProjectSystemSDKVersion>
     <SystemCollectionsImmutableVersion>1.3.1</SystemCollectionsImmutableVersion>
     <SystemReflectionMetadataVersion>1.4.2</SystemReflectionMetadataVersion>

--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -18,10 +18,12 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <RoslynDependenciesOptimizationDataVersion>2.0.0-rc-61101-16</RoslynDependenciesOptimizationDataVersion>
     <ProjectSystemSDKVersion>15.3.93-pre-g57d342093d</ProjectSystemSDKVersion>
     <SystemCollectionsImmutableVersion>1.3.1</SystemCollectionsImmutableVersion>
     <SystemReflectionMetadataVersion>1.4.2</SystemReflectionMetadataVersion>
     <SystemRuntimeInteropServicesRuntimeInformationVersion>4.3.0</SystemRuntimeInteropServicesRuntimeInformationVersion>
+    <MicrosoftDotNetIBCMergeVersion>4.7.1-alpha-00001</MicrosoftDotNetIBCMergeVersion>
     <MicrosoftVisualStudioShellInterop10Version>10.0.30319</MicrosoftVisualStudioShellInterop10Version>
     <MicrosoftVisualStudioShellInterop11Version>11.0.61030</MicrosoftVisualStudioShellInterop11Version>
     <MicrosoftVisualStudioTextManagerInterop10Version>10.0.30319</MicrosoftVisualStudioTextManagerInterop10Version>

--- a/build/ToolsetPackages/InternalToolset.csproj
+++ b/build/ToolsetPackages/InternalToolset.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(MSBuildThisFileDirectory)..\Targets\VSL.Versions.targets" />
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.IBCMerge" Version="[$(MicrosoftDotNetIBCMergeVersion)]" />
+  </ItemGroup>
+</Project>

--- a/src/ProjectSystemSetup/ProjectSystemSetup.csproj
+++ b/src/ProjectSystemSetup/ProjectSystemSetup.csproj
@@ -91,6 +91,9 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <Private>False</Private>
     </ProjectReference>
+    
+    <PackageReference Include="Microsoft.DotNet.IBCMerge" Version="[$(MicrosoftDotNetIBCMergeVersion)]" />
+    <PackageReference Include="RoslynDependencies.OptimizationData" Version="$(RoslynDependenciesOptimizationDataVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Common\ProvideBindingRedirectionAttribute.cs">

--- a/src/ProjectSystemSetup/ProjectSystemSetup.csproj
+++ b/src/ProjectSystemSetup/ProjectSystemSetup.csproj
@@ -91,9 +91,8 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <Private>False</Private>
     </ProjectReference>
-    
-    <PackageReference Include="Microsoft.DotNet.IBCMerge" Version="[$(MicrosoftDotNetIBCMergeVersion)]" />
-    <PackageReference Include="RoslynDependencies.OptimizationData" Version="$(RoslynDependenciesOptimizationDataVersion)" />
+
+        <PackageReference Include="RoslynDependencies.OptimizationData" Version="$(RoslynDependenciesOptimizationDataVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Common\ProvideBindingRedirectionAttribute.cs">


### PR DESCRIPTION
**Customer scenario**

We are seeing close solution take longer because the property pages are not optimized.  

**Bugs this fixes:** 

https://devdiv.visualstudio.com/DevDiv/_workitems?id=360010

**Workarounds, if any**

None

**Risk**

Minimal, this change is only about using the latest optprof data.

**Performance impact**

This should improve performance when these assemblies are ngen'd on install other than that there is no perf impact for assemblies that do not have optprof data.

**Is this a regression from a previous update?**

No but this is a regression from Dev14

**Root cause analysis:**

Optprof data was not setup for the project system repo

**How was the bug found?**

This was identified late in the cycle in a perf run
