### PR TITLE
Make warnaserror work from the property pages.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
@@ -24,7 +24,11 @@
   <BoolProperty Name="Optimize" DisplayName="Optimize" Visible="False"/>
   <StringProperty Name="NoWarn" DisplayName="Supress Warning" Visible="False"/>
   <BoolProperty Name="TreatWarningsAsErrors"  Default="False" Description="Treat warnings as errors" Visible="False"/>
-  <StringProperty Name="TreatSpecificWarningsAsErrors"  Description="Treat specific warnings as errors" Visible="False" />
+  <StringProperty Name="TreatSpecificWarningsAsErrors"  Description="Treat specific warnings as errors" Visible="False">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="WarningsAsErrors" />
+    </StringProperty.DataSource>
+  </StringProperty>
   <StringProperty Name="OutputPath" DisplayName="Output Path" Visible="False"/>
   <StringProperty Name="DocumentationFile" DisplayName="Documentation file" Visible="False"/>
   <EnumProperty Name="GenerateSerializationAssemblies" DisplayName="Generate serialization assemblies" Visible="False">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -106,7 +106,7 @@
                     Visible="False" 
                     ReadOnly="True" />
 
-    <StringProperty Name="TreatSpecificWarningsAsErrors" 
+    <StringProperty Name="WarningsAsErrors" 
                     Visible="False" 
                     ReadOnly="True" />
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/GeneralConfiguredBrowseObject.xaml
@@ -15,7 +15,11 @@
   <BoolProperty Name="Optimize" DisplayName="Optimalizovat" Visible="False" />
   <StringProperty Name="NoWarn" DisplayName="Potlačit upozornění" Visible="False" />
   <BoolProperty Name="TreatWarningsAsErrors" Default="False" Description="Zpracovávat upozornění jako chyby" Visible="False" />
-  <StringProperty Name="TreatSpecificWarningsAsErrors" Description="Považovat specifická upozornění za chyby" Visible="False" />
+  <StringProperty Name="TreatSpecificWarningsAsErrors" Description="Považovat specifická upozornění za chyby" Visible="False">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="WarningsAsErrors" />
+    </StringProperty.DataSource>
+  </StringProperty>
   <StringProperty Name="OutputPath" DisplayName="Výstupní cesta" Visible="False" />
   <StringProperty Name="DocumentationFile" DisplayName="Soubor dokumentace" Visible="False" />
   <EnumProperty Name="GenerateSerializationAssemblies" DisplayName="Generovat serializované sestavení" Visible="False">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/NuGetRestore.xaml
@@ -50,6 +50,6 @@
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/GeneralConfiguredBrowseObject.xaml
@@ -15,7 +15,11 @@
   <BoolProperty Name="Optimize" DisplayName="Optimieren" Visible="False" />
   <StringProperty Name="NoWarn" DisplayName="Warnung unterdrücken" Visible="False" />
   <BoolProperty Name="TreatWarningsAsErrors" Default="False" Description="Warnungen als Fehler behandeln" Visible="False" />
-  <StringProperty Name="TreatSpecificWarningsAsErrors" Description="Spezifische Warnungen als Fehler behandeln" Visible="False" />
+  <StringProperty Name="TreatSpecificWarningsAsErrors" Description="Spezifische Warnungen als Fehler behandeln" Visible="False">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="WarningsAsErrors" />
+    </StringProperty.DataSource>
+  </StringProperty>
   <StringProperty Name="OutputPath" DisplayName="Ausgabepfad" Visible="False" />
   <StringProperty Name="DocumentationFile" DisplayName="Dokumentationsdatei" Visible="False" />
   <EnumProperty Name="GenerateSerializationAssemblies" DisplayName="Serialisierungsassemblys generieren" Visible="False">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/NuGetRestore.xaml
@@ -50,6 +50,6 @@
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/GeneralConfiguredBrowseObject.xaml
@@ -15,7 +15,11 @@
   <BoolProperty Name="Optimize" DisplayName="Optimizar" Visible="False" />
   <StringProperty Name="NoWarn" DisplayName="Suprimir advertencia" Visible="False" />
   <BoolProperty Name="TreatWarningsAsErrors" Default="False" Description="Tratar advertencias como errores" Visible="False" />
