### PR TITLE
Respect "Visible" metadata in the Dependencies node

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DependencyModelTests.cs
@@ -151,6 +151,51 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal("someitemspec1\\versio1".GetHashCode() + "somprovider".GetHashCode(), model1.GetHashCode());
         }
 
+        [Fact]
+        public void DependencyModel_Visible_True()
+        {
+            var dependencyModel = new DependencyModel(
+                providerType: "someProvider",
+                path: "somePath",
+                originalItemSpec: "someItemSpec",
+                flags: ProjectTreeFlags.Empty,
+                resolved: true,
+                isImplicit: false,
+                properties: ImmutableDictionary<string, string>.Empty.Add("Visible", "true"));
+
+            Assert.True(dependencyModel.Visible);
+        }
+
+        [Fact]
+        public void DependencyModel_Visible_False()
+        {
+            var dependencyModel = new DependencyModel(
+                providerType: "someProvider",
+                path: "somePath",
+                originalItemSpec: "someItemSpec",
+                flags: ProjectTreeFlags.Empty,
+                resolved: true,
+                isImplicit: false,
+                properties: ImmutableDictionary<string, string>.Empty.Add("Visible", "false"));
+
+            Assert.False(dependencyModel.Visible);
+        }
+
+        [Fact]
+        public void DependencyModel_Visible_TrueWhenNotSpecified()
+        {
+            var dependencyModel = new DependencyModel(
+                providerType: "someProvider",
+                path: "somePath",
+                originalItemSpec: "someItemSpec",
+                flags: ProjectTreeFlags.Empty,
+                resolved: true,
+                isImplicit: false,
+                properties: null);
+
+            Assert.True(dependencyModel.Visible);
+        }
+
         private class TestableDependencyModel : DependencyModel
         {
             public TestableDependencyModel(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DependencyModel.cs
@@ -42,6 +42,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             {
                 Flags = Flags.Except(DependencyTreeFlags.SupportsRemove);
             }
+
+            if (Properties.TryGetValue("Visible", out string visibleMetadata)
+                && bool.TryParse(visibleMetadata, out bool visible))
+            {
+                Visible = visible;
+            }
         }
 
         public string ProviderType { get; protected set; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageAnalyzerAssemblyDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageAnalyzerAssemblyDependencyModel.cs
@@ -26,7 +26,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             Name = name;
             Caption = name;
             TopLevel = false;
-            Visible = true;
             Icon = KnownMonikers.CodeInformation;
             ExpandedIcon = Icon;
             UnresolvedIcon = ManagedImageMonikers.CodeInformationWarning;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageAssemblyDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageAssemblyDependencyModel.cs
@@ -26,7 +26,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             Name = name;
             Caption = name;
             TopLevel = false;
-            Visible = true;
             Icon = KnownMonikers.Reference;
             ExpandedIcon = Icon;
             UnresolvedIcon = KnownMonikers.ReferenceWarning;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageUnknownDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageUnknownDependencyModel.cs
@@ -26,7 +26,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             Name = name;
             Caption = name;
             TopLevel = false;
-            Visible = true;
             Icon = KnownMonikers.QuestionMark;
             ExpandedIcon = Icon;
             UnresolvedIcon = KnownMonikers.QuestionMark;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AnalyzerReference.xaml
@@ -11,4 +11,5 @@
                     SourceType="TargetResults" MSBuildTarget="CollectAnalyzersDesignTime"/>
     </Rule.DataSource>
     <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+    <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AssemblyReference.xaml
@@ -95,4 +95,6 @@
                     Visible="False" />
 
     <StringProperty Name="SDKName" Visible="false" />
+
+    <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ComReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ComReference.xaml
@@ -11,4 +11,5 @@
     <BoolProperty Name="Isolated" />
     <StringProperty Name="WrapperTool" />
     <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+    <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
@@ -83,4 +83,8 @@
                     Visible="True"
                     DisplayName="NoWarn"
                     Description="Comma-delimited list of warnings that should be suppressed for this package" />
+
+    <BoolProperty Name="Visible"
+                  Visible="False"
+                  ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.xaml
@@ -127,4 +127,7 @@
     <BoolProperty Name="UseLibraryDependencyInputs"
                   Visible="False" />
 
+    <BoolProperty Name="Visible"
+                  Visible="False"
+                  ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAnalyzerReference.xaml
@@ -29,4 +29,6 @@
             <DataSource PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
     </StringProperty>
+
+    <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAssemblyReference.xaml
@@ -176,6 +176,8 @@
                     ReadOnly="True" 
                     Description="{}What repository held the reference that was used to resolve this.  (&quot;{GAC}&quot; if it was in the GAC)." />
 
+    <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
+    
     <BoolProperty Name="WinMDFile" 
                   Visible="false"
                   ReadOnly="True" 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedCOMReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedCOMReference.xaml
@@ -122,4 +122,5 @@
     <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
     <StringProperty Name="Name" Visible="false" ReadOnly="True" />
     <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+    <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedPackageReference.xaml
@@ -70,7 +70,12 @@
             <DataSource Persistence="ResolvedReference" ItemType="PackageReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
         </StringListProperty.DataSource>
     </StringListProperty>
+    
     <BoolProperty Name="IsTopLevelDependency" 
                   Visible="False"
                   ReadOnly="True"/>
+
+    <BoolProperty Name="Visible"
+                  Visible="False"
+                  ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedProjectReference.xaml
@@ -184,4 +184,8 @@
     <StringProperty Name="Name"
                     Visible="false"
                     ReadOnly="True" />
+
+    <BoolProperty Name="Visible"
+                  Visible="False"
+                  ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedSdkReference.xaml
@@ -25,4 +25,5 @@
     <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Expand Reference Assemblies" ReadOnly="True" />
     <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copy Local Expanded Reference Assemblies" ReadOnly="True" />
     <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+    <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SdkReference.xaml
@@ -23,4 +23,5 @@
     <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Expand Reference Assemblies" ReadOnly="True" />
     <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copy Local Expanded Reference Assemblies" ReadOnly="True" />
     <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+    <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/AnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/AnalyzerReference.xaml
@@ -5,4 +5,5 @@
     <DataSource Persistence="ProjectFile" ItemType="Analyzer" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" SourceType="TargetResults" MSBuildTarget="CollectAnalyzersDesignTime" />
   </Rule.DataSource>
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/AssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/AssemblyReference.xaml
@@ -35,4 +35,5 @@
   <BoolProperty Name="IsWinMDFile" Visible="false" />
   <StringProperty Name="RequiredTargetFramework" DisplayName="Požadované cílové rozhraní" Visible="False" />
   <StringProperty Name="SDKName" Visible="false" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ComReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ComReference.xaml
@@ -11,4 +11,5 @@
   <BoolProperty Name="Isolated" />
   <StringProperty Name="WrapperTool" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/PackageReference.xaml
@@ -23,4 +23,5 @@
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="True" DisplayName="NoWarn" Description="Comma-delimited list of warnings that should be suppressed for this package" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ProjectItemsSchema.xaml
@@ -12,9 +12,13 @@
   <ContentType Name="EmbeddedResource" DisplayName="Vložený prostředek" ItemType="EmbeddedResource">
     <NameValuePair Name="DefaultMetadata_Generator" Value="ResXFileCodeGenerator" />
   </ContentType>
+  <ContentType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" ItemType="UpToDateCheckInput"></ContentType>
+  <ContentType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" ItemType="UpToDateCheckOutput"></ContentType>
   <ItemType Name="None" DisplayName="Žádné" />
   <ItemType Name="Content" DisplayName="Obsah" />
   <ItemType Name="EmbeddedResource" DisplayName="Vložený prostředek" />
+  <ItemType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" />
+  <ItemType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" UpToDateCheckInput="False" />
   <FileExtension Name=".asax" ContentType="Asax" />
   <FileExtension Name=".asmx" ContentType="HTML" />
   <FileExtension Name=".asp" ContentType="AspPage" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ProjectReference.xaml
@@ -43,4 +43,5 @@
   <StringProperty Name="Project" Visible="False" Description="Identifikátor GUID, pomocí něhož řešení sleduje jednotlivý cíl odkazu na projekt" />
   <StringProperty Name="ReferencedProjectIdentifier" Visible="False" Description="Starý způsob (beta verze VS2010) uložení identifikátoru GUID, pomocí něhož řešení sleduje jednotlivý cíl odkazu na projekt" />
   <BoolProperty Name="UseLibraryDependencyInputs" Visible="False" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ResolvedAnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ResolvedAnalyzerReference.xaml
@@ -15,4 +15,5 @@
       <DataSource PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ResolvedAssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ResolvedAssemblyReference.xaml
@@ -59,5 +59,6 @@
   <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" Description="Vyhodnocený název původní položky odkazu, jejíž překlad vedl ke vzniku tohoto nerozpoznaného odkazu" />
   <StringProperty Name="ReferenceFromSDK" Visible="False" ReadOnly="True" Description="Sada SDK, z níž pochází tento odkaz, při použití rozbalení cíle sady SDK" />
   <StringProperty Name="ResolvedFrom" Visible="False" ReadOnly="True" Description="{}V jakém úložišti byl uložen odkaz, který byl použit při překladu (&quot;{GAC}&quot;, pokud byl uložen v globální mezipaměti sestavení)" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
   <BoolProperty Name="WinMDFile" Visible="false" ReadOnly="True" Description="Určuje, zda systém sestavení zjistil, že se jedná o soubor WinMD (na rozdíl od sestavení)." />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ResolvedCOMReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ResolvedCOMReference.xaml
@@ -55,4 +55,5 @@
   <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
   <StringProperty Name="Name" Visible="false" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ResolvedPackageReference.xaml
@@ -21,4 +21,5 @@
     </StringListProperty.DataSource>
   </StringListProperty>
   <BoolProperty Name="IsTopLevelDependency" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ResolvedProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ResolvedProjectReference.xaml
@@ -58,4 +58,5 @@
   <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" Description="Vyhodnocený název původní položky odkazu, jejíž překlad vedl ke vzniku tohoto nerozpoznaného odkazu" />
   <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
   <StringProperty Name="Name" Visible="false" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ResolvedSdkReference.xaml
@@ -19,4 +19,5 @@
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Rozbalit referenční sestavení" ReadOnly="True" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Zkopírovat místní rozbalená referenční sestavení" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/SdkReference.xaml
@@ -17,4 +17,5 @@
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Rozbalit referenční sestavení" ReadOnly="True" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Zkopírovat místní rozbalená referenční sestavení" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/AnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/AnalyzerReference.xaml
@@ -5,4 +5,5 @@
     <DataSource Persistence="ProjectFile" ItemType="Analyzer" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" SourceType="TargetResults" MSBuildTarget="CollectAnalyzersDesignTime" />
   </Rule.DataSource>
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/AssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/AssemblyReference.xaml
@@ -35,4 +35,5 @@
   <BoolProperty Name="IsWinMDFile" Visible="false" />
   <StringProperty Name="RequiredTargetFramework" DisplayName="Erforderliches Zielframework" Visible="False" />
   <StringProperty Name="SDKName" Visible="false" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ComReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ComReference.xaml
@@ -11,4 +11,5 @@
   <BoolProperty Name="Isolated" />
   <StringProperty Name="WrapperTool" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/PackageReference.xaml
@@ -23,4 +23,5 @@
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="True" DisplayName="NoWarn" Description="Comma-delimited list of warnings that should be suppressed for this package" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ProjectItemsSchema.xaml
@@ -12,9 +12,13 @@
   <ContentType Name="EmbeddedResource" DisplayName="Eingebettete Ressource" ItemType="EmbeddedResource">
     <NameValuePair Name="DefaultMetadata_Generator" Value="ResXFileCodeGenerator" />
   </ContentType>
+  <ContentType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" ItemType="UpToDateCheckInput"></ContentType>
+  <ContentType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" ItemType="UpToDateCheckOutput"></ContentType>
   <ItemType Name="None" DisplayName="Keine" />
   <ItemType Name="Content" DisplayName="Inhalt" />
   <ItemType Name="EmbeddedResource" DisplayName="Eingebettete Ressource" />
+  <ItemType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" />
+  <ItemType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" UpToDateCheckInput="False" />
   <FileExtension Name=".asax" ContentType="Asax" />
   <FileExtension Name=".asmx" ContentType="HTML" />
   <FileExtension Name=".asp" ContentType="AspPage" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ProjectReference.xaml
@@ -43,4 +43,5 @@
   <StringProperty Name="Project" Visible="False" Description="Die GUID, mit der die Lösung ein individuelles Projektverweisziel nachverfolgt" />
   <StringProperty Name="ReferencedProjectIdentifier" Visible="False" Description="Die alte Methode (VS2010 Beta) zum Speichern der GUID, mit der die Lösung ein individuelles Projektverweisziel nachverfolgt" />
   <BoolProperty Name="UseLibraryDependencyInputs" Visible="False" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ResolvedAnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ResolvedAnalyzerReference.xaml
@@ -15,4 +15,5 @@
       <DataSource PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ResolvedAssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ResolvedAssemblyReference.xaml
@@ -59,5 +59,6 @@
   <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" Description="Der ausgewertete Elementname des ursprünglichen Verweiselements, dessen Auflösung zu diesem aufgelösten Verweiselement geführt hat." />
   <StringProperty Name="ReferenceFromSDK" Visible="False" ReadOnly="True" Description="Das SDK, von dem dieser Verweis stammte, als das erweiterte SDK-Ziel verwendet wurde." />
   <StringProperty Name="ResolvedFrom" Visible="False" ReadOnly="True" Description="{}Das Repository, das den Verweis enthielt, der für die Auflösung verwendet wurde. (&quot;{GAC}&quot;, wenn er sich im GAC befand)." />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
   <BoolProperty Name="WinMDFile" Visible="false" ReadOnly="True" Description="Gibt an, ob vom Buildsystem überprüft wurde, dass es sich hierbei um eine WinMD handelt (im Gegensatz zu einer Assembly)" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ResolvedCOMReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ResolvedCOMReference.xaml
@@ -55,4 +55,5 @@
   <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
   <StringProperty Name="Name" Visible="false" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ResolvedPackageReference.xaml
@@ -21,4 +21,5 @@
     </StringListProperty.DataSource>
   </StringListProperty>
   <BoolProperty Name="IsTopLevelDependency" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ResolvedProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ResolvedProjectReference.xaml
@@ -58,4 +58,5 @@
   <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" Description="Der ausgewertete Elementname des ursprünglichen Verweiselements, dessen Auflösung zu diesem aufgelösten Verweiselement geführt hat." />
   <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
   <StringProperty Name="Name" Visible="false" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ResolvedSdkReference.xaml
@@ -19,4 +19,5 @@
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Verweisassemblys erweitern" ReadOnly="True" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Lokale erweiterte Verweisassemblys kopieren" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/SdkReference.xaml
@@ -17,4 +17,5 @@
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Verweisassemblys erweitern" ReadOnly="True" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Lokale erweiterte Verweisassemblys kopieren" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/AnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/AnalyzerReference.xaml
@@ -5,4 +5,5 @@
     <DataSource Persistence="ProjectFile" ItemType="Analyzer" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" SourceType="TargetResults" MSBuildTarget="CollectAnalyzersDesignTime" />
   </Rule.DataSource>
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/AssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/AssemblyReference.xaml
@@ -35,4 +35,5 @@
   <BoolProperty Name="IsWinMDFile" Visible="false" />
   <StringProperty Name="RequiredTargetFramework" DisplayName="Plataforma de destino requerida" Visible="False" />
   <StringProperty Name="SDKName" Visible="false" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ComReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ComReference.xaml
@@ -11,4 +11,5 @@
   <BoolProperty Name="Isolated" />
   <StringProperty Name="WrapperTool" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/PackageReference.xaml
@@ -23,4 +23,5 @@
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="True" DisplayName="NoWarn" Description="Comma-delimited list of warnings that should be suppressed for this package" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ProjectItemsSchema.xaml
@@ -12,9 +12,13 @@
   <ContentType Name="EmbeddedResource" DisplayName="Recurso incrustado" ItemType="EmbeddedResource">
     <NameValuePair Name="DefaultMetadata_Generator" Value="ResXFileCodeGenerator" />
   </ContentType>
+  <ContentType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" ItemType="UpToDateCheckInput"></ContentType>
+  <ContentType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" ItemType="UpToDateCheckOutput"></ContentType>
   <ItemType Name="None" DisplayName="Ninguno" />
   <ItemType Name="Content" DisplayName="Contenido" />
   <ItemType Name="EmbeddedResource" DisplayName="Recurso incrustado" />
+  <ItemType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" />
+  <ItemType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" UpToDateCheckInput="False" />
   <FileExtension Name=".asax" ContentType="Asax" />
   <FileExtension Name=".asmx" ContentType="HTML" />
   <FileExtension Name=".asp" ContentType="AspPage" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ProjectReference.xaml
@@ -43,4 +43,5 @@
   <StringProperty Name="Project" Visible="False" Description="GUID que la solución usa para realizar un seguimiento de un destino de referencia de un proyecto individual." />
   <StringProperty Name="ReferencedProjectIdentifier" Visible="False" Description="Método empleado en VS2010 beta para almacenar el GUID que la solución usa para realizar un seguimiento de un destino de referencia de un proyecto individual." />
   <BoolProperty Name="UseLibraryDependencyInputs" Visible="False" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ResolvedAnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ResolvedAnalyzerReference.xaml
@@ -15,4 +15,5 @@
       <DataSource PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ResolvedAssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ResolvedAssemblyReference.xaml
@@ -59,5 +59,6 @@
   <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" Description="Nombre del elemento evaluado del elemento de referencia original cuya resolución produjo este elemento de referencia resuelto." />
   <StringProperty Name="ReferenceFromSDK" Visible="False" ReadOnly="True" Description="SDK del que procede esta referencia cuando se usa el destino de SDK expandido." />
   <StringProperty Name="ResolvedFrom" Visible="False" ReadOnly="True" Description="{}Repositorio que contiene la referencia que se usó para resolver este elemento. (&quot;{GAC}&quot; si estaba en la GAC)." />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
   <BoolProperty Name="WinMDFile" Visible="false" ReadOnly="True" Description="Indica si el sistema de compilación garantiza que se trata de un WinMD (en contraposición a un ensamblado)" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ResolvedCOMReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ResolvedCOMReference.xaml
@@ -55,4 +55,5 @@
   <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
   <StringProperty Name="Name" Visible="false" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ResolvedPackageReference.xaml
@@ -21,4 +21,5 @@
     </StringListProperty.DataSource>
   </StringListProperty>
   <BoolProperty Name="IsTopLevelDependency" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ResolvedProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ResolvedProjectReference.xaml
@@ -58,4 +58,5 @@
   <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" Description="Nombre del elemento evaluado del elemento de referencia original cuya resolución produjo este elemento de referencia resuelto." />
   <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
   <StringProperty Name="Name" Visible="false" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ResolvedSdkReference.xaml
@@ -19,4 +19,5 @@
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Expandir ensamblados de referencia" ReadOnly="True" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copia local de ensamblados de referencia expandidos" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/SdkReference.xaml
@@ -17,4 +17,5 @@
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Expandir ensamblados de referencia" ReadOnly="True" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copia local de ensamblados de referencia expandidos" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/AnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/AnalyzerReference.xaml
@@ -5,4 +5,5 @@
     <DataSource Persistence="ProjectFile" ItemType="Analyzer" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" SourceType="TargetResults" MSBuildTarget="CollectAnalyzersDesignTime" />
   </Rule.DataSource>
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/AssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/AssemblyReference.xaml
@@ -35,4 +35,5 @@
   <BoolProperty Name="IsWinMDFile" Visible="false" />
   <StringProperty Name="RequiredTargetFramework" DisplayName="Framework cible requis" Visible="False" />
   <StringProperty Name="SDKName" Visible="false" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ComReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ComReference.xaml
@@ -11,4 +11,5 @@
   <BoolProperty Name="Isolated" />
   <StringProperty Name="WrapperTool" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/PackageReference.xaml
@@ -23,4 +23,5 @@
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="True" DisplayName="NoWarn" Description="Comma-delimited list of warnings that should be suppressed for this package" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ProjectItemsSchema.xaml
@@ -12,9 +12,13 @@
   <ContentType Name="EmbeddedResource" DisplayName="Ressource incorporée" ItemType="EmbeddedResource">
     <NameValuePair Name="DefaultMetadata_Generator" Value="ResXFileCodeGenerator" />
   </ContentType>
+  <ContentType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" ItemType="UpToDateCheckInput"></ContentType>
+  <ContentType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" ItemType="UpToDateCheckOutput"></ContentType>
   <ItemType Name="None" DisplayName="Aucun" />
   <ItemType Name="Content" DisplayName="Contenu" />
   <ItemType Name="EmbeddedResource" DisplayName="Ressource incorporée" />
+  <ItemType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" />
+  <ItemType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" UpToDateCheckInput="False" />
   <FileExtension Name=".asax" ContentType="Asax" />
   <FileExtension Name=".asmx" ContentType="HTML" />
   <FileExtension Name=".asp" ContentType="AspPage" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ProjectReference.xaml
@@ -43,4 +43,5 @@
   <StringProperty Name="Project" Visible="False" Description="Guid avec lequel la solution suit une cible de référence d'un projet individuel" />
   <StringProperty Name="ReferencedProjectIdentifier" Visible="False" Description="Ancienne méthode(VS2010 bêta) pour stocker le Guid avec lequel la solution suit une cible de référence d'un projet individuel" />
   <BoolProperty Name="UseLibraryDependencyInputs" Visible="False" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ResolvedAnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ResolvedAnalyzerReference.xaml
@@ -15,4 +15,5 @@
       <DataSource PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ResolvedAssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ResolvedAssemblyReference.xaml
@@ -59,5 +59,6 @@
   <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" Description="Nom d'élément évalué de l'élément de référence d'origine dont la résolution a eu pour résultat cet élément de référence résolu." />
   <StringProperty Name="ReferenceFromSDK" Visible="False" ReadOnly="True" Description="Kit SDK dont est issue cette référence lorsque la cible SDK développée a été utilisée." />
   <StringProperty Name="ResolvedFrom" Visible="False" ReadOnly="True" Description="{}Référentiel contenant la référence ayant servi à la résolution. (&quot;{GAC}&quot; si elle se trouvait dans le GAC)." />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
   <BoolProperty Name="WinMDFile" Visible="false" ReadOnly="True" Description="Indique si le système de génération a établi qu'il s'agit d'un WinMD (et non d'un assembly)" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ResolvedCOMReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ResolvedCOMReference.xaml
@@ -55,4 +55,5 @@
   <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
   <StringProperty Name="Name" Visible="false" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ResolvedPackageReference.xaml
@@ -21,4 +21,5 @@
     </StringListProperty.DataSource>
   </StringListProperty>
   <BoolProperty Name="IsTopLevelDependency" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ResolvedProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ResolvedProjectReference.xaml
@@ -58,4 +58,5 @@
   <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" Description="Nom d'élément évalué de l'élément de référence d'origine dont la résolution a eu pour résultat cet élément de référence résolu." />
   <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
   <StringProperty Name="Name" Visible="false" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ResolvedSdkReference.xaml
@@ -19,4 +19,5 @@
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Développer les assemblys de référence" ReadOnly="True" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copier les assemblys de référence développés locaux" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/SdkReference.xaml
@@ -17,4 +17,5 @@
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Développer les assemblys de référence" ReadOnly="True" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copier les assemblys de référence développés locaux" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/AnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/AnalyzerReference.xaml
@@ -5,4 +5,5 @@
     <DataSource Persistence="ProjectFile" ItemType="Analyzer" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" SourceType="TargetResults" MSBuildTarget="CollectAnalyzersDesignTime" />
   </Rule.DataSource>
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/AssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/AssemblyReference.xaml
@@ -35,4 +35,5 @@
   <BoolProperty Name="IsWinMDFile" Visible="false" />
   <StringProperty Name="RequiredTargetFramework" DisplayName="Framework di destinazione necessario" Visible="False" />
   <StringProperty Name="SDKName" Visible="false" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ComReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ComReference.xaml
@@ -11,4 +11,5 @@
   <BoolProperty Name="Isolated" />
   <StringProperty Name="WrapperTool" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/PackageReference.xaml
@@ -23,4 +23,5 @@
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="True" DisplayName="NoWarn" Description="Comma-delimited list of warnings that should be suppressed for this package" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ProjectItemsSchema.xaml
@@ -12,9 +12,13 @@
   <ContentType Name="EmbeddedResource" DisplayName="Risorsa incorporata" ItemType="EmbeddedResource">
     <NameValuePair Name="DefaultMetadata_Generator" Value="ResXFileCodeGenerator" />
   </ContentType>
+  <ContentType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" ItemType="UpToDateCheckInput"></ContentType>
+  <ContentType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" ItemType="UpToDateCheckOutput"></ContentType>
   <ItemType Name="None" DisplayName="Nessuno" />
   <ItemType Name="Content" DisplayName="Contenuto" />
   <ItemType Name="EmbeddedResource" DisplayName="Risorsa incorporata" />
+  <ItemType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" />
+  <ItemType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" UpToDateCheckInput="False" />
   <FileExtension Name=".asax" ContentType="Asax" />
   <FileExtension Name=".asmx" ContentType="HTML" />
   <FileExtension Name=".asp" ContentType="AspPage" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ProjectReference.xaml
@@ -43,4 +43,5 @@
   <StringProperty Name="Project" Visible="False" Description="GUID con cui la soluzione tiene traccia della destinazione del riferimento di un singolo progetto" />
   <StringProperty Name="ReferencedProjectIdentifier" Visible="False" Description="Modalità precedente (VS2010 beta) per archiviare il GUID con cui la soluzione tiene traccia della destinazione del riferimento di un singolo progetto" />
   <BoolProperty Name="UseLibraryDependencyInputs" Visible="False" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ResolvedAnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ResolvedAnalyzerReference.xaml
@@ -15,4 +15,5 @@
       <DataSource PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ResolvedAssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ResolvedAssemblyReference.xaml
@@ -59,5 +59,6 @@
   <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" Description="Nome di elemento valutato dell'elemento di riferimento originale la cui risoluzione ha restituito questo elemento di riferimento risolto." />
   <StringProperty Name="ReferenceFromSDK" Visible="False" ReadOnly="True" Description="SDK da cui proviene questo riferimento quando si usa la destinazione SDK di espansione." />
   <StringProperty Name="ResolvedFrom" Visible="False" ReadOnly="True" Description="{}Repository in cui era contenuto il riferimento usato per risolverlo. È &quot;{GAC}&quot; se si trovava nella GAC." />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
   <BoolProperty Name="WinMDFile" Visible="false" ReadOnly="True" Description="Indica se il sistema di compilazione ha accertato che si tratta di un WinMD (in contrapposizione a un assembly)" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ResolvedCOMReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ResolvedCOMReference.xaml
@@ -55,4 +55,5 @@
   <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
   <StringProperty Name="Name" Visible="false" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ResolvedPackageReference.xaml
@@ -21,4 +21,5 @@
     </StringListProperty.DataSource>
   </StringListProperty>
   <BoolProperty Name="IsTopLevelDependency" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ResolvedProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ResolvedProjectReference.xaml
@@ -58,4 +58,5 @@
   <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" Description="Nome di elemento valutato dell'elemento di riferimento originale la cui risoluzione ha restituito questo elemento di riferimento risolto." />
   <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
   <StringProperty Name="Name" Visible="false" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ResolvedSdkReference.xaml
@@ -19,4 +19,5 @@
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Espandi assembly di riferimento" ReadOnly="True" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copia assembly di riferimento espansi locali" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/SdkReference.xaml
@@ -17,4 +17,5 @@
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Espandi assembly di riferimento" ReadOnly="True" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copia assembly di riferimento espansi locali" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/AnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/AnalyzerReference.xaml
@@ -5,4 +5,5 @@
     <DataSource Persistence="ProjectFile" ItemType="Analyzer" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" SourceType="TargetResults" MSBuildTarget="CollectAnalyzersDesignTime" />
   </Rule.DataSource>
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/AssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/AssemblyReference.xaml
@@ -35,4 +35,5 @@
   <BoolProperty Name="IsWinMDFile" Visible="false" />
   <StringProperty Name="RequiredTargetFramework" DisplayName="必要なターゲット フレームワーク" Visible="False" />
   <StringProperty Name="SDKName" Visible="false" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ComReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ComReference.xaml
@@ -11,4 +11,5 @@
   <BoolProperty Name="Isolated" />
   <StringProperty Name="WrapperTool" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/PackageReference.xaml
@@ -23,4 +23,5 @@
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="True" DisplayName="NoWarn" Description="Comma-delimited list of warnings that should be suppressed for this package" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ProjectItemsSchema.xaml
@@ -12,9 +12,13 @@
   <ContentType Name="EmbeddedResource" DisplayName="埋め込みリソース" ItemType="EmbeddedResource">
     <NameValuePair Name="DefaultMetadata_Generator" Value="ResXFileCodeGenerator" />
   </ContentType>
+  <ContentType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" ItemType="UpToDateCheckInput"></ContentType>
+  <ContentType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" ItemType="UpToDateCheckOutput"></ContentType>
   <ItemType Name="None" DisplayName="なし" />
   <ItemType Name="Content" DisplayName="コンテンツ" />
   <ItemType Name="EmbeddedResource" DisplayName="埋め込みリソース" />
+  <ItemType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" />
+  <ItemType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" UpToDateCheckInput="False" />
   <FileExtension Name=".asax" ContentType="Asax" />
   <FileExtension Name=".asmx" ContentType="HTML" />
   <FileExtension Name=".asp" ContentType="AspPage" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ProjectReference.xaml
@@ -43,4 +43,5 @@
   <StringProperty Name="Project" Visible="False" Description="個々のプロジェクトの参照先を追跡するためにソリューションで使用する GUID" />
   <StringProperty Name="ReferencedProjectIdentifier" Visible="False" Description="個々のプロジェクトの参照先を追跡するためにソリューションで使用する GUID を格納する以前 (VS2010 beta) の方法" />
   <BoolProperty Name="UseLibraryDependencyInputs" Visible="False" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ResolvedAnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ResolvedAnalyzerReference.xaml
@@ -15,4 +15,5 @@
       <DataSource PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ResolvedAssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ResolvedAssemblyReference.xaml
@@ -59,5 +59,6 @@
   <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" Description="結果がこの解決済みの参照項目であった元の参照項目の評価済み項目名です。" />
   <StringProperty Name="ReferenceFromSDK" Visible="False" ReadOnly="True" Description="拡張 SDK の参照を使用するときにこの参照が属していた SDK です。" />
   <StringProperty Name="ResolvedFrom" Visible="False" ReadOnly="True" Description="{}これを解決するために参照を保持していたリポジトリを示します (GAC の場合は &quot;{GAC}&quot;)。" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
   <BoolProperty Name="WinMDFile" Visible="false" ReadOnly="True" Description="ビルド システムが (アセンブリではなく) WinMD であることを確認したかどうかを示します" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ResolvedCOMReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ResolvedCOMReference.xaml
@@ -55,4 +55,5 @@
   <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
   <StringProperty Name="Name" Visible="false" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ResolvedPackageReference.xaml
@@ -21,4 +21,5 @@
     </StringListProperty.DataSource>
   </StringListProperty>
   <BoolProperty Name="IsTopLevelDependency" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ResolvedProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ResolvedProjectReference.xaml
@@ -58,4 +58,5 @@
   <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" Description="結果がこの解決済みの参照項目であった元の参照項目の評価済み項目名です。" />
   <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
   <StringProperty Name="Name" Visible="false" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ResolvedSdkReference.xaml
@@ -19,4 +19,5 @@
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="参照アセンブリの展開" ReadOnly="True" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="ローカルに展開された参照アセンブリのコピー" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/SdkReference.xaml
@@ -17,4 +17,5 @@
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="参照アセンブリの展開" ReadOnly="True" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="ローカルに展開された参照アセンブリのコピー" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/AnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/AnalyzerReference.xaml
@@ -5,4 +5,5 @@
     <DataSource Persistence="ProjectFile" ItemType="Analyzer" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" SourceType="TargetResults" MSBuildTarget="CollectAnalyzersDesignTime" />
   </Rule.DataSource>
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/AssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/AssemblyReference.xaml
@@ -35,4 +35,5 @@
   <BoolProperty Name="IsWinMDFile" Visible="false" />
   <StringProperty Name="RequiredTargetFramework" DisplayName="필요한 대상 프레임워크" Visible="False" />
   <StringProperty Name="SDKName" Visible="false" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ComReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ComReference.xaml
@@ -11,4 +11,5 @@
   <BoolProperty Name="Isolated" />
   <StringProperty Name="WrapperTool" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/PackageReference.xaml
@@ -23,4 +23,5 @@
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="True" DisplayName="NoWarn" Description="Comma-delimited list of warnings that should be suppressed for this package" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ProjectItemsSchema.xaml
@@ -12,9 +12,13 @@
   <ContentType Name="EmbeddedResource" DisplayName="포함 리소스" ItemType="EmbeddedResource">
     <NameValuePair Name="DefaultMetadata_Generator" Value="ResXFileCodeGenerator" />
   </ContentType>
+  <ContentType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" ItemType="UpToDateCheckInput"></ContentType>
+  <ContentType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" ItemType="UpToDateCheckOutput"></ContentType>
   <ItemType Name="None" DisplayName="없음" />
   <ItemType Name="Content" DisplayName="내용" />
   <ItemType Name="EmbeddedResource" DisplayName="포함 리소스" />
+  <ItemType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" />
+  <ItemType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" UpToDateCheckInput="False" />
   <FileExtension Name=".asax" ContentType="Asax" />
   <FileExtension Name=".asmx" ContentType="HTML" />
   <FileExtension Name=".asp" ContentType="AspPage" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ProjectReference.xaml
@@ -43,4 +43,5 @@
   <StringProperty Name="Project" Visible="False" Description="솔루션이 개별 프로젝트 참조 대상을 추적할 때 사용하는 GUID" />
   <StringProperty Name="ReferencedProjectIdentifier" Visible="False" Description="솔루션이 개별 프로젝트 참조 대상을 추적할 때 사용하는 GUID를 저장하는 예전의(VS2010 베타) 방법" />
   <BoolProperty Name="UseLibraryDependencyInputs" Visible="False" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ResolvedAnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ResolvedAnalyzerReference.xaml
@@ -15,4 +15,5 @@
       <DataSource PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ResolvedAssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ResolvedAssemblyReference.xaml
@@ -59,5 +59,6 @@
   <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" Description="확인 결과 이 확인된 참조 항목으로 드러난 원래 참조 항목의 평가 항목 이름입니다." />
   <StringProperty Name="ReferenceFromSDK" Visible="False" ReadOnly="True" Description="SDK 대상 확장을 사용할 때 이 참조를 호출하는 SDK입니다." />
   <StringProperty Name="ResolvedFrom" Visible="False" ReadOnly="True" Description="{}이것을 확인하는 데 사용된 참조를 포함하고 있는 리포지토리입니다(GAC에 있었던 경우 &quot;{GAC}&quot;)." />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
   <BoolProperty Name="WinMDFile" Visible="false" ReadOnly="True" Description="빌드 시스템에서 이것이 WinMD인 것(어셈블리가 아님)을 확인했는지 여부를 나타냅니다." />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ResolvedCOMReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ResolvedCOMReference.xaml
@@ -55,4 +55,5 @@
   <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
   <StringProperty Name="Name" Visible="false" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ResolvedPackageReference.xaml
@@ -21,4 +21,5 @@
     </StringListProperty.DataSource>
   </StringListProperty>
   <BoolProperty Name="IsTopLevelDependency" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ResolvedProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ResolvedProjectReference.xaml
@@ -58,4 +58,5 @@
   <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" Description="확인 결과 이 확인된 참조 항목으로 드러난 원래 참조 항목의 평가 항목 이름입니다." />
   <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
   <StringProperty Name="Name" Visible="false" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ResolvedSdkReference.xaml
@@ -19,4 +19,5 @@
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="참조 어셈블리 확장" ReadOnly="True" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="확장된 로컬 참조 어셈블리 복사" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/SdkReference.xaml
@@ -17,4 +17,5 @@
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="참조 어셈블리 확장" ReadOnly="True" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="확장된 로컬 참조 어셈블리 복사" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/AnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/AnalyzerReference.xaml
@@ -5,4 +5,5 @@
     <DataSource Persistence="ProjectFile" ItemType="Analyzer" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" SourceType="TargetResults" MSBuildTarget="CollectAnalyzersDesignTime" />
   </Rule.DataSource>
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/AssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/AssemblyReference.xaml
@@ -35,4 +35,5 @@
   <BoolProperty Name="IsWinMDFile" Visible="false" />
   <StringProperty Name="RequiredTargetFramework" DisplayName="Wymagana platforma docelowa" Visible="False" />
   <StringProperty Name="SDKName" Visible="false" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ComReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ComReference.xaml
@@ -11,4 +11,5 @@
   <BoolProperty Name="Isolated" />
   <StringProperty Name="WrapperTool" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/PackageReference.xaml
@@ -23,4 +23,5 @@
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="True" DisplayName="NoWarn" Description="Comma-delimited list of warnings that should be suppressed for this package" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ProjectItemsSchema.xaml
@@ -12,9 +12,13 @@
   <ContentType Name="EmbeddedResource" DisplayName="Osadzony zasób" ItemType="EmbeddedResource">
     <NameValuePair Name="DefaultMetadata_Generator" Value="ResXFileCodeGenerator" />
   </ContentType>
+  <ContentType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" ItemType="UpToDateCheckInput"></ContentType>
+  <ContentType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" ItemType="UpToDateCheckOutput"></ContentType>
   <ItemType Name="None" DisplayName="Brak" />
   <ItemType Name="Content" DisplayName="Zawartość" />
   <ItemType Name="EmbeddedResource" DisplayName="Osadzony zasób" />
+  <ItemType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" />
+  <ItemType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" UpToDateCheckInput="False" />
   <FileExtension Name=".asax" ContentType="Asax" />
   <FileExtension Name=".asmx" ContentType="HTML" />
   <FileExtension Name=".asp" ContentType="AspPage" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ProjectReference.xaml
@@ -43,4 +43,5 @@
   <StringProperty Name="Project" Visible="False" Description="identyfikator Guid rozwiązania śledzi docelowe odwołanie pojedynczego projektu za pomocą" />
   <StringProperty Name="ReferencedProjectIdentifier" Visible="False" Description="Stary (VS2010 beta) sposób zapisywania identyfikatora Guid rozwiązania śledzącego odwołanie pojedynczego projektu za pomocą" />
   <BoolProperty Name="UseLibraryDependencyInputs" Visible="False" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ResolvedAnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ResolvedAnalyzerReference.xaml
@@ -15,4 +15,5 @@
       <DataSource PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ResolvedAssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ResolvedAssemblyReference.xaml
@@ -59,5 +59,6 @@
   <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" Description="Sprawdzona nazwa elementu oryginalnego elementu odwołania, którego rozpoznanie spowodowało rozpoznanie tego elementu odwołania." />
   <StringProperty Name="ReferenceFromSDK" Visible="False" ReadOnly="True" Description="Zestaw SDK, z którego pochodzi to odwołanie, jeśli jest używany rozszerzony docelowy zestaw SDK." />
   <StringProperty Name="ResolvedFrom" Visible="False" ReadOnly="True" Description="{}Które repozytorium przechowuje odwołanie użyte do rozpoznania tego.  („{GAC}”, jeśli było w GAC)." />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
   <BoolProperty Name="WinMDFile" Visible="false" ReadOnly="True" Description="Wskazuje, czy system kompilacji upewnił się że jest to WinMD (w przeciwieństwie do zestawu)" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ResolvedCOMReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ResolvedCOMReference.xaml
@@ -55,4 +55,5 @@
   <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
   <StringProperty Name="Name" Visible="false" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ResolvedPackageReference.xaml
@@ -21,4 +21,5 @@
     </StringListProperty.DataSource>
   </StringListProperty>
   <BoolProperty Name="IsTopLevelDependency" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ResolvedProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ResolvedProjectReference.xaml
@@ -58,4 +58,5 @@
   <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" Description="Sprawdzona nazwa elementu oryginalnego elementu odwołania, którego rozpoznanie spowodowało rozpoznanie tego elementu odwołania." />
   <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
   <StringProperty Name="Name" Visible="false" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ResolvedSdkReference.xaml
@@ -19,4 +19,5 @@
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Rozwiń zestawy odwołań" ReadOnly="True" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Kopiuj lokalne rozwinięte zestawy referencyjne" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/SdkReference.xaml
@@ -17,4 +17,5 @@
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Rozwiń zestawy odwołań" ReadOnly="True" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Kopiuj lokalne rozwinięte zestawy referencyjne" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/AnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/AnalyzerReference.xaml
@@ -5,4 +5,5 @@
     <DataSource Persistence="ProjectFile" ItemType="Analyzer" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" SourceType="TargetResults" MSBuildTarget="CollectAnalyzersDesignTime" />
   </Rule.DataSource>
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/AssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/AssemblyReference.xaml
@@ -35,4 +35,5 @@
   <BoolProperty Name="IsWinMDFile" Visible="false" />
   <StringProperty Name="RequiredTargetFramework" DisplayName="Estrutura de Destino Necessária" Visible="False" />
   <StringProperty Name="SDKName" Visible="false" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ComReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ComReference.xaml
@@ -11,4 +11,5 @@
   <BoolProperty Name="Isolated" />
   <StringProperty Name="WrapperTool" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/PackageReference.xaml
@@ -23,4 +23,5 @@
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="True" DisplayName="NoWarn" Description="Comma-delimited list of warnings that should be suppressed for this package" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ProjectItemsSchema.xaml
@@ -12,9 +12,13 @@
   <ContentType Name="EmbeddedResource" DisplayName="Recurso inserido" ItemType="EmbeddedResource">
     <NameValuePair Name="DefaultMetadata_Generator" Value="ResXFileCodeGenerator" />
   </ContentType>
+  <ContentType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" ItemType="UpToDateCheckInput"></ContentType>
+  <ContentType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" ItemType="UpToDateCheckOutput"></ContentType>
   <ItemType Name="None" DisplayName="Nenhum" />
   <ItemType Name="Content" DisplayName="Conteúdo" />
   <ItemType Name="EmbeddedResource" DisplayName="Recurso inserido" />
+  <ItemType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" />
+  <ItemType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" UpToDateCheckInput="False" />
   <FileExtension Name=".asax" ContentType="Asax" />
   <FileExtension Name=".asmx" ContentType="HTML" />
   <FileExtension Name=".asp" ContentType="AspPage" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ProjectReference.xaml
@@ -43,4 +43,5 @@
   <StringProperty Name="Project" Visible="False" Description="o GUID com o qual a solução rastreia um destino de referência de projeto individual" />
   <StringProperty Name="ReferencedProjectIdentifier" Visible="False" Description="O meio antigo (VS2010 beta) de armazenar o GUID com o qual a solução rastreia um destino de referência de projeto individual" />
   <BoolProperty Name="UseLibraryDependencyInputs" Visible="False" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ResolvedAnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ResolvedAnalyzerReference.xaml
@@ -15,4 +15,5 @@
       <DataSource PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ResolvedAssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ResolvedAssemblyReference.xaml
@@ -59,5 +59,6 @@
   <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" Description="O nome do item avaliado do item de referência original cuja resolução resultou nesse item de referência resolvido." />
   <StringProperty Name="ReferenceFromSDK" Visible="False" ReadOnly="True" Description="O SDK de origem dessa referência ao usar o destino do SDK de expansão." />
   <StringProperty Name="ResolvedFrom" Visible="False" ReadOnly="True" Description="{}Que repositório retém a referência que foi usada para resolver isso. (&quot;{GAC}&quot; se estava no GAC)." />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
   <BoolProperty Name="WinMDFile" Visible="false" ReadOnly="True" Description="Indica se o sistema de compilação determinou que esse é um WinMD (ao contrário de um assembly)" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ResolvedCOMReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ResolvedCOMReference.xaml
@@ -55,4 +55,5 @@
   <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
   <StringProperty Name="Name" Visible="false" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ResolvedPackageReference.xaml
@@ -21,4 +21,5 @@
     </StringListProperty.DataSource>
   </StringListProperty>
   <BoolProperty Name="IsTopLevelDependency" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ResolvedProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ResolvedProjectReference.xaml
@@ -58,4 +58,5 @@
   <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" Description="O nome do item avaliado do item de referência original cuja resolução resultou nesse item de referência resolvido." />
   <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
   <StringProperty Name="Name" Visible="false" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ResolvedSdkReference.xaml
@@ -19,4 +19,5 @@
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Expandir Assemblies de Referência" ReadOnly="True" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Assemblies de Referência Expandidos do Local da Cópia" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/SdkReference.xaml
@@ -17,4 +17,5 @@
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Expandir Assemblies de Referência" ReadOnly="True" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Assemblies de Referência Expandidos do Local da Cópia" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/AnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/AnalyzerReference.xaml
@@ -5,4 +5,5 @@
     <DataSource Persistence="ProjectFile" ItemType="Analyzer" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" SourceType="TargetResults" MSBuildTarget="CollectAnalyzersDesignTime" />
   </Rule.DataSource>
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/AssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/AssemblyReference.xaml
@@ -35,4 +35,5 @@
   <BoolProperty Name="IsWinMDFile" Visible="false" />
   <StringProperty Name="RequiredTargetFramework" DisplayName="Требуемая версия .NET Framework" Visible="False" />
   <StringProperty Name="SDKName" Visible="false" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ComReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ComReference.xaml
@@ -11,4 +11,5 @@
   <BoolProperty Name="Isolated" />
   <StringProperty Name="WrapperTool" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/PackageReference.xaml
@@ -23,4 +23,5 @@
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="True" DisplayName="NoWarn" Description="Comma-delimited list of warnings that should be suppressed for this package" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ProjectItemsSchema.xaml
@@ -12,9 +12,13 @@
   <ContentType Name="EmbeddedResource" DisplayName="Внедренный ресурс" ItemType="EmbeddedResource">
     <NameValuePair Name="DefaultMetadata_Generator" Value="ResXFileCodeGenerator" />
   </ContentType>
+  <ContentType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" ItemType="UpToDateCheckInput"></ContentType>
+  <ContentType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" ItemType="UpToDateCheckOutput"></ContentType>
   <ItemType Name="None" DisplayName="Нет" />
   <ItemType Name="Content" DisplayName="Содержимое" />
   <ItemType Name="EmbeddedResource" DisplayName="Внедренный ресурс" />
+  <ItemType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" />
+  <ItemType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" UpToDateCheckInput="False" />
   <FileExtension Name=".asax" ContentType="Asax" />
   <FileExtension Name=".asmx" ContentType="HTML" />
   <FileExtension Name=".asp" ContentType="AspPage" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ProjectReference.xaml
@@ -43,4 +43,5 @@
   <StringProperty Name="Project" Visible="False" Description="идентификатор GUID, с помощью которого решение отслеживает ссылочную целевую сборку отдельного проекта" />
   <StringProperty Name="ReferencedProjectIdentifier" Visible="False" Description="Старый (из бета-версии VS2010) способ хранения идентификатора GUID, с помощью которого решение отслеживает ссылочную целевую сборку отдельного проекта" />
   <BoolProperty Name="UseLibraryDependencyInputs" Visible="False" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ResolvedAnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ResolvedAnalyzerReference.xaml
@@ -15,4 +15,5 @@
       <DataSource PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ResolvedAssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ResolvedAssemblyReference.xaml
@@ -59,5 +59,6 @@
   <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" Description="Вычисленное имя исходного ссылочного элемента, в результате разрешения которого был получен данный разрешенный ссылочный элемент." />
   <StringProperty Name="ReferenceFromSDK" Visible="False" ReadOnly="True" Description="Пакет SDK, из которого получена эта ссылочная сборка, при использовании расширенной целевой сборки SDK." />
   <StringProperty Name="ResolvedFrom" Visible="False" ReadOnly="True" Description="{}Репозиторий, в котором хранилась ссылка, с помощью которой было выполнено данное разрешение. (&quot;{GAC}&quot;, если репозиторием был глобальный кэш сборок)." />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
   <BoolProperty Name="WinMDFile" Visible="false" ReadOnly="True" Description="Указывает, действительно ли система сборки подтвердила, что файл является WinMD-файлом (а не сборкой)" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ResolvedCOMReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ResolvedCOMReference.xaml
@@ -55,4 +55,5 @@
   <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
   <StringProperty Name="Name" Visible="false" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ResolvedPackageReference.xaml
@@ -21,4 +21,5 @@
     </StringListProperty.DataSource>
   </StringListProperty>
   <BoolProperty Name="IsTopLevelDependency" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ResolvedProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ResolvedProjectReference.xaml
@@ -58,4 +58,5 @@
   <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" Description="Вычисленное имя исходного ссылочного элемента, в результате разрешения которого был получен данный разрешенный ссылочный элемент." />
   <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
   <StringProperty Name="Name" Visible="false" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ResolvedSdkReference.xaml
@@ -19,4 +19,5 @@
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Расширить эталонные сборки" ReadOnly="True" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Копировать локальные расширенные ссылочные сборки" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/SdkReference.xaml
@@ -17,4 +17,5 @@
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Расширить эталонные сборки" ReadOnly="True" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Копировать локальные расширенные ссылочные сборки" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/AnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/AnalyzerReference.xaml
@@ -5,4 +5,5 @@
     <DataSource Persistence="ProjectFile" ItemType="Analyzer" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" SourceType="TargetResults" MSBuildTarget="CollectAnalyzersDesignTime" />
   </Rule.DataSource>
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/AssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/AssemblyReference.xaml
@@ -35,4 +35,5 @@
   <BoolProperty Name="IsWinMDFile" Visible="false" />
   <StringProperty Name="RequiredTargetFramework" DisplayName="Gerekli Hedef Çerçeve" Visible="False" />
   <StringProperty Name="SDKName" Visible="false" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ComReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ComReference.xaml
@@ -11,4 +11,5 @@
   <BoolProperty Name="Isolated" />
   <StringProperty Name="WrapperTool" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/PackageReference.xaml
@@ -23,4 +23,5 @@
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="True" DisplayName="NoWarn" Description="Comma-delimited list of warnings that should be suppressed for this package" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ProjectItemsSchema.xaml
@@ -12,9 +12,13 @@
   <ContentType Name="EmbeddedResource" DisplayName="Eklenmiş kaynak" ItemType="EmbeddedResource">
     <NameValuePair Name="DefaultMetadata_Generator" Value="ResXFileCodeGenerator" />
   </ContentType>
+  <ContentType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" ItemType="UpToDateCheckInput"></ContentType>
+  <ContentType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" ItemType="UpToDateCheckOutput"></ContentType>
   <ItemType Name="None" DisplayName="Hiçbiri" />
   <ItemType Name="Content" DisplayName="İçerik" />
   <ItemType Name="EmbeddedResource" DisplayName="Eklenmiş kaynak" />
+  <ItemType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" />
+  <ItemType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" UpToDateCheckInput="False" />
   <FileExtension Name=".asax" ContentType="Asax" />
   <FileExtension Name=".asmx" ContentType="HTML" />
   <FileExtension Name=".asp" ContentType="AspPage" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ProjectReference.xaml
@@ -43,4 +43,5 @@
   <StringProperty Name="Project" Visible="False" Description="Çözümün tek bir proje başvuru hedefini birlikte izlediği Guid" />
   <StringProperty Name="ReferencedProjectIdentifier" Visible="False" Description="Çözümün tek bir proje başvuru hedefini birlikte izlediği Guid'i depolamanın eski (VS2010 beta) yöntemi" />
   <BoolProperty Name="UseLibraryDependencyInputs" Visible="False" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ResolvedAnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ResolvedAnalyzerReference.xaml
@@ -15,4 +15,5 @@
       <DataSource PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ResolvedAssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ResolvedAssemblyReference.xaml
@@ -59,5 +59,6 @@
   <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" Description="Çözümlemesi, bu çözümlenen başvuru öğesiyle sonuçlanmış olan orijinal başvuru öğesinin değerlendirilen öğe adı." />
   <StringProperty Name="ReferenceFromSDK" Visible="False" ReadOnly="True" Description="Genişletme SDK hedefi kullanılırken bu başvurunun geldiği SDK." />
   <StringProperty Name="ResolvedFrom" Visible="False" ReadOnly="True" Description="{}Bunu çözümlemek için kullanılan başvuruyu hangi deponun tuttuğu. (GAC'de ise, &quot;{GAC}&quot;)." />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
   <BoolProperty Name="WinMDFile" Visible="false" ReadOnly="True" Description="Oluşturma sisteminin (bir derlemeden farklı olarak), bunun bir WinMD olduğunu doğrulayıp doğrulamadığını gösterir" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ResolvedCOMReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ResolvedCOMReference.xaml
@@ -55,4 +55,5 @@
   <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
   <StringProperty Name="Name" Visible="false" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ResolvedPackageReference.xaml
@@ -21,4 +21,5 @@
     </StringListProperty.DataSource>
   </StringListProperty>
   <BoolProperty Name="IsTopLevelDependency" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ResolvedProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ResolvedProjectReference.xaml
@@ -58,4 +58,5 @@
   <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" Description="Çözümlemesi, bu çözümlenen başvuru öğesiyle sonuçlanmış olan orijinal başvuru öğesinin değerlendirilen öğe adı." />
   <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
   <StringProperty Name="Name" Visible="false" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ResolvedSdkReference.xaml
@@ -19,4 +19,5 @@
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Başvuru Bütünleştirilmiş Kodlarını Genişlet" ReadOnly="True" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Yerel Genişletilmiş Başvuru Derlemelerini Kopyala" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/SdkReference.xaml
@@ -17,4 +17,5 @@
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Başvuru Bütünleştirilmiş Kodlarını Genişlet" ReadOnly="True" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Yerel Genişletilmiş Başvuru Derlemelerini Kopyala" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.cs.xlf
@@ -63,6 +63,26 @@
         <target state="translated">Vložený prostředek</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.de.xlf
@@ -63,6 +63,26 @@
         <target state="translated">Eingebettete Ressource</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.es.xlf
@@ -63,6 +63,26 @@
         <target state="translated">Recurso incrustado</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.fr.xlf
@@ -63,6 +63,26 @@
         <target state="translated">Ressource incorporée</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.it.xlf
@@ -63,6 +63,26 @@
         <target state="translated">Risorsa incorporata</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.ja.xlf
@@ -63,6 +63,26 @@
         <target state="translated">埋め込みリソース</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.ko.xlf
@@ -63,6 +63,26 @@
         <target state="translated">포함 리소스</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.pl.xlf
@@ -63,6 +63,26 @@
         <target state="translated">Osadzony zasób</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.pt-BR.xlf
@@ -63,6 +63,26 @@
         <target state="translated">Recurso inserido</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.ru.xlf
@@ -63,6 +63,26 @@
         <target state="translated">Внедренный ресурс</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.tr.xlf
@@ -63,6 +63,26 @@
         <target state="translated">Eklenmiş kaynak</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.xlf
@@ -51,6 +51,22 @@
         <source>Embedded resource</source>
         <note />
       </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.zh-Hans.xlf
@@ -63,6 +63,26 @@
         <target state="translated">嵌入的资源</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.zh-Hant.xlf
@@ -63,6 +63,26 @@
         <target state="translated">內嵌資源</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/AnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/AnalyzerReference.xaml
@@ -5,4 +5,5 @@
     <DataSource Persistence="ProjectFile" ItemType="Analyzer" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" SourceType="TargetResults" MSBuildTarget="CollectAnalyzersDesignTime" />
   </Rule.DataSource>
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/AssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/AssemblyReference.xaml
@@ -35,4 +35,5 @@
   <BoolProperty Name="IsWinMDFile" Visible="false" />
   <StringProperty Name="RequiredTargetFramework" DisplayName="需要目标框架" Visible="False" />
   <StringProperty Name="SDKName" Visible="false" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ComReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ComReference.xaml
@@ -11,4 +11,5 @@
   <BoolProperty Name="Isolated" />
   <StringProperty Name="WrapperTool" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/PackageReference.xaml
@@ -23,4 +23,5 @@
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="True" DisplayName="NoWarn" Description="Comma-delimited list of warnings that should be suppressed for this package" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ProjectItemsSchema.xaml
@@ -12,9 +12,13 @@
   <ContentType Name="EmbeddedResource" DisplayName="嵌入的资源" ItemType="EmbeddedResource">
     <NameValuePair Name="DefaultMetadata_Generator" Value="ResXFileCodeGenerator" />
   </ContentType>
+  <ContentType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" ItemType="UpToDateCheckInput"></ContentType>
+  <ContentType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" ItemType="UpToDateCheckOutput"></ContentType>
   <ItemType Name="None" DisplayName="无" />
   <ItemType Name="Content" DisplayName="内容" />
   <ItemType Name="EmbeddedResource" DisplayName="嵌入的资源" />
+  <ItemType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" />
+  <ItemType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" UpToDateCheckInput="False" />
   <FileExtension Name=".asax" ContentType="Asax" />
   <FileExtension Name=".asmx" ContentType="HTML" />
   <FileExtension Name=".asp" ContentType="AspPage" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ProjectReference.xaml
@@ -43,4 +43,5 @@
   <StringProperty Name="Project" Visible="False" Description="解决方案跟踪单个项目引用目标时使用的 GUID" />
   <StringProperty Name="ReferencedProjectIdentifier" Visible="False" Description="解决方案跟踪单个项目引用目标时使用的 GUID 的旧(VS2010 beta)存储方式" />
   <BoolProperty Name="UseLibraryDependencyInputs" Visible="False" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ResolvedAnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ResolvedAnalyzerReference.xaml
@@ -15,4 +15,5 @@
       <DataSource PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ResolvedAssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ResolvedAssemblyReference.xaml
@@ -59,5 +59,6 @@
   <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" Description="经解析得到此解析的引用项的原始引用项的计算项名称。" />
   <StringProperty Name="ReferenceFromSDK" Visible="False" ReadOnly="True" Description="使用扩展的 SDK 目标时提供此引用的 SDK。" />
   <StringProperty Name="ResolvedFrom" Visible="False" ReadOnly="True" Description="{}用于对此进行解析的引用所在的存储库。(如果在 GAC 中，则为“{GAC}”)。" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
   <BoolProperty Name="WinMDFile" Visible="false" ReadOnly="True" Description="指示生成系统是否已确定此为 WinMD (而非程序集)" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ResolvedCOMReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ResolvedCOMReference.xaml
@@ -55,4 +55,5 @@
   <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
   <StringProperty Name="Name" Visible="false" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ResolvedPackageReference.xaml
@@ -21,4 +21,5 @@
     </StringListProperty.DataSource>
   </StringListProperty>
   <BoolProperty Name="IsTopLevelDependency" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ResolvedProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ResolvedProjectReference.xaml
@@ -58,4 +58,5 @@
   <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" Description="经解析得到此解析的引用项的原始引用项的计算项名称。" />
   <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
   <StringProperty Name="Name" Visible="false" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ResolvedSdkReference.xaml
@@ -19,4 +19,5 @@
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="扩展引用程序集" ReadOnly="True" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="复制本地扩展的引用程序集" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/SdkReference.xaml
@@ -17,4 +17,5 @@
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="扩展引用程序集" ReadOnly="True" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="复制本地扩展的引用程序集" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/AnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/AnalyzerReference.xaml
@@ -5,4 +5,5 @@
     <DataSource Persistence="ProjectFile" ItemType="Analyzer" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" SourceType="TargetResults" MSBuildTarget="CollectAnalyzersDesignTime" />
   </Rule.DataSource>
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/AssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/AssemblyReference.xaml
@@ -35,4 +35,5 @@
   <BoolProperty Name="IsWinMDFile" Visible="false" />
   <StringProperty Name="RequiredTargetFramework" DisplayName="需要的目標 Framework" Visible="False" />
   <StringProperty Name="SDKName" Visible="false" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ComReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ComReference.xaml
@@ -11,4 +11,5 @@
   <BoolProperty Name="Isolated" />
   <StringProperty Name="WrapperTool" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/PackageReference.xaml
@@ -23,4 +23,5 @@
   <StringProperty Name="FrameworkVersion" Visible="False" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
   <StringProperty Name="NoWarn" Visible="True" DisplayName="NoWarn" Description="Comma-delimited list of warnings that should be suppressed for this package" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ProjectItemsSchema.xaml
@@ -12,9 +12,13 @@
   <ContentType Name="EmbeddedResource" DisplayName="內嵌資源" ItemType="EmbeddedResource">
     <NameValuePair Name="DefaultMetadata_Generator" Value="ResXFileCodeGenerator" />
   </ContentType>
+  <ContentType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" ItemType="UpToDateCheckInput"></ContentType>
+  <ContentType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" ItemType="UpToDateCheckOutput"></ContentType>
   <ItemType Name="None" DisplayName="無" />
   <ItemType Name="Content" DisplayName="內容" />
   <ItemType Name="EmbeddedResource" DisplayName="內嵌資源" />
+  <ItemType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" />
+  <ItemType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" UpToDateCheckInput="False" />
   <FileExtension Name=".asax" ContentType="Asax" />
   <FileExtension Name=".asmx" ContentType="HTML" />
   <FileExtension Name=".asp" ContentType="AspPage" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ProjectReference.xaml
@@ -43,4 +43,5 @@
   <StringProperty Name="Project" Visible="False" Description="方案藉以追蹤個別專案參考目標的 GUID" />
   <StringProperty Name="ReferencedProjectIdentifier" Visible="False" Description="儲存方案藉以追蹤個別專案參考目標之 GUID 的舊 (VS2010 Beta) 方式" />
   <BoolProperty Name="UseLibraryDependencyInputs" Visible="False" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ResolvedAnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ResolvedAnalyzerReference.xaml
@@ -15,4 +15,5 @@
       <DataSource PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ResolvedAssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ResolvedAssemblyReference.xaml
@@ -59,5 +59,6 @@
   <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" Description="因解析而產生這個已解析參考項目的原始參考項目的評估項目名稱。" />
   <StringProperty Name="ReferenceFromSDK" Visible="False" ReadOnly="True" Description="使用展開 SDK 目標時，這個參考的來源 SDK。" />
   <StringProperty Name="ResolvedFrom" Visible="False" ReadOnly="True" Description="{}儲存機制為用來解析這一項的參考所保留的內容 (如果它在 GAC 中，即是 &quot;{GAC}&quot;)。" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
   <BoolProperty Name="WinMDFile" Visible="false" ReadOnly="True" Description="表示建置系統是否確認這是 WinMD (而非組件)" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ResolvedCOMReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ResolvedCOMReference.xaml
@@ -55,4 +55,5 @@
   <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
   <StringProperty Name="Name" Visible="false" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ResolvedPackageReference.xaml
@@ -21,4 +21,5 @@
     </StringListProperty.DataSource>
   </StringListProperty>
   <BoolProperty Name="IsTopLevelDependency" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ResolvedProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ResolvedProjectReference.xaml
@@ -58,4 +58,5 @@
   <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" Description="因解析而產生這個已解析參考項目的原始參考項目的評估項目名稱。" />
   <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
   <StringProperty Name="Name" Visible="false" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ResolvedSdkReference.xaml
@@ -19,4 +19,5 @@
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="展開參考組件" ReadOnly="True" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="複製展開的參考組件到本機" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/SdkReference.xaml
@@ -17,4 +17,5 @@
   <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="展開參考組件" ReadOnly="True" />
   <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="複製展開的參考組件到本機" ReadOnly="True" />
   <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>


### PR DESCRIPTION
NETStandard.Library 2.0.0 uses a .targets file to explicitly add the framework assemblies
as Reference items. Since these do not appear in the assets/lock file we don't see them
as being part of the dependency graph, and we end up showing them under the Assemblies
node instead of under the NETStandard.Library node.

We've added a work-around in the design-time targets in the SDK to add them to the
dependency graph, which causes these items to show up under the NETStandard.Library node
as expected.

Here we add support for the "Visible" metadata for all of the items that appear under the Dependencies node. That is, if a `Reference` is marked with `<Visible>false</Visible>` we won't show it under the Assemblies node. The same goes for other kinds of dependencies (though there is currently no way to add the metadata to items that are derived from the assets/lock file).

The `Reference` items added by NETStandard.Library are marked with  `<Visible>false</Visible>`, so they will no longer show.

**Customer scenario**

Customer creates or opens a .NET Standard 2.0 project and expands nodes in the Solution Explorer. The framework assemblies from the NETStandard 2.0 show up under the "Assemblies" node rather than under the "NETStandard.Library" node under "SDKs".

One of the big talking points of netstandard 2.0 is that all the APIs are now in a single reference assembly. This addresses a lot of customer confusion from earlier netstandard versions where there were a lot of constituent packages. The current UX actually is no better because a large number of facades still show up in the assemblies node and users can't find their own assembly references in its midst. 

@terrajobst says: "There is not a single day where I don’t have to answer emails from both, customers, as well as MSFT employees who don’t understand how .NET Standard works. Showing a large number of assemblies when we tell customers that .NET Standard is a single assembly is highly confusing, especially because they now see mscorlib, System.Runtime, and netstandard all side-by-side. "

**Bugs this fixes:** 

Fixes #2132. Fixes https://github.com/dotnet/project-system/issues/2320

**Workarounds, if any**

None.

**Risk**

Low; this is a very targeted change.

**Performance impact**

None expected.

**Is this a regression from a previous update?**

**Root cause analysis:**

N/A; this is a new issues to .NET Standard 2.0 support.

**How was the bug found?**

Ad hoc testing.
