### PR TITLE
DataDesign.Common and PerformanceProvider are package references rather than referenced from disk

### DIFF
--- a/build/Targets/References.targets
+++ b/build/Targets/References.targets
@@ -118,7 +118,6 @@
 	-->
 
         <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.0.26124-rc3" />
-        <PackageReference Include="Microsoft.VisualStudio.DataDesign.Common" Version="15.0.26524-alpha" />
         <PackageReference Include="Microsoft.VisualStudio.Diagnostics.PerformanceProvider" Version="15.0.26507-alpha" />
         <PackageReference Include="Microsoft.VisualStudio.Designer.Interfaces" Version="1.1.4322" />
         <PackageReference Include="Microsoft.VisualStudio.ManagedInterfaces" Version="$(MicrosoftVisualStudioManagedInterfaces)" />
@@ -209,6 +208,9 @@
         <Reference Include="Microsoft.VisualStudio.DataTools.Interop">
           <HintPath>$(DevEnvDir)\Microsoft.VisualStudio.DataTools.Interop.dll</HintPath>
         </Reference>
+
+        <PackageReference Include="Microsoft.VisualStudio.DataDesign.Common" Version="15.0.26524-alpha" />
+
       </ItemGroup>
     </When>
   </Choose>

--- a/build/Targets/References.targets
+++ b/build/Targets/References.targets
@@ -116,14 +116,10 @@
 		Microsoft.VisualStudio.Diagnostics.PerformanceProvider.dll is needed by GraphProvider unit tests.
 		if it is not provided here, tests fail to load this assembly at runtime.
 	-->
-        <Reference Include="Microsoft.VisualStudio.Diagnostics.PerformanceProvider">
-          <HintPath Condition="Exists('$(DevEnvDir)\PrivateAssemblies\Microsoft.VisualStudio.Diagnostics.PerformanceProvider.dll')">$(DevEnvDir)\PrivateAssemblies\Microsoft.VisualStudio.Diagnostics.PerformanceProvider.dll</HintPath>
-          <HintPath Condition="Exists('C:\Program Files (x86)\Microsoft Visual Studio\Preview\Enterprise\Common7\IDE\PrivateAssemblies\Microsoft.VisualStudio.Diagnostics.PerformanceProvider.dll')">C:\Program Files (x86)\Microsoft Visual Studio\Preview\Enterprise\Common7\IDE\PrivateAssemblies\Microsoft.VisualStudio.Diagnostics.PerformanceProvider.dll</HintPath>
-          <HintPath Condition="Exists('C:\Program Files (x86)\Microsoft Visual Studio\Preview\Professional\Common7\IDE\PrivateAssemblies\Microsoft.VisualStudio.Diagnostics.PerformanceProvider.dll')">C:\Program Files (x86)\Microsoft Visual Studio\Preview\Professional\Common7\IDE\PrivateAssemblies\Microsoft.VisualStudio.Diagnostics.PerformanceProvider.dll</HintPath>
-          <HintPath Condition="Exists('C:\Program Files (x86)\Microsoft Visual Studio\Preview\Community\Common7\IDE\PrivateAssemblies\Microsoft.VisualStudio.Diagnostics.PerformanceProvider.dll')">C:\Program Files (x86)\Microsoft Visual Studio\Preview\Community\Common7\IDE\PrivateAssemblies\Microsoft.VisualStudio.Diagnostics.PerformanceProvider.dll</HintPath>
-        </Reference>
 
         <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.0.26124-rc3" />
+        <PackageReference Include="Microsoft.VisualStudio.DataDesign.Common" Version="15.0.26524-alpha" />
+        <PackageReference Include="Microsoft.VisualStudio.Diagnostics.PerformanceProvider" Version="15.0.26507-alpha" />
         <PackageReference Include="Microsoft.VisualStudio.Designer.Interfaces" Version="1.1.4322" />
         <PackageReference Include="Microsoft.VisualStudio.ManagedInterfaces" Version="$(MicrosoftVisualStudioManagedInterfaces)" />
         <PackageReference Include="Microsoft.VisualStudio.WCFReference.Interop" Version="9.0.30729" />
@@ -209,12 +205,6 @@
         </Reference>
         <Reference Include="Microsoft.VisualStudio.VSHelp">
           <HintPath>$(DevEnvDir)\PublicAssemblies\Microsoft.VisualStudio.VSHelp.dll</HintPath>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.DataDesign.Common">
-          <HintPath Condition="Exists('$(DevEnvDir)Microsoft.VisualStudio.DataDesign.Common.dll')">$(DevEnvDir)Microsoft.VisualStudio.DataDesign.Common.dll</HintPath>
-          <HintPath Condition="Exists('C:\Program Files (x86)\Microsoft Visual Studio\Preview\Enterprise\Common7\IDE\Microsoft.VisualStudio.DataDesign.Common.dll')">C:\Program Files (x86)\Microsoft Visual Studio\Preview\Enterprise\Common7\IDE\Microsoft.VisualStudio.DataDesign.Common.dll</HintPath>
-          <HintPath Condition="Exists('C:\Program Files (x86)\Microsoft Visual Studio\Preview\Professional\Common7\IDE\Microsoft.VisualStudio.DataDesign.Common.dll')">C:\Program Files (x86)\Microsoft Visual Studio\Preview\Professional\Common7\IDE\Microsoft.VisualStudio.DataDesign.Common.dll</HintPath>
-          <HintPath Condition="Exists('C:\Program Files (x86)\Microsoft Visual Studio\Preview\Community\Common7\IDE\Microsoft.VisualStudio.DataDesign.Common.dll')">C:\Program Files (x86)\Microsoft Visual Studio\Preview\Community\Common7\IDE\Microsoft.VisualStudio.DataDesign.Common.dll</HintPath>
         </Reference>
         <Reference Include="Microsoft.VisualStudio.DataTools.Interop">
           <HintPath>$(DevEnvDir)\Microsoft.VisualStudio.DataTools.Interop.dll</HintPath>


### PR DESCRIPTION
Tagging @jmarolf @srivatsn  @davkean for review

**Customer scenario**

Project system signed builds are running into issues because of failure to find “Microsoft.VisualStudio.DataDesign.Common” and "Microsoft.VisualStudio.Diagnostics.PerformanceProvider"in the machine. Hence we get the references from Package rather than from disk.

**Risk**

Low- This is just infra change and no code change.

**Performance impact**

None.
