### PR TITLE
Pass AssetTargetFallback during nomination

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -58,6 +58,10 @@
                     Visible="False" 
                     ReadOnly="True" />
 
+    <StringProperty Name="AssetTargetFallback" 
+                    Visible="False" 
+                    ReadOnly="True" />
+
     <StringProperty Name="RuntimeIdentifier" 
                     Visible="False" 
                     ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/NuGetRestore.xaml
@@ -38,6 +38,7 @@
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
+  <StringProperty Name="AssetTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageId" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/NuGetRestore.xaml
@@ -38,6 +38,7 @@
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
+  <StringProperty Name="AssetTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageId" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/NuGetRestore.xaml
@@ -38,6 +38,7 @@
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
+  <StringProperty Name="AssetTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageId" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/NuGetRestore.xaml
@@ -38,6 +38,7 @@
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
+  <StringProperty Name="AssetTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageId" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/NuGetRestore.xaml
@@ -38,6 +38,7 @@
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
+  <StringProperty Name="AssetTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageId" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/NuGetRestore.xaml
@@ -38,6 +38,7 @@
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
+  <StringProperty Name="AssetTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageId" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/NuGetRestore.xaml
@@ -38,6 +38,7 @@
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
+  <StringProperty Name="AssetTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageId" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/NuGetRestore.xaml
@@ -38,6 +38,7 @@
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
+  <StringProperty Name="AssetTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageId" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/NuGetRestore.xaml
@@ -38,6 +38,7 @@
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
+  <StringProperty Name="AssetTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageId" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/NuGetRestore.xaml
@@ -38,6 +38,7 @@
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
+  <StringProperty Name="AssetTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageId" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/NuGetRestore.xaml
@@ -38,6 +38,7 @@
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
+  <StringProperty Name="AssetTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageId" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/NuGetRestore.xaml
@@ -38,6 +38,7 @@
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
+  <StringProperty Name="AssetTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageId" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/NuGetRestore.xaml
@@ -38,6 +38,7 @@
   <StringProperty Name="MSBuildProjectDirectory" Visible="False" ReadOnly="True" />
   <StringProperty Name="MSBuildProjectFile" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageTargetFallback" Visible="False" ReadOnly="True" />
+  <StringProperty Name="AssetTargetFallback" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifier" Visible="False" ReadOnly="True" />
   <StringProperty Name="RuntimeIdentifiers" Visible="False" ReadOnly="True" />
   <StringProperty Name="PackageId" Visible="False" ReadOnly="True" />


### PR DESCRIPTION

**Customer scenario**

Another property for NuGet, AssetTargetFallback,  is the successor for PackageTargetFallback and will be used by the SDK to allow compatibility with net461 for netcoreapp2.0

**Bugs this fixes:** 

#2363 

**Workarounds, if any**

N/A

**Risk**

Low

**Is this a regression from a previous update?**

No 

/cc @dotnet/project-system 
/cc @emgarten
