### PR TITLE
Avoid doing work after project has unloaded

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
@@ -195,7 +195,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             {
                 try
                 {
-                    await _projectServices.Project.Services.ProjectAsynchronousTasks.LoadedProjectAsync(async () =>
+                    await _projectServices.Project.Services.ProjectAsynchronousTasks.LoadedProjectAvoidingUnnecessaryWorkAsync(async () =>
                     {
                         using (var access = await _projectLockService.WriteLockAsync())
                         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetRuleSubscriberBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetRuleSubscriberBase.cs
@@ -173,13 +173,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
                 return;
             }
 
-            await _tasksService.LoadedProjectAsync(async () =>
+            await _tasksService.LoadedProjectAvoidingUnnecessaryWorkAsync(async () =>
             {
-                if (_tasksService.UnloadCancellationToken.IsCancellationRequested)
-                {
-                    return;
-                }
-
                 await HandleAsync(e, handlerType).ConfigureAwait(false);
             });
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
@@ -119,13 +119,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             await InitializeAsync().ConfigureAwait(false);
 
             
-            await _tasksService.LoadedProjectAsync(async () =>
+            await _tasksService.LoadedProjectAvoidingUnnecessaryWorkAsync(async () =>
             {
-                if (_tasksService.UnloadCancellationToken.IsCancellationRequested)
-                {
-                    return;
-                }
-
                 await HandleAsync(e).ConfigureAwait(false);
             });
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -104,7 +104,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             if (IsDisposing || IsDisposed)
                 return;
 
-            await _tasksService.LoadedProjectAsync(async () =>
+            await _tasksService.LoadedProjectAvoidingUnnecessaryWorkAsync(async () =>
             {
                 await HandleAsync(e, handlerType).ConfigureAwait(false);
             });

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectAsynchronousTasksServiceExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectAsynchronousTasksServiceExtensions.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    /// <summary>
+    ///     Provides extension methods for <see cref="IProjectAsynchronousTasksService"/> instances.
+    /// </summary>
+    internal static class ProjectAsynchronousTasksServiceExtensions
+    {
+        /// <summary>
+        ///     Provides protection for the specified action that the project will not close before it has completed.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="asyncTaskService"/> is <see langword="null"/>.
+        ///     <para>
+        ///         -or-
+        ///     </para>
+        ///     <paramref name="action"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">
+        ///     Thrown if the project was already unloaded before this method was invoked.
+        /// </exception>
+        /// <remarks>
+        ///     This method differs from the <see cref="CommonProjectSystemTools.LoadedProjectAsync(IProjectAsynchronousTasksService, Func{Task}, bool)"/> 
+        ///     method, in that if the project is in the process of being unloaded by the time the action is executed, then it bails earlier by throwing 
+        ///     <see cref="OperationCanceledException"/>.
+        /// </remarks>
+        public static JoinableTask LoadedProjectAvoidingUnnecessaryWorkAsync(this IProjectAsynchronousTasksService asyncTaskService, Func<Task> action)
+        {
+            Requires.NotNull(asyncTaskService, nameof(asyncTaskService));
+            Requires.NotNull(action, nameof(action));
+
+            return asyncTaskService.LoadedProjectAsync(() => {
+
+                asyncTaskService.UnloadCancellationToken.ThrowIfCancellationRequested();
+
+                return action();
+            });
+        }
+    }
+}


### PR DESCRIPTION
If the project has already begun unloading by the time we're called back, avoid doing any work that isn't absolutely necessary for Close.

In reviewing https://github.com/dotnet/project-system/issues/2377, I can see that we're doing work during Close that can be bailed early if we're already unloaded by the time we're called back. Note that this doesn't fix the deadlock - as it can still occur if we start unloading after we've done the initial check.

