### PR TITLE
Forward properties for nowarn and treat warnings as errors to NuGet

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -102,4 +102,16 @@
                     Visible="False" 
                     ReadOnly="True" />
 
+    <StringProperty Name="TreatWarningsAsErrors" 
+                    Visible="False" 
+                    ReadOnly="True" />
+
+    <StringProperty Name="TreatSpecificWarningsAsErrors" 
+                    Visible="False" 
+                    ReadOnly="True" />
+
+    <StringProperty Name="NoWarn" 
+                    Visible="False" 
+                    ReadOnly="True" />
+                    
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
@@ -78,4 +78,9 @@
     <StringProperty Name="IsImplicitlyDefined" 
                     Visible="False" 
                     ReadOnly="True" />
+
+    <StringProperty Name="NoWarn" 
+                    Visible="True"
+                    DisplayName="NoWarn"
+                    Description="Comma-delimited list of warnings that should be suppressed for this package" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/NuGetRestore.xaml
@@ -49,4 +49,7 @@
   <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/PackageReference.xaml
@@ -22,4 +22,5 @@
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <StringProperty Name="NoWarn" Visible="True" DisplayName="NoWarn" Description="Comma-delimited list of warnings that should be suppressed for this package" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/NuGetRestore.xaml
@@ -49,4 +49,7 @@
   <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/PackageReference.xaml
@@ -22,4 +22,5 @@
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <StringProperty Name="NoWarn" Visible="True" DisplayName="NoWarn" Description="Comma-delimited list of warnings that should be suppressed for this package" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/NuGetRestore.xaml
@@ -49,4 +49,7 @@
   <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/PackageReference.xaml
@@ -22,4 +22,5 @@
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <StringProperty Name="NoWarn" Visible="True" DisplayName="NoWarn" Description="Comma-delimited list of warnings that should be suppressed for this package" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/NuGetRestore.xaml
@@ -49,4 +49,7 @@
   <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/PackageReference.xaml
@@ -22,4 +22,5 @@
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <StringProperty Name="NoWarn" Visible="True" DisplayName="NoWarn" Description="Comma-delimited list of warnings that should be suppressed for this package" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/NuGetRestore.xaml
@@ -49,4 +49,7 @@
   <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/PackageReference.xaml
@@ -22,4 +22,5 @@
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <StringProperty Name="NoWarn" Visible="True" DisplayName="NoWarn" Description="Comma-delimited list of warnings that should be suppressed for this package" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/NuGetRestore.xaml
@@ -49,4 +49,7 @@
   <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/PackageReference.xaml
@@ -22,4 +22,5 @@
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <StringProperty Name="NoWarn" Visible="True" DisplayName="NoWarn" Description="Comma-delimited list of warnings that should be suppressed for this package" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/NuGetRestore.xaml
@@ -49,4 +49,7 @@
   <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/PackageReference.xaml
@@ -22,4 +22,5 @@
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <StringProperty Name="NoWarn" Visible="True" DisplayName="NoWarn" Description="Comma-delimited list of warnings that should be suppressed for this package" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/NuGetRestore.xaml
@@ -49,4 +49,7 @@
   <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/PackageReference.xaml
@@ -22,4 +22,5 @@
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <StringProperty Name="NoWarn" Visible="True" DisplayName="NoWarn" Description="Comma-delimited list of warnings that should be suppressed for this package" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/NuGetRestore.xaml
@@ -49,4 +49,7 @@
   <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/PackageReference.xaml
@@ -22,4 +22,5 @@
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <StringProperty Name="NoWarn" Visible="True" DisplayName="NoWarn" Description="Comma-delimited list of warnings that should be suppressed for this package" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/NuGetRestore.xaml
@@ -49,4 +49,7 @@
   <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/PackageReference.xaml
@@ -22,4 +22,5 @@
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <StringProperty Name="NoWarn" Visible="True" DisplayName="NoWarn" Description="Comma-delimited list of warnings that should be suppressed for this package" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/NuGetRestore.xaml
@@ -49,4 +49,7 @@
   <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/PackageReference.xaml
