### PR TITLE
Adding the remaining AutomationProperties.Name attributes to the DebugPropertyPage.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
@@ -71,7 +71,8 @@
                 MinHeight="23"
                 Margin="5,6,2,7"
                 ItemsSource="{Binding Path=LaunchProfiles, Mode=OneWay}"
-                SelectedValue="{Binding Path=SelectedDebugProfile}">
+                SelectedValue="{Binding Path=SelectedDebugProfile}"
+                AutomationProperties.Name="{x:Static Member=local:PropertyPageResources.Profile}">
                 <ComboBox.IsEnabled>
                     <MultiBinding Converter="{StaticResource MultiValueBoolToBoolAnd}">
                         <Binding Path="HasProfiles" Mode="OneWay"/>
@@ -130,7 +131,8 @@
                 SelectedValue="{Binding Path=SelectedLaunchType, Mode=TwoWay}"
                 DisplayMemberPath="Name"
                 IsReadOnly="True"
-                IsEditable="False">
+                IsEditable="False"
+                AutomationProperties.Name="{x:Static Member=local:PropertyPageResources.Launch}">
             </ComboBox>
             <Label 
                 Grid.Row="2"
@@ -152,7 +154,8 @@
                 VerticalContentAlignment="Center"
                 VerticalAlignment="Center"
                 Text="{Binding Path=ExecutablePath, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                Visibility="{Binding Path=SupportsExecutable, Mode=OneWay, Converter={StaticResource visibilityConverter}}"/>
+                Visibility="{Binding Path=SupportsExecutable, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
+                AutomationProperties.Name="{x:Static Member=local:PropertyPageResources.Executable}"/>
             <Button
                 Grid.Row="2"
                 Grid.Column="2"
@@ -190,7 +193,8 @@
                 VerticalAlignment="Center"
                 Text="{Binding Path=CommandLineArguments, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 IsEnabled="{Binding Path=IsProfileSelected, Mode=OneWay}"
-                Visibility="{Binding Path=SupportsArguments, Mode=OneWay, Converter={StaticResource visibilityConverter}}" />
+                Visibility="{Binding Path=SupportsArguments, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
+                AutomationProperties.Name="{x:Static Member=local:PropertyPageResources.ApplicationArguments}"/>
             <Label 
                 Grid.Row="5"
                 x:Uid="workingDirectoryLabel"
@@ -211,7 +215,8 @@
                 Margin="5,8,2,7"
                 IsEnabled="{Binding Path=IsProfileSelected, Mode=OneWay}"
                 Visibility="{Binding Path=SupportsWorkingDirectory, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
-                MinWidth="200"/>
+                MinWidth="200"
+                AutomationProperties.Name="{x:Static Member=local:PropertyPageResources.WorkingDirectory}"/>
             <Button
                 Grid.Row="5"
                 Grid.Column="2"
@@ -250,7 +255,8 @@
                 Text="{Binding Path=LaunchPage, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                 Visibility="{Binding Path=SupportsLaunchUrl, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
                 MinWidth="200"
-                MinHeight="23">
+                MinHeight="23"
+                AutomationProperties.Name="{x:Static Member=local:PropertyPageResources.LaunchURL}">
                 <local:WatermarkTextBox.IsEnabled>
                     <MultiBinding Converter="{StaticResource MultiValueBoolToBoolAnd}">
                         <Binding Path="HasLaunchOption" Mode="OneWay"/>
@@ -292,7 +298,8 @@
                 ScrollViewer.VerticalScrollBarVisibility="Auto"
                 ScrollViewer.HorizontalScrollBarVisibility="Auto"
                 VirtualizingPanel.IsVirtualizing="False"
-                SelectionMode="Single">
+                SelectionMode="Single"
+                AutomationProperties.Name="{x:Static Member=local:PropertyPageResources.EnvironmentVariables}">
                 <DataGrid.CellStyle>
                     <Style TargetType="DataGridCell">
                         <Setter Property="Margin" Value="0,0,-1,0" />


### PR DESCRIPTION
**Customer scenario**

Visually impaired users wont be aware about the name of the element.

**Bugs this fixes:** 

https://devdiv.visualstudio.com/DevDiv/_workitems?id=408106

**Workarounds, if any**

None

**Risk**

Minimal. This just adds a new attribute which is only used by accessibility tools

**Performance impact**

None. This just adds a new attribute which is only used by accessibility tools

**Is this a regression from a previous update?**

No

**Root cause analysis:**

Known accessibility issue

**How was the bug found?**

Accessibility Tenant