### PR TITLE
remove async void test methods

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ConfigurationProjectConfigurationDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ConfigurationProjectConfigurationDimensionProviderTests.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.Build;
 using Xunit;
 
@@ -20,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
 </Project>";
 
         [Fact]
-        public async void ConfigurationProjectConfigurationDimensionProvider_GetDefaultValuesForDimensionsAsync()
+        public async Task ConfigurationProjectConfigurationDimensionProvider_GetDefaultValuesForDimensionsAsync()
         {
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
@@ -36,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         }
 
         [Fact]
-        public async void ConfigurationProjectConfigurationDimensionProvider_GetDefaultValuesForDimensionsAsync_NoPropertyValue()
+        public async Task ConfigurationProjectConfigurationDimensionProvider_GetDefaultValuesForDimensionsAsync_NoPropertyValue()
         {
             using (var projectFile = new MsBuildProjectFile())
             {
@@ -49,7 +50,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         }
 
         [Fact]
-        public async void ConfigurationProjectConfigurationDimensionProvider_GetProjectConfigurationDimensionsAsync()
+        public async Task ConfigurationProjectConfigurationDimensionProvider_GetProjectConfigurationDimensionsAsync()
         {
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
@@ -68,7 +69,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
             }
         }
 
-        public async void ConfigurationProjectConfigurationDimensionProvider_GetProjectConfigurationDimensionsAsync_NoPropertyValue()
+        public async Task ConfigurationProjectConfigurationDimensionProvider_GetProjectConfigurationDimensionsAsync_NoPropertyValue()
         {
             using (var projectFile = new MsBuildProjectFile())
             {
@@ -81,7 +82,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         }
 
         [Fact]
-        public async void ConfigurationProjectConfigurationDimensionProvider_OnDimensionValueChanged_Add()
+        public async Task ConfigurationProjectConfigurationDimensionProvider_OnDimensionValueChanged_Add()
         {
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
@@ -116,7 +117,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         }
 
         [Fact]
-        public async void ConfigurationProjectConfigurationDimensionProvider_OnDimensionValueChanged_Remove()
+        public async Task ConfigurationProjectConfigurationDimensionProvider_OnDimensionValueChanged_Remove()
         {
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
@@ -151,7 +152,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         }
 
         [Fact]
-        public async void ConfigurationProjectConfigurationDimensionProvider_OnDimensionValueChanged_Remove_MissingValue()
+        public async Task ConfigurationProjectConfigurationDimensionProvider_OnDimensionValueChanged_Remove_MissingValue()
         {
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
@@ -173,7 +174,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         }
 
         [Fact]
-        public async void ConfigurationProjectConfigurationDimensionProvider_OnDimensionValueChanged_Rename()
+        public async Task ConfigurationProjectConfigurationDimensionProvider_OnDimensionValueChanged_Rename()
         {
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
@@ -210,7 +211,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         }
 
         [Fact]
-        public async void ConfigurationProjectConfigurationDimensionProvider_OnDimensionValueChanged_Rename_MissingValue()
+        public async Task ConfigurationProjectConfigurationDimensionProvider_OnDimensionValueChanged_Rename_MissingValue()
         {
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/PlatformProjectConfigurationDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/PlatformProjectConfigurationDimensionProviderTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.Build;
 using Xunit;
 
@@ -19,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
 </Project>";
 
         [Fact]
-        public async void PlatformProjectConfigurationDimensionProvider_GetDefaultValuesForDimensionsAsync()
+        public async Task PlatformProjectConfigurationDimensionProvider_GetDefaultValuesForDimensionsAsync()
         {
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
@@ -35,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         }
 
         [Fact]
-        public async void PlatformProjectConfigurationDimensionProvider_GetProjectConfigurationDimensionsAsync()
+        public async Task PlatformProjectConfigurationDimensionProvider_GetProjectConfigurationDimensionsAsync()
         {
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
@@ -55,7 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         }
 
         [Fact]
-        public async void PlatformProjectConfigurationDimensionProvider_OnDimensionValueChanged_Add()
+        public async Task PlatformProjectConfigurationDimensionProvider_OnDimensionValueChanged_Add()
         {
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
@@ -90,7 +91,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         }
 
         [Fact]
-        public async void PlatformProjectConfigurationDimensionProvider_OnDimensionValueChanged_Remove()
+        public async Task PlatformProjectConfigurationDimensionProvider_OnDimensionValueChanged_Remove()
         {
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
@@ -125,7 +126,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         }
 
         [Fact]
-        public async void PlatformProjectConfigurationDimensionProvider_OnDimensionValueChanged_Rename()
+        public async Task PlatformProjectConfigurationDimensionProvider_OnDimensionValueChanged_Rename()
         {
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/TargetFrameworkProjectConfigurationDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/TargetFrameworkProjectConfigurationDimensionProviderTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.Build;
 using Xunit;
 
@@ -32,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
 </Project>";
 
         [Fact]
-        public async void TargetFrameworkProjectConfigurationDimensionProvider_GetDefaultValuesForDimensionsAsync_TFM()
+        public async Task TargetFrameworkProjectConfigurationDimensionProvider_GetDefaultValuesForDimensionsAsync_TFM()
         {
             using (var projectFile = new MsBuildProjectFile(ProjectXmlTFM))
             {
@@ -47,7 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         [Theory]
         [InlineData(ProjectXmlTFMs)]
         [InlineData(ProjectXmlTFMAndTFMs)]
-        public async void TargetFrameworkProjectConfigurationDimensionProvider_GetDefaultValuesForDimensionsAsync_TFMs(string projectXml)
+        public async Task TargetFrameworkProjectConfigurationDimensionProvider_GetDefaultValuesForDimensionsAsync_TFMs(string projectXml)
         {
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
@@ -63,7 +64,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         }
 
         [Fact]
-        public async void TargetFrameworkProjectConfigurationDimensionProvider_GetProjectConfigurationDimensionsAsync_TFM()
+        public async Task TargetFrameworkProjectConfigurationDimensionProvider_GetProjectConfigurationDimensionsAsync_TFM()
         {
             using (var projectFile = new MsBuildProjectFile(ProjectXmlTFM))
             {
@@ -78,7 +79,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         [Theory]
         [InlineData(ProjectXmlTFMs)]
         [InlineData(ProjectXmlTFMAndTFMs)]
-        public async void TargetFrameworkProjectConfigurationDimensionProvider_GetProjectConfigurationDimensionsAsync_TFMs(string projectXml)
+        public async Task TargetFrameworkProjectConfigurationDimensionProvider_GetProjectConfigurationDimensionsAsync_TFMs(string projectXml)
         {
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
@@ -103,7 +104,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         [InlineData(ConfigurationDimensionChange.Rename, ChangeEventStage.After)]
         [InlineData(ConfigurationDimensionChange.Delete, ChangeEventStage.Before)]
         [InlineData(ConfigurationDimensionChange.Delete, ChangeEventStage.After)]
-        public async void TargetFrameworkProjectConfigurationDimensionProvider_OnDimensionValueChanged(ConfigurationDimensionChange change, ChangeEventStage stage)
+        public async Task TargetFrameworkProjectConfigurationDimensionProvider_OnDimensionValueChanged(ConfigurationDimensionChange change, ChangeEventStage stage)
         {
             // No changes should happen for TFM so verify that the property is the same before and after
             using (var projectFile = new MsBuildProjectFile(ProjectXmlTFMs))
@@ -121,7 +122,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
                     ConfigurationGeneral.TargetFrameworkProperty,
                     "NewTFM");
                 await provider.OnDimensionValueChangedAsync(args);
-                
+
                 Assert.NotNull(property);
                 Assert.Equal(expectedTFMs, property.Value);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/AssemblyInfoPropertiesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/AssemblyInfoPropertiesProviderTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.ProjectSystem.Properties.Package;
 using Microsoft.VisualStudio.Workspaces;
@@ -134,7 +135,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [InlineData(@"[assembly: System.Reflection.AssemblyDescriptionAttribute(""MyDescription"")]", "Company", null)]
         [InlineData(@"[assembly: System.Runtime.InteropServices.AssemblyDescriptionAttribute(true)]", "Description", null)]
         [InlineData(@"[assembly: System.Runtime.AssemblyDescriptionAttribute(""MyDescription"")]", "Description", null)]
-        public async void SourceFileProperties_GetEvalutedPropertyAsync(string code, string propertyName, string expectedValue)
+        public async Task SourceFileProperties_GetEvalutedPropertyAsync(string code, string propertyName, string expectedValue)
         {
             var provider = CreateProviderForSourceFileValidation(code, propertyName, out Workspace workspace);
             var projectFilePath = workspace.CurrentSolution.Projects.First().FilePath;
@@ -156,7 +157,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [InlineData(@"[assembly: System.Reflection.AssemblyDescriptionAttribute(true)]", "Description", "MyDescription", "MyDescription")]
         [InlineData(@"[assembly: System.Reflection.AssemblyDescriptionAttribute(""MyDescription""]", "Description", "", "")]
         [InlineData(@"[assembly: System.Reflection.AssemblyDescriptionAttribute(""MyDescription""]", "Description", null, null)]
-        public async void ProjectFileProperties_GetEvalutedPropertyAsync(string code, string propertyName, string propertyValueInProjectFile, string expectedValue)
+        public async Task ProjectFileProperties_GetEvalutedPropertyAsync(string code, string propertyName, string propertyValueInProjectFile, string expectedValue)
         {
             var provider = CreateProviderForProjectFileValidation(code, propertyName, propertyValueInProjectFile, out Workspace workspace);
             var projectFilePath = workspace.CurrentSolution.Projects.First().FilePath;
@@ -185,7 +186,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     @"[assembly: System.Reflection.AssemblyDescriptionAttribute(""MyDescription"", ""MyDescription"")]")]
         [InlineData(@"[assembly: System.AssemblyDescriptionAttribute(""MyDescription"")]", "Description", "NewDescription",
                     @"[assembly: System.AssemblyDescriptionAttribute(""MyDescription"")]")]
-        public async void SourceFileProperties_SetPropertyValueAsync(string code, string propertyName, string propertyValue, string expectedCode)
+        public async Task SourceFileProperties_SetPropertyValueAsync(string code, string propertyName, string propertyValue, string expectedCode)
         {
             var provider = CreateProviderForSourceFileValidation(code, propertyName, out Workspace workspace);
             var projectFilePath = workspace.CurrentSolution.Projects.First().FilePath;
@@ -203,7 +204,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [InlineData(@"[assembly: System.Reflection.AssemblyDescriptionAttribute(""MyDescription"")]", "Description", null, "NewDescription", "NewDescription")]
         [InlineData(@"[assembly: System.Reflection.AssemblyDescriptionAttribute(""MyDescription"")]", "Description", "OldDescription", "NewDescription", "NewDescription")]
         [InlineData(@"[assembly: System.Reflection.AssemblyDescriptionAttribute(""MyDescription"", ""MyDescription"")]", "Description", "OldDescription", "", "")]
-        public async void ProjectFileProperties_SetPropertyValueAsync(string code, string propertyName, string existingPropertyValue, string propertyValueToSet, string expectedValue)
+        public async Task ProjectFileProperties_SetPropertyValueAsync(string code, string propertyName, string existingPropertyValue, string propertyValueToSet, string expectedValue)
         {
             var propertyValues = new Dictionary<string, string>();
             var provider = CreateProviderForProjectFileValidation(code, propertyName, existingPropertyValue, out Workspace workspace, additionalProps: propertyValues);
@@ -227,7 +228,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         [Theory]
         [InlineData(@"[assembly: System.Reflection.AssemblyDescriptionAttribute(""MyDescription"")]", "Description", "MyDescription")]
-        public async void SourceFileProperties_GetUnevalutedPropertyAsync(string code, string propertyName, string expectedValue)
+        public async Task SourceFileProperties_GetUnevalutedPropertyAsync(string code, string propertyName, string expectedValue)
         {
             var provider = CreateProviderForSourceFileValidation(code, propertyName, out Workspace workspace);
             var projectFilePath = workspace.CurrentSolution.Projects.First().FilePath;
@@ -241,7 +242,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [Theory]
         [InlineData(@"[assembly: System.Reflection.AssemblyDescriptionAttribute(""MyDescription"")]", "Description", "MyDescription2", "MyDescription2")]
         [InlineData("", "Description", "MyDescription", "MyDescription")]
-        public async void ProjectFileProperties_GetUnevalutedPropertyAsync(string code, string propertyName, string propertyValueInProjectFile, string expectedValue)
+        public async Task ProjectFileProperties_GetUnevalutedPropertyAsync(string code, string propertyName, string propertyValueInProjectFile, string expectedValue)
         {
             var provider = CreateProviderForProjectFileValidation(code, propertyName, propertyValueInProjectFile, out Workspace workspace);
             var projectFilePath = workspace.CurrentSolution.Projects.First().FilePath;
@@ -277,7 +278,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [InlineData(@"[assembly: System.Reflection.AssemblyInformationalVersionAttribute(""2.0.0"")]", "Version", "2.0.0", null)]
         [InlineData(@"[assembly: System.Reflection.AssemblyInformationalVersionAttribute(""2.0.1-beta1"")]", "Version", "2.0.1-beta1", null)]
         [InlineData(@"[assembly: System.Reflection.AssemblyInformationalVersionAttribute(""2016.2"")]", "Version", "2016.2", null)]
-        internal async void SourceFileProperties_DefaultValues_GetEvalutedPropertyAsync(string code, string propertyName, string expectedValue, Type interceptingProviderType)
+        internal async Task SourceFileProperties_DefaultValues_GetEvalutedPropertyAsync(string code, string propertyName, string expectedValue, Type interceptingProviderType)
         {
             var interceptingProvider = interceptingProviderType != null ?
                 new Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>(
@@ -306,7 +307,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [InlineData("MyApp", "Product", null, null)]
         [InlineData("MyApp", "Product", "", "")]
         [InlineData("MyApp", "Product", "ExistingValue", "ExistingValue")]
-        internal async void ProjectFileProperties_DefaultValues_GetEvalutedPropertyAsync(string assemblyName, string propertyName, string existingPropertyValue, string expectedValue)
+        internal async Task ProjectFileProperties_DefaultValues_GetEvalutedPropertyAsync(string assemblyName, string propertyName, string existingPropertyValue, string expectedValue)
         {
             var additionalProps = new Dictionary<string, string>() { { "AssemblyName", assemblyName } };
 
@@ -349,14 +350,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [InlineData("Version", "1.1.1", "1.0.0.0", "1.0.0.0", null)]
         [InlineData("Version", "1.0.0", "1.0.0.0", "1.0.0.0", null)]
         [InlineData("Version", null, "2016.2", "2016.2", null)]
-        internal async void ProjectFileProperties_WithInterception_SetEvalutedPropertyAsync(string propertyName, string existingPropertyValue, string propertyValueToSet, string expectedValue, Type interceptingProviderType)
+        internal async Task ProjectFileProperties_WithInterception_SetEvalutedPropertyAsync(string propertyName, string existingPropertyValue, string propertyValueToSet, string expectedValue, Type interceptingProviderType)
         {
             var interceptingProvider = interceptingProviderType != null ?
                 new Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>(
                     valueFactory: () => (IInterceptingPropertyValueProvider)Activator.CreateInstance(interceptingProviderType),
                     metadata: IInterceptingPropertyValueProviderMetadataFactory.Create(propertyName)) :
                 null;
-            
+
             string code = "";
             var provider = CreateProviderForProjectFileValidation(code, propertyName, existingPropertyValue, out Workspace workspace, interceptingProvider);
             var projectFilePath = workspace.CurrentSolution.Projects.First().FilePath;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Build/LanguageServiceErrorListProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Build/LanguageServiceErrorListProviderTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 using Microsoft.Build.Framework;
 using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 using Moq;
+using System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
 {
@@ -66,7 +67,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
         }
 
         [Fact]
-        public async void ClearAllAsync_WhenHostSpecificErrorReporter_CallsClearErrors()
+        public async Task ClearAllAsync_WhenHostSpecificErrorReporter_CallsClearErrors()
         {
             int callCount = 0;
             var reporter = IVsLanguageServiceBuildErrorReporter2Factory.ImplementClearErrors(() => { callCount++; return 0; });
@@ -83,7 +84,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
 
 
         [Fact]
-        public async void AddMessageAsync_NullAsTask_ThrowsArgumentNull()
+        public async Task AddMessageAsync_NullAsTask_ThrowsArgumentNull()
         {
             var provider = CreateInstance();
 
@@ -93,7 +94,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
         }
 
         [Fact]
-        public async void AddMessageAsync_WhenNoHostSpecificErrorReporter_ReturnsNotHandled()
+        public async Task AddMessageAsync_WhenNoHostSpecificErrorReporter_ReturnsNotHandled()
         {
             var provider = CreateInstance();
 
@@ -105,7 +106,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
         }
 
         [Fact]
-        public async void AddMessageAsync_UnrecognizedArgsAsTaskBuildEventArgs_ReturnsNotHandled()
+        public async Task AddMessageAsync_UnrecognizedArgsAsTaskBuildEventArgs_ReturnsNotHandled()
         {
             var provider = CreateInstance();
 
@@ -118,7 +119,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
 
 
         [Fact]
-        public async void AddMessageAsync_ArgsWithNoCodeAsTask_ReturnsNotHandled()
+        public async Task AddMessageAsync_ArgsWithNoCodeAsTask_ReturnsNotHandled()
         {
             var provider = CreateInstance();
 
@@ -130,7 +131,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
         }
 
         [Fact]
-        public async void AddMessageAsync_WhenHostSpecificErrorReporterThrowsNotImplemented_ReturnsNotHandled()
+        public async Task AddMessageAsync_WhenHostSpecificErrorReporterThrowsNotImplemented_ReturnsNotHandled()
         {
             var reporter = IVsLanguageServiceBuildErrorReporter2Factory.ImplementReportError((string bstrErrorMessage, string bstrErrorId, VSTASKPRIORITY nPriority, int iLine, int iColumn, int iEndLine, int iEndColumn, string bstrFileName) =>
             {
@@ -147,7 +148,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
         }
 
         [Fact]
-        public async void AddMessageAsync_WhenHostSpecificErrorReporterThrows_Throws()
+        public async Task AddMessageAsync_WhenHostSpecificErrorReporterThrows_Throws()
         {
             var reporter = IVsLanguageServiceBuildErrorReporter2Factory.ImplementReportError((string bstrErrorMessage, string bstrErrorId, VSTASKPRIORITY nPriority, int iLine, int iColumn, int iEndLine, int iEndColumn, string bstrFileName) =>
             {
@@ -164,7 +165,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
         }
 
         [Fact]
-        public async void AddMessageAsync_ReturnsHandledAndStopProcessing()
+        public async Task AddMessageAsync_ReturnsHandledAndStopProcessing()
         {
             var reporter = IVsLanguageServiceBuildErrorReporter2Factory.ImplementReportError((string bstrErrorMessage, string bstrErrorId, VSTASKPRIORITY nPriority, int iLine, int iColumn, int iEndLine, int iEndColumn, string bstrFileName) => { });
             var host = ILanguageServiceHostFactory.ImplementHostSpecificErrorReporter(() => reporter);
@@ -177,7 +178,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
         }
 
         [Fact]
-        public async void AddMessageAsync_WarningTaskAsTask_PassesTP_NORMALAsPriority()
+        public async Task AddMessageAsync_WarningTaskAsTask_PassesTP_NORMALAsPriority()
         {
             VSTASKPRIORITY? result = null;
             var reporter = IVsLanguageServiceBuildErrorReporter2Factory.ImplementReportError((string bstrErrorMessage, string bstrErrorId, VSTASKPRIORITY nPriority, int iLine, int iColumn, int iEndLine, int iEndColumn, string bstrFileName) => {
@@ -192,7 +193,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
         }
 
         [Fact]
-        public async void AddMessageAsync_ErrorTaskAsTask_PassesTP_HIGHAsPriority()
+        public async Task AddMessageAsync_ErrorTaskAsTask_PassesTP_HIGHAsPriority()
         {
             VSTASKPRIORITY? result = null;
             var reporter = IVsLanguageServiceBuildErrorReporter2Factory.ImplementReportError((string bstrErrorMessage, string bstrErrorId, VSTASKPRIORITY nPriority, int iLine, int iColumn, int iEndLine, int iEndColumn, string bstrFileName) => {
@@ -207,7 +208,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
         }
 
         [Fact]
-        public async void AddMessageAsync_CriticalBuildMessageTaskAsTask_PassesTP_LOWAsPriority()
+        public async Task AddMessageAsync_CriticalBuildMessageTaskAsTask_PassesTP_LOWAsPriority()
         {
             VSTASKPRIORITY? result = null;
             var reporter = IVsLanguageServiceBuildErrorReporter2Factory.ImplementReportError((string bstrErrorMessage, string bstrErrorId, VSTASKPRIORITY nPriority, int iLine, int iColumn, int iEndLine, int iEndColumn, string bstrFileName) => {
@@ -221,16 +222,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
             Assert.Equal(result, VSTASKPRIORITY.TP_LOW);
         }
 
-        //          ErrorMessage                                    Code         
+        //          ErrorMessage                                    Code
         [Theory]
         [InlineData(null,                                           "A")]
         [InlineData("",                                             "0000")]
-        [InlineData(" ",                                            "1000")]          
-        [InlineData("This is an error message.",                    "CA1000")]       
+        [InlineData(" ",                                            "1000")]
+        [InlineData("This is an error message.",                    "CA1000")]
         [InlineData("This is an error message\r\n",                 "CS1000")]
         [InlineData("This is an error message.\r\n",                "BC1000")]
         [InlineData("This is an error message.\r\n.And another",    "BC1000\r\n")]
-        public async void AddMessageAsync_BuildErrorAsTask_CallsReportErrorSettingErrorMessageAndCode(string errorMessage, string code)
+        public async Task AddMessageAsync_BuildErrorAsTask_CallsReportErrorSettingErrorMessageAndCode(string errorMessage, string code)
         {
             string errorMessageResult = "NotSet";
             string errorIdResult = "NotSet";
@@ -261,7 +262,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
         [InlineData(  10,          100,                     9,              99)]
         [InlineData( 100,           10,                    99,               9)]
         [InlineData( 100,          100,                    99,              99)]
-        public async void AddMessageAsync_BuildErrorAsTask_CallsReportErrorSettingLineAndColumnAdjustingBy1(int lineNumber, int columnNumber, int expectedLineNumber, int expectedColumnNumber)
+        public async Task AddMessageAsync_BuildErrorAsTask_CallsReportErrorSettingLineAndColumnAdjustingBy1(int lineNumber, int columnNumber, int expectedLineNumber, int expectedColumnNumber)
         {
             int? lineResult = null;
             int? columnResult = null;
@@ -293,7 +294,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
         [InlineData( 100,          100,          100,           100,                           99,                  99)]
         [InlineData( 100,          100,          101,           102,                          100,                 101)]
         [InlineData( 100,          101,            1,             1,                           99,                 100)]       //  Roslyn's ProjectExternalErrorReporter throws if end is less than start
-        public async void AddMessageAsync_BuildErrorAsTask_CallsReportErrorSettingEndLineAndColumn(int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, int expectedEndLineNumber, int expectedEndColumnNumber)
+        public async Task AddMessageAsync_BuildErrorAsTask_CallsReportErrorSettingEndLineAndColumn(int lineNumber, int columnNumber, int endLineNumber, int endColumnNumber, int expectedEndLineNumber, int expectedEndColumnNumber)
         {
             int? endLineResult = null;
             int? endColumnResult = null;
@@ -314,7 +315,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
         }
 
         //          File                                        ProjectFile                             ExpectedFileName
-        [Theory]                                                                                        
+        [Theory]
         [InlineData(null,                                       null,                                   @"")]
         [InlineData(@"",                                        @"",                                    @"")]
         [InlineData(@"Foo.txt",                                 @"",                                    @"")]                // Is this the right behavior?  See https://github.com/dotnet/roslyn-project-system/issues/146
@@ -329,7 +330,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
         [InlineData(@"C:\Foo\..\MyProject.csproj",              @"C:\MyProject.csproj",                 @"C:\MyProject.csproj")]
         [InlineData(@"C:\Foo\Foo.txt",                          @"C:\Bar\MyProject.csproj",             @"C:\Foo\Foo.txt")]
         [InlineData(@"Foo.txt",                                 @"C:\Bar\MyProject.csproj",             @"C:\Bar\Foo.txt")]
-        public async void AddMessageAsync_BuildErrorAsTask_CallsReportErrorSettingFileName(string file, string projectFile, string expectedFileName)
+        public async Task AddMessageAsync_BuildErrorAsTask_CallsReportErrorSettingFileName(string file, string projectFile, string expectedFileName)
         {
             string fileNameResult = "NotSet";
             var reporter = IVsLanguageServiceBuildErrorReporter2Factory.ImplementReportError((string bstrErrorMessage, string bstrErrorId, VSTASKPRIORITY nPriority, int iLine, int iColumn, int iEndLine, int iEndColumn, string bstrFileName) =>
@@ -352,7 +353,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
         {
             return new TargetGeneratedError("Test", new BuildErrorEventArgs(null, "Code", "File", 1, 1, 1, 1, "Message", "HelpKeyword", "Sender"));
         }
-        
+
         private static LanguageServiceErrorListProvider CreateInstance()
         {
             return CreateInstance(null);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/OutputTypeExValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/OutputTypeExValueProviderTests.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
@@ -16,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [InlineData("WinMDObj", "3")]
         [InlineData("AppContainerExe", "4")]
         [InlineData("", "0")]
-        public async void GetEvaluatedValue(object outputTypePropertyValue, string expectedMappedValue)
+        public async Task GetEvaluatedValue(object outputTypePropertyValue, string expectedMappedValue)
         {
             var properties = ProjectPropertiesFactory.Create(
                 UnconfiguredProjectFactory.Create(),
@@ -38,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [InlineData("2", "Library")]
         [InlineData("3", "WinMDObj")]
         [InlineData("4", "AppContainerExe")]
-        public async void SetValue(string incomingValue, string expectedOutputTypeValue)
+        public async Task SetValue(string incomingValue, string expectedOutputTypeValue)
         {
             var setValues = new List<object>();
             var properties = ProjectPropertiesFactory.Create(
@@ -56,7 +57,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             Assert.Equal(setValues.Single(), expectedOutputTypeValue);
         }
 
-        public async void SetValue_ThrowsKeyNotFoundException()
+        public async Task SetValue_ThrowsKeyNotFoundException()
         {
             var setValues = new List<object>();
             var properties = ProjectPropertiesFactory.Create(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/OutputTypeValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/OutputTypeValueProviderTests.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
@@ -16,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [InlineData("WinMDObj", "2")]
         [InlineData("AppContainerExe", "1")]
         [InlineData("", "0")]
-        public async void GetEvaluatedValue(object outputTypePropertyValue, string expectedMappedValue)
+        public async Task GetEvaluatedValue(object outputTypePropertyValue, string expectedMappedValue)
         {
             var properties = ProjectPropertiesFactory.Create(
                 UnconfiguredProjectFactory.Create(),
@@ -36,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [InlineData("0", "WinExe")]
         [InlineData("1", "Exe")]
         [InlineData("2", "Library")]
-        public async void SetValue(string incomingValue, string expectedOutputTypeValue)
+        public async Task SetValue(string incomingValue, string expectedOutputTypeValue)
         {
             var setValues = new List<object>();
             var properties = ProjectPropertiesFactory.Create(
@@ -57,7 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Theory]
         [InlineData("3")]
         [InlineData("InvalidValue")]
-        public async void SetValue_ThrowsKeyNotFoundException(string invalidValue)
+        public async Task SetValue_ThrowsKeyNotFoundException(string invalidValue)
         {
             var setValues = new List<object>();
             var properties = ProjectPropertiesFactory.Create(

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Properties/MapDynamicEnumValuesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Properties/MapDynamicEnumValuesProviderTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
-        public async void OptionStrictEnumProviderTest()
+        public async Task OptionStrictEnumProviderTest()
         {
             var dynamicEnumValuesGenerator = await new OptionStrictEnumProvider().GetProviderAsync(null);
             var values = await dynamicEnumValuesGenerator.GetListedValuesAsync();
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
-        public async void WarningLevelEnumProviderTest()
+        public async Task WarningLevelEnumProviderTest()
         {
             var dynamicEnumValuesGenerator = await new WarningLevelEnumProvider().GetProviderAsync(null);
             var values = await dynamicEnumValuesGenerator.GetListedValuesAsync();


### PR DESCRIPTION
`async void` methods do not return a `Task` object which xUnit could possibly examine for exceptions. xUnit cannot even track the completion of a particular `async void` method, as opposed to an `async Task` method.

Moreover, `async void` methods do not throw exceptions on the same stack frame, even for exceptions thrown from the synchronous part of the method. Rather, exceptions are propagated to the current synchronization context via `SynchronizationContext.Post` (in case `SynchronizationContext.Current != null)`, or otherwise via `ThreadPool.QueueUserWorkItem`.

This is an infrastructure only change.