### PR TITLE
Fix spurious warnings in dependency node

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DiagnosticDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DiagnosticDependencyModelTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.False(model.TopLevel);
             Assert.Equal(true, model.Visible);
             Assert.Equal(null, model.SchemaName);
-            Assert.Equal(true, model.Resolved);
+            Assert.Equal(false, model.Resolved);
             Assert.Equal(false, model.Implicit);
             Assert.Equal(properties, model.Properties);
             Assert.Equal(Dependency.DiagnosticsErrorNodePriority, model.Priority);
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.False(model.TopLevel);
             Assert.Equal(true, model.Visible);
             Assert.Equal(null, model.SchemaName);
-            Assert.Equal(true, model.Resolved);
+            Assert.Equal(false, model.Resolved);
             Assert.Equal(false, model.Implicit);
             Assert.Equal(properties, model.Properties);
             Assert.Equal(Dependency.DiagnosticsWarningNodePriority, model.Priority);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyTests.cs
@@ -122,8 +122,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Theory]
-        [InlineData(@"../../somepath", @"tfm1\xxx\..\..\somepath")]
-        [InlineData(@"__\somepath..\", @"tfm1\xxx\__\somepath..")]
+        [InlineData(@"../../somepath", @"tfm1\xxx\__\__\somepath")]
+        [InlineData(@"__\somepath..\", @"tfm1\xxx\__\somepath__")]
         [InlineData(@"somepath", @"tfm1\xxx\somepath")]
         public void Dependency_Id_NoSnapsotTargetFramework(string modelId, string expectedId)
         {
@@ -137,8 +137,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Theory]
-        [InlineData(@"../../somepath", @"tfm\providerType\..\..\somepath")]
-        [InlineData(@"__\somepath..\", @"tfm\providerType\__\somepath..")]
+        [InlineData(@"../../somepath", @"tfm\providerType\__\__\somepath")]
+        [InlineData(@"__\somepath..\", @"tfm\providerType\__\somepath__")]
         [InlineData(@"somepath", @"tfm\providerType\somepath")]
         public void Dependency_Id(string modelId, string expectedId)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnsupportedProjectsSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnsupportedProjectsSnapshotFilterTests.cs
@@ -135,7 +135,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void UnsupportedProjectsSnapshotFilter_WhenProjectSnapshotNotFound_ShouldMakeUnresolved()
+        public void UnsupportedProjectsSnapshotFilter_WhenProjectSnapshotNotFound_ShouldDoNothing()
         {
             // Arrange 
             var snapshotProvider = IDependenciesSnapshotProviderFactory.Implement(currentSnapshot: null);
@@ -145,10 +145,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     topLevel: true,
                     resolved: true,
                     flags: DependencyTreeFlags.ProjectNodeFlags.Union(DependencyTreeFlags.ResolvedFlags),
-                    originalItemSpec: @"c:\myproject2\project.csproj",
-                    setPropertiesResolved: false,
-                    setPropertiesSchemaName: ProjectReference.SchemaName,
-                    setPropertiesFlags: DependencyTreeFlags.ProjectNodeFlags.Union(DependencyTreeFlags.UnresolvedFlags));
+                    originalItemSpec: @"c:\myproject2\project.csproj");
 
             var filter = new UnsupportedProjectsSnapshotFilter(aggregateSnapshotProvider, null);
 
@@ -166,7 +163,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void UnsupportedProjectsSnapshotFilter_WhenProjectSnapshotFoundAndTargetFrameworkNull_ShouldMakeUnresolved()
+        public void UnsupportedProjectsSnapshotFilter_WhenProjectSnapshotFoundAndTargetFrameworkNull_ShouldDoNothing()
         {
             // Arrange 
             var targetFramework = ITargetFrameworkFactory.Implement(moniker: "tfm1");
@@ -185,10 +182,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     resolved: true,
                     flags: DependencyTreeFlags.ProjectNodeFlags.Union(DependencyTreeFlags.ResolvedFlags),
                     originalItemSpec: @"c:\myproject2\project.csproj",
-                    targetFramework: targetFramework,
-                    setPropertiesResolved: false,
-                    setPropertiesSchemaName: ProjectReference.SchemaName,
-                    setPropertiesFlags: DependencyTreeFlags.ProjectNodeFlags.Union(DependencyTreeFlags.UnresolvedFlags));
+                    targetFramework: targetFramework);
 
             var filter = new UnsupportedProjectsSnapshotFilter(aggregateSnapshotProvider, targetFrameworkProvider);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DiagnosticDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DiagnosticDependencyModel.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             ProjectTreeFlags flags,
             bool isVisible,
             IImmutableDictionary<string, string> properties)
-            : base(providerType, originalItemSpec, originalItemSpec, flags, resolved:true, isImplicit:false, properties:properties)
+            : base(providerType, originalItemSpec, originalItemSpec, flags, resolved:false, isImplicit:false, properties:properties)
         {
             Requires.NotNullOrEmpty(originalItemSpec, nameof(originalItemSpec));
             Requires.NotNullOrEmpty(message, nameof(message));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
@@ -266,7 +266,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
         private static string Normalize(string id)
         {
-            return id.Replace('/', '\\');
+            return id
+                .Replace('/', '\\')
+                .Replace("..", "__");
         }
 
         public static string GetID(ITargetFramework targetFramework, string providerType, string modelId)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/UnsupportedProjectsSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/UnsupportedProjectsSnapshotFilter.cs
@@ -9,7 +9,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
 {
     /// <summary>
     /// Changes resolved top level project dependencies to unresolved if:
-    ///     - dependent project does not have targets supporting given target framework in current project
     ///     - dependent project has any unresolved dependencies in a snapshot for given target framework
     /// This helps to bubble up error status (yellow icon) for project dependencies.
     /// </summary>
@@ -51,7 +50,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
                 && !resultDependency.Flags.Contains(DependencyTreeFlags.SharedProjectFlags))
             {
                 var snapshot = GetSnapshot(projectPath, resultDependency, out string dependencyProjectPath);
-                if (snapshot == null || snapshot.HasUnresolvedDependency)
+                if (snapshot != null && snapshot.HasUnresolvedDependency)
                 {
                     filterAnyChanges = true;
                     resultDependency = resultDependency.ToUnresolved(ProjectReference.SchemaName);


### PR DESCRIPTION
**Customer scenario**

Customers observe spurious and confusing warning icons in dependency node when there should not be any, or do not observe warning icons when there should be. This collection of small targeted fixes addresses the most common cases, including:
- referencing a .NET Framework project always warns even though these P2P refs are valid, which is a regression from 15.2
- valid P2P refs sometimes do not expand (particularly to cps-based .NET Framework projects) because of invalid IDs being passed around
- (NuGet) diagnostics do not bubble up correctly

One side-effect: P2P references to incompatible projects should have a warning icon but does not (however, there are warning messages in the error list). Three separate bugs in NuGet, SDK and Project System are preventing this scenario from working properly, and will need to be addressed later or post 15.3. I've filed https://github.com/dotnet/project-system/issues/2436 and https://github.com/NuGet/Home/issues/5405 to track fixing this. This seems like a fair tradeoff since users are still warned and the build will fail if user tries to setup an incompatible dependency. Additionally, this side effect is not a regression since this did not work in 15.2 either.

**Bugs this fixes:** 

Fixes #2242 
[Bug 431059](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/431059)

**Workarounds, if any**

None

**Risk**

Low, targeted fixes that only affect dependency node. Postponed more complicated fixes to SDK (https://github.com/dotnet/project-system/issues/2436)

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

**Is this a regression from a previous update?**

Yes. Dependency node was rewritten and we are working through some behavior changes.

**Root cause analysis:**

Incorrect IDs is a subtle bug occurring because a CPS method is calling `UnconfiguredProject.MakeRooted` (see [UnattachedProjectItemTreeNode.cs:75](http://index/?leftProject=Microsoft.VisualStudio.ProjectSystem&leftSymbol=iuqusshx0kyi&rightProject=Microsoft.VisualStudio.ProjectSystem.Implementation&file=Designers%5CUnattachedProjectItemTreeNode.cs&line=75) ). The warning on all .NET Framework projects is because the heuristic to determine if TargetFrameworks are compatible is unable to find information for these projects -- this fix changes the heuristic to only report warnings when it can find information.

**How was the bug found?**

Internal Dogfooders

/cc @dotnet/project-system 
