### PR TITLE
Remove ExecuteSynchronously from LaunchSettingsProvider

### DIFF
--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -337,7 +337,7 @@
   <!-- This is a copy of the Microsoft.VisualStudio.SDK.EmbedInteropTypes NuGet package, but only the list of
        assemblies that we need. The package includes things like EnvDTE which are reasonable for consumers, but
        strange since we actually _implement_ DTE and use it as an exchange type with generics in a few places. -->
-  <Target Name="LinkVSSDKEmbeddableAssemblies" BeforeTargets="FindReferenceAssembliesForReferences">
+  <Target Name="LinkVSSDKEmbeddableAssemblies" DependsOnTargets="ResolveReferences" AfterTargets="ResolveReferences">
     <ItemGroup>
       <ReferencePath Condition="
               '%(FileName)' == 'Microsoft.VisualStudio.Shell.Embeddable'

--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -337,7 +337,7 @@
   <!-- This is a copy of the Microsoft.VisualStudio.SDK.EmbedInteropTypes NuGet package, but only the list of
        assemblies that we need. The package includes things like EnvDTE which are reasonable for consumers, but
        strange since we actually _implement_ DTE and use it as an exchange type with generics in a few places. -->
-  <Target Name="LinkVSSDKEmbeddableAssemblies" DependsOnTargets="ResolveReferences" AfterTargets="ResolveReferences">
+  <Target Name="LinkVSSDKEmbeddableAssemblies" BeforeTargets="FindReferenceAssembliesForReferences">
     <ItemGroup>
       <ReferencePath Condition="
               '%(FileName)' == 'Microsoft.VisualStudio.Shell.Embeddable'

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -270,7 +270,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public void  LaunchSettingsProvider_SaveProfilesToDiskTests()
+        public async Task LaunchSettingsProvider_SaveProfilesToDiskTests()
         {
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
@@ -302,7 +302,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 return ImmutableDictionary<string, object>.Empty.Add("iisSettings", iisSettings);
             });
 
-            provider.SaveSettingsToDiskTest(testSettings.Object);
+            await provider.SaveSettingsToDiskAsyncTest(testSettings.Object);
 
             // Last Write time should be set
             Assert.Equal(moqFS.LastFileWriteTime(provider.LaunchSettingsFile), provider.LastSettingsFileSyncTimeTest);
@@ -793,7 +793,7 @@ string JsonString1 = @"{
         // Wrappers to call protected members
         public void SetCurrentSnapshot(ILaunchSettings profiles) { CurrentSnapshot = profiles;}
         public Task<LaunchSettingsData> ReadSettingsFileFromDiskTestAsync() { return ReadSettingsFileFromDiskAsync();}
-        public void SaveSettingsToDiskTest(ILaunchSettings curSettings) { SaveSettingsToDisk(curSettings);}
+        public Task SaveSettingsToDiskAsyncTest(ILaunchSettings curSettings) { return SaveSettingsToDiskAsync(curSettings);}
         public DateTime LastSettingsFileSyncTimeTest { get { return LastSettingsFileSyncTime; } set { LastSettingsFileSyncTime = value; } }
         public Task UpdateProfilesAsyncTest(string activeProfile) { return UpdateProfilesAsync(activeProfile);}
         public void SetIgnoreFileChanges(bool value) { IgnoreFileChanges = value; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             var provider = GetLaunchSettingsProvider(null, appDesignerFolder: appDesignerFolder);
 
-            string result = await provider.GetLaunchSettingsFileAsync();
+            string result = await provider.GetLaunchSettingsFilePathAsync();
 
             Assert.Equal(expected, result);
         }
@@ -339,7 +339,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
 
-            string fileName = await provider.GetLaunchSettingsFileAsync();
+            string fileName = await provider.GetLaunchSettingsFilePathAsync();
             // Write file and generate disk change
             var eventArgs = new FileSystemEventArgs(WatcherChangeTypes.Changed, Path.GetDirectoryName(fileName), Path.GetFileName(fileName));
             moqFS.WriteAllText(fileName, JsonString1);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -171,18 +171,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public void LaunchSettingsProvider_SettingsFileHasChangedTests()
