### PR TITLE
Fixing some of the property pages to use "Browse..." rather than "..."

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.resx
@@ -703,7 +703,7 @@
     <value>5</value>
   </data>
   <data name="AppIconBrowse.Text" xml:space="preserve">
-    <value>...</value>
+    <value>Browse...</value>
   </data>
   <data name="&gt;&gt;AppIconBrowse.Name" xml:space="preserve">
     <value>AppIconBrowse</value>
@@ -898,7 +898,7 @@
     <value>10</value>
   </data>
   <data name="Win32ResourceFileBrowse.Text" xml:space="preserve">
-    <value>...</value>
+    <value>Browse...</value>
   </data>
   <data name="&gt;&gt;Win32ResourceFileBrowse.Name" xml:space="preserve">
     <value>Win32ResourceFileBrowse</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventsPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventsPropPage.resx
@@ -217,7 +217,7 @@
     <value>2</value>
   </data>
   <data name="btnPreBuildBuilder.Text" xml:space="preserve">
-    <value>Ed&amp;it Pre-build ...</value>
+    <value>Ed&amp;it Pre-build...</value>
   </data>
   <data name="&gt;&gt;btnPreBuildBuilder.Name" xml:space="preserve">
     <value>btnPreBuildBuilder</value>
@@ -328,7 +328,7 @@
     <value>5</value>
   </data>
   <data name="btnPostBuildBuilder.Text" xml:space="preserve">
-    <value>Edit Post-b&amp;uild ...</value>
+    <value>Edit Post-b&amp;uild...</value>
   </data>
   <data name="&gt;&gt;btnPostBuildBuilder.Name" xml:space="preserve">
     <value>btnPostBuildBuilder</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePathsPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePathsPropPage.resx
@@ -337,7 +337,7 @@
     <value>2</value>
   </data>
   <data name="FolderBrowse.Text">
-    <value xml:space="preserve">...</value>
+    <value xml:space="preserve">Browse...</value>
   </data>
   <data name="&gt;&gt;FolderBrowse.Name">
     <value xml:space="preserve">FolderBrowse</value>


### PR DESCRIPTION
**Customer scenario**

Users relying on screenreaders will not understand the name and purpose of the button if the name property is inappropriate.

**Bugs this fixes:** 

https://devdiv.visualstudio.com/DevDiv/_workitems?id=441876

**Workarounds, if any**

None

**Risk**

Low, this just changes the text displayed from "..." to "Browse...", which is inline with what we do elsewhere

**Performance impact**

None

**Is this a regression from a previous update?**

No

**Root cause analysis:**

Known accessibility issue

**How was the bug found?**

Accessibility Tenant