### PR TITLE
Add ruleset as input to fast up to date

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/BuildUpToDateCheck.cs
@@ -79,6 +79,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         private bool _isDisabled = true;
         private bool _itemsChangedSinceLastCheck = true;
         private string _msBuildProjectFullPath;
+        private string _ruleset;
         private HashSet<string> _imports = new HashSet<string>();
         private HashSet<string> _itemTypes = new HashSet<string>();
         private Dictionary<string, HashSet<string>> _items = new Dictionary<string, HashSet<string>>();
@@ -117,6 +118,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
             _isDisabled = disableFastUpToDateCheckString != null && string.Equals(disableFastUpToDateCheckString, TrueValue, StringComparison.OrdinalIgnoreCase);
 
             _msBuildProjectFullPath = e.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildProjectFullPathProperty, _msBuildProjectFullPath);
+            _ruleset = e.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.CodeAnalysisRuleSetProperty, _ruleset);
+
             foreach (var referenceSchema in ReferenceSchemas)
             {
                 if (e.ProjectChanges.TryGetValue(referenceSchema, out var changes) &&
@@ -282,6 +285,12 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var inputs = new HashSet<string>();
 
             AddInput(logger, inputs, _msBuildProjectFullPath, "project file");
+
+            if (_ruleset != null)
+            {
+                AddInput(logger, inputs, _ruleset, "ruleset");
+            }
+
             AddInputs(logger, inputs, _imports, "import");
 
             foreach (var pair in _items)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/BuildUpToDateCheck.cs
@@ -79,7 +79,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
         private bool _isDisabled = true;
         private bool _itemsChangedSinceLastCheck = true;
         private string _msBuildProjectFullPath;
-        private string _ruleset;
         private HashSet<string> _imports = new HashSet<string>();
         private HashSet<string> _itemTypes = new HashSet<string>();
         private Dictionary<string, HashSet<string>> _items = new Dictionary<string, HashSet<string>>();
@@ -118,7 +117,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
             _isDisabled = disableFastUpToDateCheckString != null && string.Equals(disableFastUpToDateCheckString, TrueValue, StringComparison.OrdinalIgnoreCase);
 
             _msBuildProjectFullPath = e.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildProjectFullPathProperty, _msBuildProjectFullPath);
-            _ruleset = e.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.CodeAnalysisRuleSetProperty, _ruleset);
 
             foreach (var referenceSchema in ReferenceSchemas)
             {
@@ -285,11 +283,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var inputs = new HashSet<string>();
 
             AddInput(logger, inputs, _msBuildProjectFullPath, "project file");
-
-            if (_ruleset != null)
-            {
-                AddInput(logger, inputs, _ruleset, "ruleset");
-            }
 
             AddInputs(logger, inputs, _imports, "import");
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -60,6 +60,11 @@
             <DataSource Persistence="ProjectFile" PersistedName="DisableFastUpToDateCheck" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
         </BoolProperty.DataSource>
     </BoolProperty>
+    <StringProperty Name="CodeAnalysisRuleSet" DisplayName="Code analysis rule set">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFile" PersistedName="CodeAnalysisRuleSet" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
 
     <StringProperty Name="TargetPath" />
     <StringProperty Name="DocumentationFile" DisplayName="XML doc comments file" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -60,11 +60,6 @@
             <DataSource Persistence="ProjectFile" PersistedName="DisableFastUpToDateCheck" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
         </BoolProperty.DataSource>
     </BoolProperty>
-    <StringProperty Name="CodeAnalysisRuleSet" DisplayName="Code analysis rule set">
-        <StringProperty.DataSource>
-            <DataSource Persistence="ProjectFile" PersistedName="CodeAnalysisRuleSet" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-        </StringProperty.DataSource>
-    </StringProperty>
 
     <StringProperty Name="TargetPath" />
     <StringProperty Name="DocumentationFile" DisplayName="XML doc comments file" />

--- a/src/Targets/Microsoft.Managed.DesignTime.targets
+++ b/src/Targets/Microsoft.Managed.DesignTime.targets
@@ -25,6 +25,11 @@
     <SuppressOutOfDateMessageOnBuild Condition="'$(SuppressOutOfDateMessageOnBuild)' == ''">true</SuppressOutOfDateMessageOnBuild>
   </PropertyGroup>
 
+  <!-- If the project we're compiling has a ruleset, make sure we check it for up-to-date checks. -->
+  <ItemGroup Condition="'$(CodeAnalysisRuleSet)' != ''">
+    <UpToDateCheckInput Include="$(CodeAnalysisRuleSet)" />
+  </ItemGroup>
+
   <!--
     Locate the approriate localized xaml resources based on the language ID or name.
 


### PR DESCRIPTION
**Customer scenario**

The user's SDK-based project uses a ruleset as input to project analyzers. The user changes the ruleset to include rules that would cause the project to no longer build due to new errors. The user builds but because we didn't take into account the change to the ruleset, we think the project is up to date and the build is incorrectly successful.

**Bugs this fixes:** 

Fixes #2374 

**Workarounds, if any**

User would have to perform a rebuild.

**Risk**

Low, this just adds a new file into the up to date check. Biggest risk is that we would think a project was not up to date when it was, resulting in calling MSBuild.

**Performance impact**

Low, looks at one additional file.

**Is this a regression from a previous update?**

No.

