### PR TITLE
remove OnceInitializedOnceDisposed and instead import services via MEF

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetFrameworkProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetFrameworkProvider.cs
@@ -3,71 +3,32 @@
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
-using Microsoft.VisualStudio.ComponentModelHost;
-using Microsoft.VisualStudio.Shell;
 using NuGet.VisualStudio;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 {
     [Export(typeof(ITargetFrameworkProvider))]
     [AppliesTo(ProjectCapability.DependenciesTree)]
-    internal class TargetFrameworkProvider : OnceInitializedOnceDisposed, ITargetFrameworkProvider
+    internal sealed class TargetFrameworkProvider : ITargetFrameworkProvider
     {
         [ImportingConstructor]
-        public TargetFrameworkProvider(SVsServiceProvider serviceProvider)
+        public TargetFrameworkProvider(
+            IVsFrameworkCompatibility nugetComparer,
+            IVsFrameworkParser nugetFrameworkParser)
         {
-            ServiceProvider = serviceProvider;
+            NugetComparer = nugetComparer;
+            NugetFrameworkParser = nugetFrameworkParser;
         }
-        
-        private SVsServiceProvider ServiceProvider { get; }
-        protected IVsFrameworkCompatibility NugetComparer { get; set; }
-        protected IVsFrameworkParser NugetFrameworkParser { get; set; }
+
+        private IVsFrameworkCompatibility NugetComparer { get; }
+
+        private IVsFrameworkParser NugetFrameworkParser { get; }
 
         private readonly object _targetsLock = new object();
         private List<ITargetFramework> CachedTargetFrameworks = new List<ITargetFramework>();
 
-        protected override void Initialize()
-        {
-            if (!ShouldInitialize())
-            {
-                return;
-            }
-
-            ThreadHelper.JoinableTaskFactory.Run(async delegate
-            {
-                await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
-
-                var container = ServiceProvider.GetService<IComponentModel, SComponentModel>();
-                if (container != null)
-                {
-                    NugetComparer = container.GetExtensions<IVsFrameworkCompatibility>().FirstOrDefault();
-                    NugetFrameworkParser = container.GetExtensions<IVsFrameworkParser>().FirstOrDefault();
-                }
-            });
-        }
-
-        /// <summary>
-        /// For unit tests to avoid UI initialization.
-        /// </summary>
-        /// <returns></returns>
-        protected virtual bool ShouldInitialize()
-        {
-            return NugetComparer == null || NugetFrameworkParser == null;
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                NugetComparer = null;
-                NugetFrameworkParser = null;
-            }
-        }
-
         public ITargetFramework GetTargetFramework(string shortOrFullName)
         {
-            EnsureInitialized();
-
             if (string.IsNullOrEmpty(shortOrFullName))
             {
                 return null;
@@ -90,7 +51,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
                     {
                         var shortName = NugetFrameworkParser.GetShortFrameworkName(frameworkName);
                         targetFramework = new TargetFramework(frameworkName, shortName);
-                        // remember target framework - there can not bee too many of them accross the solution.
+                        // remember target framework - there can not bee too many of them across the solution.
                         CachedTargetFrameworks.Add(targetFramework);
                     }
                 }
@@ -104,11 +65,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             return targetFramework;
         }
 
-        public ITargetFramework GetNearestFramework(ITargetFramework targetFramework, 
+        public ITargetFramework GetNearestFramework(ITargetFramework targetFramework,
                                                     IEnumerable<ITargetFramework> otherFrameworks)
         {
-            EnsureInitialized();
-
             if (targetFramework == null || otherFrameworks == null || !otherFrameworks.Any())
             {
                 return null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetFrameworkProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetFrameworkProvider.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 {
     [Export(typeof(ITargetFrameworkProvider))]
     [AppliesTo(ProjectCapability.DependenciesTree)]
-    internal sealed class TargetFrameworkProvider : ITargetFrameworkProvider
+    internal class TargetFrameworkProvider : ITargetFrameworkProvider
     {
         [ImportingConstructor]
         public TargetFrameworkProvider(


### PR DESCRIPTION
**Customer scenario**

Customer notices that projects take a very long time to load.

**Bugs this fixes:** 

Fixes https://github.com/dotnet/project-system/issues/2421

**Workarounds, if any**

None

**Risk**

This is changing MEF imports so I would need manual verification of the scenario to ensure that nothing has regressed.

**Regression**

This is a perf regression in 15.3 because of new code in the dependencies node.

**Performance impact**

This will improve perf for project load and restore.

**Root cause analysis:**

Perviously we would switch to the UI thread, acquire the component catalog, and manually pick out the types we needed from the catalog while still on the UI thread.  Since we were in a pumping wait this would not deadlock the operation, but all threads waiting for this opertation would be blocked, causing the hill climbing algorithm in the threadpool to allocate more threads as no forward progress was being made.  Operations happening on the UI thread would also take longer as we where adding more work that needed to happen there.  This change ensures that the nuget types we need are composed by MEF when we are created so there in no wait.

**How was the bug found?**

dogfooding
