### PR TITLE
[Logging] Language service logging

### DIFF
--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -337,7 +337,7 @@
   <!-- This is a copy of the Microsoft.VisualStudio.SDK.EmbedInteropTypes NuGet package, but only the list of
        assemblies that we need. The package includes things like EnvDTE which are reasonable for consumers, but
        strange since we actually _implement_ DTE and use it as an exchange type with generics in a few places. -->
-  <Target Name="LinkVSSDKEmbeddableAssemblies" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">
+  <Target Name="LinkVSSDKEmbeddableAssemblies" DependsOnTargets="ResolveReferences" AfterTargets="ResolveReferences">
     <ItemGroup>
       <ReferencePath Condition="
               '%(FileName)' == 'Microsoft.VisualStudio.Shell.Embeddable'

--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -337,7 +337,7 @@
   <!-- This is a copy of the Microsoft.VisualStudio.SDK.EmbedInteropTypes NuGet package, but only the list of
        assemblies that we need. The package includes things like EnvDTE which are reasonable for consumers, but
        strange since we actually _implement_ DTE and use it as an exchange type with generics in a few places. -->
-  <Target Name="LinkVSSDKEmbeddableAssemblies" DependsOnTargets="ResolveReferences" AfterTargets="ResolveReferences">
+  <Target Name="LinkVSSDKEmbeddableAssemblies" BeforeTargets="FindReferenceAssembliesForReferences;ResolveReferences">
     <ItemGroup>
       <ReferencePath Condition="
               '%(FileName)' == 'Microsoft.VisualStudio.Shell.Embeddable'

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
@@ -41,31 +41,33 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             {
                 var fullPath = _project.MakeRooted(additionalFile.Path);
 
-                RemoveFromContextIfPresent(fullPath);
+                RemoveFromContextIfPresent(fullPath, logger);
             }
 
             foreach (CommandLineSourceFile additionalFile in added.AdditionalFiles)
             {
                 var fullPath = _project.MakeRooted(additionalFile.Path);
 
-                AddToContextIfNotPresent(fullPath, isActiveContext);
+                AddToContextIfNotPresent(fullPath, isActiveContext, logger);
             }
         }
 
-        private void AddToContextIfNotPresent(string fullPath, bool isActiveContext)
+        private void AddToContextIfNotPresent(string fullPath, bool isActiveContext, IProjectLogger logger)
         {
             if (!_paths.Contains(fullPath))
             {
+                logger.WriteLine("Adding additional file '{0}'", fullPath);
                 _context.AddAdditionalFile(fullPath, isActiveContext);
                 bool added = _paths.Add(fullPath);
                 Assumes.True(added);
             }
         }
 