@@ -22,4 +22,5 @@
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <StringProperty Name="NoWarn" Visible="True" DisplayName="NoWarn" Description="Comma-delimited list of warnings that should be suppressed for this package" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.cs.xlf
@@ -68,6 +68,16 @@
         <target state="translated">Vyhodnocený název původní položky odkazu, jejíž překlad vedl ke vzniku tohoto nerozpoznaného odkazu</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|NoWarn|DisplayName">
+        <source>NoWarn</source>
+        <target state="new">NoWarn</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|NoWarn|Description">
+        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
+        <target state="new">Comma-delimited list of warnings that should be suppressed for this package</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.de.xlf
@@ -68,6 +68,16 @@
         <target state="translated">Der ausgewertete Elementname des ursprünglichen Verweiselements, dessen Auflösung zu diesem aufgelösten Verweiselement geführt hat.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|NoWarn|DisplayName">
+        <source>NoWarn</source>
+        <target state="new">NoWarn</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|NoWarn|Description">
+        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
+        <target state="new">Comma-delimited list of warnings that should be suppressed for this package</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.es.xlf
@@ -68,6 +68,16 @@
         <target state="translated">Nombre del elemento evaluado del elemento de referencia original cuya resolución produjo este elemento de referencia resuelto.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|NoWarn|DisplayName">
+        <source>NoWarn</source>
+        <target state="new">NoWarn</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|NoWarn|Description">
+        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
+        <target state="new">Comma-delimited list of warnings that should be suppressed for this package</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.fr.xlf
@@ -68,6 +68,16 @@
         <target state="translated">Nom d'élément évalué de l'élément de référence d'origine dont la résolution a eu pour résultat cet élément de référence résolu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|NoWarn|DisplayName">
+        <source>NoWarn</source>
+        <target state="new">NoWarn</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|NoWarn|Description">
+        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
+        <target state="new">Comma-delimited list of warnings that should be suppressed for this package</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.it.xlf
@@ -68,6 +68,16 @@
         <target state="translated">Nome di elemento valutato dell'elemento di riferimento originale la cui risoluzione ha restituito questo elemento di riferimento risolto.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|NoWarn|DisplayName">
+        <source>NoWarn</source>
+        <target state="new">NoWarn</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|NoWarn|Description">
+        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
+        <target state="new">Comma-delimited list of warnings that should be suppressed for this package</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ja.xlf
@@ -68,6 +68,16 @@
         <target state="translated">結果がこの解決済みの参照項目であった元の参照項目の評価済み項目名です。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|NoWarn|DisplayName">
+        <source>NoWarn</source>
+        <target state="new">NoWarn</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|NoWarn|Description">
+        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
+        <target state="new">Comma-delimited list of warnings that should be suppressed for this package</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ko.xlf
@@ -68,6 +68,16 @@
         <target state="translated">확인 결과 이 확인된 참조 항목으로 드러난 원래 참조 항목의 평가 항목 이름입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|NoWarn|DisplayName">
+        <source>NoWarn</source>
+        <target state="new">NoWarn</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|NoWarn|Description">
+        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
+        <target state="new">Comma-delimited list of warnings that should be suppressed for this package</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.pl.xlf
@@ -68,6 +68,16 @@
         <target state="translated">Sprawdzona nazwa elementu oryginalnego elementu odwołania, którego rozpoznanie spowodowało rozpoznanie tego elementu odwołania.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|NoWarn|DisplayName">
+        <source>NoWarn</source>
+        <target state="new">NoWarn</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|NoWarn|Description">
+        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
+        <target state="new">Comma-delimited list of warnings that should be suppressed for this package</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.pt-BR.xlf
@@ -68,6 +68,16 @@
         <target state="translated">O nome do item avaliado do item de referência original cuja resolução resultou nesse item de referência resolvido.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|NoWarn|DisplayName">
