### PR TITLE
Deploy to the RoslynDev hive when not running integration tests

### DIFF
--- a/src/ProjectSystemSetup/ProjectSystemSetup.csproj
+++ b/src/ProjectSystemSetup/ProjectSystemSetup.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
     <AssemblyName>ProjectSystem</AssemblyName>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
-    <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' == 'false'">RoslynDev</VSSDKTargetPlatformRegRootSuffix>
+    <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' != 'true'">RoslynDev</VSSDKTargetPlatformRegRootSuffix>
     <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' == 'true'">ProjectSystem</VSSDKTargetPlatformRegRootSuffix>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>

--- a/src/Templates/Microsoft.NetCore.CSharp.ProjectTemplates.Test.Vsix/Microsoft.NetCore.CSharp.ProjectTemplates.Test.Vsix.csproj
+++ b/src/Templates/Microsoft.NetCore.CSharp.ProjectTemplates.Test.Vsix/Microsoft.NetCore.CSharp.ProjectTemplates.Test.Vsix.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
     <AssemblyName>Microsoft.NetCore.CSharp.ProjectTemplates.Test</AssemblyName>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
-    <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' == 'false'">RoslynDev</VSSDKTargetPlatformRegRootSuffix>
+    <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' != 'true'">RoslynDev</VSSDKTargetPlatformRegRootSuffix>
     <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' == 'true'">ProjectSystem</VSSDKTargetPlatformRegRootSuffix>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>

--- a/src/Templates/Microsoft.NetCore.CSharp.ProjectTemplates.Vsix/Microsoft.NetCore.CSharp.ProjectTemplates.Vsix.csproj
+++ b/src/Templates/Microsoft.NetCore.CSharp.ProjectTemplates.Vsix/Microsoft.NetCore.CSharp.ProjectTemplates.Vsix.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
     <AssemblyName>Microsoft.NetCore.CSharp.ProjectTemplates</AssemblyName>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
-    <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' == 'false'">RoslynDev</VSSDKTargetPlatformRegRootSuffix>
+    <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' != 'true'">RoslynDev</VSSDKTargetPlatformRegRootSuffix>
     <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' == 'true'">ProjectSystem</VSSDKTargetPlatformRegRootSuffix>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>

--- a/src/Templates/Microsoft.NetCore.FSharp.ProjectTemplates.Test.Vsix/Microsoft.NetCore.FSharp.ProjectTemplates.Test.Vsix.csproj
+++ b/src/Templates/Microsoft.NetCore.FSharp.ProjectTemplates.Test.Vsix/Microsoft.NetCore.FSharp.ProjectTemplates.Test.Vsix.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
     <AssemblyName>Microsoft.NetCore.FSharp.ProjectTemplates.Test</AssemblyName>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
-    <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' == 'false'">RoslynDev</VSSDKTargetPlatformRegRootSuffix>
+    <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' != 'true'">RoslynDev</VSSDKTargetPlatformRegRootSuffix>
     <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' == 'true'">ProjectSystem</VSSDKTargetPlatformRegRootSuffix>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>

--- a/src/Templates/Microsoft.NetCore.FSharp.ProjectTemplates.Vsix/Microsoft.NetCore.FSharp.ProjectTemplates.Vsix.csproj
+++ b/src/Templates/Microsoft.NetCore.FSharp.ProjectTemplates.Vsix/Microsoft.NetCore.FSharp.ProjectTemplates.Vsix.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
     <AssemblyName>Microsoft.NetCore.FSharp.ProjectTemplates</AssemblyName>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
-    <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' == 'false'">RoslynDev</VSSDKTargetPlatformRegRootSuffix>
+    <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' != 'true'">RoslynDev</VSSDKTargetPlatformRegRootSuffix>
     <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' == 'true'">ProjectSystem</VSSDKTargetPlatformRegRootSuffix>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>

--- a/src/Templates/Microsoft.NetCore.VB.ProjectTemplates.Test.Vsix/Microsoft.NetCore.VB.ProjectTemplates.Test.Vsix.csproj
+++ b/src/Templates/Microsoft.NetCore.VB.ProjectTemplates.Test.Vsix/Microsoft.NetCore.VB.ProjectTemplates.Test.Vsix.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
     <AssemblyName>Microsoft.NetCore.VB.ProjectTemplates.Test</AssemblyName>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
