### PR TITLE
Have NuGetRestorer only respond to PackageRefs capability

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             return Task.CompletedTask;
         }
 
-        public Task UnloadAsync() => Task.CompletedTask;
+        public Task UnloadAsync() => DisposeAsync();
 
         private async Task OnProjectChangedAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
 {
     using TIdentityDictionary = IImmutableDictionary<NamedIdentity, IComparable>;
 
-    [Export(ExportContractNames.Scopes.ConfiguredProject, typeof(IProjectDynamicLoadComponent))]
+    [Export(ExportContractNames.Scopes.UnconfiguredProject, typeof(IProjectDynamicLoadComponent))]
     [AppliesTo(ProjectCapabilities.PackageReferences)]
     internal class NuGetRestorer : OnceInitializedOnceDisposedAsync, IProjectDynamicLoadComponent
     {


### PR DESCRIPTION
**Customer scenario**

Customer is getting errors from the project system attempting to run a restore on a shared project.

**Bugs this fixes:** 

Fixes https://github.com/dotnet/project-system/issues/2231

**Workarounds, if any**

None

**Risk**

Code is hard to unit test.  Manually buddy testing is required to merge this.

**Performance impact**

This code has the potential to change the perf for nuget restores so it should be validated before checkin