+        <source>NoWarn</source>
+        <target state="new">NoWarn</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|NoWarn|Description">
+        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
+        <target state="new">Comma-delimited list of warnings that should be suppressed for this package</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ru.xlf
@@ -68,6 +68,16 @@
         <target state="translated">Вычисленное имя исходного ссылочного элемента, в результате разрешения которого был получен данный разрешенный ссылочный элемент.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|NoWarn|DisplayName">
+        <source>NoWarn</source>
+        <target state="new">NoWarn</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|NoWarn|Description">
+        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
+        <target state="new">Comma-delimited list of warnings that should be suppressed for this package</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.tr.xlf
@@ -68,6 +68,16 @@
         <target state="translated">Çözümlemesi, bu çözümlenen başvuru öğesiyle sonuçlanmış olan orijinal başvuru öğesinin değerlendirilen öğe adı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|NoWarn|DisplayName">
+        <source>NoWarn</source>
+        <target state="new">NoWarn</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|NoWarn|Description">
+        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
+        <target state="new">Comma-delimited list of warnings that should be suppressed for this package</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.xlf
@@ -55,6 +55,14 @@
         <source>The evaluated item name of the original reference item whose resolution resulted in this resolved reference item.</source>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|NoWarn|DisplayName">
+        <source>NoWarn</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|NoWarn|Description">
+        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.zh-Hans.xlf
@@ -68,6 +68,16 @@
         <target state="translated">经解析得到此解析的引用项的原始引用项的计算项名称。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|NoWarn|DisplayName">
+        <source>NoWarn</source>
+        <target state="new">NoWarn</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|NoWarn|Description">
+        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
+        <target state="new">Comma-delimited list of warnings that should be suppressed for this package</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.zh-Hant.xlf
@@ -68,6 +68,16 @@
         <target state="translated">因解析而產生這個已解析參考項目的原始參考項目的評估項目名稱。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|NoWarn|DisplayName">
+        <source>NoWarn</source>
+        <target state="new">NoWarn</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="StringProperty|NoWarn|Description">
+        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
+        <target state="new">Comma-delimited list of warnings that should be suppressed for this package</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/NuGetRestore.xaml
@@ -49,4 +49,7 @@
   <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/PackageReference.xaml
@@ -22,4 +22,5 @@
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <StringProperty Name="NoWarn" Visible="True" DisplayName="NoWarn" Description="Comma-delimited list of warnings that should be suppressed for this package" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/NuGetRestore.xaml
@@ -49,4 +49,7 @@
   <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/PackageReference.xaml
@@ -22,4 +22,5 @@
   <StringProperty Name="FrameworkName" Visible="False" ReadOnly="True" />
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <StringProperty Name="NoWarn" Visible="True" DisplayName="NoWarn" Description="Comma-delimited list of warnings that should be suppressed for this package" />
 </Rule>


### PR DESCRIPTION
**Customer scenario**

Users receiving NuGet warnings need a way to suppress and manage the results. NuGet is completing its implementation of the spec at https://github.com/NuGet/Home/wiki/Improved-NuGet-warnings and has requested Project System to forward the following relevant properties for Preview 3:
- TreatWarningsAsErrors
- TreatSpecificWarningsAsErrors
- NoWarn (property and package reference metadata)

**Bugs this fixes:** 

Fixes https://github.com/dotnet/project-system/issues/2322

**Validation**

Confirmed corresponding properties can be accessed from `IVsProjectRestoreInfo` as:
```csharp
var targetFramework = projectRestoreInfo.TargetFrameworks.Item(tfString);

// properties
targetFramework.Properties.Item("TreatWarningsAsErrors");
targetFramework.Properties.Item("TreatSpecificWarningsAsErrors");
targetFramework.Properties.Item("NoWarn");

// metadata
targetFramework.PackageReferences.Item(packageId).Properties.Item("NoWarn");
```

**Workarounds, if any**

N/A

**Risk**

Low

**Is this a regression from a previous update?**

No

**Root cause analysis:**

We initially implemented this filtering ourselves but decided to move the implementation to NuGet after they determined that NuGet needs this information to decide if restore was successful. 

**How was the bug found?**

NuGet team requested

/cc @dotnet/project-system 
/cc @emgarten @rrelyea 