### PR TITLE
Pass additional fallback folder properties during nominate

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -102,6 +102,14 @@
                     Visible="False" 
                     ReadOnly="True" />
 
+    <StringProperty Name="RestoreAdditionalProjectSources" 
+                    Visible="False" 
+                    ReadOnly="True" />
+
+    <StringProperty Name="RestoreAdditionalProjectFallbackFolders" 
+                    Visible="False" 
+                    ReadOnly="True" />
+                    
     <StringProperty Name="TreatWarningsAsErrors" 
                     Visible="False" 
                     ReadOnly="True" />
@@ -113,5 +121,5 @@
     <StringProperty Name="NoWarn" 
                     Visible="False" 
                     ReadOnly="True" />
-                    
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/NuGetRestore.xaml
@@ -49,6 +49,8 @@
   <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/NuGetRestore.xaml
@@ -49,6 +49,8 @@
   <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/NuGetRestore.xaml
@@ -49,6 +49,8 @@
   <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/NuGetRestore.xaml
@@ -49,6 +49,8 @@
   <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/NuGetRestore.xaml
@@ -49,6 +49,8 @@
   <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/NuGetRestore.xaml
@@ -49,6 +49,8 @@
   <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/NuGetRestore.xaml
@@ -49,6 +49,8 @@
   <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/NuGetRestore.xaml
@@ -49,6 +49,8 @@
   <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/NuGetRestore.xaml
@@ -49,6 +49,8 @@
   <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/NuGetRestore.xaml
@@ -49,6 +49,8 @@
   <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/NuGetRestore.xaml
@@ -49,6 +49,8 @@
   <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/NuGetRestore.xaml
@@ -49,6 +49,8 @@
   <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/NuGetRestore.xaml
@@ -49,6 +49,8 @@
   <StringProperty Name="RestoreSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />


### PR DESCRIPTION
**Customer scenario**

These additional properties will be used to pass source and fallback folders from the SDK to NuGet restore.
https://github.com/NuGet/Home/wiki/%5BSpec%5D-NuGet-settings-in-MSBuild

**Bugs this fixes:** 

Fixes #2360 

**Workarounds, if any**

N/A

**Risk**

Low, another pair of values added to project property bag.

**Is this a regression from a previous update?**

No

**Root cause analysis:**

More properties emerging from NuGet work

/cc @dotnet/project-system 
/cc @Emgarten