-  <StringProperty Name="TreatSpecificWarningsAsErrors" Description="Tratar advertencias específicas como errores" Visible="False" />
+  <StringProperty Name="TreatSpecificWarningsAsErrors" Description="Tratar advertencias específicas como errores" Visible="False">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="WarningsAsErrors" />
+    </StringProperty.DataSource>
+  </StringProperty>
   <StringProperty Name="OutputPath" DisplayName="Ruta de acceso de salida" Visible="False" />
   <StringProperty Name="DocumentationFile" DisplayName="Archivo de documentación" Visible="False" />
   <EnumProperty Name="GenerateSerializationAssemblies" DisplayName="Generar ensamblados de serialización" Visible="False">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/NuGetRestore.xaml
@@ -50,6 +50,6 @@
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/GeneralConfiguredBrowseObject.xaml
@@ -15,7 +15,11 @@
   <BoolProperty Name="Optimize" DisplayName="Optimiser" Visible="False" />
   <StringProperty Name="NoWarn" DisplayName="Supprimer l'avertissement" Visible="False" />
   <BoolProperty Name="TreatWarningsAsErrors" Default="False" Description="Considérer les avertissements comme des erreurs" Visible="False" />
-  <StringProperty Name="TreatSpecificWarningsAsErrors" Description="Considérer les avertissements spécifiques comme des erreurs" Visible="False" />
+  <StringProperty Name="TreatSpecificWarningsAsErrors" Description="Considérer les avertissements spécifiques comme des erreurs" Visible="False">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="WarningsAsErrors" />
+    </StringProperty.DataSource>
+  </StringProperty>
   <StringProperty Name="OutputPath" DisplayName="Chemin de sortie" Visible="False" />
   <StringProperty Name="DocumentationFile" DisplayName="Fichier de documentation" Visible="False" />
   <EnumProperty Name="GenerateSerializationAssemblies" DisplayName="Générer des assemblys de sérialisation" Visible="False">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/NuGetRestore.xaml
@@ -50,6 +50,6 @@
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/GeneralConfiguredBrowseObject.xaml
@@ -15,7 +15,11 @@
   <BoolProperty Name="Optimize" DisplayName="Ottimizza" Visible="False" />
   <StringProperty Name="NoWarn" DisplayName="Non visualizzare l'avviso" Visible="False" />
   <BoolProperty Name="TreatWarningsAsErrors" Default="False" Description="Considera gli avvisi come errori" Visible="False" />
-  <StringProperty Name="TreatSpecificWarningsAsErrors" Description="Considera avvisi specifici come errori" Visible="False" />
+  <StringProperty Name="TreatSpecificWarningsAsErrors" Description="Considera avvisi specifici come errori" Visible="False">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="WarningsAsErrors" />
+    </StringProperty.DataSource>
+  </StringProperty>
   <StringProperty Name="OutputPath" DisplayName="Percorso di output" Visible="False" />
   <StringProperty Name="DocumentationFile" DisplayName="File di documentazione" Visible="False" />
   <EnumProperty Name="GenerateSerializationAssemblies" DisplayName="Genera assembly di serializzazione" Visible="False">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/NuGetRestore.xaml
@@ -50,6 +50,6 @@
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/GeneralConfiguredBrowseObject.xaml
@@ -15,7 +15,11 @@
   <BoolProperty Name="Optimize" DisplayName="最適化" Visible="False" />
   <StringProperty Name="NoWarn" DisplayName="警告を抑制する" Visible="False" />
   <BoolProperty Name="TreatWarningsAsErrors" Default="False" Description="警告をエラーとして扱う" Visible="False" />
-  <StringProperty Name="TreatSpecificWarningsAsErrors" Description="特定の警告をエラーとして扱う" Visible="False" />
+  <StringProperty Name="TreatSpecificWarningsAsErrors" Description="特定の警告をエラーとして扱う" Visible="False">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="WarningsAsErrors" />
+    </StringProperty.DataSource>
+  </StringProperty>
   <StringProperty Name="OutputPath" DisplayName="出力パス" Visible="False" />
   <StringProperty Name="DocumentationFile" DisplayName="ドキュメント ファイル" Visible="False" />
   <EnumProperty Name="GenerateSerializationAssemblies" DisplayName="シリアル化アセンブリの生成" Visible="False">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/NuGetRestore.xaml
@@ -50,6 +50,6 @@
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/GeneralConfiguredBrowseObject.xaml
@@ -15,7 +15,11 @@
   <BoolProperty Name="Optimize" DisplayName="최적화" Visible="False" />
   <StringProperty Name="NoWarn" DisplayName="경고 표시 안 함" Visible="False" />
   <BoolProperty Name="TreatWarningsAsErrors" Default="False" Description="경고를 오류로 처리" Visible="False" />
