### PR TITLE
Updating the PropPageDesignerView and PropPageUserControlBase to use `SystemColors.Control` as the fallback/unthemed color.

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerView.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerView.vb
@@ -554,9 +554,9 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         Private Sub OnThemeChanged()
             Dim VsUIShell5 = VsUIShell5Service
             If TypeOf PropPage Is PropPageBase AndAlso CType(PropPage, PropPageBase).SupportsTheming Then
-                BackColor = ShellUtil.GetProjectDesignerThemeColor(VsUIShell5Service, "Background", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Window)
+                BackColor = ShellUtil.GetProjectDesignerThemeColor(VsUIShell5Service, "Background", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Control)
             Else
-                BackColor = SystemColors.Window
+                BackColor = SystemColors.Control
             End If
 
             ConfigurationPanel.BackColor = BackColor

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
@@ -3825,9 +3825,9 @@ NextControl:
         Protected Overridable Sub OnThemeChanged()
             If SupportsTheming Then
                 Dim VsUIShell5 = VsUIShell5Service
-                BackColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell5, "Background", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Window)
+                BackColor = Common.ShellUtil.GetProjectDesignerThemeColor(VsUIShell5, "Background", __THEMEDCOLORTYPE.TCT_Background, SystemColors.Control)
             Else
-                BackColor = SystemColors.Window
+                BackColor = SystemColors.Control
             End If
         End Sub
 


### PR DESCRIPTION
**Customer scenario**

The experience is "visually poor" for unthemed property pages under one of the three default themes.

**Bugs this fixes:** 

https://github.com/dotnet/project-system/issues/2288

**Workarounds, if any**

None

**Risk**

Minimal, this just changes the default background color for unthemed property pages back to what it was before theming support was added.

**Performance impact**

None

**Is this a regression from a previous update?**

Yes

**Root cause analysis:**

There was a deployment bug in the project system repo

**How was the bug found?**

Ad Hoc Testing