-        private void RemoveFromContextIfPresent(string fullPath)
+        private void RemoveFromContextIfPresent(string fullPath, IProjectLogger logger)
         {
             if (_paths.Contains(fullPath))
             {
+                logger.WriteLine("Removing additional file '{0}'", fullPath);
                 _context.RemoveAdditionalFile(fullPath);
                 bool removed = _paths.Remove(fullPath);
                 Assumes.True(removed);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Logging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
@@ -29,11 +30,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             _context = context;
         }
 
-        public void Handle(IComparable version, BuildOptions added, BuildOptions removed, bool isActiveContext)
+        public void Handle(IComparable version, BuildOptions added, BuildOptions removed, bool isActiveContext, IProjectLogger logger)
         {
             Requires.NotNull(version, nameof(version));
             Requires.NotNull(added, nameof(added));
             Requires.NotNull(removed, nameof(removed));
+            Requires.NotNull(logger, nameof(logger));
 
             foreach (CommandLineSourceFile additionalFile in removed.AdditionalFiles)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Logging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
@@ -31,11 +32,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             _context = context;
         }
 
-        public void Handle(IComparable version, BuildOptions added, BuildOptions removed, bool isActiveContext)
+        public void Handle(IComparable version, BuildOptions added, BuildOptions removed, bool isActiveContext, IProjectLogger logger)
         {
             Requires.NotNull(version, nameof(version));
             Requires.NotNull(added, nameof(added));
             Requires.NotNull(removed, nameof(removed));
+            Requires.NotNull(logger, nameof(logger));
 
             foreach (CommandLineAnalyzerReference analyzer in removed.AnalyzerReferences)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
@@ -43,31 +43,33 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             {
                 var fullPath = _project.MakeRooted(analyzer.FilePath);
 
-                RemoveFromContextIfPresent(fullPath);
+                RemoveFromContextIfPresent(fullPath, logger);
             }
 
             foreach (CommandLineAnalyzerReference analyzer in added.AnalyzerReferences)
             {
                 var fullPath = _project.MakeRooted(analyzer.FilePath);
 
-                AddToContextIfNotPresent(fullPath);
+                AddToContextIfNotPresent(fullPath, logger);
             }
         }
 
-        private void AddToContextIfNotPresent(string fullPath)
+        private void AddToContextIfNotPresent(string fullPath, IProjectLogger logger)
         {
             if (!_paths.Contains(fullPath))
             {
+                logger.WriteLine("Adding analyzer '{0}'", fullPath);
                 _context.AddAdditionalFile(fullPath);
                 bool added = _paths.Add(fullPath);
                 Assumes.True(added);
             }
         }
 
-        private void RemoveFromContextIfPresent(string fullPath)
+        private void RemoveFromContextIfPresent(string fullPath, IProjectLogger logger)
         {
             if (_paths.Contains(fullPath))
             {
+                logger.WriteLine("Removing analyzer '{0}'", fullPath);
                 _context.RemoveAdditionalFile(fullPath);
                 bool removed = _paths.Remove(fullPath);
                 Assumes.True(removed);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Logging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
@@ -29,11 +30,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             _context = context;
         }
 
-        public void Handle(IComparable version, BuildOptions added, BuildOptions removed, bool isActiveContext)
+        public void Handle(IComparable version, BuildOptions added, BuildOptions removed, bool isActiveContext, IProjectLogger logger)
         {
             Requires.NotNull(version, nameof(version));
             Requires.NotNull(added, nameof(added));
             Requires.NotNull(removed, nameof(removed));
+            Requires.NotNull(logger, nameof(logger));
 
             foreach (CommandLineReference reference in removed.MetadataReferences)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
@@ -41,31 +41,33 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             {
                 var fullPath = _project.MakeRooted(reference.Reference);
 
-                RemoveFromContextIfPresent(fullPath);
+                RemoveFromContextIfPresent(fullPath, logger);
             }
 
             foreach (CommandLineReference reference in added.MetadataReferences)
             {
                 var fullPath = _project.MakeRooted(reference.Reference);
 
-                AddToContextIfNotPresent(fullPath, reference.Properties);
+                AddToContextIfNotPresent(fullPath, reference.Properties, logger);
             }
         }
 
-        private void AddToContextIfNotPresent(string fullPath, MetadataReferenceProperties properties)
+        private void AddToContextIfNotPresent(string fullPath, MetadataReferenceProperties properties, IProjectLogger logger)
         {
             if (!_paths.Contains(fullPath))
             {
+                logger.WriteLine("Adding reference '{0}'", fullPath);
                 _context.AddMetadataReference(fullPath, properties);
                 bool added = _paths.Add(fullPath);
                 Assumes.True(added);
             }
         }
 
-        private void RemoveFromContextIfPresent(string fullPath)
+        private void RemoveFromContextIfPresent(string fullPath, IProjectLogger logger)
         {
             if (_paths.Contains(fullPath))
             {
+                logger.WriteLine("Removing reference '{0}'", fullPath);
                 _context.RemoveMetadataReference(fullPath);
                 bool removed = _paths.Remove(fullPath);
                 Assumes.True(removed);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
@@ -2,6 +2,7 @@
 
 using System;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Logging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
@@ -19,10 +20,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             _context = context;
         }
 
-        public void Handle(IComparable version, IProjectChangeDescription projectChange, bool isActiveContext)
+        public void Handle(IComparable version, IProjectChangeDescription projectChange, bool isActiveContext, IProjectLogger logger)
         {
             Requires.NotNull(version, nameof(version));
             Requires.NotNull(projectChange, nameof(projectChange));
+            Requires.NotNull(logger, nameof(logger));
 
             if (projectChange.Difference.ChangedProperties.Contains(ConfigurationGeneral.ProjectGuidProperty))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
@@ -30,6 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             {
                 if (Guid.TryParse(projectChange.After.Properties[ConfigurationGeneral.ProjectGuidProperty], out Guid result))
                 {
+                    logger.WriteLine("ProjectGuid: {0}", result);
                     _context.Guid = result;
                 }
             }
@@ -46,6 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
                 var newBinOutputPath = projectChange.After.Properties[ConfigurationGeneral.TargetPathProperty];
                 if (!string.IsNullOrEmpty(newBinOutputPath))
                 {
+                    logger.WriteLine("BinOutputPath: {0}", newBinOutputPath);
                     _context.BinOutputPath = newBinOutputPath;
                 }
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Logging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
@@ -28,19 +29,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             _context = context;
         }
 
-        public void Handle(IComparable version, IProjectChangeDescription projectChange, bool isActiveContext)
+        public void Handle(IComparable version, IProjectChangeDescription projectChange, bool isActiveContext, IProjectLogger logger)
         {
             Requires.NotNull(version, nameof(version));
             Requires.NotNull(projectChange, nameof(projectChange));
+            Requires.NotNull(logger, nameof(logger));
 
             ApplyEvaluationChanges(version, projectChange.Difference, projectChange.After.Items, isActiveContext);
         }
 
-        public void Handle(IComparable version, BuildOptions added, BuildOptions removed, bool isActiveContext)
+        public void Handle(IComparable version, BuildOptions added, BuildOptions removed, bool isActiveContext, IProjectLogger logger)
         {
             Requires.NotNull(version, nameof(version));
             Requires.NotNull(added, nameof(added));
             Requires.NotNull(removed, nameof(removed));
+            Requires.NotNull(logger, nameof(logger));
 
             IProjectChangeDiff difference = ConvertToProjectDiff(added, removed);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Requires.NotNull(projectChange, nameof(projectChange));
             Requires.NotNull(logger, nameof(logger));
 
-            ApplyEvaluationChanges(version, projectChange.Difference, projectChange.After.Items, isActiveContext);
+            ApplyEvaluationChanges(version, projectChange.Difference, projectChange.After.Items, isActiveContext, logger);
         }
 
         public void Handle(IComparable version, BuildOptions added, BuildOptions removed, bool isActiveContext, IProjectLogger logger)
@@ -47,18 +47,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             IProjectChangeDiff difference = ConvertToProjectDiff(added, removed);
 
-            ApplyDesignTimeChanges(version, difference, isActiveContext);
+            ApplyDesignTimeChanges(version, difference, isActiveContext, logger);
         }
 
-        protected override void AddToContext(string fullPath, IImmutableDictionary<string, string> metadata, bool isActiveContext)
+        protected override void AddToContext(string fullPath, IImmutableDictionary<string, string> metadata, bool isActiveContext, IProjectLogger logger)
         {
             string[] folderNames = GetFolderNames(fullPath, metadata);
 
+            logger.WriteLine("Adding source file '{0}'", fullPath);
             _context.AddSourceFile(fullPath, isInCurrentContext: isActiveContext, folderNames: folderNames);
         }
 
-        protected override void RemoveFromContext(string fullPath)
+        protected override void RemoveFromContext(string fullPath, IProjectLogger logger)
         {
+            logger.WriteLine("Removing source file '{0}'", fullPath);
             _context.RemoveSourceFile(fullPath);
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ICommandLineHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ICommandLineHandler.cs
@@ -2,6 +2,7 @@
 
 using System;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Logging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
@@ -29,13 +30,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ///     <see langword="true"/> if the underlying <see cref="IWorkspaceProjectContext"/>
         ///     is the active context; otherwise, <see langword="false"/>.
         /// </param>
+        /// <param name="logger">
+        ///     The <see cref="IProjectLogger"/> for logging to the log.
+        /// </param>
         /// <exception cref="ArgumentNullException">
+        ///     <paramref name="version"/> is <see langword="null"/>.
+        ///     <para>
+        ///         -or-
+        ///     </para>
         ///     <paramref name="added"/> is <see langword="null"/>.
         ///     <para>
         ///         -or-
         ///     </para>
         ///     <paramref name="removed"/> is <see langword="null"/>.
+        ///     <para>
+        ///         -or-
+        ///     </para>
+        ///     <paramref name="logger"/> is <see langword="null"/>.
         /// </exception>
-        void Handle(IComparable version, BuildOptions added, BuildOptions removed, bool isActiveContext);
+        void Handle(IComparable version, BuildOptions added, BuildOptions removed, bool isActiveContext, IProjectLogger logger);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IEvaluationHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IEvaluationHandler.cs
@@ -2,6 +2,7 @@
 
 using System;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Logging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
@@ -27,9 +28,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ///     <see langword="true"/> if the underlying <see cref="IWorkspaceProjectContext"/>
         ///     is the active context; otherwise, <see langword="false"/>.
         /// </param>
+        /// <param name="logger">
+        ///     The <see cref="IProjectLogger"/> for logging to the log.
+        /// </param>
         /// <exception cref="ArgumentNullException">
+        ///     <paramref name="version"/> is <see langword="null"/>.
+        ///     <para>
+        ///         -or-
+        ///     </para>
         ///     <paramref name="projectChange"/> is <see langword="null"/>.
+        ///     <para>
+        ///         -or-
+        ///     </para>
+        ///     <paramref name="logger"/> is <see langword="null"/>.
         /// </exception>
-        void Handle(IComparable version, IProjectChangeDescription projectChange, bool isActiveContext);
+        void Handle(IComparable version, IProjectChangeDescription projectChange, bool isActiveContext, IProjectLogger logger);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHandlerManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHandlerManager.cs
@@ -189,6 +189,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         private void WriteFooter(IProjectLoggerBatch logger, IProjectVersionedValue<IProjectSubscriptionUpdate> update)
         {
             logger.IndentLevel--;
+            logger.WriteLine();
             logger.WriteLine("Finished language service changes for '{0}' [{1}]", _project.FullPath, update.Value.ProjectConfiguration.Name);
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHandlerManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHandlerManager.cs
@@ -12,6 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     [Export]
     internal class LanguageServiceHandlerManager
     {
+        private readonly UnconfiguredProject _project;
         private readonly ICommandLineParserService _commandLineParser;
         private readonly IContextHandlerProvider _handlerProvider;
         private readonly IProjectLogger _logger;
@@ -24,6 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             Requires.NotNull(handlerProvider, nameof(handlerProvider));
             Requires.NotNull(logger, nameof(logger));
 
+            _project = project;
             _commandLineParser = commandLineParser;
             _handlerProvider = handlerProvider;
             _logger = logger;
@@ -48,18 +50,32 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         {
             ImmutableArray<(IEvaluationHandler Value, string EvaluationRuleName)> handlers = _handlerProvider.GetEvaluationHandlers(context);
 
+            IComparable version = update.DataSourceVersions[ProjectDataSources.ConfiguredProjectVersion];
+
             using (IProjectLoggerBatch logger = _logger.BeginBatch())
             {
-                IComparable version = update.DataSourceVersions[ProjectDataSources.ConfiguredProjectVersion];
+                WriteHeader(logger, update, version, RuleHandlerType.Evaluation, isActiveContext);
 
                 foreach (var handler in handlers)
                 {
-                    IProjectChangeDescription projectChange = update.Value.ProjectChanges[handler.EvaluationRuleName];
+                    string ruleName = handler.EvaluationRuleName;
+
+                    WriteRuleHeader(logger, ruleName);
+                    
+                    IProjectChangeDescription projectChange = update.Value.ProjectChanges[ruleName];
                     if (projectChange.Difference.AnyChanges)
                     {
                         handler.Value.Handle(version, projectChange, isActiveContext, logger);
                     }
+                    else
+                    {
+                        WriteRuleHasNoChanges(logger);
+                    }
+
+                    WriteRuleFooter(logger, ruleName);
                 }
+
+                WriteFooter(logger, update);
             }
         }
 
@@ -67,18 +83,31 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         {
             Assumes.False(update.Value.ProjectChanges.Count == 0, "CPS should never send us an empty design-time build data.");
 
+            IComparable version = update.DataSourceVersions[ProjectDataSources.ConfiguredProjectVersion];
+
             using (IProjectLoggerBatch logger = _logger.BeginBatch())
             {
-                IProjectChangeDescription projectChange = update.Value.ProjectChanges[CompilerCommandLineArgs.SchemaName];
-                IComparable version = update.DataSourceVersions[ProjectDataSources.ConfiguredProjectVersion];
+                string ruleName = CompilerCommandLineArgs.SchemaName;
+
+                WriteHeader(logger, update, version, RuleHandlerType.DesignTimeBuild, isActiveContext);
+                WriteRuleHeader(logger, ruleName);
+
+                IProjectChangeDescription projectChange = update.Value.ProjectChanges[ruleName];
 
                 // If nothing changed (even another failed design-time build), don't do anything
                 if (projectChange.Difference.AnyChanges)
                 {
-                    ProcessDesignTimeBuildFailure(projectChange, context);
-                    ProcessOptions(projectChange, context);
+                    ProcessDesignTimeBuildFailure(projectChange, context, logger);
+                    ProcessOptions(projectChange, context, logger);
                     ProcessItems(version, projectChange, context, isActiveContext, logger);
                 }
+                else
+                {
+                    WriteRuleHasNoChanges(logger);
+                }
+
+                WriteRuleFooter(logger, ruleName);
+                WriteFooter(logger, update);
             }
         }
 
@@ -108,7 +137,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             return new string[] { CompilerCommandLineArgs.SchemaName };
         }
 
-        private void ProcessDesignTimeBuildFailure(IProjectChangeDescription projectChange, IWorkspaceProjectContext context)
+        private void ProcessDesignTimeBuildFailure(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, IProjectLogger logger)
         {
             // If 'CompileDesignTime' didn't run due to a preceeding failed target, or a failure in itself, CPS will send us an empty IProjectChangeDescription
             // that represents as if 'CompileDesignTime' ran but returned zero results.
@@ -116,14 +145,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             // We still forward those 'removes' of references, sources, etc onto Roslyn to avoid duplicate/incorrect results when the next
             // successful build occurs, because it will be diff between it and this failed build.
 
-            context.LastDesignTimeBuildSucceeded = projectChange.After.Items.Count > 0;
+            bool succeeded = projectChange.After.Items.Count > 0;
+
+            if (context.LastDesignTimeBuildSucceeded != succeeded)
+            {
+                WriteDesignTimeBuildSuccess(logger, succeeded);
+                context.LastDesignTimeBuildSucceeded = succeeded;
+            }
         }
 
-        private static void ProcessOptions(IProjectChangeDescription projectChange, IWorkspaceProjectContext context)
+        private static void ProcessOptions(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, IProjectLogger logger)
         {
             // We don't pass differences to Roslyn for options, we just pass them all
-            IEnumerable<string> commandlineArguments = projectChange.After.Items.Keys;
-            context.SetOptions(string.Join(" ", commandlineArguments));
+            string commandlineArguments = string.Join(" ", projectChange.After.Items.Keys);
+
+            WriteCommandLineArguments(logger, commandlineArguments);
+            context.SetOptions(commandlineArguments);
         }
 
         private void ProcessItems(IComparable version, IProjectChangeDescription projectChange, IWorkspaceProjectContext context, bool isActiveContext, IProjectLogger logger)
@@ -137,6 +174,56 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             {
                 handler.Handle(version, addedItems, removedItems, isActiveContext, logger);
             }
+        }
+
+        private void WriteHeader(IProjectLoggerBatch logger, IProjectVersionedValue<IProjectSubscriptionUpdate> update, IComparable version, RuleHandlerType source, bool isActiveContext)
+        {
+            logger.WriteLine();
+            logger.WriteLine("Processing language service changes for '{0}' [{1}]...", _project.FullPath, update.Value.ProjectConfiguration.Name);
+            logger.WriteLine("Version:         {0}", version);
+            logger.WriteLine("Source:          {0}", source);
+            logger.WriteLine("IsActiveContext: {0}", isActiveContext);
+            logger.IndentLevel++;
+        }
+
+        private void WriteFooter(IProjectLoggerBatch logger, IProjectVersionedValue<IProjectSubscriptionUpdate> update)
+        {
+            logger.IndentLevel--;
+            logger.WriteLine("Finished language service changes for '{0}' [{1}]", _project.FullPath, update.Value.ProjectConfiguration.Name);
+        }
+
+        private static void WriteRuleHeader(IProjectLoggerBatch logger, string ruleName)
+        {
+            logger.WriteLine();
+            logger.WriteLine("Processing rule '{0}'...", ruleName);
+            logger.IndentLevel++;
+        }
+
+        private static void WriteRuleFooter(IProjectLoggerBatch logger, string ruleName)
+        {
+            logger.IndentLevel--;
+        }
+
+        private static void WriteRuleHasNoChanges(IProjectLoggerBatch logger)
+        {
+            logger.WriteLine("No changes.");
+        }
+
+        private static void WriteDesignTimeBuildSuccess(IProjectLogger logger, bool succeeded)
+        {
+            if (succeeded)
+            {
+                logger.WriteLine("Last design-time build suceeeded, turning semantic errors back on.");
+            }
+            else
+            {
+                logger.WriteLine("Last design-time build failed, turning semantic errors off.");
+            }
+        }
+
+        private static void WriteCommandLineArguments(IProjectLogger logger, string commandLineArguments)
+        {
+            logger.WriteLine("Options: {0}", commandLineArguments);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/ProjectLoggerExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/ProjectLoggerExtensions.cs
@@ -25,6 +25,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.Logging
 
         /// <summary>
         ///     If <see cref="IProjectLogger.IsEnabled"/> is <see langword="true"/>,
+        ///     writes the current line terminator to the log.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="logger"/> is <see langword="null"/>
+        /// </exception>
+        public static void WriteLine(this IProjectLogger logger)
+        {
+            Requires.NotNull(logger, nameof(logger));
+
+            logger.WriteLine(new StringFormat(string.Empty));
+        }
+
+        /// <summary>
+        ///     If <see cref="IProjectLogger.IsEnabled"/> is <see langword="true"/>,
         ///     writes the specified text, followed by the current line terminator,
         ///     to the log.
         /// </summary>


### PR DESCRIPTION
Added logging to the language service. With logging turned on we fire up a "project" category, and log something like the following for evaluation/design-time builds:

```
Processing language service changes for 'C:\Users\davkean\Source\Repos\ConsoleApp27\ConsoleApp27\ConsoleApp27.csproj' [Debug|AnyCPU]...
Version:         0
Source:          DesignTimeBuild
IsActiveContext: True
    
    Processing rule 'CompilerCommandLineArgs'...
        Last design-time build suceeeded, turning semantic errors back on.
        Options: /reference:C:\Users\davkean\.nuget\packages\system.buffers\4.3.0\lib\netstandard1.1\System.Buffers.dll /warn:4 /reference:C:\Users\davkean\.nuget\packages\system.runtime.interopservices.runtimeinformation\4.3.0\ref\netstandard1.1\System.Runtime.InteropServices.RuntimeInformation.dll /warnaserror- /analyzer:C:\Users\davkean\.nuget\packages\microsoft.codeanalysis.analyzers\1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll /reference:C:\Users\davkean\.nuget\packages\system.text.regularexpressions\4.3.0\ref\netcoreapp1.1\System.Text.RegularExpressions.dll /errorreport:prompt /reference:C:\Users\davkean\.nuget\packages\system.dynamic.runtime\4.3.0\ref\netstandard1.3\System.Dynamic.Runtime.dll /reference:C:\Users\davkean\.nuget\packages\system.xml.readerwriter\4.3.0\ref\netstandard1.3\System.Xml.ReaderWriter.dll /reference:C:\Users\davkean\.nuget\packages\system.collections.immutable\1.3.0\lib\netstandard1.0\System.Collections.Immutable.dll /reference:C:\Users\davkean\.nuget\packages\system.collections\4.3.0\ref\netstandard1.3\System.Collections.dll /reference:C:\Users\davkean\.nuget\packages\system.security.cryptography.primitives\4.3.0\ref\netstandard1.3\System.Security.Cryptography.Primitives.dll /debug:portable /reference:C:\Users\davkean\.nuget\packages\system.io.unmanagedmemorystream\4.3.0\ref\netstandard1.3\System.IO.UnmanagedMemoryStream.dll obj\Debug\netcoreapp1.1\ConsoleApp27.AssemblyInfo.cs /reference:C:\Users\davkean\.nuget\packages\system.appcontext\4.3.0\ref\netstandard1.6\System.AppContext.dll /reference:C:\Users\davkean\.nuget\packages\system.io.compression.zipfile\4.3.0\ref\netstandard1.3\System.IO.Compression.ZipFile.dll /nowarn:1701,1702,1705,2008 /reference:C:\Users\davkean\.nuget\packages\system.runtime.extensions\4.3.0\ref\netstandard1.5\System.Runtime.Extensions.dll /reference:C:\Users\davkean\.nuget\packages\system.reflection.typeextensions\4.3.0\ref\netstandard1.5\System.Reflection.TypeExtensions.dll /reference:C:\Users\davkean\.nuget\packages\system.linq.expressions\4.3.0\ref\netstandard1.6\System.Linq.Expressions.dll /reference:C:\Users\davkean\.nuget\packages\system.collections.concurrent\4.3.0\ref\netstandard1.3\System.Collections.Concurrent.dll obj\Debug\netcoreapp1.1\\TemporaryGeneratedFile_5937a670-0e60-4077-877b-f7221da3dda1.cs /reference:C:\Users\davkean\.nuget\packages\system.resources.reader\4.3.0\lib\netstandard1.0\System.Resources.Reader.dll /reference:C:\Users\davkean\.nuget\packages\system.runtime.interopservices\4.3.0\ref\netcoreapp1.1\System.Runtime.InteropServices.dll /reference:C:\Users\davkean\.nuget\packages\system.security.cryptography.algorithms\4.3.0\ref\netstandard1.6\System.Security.Cryptography.Algorithms.dll /reference:C:\Users\davkean\.nuget\packages\system.io.filesystem.primitives\4.3.0\ref\netstandard1.3\System.IO.FileSystem.Primitives.dll /reference:C:\Users\davkean\.nuget\packages\system.threading.tasks.parallel\4.3.0\ref\netstandard1.1\System.Threading.Tasks.Parallel.dll /reference:C:\Users\davkean\.nuget\packages\system.diagnostics.tracing\4.3.0\ref\netstandard1.5\System.Diagnostics.Tracing.dll /reference:C:\Users\davkean\.nuget\packages\system.numerics.vectors\4.3.0\ref\netstandard1.0\System.Numerics.Vectors.dll /define:TRACE;DEBUG;NETCOREAPP1_1 /reference:C:\Users\davkean\.nuget\packages\system.reflection.dispatchproxy\4.3.0\ref\netstandard1.3\System.Reflection.DispatchProxy.dll /reference:C:\Users\davkean\.nuget\packages\system.net.requests\4.3.0\ref\netstandard1.3\System.Net.Requests.dll
        Adding source file 'C:\Users\davkean\Source\Repos\ConsoleApp27\ConsoleApp27\obj\Debug\netcoreapp1.1\ConsoleApp27.AssemblyInfo.cs'
        Adding source file 'C:\Users\davkean\Source\Repos\ConsoleApp27\ConsoleApp27\obj\Debug\netcoreapp1.1\TemporaryGeneratedFile_036C0B5B-1481-4323-8D20-8F5ADCB23D92.cs'
        Adding source file 'C:\Users\davkean\AppData\Local\Temp\.NETCoreApp,Version=v1.1.AssemblyAttributes.cs'
        Adding source file 'C:\Users\davkean\Source\Repos\ConsoleApp27\ConsoleApp27\obj\Debug\netcoreapp1.1\TemporaryGeneratedFile_E7A71F73-0F8D-4B9B-B56E-8E70B10BC5D3.cs'
        Adding source file 'C:\Users\davkean\Source\Repos\ConsoleApp27\ConsoleApp27\obj\Debug\netcoreapp1.1\TemporaryGeneratedFile_5937a670-0e60-4077-877b-f7221da3dda1.cs'
        Adding reference 'C:\Users\davkean\.nuget\packages\system.collections\4.3.0\ref\netstandard1.3\System.Collections.dll'
        Adding reference 'C:\Users\davkean\.nuget\packages\system.globalization.calendars\4.3.0\ref\netstandard1.3\System.Globalization.Calendars.dll'
        Adding reference 'C:\Users\davkean\.nuget\packages\system.io.compression.zipfile\4.3.0\ref\netstandard1.3\System.IO.Compression.ZipFile.dll'
        Adding reference 'C:\Users\davkean\.nuget\packages\system.xml.xdocument\4.3.0\ref\netstandard1.3\System.Xml.XDocument.dll'
        Adding reference 'C:\Users\davkean\.nuget\packages\system.io.filesystem.watcher\4.3.0\ref\netstandard1.3\System.IO.FileSystem.Watcher.dll'
        Adding reference 'C:\Users\davkean\.nuget\packages\system.runtime.numerics\4.3.0\ref\netstandard1.1\System.Runtime.Numerics.dll'
        Adding reference 'C:\Users\davkean\.nuget\packages\microsoft.visualbasic\10.1.0\ref\netstandard1.1\Microsoft.VisualBasic.dll'
        Adding reference 'C:\Users\davkean\.nuget\packages\system.io.unmanagedmemorystream\4.3.0\ref\netstandard1.3\System.IO.UnmanagedMemoryStream.dll'
        Adding analyzer 'C:\Users\davkean\.nuget\packages\microsoft.codeanalysis.analyzers\1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll'
        Adding analyzer 'C:\Users\davkean\.nuget\packages\microsoft.codeanalysis.analyzers\1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll'

Finished language service changes for 'C:\Users\davkean\Source\Repos\ConsoleApp27\ConsoleApp27\ConsoleApp27.csproj' [Debug|AnyCPU]
```