-  <StringProperty Name="TreatSpecificWarningsAsErrors" Description="특정 경고를 오류로 처리" Visible="False" />
+  <StringProperty Name="TreatSpecificWarningsAsErrors" Description="특정 경고를 오류로 처리" Visible="False">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="WarningsAsErrors" />
+    </StringProperty.DataSource>
+  </StringProperty>
   <StringProperty Name="OutputPath" DisplayName="출력 경로" Visible="False" />
   <StringProperty Name="DocumentationFile" DisplayName="문서 파일" Visible="False" />
   <EnumProperty Name="GenerateSerializationAssemblies" DisplayName="Serialization 어셈블리 생성" Visible="False">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/NuGetRestore.xaml
@@ -50,6 +50,6 @@
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/GeneralConfiguredBrowseObject.xaml
@@ -15,7 +15,11 @@
   <BoolProperty Name="Optimize" DisplayName="Optymalizuj" Visible="False" />
   <StringProperty Name="NoWarn" DisplayName="Pomiń ostrzeżenie" Visible="False" />
   <BoolProperty Name="TreatWarningsAsErrors" Default="False" Description="Traktuj ostrzeżenia jako błędy" Visible="False" />
-  <StringProperty Name="TreatSpecificWarningsAsErrors" Description="Traktuj konkretne ostrzeżenia jako błędy" Visible="False" />
+  <StringProperty Name="TreatSpecificWarningsAsErrors" Description="Traktuj konkretne ostrzeżenia jako błędy" Visible="False">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="WarningsAsErrors" />
+    </StringProperty.DataSource>
+  </StringProperty>
   <StringProperty Name="OutputPath" DisplayName="Ścieżka wyjściowa" Visible="False" />
   <StringProperty Name="DocumentationFile" DisplayName="Plik dokumentacji" Visible="False" />
   <EnumProperty Name="GenerateSerializationAssemblies" DisplayName="Generuj zestawy serializacji" Visible="False">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/NuGetRestore.xaml
@@ -50,6 +50,6 @@
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/GeneralConfiguredBrowseObject.xaml
@@ -15,7 +15,11 @@
   <BoolProperty Name="Optimize" DisplayName="Otimizar" Visible="False" />
   <StringProperty Name="NoWarn" DisplayName="Suprimir Aviso" Visible="False" />
   <BoolProperty Name="TreatWarningsAsErrors" Default="False" Description="Tratar avisos como erros" Visible="False" />
-  <StringProperty Name="TreatSpecificWarningsAsErrors" Description="Tratar avisos específicos como erros" Visible="False" />
+  <StringProperty Name="TreatSpecificWarningsAsErrors" Description="Tratar avisos específicos como erros" Visible="False">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="WarningsAsErrors" />
+    </StringProperty.DataSource>
+  </StringProperty>
   <StringProperty Name="OutputPath" DisplayName="Caminho de Saída" Visible="False" />
   <StringProperty Name="DocumentationFile" DisplayName="Arquivo de documentação" Visible="False" />
   <EnumProperty Name="GenerateSerializationAssemblies" DisplayName="Gerar assemblies de serialização" Visible="False">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/NuGetRestore.xaml
@@ -50,6 +50,6 @@
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/GeneralConfiguredBrowseObject.xaml
@@ -15,7 +15,11 @@
   <BoolProperty Name="Optimize" DisplayName="Оптимизировать" Visible="False" />
   <StringProperty Name="NoWarn" DisplayName="Отключить предупреждение" Visible="False" />
   <BoolProperty Name="TreatWarningsAsErrors" Default="False" Description="Обрабатывать предупреждения как ошибки" Visible="False" />
-  <StringProperty Name="TreatSpecificWarningsAsErrors" Description="Интерпретировать указанные предупреждения как ошибки" Visible="False" />
+  <StringProperty Name="TreatSpecificWarningsAsErrors" Description="Интерпретировать указанные предупреждения как ошибки" Visible="False">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="WarningsAsErrors" />
+    </StringProperty.DataSource>
+  </StringProperty>
   <StringProperty Name="OutputPath" DisplayName="Выходной путь" Visible="False" />
   <StringProperty Name="DocumentationFile" DisplayName="Файл документации" Visible="False" />
   <EnumProperty Name="GenerateSerializationAssemblies" DisplayName="Создать сборки сериализации" Visible="False">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/NuGetRestore.xaml
