### PR TITLE
Fix Hang on VS Close (Enable ProjectLoadedInHost waits to be cancelled)

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
@@ -202,7 +202,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         private async Task<AggregateCrossTargetProjectContext> CreateProjectContextAsyncCore()
         {           
             // Don't initialize until the project has been loaded into the IDE and available in Solution Explorer
-            await _asyncLoadDashboard.ProjectLoadedInHost.ConfigureAwait(false);
+            await _asyncLoadDashboard.ProjectLoadedInHostWithCancellation(_commonServices.Project).ConfigureAwait(false);
 
             return await _taskScheduler.RunAsync(TaskSchedulerPriority.UIThreadBackgroundPriority, async () => 
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/UnconfiguredProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/UnconfiguredProjectContextProvider.cs
@@ -233,7 +233,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
                 return null;
 
             // Don't initialize until the project has been loaded into the IDE and available in Solution Explorer
-            await _asyncLoadDashboard.ProjectLoadedInHost.ConfigureAwait(false);
+            await _asyncLoadDashboard.ProjectLoadedInHostWithCancellation(_commonServices.Project).ConfigureAwait(false);
 
             // TODO: https://github.com/dotnet/roslyn-project-system/issues/353
             return await _taskScheduler.RunAsync(TaskSchedulerPriority.UIThreadBackgroundPriority, async () =>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectAsyncLoadDashboardExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectAsyncLoadDashboardExtensions.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.ProjectSystem.VS;
+using Microsoft.VisualStudio.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    /// <summary>
+    /// Provides <see langword="static"/> extensions for <see cref="IProjectAsyncLoadDashboard"/> instances.
+    /// </summary>
+    internal static class ProjectAsyncLoadDashboardExtensions
+    {
+        /// <summary>
+        /// Gets a task that completes when the host recognizes that this project is loaded.
+        /// The returned task is cancelled if the project is unloaded before it completes.
+        /// This extension should be used instead of waiting on ProjectLoadedInHost directly.
+        /// </summary>
+        public static Task ProjectLoadedInHostWithCancellation(
+            this IProjectAsyncLoadDashboard dashboard, UnconfiguredProject project)
+            => dashboard.ProjectLoadedInHost.WithCancellation(
+                project.Services.ProjectAsynchronousTasks.UnloadCancellationToken);
+    }
+}


### PR DESCRIPTION
**Customer scenario**

Users may experience a hang when closing a project if the `ProjectLoadedInHost` task is still pending. This is because the Dependency node and Language service wait on this task, and it never resolves if the project is unloaded beforehand.

**Bugs this fixes:** 

[Bug 395991](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/395991) VS hung when closing solution

**Workarounds, if any**

N/A occasional hang

**Risk**

Low. The fix wraps the task in a helper that cancels the task if an Unload cancellation token is triggered

**Performance impact**

Low

**Is this a regression from a previous update?**

The instance in the language service has existed for multiple releases, however the instance in the dependency node was introduced in 15.3. The call stack in the bug refers to the dependency node.

**Root cause analysis:**

Incorrect use of an existing API. This fix introduces a new internal API to enforce correct code pattern.

**How was the bug found?**

Internal dogfooding

**Validation**

Was able to repro the hang a few times using solutions in https://github.com/dotnet/eShopOnContainers but have not reproed it with the fix applied.

/cc @dotnet/project-system 
/cc @lifengl