### PR TITLE
Updating the custom accessibility object for DesignerTabButton to properly report 'Focusable'

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabButton.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabButton.vb
@@ -248,7 +248,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             ''' </summary>
             Public Overrides ReadOnly Property State() As AccessibleStates
                 Get
-                    Return _button.AccessibleState
+                    Return MyBase.State Or _button.AccessibleState
                 End Get
             End Property
 


### PR DESCRIPTION
**Customer scenario**

Users who rely on the narrator will not know when the DesignerTabButtons get focus.

**Bugs this fixes:** 

https://devdiv.visualstudio.com/DevDiv/_workitems?id=409661

**Workarounds, if any**

Use a different narrator (such as NVDA)

**Risk**

Low. This just updates the accessibility object to properly report that the control is focusable.

**Performance impact**

None

**Is this a regression from a previous update?**

No

**Root cause analysis:**

It was thought that the Windows Narrator not reading the control text was due to a bug in Windows Narrator. It was later determined that it is because Windows Narrator is dependent on the accessibility object reporting that a control is focusable (where-as other narrators just read the text of the currently focused object).

**How was the bug found?**

Accessibility Tenet