+        public async Task LaunchSettingsProvider_SettingsFileHasChangedTests()
         {
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
 
             // No settings  file
-            Assert.True(provider.SettingsFileHasChangedTest());
+            Assert.True(await provider.SettingsFileHasChangedAsyncTest());
             moqFS.WriteAllText(provider.LaunchSettingsFile, JsonString1);
 
-            Assert.True(provider.SettingsFileHasChangedTest());
+            Assert.True(await provider.SettingsFileHasChangedAsyncTest());
             provider.LastSettingsFileSyncTimeTest = moqFS.LastFileWriteTime(provider.LaunchSettingsFile);
-            Assert.False(provider.SettingsFileHasChangedTest());
+            Assert.False(await provider.SettingsFileHasChangedAsyncTest());
         }
 
 
@@ -797,7 +797,7 @@ string JsonString1 = @"{
         public DateTime LastSettingsFileSyncTimeTest { get { return LastSettingsFileSyncTime; } set { LastSettingsFileSyncTime = value; } }
         public Task UpdateProfilesAsyncTest(string activeProfile) { return UpdateProfilesAsync(activeProfile);}
         public void SetIgnoreFileChanges(bool value) { IgnoreFileChanges = value; }
-        public bool SettingsFileHasChangedTest() { return SettingsFileHasChanged(); }
+        public Task<bool> SettingsFileHasChangedAsyncTest() { return SettingsFileHasChangedAsync(); }
         public void LaunchSettingsFile_ChangedTest(FileSystemEventArgs args)
         {
             LaunchSettingsFile_Changed(null, args);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#pragma warning disable CS0618 // Type or member is obsolete
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -9,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders;
 using Microsoft.VisualStudio.Threading.Tasks;
 using Moq;
 using Newtonsoft.Json;
@@ -17,19 +20,11 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
-
     [ProjectSystemTrait]
     public class LaunchSettingsProviderTests
     {
-
-        internal LaunchSettingsUnderTest GetLaunchSettingsProvider(IFileSystem fileSystem, string appDesignerFolder = "Properties", string activeProfile = "")
+        internal LaunchSettingsUnderTest GetLaunchSettingsProvider(IFileSystem fileSystem, string appDesignerFolder = @"c:\test\Project1\Properties", string activeProfile = "")
         {
-            var appDesignerData = new PropertyPageData() {
-                Category = AppDesigner.SchemaName,
-                PropertyName = AppDesigner.FolderNameProperty,
-                Value = appDesignerFolder
-            };
-
             Mock<IEnumValue> activeProfileValue = new Mock<IEnumValue>();
             activeProfileValue.Setup(s => s.Name).Returns(activeProfile);
             var debuggerData = new PropertyPageData() {
@@ -38,11 +33,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 Value = activeProfileValue.Object
             };
 
-            var unconfiguredProject = UnconfiguredProjectFactory.Create(null, null, @"c:\\test\Project1\Project1.csproj");
-            var properties = ProjectPropertiesFactory.Create(unconfiguredProject, new[] { debuggerData, appDesignerData  });
+            var specialFilesManager = ISpecialFilesManagerFactory.ImplementGetFile(appDesignerFolder);
+            var unconfiguredProject = UnconfiguredProjectFactory.Create(null, null, @"c:\test\Project1\Project1.csproj");
+            var properties = ProjectPropertiesFactory.Create(unconfiguredProject, new[] { debuggerData  });
             var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(unconfiguredProject, null,  new IProjectThreadingServiceMock(), null, properties);
             var projectServices = IUnconfiguredProjectServicesFactory.Create(IProjectAsynchronousTasksServiceFactory.Create(CancellationToken.None));
-            var provider = new LaunchSettingsUnderTest(unconfiguredProject, projectServices, fileSystem ?? new IFileSystemMock(), commonServices, null);
+            var provider = new LaunchSettingsUnderTest(unconfiguredProject, projectServices, fileSystem ?? new IFileSystemMock(), commonServices, null, specialFilesManager);
             return provider;
         }
 
@@ -64,15 +60,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public void LaunchSettingsProvider_LaunchSettingsFileTests()
+        public void WhenNoAppDesignerFolder_LaunchSettingsIsInRoot()
         {
-            // No app designer folder should use default
-            var provider = GetLaunchSettingsProvider(null);
-            Assert.Equal(@"c:\test\Project1\Properties\launchSettings.json", provider.LaunchSettingsFile);
+            var provider = GetLaunchSettingsProvider(null, appDesignerFolder: null);
 
-            // Test specific app designer folder
-            provider = GetLaunchSettingsProvider(null, "My Project");
-            Assert.Equal(@"c:\test\Project1\My Project\launchSettings.json", provider.LaunchSettingsFile);
+            Assert.Equal(@"c:\test\Project1\launchSettings.json", provider.LaunchSettingsFile);
+        }
+
+        [Theory]
+        [InlineData(@"C:\Properties",                @"C:\Properties\launchSettings.json")]
+        [InlineData(@"C:\Project\Properties",        @"C:\Project\Properties\launchSettings.json")]
+        [InlineData(@"C:\Project\My Project",        @"C:\Project\My Project\launchSettings.json")]
+        public async Task WhenAppDesignerFolder_LaunchSettingsIsInAppDesignerFolder(string appDesignerFolder, string expected)
+        {
+            var provider = GetLaunchSettingsProvider(null, appDesignerFolder: appDesignerFolder);
+
+            string result = await provider.GetLaunchSettingsFileAsync();
+
+            Assert.Equal(expected, result);
         }
 
         [Fact]
@@ -123,7 +128,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             // Change the value of activeDebugProfile to web it should be the active one. Similates a change
             // on disk doesn't affect active profile
-            provider = GetLaunchSettingsProvider(moqFS, "Properties", "web");
+            provider = GetLaunchSettingsProvider(moqFS, activeProfile: "web");
             await provider.UpdateProfilesAsyncTest(null);
             Assert.Equal("web", provider.CurrentSnapshot.ActiveProfile.Name);
         }
@@ -334,9 +339,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
 
+            string fileName = await provider.GetLaunchSettingsFileAsync();
             // Write file and generate disk change
-            var eventArgs = new FileSystemEventArgs(WatcherChangeTypes.Changed, Path.GetDirectoryName(provider.LaunchSettingsFile), Path.GetFileName(provider.LaunchSettingsFile));
-            moqFS.WriteAllText(provider.LaunchSettingsFile, JsonString1);
+            var eventArgs = new FileSystemEventArgs(WatcherChangeTypes.Changed, Path.GetDirectoryName(fileName), Path.GetFileName(fileName));
+            moqFS.WriteAllText(fileName, JsonString1);
 
             // Set the ignore flag. It should be ignored.
             provider.LastSettingsFileSyncTimeTest = DateTime.MinValue;
@@ -779,8 +785,8 @@ string JsonString1 = @"{
         // ECan pass null for all and a default will be crewated
         public LaunchSettingsUnderTest(UnconfiguredProject unconfiguredProject, IUnconfiguredProjectServices projectServices, 
                                       IFileSystem fileSystem,   IUnconfiguredProjectCommonServices commonProjectServices, 
-                                      IActiveConfiguredProjectSubscriptionService projectSubscriptionService)
-          : base(unconfiguredProject, projectServices, fileSystem, commonProjectServices, projectSubscriptionService)
+                                      IActiveConfiguredProjectSubscriptionService projectSubscriptionService, ISpecialFilesManager specialFilesManager)
+          : base(unconfiguredProject, projectServices, fileSystem, commonProjectServices, projectSubscriptionService, specialFilesManager)
         {
             // Block the code from setting up one on the real file system. Since we block, it we need to set up the fileChange scheduler manually
             FileWatcher = new SimpleFileWatcher();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -187,7 +187,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
 
         [Fact]
-        public void LaunchSettingsProvider_ReadProfilesFromDisk_NoFile()
+        public async Task LaunchSettingsProvider_ReadProfilesFromDisk_NoFile()
         {
 
             IFileSystemMock moqFS = new IFileSystemMock();
@@ -197,7 +197,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             LaunchSettingsData launchSettings;
             try
             {
-                launchSettings = provider.ReadSettingsFileFromDiskTest();
+                launchSettings = await provider.ReadSettingsFileFromDiskTestAsync();
                 Assert.True(false);
             }
             catch
@@ -207,7 +207,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public void LaunchSettingsProvider_ReadProfilesFromDisk_GoodFile()
+        public async Task LaunchSettingsProvider_ReadProfilesFromDisk_GoodFile()
         {
 
             IFileSystemMock moqFS = new IFileSystemMock();
@@ -216,12 +216,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             // write a good file
             moqFS.WriteAllText(provider.LaunchSettingsFile, JsonString1);
 
-            var launchSettings = provider.ReadSettingsFileFromDiskTest();
+            var launchSettings = await provider.ReadSettingsFileFromDiskTestAsync();
             Assert.Equal(4, launchSettings.Profiles.Count);
         }
 
         [Fact]
-        public void LaunchSettingsProvider_ReadProfilesFromDisk_BadJsonFile()
+        public async Task LaunchSettingsProvider_ReadProfilesFromDisk_BadJsonFile()
         {
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
@@ -229,7 +229,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             moqFS.WriteAllText(provider.LaunchSettingsFile, BadJsonString);
             try
             {
-                var launchSettings = provider.ReadSettingsFileFromDiskTest();
+                var launchSettings = await provider.ReadSettingsFileFromDiskTestAsync();
                 Assert.True(false);
             }
             catch
@@ -238,21 +238,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public void LaunchSettingsProvider_ReadProfilesFromDisk_JsonWithExtensionsNoProvider()
+        public async Task LaunchSettingsProvider_ReadProfilesFromDisk_JsonWithExtensionsNoProvider()
         {
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
 
             // Write a json file containing extension settings
             moqFS.WriteAllText(provider.LaunchSettingsFile, JsonStringWithWebSettings);
-            var launchSettings = provider.ReadSettingsFileFromDiskTest();
+            var launchSettings = await provider.ReadSettingsFileFromDiskTestAsync();
             Assert.Equal(2, launchSettings.Profiles.Count);
             Assert.Equal(1, launchSettings.OtherSettings.Count);
             Assert.True(launchSettings.OtherSettings["iisSettings"] is JObject);
         }
 
         [Fact]
-        public void LaunchSettingsProvider_ReadProfilesFromDisk_JsonWithExtensionsWithProvider()
+        public async Task LaunchSettingsProvider_ReadProfilesFromDisk_JsonWithExtensionsWithProvider()
         {
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
@@ -263,7 +263,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             // Set the serialization provider
             SetJsonSerializationProviders(provider);
 
-            var launchSettings = provider.ReadSettingsFileFromDiskTest();
+            var launchSettings = await provider.ReadSettingsFileFromDiskTestAsync();
             Assert.Equal(2, launchSettings.Profiles.Count);
             Assert.Equal(1, launchSettings.OtherSettings.Count);
             Assert.True(launchSettings.OtherSettings["iisSettings"] is IISSettingsData);
@@ -792,7 +792,7 @@ string JsonString1 = @"{
 
         // Wrappers to call protected members
         public void SetCurrentSnapshot(ILaunchSettings profiles) { CurrentSnapshot = profiles;}
-        public LaunchSettingsData ReadSettingsFileFromDiskTest() { return ReadSettingsFileFromDisk();}
+        public Task<LaunchSettingsData> ReadSettingsFileFromDiskTestAsync() { return ReadSettingsFileFromDiskAsync();}
         public void SaveSettingsToDiskTest(ILaunchSettings curSettings) { SaveSettingsToDisk(curSettings);}
         public DateTime LastSettingsFileSyncTimeTest { get { return LastSettingsFileSyncTime; } set { LastSettingsFileSyncTime = value; } }
         public Task UpdateProfilesAsyncTest(string activeProfile) { return UpdateProfilesAsync(activeProfile);}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -107,7 +107,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             {
                 if (_launchSettingsFile == null)
                 {
-                    _launchSettingsFile = Path.Combine(Path.GetDirectoryName(CommonProjectServices.Project.FullPath), LaunchSettingsFileFolder, LaunchSettingsFilename);
+                    _launchSettingsFile = Path.Combine(Path.GetDirectoryName(CommonProjectServices.Project.FullPath), GetLaunchSettingsFileFolder(), LaunchSettingsFilename);
                 }
                 return _launchSettingsFile;
             }
@@ -117,24 +117,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// Queries msbuld for the App designer folder name property. Falls back to Properties if none defined.
         /// </summary>
         private string _launchSettingsFileFolder;
-        private string LaunchSettingsFileFolder
-        {
-            get
-            {
-                if (_launchSettingsFileFolder == null)
-                {
-                    _launchSettingsFileFolder = CommonProjectServices.ThreadingService.ExecuteSynchronously(async () => {
-                        var props = await CommonProjectServices.ActiveConfiguredProjectProperties.GetAppDesignerPropertiesAsync().ConfigureAwait(true);
-                        return await props.FolderName.GetValueAsync().ConfigureAwait(true) as string;
-                    });
 
-                    if (string.IsNullOrEmpty(_launchSettingsFileFolder))
-                    {
-                        _launchSettingsFileFolder = DefaultSettingsFileFolder;
-                    }
+        private string GetLaunchSettingsFileFolder()
+        {
+            if (_launchSettingsFileFolder == null)
+            {
+                _launchSettingsFileFolder = CommonProjectServices.ThreadingService.ExecuteSynchronously(async () => {
+                    var props = await CommonProjectServices.ActiveConfiguredProjectProperties.GetAppDesignerPropertiesAsync().ConfigureAwait(true);
+                    return await props.FolderName.GetValueAsync().ConfigureAwait(true) as string;
+                });
+
+                if (string.IsNullOrEmpty(_launchSettingsFileFolder))
+                {
+                    _launchSettingsFileFolder = DefaultSettingsFileFolder;
                 }
-                return _launchSettingsFileFolder;
             }
+            return _launchSettingsFileFolder;
         }
 
         /// <summary>
@@ -608,7 +606,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </summary>
         protected Task EnsureSettingsFolderAsync()
         {
-            var launchSettingsFileFolderPath = Path.Combine(Path.GetDirectoryName(CommonProjectServices.Project.FullPath), LaunchSettingsFileFolder);
+            var launchSettingsFileFolderPath = Path.Combine(Path.GetDirectoryName(CommonProjectServices.Project.FullPath), GetLaunchSettingsFileFolder());
             if (!FileManager.DirectoryExists(launchSettingsFileFolderPath))
             {
                 FileManager.CreateDirectory(launchSettingsFileFolderPath);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -221,7 +221,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         protected async Task UpdateActiveProfileInSnapshotAsync(string activeProfile)
         {
             var snapshot = CurrentSnapshot;
-            if (snapshot == null || await SettingsFileHasChangedAsync())
+            if (snapshot == null || await SettingsFileHasChangedAsync().ConfigureAwait(false))
             {
                 await UpdateProfilesAsync(activeProfile).ConfigureAwait(false);
                 return;
@@ -251,7 +251,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                     }
                 }
 
-                var launchSettingData = await GetLaunchSettingsAsync();
+                var launchSettingData = await GetLaunchSettingsAsync().ConfigureAwait(false);
 
 
                 // If there are no profiles, we will add a default profile to run the prroject. W/o it our debugger
@@ -330,7 +330,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             LaunchSettingsData settings;
             if (FileManager.FileExists(fileName))
             {
-                settings = await ReadSettingsFileFromDiskAsync();
+                settings = await ReadSettingsFileFromDiskAsync().ConfigureAwait(false);
             }
             else
             {
@@ -697,7 +697,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var activeProfileName = ActiveProfile?.Name;
 
             ILaunchSettings newSnapshot = new LaunchSettings(newSettings.Profiles, newSettings.GlobalSettings, activeProfileName);
-            await SaveSettingsToDiskAsync(newSettings);
+            await SaveSettingsToDiskAsync(newSettings).ConfigureAwait(false);
 
             FinishUpdate(newSnapshot);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -476,7 +476,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             try
             {
-                await EnsureSettingsFolderAsync();
+                await EnsureSettingsFolderAsync().ConfigureAwait(false);
 
                 // We don't want to write null values. We want to keep the file as small as possible
                 JsonSerializerSettings settings = new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore };

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -275,7 +275,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                     }
                 }
 
-                var launchSettingData = GetLaunchSettings();
+                var launchSettingData = await GetLaunchSettingsAsync();
 
 
                 // If there are no profiles, we will add a default profile to run the prroject. W/o it our debugger
@@ -343,12 +343,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// <summary>
         /// Creates the intiial set of settings based on the file on disk 
         /// </summary>
-        protected LaunchSettingsData GetLaunchSettings()
+        protected async Task<LaunchSettingsData> GetLaunchSettingsAsync()
         {
             LaunchSettingsData settings;
             if (FileManager.FileExists(LaunchSettingsFile))
             {
-                settings = ReadSettingsFileFromDisk();
+                settings = await ReadSettingsFileFromDiskAsync();
             }
             else
             {
@@ -371,7 +371,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// Reads the data from the launch settings file and returns it in a dictionary of settings section to object. Adds n error list entries
         /// and throws if an exception occurs
         /// </summary>
-        protected LaunchSettingsData ReadSettingsFileFromDisk()
+        protected Task<LaunchSettingsData> ReadSettingsFileFromDiskAsync()
         {
             // Clear errors
             ClearErrors();
@@ -410,7 +410,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
                 // Remember the time we are sync'd to
                 LastSettingsFileSyncTime = FileManager.LastFileWriteTime(LaunchSettingsFile);
-                return launchSettingsData;
+                return Task.FromResult(launchSettingsData);
             }
             catch (JsonReaderException readerEx)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -481,14 +481,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// Saves the launch settings to the launch settings file. Adds an errorstring and throws if an exception. Note
         /// that the caller is responsible for checking out the file
         /// </summary>
-        protected void SaveSettingsToDisk(ILaunchSettings newSettings)
+        protected async Task SaveSettingsToDiskAsync(ILaunchSettings newSettings)
         {
             // Clear stale errors since we are saving
             ClearErrors();
             var serializationData = GetSettingsToSerialize(newSettings);
             try
             {
-                EnsureSettingsFolder();
+                await EnsureSettingsFolderAsync();
 
                 // We don't want to write null values. We want to keep the file as small as possible
                 JsonSerializerSettings settings = new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore };
@@ -597,13 +597,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// Makes sure the settings folder exists on disk. Doesn't add the folder to
         /// the project.
         /// </summary>
-        protected void EnsureSettingsFolder()
+        protected Task EnsureSettingsFolderAsync()
         {
             var launchSettingsFileFolderPath = Path.Combine(Path.GetDirectoryName(CommonProjectServices.Project.FullPath), LaunchSettingsFileFolder);
             if (!FileManager.DirectoryExists(launchSettingsFileFolderPath))
             {
                 FileManager.CreateDirectory(launchSettingsFileFolderPath);
             }
+
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -702,7 +704,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var activeProfileName = ActiveProfile?.Name;
 
             ILaunchSettings newSnapshot = new LaunchSettings(newSettings.Profiles, newSettings.GlobalSettings, activeProfileName);
-            SaveSettingsToDisk(newSettings);
+            await SaveSettingsToDiskAsync(newSettings);
 
             FinishUpdate(newSnapshot);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -245,7 +245,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         protected async Task UpdateActiveProfileInSnapshotAsync(string activeProfile)
         {
             var snapshot = CurrentSnapshot;
-            if (snapshot == null || SettingsFileHasChanged())
+            if (snapshot == null || await SettingsFileHasChangedAsync())
             {
                 await UpdateProfilesAsync(activeProfile).ConfigureAwait(false);
                 return;
@@ -310,9 +310,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// Returns true of the file has changed since we last read it. Note that it returns true if the file
         /// does not exist
         /// </summary>
-        protected bool SettingsFileHasChanged()
+        protected Task<bool> SettingsFileHasChangedAsync()
         {
-            return !FileManager.FileExists(LaunchSettingsFile) || FileManager.LastFileWriteTime(LaunchSettingsFile) != LastSettingsFileSyncTime;
+            bool changed = !FileManager.FileExists(LaunchSettingsFile) || FileManager.LastFileWriteTime(LaunchSettingsFile) != LastSettingsFileSyncTime;
+
+            return Task.FromResult(changed);
         }
 
         /// <summary>


### PR DESCRIPTION
This removes most usage of ExecuteSynchronously from LaunchSettingsProvider, which can cause threadpool exhaustion. In some dumps debugging sessions that I investigated for Roslyn/ProjectSystem I saw large amounts of threads (> 60) waiting on these paths. 

After installing one of the 15.3 Previews customers will start experiencing more "random" UI delays in normal VS operations.

**Bugs this fixes:** 

Part of the general effort of chasing down the UI delays introduced in the project system in 15.3: https://github.com/dotnet/project-system/issues/2297.

This particular PR fixes https://github.com/dotnet/project-system/issues/1342

**Workarounds, if any**

None

**Risk**

Low. 

**Performance impact**

This will reduce UI delays and reduce the number of active threads.

**Is this a regression from a previous update?**

This code existed in RTM as well but this was exacerbated by other such ExecuteSynchronously calls. This is part of cleaning up them all to avoid the UI delays.

**Root cause analysis:**

Threading is hard. Threading in VS is even harder. Here we were doing a blocking call from a ThreadPool thread that was blocked on a lock that the UI thread held, which itself was blocked on thread pool creation. This issue is discussed at length here: https://github.com/Microsoft/vs-threading/blob/v15.3/doc/threadpool_starvation.md.

We're still learning how this all works, but we're [talking about strategies (compilation errors)](https://github.com/dotnet/project-system/issues/2391) to prevent these sorts of issues in the future. They are hard to find, diagnose and write tests for.

**How was the bug found?**

Many internal reports both from ASP.NET, Roslyn, ProjectSystem itself and opening external projects (such as https://github.com/aarnott/pinvoke). Also had external reports from MVPs.