@@ -50,6 +50,6 @@
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/GeneralConfiguredBrowseObject.xaml
@@ -15,7 +15,11 @@
   <BoolProperty Name="Optimize" DisplayName="İyileştir" Visible="False" />
   <StringProperty Name="NoWarn" DisplayName="Uyarıyı Gösterme" Visible="False" />
   <BoolProperty Name="TreatWarningsAsErrors" Default="False" Description="Uyarıları hata olarak değerlendir" Visible="False" />
-  <StringProperty Name="TreatSpecificWarningsAsErrors" Description="Belirli uyarıları hata olarak değerlendir" Visible="False" />
+  <StringProperty Name="TreatSpecificWarningsAsErrors" Description="Belirli uyarıları hata olarak değerlendir" Visible="False">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="WarningsAsErrors" />
+    </StringProperty.DataSource>
+  </StringProperty>
   <StringProperty Name="OutputPath" DisplayName="Çıkış Yolu" Visible="False" />
   <StringProperty Name="DocumentationFile" DisplayName="Belge dosyası" Visible="False" />
   <EnumProperty Name="GenerateSerializationAssemblies" DisplayName="Serileştirme bütünleştirilmiş kodları oluştur" Visible="False">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/NuGetRestore.xaml
@@ -50,6 +50,6 @@
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/GeneralConfiguredBrowseObject.xaml
@@ -15,7 +15,11 @@
   <BoolProperty Name="Optimize" DisplayName="优化" Visible="False" />
   <StringProperty Name="NoWarn" DisplayName="取消警告" Visible="False" />
   <BoolProperty Name="TreatWarningsAsErrors" Default="False" Description="将警告视为错误" Visible="False" />
-  <StringProperty Name="TreatSpecificWarningsAsErrors" Description="将特定的警告视为错误" Visible="False" />
+  <StringProperty Name="TreatSpecificWarningsAsErrors" Description="将特定的警告视为错误" Visible="False">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="WarningsAsErrors" />
+    </StringProperty.DataSource>
+  </StringProperty>
   <StringProperty Name="OutputPath" DisplayName="输出路径" Visible="False" />
   <StringProperty Name="DocumentationFile" DisplayName="文档文件" Visible="False" />
   <EnumProperty Name="GenerateSerializationAssemblies" DisplayName="生成序列化程序集" Visible="False">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/NuGetRestore.xaml
@@ -50,6 +50,6 @@
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/GeneralConfiguredBrowseObject.xaml
@@ -15,7 +15,11 @@
   <BoolProperty Name="Optimize" DisplayName="最佳化" Visible="False" />
   <StringProperty Name="NoWarn" DisplayName="隱藏警告" Visible="False" />
   <BoolProperty Name="TreatWarningsAsErrors" Default="False" Description="將警告視為錯誤" Visible="False" />
-  <StringProperty Name="TreatSpecificWarningsAsErrors" Description="將特定警告視為錯誤" Visible="False" />
+  <StringProperty Name="TreatSpecificWarningsAsErrors" Description="將特定警告視為錯誤" Visible="False">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="WarningsAsErrors" />
+    </StringProperty.DataSource>
+  </StringProperty>
   <StringProperty Name="OutputPath" DisplayName="輸出路徑" Visible="False" />
   <StringProperty Name="DocumentationFile" DisplayName="文件檔案" Visible="False" />
   <EnumProperty Name="GenerateSerializationAssemblies" DisplayName="產生序列化組件" Visible="False">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/NuGetRestore.xaml
@@ -50,6 +50,6 @@
   <StringProperty Name="RestoreFallbackFolders" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
-  <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False" ReadOnly="True" />
+  <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />
 </Rule>


### PR DESCRIPTION
**Customer scenario**

If a user goes to the build property pages and enters a warning number in the "Treat Warnings as errors" textbox then those warnings weren't being treated as errors.

This is because the prop page was persisting the warnings to a property called TreatSpecificWarningsAsErrors in the project file - however, the compiler only understands a  `WarningsAsErrors` property. Making the prop page persist the warnings as WarningsAsErrors instead.

@natidea @emgarten - note that this means that NuGet needs to read the WarningsAsErrors property as well. I've updated the nomination rule as well so that we send WarningsAsErrors to NuGet.

**Bugs this fixes:** 

https://devdiv.visualstudio.com/DevDiv/_workitems?id=435264&_a=edit&triage=true

**Workarounds, if any**

Manually edit the project file.

**Risk**

Low - just changing the property name.

**Performance impact**

Low - just changing the property name.

**Is this a regression from a previous update?**

No

**How was the bug found?**

VS Feedback - https://developercommunity.visualstudio.com/content/problem/55418/cs4014-warning-as-error.html

@dotnet/project-system 