### PR TITLE
make pre build events post build events work using targets

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             IProjectPropertiesFactory.MockWithProperty(string.Empty).Object;
 
         [Fact]
-        public static void GetPropertyTest_AllTargetsPresent()
+        public static async Task GetPropertyTest_AllTargetsPresentAsync()
         {
             var root = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
@@ -38,12 +38,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
 </Project>
 ".AsProjectRootElement();
-            var actual = systemUnderTest.GetProperty(root);
+            var actual = await systemUnderTest.GetPropertyAsync(root, emptyProjectProperties);
             Assert.Equal(@"echo ""post build output""", actual);
         }
 
         [Fact]
-        public static void GetPropertyTest_PostBuildTargetPresent()
+        public static async Task GetPropertyTest_PostBuildTargetPresentAsync()
         {
             var root = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
@@ -59,12 +59,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
 </Project>
 ".AsProjectRootElement();
-            var actual = systemUnderTest.GetProperty(root);
+            var actual = await systemUnderTest.GetPropertyAsync(root, emptyProjectProperties);
             Assert.Equal(@"echo ""post build output""", actual);
         }
 
         [Fact]
-        public static void GetPropertyTest_PostBuildTargetPresent_LowerCase()
+        public static async Task GetPropertyTest_PostBuildTargetPresent_LowerCaseAsync()
         {
             var root = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
@@ -80,12 +80,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
 </Project>
 ".AsProjectRootElement();
-            var actual = systemUnderTest.GetProperty(root);
+            var actual = await systemUnderTest.GetPropertyAsync(root, emptyProjectProperties);
             Assert.Equal(@"echo ""post build output""", actual);
         }
 
         [Fact]
-        public static void GetPropertyTest_NoTargetsPresent()
+        public static async Task GetPropertyTest_NoTargetsPresentAsync()
         {
             var root = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
@@ -97,12 +97,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
 </Project>
 ".AsProjectRootElement();
-            var actual = systemUnderTest.GetProperty(root);
+            var actual = await systemUnderTest.GetPropertyAsync(root, emptyProjectProperties);
             Assert.Null(actual);
         }
 
         [Fact]
-        public static void GetPropertyTest_ExistingProperties()
+        public static async Task GetPropertyTest_ExistingPropertiesAsync()
         {
             var root = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
@@ -115,12 +115,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
 </Project>
 ".AsProjectRootElement();
-            var result = systemUnderTest.GetProperty(root);
-            Assert.Null(result);
+
+            var expected = "echo $(ProjectDir)";
+            var projectProperties = IProjectPropertiesFactory.CreateWithPropertyAndValue("PostBuildEvent", expected);
+            var actual = await systemUnderTest.GetPropertyAsync(root, projectProperties);
+            Assert.Equal(expected, actual);
         }
 
         [Fact]
