### PR TITLE
Fix up to date check & improve logging

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageControl.xaml
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageControl.xaml
@@ -5,8 +5,15 @@
                          xmlns:local="clr-namespace:Microsoft.VisualStudio.Editors.OptionPages">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <StackPanel>
-            <CheckBox x:Name="FastUpToDateCheck" x:Uid="General_FastUpToDateCheck" Content="{x:Static r:GeneralOptionPageResources.General_FastUpToDateCheck}" Margin="0" />
-            <CheckBox x:Name="VerboseFastUpToDateLogging" x:Uid="General_VerboseFastUpToDateLogging" Content="{x:Static r:GeneralOptionPageResources.General_VerboseFastUpToDateLogging}" Margin="0" />
+            <GroupBox x:Uid="FastUpToDateGroupBox" Header="{x:Static r:GeneralOptionPageResources.General_FastUpToDateCheck_Title}">
+                <StackPanel Orientation="Vertical">
+                    <CheckBox x:Name="FastUpToDateCheck" x:Uid="General_FastUpToDateCheck" Content="{x:Static r:GeneralOptionPageResources.General_FastUpToDateCheck}" Margin="0" />
+                    <StackPanel Orientation="Horizontal">
+                        <Label Content="{x:Static r:GeneralOptionPageResources.General_FastUpToDateCheck_LogLevel}" Margin="0" />
+                        <ComboBox x:Name="FastUpToDateLogLevel" SelectedIndex="2" ItemsSource="{x:Static local:GeneralOptionPageControl.FastUpToDateLogLevelItemSource}" x:Uid="General_LogLevel" VerticalContentAlignment="Center" Margin="0"/>
+                    </StackPanel>
+                </StackPanel>
+            </GroupBox>
         </StackPanel>
     </ScrollViewer>
 </local:OptionPageControl>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageControl.xaml.vb
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageControl.xaml.vb
@@ -9,6 +9,12 @@ Namespace Microsoft.VisualStudio.Editors.OptionPages
 
         Private _generalOptions As GeneralOptions
 
+        Public Shared ReadOnly FastUpToDateLogLevelItemSource As String() = {
+            My.Resources.GeneralOptionPageResources.General_FastUpToDateCheck_LogLevel_None,
+            My.Resources.GeneralOptionPageResources.General_FastUpToDateCheck_LogLevel_Info,
+            My.Resources.GeneralOptionPageResources.General_FastUpToDateCheck_LogLevel_Verbose
+        }
+
         Public Sub New(serviceProvider As IServiceProvider)
             MyBase.New()
 
@@ -27,11 +33,12 @@ Namespace Microsoft.VisualStudio.Editors.OptionPages
 
             binding = New Binding() With {
                     .Source = _generalOptions,
-                    .Path = New Windows.PropertyPath(NameOf(GeneralOptions.VerboseFastUpToDateLogging)),
-                    .UpdateSourceTrigger = UpdateSourceTrigger.Explicit
+                    .Path = New Windows.PropertyPath(NameOf(GeneralOptions.FastUpToDateLogLevel)),
+                    .UpdateSourceTrigger = UpdateSourceTrigger.Explicit,
+                    .Converter = LoggingLevelToInt32Converter.Instance
                     }
 
-            bindingExpression = VerboseFastUpToDateLogging.SetBinding(CheckBox.IsCheckedProperty, binding)
+            bindingExpression = FastUpToDateLogLevel.SetBinding(ComboBox.SelectedIndexProperty, binding)
             AddBinding(bindingExpression)
         End Sub
     End Class

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.Designer.vb
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.Designer.vb
@@ -49,21 +49,21 @@ Namespace My.Resources
                 Return resourceMan
             End Get
         End Property
-
+        
         '''<summary>
         '''  Overrides the current thread's CurrentUICulture property for all
         '''  resource lookups using this strongly typed resource class.
         '''</summary>
