### PR TITLE
Fail fast up to date check if items changed

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/BuildUpToDateCheck.cs
@@ -120,9 +120,10 @@ namespace Microsoft.VisualStudio.ProjectSystem
             _msBuildProjectFullPath = e.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildProjectFullPathProperty, _msBuildProjectFullPath);
             foreach (var referenceSchema in ReferenceSchemas)
             {
-                if (e.CurrentState.TryGetValue(referenceSchema, out var snapshot))
+                if (e.ProjectChanges.TryGetValue(referenceSchema, out var changes) &&
+                    changes.Difference.AnyChanges)
                 {
-                    _references[referenceSchema] = new HashSet<string>(snapshot.Items.Select(item => item.Value[ResolvedPath]));
+                    _references[referenceSchema] = new HashSet<string>(changes.After.Items.Select(item => item.Value[ResolvedPath]));
                 }
             }
         }


### PR DESCRIPTION
**Customer scenario**

A user adds or removes files from a .NET Core project that uses globs. The project system thinks the project is up to date and doesn't build it when the user requests a build.

**Bugs this fixes:** 

#2347 

**Workarounds, if any**

User would have to manually touch the project file to make it out of date.

**Risk**

Low, only affects the bug scenario.

**Performance impact**

Low, doesn't change the amount of work we're doing for up to date checks.

**Is this a regression from a previous update?**

No

**How was the bug found?**

Ad hoc testing