-    <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' == 'false'">RoslynDev</VSSDKTargetPlatformRegRootSuffix>
+    <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' != 'true'">RoslynDev</VSSDKTargetPlatformRegRootSuffix>
     <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' == 'true'">ProjectSystem</VSSDKTargetPlatformRegRootSuffix>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>

--- a/src/Templates/Microsoft.NetCore.VB.ProjectTemplates.Vsix/Microsoft.NetCore.VB.ProjectTemplates.Vsix.csproj
+++ b/src/Templates/Microsoft.NetCore.VB.ProjectTemplates.Vsix/Microsoft.NetCore.VB.ProjectTemplates.Vsix.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
     <AssemblyName>Microsoft.NetCore.VB.ProjectTemplates</AssemblyName>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
-    <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' == 'false'">RoslynDev</VSSDKTargetPlatformRegRootSuffix>
+    <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' != 'true'">RoslynDev</VSSDKTargetPlatformRegRootSuffix>
     <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' == 'true'">ProjectSystem</VSSDKTargetPlatformRegRootSuffix>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>

--- a/src/Templates/Microsoft.NetStandard.CSharp.ProjectTemplates.Vsix/Microsoft.NetStandard.CSharp.ProjectTemplates.Vsix.csproj
+++ b/src/Templates/Microsoft.NetStandard.CSharp.ProjectTemplates.Vsix/Microsoft.NetStandard.CSharp.ProjectTemplates.Vsix.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
     <AssemblyName>Microsoft.NetStandard.CSharp.ProjectTemplates</AssemblyName>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
-    <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' == 'false'">RoslynDev</VSSDKTargetPlatformRegRootSuffix>
+    <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' != 'true'">RoslynDev</VSSDKTargetPlatformRegRootSuffix>
     <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' == 'true'">ProjectSystem</VSSDKTargetPlatformRegRootSuffix>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>

--- a/src/Templates/Microsoft.NetStandard.FSharp.ProjectTemplates.Vsix/Microsoft.NetStandard.FSharp.ProjectTemplates.Vsix.csproj
+++ b/src/Templates/Microsoft.NetStandard.FSharp.ProjectTemplates.Vsix/Microsoft.NetStandard.FSharp.ProjectTemplates.Vsix.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
     <AssemblyName>Microsoft.NetStandard.FSharp.ProjectTemplates</AssemblyName>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
-    <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' == 'false'">RoslynDev</VSSDKTargetPlatformRegRootSuffix>
+    <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' != 'true'">RoslynDev</VSSDKTargetPlatformRegRootSuffix>
     <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' == 'true'">ProjectSystem</VSSDKTargetPlatformRegRootSuffix>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>

--- a/src/Templates/Microsoft.NetStandard.VB.ProjectTemplates.Vsix/Microsoft.NetStandard.VB.ProjectTemplates.Vsix.csproj
+++ b/src/Templates/Microsoft.NetStandard.VB.ProjectTemplates.Vsix/Microsoft.NetStandard.VB.ProjectTemplates.Vsix.csproj
@@ -7,7 +7,7 @@
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
     <AssemblyName>Microsoft.NetStandard.VB.ProjectTemplates</AssemblyName>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
-    <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' == 'false'">RoslynDev</VSSDKTargetPlatformRegRootSuffix>
+    <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' != 'true'">RoslynDev</VSSDKTargetPlatformRegRootSuffix>
     <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' == 'true'">ProjectSystem</VSSDKTargetPlatformRegRootSuffix>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>

--- a/src/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
+++ b/src/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
@@ -8,7 +8,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
-    <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' == 'false'">RoslynDev</VSSDKTargetPlatformRegRootSuffix>
+    <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' != 'true'">RoslynDev</VSSDKTargetPlatformRegRootSuffix>
     <VSSDKTargetPlatformRegRootSuffix Condition="'$(RunIntegrationTests)' == 'true'">ProjectSystem</VSSDKTargetPlatformRegRootSuffix>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>


### PR DESCRIPTION
This broke recently and building projects was deploying to the Exp hive. 

@dotnet/project-system @jmarolf 