### PR TITLE
Don't check files that aren't copied for fast-up-to-date check

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/BuildUpToDateCheck.cs
@@ -147,8 +147,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
             {
                 var items = itemType.Value
                     .After.Items
-                    .Where(item => !item.Value.ContainsKey(CopyToOutputDirectory) 
-                        || !string.Equals(item.Value[CopyToOutputDirectory], Never, StringComparison.InvariantCultureIgnoreCase))
                     .Select(item => item.Value[FullPath]);
                 _items[itemType.Key] = new HashSet<string>(items);
             }


### PR DESCRIPTION
**Customer scenario**

In a project with Content files that are CopyToOutputDirectory Never (for example, web projects), we fail the fast up to date check always because we are checking files that are never copied to the output.

**Bugs this fixes:** 

#2345

**Workarounds, if any**

None, fast up to date check doesn't work.

**Risk**

Low, this makes a scenario that doesn't work, work.

**Performance impact**

Low, just checking an extra field when collecting inputs/outputs.

**Is this a regression from a previous update?**

No

**How was the bug found?**

Ad hoc testing