### PR TITLE
	Remove JoinableTaskFactory.Run usage in GetRule

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/MockIDependenciesTreeServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/MockIDependenciesTreeServices.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
@@ -54,11 +55,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             };
         }
 
-        public IRule GetRule(IDependency dependency, IProjectCatalogSnapshot catalogs)
+        public Task<IRule> GetRuleAsync(IDependency dependency, IProjectCatalogSnapshot catalogs)
         {
             var mockRule = new Mock<IRule>(MockBehavior.Strict);
             mockRule.Setup(x => x.Name).Returns(dependency.SchemaItemType);
-            return mockRule.Object;
+            return Task.FromResult(mockRule.Object);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/GroupedByTargetTreeViewProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/GroupedByTargetTreeViewProviderTests.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
@@ -14,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     public class GroupedByTargetTreeViewProviderTests
     {
         [Fact]
-        public void GrouppedByTargetTreeViewProvider_WhenEmptySnapshot_ShouldJustUpdateDependencyRootNode()
+        public async Task GrouppedByTargetTreeViewProvider_WhenEmptySnapshot_ShouldJustUpdateDependencyRootNode()
         {
             // Arrange
             var treeServices = new MockIDependenciesTreeServices();
@@ -32,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             // Act
             var provider = new GroupedByTargetTreeViewProvider(treeServices, treeViewModelFactory, commonServices);
-            var resultTree = provider.BuildTree(dependenciesRoot, snapshot);
+            var resultTree = await provider.BuildTreeAsync(dependenciesRoot, snapshot);
 
             // Assert
             var expectedFlatHierarchy =
@@ -44,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void GrouppedByTargetTreeViewProvider_WhenOneTargetSnapshotWithExistingDependencies_ShouldApplyChanges()
+        public async Task GrouppedByTargetTreeViewProvider_WhenOneTargetSnapshotWithExistingDependencies_ShouldApplyChanges()
         {
             var tfm1 = ITargetFrameworkFactory.Implement(moniker: "tfm1");
             var dependencyRootXxx = IDependencyFactory.FromJson(@"
@@ -150,7 +151,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 commonServices);
 
             // Act
-            var resultTree = provider.BuildTree(dependenciesRoot, GetSnapshot(testData));
+            var resultTree = await provider.BuildTreeAsync(dependenciesRoot, GetSnapshot(testData));
 
             // Assert            
             var expectedFlatHierarchy =
@@ -165,7 +166,7 @@ Caption=Dependency1, FilePath=tfm1\Xxx\dependencyXxxpath, IconHash=325249260, Ex
         }
 
         [Fact]
-        public void GrouppedByTargetTreeViewProvider_WhenOneTargetSnapshotAndDependencySupportsHierarchyAndIsResolved_ShouldReadd()
+        public async Task GrouppedByTargetTreeViewProvider_WhenOneTargetSnapshotAndDependencySupportsHierarchyAndIsResolved_ShouldReadd()
         {
             var tfm1 = ITargetFrameworkFactory.Implement(moniker: "tfm1");
             var dependencyRootYyy = IDependencyFactory.FromJson(@"
@@ -236,7 +237,7 @@ Caption=Dependency1, FilePath=tfm1\Xxx\dependencyXxxpath, IconHash=325249260, Ex
                 commonServices);
 
             // Act
-            var resultTree = provider.BuildTree(dependenciesRoot, GetSnapshot(testData));
+            var resultTree = await provider.BuildTreeAsync(dependenciesRoot, GetSnapshot(testData));
 
             // Assert            
             var expectedFlatHierarchy =
@@ -248,7 +249,7 @@ Caption=DependencyExisting, FilePath=tfm1\Yyy\dependencyExistingpath, IconHash=3
         }
 
         [Fact]
-        public void GrouppedByTargetTreeViewProvider_WhenOneTargetSnapshotAndDependencySupportsHierarchyAndIsUnresolved_ShouldReadd()
+        public async Task GrouppedByTargetTreeViewProvider_WhenOneTargetSnapshotAndDependencySupportsHierarchyAndIsUnresolved_ShouldReadd()
         {
             var dependencyRootYyy = IDependencyFactory.FromJson(@"
 {
@@ -318,7 +319,7 @@ Caption=DependencyExisting, FilePath=tfm1\Yyy\dependencyExistingpath, IconHash=3
                 commonServices);
 
             // Act
-            var resultTree = provider.BuildTree(dependenciesRoot, GetSnapshot(testData));
+            var resultTree = await provider.BuildTreeAsync(dependenciesRoot, GetSnapshot(testData));
 
             // Assert            
             var expectedFlatHierarchy =
@@ -330,7 +331,7 @@ Caption=DependencyExisting, FilePath=tfm1\yyy\dependencyExisting, IconHash=32524
         }
 
         [Fact]
-        public void GrouppedByTargetTreeViewProvider_WhenOneTargetSnapshotAndDependencySupportsRule_ShouldCreateRule()
+        public async Task GrouppedByTargetTreeViewProvider_WhenOneTargetSnapshotAndDependencySupportsRule_ShouldCreateRule()
         {
             var dependencyRootYyy = IDependencyFactory.FromJson(@"
 {
@@ -397,7 +398,7 @@ Caption=DependencyExisting, FilePath=tfm1\yyy\dependencyExisting, IconHash=32524
                 commonServices);
 
             // Act
-            var resultTree = provider.BuildTree(dependenciesRoot, GetSnapshot(testData));
+            var resultTree = await provider.BuildTreeAsync(dependenciesRoot, GetSnapshot(testData));
 
             // Assert            
             var expectedFlatHierarchy =
@@ -409,7 +410,7 @@ Caption=DependencyExisting, FilePath=tfm1\yyy\dependencyExisting, IconHash=32524
         }
 
         [Fact]
-        public void GrouppedByTargetTreeViewProvider_WheEmptySnapshotAndVisibilityMarkerProvided_ShouldDisplaySubTreeRoot()
+        public async Task GrouppedByTargetTreeViewProvider_WheEmptySnapshotAndVisibilityMarkerProvided_ShouldDisplaySubTreeRoot()
         {
             var dependencyRootYyy = IDependencyFactory.FromJson(@"
 {
@@ -466,7 +467,7 @@ Caption=DependencyExisting, FilePath=tfm1\yyy\dependencyExisting, IconHash=32524
                 commonServices);
 
             // Act
-            var resultTree = provider.BuildTree(dependenciesRoot, GetSnapshot(testData));
+            var resultTree = await provider.BuildTreeAsync(dependenciesRoot, GetSnapshot(testData));
 
             // Assert            
             var expectedFlatHierarchy =
@@ -477,7 +478,7 @@ Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconH
         }
 
         [Fact]
-        public void GrouppedByTargetTreeViewProvider_WheEmptySnapshotAndVisibilityMarkerNotProvided_ShouldHideSubTreeRoot()
+        public async Task GrouppedByTargetTreeViewProvider_WheEmptySnapshotAndVisibilityMarkerNotProvided_ShouldHideSubTreeRoot()
         {
             var dependencyRootYyy = IDependencyFactory.FromJson(@"
 {
@@ -534,7 +535,7 @@ Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconH
                 commonServices);
 
             // Act
-            var resultTree = provider.BuildTree(dependenciesRoot, GetSnapshot(testData));
+            var resultTree = await provider.BuildTreeAsync(dependenciesRoot, GetSnapshot(testData));
 
             // Assert            
             var expectedFlatHierarchy =
@@ -544,7 +545,7 @@ Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconH
         }
 
         [Fact]
-        public void GrouppedByTargetTreeViewProvider_WhenMultipleTargetSnapshotsWithExistingDependencies_ShouldApplyChanges()
+        public async Task GrouppedByTargetTreeViewProvider_WhenMultipleTargetSnapshotsWithExistingDependencies_ShouldApplyChanges()
         {
             var tfm1 = ITargetFrameworkFactory.Implement(moniker: "tfm1");
             var tfm2 = ITargetFrameworkFactory.Implement(moniker: "tfm2");
@@ -697,7 +698,7 @@ Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconH
                 commonServices);
 
             // Act
-            var resultTree = provider.BuildTree(dependenciesRoot, GetSnapshot(testData));
+            var resultTree = await provider.BuildTreeAsync(dependenciesRoot, GetSnapshot(testData));
 
             // Assert            
             var expectedFlatHierarchy =

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependenciesTreeServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependenciesTreeServices.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 
@@ -59,6 +60,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// <param name="dependency"></param>
         /// <param name="catalogs"></param>
         /// <returns></returns>
-        IRule GetRule(IDependency dependency, IProjectCatalogSnapshot catalogs);
+        Task<IRule> GetRuleAsync(IDependency dependency, IProjectCatalogSnapshot catalogs);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependenciesTreeViewProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
@@ -20,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// <param name="snapshot">Current dependencies snapshot</param>
         /// <param name="cancellationToken">Cancellation token if need to stop building the view</param>
         /// <returns>New dependencies node</returns>
-        IProjectTree BuildTree(
+        Task<IProjectTree> BuildTreeAsync(
             IProjectTree dependenciesTree, 
             IDependenciesSnapshot snapshot, 
             CancellationToken cancellationToken = default(CancellationToken));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DependenciesViewModelFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DependenciesViewModelFactory.cs
@@ -32,8 +32,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 
         public IDependencyViewModel CreateRootViewModel(string providerType, bool hasUnresolvedDependency)
         {
-            var provider = GetProvider(providerType);
-            return provider.CreateRootDependencyNode().ToViewModel(hasUnresolvedDependency);
+            IProjectDependenciesSubTreeProvider provider = GetProvider(providerType);
+            IDependencyModel dependencyModel = provider.CreateRootDependencyNode();
+            return dependencyModel.ToViewModel(hasUnresolvedDependency);
         }
 
         public ImageMoniker GetDependenciesRootIcon(bool hasUnresolvedDependencies)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/TreeViewProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/TreeViewProviderBase.cs
@@ -3,6 +3,7 @@
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.ProjectSystem.References;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
@@ -26,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         private OrderPrecedenceImportCollection<IProjectTreePropertiesProvider> ProjectTreePropertiesProviders { get; set; }
 
 
-        public abstract IProjectTree BuildTree(
+        public abstract Task<IProjectTree> BuildTreeAsync(
             IProjectTree dependenciesTree, 
             IDependenciesSnapshot snapshot, 
             CancellationToken cancellationToken = default(CancellationToken));


### PR DESCRIPTION
**Customer scenario**

After installing one of the 15.3 Previews customers will start experiencing more "random" UI delays in normal VS operations including:

- Expanding nodes in Solution Explorer
- Add new and removing items to and from the tree
- Opening C# source files
- Opening XML files
- Typing
- Opening and closing the solution

**Bugs this fixes:** 

Part of the general effort of chasing down the UI delays introduced in the project system in 15.3: https://github.com/dotnet/project-system/issues/2297.

This particular case is tracked by: https://github.com/dotnet/project-system/issues/2389 and affects cross-targeting projects..

**Workarounds, if any**

None

**Risk**

Low. This simply replaces an _async -> synchronous -> async_ call with _async -> async_.

**Performance impact**

This will reduce UI delays and reduce the number of active threads (we were blocking ~20 threadpool threads due to the call)

**Is this a regression from a previous update?**

Yes, the dependency node was rewritten in 15.3.

**Root cause analysis:**

Threading is hard. Threading in VS is even harder. Here we were doing a blocking call from a ThreadPool thread that was blocked on a lock that the UI thread held, which itself was blocked on thread pool creation. This issue is discussed at length here: https://github.com/Microsoft/vs-threading/blob/v15.3/doc/threadpool_starvation.md.

We're still learning how this all works, but we're [talking about strategies (compilation errors)](https://github.com/dotnet/project-system/issues/2391) to prevent these sorts of issues in the future. They are hard to find, diagnose and write tests for.

**How was the bug found?**

Many internal reports both from ASP.NET, Roslyn, ProjectSystem itself and opening external projects (such as https://github.com/aarnott/pinvoke). 
