### PR TITLE
Remove synchronous call in DependencySubscriptionsHost

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/IDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/IDependenciesSnapshotFilter.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
         /// <param name="worldBuilder">Builder for immutable world dictionary of updating snapshot.</param>
         /// <param name="topLevelBuilder">Top level dependencies list builder of updating snapshot.</param>
         /// <param name="subTreeProviders">All known subtree providers</param>
-        /// <param name="projectItemSpecs">List of all items contained in project's xml at given moment</param>
+        /// <param name="projectItemSpecs">List of all items contained in project's xml at given moment, otherwise, <see langword="null"/> if we do not have any data.</param>
         /// <param name="filterAnyChanges">True if filter did any changes in the snapshot</param>
         /// <returns>Dependency to be added if addition is approved, null if dependency should not be added to snapshot</returns>
         IDependency BeforeAdd(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/ImplicitTopLevelDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/ImplicitTopLevelDependenciesSnapshotFilter.cs
@@ -44,6 +44,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
                 return resultDependency;
             }
 
+            if (projectItemSpecs == null)   // No data, so don't update
+                return resultDependency;
+
             if (!projectItemSpecs.Contains(resultDependency.OriginalItemSpec))
             {
                 // it is an implicit dependency

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildUtilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildUtilities.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using Microsoft.Build.Construction;
+using Microsoft.Build.Execution;
 
 namespace Microsoft.VisualStudio.Build
 {
@@ -192,6 +193,27 @@ namespace Microsoft.VisualStudio.Build
 
                 return propertyGroup.AddProperty(propertyName, string.Empty);
             }
+        }
+
+        /// <summary>
+        ///     Returns a value indicating if the specified <see cref="ProjectItemInstance"/>
+        ///     originated in an imported file.
+        /// </summary>
+        /// <returns>
+        ///     <see langword="true"/> if <paramref name="item"/> originated in an imported file;
+        ///     otherwise, <see langword="false"/> if it was defined in the project being built.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="item"/> is <see langword="null"/>.
+        /// </exception>
+        public static bool IsImported(this ProjectItemInstance item)
+        {
+            Requires.NotNull(item, nameof(item));
+
+            string definingProjectFullPath = item.GetMetadataValue("DefiningProjectFullPath");
+            string projectFullPath = item.Project.FullPath; // NOTE: This returns project being built, not owning target
+
+            return !StringComparers.Paths.Equals(definingProjectFullPath, projectFullPath);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectXmlAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectXmlAccessor.cs
@@ -41,12 +41,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
         Task ExecuteInWriteLock(Action<ProjectRootElement> action);
 
         /// <summary>
-        /// Returns a hash set of all project items contained in project's xml at given moment
-        /// </summary>
-        /// <returns></returns>
-        Task<HashSet<string>> GetProjectItems();
-
-        /// <summary>
         /// Returns a collection of items.
         /// </summary>
         /// <param name="configuredProject">The configured project.</param>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/MSBuildXmlAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/MSBuildXmlAccessor.cs
@@ -79,15 +79,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
             }
         }
 
-        public async Task<HashSet<string>> GetProjectItems()
-        {
-            using (var access = await _projectLockService.ReadLockAsync())
-            {
-                var projectXml = await access.GetProjectXmlAsync(_unconfiguredProject.FullPath).ConfigureAwait(true);
-                return new HashSet<string>(projectXml.Items.Select(x => x.Include), StringComparer.OrdinalIgnoreCase);
-            }
-        }
-
         public async Task<ICollection<(string evaluatedInclude, string metadataValue)>> GetItems(ConfiguredProject configuredProject, string itemType, string metadataName)
         {
             using (var access = await _projectLockService.ReadLockAsync())


### PR DESCRIPTION
**Customer scenario**

After installing one of the 15.3 Previews customers will start experiencing more "random" UI delays in normal VS operations including:

- Expanding nodes in Solution Explorer
- Add new and removing items to and from the tree
- Opening C# source files
- Opening XML files
- Typing
- Opening and closing the solution

**Bugs this fixes:** 

Part of the general effort of chasing down the UI delays introduced in the project system in 15.3: https://github.com/dotnet/project-system/issues/2297.

This particular bug is tracked by: 2379

**Workarounds, if any**

None

**Risk**

Low. 

**Performance impact**

This will reduce UI delays and reduce the number of active threads.

**Is this a regression from a previous update?**

Yes, the dependency node was rewritten in 15.3.

**Root cause analysis:**

Threading is hard. Threading in VS is even harder. Here we were doing a blocking call from a ThreadPool thread that was blocked on a lock that the UI thread held, which itself was blocked on thread pool creation. This issue is discussed at length here: https://github.com/Microsoft/vs-threading/blob/v15.3/doc/threadpool_starvation.md.

We're still learning how this all works, but we're [talking about strategies (compilation errors)](https://github.com/dotnet/project-system/issues/2391) to prevent these sorts of issues in the future. They are hard to find, diagnose and write tests for.

**How was the bug found?**

Many internal reports both from ASP.NET, Roslyn, ProjectSystem itself and opening external projects (such as https://github.com/aarnott/pinvoke). Also had external reports from MVPs.

**Dev Notes**

Replace the synchronous call to read the project file, and replaced it with reading from snapshot data.

There were two issues:

1) We were blocking a ThreadPool thread with a synchronous call, which was leading to ThreadPool exchaustion.

2) We were reading from the live project instead of the snapshot of the project - these can be out of sync.

We read the project file to figure if a given item is imported or lives in the project file ("implicit"). This affects a few things, including it's icon (which we change to a lock) and the ability to delete it.

Note, there are a few entrypoints into this method, some of which have project snapshot data (from the evaluation.design-time build) and some of which don't (when we get an event from a referenced project indicating that it changed).

The simplest approach without pushing async through all events (which requires a public API change of an API used by Web Tooling), was just to push a null set of project items indicating what we "no data" and avoid flipping/setting the "implicit" setting when another project changes its results.