-        public static void GetPropertyTest_WrongTargetName()
+        public static async Task GetPropertyTest_WrongTargetNameAsync()
         {
             var root = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
@@ -134,7 +137,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   </Target>
 </Project>
 ".AsProjectRootElement();
-            var result = systemUnderTest.GetProperty(root);
+            var result = await systemUnderTest.GetPropertyAsync(root, emptyProjectProperties);
             Assert.Null(result);
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
@@ -59,6 +59,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
+        public static void GetPropertyTest_PostBuildTargetPresent_LowerCase()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name=""postbuild"" AfterTargets=""postbuildevent"">
+    <Exec Command=""echo &quot;post build output&quot;"" />
+  </Target>
+
+</Project>
+".AsProjectRootElement();
+            var actual = systemUnderTest.GetProperty(root);
+            Assert.Equal(@"echo ""post build output""", actual);
+        }
+
+        [Fact]
         public static void GetPropertyTest_NoTargetsPresent()
         {
             var root = @"
@@ -147,6 +168,34 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
+        public static void SetPropertyTest_TargetPresent_LowerCase()
+        {
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""postbuild"" AfterTargets=""postbuildevent"">
+    <Exec Command=""echo &quot;post build output&quot;"" />
+  </Target>
+</Project>".AsProjectRootElement();
+            systemUnderTest.SetProperty(@"echo ""post build $(OutDir)""", root);
+
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""postbuild"" AfterTargets=""postbuildevent"">
+    <Exec Command=""echo &quot;post build $(OutDir)&quot;"" />
+  </Target>
+</Project>";
+
+            var actual = root.SaveAndGetChanges();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
         public static void SetPropertyTest_TargetPresent_NoTasks()
         {
             var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
@@ -168,6 +217,35 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   </Target>
   <Target Name=""PostBuild1"" AfterTargets=""PostBuildEvent"">
     <Exec Command=""echo &quot;post build $(OutDir)&quot;"" />
+  </Target>
+</Project>";
+
+            var actual = root.SaveAndGetChanges();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_TargetPresent_NoTasks_Removal()
+        {
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
+  </Target>
+  <Target Name=""PostBuild1"" AfterTargets=""PostBuildEvent"">
+    <Exec Command=""echo &quot;post build $(OutDir)&quot;"" />
+  </Target>
+</Project>".AsProjectRootElement();
+            systemUnderTest.SetProperty(@"", root);
+
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
   </Target>
 </Project>";
 
@@ -391,6 +469,40 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   <Target Name=""PostBuild"">
   </Target>
   <Target Name=""PostBuild1"">
+  </Target>
+  <Target Name=""PostBuild2"" AfterTargets=""PostBuildEvent"">
+    <Exec Command=""echo &quot;post build $(OutDir)&quot;"" />
+  </Target>
+</Project>";
+
+            var actual = root.SaveAndGetChanges();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_TargetNameCollision_LowerCase()
+        {
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""postBuild"">
+  </Target>
+  <Target Name=""postBuild1"">
+  </Target>
+</Project>
+".AsProjectRootElement();
+            systemUnderTest.SetProperty(@"echo ""post build $(OutDir)""", root);
+
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""postBuild"">
+  </Target>
+  <Target Name=""postBuild1"">
   </Target>
   <Target Name=""PostBuild2"" AfterTargets=""PostBuildEvent"">
     <Exec Command=""echo &quot;post build $(OutDir)&quot;"" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
@@ -115,6 +115,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
+        public static void GetPropertyTest_WrongTargetName()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PoostBuild"" AfterTargets=""PostBuildEvent"">
+    <Exec Command=""echo &quot;post build output&quot;"" />
+  </Target>
+</Project>
+".AsProjectRootElement();
+            var result = systemUnderTest.GetProperty(root);
+            Assert.Null(result);
+        }
+
+        [Fact]
         public static void SetPropertyTest_NoTargetsPresent()
         {
             var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
@@ -533,6 +552,37 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
     <PreBuildEvent>echo $(ProjectDir)</PreBuildEvent>
     <PostBuildEvent>echo ""post build $(OutDir)""</PostBuildEvent>
   </PropertyGroup>
+</Project>";
+
+            var actual = root.SaveAndGetChanges();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_WrongTargetName()
+        {
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PoostBuild"" AfterTargets=""PostBuildEvent"">
+    <Exec Command=""echo &quot;post build output&quot;"" />
+  </Target>
+</Project>".AsProjectRootElement();
+            systemUnderTest.SetProperty(@"echo ""post build $(OutDir)""", root);
+
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PoostBuild"" AfterTargets=""PostBuildEvent"">
+    <Exec Command=""echo &quot;post build output&quot;"" />
+  </Target>
+  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
+    <Exec Command=""echo &quot;post build $(OutDir)&quot;"" />
+  </Target>
 </Project>";
 
             var actual = root.SaveAndGetChanges();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             IProjectPropertiesFactory.MockWithProperty(string.Empty).Object;
 
         [Fact]
-        public static async Task GetPropertyTest_AllTargetsPresentAsync()
+        public static async Task GetPropertyTest_AllTargetsPresent()
         {
             var root = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
-        public static async Task GetPropertyTest_PostBuildTargetPresentAsync()
+        public static async Task GetPropertyTest_PostBuildTargetPresent()
         {
             var root = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
-        public static async Task GetPropertyTest_PostBuildTargetPresent_LowerCaseAsync()
+        public static async Task GetPropertyTest_PostBuildTargetPresent_LowerCase()
         {
             var root = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
-        public static async Task GetPropertyTest_NoTargetsPresentAsync()
+        public static async Task GetPropertyTest_NoTargetsPresent()
         {
             var root = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
@@ -102,7 +102,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
-        public static async Task GetPropertyTest_ExistingPropertiesAsync()
+        public static async Task GetPropertyTest_ExistingProperties()
         {
             var root = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
@@ -123,7 +123,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
-        public static async Task GetPropertyTest_WrongTargetNameAsync()
+        public static async Task GetPropertyTest_WrongTargetName()
         {
             var root = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
@@ -134,6 +134,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   </PropertyGroup>
   <Target Name=""PoostBuild"" AfterTargets=""PostBuildEvent"">
     <Exec Command=""echo &quot;post build output&quot;"" />
+  </Target>
+</Project>
+".AsProjectRootElement();
+            var result = await systemUnderTest.GetPropertyAsync(root, emptyProjectProperties);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public static async Task GetPropertyTest_WrongExec()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
+    <Exec Commmand=""echo &quot;post build output&quot;"" />
   </Target>
 </Project>
 ".AsProjectRootElement();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
@@ -304,7 +304,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
   <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Command=""echo &quot;post build output&quot;"" />
+    <Exec Command="""" />
     <Exec Command=""echo &quot;post build output&quot;"" />
   </Target>
 </Project>";

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
@@ -1,0 +1,473 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectProperties;
+using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
+{
+    [ProjectSystemTrait]
+    public class PostBuildEventValueProviderTests
+    {
+        private static PostBuildEventValueProvider.PostBuildEventHelper systemUnderTest =
+            new PostBuildEventValueProvider.PostBuildEventHelper();
+
+        [Fact]
+        public static void GetPropertyTest_AllTargetsPresent()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
+    <Exec Command=""echo &quot;prebuild output&quot;"" />
+  </Target>
+
+  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
+    <Exec Command=""echo &quot;post build output&quot;"" />
+  </Target>
+
+</Project>
+".AsProjectRootElement();
+            var actual = systemUnderTest.GetProperty(root);
+            Assert.Equal(@"echo ""post build output""", actual);
+        }
+
+        [Fact]
+        public static void GetPropertyTest_PostBuildTargetPresent()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
+    <Exec Command=""echo &quot;post build output&quot;"" />
+  </Target>
+
+</Project>
+".AsProjectRootElement();
+            var actual = systemUnderTest.GetProperty(root);
+            Assert.Equal(@"echo ""post build output""", actual);
+        }
+
+        [Fact]
+        public static void GetPropertyTest_NoTargetsPresent()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>
+".AsProjectRootElement();
+            var actual = systemUnderTest.GetProperty(root);
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_NoTargetsPresent()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>
+".AsProjectRootElement();
+            systemUnderTest.SetProperty(@"echo ""post build output""", root);
+            var stringWriter = new System.IO.StringWriter();
+            root.Save(stringWriter);
+
+            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
+    <Exec Command=""echo &quot;post build output&quot;"" />
+  </Target>
+</Project>";
+
+            var actual = stringWriter.ToString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_TargetPresent()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
+    <Exec Command=""echo &quot;post build output&quot;"" />
+  </Target>
+
+</Project>
+".AsProjectRootElement();
+            systemUnderTest.SetProperty(@"echo ""post build $(OutDir)""", root);
+            var stringWriter = new System.IO.StringWriter();
+            root.Save(stringWriter);
+
+            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
+    <Exec Command=""echo &quot;post build $(OutDir)&quot;"" />
+  </Target>
+</Project>";
+
+            var actual = stringWriter.ToString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_TargetPresent_NoTasks()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
+  </Target>
+
+</Project>
+".AsProjectRootElement();
+            systemUnderTest.SetProperty(@"echo ""post build $(OutDir)""", root);
+            var stringWriter = new System.IO.StringWriter();
+            root.Save(stringWriter);
+
+            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
+  </Target>
+  <Target Name=""PostBuild1"" AfterTargets=""PostBuildEvent"">
+    <Exec Command=""echo &quot;post build $(OutDir)&quot;"" />
+  </Target>
+</Project>";
+
+            var actual = stringWriter.ToString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_TargetPresent_MultipleTasks()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
+    <Exec Command=""echo &quot;post build output&quot;"" />
+    <Exec Command=""echo &quot;post build output&quot;"" />
+  </Target>
+
+</Project>
+".AsProjectRootElement();
+            systemUnderTest.SetProperty(@"echo ""post build $(OutDir)""", root);
+            var stringWriter = new System.IO.StringWriter();
+            root.Save(stringWriter);
+
+            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
+    <Exec Command=""echo &quot;post build $(OutDir)&quot;"" />
+    <Exec Command=""echo &quot;post build output&quot;"" />
+  </Target>
+</Project>";
+
+            var actual = stringWriter.ToString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_DoNotRemoveTarget_EmptyString()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
+    <Exec Command=""echo &quot;post build output&quot;"" />
+    <Exec Command=""echo &quot;post build output&quot;"" />
+  </Target>
+
+</Project>
+".AsProjectRootElement();
+            systemUnderTest.SetProperty(string.Empty, root);
+            var stringWriter = new System.IO.StringWriter();
+            root.Save(stringWriter);
+
+            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
+    <Exec Command=""echo &quot;post build output&quot;"" />
+    <Exec Command=""echo &quot;post build output&quot;"" />
+  </Target>
+</Project>";
+
+            var actual = stringWriter.ToString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_RemoveTarget_EmptyString()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
+    <Exec Command=""echo &quot;post build output&quot;"" />
+  </Target>
+
+</Project>
+".AsProjectRootElement();
+            systemUnderTest.SetProperty(string.Empty, root);
+            var stringWriter = new System.IO.StringWriter();
+            root.Save(stringWriter);
+
+            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+</Project>";
+
+            var actual = stringWriter.ToString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_RemoveTarget_WhitespaceCharacter()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
+    <Exec Command=""echo &quot;post build output&quot;"" />
+  </Target>
+
+</Project>
+".AsProjectRootElement();
+            systemUnderTest.SetProperty("       ", root);
+            var stringWriter = new System.IO.StringWriter();
+            root.Save(stringWriter);
+
+            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+</Project>";
+
+            var actual = stringWriter.ToString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_RemoveTarget_TabCharacter()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
+    <Exec Command=""echo &quot;post build output&quot;"" />
+  </Target>
+
+</Project>
+".AsProjectRootElement();
+            systemUnderTest.SetProperty("\t\t\t", root);
+            var stringWriter = new System.IO.StringWriter();
+            root.Save(stringWriter);
+
+            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+</Project>";
+
+            var actual = stringWriter.ToString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_RemoveTarget_NewlineCharacter()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
+    <Exec Command=""echo &quot;post build output&quot;"" />
+  </Target>
+
+</Project>
+".AsProjectRootElement();
+            systemUnderTest.SetProperty("\r\n", root);
+            var stringWriter = new System.IO.StringWriter();
+            root.Save(stringWriter);
+
+            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
+    <Exec Command=""&#xD;&#xA;"" />
+  </Target>
+</Project>";
+
+            var actual = stringWriter.ToString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_TargetNameCollision()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name=""PostBuild"">
+  </Target>
+
+</Project>
+".AsProjectRootElement();
+            systemUnderTest.SetProperty(@"echo ""post build $(OutDir)""", root);
+            var stringWriter = new System.IO.StringWriter();
+            root.Save(stringWriter);
+
+            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PostBuild"">
+  </Target>
+  <Target Name=""PostBuild1"" AfterTargets=""PostBuildEvent"">
+    <Exec Command=""echo &quot;post build $(OutDir)&quot;"" />
+  </Target>
+</Project>";
+
+            var actual = stringWriter.ToString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_TargetNameCollision02()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name=""PostBuild"">
+  </Target>
+
+  <Target Name=""PostBuild1"">
+  </Target>
+
+</Project>
+".AsProjectRootElement();
+            systemUnderTest.SetProperty(@"echo ""post build $(OutDir)""", root);
+            var stringWriter = new System.IO.StringWriter();
+            root.Save(stringWriter);
+
+            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PostBuild"">
+  </Target>
+  <Target Name=""PostBuild1"">
+  </Target>
+  <Target Name=""PostBuild2"" AfterTargets=""PostBuildEvent"">
+    <Exec Command=""echo &quot;post build $(OutDir)&quot;"" />
+  </Target>
+</Project>";
+
+            var actual = stringWriter.ToString();
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
@@ -96,22 +96,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyTest_NoTargetsPresent()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
-
-</Project>
-".AsProjectRootElement();
+</Project>".AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""post build output""", root);
-            var stringWriter = new System.IO.StringWriter();
-            root.Save(stringWriter);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
@@ -121,33 +114,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   </Target>
 </Project>";
 
-            var actual = stringWriter.ToString();
+            var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
         }
 
         [Fact]
         public static void SetPropertyTest_TargetPresent()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
-
   <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
     <Exec Command=""echo &quot;post build output&quot;"" />
   </Target>
-
-</Project>
-".AsProjectRootElement();
+</Project>".AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""post build $(OutDir)""", root);
-            var stringWriter = new System.IO.StringWriter();
-            root.Save(stringWriter);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
@@ -157,32 +142,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   </Target>
 </Project>";
 
-            var actual = stringWriter.ToString();
+            var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
         }
 
         [Fact]
         public static void SetPropertyTest_TargetPresent_NoTasks()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
-
   <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
   </Target>
-
-</Project>
-".AsProjectRootElement();
+</Project>".AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""post build $(OutDir)""", root);
-            var stringWriter = new System.IO.StringWriter();
-            root.Save(stringWriter);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
@@ -194,34 +171,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   </Target>
 </Project>";
 
-            var actual = stringWriter.ToString();
+            var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
         }
 
         [Fact]
         public static void SetPropertyTest_TargetPresent_MultipleTasks()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
-
   <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
     <Exec Command=""echo &quot;post build output&quot;"" />
     <Exec Command=""echo &quot;post build output&quot;"" />
   </Target>
-
-</Project>
-".AsProjectRootElement();
+</Project>".AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""post build $(OutDir)""", root);
-            var stringWriter = new System.IO.StringWriter();
-            root.Save(stringWriter);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
@@ -232,34 +201,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   </Target>
 </Project>";
 
-            var actual = stringWriter.ToString();
+            var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
         }
 
         [Fact]
         public static void SetPropertyTest_DoNotRemoveTarget_EmptyString()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
-
   <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
     <Exec Command=""echo &quot;post build output&quot;"" />
     <Exec Command=""echo &quot;post build output&quot;"" />
   </Target>
-
-</Project>
-".AsProjectRootElement();
+</Project>".AsProjectRootElement();
             systemUnderTest.SetProperty(string.Empty, root);
-            var stringWriter = new System.IO.StringWriter();
-            root.Save(stringWriter);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
@@ -270,132 +231,100 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   </Target>
 </Project>";
 
-            var actual = stringWriter.ToString();
+            var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
         }
 
         [Fact]
         public static void SetPropertyTest_RemoveTarget_EmptyString()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
-
   <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
     <Exec Command=""echo &quot;post build output&quot;"" />
   </Target>
-
-</Project>
-".AsProjectRootElement();
+</Project>".AsProjectRootElement();
             systemUnderTest.SetProperty(string.Empty, root);
-            var stringWriter = new System.IO.StringWriter();
-            root.Save(stringWriter);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
 </Project>";
 
-            var actual = stringWriter.ToString();
+            var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
         }
 
         [Fact]
         public static void SetPropertyTest_RemoveTarget_WhitespaceCharacter()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
-
   <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
     <Exec Command=""echo &quot;post build output&quot;"" />
   </Target>
-
-</Project>
-".AsProjectRootElement();
+</Project>".AsProjectRootElement();
             systemUnderTest.SetProperty("       ", root);
-            var stringWriter = new System.IO.StringWriter();
-            root.Save(stringWriter);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
 </Project>";
 
-            var actual = stringWriter.ToString();
+            var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
         }
 
         [Fact]
         public static void SetPropertyTest_RemoveTarget_TabCharacter()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
-
   <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
     <Exec Command=""echo &quot;post build output&quot;"" />
   </Target>
-
-</Project>
-".AsProjectRootElement();
+</Project>".AsProjectRootElement();
             systemUnderTest.SetProperty("\t\t\t", root);
-            var stringWriter = new System.IO.StringWriter();
-            root.Save(stringWriter);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
 </Project>";
 
-            var actual = stringWriter.ToString();
+            var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
         }
 
         [Fact]
         public static void SetPropertyTest_RemoveTarget_NewlineCharacter()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
-
   <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
     <Exec Command=""echo &quot;post build output&quot;"" />
   </Target>
-
-</Project>
-".AsProjectRootElement();
+</Project>".AsProjectRootElement();
             systemUnderTest.SetProperty("\r\n", root);
-            var stringWriter = new System.IO.StringWriter();
-            root.Save(stringWriter);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
@@ -405,32 +334,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   </Target>
 </Project>";
 
-            var actual = stringWriter.ToString();
+            var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
         }
 
         [Fact]
         public static void SetPropertyTest_TargetNameCollision()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
-
   <Target Name=""PostBuild"">
   </Target>
-
-</Project>
-".AsProjectRootElement();
+</Project>".AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""post build $(OutDir)""", root);
-            var stringWriter = new System.IO.StringWriter();
-            root.Save(stringWriter);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
@@ -442,35 +363,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   </Target>
 </Project>";
 
