### PR TITLE
Updating the ApplicationPropPage to properly cycle through the radio buttons

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.vb
@@ -540,6 +540,22 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             SetDirty(Win32ResourceFile, True)
         End Sub
 
+        Protected Overrides Function ProcessDialogKey(keyData As Keys) As Boolean
+            ' Our control is currently setup so that the radio buttons and the corresponding controls are all siblings
+            ' This prevents Up/Down from just navigating between the radio buttons and breaks accessibility
+            If (ActiveControl Is IconRadioButton OrElse ActiveControl Is Win32ResourceRadioButton) Then
+                If (keyData = Keys.Down OrElse keyData = Keys.Up) Then
+                    If ActiveControl Is IconRadioButton Then
+                        Win32ResourceRadioButton.Select()
+                    Else
+                        IconRadioButton.Select()
+                    End If
+                    Return True
+                End If
+            End If
+            Return MyBase.ProcessDialogKey(keyData)
+        End Function
+
         ''' <summary>
         ''' validate a property
         ''' </summary>


### PR DESCRIPTION
**Customer scenario**

Visually impaired users who depend on keyboard will not be able to access radio button by using up down arrow

**Bugs this fixes:** 

https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems?id=448954

**Workarounds, if any**

Exclusively use the Up arrow key to navigate between radio buttons.

**Risk**

Low. This just updates the handling of the Up/Down arrow keys to explicitly move between the radio buttons

**Performance impact**

Low.

**Is this a regression from a previous update?**

Partial.

Previously, pushing down would move focus from the first radio button to the second and pushing 'Up' would move focus back. However, pushing 'Down' a second time would not move focus back and would instead move to the Resource File text box.

Presently, pushing down moves focus to the ManifestExplanationLabel. While pushing Up would move focus to the 'Resources' radio button. Pushing 'Up' again would continue moving focus to the previous radio button.

So, the issue was the same as original, just exposed in a different manner.

**Root cause analysis:**

Accessibility Issue

**How was the bug found?**

Accessibility Tenet
