### PR TITLE
Redirect netstandard types in the designer

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
@@ -27,8 +27,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     '''  - Implements IComponent to be able to push the resource through SelectionService, so that the name of the resource 
     '''      appears on the Property Window's drop down list.
     ''' </remarks>
-    <Serializable()> _
-    <TypeDescriptionProvider(GetType(ResourceTypeDescriptionProvider))> _
+    <Serializable()>
+    <TypeDescriptionProvider(GetType(ResourceTypeDescriptionProvider))>
     Friend NotInheritable Class Resource
         Implements IComponent
         Implements ISerializable 'This allows us to fully control the serialization process
@@ -67,7 +67,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''  The persistence mode of the resource to show in PropertyWindow.
         ''' </summary>
         ''' <remarks></remarks>
-        <TypeConverter(GetType(ResourcePersistenceModeEnumConverter))> _
+        <TypeConverter(GetType(ResourcePersistenceModeEnumConverter))>
         Public Enum ResourcePersistenceMode
             'The resource is a link to a file on disk which is read and compiled into the manifest resources at compile time.
             Linked
@@ -1627,9 +1627,15 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Private Shared Function AdjustAssemblyQualifiedNameForNetStandard(AssemblyQualifiedName As String) As String
             Static MscorlibAssemblyName As AssemblyName
 
-            If AssemblyQualifiedName.Contains("netstandard") Then
-                Dim indexOfFirstComma = AssemblyQualifiedName.IndexOf(",")
-                If indexOfFirstComma <> -1 Then
+            ' If this type definitely isn't from netstandard.dll then bail out before we allocate.
+            If Not AssemblyQualifiedName.Contains("netstandard") Then
+                Return AssemblyQualifiedName
+            End If
+
+            Dim indexOfFirstComma = AssemblyQualifiedName.IndexOf(",")
+            If indexOfFirstComma <> -1 Then
+                Dim assemblyName = New AssemblyName(AssemblyQualifiedName.Substring(indexOfFirstComma + 1))
+                If assemblyName.Name = "netstandard" Then
                     Dim typeName = AssemblyQualifiedName.Substring(startIndex:=0, length:=indexOfFirstComma)
 
                     If MscorlibAssemblyName Is Nothing Then

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
@@ -1160,6 +1160,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     End If
 
                     Debug.Assert(TypeName <> "", "ResXDataNode.GetValueTypeName() should never return an empty string or Nothing (not even for ResXNullRef)")
+
+                    TypeName = AdjustAssemblyQualifiedNameForNetStandard(TypeName)
+
                     Return TypeName
                 Catch ex As Exception When ReportWithoutCrash(ex, "Unexpected exception - ResXDataNode.GetValueTypeName() is not supposed to throw exceptions (except unrecoverable ones), it should instead return the typename as in the original .resx file", NameOf(Resource))
                     Return My.Resources.Designer.RSE_UnknownType
@@ -1601,6 +1604,45 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Else
                 Return Type.GetType(ValueTypeName, ThrowOnError, ignoreCase:=True)
             End If
+        End Function
+
+        ''' <remarks>
+        ''' This is a bit of a hack to allow the designer to work properly with netstandard2.0 projects.
+        ''' Our multi-targeting support quite correctly tells us that types like System.String are found
+        ''' in netstandard.dll. However, VS (and thus the resx designer) and resgen.exe run on the net462
+        ''' framework, which does not have a netstandard.dll. As such the designer doesn't understand the
+        ''' types involved and crashes while trying to create or update resource strings. Even if we
+        ''' could get past that, resgen.exe would see the references to netstandard.dll in the .resx
+        ''' file, fail to locate it, and die while trying to produce the .designer.cs file.
+        ''' 
+        ''' The workaround here is to check if the assembly-qualified type name refers to a type in 
+        ''' netstandard.dll, and if it does swap in mscorlib.dll instead. This allows the designer to
+        ''' work. The updated assembly-qualified typename also makes its way into the .resx file,
+        ''' allowing resgen.exe to work properly and produce the .designer.cs file.
+        ''' 
+        ''' This does not affect the runtime behavior of the app in any way as the types in the .resx
+        ''' file are only used to produce the .designer.cs file, which is still built against
+        ''' netstandard.dll.
+        ''' </remarks>
+        Private Shared Function AdjustAssemblyQualifiedNameForNetStandard(AssemblyQualifiedName As String) As String
+            Static MscorlibAssemblyName As AssemblyName
+
+            If AssemblyQualifiedName.Contains("netstandard") Then
+                Dim indexOfFirstComma = AssemblyQualifiedName.IndexOf(",")
+                If indexOfFirstComma <> -1 Then
+                    Dim typeName = AssemblyQualifiedName.Substring(startIndex:=0, length:=indexOfFirstComma)
+
+                    If MscorlibAssemblyName Is Nothing Then
+                        MscorlibAssemblyName = AppDomain.CurrentDomain().GetAssemblies().
+                            Select(Function(a) a.GetName()).
+                            First(Function(a) a.Name = "mscorlib")
+                    End If
+
+                    AssemblyQualifiedName = typeName + ", " + MscorlibAssemblyName.FullName
+                End If
+            End If
+
+            Return AssemblyQualifiedName
         End Function
 
         Public Function TryGetValueType() As Type


### PR DESCRIPTION
This is a bit of a hack to allow the designer to work properly with netstandard2.0 projects.
Our multi-targeting support quite correctly tells us that types like System.String are found
in netstandard.dll. However, VS (and thus the resx designer) and resgen.exe run on the net462
framework, which does not have a netstandard.dll. As such the designer doesn't understand the
types involved and crashes while trying to create or update resource strings. Even if we
could get past that, resgen.exe would see the references to netstandard.dll in the .resx
file, fail to locate it, and die while trying to produce the .designer.cs file.

The workaround here is to check if the assembly-qualified type name refers to a type in
netstandard.dll, and if it does swap in mscorlib.dll instead. This allows the designer to
work. The updated assembly-qualified typename also makes its way into the .resx file,
allowing resgen.exe to work properly and produce the .designer.cs file.

This does not affect the runtime behavior of the app in any way as the types in the .resx
file are only used to produce the .designer.cs file, which is still built against
netstandard.dll.

**Customer scenario**

Customer opens a .resx file in a .NET Core 2.0 or .NET Standard 2.0 project and attempts to add a new string value, or update an existing string value. VS crashes.

**Bugs this fixes:** 

Fixes #2155.

**Workarounds, if any**

Edit .resx files by hand as XML files. Even then you will still need to replace any references to the netstandard assembly in the .resx file with the corresponding mscorlib, otherwise resgen.exe will fail and the project won't compile.

**Risk**

Low. This only affects .NET Core and .NET Standard projects (as they are the only ones that reference netstandard), and this scenario doesn't work at all for .NET Core 2.0/.NET Standard 2.0 projects anyway.

**Performance impact**

Low. We avoid any additional memory allocations until we're sure the assembly-qualified type name needs to be updated.

**Is this a regression from a previous update?**

Yes, insofar as the designer works properly for .NET Core 1.x/.NET Standard 1.x projects. However this has never worked for 2.0 projects.

**Root cause analysis:**

N/A.

**How was the bug found?**

Ad hoc testing.
