### PR TITLE
Implement OutputPath for ProjectConfigurationProperties

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Properties/CSharpProjectConfigurationPropertiesTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Properties/CSharpProjectConfigurationPropertiesTests.cs
@@ -73,6 +73,30 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             Assert.Equal(setValues.Single(), testValue);
         }
 
+        [Fact]
+        public void CSharpProjectConfigurationProperties_OutputPath()
+        {
+            var setValues = new List<object>();
+            var project = UnconfiguredProjectFactory.Create();
+            var data = new PropertyPageData()
+            {
+                Category = ConfiguredBrowseObject.SchemaName,
+                PropertyName = ConfiguredBrowseObject.OutputPathProperty,
+                Value = "OldPath",
+                SetValues = setValues
+            };
+
+            var projectProperties = ProjectPropertiesFactory.Create(project, data);
+
+            var vsLangProjectProperties = CreateInstance(projectProperties, IProjectThreadingServiceFactory.Create());
+            Assert.Equal(vsLangProjectProperties.OutputPath, "OldPath");
+
+            var testValue = "newPath";
+            vsLangProjectProperties.OutputPath = testValue;
+            Assert.Equal(setValues.Single(), testValue);
+        }
+
+
         private CSharpProjectConfigurationProperties CreateInstance(ProjectProperties projectProperties, IProjectThreadingService projectThreadingService)
         {
             return new CSharpProjectConfigurationProperties(projectProperties, projectThreadingService);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AbstractProjectConfigurationProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AbstractProjectConfigurationProperties.cs
@@ -63,12 +63,32 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             }
         }
 
+        public string OutputPath
+        {
+            get
+            {
+                return _threadingService.ExecuteSynchronously(async () =>
+                {
+                    var browseObjectProperties = await _projectProperties.GetConfiguredBrowseObjectPropertiesAsync().ConfigureAwait(true);
+                    return await browseObjectProperties.OutputPath.GetEvaluatedValueAtEndAsync().ConfigureAwait(true);
+                });
+            }
+
+            set
+            {
+                _threadingService.ExecuteSynchronously(async () =>
+                {
+                    var browseObjectProperties = await _projectProperties.GetConfiguredBrowseObjectPropertiesAsync().ConfigureAwait(true);
+                    await browseObjectProperties.OutputPath.SetValueAsync(value).ConfigureAwait(true);
+                });
+            }
+        }
+
         public object ExtenderNames => null;
         public string __id => throw new System.NotImplementedException();
         public bool DebugSymbols { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
         public bool DefineDebug { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
         public bool DefineTrace { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
-        public string OutputPath { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
         public string IntermediatePath { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
         public string DefineConstants { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
         public bool RemoveIntegerChecks { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Properties/VisualBasicProjectConfigurationPropertiesTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Properties/VisualBasicProjectConfigurationPropertiesTests.cs
@@ -73,6 +73,29 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             Assert.Equal(setValues.Single(), testValue);
         }
 
+        [Fact]
+        public void VisualBasicProjectConfigurationProperties_OutputPath()
+        {
+            var setValues = new List<object>();
+            var project = UnconfiguredProjectFactory.Create();
+            var data = new PropertyPageData()
+            {
+                Category = ConfiguredBrowseObject.SchemaName,
+                PropertyName = ConfiguredBrowseObject.OutputPathProperty,
+                Value = "OldPath",
+                SetValues = setValues
+            };
+
+            var projectProperties = ProjectPropertiesFactory.Create(project, data);
+
+            var vsLangProjectProperties = CreateInstance(projectProperties, IProjectThreadingServiceFactory.Create());
+            Assert.Equal(vsLangProjectProperties.OutputPath, "OldPath");
+
+            var testValue = "NewPath";
+            vsLangProjectProperties.OutputPath = testValue;
+            Assert.Equal(setValues.Single(), testValue);
+        }
+
         private VisualBasicProjectConfigurationProperties CreateInstance(ProjectProperties projectProperties, IProjectThreadingService projectThreadingService)
         {
             return new VisualBasicProjectConfigurationProperties(projectProperties, projectThreadingService);


### PR DESCRIPTION
Tagging @dotnet/project-system @srivatsn for review

The default implementation of the configuration properties provided by CPS had this property implemented. Since these properties are accessed using String, we did not see other teams using this property.

This change implements OutputPath property so that people who were consuming this property can continue to use this property.

**Customer scenario**

Customers using the automation object to get the OutputPath will be affected

**Bugs this fixes:** 

#2293 vso_bug [441321](https://devdiv.visualstudio.com/DevDiv/_workitems?id=441321&fullScreen=false&_a=edit)

**Workarounds, if any**

None.

**Risk**

Low risk. This is a simple implementation and the changes do not modify the behavior of any component.

**Is this a regression from a previous update?**

Yes, this property was previously implemented by CPS. When we provided a new implementation, we did not implement the previously implemented property because of lack of way to find out.  

**Root cause analysis:**

OutputPath was the only property implemented by CPS. There is no more.

**How was the bug found?**

Customer reported