### PR TITLE
Fix warning icons that show up incorrectly some analyzers in solution explorer.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAnalyzerReference.xaml
@@ -16,7 +16,7 @@
                     ReadOnly="True" 
                     Description="The evaluated item name of the original reference item whose resolution resulted in this resolved reference item.">
         <StringProperty.DataSource>
-            <DataSource Persistence="Intrinsic" ItemType="Analyzer" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
+            <DataSource Persistence="Intrinsic" ItemType="Analyzer" PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
     </StringProperty>
     <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />


### PR DESCRIPTION
**Customer scenario**

If a project includes an analyzer where the path is not normalized, then it shows up with a warning icon in solution explorer. This can happen with nuget packages for eg where extra backslashes can get appended.

The cause of this bug is that the dependencies node first gets the unresolved reference and then the resolved reference and it matches the OriginalItemSpec on the resolved reference to see if there's an unresolved reference corresponding to it. If so, it shows the resolved one. In the case of Analyzers, we were using the FullPath property for the OriginaltemSpec which is normalized. So it wouldn't match the unresolved reference path if that wasn't normalized. Switching to the Identity property just gets the evaluated value of whatever was in the project file.

**Bugs this fixes:** 
Fixes https://github.com/dotnet/project-system/issues/1634

(either VSO or GitHub links)

**Workarounds, if any**

Fix the path if possible to be resolved path.

**Risk**

Low

**Performance impact**

Low - just using a different property.

**Is this a regression from a previous update?**
No

**How was the bug found?**

Dogfooding.


@dotnet/project-system @natidea @tmeschter 