-        <Global.System.ComponentModel.EditorBrowsableAttribute(Global.System.ComponentModel.EditorBrowsableState.Advanced)>
+        <Global.System.ComponentModel.EditorBrowsableAttribute(Global.System.ComponentModel.EditorBrowsableState.Advanced)>  _
         Public Shared Property Culture() As Global.System.Globalization.CultureInfo
             Get
                 Return resourceCulture
             End Get
             Set
-                resourceCulture = Value
+                resourceCulture = value
             End Set
         End Property
-
+        
         '''<summary>
         '''  Looks up a localized string similar to Don&apos;t call MSBuild if a project appears to be up to date..
         '''</summary>
@@ -74,11 +74,47 @@ Namespace My.Resources
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to Log diagnostic information for project up to date checks to the output window..
+        '''  Looks up a localized string similar to Logging Level:.
         '''</summary>
-        Public Shared ReadOnly Property General_VerboseFastUpToDateLogging() As String
+        Public Shared ReadOnly Property General_FastUpToDateCheck_LogLevel() As String
             Get
-                Return ResourceManager.GetString("General_VerboseFastUpToDateLogging", resourceCulture)
+                Return ResourceManager.GetString("General_FastUpToDateCheck_LogLevel", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Info.
+        '''</summary>
+        Public Shared ReadOnly Property General_FastUpToDateCheck_LogLevel_Info() As String
+            Get
+                Return ResourceManager.GetString("General_FastUpToDateCheck_LogLevel_Info", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to None.
+        '''</summary>
+        Public Shared ReadOnly Property General_FastUpToDateCheck_LogLevel_None() As String
+            Get
+                Return ResourceManager.GetString("General_FastUpToDateCheck_LogLevel_None", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Verbose.
+        '''</summary>
+        Public Shared ReadOnly Property General_FastUpToDateCheck_LogLevel_Verbose() As String
+            Get
+                Return ResourceManager.GetString("General_FastUpToDateCheck_LogLevel_Verbose", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Up to Date Checks.
+        '''</summary>
+        Public Shared ReadOnly Property General_FastUpToDateCheck_Title() As String
+            Get
+                Return ResourceManager.GetString("General_FastUpToDateCheck_Title", resourceCulture)
             End Get
         End Property
     End Class

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.cs.resx
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.cs.resx
@@ -120,7 +120,4 @@
   <data name="General_FastUpToDateCheck" xml:space="preserve">
     <value>Don't call MSBuild if a project appears to be up to date.</value>
   </data>
-  <data name="General_VerboseFastUpToDateLogging" xml:space="preserve">
-    <value>Log diagnostic information for project up to date checks to the output window.</value>
-  </data>
 </root>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.de.resx
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.de.resx
@@ -120,7 +120,4 @@
   <data name="General_FastUpToDateCheck" xml:space="preserve">
     <value>Don't call MSBuild if a project appears to be up to date.</value>
   </data>
-  <data name="General_VerboseFastUpToDateLogging" xml:space="preserve">
-    <value>Log diagnostic information for project up to date checks to the output window.</value>
-  </data>
 </root>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.es.resx
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.es.resx
@@ -120,7 +120,4 @@
   <data name="General_FastUpToDateCheck" xml:space="preserve">
     <value>Don't call MSBuild if a project appears to be up to date.</value>
   </data>
-  <data name="General_VerboseFastUpToDateLogging" xml:space="preserve">
-    <value>Log diagnostic information for project up to date checks to the output window.</value>
-  </data>
 </root>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.fr.resx
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.fr.resx
@@ -120,7 +120,4 @@
   <data name="General_FastUpToDateCheck" xml:space="preserve">
     <value>Don't call MSBuild if a project appears to be up to date.</value>
   </data>
-  <data name="General_VerboseFastUpToDateLogging" xml:space="preserve">
-    <value>Log diagnostic information for project up to date checks to the output window.</value>
-  </data>
 </root>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.it.resx
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.it.resx
@@ -120,7 +120,4 @@
   <data name="General_FastUpToDateCheck" xml:space="preserve">
     <value>Don't call MSBuild if a project appears to be up to date.</value>
   </data>
-  <data name="General_VerboseFastUpToDateLogging" xml:space="preserve">
-    <value>Log diagnostic information for project up to date checks to the output window.</value>
-  </data>
 </root>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.ja.resx
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.ja.resx
@@ -120,7 +120,4 @@
   <data name="General_FastUpToDateCheck" xml:space="preserve">
     <value>Don't call MSBuild if a project appears to be up to date.</value>
   </data>
-  <data name="General_VerboseFastUpToDateLogging" xml:space="preserve">
-    <value>Log diagnostic information for project up to date checks to the output window.</value>
-  </data>
 </root>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.ko.resx
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.ko.resx
@@ -120,7 +120,4 @@
   <data name="General_FastUpToDateCheck" xml:space="preserve">
     <value>Don't call MSBuild if a project appears to be up to date.</value>
   </data>
-  <data name="General_VerboseFastUpToDateLogging" xml:space="preserve">
-    <value>Log diagnostic information for project up to date checks to the output window.</value>
-  </data>
 </root>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.pl.resx
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.pl.resx
@@ -120,7 +120,4 @@
   <data name="General_FastUpToDateCheck" xml:space="preserve">
     <value>Don't call MSBuild if a project appears to be up to date.</value>
   </data>
-  <data name="General_VerboseFastUpToDateLogging" xml:space="preserve">
-    <value>Log diagnostic information for project up to date checks to the output window.</value>
-  </data>
 </root>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.pt-BR.resx
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.pt-BR.resx
@@ -120,7 +120,4 @@
   <data name="General_FastUpToDateCheck" xml:space="preserve">
     <value>Don't call MSBuild if a project appears to be up to date.</value>
   </data>
-  <data name="General_VerboseFastUpToDateLogging" xml:space="preserve">
-    <value>Log diagnostic information for project up to date checks to the output window.</value>
-  </data>
 </root>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.resx
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.resx
@@ -120,7 +120,19 @@
   <data name="General_FastUpToDateCheck" xml:space="preserve">
     <value>Don't call MSBuild if a project appears to be up to date.</value>
   </data>
-  <data name="General_VerboseFastUpToDateLogging" xml:space="preserve">
-    <value>Log diagnostic information for project up to date checks to the output window.</value>
+  <data name="General_FastUpToDateCheck_LogLevel" xml:space="preserve">
+    <value>Logging Level:</value>
+  </data>
+  <data name="General_FastUpToDateCheck_LogLevel_Info" xml:space="preserve">
+    <value>Info</value>
+  </data>
+  <data name="General_FastUpToDateCheck_LogLevel_None" xml:space="preserve">
+    <value>None</value>
+  </data>
+  <data name="General_FastUpToDateCheck_LogLevel_Verbose" xml:space="preserve">
+    <value>Verbose</value>
+  </data>
+  <data name="General_FastUpToDateCheck_Title" xml:space="preserve">
+    <value>Up to Date Checks</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.ru.resx
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.ru.resx
@@ -120,7 +120,4 @@
   <data name="General_FastUpToDateCheck" xml:space="preserve">
     <value>Don't call MSBuild if a project appears to be up to date.</value>
   </data>
-  <data name="General_VerboseFastUpToDateLogging" xml:space="preserve">
-    <value>Log diagnostic information for project up to date checks to the output window.</value>
-  </data>
 </root>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.tr.resx
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.tr.resx
@@ -120,7 +120,4 @@
   <data name="General_FastUpToDateCheck" xml:space="preserve">
     <value>Don't call MSBuild if a project appears to be up to date.</value>
   </data>
-  <data name="General_VerboseFastUpToDateLogging" xml:space="preserve">
-    <value>Log diagnostic information for project up to date checks to the output window.</value>
-  </data>
 </root>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.zh-Hans.resx
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.zh-Hans.resx
@@ -120,7 +120,4 @@
   <data name="General_FastUpToDateCheck" xml:space="preserve">
     <value>Don't call MSBuild if a project appears to be up to date.</value>
   </data>
-  <data name="General_VerboseFastUpToDateLogging" xml:space="preserve">
-    <value>Log diagnostic information for project up to date checks to the output window.</value>
-  </data>
 </root>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.zh-Hant.resx
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.zh-Hant.resx
@@ -120,7 +120,4 @@
   <data name="General_FastUpToDateCheck" xml:space="preserve">
     <value>Don't call MSBuild if a project appears to be up to date.</value>
   </data>
-  <data name="General_VerboseFastUpToDateLogging" xml:space="preserve">
-    <value>Log diagnostic information for project up to date checks to the output window.</value>
-  </data>
 </root>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptions.vb
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptions.vb
@@ -10,7 +10,7 @@ Namespace Microsoft.VisualStudio.Editors.OptionPages
         End Class
 
         Private Const FastUpToDateEnabledSettingKey As String = "ManagedProjectSystem\FastUpToDateCheckEnabled"
-        Private Const VerboseFastUpToDateLoggingSettingKey As String = "ManagedProjectSystem\VerboseFastUpToDateLogging"
+        Private Const FastUpToDateLogLevelSettingKey As String = "ManagedProjectSystem\FastUpToDateLogLevel"
 
         Private ReadOnly _settingsManager As ISettingsManager
 
@@ -23,12 +23,12 @@ Namespace Microsoft.VisualStudio.Editors.OptionPages
             End Set
         End Property
 
-        Public Property VerboseFastUpToDateLogging As Boolean
+        Public Property FastUpToDateLogLevel As LogLevel
             Get
-                Return If(_settingsManager?.GetValueOrDefault(VerboseFastUpToDateLoggingSettingKey, False), False)
+                Return If(_settingsManager?.GetValueOrDefault(FastUpToDateLogLevelSettingKey, LogLevel.None), LogLevel.None)
             End Get
             Set
-                _settingsManager.SetValueAsync(VerboseFastUpToDateLoggingSettingKey, Value, isMachineLocal:=False)
+                _settingsManager.SetValueAsync(FastUpToDateLogLevelSettingKey, Value, isMachineLocal:=False)
             End Set
         End Property
 

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/LogLevel.vb
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/LogLevel.vb
@@ -1,0 +1,7 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Public Enum LogLevel
+    None
+    Info
+    Verbose
+End Enum

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/LoggingLevelToInt32Converter.vb
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/LoggingLevelToInt32Converter.vb
@@ -1,0 +1,36 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Globalization
+Imports System.Windows.Data
+
+Namespace Microsoft.VisualStudio.Editors.OptionPages
+    Friend NotInheritable Class LoggingLevelToInt32Converter
+        Implements IValueConverter
+
+        Private Shared ReadOnly _instance As New LoggingLevelToInt32Converter()
+
+        Public Shared ReadOnly Property Instance As LoggingLevelToInt32Converter
+            Get
+                Return _instance
+            End Get
+        End Property
+
+        Public Function Convert(value As Object, targetType As Type, parameter As Object, culture As CultureInfo) As Object Implements IValueConverter.Convert
+            Debug.Assert(value IsNot Nothing)
+            Debug.Assert(TypeOf value Is LogLevel)
+            Debug.Assert([Enum].IsDefined(GetType(LogLevel), value))
+            Debug.Assert(targetType = GetType(Integer))
+
+            Return CInt(CType(value, LogLevel))
+        End Function
+
+        Public Function ConvertBack(value As Object, targetType As Type, parameter As Object, culture As CultureInfo) As Object Implements IValueConverter.ConvertBack
+            Debug.Assert(value IsNot Nothing)
+            Debug.Assert(TypeOf value Is Integer)
+            Debug.Assert(CInt(value) >= 0 AndAlso CInt(value) < [Enum].GetValues(GetType(LogLevel)).Length)
+            Debug.Assert(targetType = GetType(LogLevel))
+
+            Return CType(CInt(value), LogLevel)
+        End Function
+    End Class
+End Namespace

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/OptionPageControl.vb
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/OptionPageControl.vb
@@ -22,6 +22,17 @@ Namespace Microsoft.VisualStudio.Editors.OptionPages
             checkBoxStyle.Setters.Add(New Setter(ForegroundProperty, New DynamicResourceExtension(SystemColors.WindowTextBrushKey)))
             checkBoxStyle.Setters.Add(New Setter(MarginProperty, New Thickness(left:=0, top:=7, right:=0, bottom:=7)))
             Resources.Add(GetType(CheckBox), checkBoxStyle)
+
+            Dim comboBoxStyle = New Style(GetType(ComboBox))
+            comboBoxStyle.Setters.Add(New Setter(ForegroundProperty, New DynamicResourceExtension(SystemColors.WindowTextBrushKey)))
+            comboBoxStyle.Setters.Add(New Setter(MarginProperty, New Thickness(left:=0, top:=7, right:=0, bottom:=7)))
+            Resources.Add(GetType(ComboBox), comboBoxStyle)
+
+            Dim groupBoxStyle = New Style(GetType(GroupBox))
+            groupBoxStyle.Setters.Add(New Setter(ForegroundProperty, New DynamicResourceExtension(SystemColors.WindowTextBrushKey)))
+            groupBoxStyle.Setters.Add(New Setter(MarginProperty, New Thickness(left:=0, top:=0, right:=0, bottom:=3)))
+            groupBoxStyle.Setters.Add(New Setter(PaddingProperty, New Thickness(left:=7, top:=7, right:=7, bottom:=0)))
+            Resources.Add(GetType(GroupBox), groupBoxStyle)
         End Sub
 
         Protected Sub AddBinding(bindingExpression As BindingExpressionBase)

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.cs.xlf
@@ -8,11 +8,6 @@
         <target state="new">Don't call MSBuild if a project appears to be up to date.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="General_VerboseFastUpToDateLogging">
-        <source>Log diagnostic information for project up to date checks to the output window.</source>
-        <target state="new">Log diagnostic information for project up to date checks to the output window.</target>
-        <note></note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.de.xlf
@@ -8,11 +8,6 @@
         <target state="new">Don't call MSBuild if a project appears to be up to date.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="General_VerboseFastUpToDateLogging">
-        <source>Log diagnostic information for project up to date checks to the output window.</source>
-        <target state="new">Log diagnostic information for project up to date checks to the output window.</target>
-        <note></note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.es.xlf
@@ -8,11 +8,6 @@
         <target state="new">Don't call MSBuild if a project appears to be up to date.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="General_VerboseFastUpToDateLogging">
-        <source>Log diagnostic information for project up to date checks to the output window.</source>
-        <target state="new">Log diagnostic information for project up to date checks to the output window.</target>
-        <note></note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.fr.xlf
@@ -8,11 +8,6 @@
         <target state="new">Don't call MSBuild if a project appears to be up to date.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="General_VerboseFastUpToDateLogging">
-        <source>Log diagnostic information for project up to date checks to the output window.</source>
-        <target state="new">Log diagnostic information for project up to date checks to the output window.</target>
-        <note></note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.it.xlf
@@ -8,11 +8,6 @@
         <target state="new">Don't call MSBuild if a project appears to be up to date.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="General_VerboseFastUpToDateLogging">
-        <source>Log diagnostic information for project up to date checks to the output window.</source>
-        <target state="new">Log diagnostic information for project up to date checks to the output window.</target>
-        <note></note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.ja.xlf
@@ -8,11 +8,6 @@
         <target state="new">Don't call MSBuild if a project appears to be up to date.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="General_VerboseFastUpToDateLogging">
-        <source>Log diagnostic information for project up to date checks to the output window.</source>
-        <target state="new">Log diagnostic information for project up to date checks to the output window.</target>
-        <note></note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.ko.xlf
@@ -8,11 +8,6 @@
         <target state="new">Don't call MSBuild if a project appears to be up to date.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="General_VerboseFastUpToDateLogging">
-        <source>Log diagnostic information for project up to date checks to the output window.</source>
-        <target state="new">Log diagnostic information for project up to date checks to the output window.</target>
-        <note></note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.pl.xlf
@@ -8,11 +8,6 @@
         <target state="new">Don't call MSBuild if a project appears to be up to date.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="General_VerboseFastUpToDateLogging">
-        <source>Log diagnostic information for project up to date checks to the output window.</source>
-        <target state="new">Log diagnostic information for project up to date checks to the output window.</target>
-        <note></note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.pt-BR.xlf
@@ -8,11 +8,6 @@
         <target state="new">Don't call MSBuild if a project appears to be up to date.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="General_VerboseFastUpToDateLogging">
-        <source>Log diagnostic information for project up to date checks to the output window.</source>
-        <target state="new">Log diagnostic information for project up to date checks to the output window.</target>
-        <note></note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.ru.xlf
@@ -8,11 +8,6 @@
         <target state="new">Don't call MSBuild if a project appears to be up to date.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="General_VerboseFastUpToDateLogging">
-        <source>Log diagnostic information for project up to date checks to the output window.</source>
-        <target state="new">Log diagnostic information for project up to date checks to the output window.</target>
-        <note></note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.tr.xlf
@@ -8,11 +8,6 @@
         <target state="new">Don't call MSBuild if a project appears to be up to date.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="General_VerboseFastUpToDateLogging">
-        <source>Log diagnostic information for project up to date checks to the output window.</source>
-        <target state="new">Log diagnostic information for project up to date checks to the output window.</target>
-        <note></note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.xlf
@@ -7,10 +7,6 @@
         <source>Don't call MSBuild if a project appears to be up to date.</source>
         <note></note>
       </trans-unit>
-      <trans-unit id="General_VerboseFastUpToDateLogging">
-        <source>Log diagnostic information for project up to date checks to the output window.</source>
-        <note></note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.zh-Hans.xlf
@@ -8,11 +8,6 @@
         <target state="new">Don't call MSBuild if a project appears to be up to date.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="General_VerboseFastUpToDateLogging">
-        <source>Log diagnostic information for project up to date checks to the output window.</source>
-        <target state="new">Log diagnostic information for project up to date checks to the output window.</target>
-        <note></note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.zh-Hant.xlf
@@ -8,11 +8,6 @@
         <target state="new">Don't call MSBuild if a project appears to be up to date.</target>
         <note></note>
       </trans-unit>
-      <trans-unit id="General_VerboseFastUpToDateLogging">
-        <source>Log diagnostic information for project up to date checks to the output window.</source>
-        <target state="new">Log diagnostic information for project up to date checks to the output window.</target>
-        <note></note>
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectSystemOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectSystemOptions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         private class SVsSettingsPersistenceManager { }
 
         private const string FastUpToDateEnabledSettingKey = @"ManagedProjectSystem\FastUpToDateCheckEnabled";
-        private const string VerboseFastUpToDateLoggingSettingKey = @"ManagedProjectSystem\VerboseFastUpToDateLogging";
+        private const string FastUpToDateLogLevelSettingKey = @"ManagedProjectSystem\FastUpToDateLogLevel";
 
         private readonly IVsOptionalService<SVsSettingsPersistenceManager, ISettingsManager> _settingsManager;
         private readonly IEnvironmentHelper _environment;
@@ -49,10 +49,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             return _settingsManager.Value?.GetValueOrDefault(FastUpToDateEnabledSettingKey, true) ?? true;
         }
 
-        public async Task<bool> GetVerboseFastUpToDateLoggingAsync()
+        public async Task<LogLevel> GetFastUpToDateLoggingLevelAsync()
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-            return _settingsManager.Value?.GetValueOrDefault(VerboseFastUpToDateLoggingSettingKey, false) ?? false;
+            return _settingsManager.Value?.GetValueOrDefault(FastUpToDateLogLevelSettingKey, LogLevel.None) ?? LogLevel.None;
         }
 
         private bool IsEnabled(string variable)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/BuildUpToDateCheck.cs
@@ -22,25 +22,24 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             private TextWriter _logger;
             private LogLevel _requestedLogLevel;
-            private string _projectPath;
+            private string _fileName;
 
             public Logger(TextWriter logger, LogLevel requestedLogLevel, string projectPath)
             {
                 _logger = logger;
                 _requestedLogLevel = requestedLogLevel;
-                _projectPath = projectPath;
+                _fileName = Path.GetFileNameWithoutExtension(projectPath);
             }
 
             private void Log(LogLevel level, string message, params object[] values)
             {
                 if (level <= _requestedLogLevel)
                 {
-                    _logger?.WriteLine("FastUpToDate: " + string.Format(message, values) + " (" + Path.GetFileNameWithoutExtension(_projectPath) + ")");
+                    _logger?.WriteLine($"FastUpToDate: {string.Format(message, values)} ({Path.GetFileNameWithoutExtension(_fileName)})");
                 }
             }
 
             public void Info(string message, params object[] values) => Log(LogLevel.Info, message, values);
-
             public void Verbose(string message, params object[] values) => Log(LogLevel.Verbose, message, values);
         }
         private const string TrueValue = "true";
@@ -346,7 +345,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 logger.Info("Output '{0}' does not exist.", earliestOutput.path);
             }
 
-            // We are up to date if the earliest output write happened before the latest input write
+            // We are up to date if the earliest output write happened after the latest input write
             var isUpToDate = latestInput.time != null && earliestOutput.time != null && earliestOutput.time > latestInput.time;
             logger.Info("Project is{0} up to date.", (!isUpToDate ? " not" : ""));
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectSystemOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectSystemOptions.cs
@@ -29,11 +29,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
         Task<bool> GetIsFastUpToDateCheckEnabledAsync();
 
         /// <summary>
-        ///     Gets a value indicating if fast up to date check logging should be verbose.
+        ///     Gets a value indicating the level of fast up to date check logging.
         /// </summary>
         /// <value>
-        ///     <see langword="true"/> if the project fast up to date logging is verbose; otherwise, <see langword="false"/>
+        ///     The level of fast up to date check logging.
         /// </value>
-        Task<bool> GetVerboseFastUpToDateLoggingAsync();
+        Task<LogLevel> GetFastUpToDateLoggingLevelAsync();
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LogLevel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LogLevel.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal enum LogLevel
+    {
+        None,
+        Info,
+        Verbose
+    }
+}


### PR DESCRIPTION
**Customer scenario**

The fast up to date check is broken since it erroneously believes all projects have opted out of up to date checks. Also, logging is too verbose and needs to be reined in to be useful in large solutions. This adds levels of logging that allow more terse logging that can be useful to see problems and then more verbose logging to diagnose issues.

**Workarounds, if any**

None.

**Risk**

Low, fixes a broken new feature.

**Performance impact**

Just turned on a broken feature.

**Is this a regression from a previous update?**

No. 

**Root cause analysis:**

We're currently missing integration tests for fast up to date. Once integration tests are actually running again, I'm going to add tests to prevent breaks like this.

**How was the bug found?**

Ad hoc testing.