-            var actual = stringWriter.ToString();
+            var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
         }
 
         [Fact]
         public static void SetPropertyTest_TargetNameCollision02()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
-
   <Target Name=""PostBuild"">
   </Target>
-
   <Target Name=""PostBuild1"">
   </Target>
-
 </Project>
 ".AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""post build $(OutDir)""", root);
-            var stringWriter = new System.IO.StringWriter();
-            root.Save(stringWriter);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
@@ -484,31 +397,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   </Target>
 </Project>";
 
-            var actual = stringWriter.ToString();
+            var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
         }
 
         [Fact]
         public static void SetPropertyTest_ExistingProperties()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <PreBuildEvent>echo $(ProjectDir)</PreBuildEvent>
     <PostBuildEvent>echo $(ProjectDir)</PostBuildEvent>
   </PropertyGroup>
-
-</Project>
-".AsProjectRootElement();
+</Project>".AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""post build $(OutDir)""", root);
-            var stringWriter = new System.IO.StringWriter();
-            root.Save(stringWriter);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
@@ -517,7 +423,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   </PropertyGroup>
 </Project>";
 
-            var actual = stringWriter.ToString();
+            var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
@@ -587,6 +587,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
+        public static async Task SetPropertyTest_RemoveExistingProperties()
+        {
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <PreBuildEvent>echo $(ProjectDir)</PreBuildEvent>
+    <PostBuildEvent>echo $(ProjectDir)</PostBuildEvent>
+  </PropertyGroup>
+</Project>".AsProjectRootElement();
+
+            var postbuildEventProjectProperties =
+                IProjectPropertiesFactory.CreateWithPropertyAndValue("PostBuildEvent", "echo $(ProjectDir)");
+            await systemUnderTest.SetPropertyAsync(" ", postbuildEventProjectProperties, root);
+
+            var result = await postbuildEventProjectProperties.GetUnevaluatedPropertyValueAsync("PostBuildEvent");
+            Assert.Null(result);
+        }
+
+        [Fact]
         public static async Task SetPropertyTest_WrongTargetName()
         {
             var root = @"<Project Sdk=""Microsoft.NET.Sdk"">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
@@ -389,7 +389,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
-        public static void SetPropertyTest_RemoveTarget_NewlineCharacter()
+        public static void SetPropertyTest_DoNotRemoveTarget_NewlineCharacter()
         {
             var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
@@ -76,6 +76,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
+        public static void GetPropertyTest_ExistingProperties()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <PostBuildEvent>echo $(ProjectDir)</PostBuildEvent>
+  </PropertyGroup>
+
+</Project>
+".AsProjectRootElement();
+            var actual = systemUnderTest.GetProperty(root);
+            Assert.Equal(@"echo $(ProjectDir)", actual);
+        }
+
+        [Fact]
         public static void SetPropertyTest_NoTargetsPresent()
         {
             var root = @"
@@ -464,6 +482,39 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   <Target Name=""PostBuild2"" AfterTargets=""PostBuildEvent"">
     <Exec Command=""echo &quot;post build $(OutDir)&quot;"" />
   </Target>
+</Project>";
+
+            var actual = stringWriter.ToString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_ExistingProperties()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <PreBuildEvent>echo $(ProjectDir)</PreBuildEvent>
+    <PostBuildEvent>echo $(ProjectDir)</PostBuildEvent>
+  </PropertyGroup>
+
+</Project>
+".AsProjectRootElement();
+            systemUnderTest.SetProperty(@"echo ""post build $(OutDir)""", root);
+            var stringWriter = new System.IO.StringWriter();
+            root.Save(stringWriter);
+
+            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <PreBuildEvent>echo $(ProjectDir)</PreBuildEvent>
+    <PostBuildEvent>echo ""post build $(OutDir)""</PostBuildEvent>
+  </PropertyGroup>
 </Project>";
 
             var actual = stringWriter.ToString();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
@@ -59,6 +59,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
+        public static void GetPropertyTest_PreBuildTargetPresent_LowerCase()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name=""prebuild"" BeforeTargets=""prebuildevent"">
+    <Exec Command=""echo &quot;prebuild output&quot;"" />
+  </Target>
+
+</Project>
+".AsProjectRootElement();
+            var actual = systemUnderTest.GetProperty(root);
+            Assert.Equal(@"echo ""prebuild output""", actual);
+        }
+
+        [Fact]
         public static void GetPropertyTest_NoTargetsPresent()
         {
             var root = @"
@@ -146,6 +167,34 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
+        public static void SetPropertyTest_TargetPresent_LowerCase()
+        {
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""prebuild"" BeforeTargets=""prebuildevent"">
+    <Exec Command=""echo &quot;pre build output&quot;"" />
+  </Target>
+</Project>".AsProjectRootElement();
+            systemUnderTest.SetProperty(@"echo ""pre build $(OutDir)""", root);
+
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""prebuild"" BeforeTargets=""prebuildevent"">
+    <Exec Command=""echo &quot;pre build $(OutDir)&quot;"" />
+  </Target>
+</Project>";
+
+            var actual = root.SaveAndGetChanges();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
         public static void SetPropertyTest_TargetPresent_NoTasks()
         {
             var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
@@ -167,6 +216,35 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   </Target>
   <Target Name=""PreBuild1"" BeforeTargets=""PreBuildEvent"">
     <Exec Command=""echo &quot;pre build $(OutDir)&quot;"" />
+  </Target>
+</Project>";
+
+            var actual = root.SaveAndGetChanges();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_TargetPresent_NoTasks_Removal()
+        {
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
+  </Target>
+  <Target Name=""PreBuild1"" BeforeTargets=""PreBuildEvent"">
+    <Exec Command=""echo &quot;pre build $(OutDir)&quot;"" />
+  </Target>
+</Project>".AsProjectRootElement();
+            systemUnderTest.SetProperty(@"", root);
+
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
   </Target>
 </Project>";
 
@@ -394,6 +472,39 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   <Target Name=""PreBuild"">
   </Target>
   <Target Name=""PreBuild1"">
+  </Target>
+  <Target Name=""PreBuild2"" BeforeTargets=""PreBuildEvent"">
+    <Exec Command=""echo &quot;pre build $(OutDir)&quot;"" />
+  </Target>
+</Project>";
+
+            var actual = root.SaveAndGetChanges();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_TargetNameCollision_LowerCase()
+        {
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""prebuild"">
+  </Target>
+  <Target Name=""prebuild1"">
+  </Target>
+</Project>".AsProjectRootElement();
+            systemUnderTest.SetProperty(@"echo ""pre build $(OutDir)""", root);
+
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""prebuild"">
+  </Target>
+  <Target Name=""prebuild1"">
   </Target>
   <Target Name=""PreBuild2"" BeforeTargets=""PreBuildEvent"">
     <Exec Command=""echo &quot;pre build $(OutDir)&quot;"" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
 
         [Fact]
-        public static void GetPropertyTest_AllTargetsPresent()
+        public static async Task GetPropertyTest_AllTargetsPresentAsync()
         {
             var root = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
@@ -39,12 +39,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
 </Project>
 ".AsProjectRootElement();
-            var actual = systemUnderTest.GetProperty(root);
+            var actual = await systemUnderTest.GetPropertyAsync(root, emptyProjectProperties);
             Assert.Equal(@"echo ""prebuild output""", actual);
         }
 
         [Fact]
-        public static void GetPropertyTest_PreBuildTargetPresent()
+        public static async Task GetPropertyTest_PreBuildTargetPresentAsync()
         {
             var root = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
@@ -60,12 +60,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
 </Project>
 ".AsProjectRootElement();
-            var actual = systemUnderTest.GetProperty(root);
+            var actual = await systemUnderTest.GetPropertyAsync(root, emptyProjectProperties);
             Assert.Equal(@"echo ""prebuild output""", actual);
         }
 
         [Fact]
-        public static void GetPropertyTest_PreBuildTargetPresent_LowerCase()
+        public static async Task GetPropertyTest_PreBuildTargetPresent_LowerCaseAsync()
         {
             var root = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
@@ -81,12 +81,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
 </Project>
 ".AsProjectRootElement();
-            var actual = systemUnderTest.GetProperty(root);
+            var actual = await systemUnderTest.GetPropertyAsync(root, emptyProjectProperties);
             Assert.Equal(@"echo ""prebuild output""", actual);
         }
 
         [Fact]
-        public static void GetPropertyTest_NoTargetsPresent()
+        public static async Task GetPropertyTest_NoTargetsPresentAsync()
         {
             var root = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
@@ -98,12 +98,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
 </Project>
 ".AsProjectRootElement();
-            var actual = systemUnderTest.GetProperty(root);
+            var actual = await systemUnderTest.GetPropertyAsync(root, emptyProjectProperties);
             Assert.Null(actual);
         }
 
         [Fact]
-        public static void GetPropertyTest_ExistingProperties()
+        public static async Task GetPropertyTest_ExistingPropertiesAsync()
         {
             var root = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
@@ -115,12 +115,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   </PropertyGroup>
 
 </Project>".AsProjectRootElement();
-            var result = systemUnderTest.GetProperty(root);
-            Assert.Null(result);
+            var expected = "echo $(ProjectDir)";
+            var projectProperties = IProjectPropertiesFactory.CreateWithPropertyAndValue("PreBuildEvent", expected);
+            var actual = await systemUnderTest.GetPropertyAsync(root, projectProperties);
+            Assert.Equal(expected, actual);
         }
 
         [Fact]
-        public static void GetPropertyTest_WrongTargetName()
+        public static async Task GetPropertyTest_WrongTargetNameAsync()
         {
             var root = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
@@ -136,7 +138,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
 </Project>
 ".AsProjectRootElement();
-            var result = systemUnderTest.GetProperty(root);
+            var result = await systemUnderTest.GetPropertyAsync(root, emptyProjectProperties);
             Assert.Null(result);
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
@@ -114,6 +114,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
+        public static void GetPropertyTest_WrongTargetName()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name=""PreeBuild"" BeforeTargets=""PreBuildEvent"">
+    <Exec Command=""echo &quot;prebuild output&quot;"" />
+  </Target>
+
+</Project>
+".AsProjectRootElement();
+            var result = systemUnderTest.GetProperty(root);
+            Assert.Null(result);
+        }
+
+        [Fact]
         public static void SetPropertyTest_NoTargetsPresent()
         {
             var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
@@ -535,6 +556,38 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
     <PreBuildEvent>echo ""post build $(OutDir)""</PreBuildEvent>
     <PostBuildEvent>echo $(ProjectDir)</PostBuildEvent>
   </PropertyGroup>
+</Project>";
+
+            var actual = root.SaveAndGetChanges();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_WrongTargetName()
+        {
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PreeBuild"" BeforeTargets=""PreBuildEvent"">
+    <Exec Command=""echo &quot;pre build output&quot;"" />
+  </Target>
+</Project>
+".AsProjectRootElement();
+            systemUnderTest.SetProperty(@"echo ""post build $(OutDir)""", root);
+
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PreeBuild"" BeforeTargets=""PreBuildEvent"">
+    <Exec Command=""echo &quot;pre build output&quot;"" />
+  </Target>
+  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
+    <Exec Command=""echo &quot;post build $(OutDir)&quot;"" />
+  </Target>
 </Project>";
 
             var actual = root.SaveAndGetChanges();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
@@ -1,0 +1,473 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectProperties;
+using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
+{
+    [ProjectSystemTrait]
+    public class PreBuildEventValueProviderTests
+    {
+        private static PreBuildEventValueProvider.PreBuildEventHelper systemUnderTest =
+            new PreBuildEventValueProvider.PreBuildEventHelper();
+
+        [Fact]
+        public static void GetPropertyTest_AllTargetsPresent()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
+    <Exec Command=""echo &quot;prebuild output&quot;"" />
+  </Target>
+
+  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
+    <Exec Command=""echo &quot;post build output&quot;"" />
+  </Target>
+
+</Project>
+".AsProjectRootElement();
+            var actual = systemUnderTest.GetProperty(root);
+            Assert.Equal(@"echo ""prebuild output""", actual);
+        }
+
+        [Fact]
+        public static void GetPropertyTest_PreBuildTargetPresent()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
+    <Exec Command=""echo &quot;prebuild output&quot;"" />
+  </Target>
+
+</Project>
+".AsProjectRootElement();
+            var actual = systemUnderTest.GetProperty(root);
+            Assert.Equal(@"echo ""prebuild output""", actual);
+        }
+
+        [Fact]
+        public static void GetPropertyTest_NoTargetsPresent()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>
+".AsProjectRootElement();
+            var actual = systemUnderTest.GetProperty(root);
+            Assert.Null(actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_NoTargetsPresent()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>
+".AsProjectRootElement();
+            systemUnderTest.SetProperty(@"echo ""pre build output""", root);
+            var stringWriter = new System.IO.StringWriter();
+            root.Save(stringWriter);
+
+            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
+    <Exec Command=""echo &quot;pre build output&quot;"" />
+  </Target>
+</Project>";
+
+            var actual = stringWriter.ToString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_TargetPresent()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
+    <Exec Command=""echo &quot;pre build output&quot;"" />
+  </Target>
+
+</Project>
+".AsProjectRootElement();
+            systemUnderTest.SetProperty(@"echo ""pre build $(OutDir)""", root);
+            var stringWriter = new System.IO.StringWriter();
+            root.Save(stringWriter);
+
+            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
+    <Exec Command=""echo &quot;pre build $(OutDir)&quot;"" />
+  </Target>
+</Project>";
+
+            var actual = stringWriter.ToString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_TargetPresent_NoTasks()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
+  </Target>
+
+</Project>
+".AsProjectRootElement();
+            systemUnderTest.SetProperty(@"echo ""pre build $(OutDir)""", root);
+            var stringWriter = new System.IO.StringWriter();
+            root.Save(stringWriter);
+
+            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
+  </Target>
+  <Target Name=""PreBuild1"" BeforeTargets=""PreBuildEvent"">
+    <Exec Command=""echo &quot;pre build $(OutDir)&quot;"" />
+  </Target>
+</Project>";
+
+            var actual = stringWriter.ToString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_TargetPresent_MultipleTasks()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
+    <Exec Command=""echo &quot;pre build output&quot;"" />
+    <Exec Command=""echo &quot;pre build output&quot;"" />
+  </Target>
+
+</Project>
+".AsProjectRootElement();
+            systemUnderTest.SetProperty(@"echo ""pre build $(OutDir)""", root);
+            var stringWriter = new System.IO.StringWriter();
+            root.Save(stringWriter);
+
+            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
+    <Exec Command=""echo &quot;pre build $(OutDir)&quot;"" />
+    <Exec Command=""echo &quot;pre build output&quot;"" />
+  </Target>
+</Project>";
+
+            var actual = stringWriter.ToString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_DoNotRemoveTarget_EmptyString()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
+    <Exec Command=""echo &quot;pre build output&quot;"" />
+    <Exec Command=""echo &quot;pre build output&quot;"" />
+  </Target>
+
+</Project>
+".AsProjectRootElement();
+            systemUnderTest.SetProperty(string.Empty, root);
+            var stringWriter = new System.IO.StringWriter();
+            root.Save(stringWriter);
+
+            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
+    <Exec Command=""echo &quot;pre build output&quot;"" />
+    <Exec Command=""echo &quot;pre build output&quot;"" />
+  </Target>
+</Project>";
+
+            var actual = stringWriter.ToString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_RemoveTarget_EmptyString()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
+    <Exec Command=""echo &quot;pre build output&quot;"" />
+  </Target>
+
+</Project>
+".AsProjectRootElement();
+            systemUnderTest.SetProperty(string.Empty, root);
+            var stringWriter = new System.IO.StringWriter();
+            root.Save(stringWriter);
+
+            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+</Project>";
+
+            var actual = stringWriter.ToString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_RemoveTarget_WhitespaceCharacter()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
+    <Exec Command=""echo &quot;pre build output&quot;"" />
+  </Target>
+
+</Project>
+".AsProjectRootElement();
+            systemUnderTest.SetProperty("       ", root);
+            var stringWriter = new System.IO.StringWriter();
+            root.Save(stringWriter);
+
+            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+</Project>";
+
+            var actual = stringWriter.ToString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_RemoveTarget_TabCharacter()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
+    <Exec Command=""echo &quot;pre build output&quot;"" />
+  </Target>
+
+</Project>
+".AsProjectRootElement();
+            systemUnderTest.SetProperty("\t\t\t", root);
+            var stringWriter = new System.IO.StringWriter();
+            root.Save(stringWriter);
+
+            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+</Project>";
+
+            var actual = stringWriter.ToString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_RemoveTarget_NewlineCharacter()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
+    <Exec Command=""echo &quot;pre build output&quot;"" />
+  </Target>
+
+</Project>
+".AsProjectRootElement();
+            systemUnderTest.SetProperty("\r\n", root);
+            var stringWriter = new System.IO.StringWriter();
+            root.Save(stringWriter);
+
+            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
+    <Exec Command=""&#xD;&#xA;"" />
+  </Target>
+</Project>";
+
+            var actual = stringWriter.ToString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_TargetNameCollision()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name=""PreBuild"">
+  </Target>
+
+</Project>
+".AsProjectRootElement();
+            systemUnderTest.SetProperty(@"echo ""pre build $(OutDir)""", root);
+            var stringWriter = new System.IO.StringWriter();
+            root.Save(stringWriter);
+
+            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PreBuild"">
+  </Target>
+  <Target Name=""PreBuild1"" BeforeTargets=""PreBuildEvent"">
+    <Exec Command=""echo &quot;pre build $(OutDir)&quot;"" />
+  </Target>
+</Project>";
+
+            var actual = stringWriter.ToString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_TargetNameCollision02()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name=""PreBuild"">
+  </Target>
+
+  <Target Name=""PreBuild1"">
+  </Target>
+
+</Project>
+".AsProjectRootElement();
+            systemUnderTest.SetProperty(@"echo ""pre build $(OutDir)""", root);
+            var stringWriter = new System.IO.StringWriter();
+            root.Save(stringWriter);
+
+            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PreBuild"">
+  </Target>
+  <Target Name=""PreBuild1"">
+  </Target>
+  <Target Name=""PreBuild2"" BeforeTargets=""PreBuildEvent"">
+    <Exec Command=""echo &quot;pre build $(OutDir)&quot;"" />
+  </Target>
+</Project>";
+
+            var actual = stringWriter.ToString();
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
@@ -76,6 +76,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
+        public static void GetPropertyTest_ExistingProperties()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <PreBuildEvent>echo $(ProjectDir)</PreBuildEvent>
+  </PropertyGroup>
+
+</Project>
+".AsProjectRootElement();
+            var actual = systemUnderTest.GetProperty(root);
+            Assert.Equal(@"echo $(ProjectDir)", actual);
+        }
+
+        [Fact]
         public static void SetPropertyTest_NoTargetsPresent()
         {
             var root = @"
@@ -464,6 +482,39 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   <Target Name=""PreBuild2"" BeforeTargets=""PreBuildEvent"">
     <Exec Command=""echo &quot;pre build $(OutDir)&quot;"" />
   </Target>
+</Project>";
+
+            var actual = stringWriter.ToString();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void SetPropertyTest_ExistingProperties()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <PreBuildEvent>echo $(ProjectDir)</PreBuildEvent>
+    <PostBuildEvent>echo $(ProjectDir)</PostBuildEvent>
+  </PropertyGroup>
+
+</Project>
+".AsProjectRootElement();
+            systemUnderTest.SetProperty(@"echo ""post build $(OutDir)""", root);
+            var stringWriter = new System.IO.StringWriter();
+            root.Save(stringWriter);
+
+            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <PreBuildEvent>eecho ""post build $(OutDir)""</PreBuildEvent>
+    <PostBuildEvent>echo $(ProjectDir)</PostBuildEvent>
+  </PropertyGroup>
 </Project>";
 
             var actual = stringWriter.ToString();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
 
         [Fact]
-        public static async Task GetPropertyTest_AllTargetsPresentAsync()
+        public static async Task GetPropertyTest_AllTargetsPresent()
         {
             var root = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
-        public static async Task GetPropertyTest_PreBuildTargetPresentAsync()
+        public static async Task GetPropertyTest_PreBuildTargetPresent()
         {
             var root = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
-        public static async Task GetPropertyTest_PreBuildTargetPresent_LowerCaseAsync()
+        public static async Task GetPropertyTest_PreBuildTargetPresent_LowerCase()
         {
             var root = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
-        public static async Task GetPropertyTest_NoTargetsPresentAsync()
+        public static async Task GetPropertyTest_NoTargetsPresent()
         {
             var root = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
@@ -103,7 +103,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
-        public static async Task GetPropertyTest_ExistingPropertiesAsync()
+        public static async Task GetPropertyTest_ExistingProperties()
         {
             var root = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
@@ -122,7 +122,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
-        public static async Task GetPropertyTest_WrongTargetNameAsync()
+        public static async Task GetPropertyTest_WrongTargetName()
         {
             var root = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
@@ -136,6 +136,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
     <Exec Command=""echo &quot;prebuild output&quot;"" />
   </Target>
 
+</Project>
+".AsProjectRootElement();
+            var result = await systemUnderTest.GetPropertyAsync(root, emptyProjectProperties);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public static async Task GetPropertyTest_WrongExec()
+        {
+            var root = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <Target Name=""PreBuild"" AfterTargets=""PreBuildEvent"">
+    <Exec Commmand=""echo &quot;prebuild output&quot;"" />
+  </Target>
 </Project>
 ".AsProjectRootElement();
             var result = await systemUnderTest.GetPropertyAsync(root, emptyProjectProperties);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
@@ -304,7 +304,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
   <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command=""echo &quot;pre build output&quot;"" />
+    <Exec Command="""" />
     <Exec Command=""echo &quot;pre build output&quot;"" />
   </Target>
 </Project>";

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
@@ -592,6 +592,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
+        public static async Task SetPropertyTest_RemoveExistingProperties()
+        {
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <PreBuildEvent>echo $(ProjectDir)</PreBuildEvent>
+  </PropertyGroup>
+</Project>".AsProjectRootElement();
+
+            var prebuildEventProjectProperties =
+                IProjectPropertiesFactory.CreateWithPropertyAndValue("PreBuildEvent", "echo $(ProjectDir)");
+            await systemUnderTest.SetPropertyAsync(" ", prebuildEventProjectProperties, root);
+
+            var result = await prebuildEventProjectProperties.GetUnevaluatedPropertyValueAsync("PreBuildEvent");
+            Assert.Null(result);
+        }
+
+        [Fact]
         public static async Task SetPropertyTest_WrongTargetName()
         {
             var root = @"<Project Sdk=""Microsoft.NET.Sdk"">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
@@ -391,7 +391,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
-        public static void SetPropertyTest_RemoveTarget_NewlineCharacter()
+        public static void SetPropertyTest_DoNotRemoveTarget_NewlineCharacter()
         {
             var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
@@ -87,8 +87,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
     <PreBuildEvent>echo $(ProjectDir)</PreBuildEvent>
   </PropertyGroup>
 
-</Project>
-".AsProjectRootElement();
+</Project>".AsProjectRootElement();
             var actual = systemUnderTest.GetProperty(root);
             Assert.Equal(@"echo $(ProjectDir)", actual);
         }
@@ -96,22 +95,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyTest_NoTargetsPresent()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
-
-</Project>
-".AsProjectRootElement();
+</Project>".AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""pre build output""", root);
-            var stringWriter = new System.IO.StringWriter();
-            root.Save(stringWriter);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
@@ -121,33 +113,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   </Target>
 </Project>";
 
-            var actual = stringWriter.ToString();
+            var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
         }
 
         [Fact]
         public static void SetPropertyTest_TargetPresent()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
-
   <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
     <Exec Command=""echo &quot;pre build output&quot;"" />
   </Target>
-
-</Project>
-".AsProjectRootElement();
+</Project>".AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""pre build $(OutDir)""", root);
-            var stringWriter = new System.IO.StringWriter();
-            root.Save(stringWriter);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
@@ -157,32 +141,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   </Target>
 </Project>";
 
-            var actual = stringWriter.ToString();
+            var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
         }
 
         [Fact]
         public static void SetPropertyTest_TargetPresent_NoTasks()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
-
   <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
   </Target>
-
-</Project>
-".AsProjectRootElement();
+</Project>".AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""pre build $(OutDir)""", root);
-            var stringWriter = new System.IO.StringWriter();
-            root.Save(stringWriter);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
@@ -194,34 +170,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   </Target>
 </Project>";
 
-            var actual = stringWriter.ToString();
+            var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
         }
 
         [Fact]
         public static void SetPropertyTest_TargetPresent_MultipleTasks()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
-
   <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
     <Exec Command=""echo &quot;pre build output&quot;"" />
     <Exec Command=""echo &quot;pre build output&quot;"" />
   </Target>
-
-</Project>
-".AsProjectRootElement();
+</Project>".AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""pre build $(OutDir)""", root);
-            var stringWriter = new System.IO.StringWriter();
-            root.Save(stringWriter);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
@@ -232,34 +200,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   </Target>
 </Project>";
 
-            var actual = stringWriter.ToString();
+            var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
         }
 
         [Fact]
         public static void SetPropertyTest_DoNotRemoveTarget_EmptyString()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
-
   <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
     <Exec Command=""echo &quot;pre build output&quot;"" />
     <Exec Command=""echo &quot;pre build output&quot;"" />
   </Target>
-
 </Project>
 ".AsProjectRootElement();
             systemUnderTest.SetProperty(string.Empty, root);
-            var stringWriter = new System.IO.StringWriter();
-            root.Save(stringWriter);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
@@ -270,132 +231,103 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   </Target>
 </Project>";
 
-            var actual = stringWriter.ToString();
+            var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
         }
 
         [Fact]
         public static void SetPropertyTest_RemoveTarget_EmptyString()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
-
   <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
     <Exec Command=""echo &quot;pre build output&quot;"" />
   </Target>
-
-</Project>
-".AsProjectRootElement();
+</Project>".AsProjectRootElement();
             systemUnderTest.SetProperty(string.Empty, root);
-            var stringWriter = new System.IO.StringWriter();
-            root.Save(stringWriter);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
 </Project>";
 
-            var actual = stringWriter.ToString();
+            var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
         }
 
         [Fact]
         public static void SetPropertyTest_RemoveTarget_WhitespaceCharacter()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
-
   <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
     <Exec Command=""echo &quot;pre build output&quot;"" />
   </Target>
-
-</Project>
-".AsProjectRootElement();
+</Project>".AsProjectRootElement();
             systemUnderTest.SetProperty("       ", root);
             var stringWriter = new System.IO.StringWriter();
             root.Save(stringWriter);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
 </Project>";
 
-            var actual = stringWriter.ToString();
+            var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
         }
 
         [Fact]
         public static void SetPropertyTest_RemoveTarget_TabCharacter()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
-
   <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
     <Exec Command=""echo &quot;pre build output&quot;"" />
   </Target>
-
-</Project>
-".AsProjectRootElement();
+</Project>".AsProjectRootElement();
             systemUnderTest.SetProperty("\t\t\t", root);
-            var stringWriter = new System.IO.StringWriter();
-            root.Save(stringWriter);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
 </Project>";
 
-            var actual = stringWriter.ToString();
+            var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
         }
 
         [Fact]
         public static void SetPropertyTest_RemoveTarget_NewlineCharacter()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
-
   <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
     <Exec Command=""echo &quot;pre build output&quot;"" />
   </Target>
-
 </Project>
 ".AsProjectRootElement();
             systemUnderTest.SetProperty("\r\n", root);
-            var stringWriter = new System.IO.StringWriter();
-            root.Save(stringWriter);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
@@ -405,32 +337,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   </Target>
 </Project>";
 
-            var actual = stringWriter.ToString();
+            var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
         }
 
         [Fact]
         public static void SetPropertyTest_TargetNameCollision()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
-
   <Target Name=""PreBuild"">
   </Target>
-
 </Project>
 ".AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""pre build $(OutDir)""", root);
-            var stringWriter = new System.IO.StringWriter();
-            root.Save(stringWriter);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
@@ -442,35 +367,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   </Target>
 </Project>";
 
-            var actual = stringWriter.ToString();
+            var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
         }
 
         [Fact]
         public static void SetPropertyTest_TargetNameCollision02()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
-
   <Target Name=""PreBuild"">
   </Target>
-
   <Target Name=""PreBuild1"">
   </Target>
-
-</Project>
-".AsProjectRootElement();
+</Project>".AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""pre build $(OutDir)""", root);
-            var stringWriter = new System.IO.StringWriter();
-            root.Save(stringWriter);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
@@ -484,31 +400,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   </Target>
 </Project>";
 
