### PR TITLE
Add public async replacement for LaunchSettingsFile

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             var provider = GetLaunchSettingsProvider(null, appDesignerFolder: appDesignerFolder);
 
-            string result = await provider.GetLaunchSettingsFilePathAsync();
+            string result = await provider.GetLaunchSettingsFilePathNoCacheAsync();
 
             Assert.Equal(expected, result);
         }
@@ -339,7 +339,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
 
-            string fileName = await provider.GetLaunchSettingsFilePathAsync();
+            string fileName = await provider.GetLaunchSettingsFilePathNoCacheAsync();
             // Write file and generate disk change
             var eventArgs = new FileSystemEventArgs(WatcherChangeTypes.Changed, Path.GetDirectoryName(fileName), Path.GetFileName(fileName));
             moqFS.WriteAllText(fileName, JsonString1);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 
@@ -14,7 +15,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         IReceivableSourceBlock<ILaunchSettings> SourceBlock { get; }
 
         ILaunchSettings CurrentSnapshot { get; }
-        
+
+        [Obsolete("Use ILaunchSettingsProvider2.GetLaunchSettingsFilePathAsync instead.")]
         string LaunchSettingsFile { get; }
         
         ILaunchProfile ActiveProfile { get; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider2.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider2.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+  
+    public interface ILaunchSettingsProvider2 : ILaunchSettingsProvider
+    {
+        /// <summary>
+        ///     Gets the path to the lauch settings file, typically, "launchSettings.json".
+        /// </summary>
+        Task<string> GetLaunchSettingsFilePathAsync();
+    }
+}
+

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider2.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider2.cs
@@ -4,11 +4,17 @@ using System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
-  
+    /// <summary>
+    ///     Provides an implementation of <see cref="ILaunchSettingsProvider"/> with an
+    ///     additional method <see cref="GetLaunchSettingsFilePathAsync"/> for retrieving
+    ///     the launch settings file.
+    /// </summary>
     public interface ILaunchSettingsProvider2 : ILaunchSettingsProvider
     {
         /// <summary>
-        ///     Gets the path to the lauch settings file, typically, "launchSettings.json".
+        ///     Gets the full path to the launch settings file, typically located under
+        ///     "Properties\launchSettings.json" or "My Project\launchSettings.json" of
+        ///     the project directory.
         /// </summary>
         Task<string> GetLaunchSettingsFilePathAsync();
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -104,7 +104,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
         private SequencialTaskExecutor _sequentialTaskQueue = new SequencialTaskExecutor();
 
-        [Obsolete("Use GetLaunchSettingsFileAsync instead.")]
+        [Obsolete("Use GetLaunchSettingsFilePathAsync instead.")]
         public string LaunchSettingsFile
         {
             get

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -110,7 +110,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             get
             {
                 return CommonProjectServices.ThreadingService.ExecuteSynchronously(() => {
-                    return _launchSettingsFilePath.GetValueAsync();
+                    return GetLaunchSettingsFilePathAsync();
                 });
             }
         }
@@ -289,8 +289,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </summary>
         protected async Task<bool> SettingsFileHasChangedAsync()
         {
-            string fileName = await _launchSettingsFilePath.GetValueAsync()
-                                                           .ConfigureAwait(false);
+            string fileName = await GetLaunchSettingsFilePathAsync().ConfigureAwait(false);
 
             return !FileManager.FileExists(fileName) || FileManager.LastFileWriteTime(fileName) != LastSettingsFileSyncTime;
         }
@@ -325,8 +324,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </summary>
         protected async Task<LaunchSettingsData> GetLaunchSettingsAsync()
         {
-            string fileName = await _launchSettingsFilePath.GetValueAsync()
-                                                           .ConfigureAwait(false);
+            string fileName = await GetLaunchSettingsFilePathAsync().ConfigureAwait(false);
 
             LaunchSettingsData settings;
             if (FileManager.FileExists(fileName))
@@ -356,8 +354,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </summary>
         protected async Task<LaunchSettingsData> ReadSettingsFileFromDiskAsync()
         {
-            string fileName = await _launchSettingsFilePath.GetValueAsync()
-                                                           .ConfigureAwait(false);
+            string fileName = await GetLaunchSettingsFilePathAsync().ConfigureAwait(false);
 
             // Clear errors
             ClearErrors();
@@ -477,8 +474,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             // Clear stale errors since we are saving
             ClearErrors();
             var serializationData = GetSettingsToSerialize(newSettings);
-            string fileName = await _launchSettingsFilePath.GetValueAsync()
-                                                           .ConfigureAwait(false);
+            string fileName = await GetLaunchSettingsFilePathAsync().ConfigureAwait(false);
 
             try
             {
@@ -552,8 +548,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var sourceControlIntegration = SourceControlIntegrations.FirstOrDefault();
             if (sourceControlIntegration != null && sourceControlIntegration.Value != null)
             {
-                string fileName = await _launchSettingsFilePath.GetValueAsync()
-                                                               .ConfigureAwait(false);
+                string fileName = await GetLaunchSettingsFilePathAsync().ConfigureAwait(false);
 
                 await sourceControlIntegration.Value.CanChangeProjectFilesAsync(new[] { fileName }).ConfigureAwait(false);
             }
@@ -599,8 +594,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </summary>
         protected async Task EnsureSettingsFolderAsync()
         {
-            string fileName = await _launchSettingsFilePath.GetValueAsync()
-                                                           .ConfigureAwait(false);
+            string fileName = await GetLaunchSettingsFilePathAsync().ConfigureAwait(false);
 
             string parentPath = Path.GetDirectoryName(fileName);
 
@@ -845,8 +839,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var currentSettings = await WaitForFirstSnapshot(WaitForFirstSnapshotDelay).ConfigureAwait(false);
             if (currentSettings == null || (currentSettings.Profiles.Count == 1 && string.Equals(currentSettings.Profiles[0].CommandName, ErrorProfileCommandName, StringComparison.Ordinal)))
             {
-                string fileName = await _launchSettingsFilePath.GetValueAsync()
-                                                               .ConfigureAwait(false);
+                string fileName = await GetLaunchSettingsFilePathAsync().ConfigureAwait(false);
 
                 throw new Exception(string.Format(Resources.JsonErrorNeedToBeCorrected, fileName));
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProvider.cs
@@ -32,6 +32,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
 
         public async Task<string> GetFileAsync(SpecialFiles fileId, SpecialFileFlags flags, CancellationToken cancellationToken = default(CancellationToken))
         {
+            // Make sure at least have a tree before we start searching it
+            await _projectTree.Value.TreeService.PublishAnyNonLoadingTreeAsync(cancellationToken)
+                                                .ConfigureAwait(false);
+
             string path = FindAppDesignerFolder();
             if (path == null)
             {   


### PR DESCRIPTION
**Customer scenario**

Opening certain ASP.NET Core projects can deadlock.
Unloading and reloading an ASP.NET Core project always deadlocks.

**Bugs this fixes:** 

Partially fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/index?id=451907. ASP.NET tooling also need to make a change on their side.

**Workarounds, if any**

For projects that open first time, a workround is not to unload/reload project.
For projects that don't open first time, there is no workaround.

**Risk**

Low. Changing async -> sync -> async to async -> async.

**Performance impact**

Low perf impact, no extra complexity.

**Is this a regression from a previous update?**

Yes

**Root cause analysis:**

In a previous change, https://github.com/dotnet/project-system/pull/2317, we introduced a new code path that caused a switch to the UI thread along a path that ASP.NET tooling was calling during project initialization. Due to a convoluted Task graph, this switch was blocked because the UI thread itself was busy waiting for the task doing the switch to complete/yield. Catch 22. Moving from async -> async resolved the issue.

Note this also includes a fix that avoids a race where we get called by the ASP.NET tooling on same path **before** the tree has finished loading, and we null-ref.

**How was the bug found?**

Many internal reports.
