### PR TITLE
Fix VS becomes unresponsive opening large project

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetSubscriptionHostBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetSubscriptionHostBase.cs
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             return await ExecuteWithinLockAsync(() =>
             {
                 return Task.FromResult(_currentAggregateProjectContext);
-            });
+            }).ConfigureAwait(false);
         }
 
         public async Task<ConfiguredProject> GetConfiguredProject(ITargetFramework target)
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             return await ExecuteWithinLockAsync(() =>
             {
                 return Task.FromResult(_currentAggregateProjectContext.GetInnerConfiguredProject(target));
-            });
+            }).ConfigureAwait(false);
         }
 
         protected async Task AddInitialSubscriptionsAsync()
@@ -155,7 +155,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             var previousProjectContext = await ExecuteWithinLockAsync(() =>
             {
                 return Task.FromResult(_currentAggregateProjectContext);
-            });
+            }).ConfigureAwait(false);
 
             var newProjectContext = await UpdateProjectContextAsync().ConfigureAwait(false);
             if (previousProjectContext != newProjectContext)
@@ -227,7 +227,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
                 OnAggregateContextChanged(previousContextToDispose, _currentAggregateProjectContext);
 
                 return _currentAggregateProjectContext;
-            });
+            }).ConfigureAwait(false);
         }
 
         private async Task DisposeAggregateProjectContextAsync(AggregateCrossTargetProjectContext projectContext)
@@ -299,7 +299,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
                     {
                         await _contextProvider.Value.ReleaseProjectContextAsync(_currentAggregateProjectContext).ConfigureAwait(false);
                     }
-                });
+                }).ConfigureAwait(false);
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -128,34 +128,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             }
         }
 
-        private JoinableTask<T> ExecuteWithinLockAsync<T>(Func<Task<T>> task)
+        private Task<T> ExecuteWithinLockAsync<T>(Func<Task<T>> task)
         {
-            // We need to request the lock within a joinable task to ensure that if we are blocking the UI
-            // thread (i.e. when CPS is draining critical tasks on the UI thread and is waiting on this task),
-            // and the lock is already held by another task requesting UI thread access, we don't reach a deadlock.
-            return JoinableFactory.RunAsync(async delegate
-            {
-                using (JoinableCollection.Join())
-                using (await _gate.DisposableWaitAsync().ConfigureAwait(false))
-                {
-                    return await task().ConfigureAwait(false);
-                }
-            });
+            return _gate.ExecuteWithinLockAsync(JoinableCollection, JoinableFactory, task);
         }
 
-        private JoinableTask ExecuteWithinLockAsync(Func<Task> task)
+        private Task ExecuteWithinLockAsync(Func<Task> task)
         {
-            // We need to request the lock within a joinable task to ensure that if we are blocking the UI
-            // thread (i.e. when CPS is draining critical tasks on the UI thread and is waiting on this task),
-            // and the lock is already held by another task requesting UI thread access, we don't reach a deadlock.
-            return JoinableFactory.RunAsync(async delegate
-            {
-                using (JoinableCollection.Join())
-                using (await _gate.DisposableWaitAsync().ConfigureAwait(false))
-                {
-                    await task().ConfigureAwait(false);
-                }
-            });
+            return _gate.ExecuteWithinLockAsync(JoinableCollection, JoinableFactory, task);
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -205,7 +205,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 }
 
                 return _currentAggregateProjectContext;
-            });
+            }).ConfigureAwait(false);
         }
 
         private async Task DisposeAggregateProjectContextAsync(AggregateWorkspaceProjectContext projectContext)
@@ -267,7 +267,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 }
 
                 _languageServiceHandlerManager.Handle(update, handlerType, projectContextToUpdate, isActiveContext);
-            });
+            }).ConfigureAwait(false);
         }
         
         private bool HasTargetFrameworksChanged(IProjectVersionedValue<IProjectSubscriptionUpdate> e)
@@ -288,7 +288,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                     {
                         await _contextProvider.Value.ReleaseProjectContextAsync(_currentAggregateProjectContext).ConfigureAwait(false);
                     }
-                });
+                }).ConfigureAwait(false);
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/SemaphoreSlimExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/SemaphoreSlimExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -17,6 +18,44 @@ namespace Microsoft.VisualStudio.Threading
         {
             await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
             return new SemaphoreDisposer(semaphore);
+        }
+
+        public static async Task<T> ExecuteWithinLockAsync<T>(this SemaphoreSlim semaphore, JoinableTaskCollection collection, JoinableTaskFactory factory, Func<Task<T>> task)
+        {
+            // Join the caller to our collection, so that if the lock is already held by another task that needs UI 
+            // thread access we don't deadlock if we're also being waited on by the UI thread. For example, when CPS
+            // is draining critical tasks and is waiting us.
+            using (collection.Join())
+            {
+                using (await semaphore.DisposableWaitAsync().ConfigureAwait(false))
+                {
+                    // We do an inner JoinableTaskFactory.RunAsync here to workaround
+                    // https://github.com/Microsoft/vs-threading/issues/132
+                    JoinableTask<T> joinableTask = factory.RunAsync(task);
+
+                    return await joinableTask.Task
+                                             .ConfigureAwait(false);
+                }
+            }
+        }
+
+        public static async Task ExecuteWithinLockAsync(this SemaphoreSlim semaphore, JoinableTaskCollection collection, JoinableTaskFactory factory, Func<Task> task)
+        {
+            // Join the caller to our collection, so that if the lock is already held by another task that needs UI 
+            // thread access we don't deadlock if we're also being waited on by the UI thread. For example, when CPS
+            // is draining critical tasks and is waiting us.
+            using (collection.Join())
+            {
+                using (await semaphore.DisposableWaitAsync().ConfigureAwait(false))
+                {
+                    // We do an inner JoinableTaskFactory.RunAsync here to workaround
+                    // https://github.com/Microsoft/vs-threading/issues/132
+                    JoinableTask joinableTask = factory.RunAsync(task);
+
+                    await joinableTask.Task
+                                      .ConfigureAwait(false);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
**Customer scenario**

After installing one of the 15.3 Previews customers will start experiencing more "random" UI delays in normal VS operations including:

- Expanding nodes in Solution Explorer
- Add new and removing items to and from the tree
- Opening C# source files
- Opening XML files
- Typing
- Opening and closing the solution

**Bugs this fixes:** 

Part of the general effort of chasing down the UI delays introduced in the project system in 15.3: https://github.com/dotnet/project-system/issues/2297.

This particular issue is being tracked by: https://github.com/dotnet/project-system/issues/2383.

**Workarounds, if any**

None

**Risk**

Low.

**Performance impact**

This will reduce UI delays and reduce the number of active threads.

**Is this a regression from a previous update?**

Yes, the dependency node was rewritten in 15.3.

**Root cause analysis:**

We were hitting an [issue in JoinableTaskFactory](https://github.com/Microsoft/vs-threading/issues/132) which resulted in a bunch of threads blocked on a single thread. This pattern is unusual and is something we only hit - we felt that a change to us was less risky for 15.3 to VS than to the JoinableTaskFactory which is used by all of VS.

**How was the bug found?**

Many internal reports both from ASP.NET, Roslyn, ProjectSystem itself and opening external projects (such as https://github.com/aarnott/pinvoke). Also had external reports from MVPs.
