### PR TITLE
Add notes on testing a locally-produced SDK

### DIFF
--- a/docs/repo/debugging-tips.md
+++ b/docs/repo/debugging-tips.md
@@ -73,3 +73,13 @@ To get Windows to automatically send on data about UI delays in Visual Studio, m
 [AlwaysSendPerfWatsonData.reg](/docs/repo/content/AlwaysSendPerfWatsonData.reg?raw=true)
 
 For more information on these settings, see [Configure Windows telemetry in your organization](https://docs.microsoft.com/en-us/windows/configuration/configure-windows-telemetry-in-your-organization).
+
+## Testing SDK Changes
+
+If you're making changes to the SDK (that is, the [dotnet/sdk](https://github.com/dotnet/sdk) repo) you can easily test VS or msbuild.exe with those changes by setting the `DOTNET_MSBUILD_SDK_RESOLVER_SDKS_DIR` environment variable.
+
+After you build, find the generated Sdks directory. For example, if your repo is at D:\Projects\sdk, you'll find it at D:\Projects\sdk\bin\Debug\Sdks. Set the environment variable to point to this location:
+
+`set DOTNET_MSBUILD_SDK_RESOLVER_SDKS_DIR=D:\Projects\sdk\bin\Debug\Sdks`
+
+Now any instances of msbuild.exe or VS that inherit that setting will use your locally-produced SDK.


### PR DESCRIPTION
Add some notes on how to test a locally-produced SDK with msbuild.exe and VS. This is only a change to the repo documentation.