### PR TITLE
Nominate DotnetCliToolTargetFramework to NuGet 

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -114,6 +114,10 @@
                     Visible="False" 
                     ReadOnly="True" />
                     
+    <StringProperty Name="DotnetCliToolTargetFramework" 
+                    Visible="False" 
+                    ReadOnly="True" />
+                    
     <StringProperty Name="TreatWarningsAsErrors" 
                     Visible="False" 
                     ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/NuGetRestore.xaml
@@ -52,6 +52,7 @@
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="DotnetCliToolTargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/NuGetRestore.xaml
@@ -52,6 +52,7 @@
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="DotnetCliToolTargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/NuGetRestore.xaml
@@ -52,6 +52,7 @@
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="DotnetCliToolTargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/NuGetRestore.xaml
@@ -52,6 +52,7 @@
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="DotnetCliToolTargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/NuGetRestore.xaml
@@ -52,6 +52,7 @@
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="DotnetCliToolTargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/NuGetRestore.xaml
@@ -52,6 +52,7 @@
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="DotnetCliToolTargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/NuGetRestore.xaml
@@ -52,6 +52,7 @@
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="DotnetCliToolTargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/NuGetRestore.xaml
@@ -52,6 +52,7 @@
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="DotnetCliToolTargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/NuGetRestore.xaml
@@ -52,6 +52,7 @@
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="DotnetCliToolTargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/NuGetRestore.xaml
@@ -52,6 +52,7 @@
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="DotnetCliToolTargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/NuGetRestore.xaml
@@ -52,6 +52,7 @@
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="DotnetCliToolTargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/NuGetRestore.xaml
@@ -52,6 +52,7 @@
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="DotnetCliToolTargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/NuGetRestore.xaml
@@ -52,6 +52,7 @@
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="DotnetCliToolTargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="False" ReadOnly="True" />


### PR DESCRIPTION
**Customer scenario**

NuGet requests us to pass this property during nomination. SDK uses this to set the target framework used to restore cli tools, and NuGet [reads this property](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Build.Tasks/NuGet.targets#L306) when restoring with `GetRestoreDotnetCliToolsTask`

**Bugs this fixes:** 

Fixes #2427 

**Workarounds, if any**

N/A

**Risk**

None

**Is this a regression from a previous update?**

No

**How was the bug found?**

New request from NuGet

/cc @dotnet/project-system 