-            var actual = stringWriter.ToString();
+            var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
         }
 
         [Fact]
         public static void SetPropertyTest_ExistingProperties()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <PreBuildEvent>echo $(ProjectDir)</PreBuildEvent>
     <PostBuildEvent>echo $(ProjectDir)</PostBuildEvent>
   </PropertyGroup>
-
-</Project>
-".AsProjectRootElement();
+</Project>".AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""post build $(OutDir)""", root);
-            var stringWriter = new System.IO.StringWriter();
-            root.Save(stringWriter);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
@@ -517,7 +426,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
   </PropertyGroup>
 </Project>";
 
-            var actual = stringWriter.ToString();
+            var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Utilities/StringExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Utilities/StringExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System.Xml;
+﻿using System;
+using System.IO;
+using System.Xml;
 using Microsoft.Build.Construction;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
@@ -11,6 +13,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
             var xmlReader = new XmlTextReader(stringReader);
             var root = ProjectRootElement.Create(xmlReader);
             return root;
+        }
+
+        public static string SaveAndGetChanges(this ProjectRootElement root)
+        {
+            var tempFile = Path.GetTempFileName();
+            root.Save(tempFile);
+            var result = File.ReadAllText(tempFile);
+            File.Delete(tempFile);
+            return result;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Utilities/StringExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Utilities/StringExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System.Xml;
+using Microsoft.Build.Construction;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
+{
+    public static class StringExtensions
+    {
+        public static ProjectRootElement AsProjectRootElement(this string @string)
+        {
+            var stringReader = new System.IO.StringReader(@string);
+            var xmlReader = new XmlTextReader(stringReader);
+            var root = ProjectRootElement.Create(xmlReader);
+            return root;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.AbstractBuildEventHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.AbstractBuildEventHelper.cs
@@ -32,8 +32,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
             private string BuildEvent { get; }
             private string TargetName { get; }
 
-            public string GetProperty(ProjectRootElement projectXml)
+            public async Task<string> GetPropertyAsync(ProjectRootElement projectXml, IProjectProperties defaultProperties)
             {
+                // check if value already exists
+                var unevaluatedPropertyValue = await defaultProperties.GetUnevaluatedPropertyValueAsync(BuildEvent).ConfigureAwait(true);
+                if (unevaluatedPropertyValue != null)
+                {
+                    return unevaluatedPropertyValue;
+                }
+
                 // Check if build events can be found in targets
                 return GetFromTargets(projectXml);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.AbstractBuildEventHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.AbstractBuildEventHelper.cs
@@ -58,12 +58,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
                     if (result.success)
                     {
                         projectXml.RemoveChild(result.target);
+                        return;
                     }
                 }
-                else
-                {
-                    SetParameter(projectXml, unevaluatedPropertyValue);
-                }
+
+                SetParameter(projectXml, unevaluatedPropertyValue);
             }
 
             private (bool success, string property) TryGetFromProperty(ProjectRootElement projectXml)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.AbstractBuildEventHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.AbstractBuildEventHelper.cs
@@ -119,7 +119,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
             private (bool success, ProjectTaskElement execTask) FindExecTaskInTargets(ProjectRootElement projectXml)
             {
                 var execTask = projectXml.Targets
-                                    .Where(target => StringComparer.OrdinalIgnoreCase.Compare(GetTarget(target), BuildEvent) == 0)
+                                    .Where(target =>
+                                        StringComparer.OrdinalIgnoreCase.Compare(GetTarget(target), BuildEvent) == 0 &&
+                                        StringComparer.OrdinalIgnoreCase.Compare(target.Name, TargetName) == 0)
                                     .SelectMany(target => target.Tasks)
                                     .Where(task => StringComparer.OrdinalIgnoreCase.Compare(task.Name, ExecTask) == 0)
                                     .FirstOrDefault();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.Helper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.Helper.cs
@@ -1,0 +1,136 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+
+using System;
+using System.Linq;
+using Microsoft.Build.Construction;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectProperties
+{
+    internal abstract partial class AbstractBuildEventValueProvider
+    {
+        public abstract class Helper
+        {
+            private const string _execTaskName = "Exec";
+            private const string _commandString = "Command";
+
+            protected Helper(string buildEventString,
+                   string targetNameString,
+                   Func<ProjectTargetElement, string> getTargetString,
+                   Action<ProjectTargetElement> setTargetDependencies)
+            {
+                BuildEventString = buildEventString;
+                TargetNameString = targetNameString;
+                GetTargetString = getTargetString;
+                SetTargetDependencies = setTargetDependencies;
+            }
+
+            private Func<ProjectTargetElement, string> GetTargetString { get; }
+            private Action<ProjectTargetElement> SetTargetDependencies { get; }
+            private string BuildEventString { get; }
+            private string TargetNameString { get; }
+
+            public string GetProperty(ProjectRootElement projectXml)
+            {
+                var result = FindExecTaskInTargets(projectXml);
+
+                if (result.success == false)
+                {
+                    return null;
+                }
+
+                if (result.execTask.Parameters.TryGetValue(_commandString, out var commandText))
+                {
+                    return commandText;
+                }
+
+                return null; //unreachable
+            }
+
+            public void SetProperty(string unevaluatedPropertyValue, ProjectRootElement projectXml)
+            {
+                if (string.IsNullOrWhiteSpace(unevaluatedPropertyValue) &&
+                    !unevaluatedPropertyValue.Contains("\n"))
+                {
+                    var result = FindTargetToRemove(projectXml);
+                    if (result.success)
+                    {
+                        projectXml.RemoveChild(result.target);
+                    }
+                }
+                else
+                {
+                    SetParameter(projectXml, unevaluatedPropertyValue);
+                }
+            }
+
+            private (bool success, ProjectTaskElement execTask) FindExecTaskInTargets(ProjectRootElement projectXml)
+            {
+                var execTask = projectXml.Targets
+                                    .Where(target => GetTargetString(target) == BuildEventString)
+                                    .SelectMany(target => target.Tasks)
+                                    .Where(task => task.Name == _execTaskName)
+                                    .FirstOrDefault();
+                return (success: execTask != null, execTask: execTask);
+            }
+
+            private (bool success, ProjectTargetElement target) FindTargetToRemove(ProjectRootElement projectXml)
+            {
+                var targetArray = projectXml.Targets
+                                        .Where(target =>
+                                            GetTargetString(target) == BuildEventString &&
+                                            target.Children.Count == 1 &&
+                                            target.Tasks.Count == 1 &&
+                                            target.Tasks.First().Name == _execTaskName);
+                return (success: targetArray.Count() == 1, target: targetArray.SingleOrDefault());
+            }
+
+            private void SetParameter(ProjectRootElement projectXml, string unevaluatedPropertyValue)
+            {
+                var result = FindExecTaskInTargets(projectXml);
+
+                if (result.success == true)
+                {
+                    SetExecParameter(result.execTask, unevaluatedPropertyValue);
+                }
+                else
+                {
+                    var targetName = GetTargetName(projectXml);
+                    var target = projectXml.AddTarget(targetName);
+                    SetTargetDependencies(target);
+                    var execTask = target.AddTask(_execTaskName);
+                    SetExecParameter(execTask, unevaluatedPropertyValue);
+                }
+            }
+
+            private void SetExecParameter(ProjectTaskElement execTask, string unevaluatedPropertyValue)
+                => execTask.SetParameter(_commandString, unevaluatedPropertyValue);
+
+            private string GetTargetName(ProjectRootElement projectXml)
+            {
+                var targetNames = projectXml.Targets.Select(t => t.Name).ToArray();
+                var targetName = TargetNameString;
+                if (targetNames.Contains(targetName))
+                {
+                    targetName = FindNonCollidingName(targetName, targetNames);
+                }
+
+                return targetName;
+
+            }
+
+            private string FindNonCollidingName(string buildEventString, string[] targetNames)
+            {
+                var initialValue = 1;
+                var newName = buildEventString + initialValue.ToString();
+                while (targetNames.Contains(newName))
+                {
+                    initialValue++;
+                    newName = buildEventString + initialValue.ToString();
+                }
+
+                return newName;
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
             using (var access = await _projectLockService.ReadLockAsync())
             {
                 var projectXml = await access.GetProjectXmlAsync(_unconfiguredProject.FullPath).ConfigureAwait(true);
-                return await _helper.GetPropertyAsync(projectXml, defaultProperties);
+                return await _helper.GetPropertyAsync(projectXml, defaultProperties).ConfigureAwait(true);
             }
         }
 
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
             using (var access = await _projectLockService.WriteLockAsync())
             {
                 var projectXml = await access.GetProjectXmlAsync(_unconfiguredProject.FullPath).ConfigureAwait(true);
-                await _helper.SetPropertyAsync(unevaluatedPropertyValue, defaultProperties, projectXml).ConfigureAwait(true); ;
+                await _helper.SetPropertyAsync(unevaluatedPropertyValue, defaultProperties, projectXml).ConfigureAwait(true);
             }
 
             return null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.cs
@@ -26,15 +26,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
             string evaluatedPropertyValue,
             IProjectProperties defaultProperties)
         {
-            if (evaluatedPropertyValue != null)
-            {
-                return evaluatedPropertyValue;
-            }
-
             using (var access = await _projectLockService.ReadLockAsync())
             {
                 var projectXml = await access.GetProjectXmlAsync(_unconfiguredProject.FullPath).ConfigureAwait(true);
-                return _helper.GetProperty(projectXml);
+                return await _helper.GetPropertyAsync(projectXml, defaultProperties);
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.cs
@@ -26,6 +26,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
             string evaluatedPropertyValue,
             IProjectProperties defaultProperties)
         {
+            if (evaluatedPropertyValue != null)
+            {
+                return evaluatedPropertyValue;
+            }
+
             using (var access = await _projectLockService.ReadLockAsync())
             {
                 var projectXml = await access.GetProjectXmlAsync(_unconfiguredProject.FullPath).ConfigureAwait(true);
@@ -41,7 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
             using (var access = await _projectLockService.WriteLockAsync())
             {
                 var projectXml = await access.GetProjectXmlAsync(_unconfiguredProject.FullPath).ConfigureAwait(true);
-                _helper.SetProperty(unevaluatedPropertyValue, projectXml);
+                await _helper.SetPropertyAsync(unevaluatedPropertyValue, defaultProperties, projectXml).ConfigureAwait(true); ;
             }
 
             return null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.cs
@@ -1,33 +1,26 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Build.Construction;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectProperties
 {
-    internal abstract class AbstractBuildEventValueProvider : InterceptingPropertyValueProviderBase
+    internal abstract partial class AbstractBuildEventValueProvider : InterceptingPropertyValueProviderBase
     {
-        private const string _execTaskName = "Exec";
-        private const string _commandString = "Command";
-
         protected readonly IProjectLockService _projectLockService;
         protected readonly UnconfiguredProject _unconfiguredProject;
+        private readonly Helper _helper;
 
         protected AbstractBuildEventValueProvider(
             IProjectLockService projectLockService,
-            UnconfiguredProject unconfiguredProject)
+            UnconfiguredProject unconfiguredProject,
+            Helper helper)
         {
             _projectLockService = projectLockService;
             _unconfiguredProject = unconfiguredProject;
+            _helper = helper;
         }
-
-        protected abstract string GetTargetString(ProjectTargetElement target);
-        protected abstract void SetTargetDependencies(ProjectTargetElement target);
-        protected abstract string BuildEventString { get; }
-        protected abstract string TargetNameString { get; }
 
         public override async Task<string> OnGetEvaluatedPropertyValueAsync(
             string evaluatedPropertyValue,
@@ -36,19 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
             using (var access = await _projectLockService.ReadLockAsync())
             {
                 var projectXml = await access.GetProjectXmlAsync(_unconfiguredProject.FullPath).ConfigureAwait(true);
-                var result = FindExecTaskInTargets(projectXml);
-
-                if (result.success == false)
-                {
-                    return null;
-                }
-
-                if (result.execTask.Parameters.TryGetValue(_commandString, out var commandText))
-                {
-                    return commandText;
-                }
-
-                return null;
+                return _helper.GetProperty(projectXml);
             }
         }
 
@@ -61,90 +42,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
             {
                 var projectXml = await access.GetProjectXmlAsync(_unconfiguredProject.FullPath).ConfigureAwait(true);
 
-                if (string.IsNullOrWhiteSpace(unevaluatedPropertyValue))
-                {
-                    var result = FindTargetToRemove(projectXml);
-                    if (result.success)
-                    {
-                        projectXml.RemoveChild(result.target);
-                    }
-                }
-                else
-                {
-                    SetParameter(projectXml, unevaluatedPropertyValue);
-                }
+                _helper.SetProperty(unevaluatedPropertyValue, projectXml);
             }
 
             return null;
-        }
-
-        private void SetParameter(ProjectRootElement projectXml, string unevaluatedPropertyValue)
-        {
-            var result = FindExecTaskInTargets(projectXml);
-
-            if (result.success == true)
-            {
-                SetExecParameter(result.execTask, unevaluatedPropertyValue);
-            }
-            else
-            {
-                var targetName = GetTargetName(projectXml);
-                var target = projectXml.AddTarget(targetName);
-                SetTargetDependencies(target);
-                var execTask = target.AddTask(_execTaskName);
-                SetExecParameter(execTask, unevaluatedPropertyValue);
-            }
-        }
-
-        private string GetTargetName(ProjectRootElement projectXml)
-        {
-            var targetNames = projectXml.Targets.Select(t => t.Name).ToArray();
-            var targetName = TargetNameString;
-            if (targetNames.Contains(targetName))
-            {
-                targetName = FindNonCollidingName(targetName, targetNames);
-            }
-
-            return targetName;
-        }
-
-        private string FindNonCollidingName(string buildEventString, string[] targetNames)
-        {
-            var initialValue = 1;
-            var newName = buildEventString + initialValue.ToString();
-            while (targetNames.Contains(newName))
-            {
-                initialValue++;
-                newName = buildEventString + initialValue.ToString();
-            }
-
-            return newName;
-        }
-
-        private void SetExecParameter(ProjectTaskElement execTask, string unevaluatedPropertyValue)
-        {
-            execTask.SetParameter(_commandString, unevaluatedPropertyValue);
-        }
-
-        private (bool success, ProjectTaskElement execTask) FindExecTaskInTargets(ProjectRootElement projectXml)
-        {
-            var execTask = projectXml.Targets
-                                .Where(target => GetTargetString(target) == BuildEventString)
-                                .SelectMany(target => target.Tasks)
-                                .Where(task => task.Name == _execTaskName)
-                                .FirstOrDefault();
-            return (success: execTask != null, execTask: execTask);
-        }
-
-        private (bool success, ProjectTargetElement target) FindTargetToRemove(ProjectRootElement projectXml)
-        {
-            var targetArray = projectXml.Targets
-                                    .Where(target =>
-                                        GetTargetString(target) == BuildEventString &&
-                                        target.Children.Count == 1 &&
-                                        target.Tasks.Count == 1 &&
-                                        target.Tasks.First().Name == _execTaskName);
-            return (success: targetArray.Count() == 1, target: targetArray.SingleOrDefault());
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.cs
@@ -61,10 +61,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
             {
                 var projectXml = await access.GetProjectXmlAsync(_unconfiguredProject.FullPath).ConfigureAwait(true);
 
-                if (string.IsNullOrEmpty(unevaluatedPropertyValue))
+                if (string.IsNullOrWhiteSpace(unevaluatedPropertyValue))
                 {
-                    // TODO: What if the user only enters whitespace characters?
-
                     var targets = projectXml.Targets
                         .Where(target =>
                             GetTargetString(target) == BuildEventString &&
@@ -96,7 +94,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
             }
             else
             {
-                // What if there is already a target named "PreBuild"?
+                // TODO: What if there is already a target named "PreBuild" or "PostBuild"?
                 var prebuildTarget = projectXml.AddTarget(TargetNameString);
                 SetTargetString(prebuildTarget, BuildEventString);
                 var execTask = prebuildTarget.AddTask(_execTaskName);
@@ -107,6 +105,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
         private void SetExecParameter(ProjectTaskElement execTask, string unevaluatedPropertyValue)
         {
             // TODO: what characters should be escaped and what should remain as is?
+            // 1. newline characters
+            // 2. quotations?
             execTask.SetParameter(_commandString, unevaluatedPropertyValue);
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.cs
@@ -10,12 +10,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
     {
         protected readonly IProjectLockService _projectLockService;
         protected readonly UnconfiguredProject _unconfiguredProject;
-        private readonly Helper _helper;
+        private readonly AbstractBuildEventHelper _helper;
 
         protected AbstractBuildEventValueProvider(
             IProjectLockService projectLockService,
             UnconfiguredProject unconfiguredProject,
-            Helper helper)
+            AbstractBuildEventHelper helper)
         {
             _projectLockService = projectLockService;
             _unconfiguredProject = unconfiguredProject;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.cs
@@ -41,7 +41,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
             using (var access = await _projectLockService.WriteLockAsync())
             {
                 var projectXml = await access.GetProjectXmlAsync(_unconfiguredProject.FullPath).ConfigureAwait(true);
-
                 _helper.SetProperty(unevaluatedPropertyValue, projectXml);
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Build.Construction;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectProperties
+{
+    internal abstract class AbstractBuildEventValueProvider : InterceptingPropertyValueProviderBase
+    {
+        private const string _execTaskName = "Exec";
+        private const string _commandString = "Command";
+
+        protected readonly IProjectLockService _projectLockService;
+        protected readonly UnconfiguredProject _unconfiguredProject;
+
+        protected AbstractBuildEventValueProvider(
+            IProjectLockService projectLockService,
+            UnconfiguredProject unconfiguredProject)
+        {
+            _projectLockService = projectLockService;
+            _unconfiguredProject = unconfiguredProject;
+        }
+
+        protected abstract string GetTargetString(ProjectTargetElement target);
+        protected abstract void SetTargetString(ProjectTargetElement target, string targetName);
+        protected abstract string BuildEventString { get; }
+        protected abstract string TargetNameString { get; }
+
+        public override async Task<string> OnGetEvaluatedPropertyValueAsync(
+            string evaluatedPropertyValue,
+            IProjectProperties defaultProperties)
+        {
+            using (var access = await _projectLockService.ReadLockAsync())
+            {
+                var projectXml = await access.GetProjectXmlAsync(_unconfiguredProject.FullPath).ConfigureAwait(true);
+                var result = TryFindExecTaskInTargets(projectXml);
+
+                if (result.success == false)
+                {
+                    return string.Empty;
+                }
+
+                if (result.execTask.Parameters.TryGetValue(_commandString, out var commandText))
+                {
+                    return commandText;
+                }
+
+                return string.Empty;
+            }
+        }
+
+        public override async Task<string> OnSetPropertyValueAsync(
+            string unevaluatedPropertyValue,
+            IProjectProperties defaultProperties,
+            IReadOnlyDictionary<string, string> dimensionalConditions = null)
+        {
+            using (var access = await _projectLockService.WriteLockAsync())
+            {
+                var projectXml = await access.GetProjectXmlAsync(_unconfiguredProject.FullPath).ConfigureAwait(true);
+
+                if (string.IsNullOrEmpty(unevaluatedPropertyValue))
+                {
+                    // TODO: What if the user only enters whitespace characters?
+
+                    var targets = projectXml.Targets
+                        .Where(target =>
+                            GetTargetString(target) == BuildEventString &&
+                            target.Children.Count == 1 &&
+                            target.Tasks.Count == 1 &&
+                            target.Tasks.First().Name == _execTaskName)
+                            .ToArray();
+                    if (targets.Length == 1)
+                    {
+                        projectXml.RemoveChild(targets[0]);
+                    }
+                }
+                else
+                {
+                    SetParameter(projectXml, unevaluatedPropertyValue);
+                }
+            }
+
+            return string.Empty;
+        }
+
+        private void SetParameter(ProjectRootElement projectXml, string unevaluatedPropertyValue)
+        {
+            var result = TryFindExecTaskInTargets(projectXml);
+
+            if (result.success == true)
+            {
+                SetExecParameter(result.execTask, unevaluatedPropertyValue);
+            }
+            else
+            {
+                // What if there is already a target named "PreBuild"?
+                var prebuildTarget = projectXml.AddTarget(TargetNameString);
+                SetTargetString(prebuildTarget, BuildEventString);
+                var execTask = prebuildTarget.AddTask(_execTaskName);
+                SetExecParameter(execTask, unevaluatedPropertyValue);
+            }
+        }
+
+        private void SetExecParameter(ProjectTaskElement execTask, string unevaluatedPropertyValue)
+        {
+            // TODO: what characters should be escaped and what should remain as is?
+            execTask.SetParameter(_commandString, unevaluatedPropertyValue);
+        }
+
+        private (bool success, ProjectTaskElement execTask) TryFindExecTaskInTargets(ProjectRootElement projectXml)
+        {
+            var execTask = projectXml.Targets
+                                .Where(target => GetTargetString(target) == BuildEventString)
+                                .SelectMany(target => target.Tasks)
+                                .Where(task => task.Name == _execTaskName)
+                                .FirstOrDefault();
+            return (success: execTask != null, execTask: execTask);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/PostBuildEventValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/PostBuildEventValueProvider.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+using Microsoft.Build.Construction;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectProperties
+{
+    [ExportInterceptingPropertyValueProvider(_postBuildEventString, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+    internal class PostBuildEventValueProvider : AbstractBuildEventValueProvider
+    {
+        private const string _postBuildEventString = "PostBuildEvent";
+
+        [ImportingConstructor]
+        public PostBuildEventValueProvider(
+            IProjectLockService projectLockService,
+            UnconfiguredProject unconfiguredProject)
+            : base(projectLockService, unconfiguredProject)
+        {}
+
+        protected override string BuildEventString => _postBuildEventString;
+
+        protected override string TargetNameString => "PostBuild";
+
+        protected override string GetTargetString(ProjectTargetElement target)
+            => target.AfterTargets;
+
+        protected override void SetTargetString(ProjectTargetElement target, string targetName)
+            => target.AfterTargets = targetName;
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/PostBuildEventValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/PostBuildEventValueProvider.cs
@@ -5,11 +5,11 @@ using Microsoft.VisualStudio.ProjectSystem.Properties;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectProperties
 {
-    [ExportInterceptingPropertyValueProvider(_postBuildEventString, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+    [ExportInterceptingPropertyValueProvider(_postBuildEvent, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
     internal class PostBuildEventValueProvider : AbstractBuildEventValueProvider
     {
-        private const string _postBuildEventString = "PostBuildEvent";
-        private const string _targetNameString = "PostBuild";
+        private const string _postBuildEvent = "PostBuildEvent";
+        private const string _targetName = "PostBuild";
 
         [ImportingConstructor]
         public PostBuildEventValueProvider(
@@ -23,10 +23,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
         internal class PostBuildEventHelper : AbstractBuildEventHelper
         {
             internal PostBuildEventHelper()
-                : base(_postBuildEventString,
-                       _targetNameString,
+                : base(_postBuildEvent,
+                       _targetName,
                        target => target.AfterTargets,
-                       target => { target.AfterTargets = _postBuildEventString; })
+                       target => { target.AfterTargets = _postBuildEvent; })
             { }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/PostBuildEventValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/PostBuildEventValueProvider.cs
@@ -5,11 +5,11 @@ using Microsoft.VisualStudio.ProjectSystem.Properties;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectProperties
 {
-    [ExportInterceptingPropertyValueProvider(_postBuildEvent, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+    [ExportInterceptingPropertyValueProvider(PostBuildEvent, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
     internal class PostBuildEventValueProvider : AbstractBuildEventValueProvider
     {
-        private const string _postBuildEvent = "PostBuildEvent";
-        private const string _targetName = "PostBuild";
+        private const string PostBuildEvent = "PostBuildEvent";
+        private const string TargetName = "PostBuild";
 
         [ImportingConstructor]
         public PostBuildEventValueProvider(
@@ -23,10 +23,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
         internal class PostBuildEventHelper : AbstractBuildEventHelper
         {
             internal PostBuildEventHelper()
-                : base(_postBuildEvent,
-                       _targetName,
+                : base(PostBuildEvent,
+                       TargetName,
                        target => target.AfterTargets,
-                       target => { target.AfterTargets = _postBuildEvent; })
+                       target => { target.AfterTargets = PostBuildEvent; })
             { }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/PostBuildEventValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/PostBuildEventValueProvider.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.ComponentModel.Composition;
-using Microsoft.Build.Construction;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectProperties
@@ -10,22 +9,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
     internal class PostBuildEventValueProvider : AbstractBuildEventValueProvider
     {
         private const string _postBuildEventString = "PostBuildEvent";
+        private const string _targetNameString = "PostBuild";
 
         [ImportingConstructor]
         public PostBuildEventValueProvider(
             IProjectLockService projectLockService,
             UnconfiguredProject unconfiguredProject)
-            : base(projectLockService, unconfiguredProject)
+            : base(projectLockService,
+                   unconfiguredProject,
+                   new PostBuildEventHelper())
         {}
 
-        protected override string BuildEventString => _postBuildEventString;
-
-        protected override string TargetNameString => "PostBuild";
-
-        protected override string GetTargetString(ProjectTargetElement target)
-            => target.AfterTargets;
-
-        protected override void SetTargetDependencies(ProjectTargetElement target)
-            => target.AfterTargets = _postBuildEventString;
+        internal class PostBuildEventHelper : Helper
+        {
+            internal PostBuildEventHelper()
+                : base(_postBuildEventString,
+                       _targetNameString,
+                       target => target.AfterTargets,
+                       target => { target.AfterTargets = _postBuildEventString; })
+            { }
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/PostBuildEventValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/PostBuildEventValueProvider.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
         protected override string GetTargetString(ProjectTargetElement target)
             => target.AfterTargets;
 
-        protected override void SetTargetString(ProjectTargetElement target, string targetName)
-            => target.AfterTargets = targetName;
+        protected override void SetTargetDependencies(ProjectTargetElement target)
+            => target.AfterTargets = _postBuildEventString;
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/PostBuildEventValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/PostBuildEventValueProvider.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
                    new PostBuildEventHelper())
         {}
 
-        internal class PostBuildEventHelper : Helper
+        internal class PostBuildEventHelper : AbstractBuildEventHelper
         {
             internal PostBuildEventHelper()
                 : base(_postBuildEventString,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/PreBuildEventValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/PreBuildEventValueProvider.cs
@@ -5,10 +5,10 @@ using Microsoft.VisualStudio.ProjectSystem.Properties;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectProperties
 {
-    [ExportInterceptingPropertyValueProvider(_preBuildEventName, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+    [ExportInterceptingPropertyValueProvider(_preBuildEvent, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
     internal class PreBuildEventValueProvider : AbstractBuildEventValueProvider
     {
-        private const string _preBuildEventName = "PreBuildEvent";
+        private const string _preBuildEvent = "PreBuildEvent";
         private const string _targetName = "PreBuild";
 
         [ImportingConstructor]
@@ -23,10 +23,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
         internal class PreBuildEventHelper : AbstractBuildEventHelper
         {
             internal PreBuildEventHelper()
-                : base(_preBuildEventString,
+                : base(_preBuildEvent,
                        _targetName,
                        target => target.BeforeTargets,
-                       target => { target.BeforeTargets = _preBuildEventString; })
+                       target => { target.BeforeTargets = _preBuildEvent; })
             { }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/PreBuildEventValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/PreBuildEventValueProvider.cs
@@ -5,11 +5,11 @@ using Microsoft.VisualStudio.ProjectSystem.Properties;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectProperties
 {
-    [ExportInterceptingPropertyValueProvider(_preBuildEventString, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+    [ExportInterceptingPropertyValueProvider(_preBuildEventName, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
     internal class PreBuildEventValueProvider : AbstractBuildEventValueProvider
     {
-        private const string _preBuildEventString = "PreBuildEvent";
-        private const string _targetNameString = "PreBuild";
+        private const string _preBuildEventName = "PreBuildEvent";
+        private const string _targetName = "PreBuild";
 
         [ImportingConstructor]
         public PreBuildEventValueProvider(
@@ -20,11 +20,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
                    new PreBuildEventHelper())
         { }
 
-        internal class PreBuildEventHelper : Helper
+        internal class PreBuildEventHelper : AbstractBuildEventHelper
         {
             internal PreBuildEventHelper()
                 : base(_preBuildEventString,
-                       _targetNameString,
+                       _targetName,
                        target => target.BeforeTargets,
                        target => { target.BeforeTargets = _preBuildEventString; })
             { }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/PreBuildEventValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/PreBuildEventValueProvider.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.ComponentModel.Composition;
-using Microsoft.Build.Construction;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectProperties
@@ -10,22 +9,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
     internal class PreBuildEventValueProvider : AbstractBuildEventValueProvider
     {
         private const string _preBuildEventString = "PreBuildEvent";
+        private const string _targetNameString = "PreBuild";
 
         [ImportingConstructor]
         public PreBuildEventValueProvider(
             IProjectLockService projectLockService,
             UnconfiguredProject unconfiguredProject)
-            : base(projectLockService, unconfiguredProject)
-        {}
+            : base(projectLockService,
+                   unconfiguredProject,
+                   new PreBuildEventHelper())
+        { }
 
-        protected override string BuildEventString => _preBuildEventString;
-
-        protected override string TargetNameString => "PreBuild";
-
-        protected override string GetTargetString(ProjectTargetElement target)
-            => target.BeforeTargets;
-
-        protected override void SetTargetDependencies(ProjectTargetElement target)
-            => target.BeforeTargets = _preBuildEventString;
+        internal class PreBuildEventHelper : Helper
+        {
+            internal PreBuildEventHelper()
+                : base(_preBuildEventString,
+                       _targetNameString,
+                       target => target.BeforeTargets,
+                       target => { target.BeforeTargets = _preBuildEventString; })
+            { }
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/PreBuildEventValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/PreBuildEventValueProvider.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
         protected override string GetTargetString(ProjectTargetElement target)
             => target.BeforeTargets;
 
-        protected override void SetTargetString(ProjectTargetElement target, string targetName)
-            => target.BeforeTargets = targetName;
+        protected override void SetTargetDependencies(ProjectTargetElement target)
+            => target.BeforeTargets = _preBuildEventString;
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/PreBuildEventValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/PreBuildEventValueProvider.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+using Microsoft.Build.Construction;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectProperties
+{
+    [ExportInterceptingPropertyValueProvider(_preBuildEventString, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+    internal class PreBuildEventValueProvider : AbstractBuildEventValueProvider
+    {
+        private const string _preBuildEventString = "PreBuildEvent";
+
+        [ImportingConstructor]
+        public PreBuildEventValueProvider(
+            IProjectLockService projectLockService,
+            UnconfiguredProject unconfiguredProject)
+            : base(projectLockService, unconfiguredProject)
+        {}
+
+        protected override string BuildEventString => _preBuildEventString;
+
+        protected override string TargetNameString => "PreBuild";
+
+        protected override string GetTargetString(ProjectTargetElement target)
+            => target.BeforeTargets;
+
+        protected override void SetTargetString(ProjectTargetElement target, string targetName)
+            => target.BeforeTargets = targetName;
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/PreBuildEventValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/PreBuildEventValueProvider.cs
@@ -5,11 +5,11 @@ using Microsoft.VisualStudio.ProjectSystem.Properties;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectProperties
 {
-    [ExportInterceptingPropertyValueProvider(_preBuildEvent, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+    [ExportInterceptingPropertyValueProvider(PreBuildEvent, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
     internal class PreBuildEventValueProvider : AbstractBuildEventValueProvider
     {
-        private const string _preBuildEvent = "PreBuildEvent";
-        private const string _targetName = "PreBuild";
+        private const string PreBuildEvent = "PreBuildEvent";
+        private const string TargetName = "PreBuild";
 
         [ImportingConstructor]
         public PreBuildEventValueProvider(
@@ -23,10 +23,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
         internal class PreBuildEventHelper : AbstractBuildEventHelper
         {
             internal PreBuildEventHelper()
-                : base(_preBuildEvent,
-                       _targetName,
+                : base(PreBuildEvent,
+                       TargetName,
                        target => target.BeforeTargets,
-                       target => { target.BeforeTargets = _preBuildEvent; })
+                       target => { target.BeforeTargets = PreBuildEvent; })
             { }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -71,12 +71,12 @@
     </StringProperty>
     <StringProperty Name="PreBuildEvent" DisplayName="Pre Build Event" Visible="False">
         <StringProperty.DataSource>
-            <DataSource Persistence="ProjectFileWithInterception" PersistedName="PreBuildEvent" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext"/>
+            <DataSource Persistence="ProjectFileWithInterception" PersistedName="PreBuildEvent" HasConfigurationCondition="False" SourceOfDefaultValue="BeforeContext"/>
         </StringProperty.DataSource>
     </StringProperty>
     <StringProperty Name="PostBuildEvent" DisplayName="Post Build Event" Visible="False">
         <StringProperty.DataSource>
-            <DataSource Persistence="ProjectFileWithInterception" PersistedName="PostBuildEvent" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext"/>
+            <DataSource Persistence="ProjectFileWithInterception" PersistedName="PostBuildEvent" HasConfigurationCondition="False" SourceOfDefaultValue="BeforeContext"/>
         </StringProperty.DataSource>
     </StringProperty>
     <EnumProperty Name="RunPostBuildEvent" DisplayName="Run Post Build Event" Visible="False">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -69,8 +69,16 @@
             <DataSource Persistence="ProjectFile" PersistedName="Win32Resource" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
     </StringProperty>
-    <StringProperty Name="PreBuildEvent" DisplayName="Pre Build Event" Visible="False"/>
-    <StringProperty Name="PostBuildEvent" DisplayName="Post Build Event" Visible="False"/>
+    <StringProperty Name="PreBuildEvent" DisplayName="Pre Build Event" Visible="False">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFileWithInterception" PersistedName="PreBuildEvent" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext"/>
+        </StringProperty.DataSource>
+    </StringProperty>
+    <StringProperty Name="PostBuildEvent" DisplayName="Post Build Event" Visible="False">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFileWithInterception" PersistedName="PostBuildEvent" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext"/>
+        </StringProperty.DataSource>
+    </StringProperty>
     <EnumProperty Name="RunPostBuildEvent" DisplayName="Run Post Build Event" Visible="False">
         <EnumValue Name="Always" DisplayName="Always" />
         <EnumValue Name="OnBuildSuccess" DisplayName="On successful build"  IsDefault="True" />


### PR DESCRIPTION
**Customer scenario**

User wants to have their pre-build and post build events use MSBuild variables but they are evaluated as empty strings without this fix

**Bugs this fixes:** 

https://github.com/dotnet/project-system/issues/1569
https://github.com/dotnet/project-system/issues/1879

**Workarounds, if any**
User can manually modify their project file.

**Risk**

this only affects the project file if the user writes pre or post build events from the properties pages.  risk is low.

**Performance impact**

Code is only called when the user changes the value in the property page.  Risk is low.

**Is this a regression from a previous update?**

It is a regression from the native project system

**Root cause analysis:**

Targets are now implicitly imported to MSBuild variables do not exist.  The fix is to add a target to the project file so that when the user add pre and post build events, by the time they are evaluated the MeBuild variables exist.

**How was the bug found?**

customer reported - This is one of the top VS Feedback reports with 20+ votes.
