### PR TITLE
Fix contract for up to date check

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/BuildUpToDateCheck.cs
@@ -93,7 +93,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             IProjectSystemOptions projectSystemOptions,
             ConfiguredProject configuredProject,
             Lazy<IFileTimestampCache> fileTimestampCache,
-            IProjectAsynchronousTasksService tasksService,
+            [Import(ExportContractNames.Scopes.ConfiguredProject)] IProjectAsynchronousTasksService tasksService,
             IProjectItemSchemaService projectItemSchemaService)
         {
             _projectSystemOptions = projectSystemOptions;


### PR DESCRIPTION
**Customer scenario**

As of recent builds of d15prerel, the up to date check for SDK-based projects is broken due to composition errors.

**Workarounds, if any**

None, up to date checks won't work.

**Risk**

Low, restores functionality that is broken.

**Performance impact**

Low, restores functionality that is broken

**Is this a regression from a previous update?**

Yes

**Root cause analysis:**

The up to date checker imports a contract through MEF from CPS. This contract had two scopes associated with it, but the up to date checker didn't specify a scope on import. This worked by accident until changes on the CPS side caused this bug to surface. The fix is to add a proper scope to the import.

**How was the bug found?**

Ad hoc testing.