### PR TITLE
fixing up some threading cases

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
@@ -49,11 +49,11 @@ namespace Microsoft.VisualStudio.Packaging
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-            IComponentModel componentModel = (IComponentModel)GetService(typeof(SComponentModel));
+            IComponentModel componentModel = (IComponentModel)(await GetServiceAsync(typeof(SComponentModel)).ConfigureAwait(true));
             ICompositionService compositionService = componentModel.DefaultCompositionService;
             var debugFrameworksCmd = componentModel.DefaultExportProvider.GetExport<DebugFrameworksDynamicMenuCommand>();
 
-            var mcs = GetService(typeof(IMenuCommandService)) as OleMenuCommandService;
+            var mcs = (await GetServiceAsync(typeof(IMenuCommandService)).ConfigureAwait(true)) as OleMenuCommandService;
             mcs.AddCommand(debugFrameworksCmd.Value);
 
             var debugFrameworksMenuTextUpdater = componentModel.DefaultExportProvider.GetExport<DebugFrameworkPropertyMenuTextUpdater>();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         /// Current TargetFramework for non-cross targeting project - accesses to this field must be done with a lock on <see cref="_gate"/>.
         /// </summary>
         private string _currentTargetFramework;
-        
+
 
         [ImportingConstructor]
         public LanguageServiceHost(IUnconfiguredProjectCommonServices commonServices,
@@ -243,8 +243,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             Requires.NotNull(newProjectContext, nameof(newProjectContext));
 
             await _commonServices.ThreadingService.SwitchToUIThread();
-
-            using (_tasksService.LoadedProject())
+            await _tasksService.LoadedProjectAsync(() =>
             {
                 var watchedEvaluationRules = _languageServiceHandlerManager.GetWatchedRules(RuleHandlerType.Evaluation);
                 var watchedDesignTimeBuildRules = _languageServiceHandlerManager.GetWatchedRules(RuleHandlerType.DesignTimeBuild);
@@ -266,14 +265,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
                     _projectConfigurationsWithSubscriptions.Add(configuredProject.ProjectConfiguration);
                 }
-            }
+
+                return Task.CompletedTask;
+            });
         }
 
         private async Task HandleAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update, RuleHandlerType handlerType)
         {
             // We need to process the update within a lock to ensure that we do not release this context during processing.
             // TODO: Enable concurrent execution of updates themeselves, i.e. two separate invocations of HandleAsync
-            //       should be able to run concurrently. 
+            //       should be able to run concurrently.
             await ExecuteWithinLockAsync(async () =>
             {
                 // TODO: https://github.com/dotnet/roslyn-project-system/issues/353
@@ -289,7 +290,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 _languageServiceHandlerManager.Handle(update, handlerType, projectContextToUpdate, isActiveContext);
             });
         }
-        
+
         private bool HasTargetFrameworksChanged(IProjectVersionedValue<IProjectSubscriptionUpdate> e)
         {
             return e.Value.ProjectChanges.TryGetValue(ConfigurationGeneral.SchemaName, out IProjectChangeDescription projectChange) &&


### PR DESCRIPTION
`_tasksService.LoadedProject()` assumes that all logic run inside the using is correct and never causes a deadlock.  `_tasksService.LoadedProjectAsync` explicitly uses JTF to ensure no deadlocks occur.

`GetService` blocks the calling thread where as `GetServiceAsync` will try several techniques to acquire the service in a non-blocking way before falling back to a blocking approach.

`AddSubscriptionsAsync` was locking but then calling asynchronus methods and not waiting for them to complete.  This could have led to races or interactions with the project after it had closed.

@davkean to double check my understanding of this threading code

Ask mode template forthcoming