### PR TITLE
Adding threading  analyzers.

### DIFF
--- a/build/Rulesets/NonShippingProjectRules.ruleset
+++ b/build/Rulesets/NonShippingProjectRules.ruleset
@@ -20,4 +20,11 @@
     <Rule Id="IDE1006" Action="None" />                       <!-- Naming styles                                Task Open()                                         Task OpenAsync()                      -->
     <Rule Id="IDE1006WithoutSuggestion" Action="None" />
   </Rules>
+  <Rules AnalyzerId="Microsoft.VisualStudio.Threading.Analyzers" RuleNamespace="Microsoft.VisualStudio.Threading.Analyzers">
+    <Rule Id="VSTHRD001" Action="None" />                     <!-- Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.-->
+    <Rule Id="VSTHRD002" Action="None" />                     <!-- Synchronously waiting on tasks or awaiters may cause deadlocks. Use JoinableTaskFactory.Run instead.-->
+    <Rule Id="VSTHRD010" Action="None" />                     <!-- Visual Studio service should be used on main thread explicitly.-->
+    <Rule Id="VSTHRD103" Action="None" />                     <!-- Synchronously blocks. Await ThrowsAsync instead.-->
+    <Rule Id="VSTHRD200" Action="None" />                     <!-- Naming styles                                Task Open()                                         Task OpenAsync()                      -->
+  </Rules>
 </RuleSet>

--- a/build/Rulesets/Roslyn.ruleset
+++ b/build/Rulesets/Roslyn.ruleset
@@ -144,4 +144,9 @@
     <Rule Id="IDE1006" Action="Error" />                      <!-- Naming styles                                Task Open()                                         Task OpenAsync()                      -->
     <Rule Id="IDE1006WithoutSuggestion" Action="Info" />
   </Rules>
+  <Rules AnalyzerId="Microsoft.VisualStudio.Threading.Analyzers" RuleNamespace="Microsoft.VisualStudio.Threading.Analyzers">
+    <Rule Id="VSTHRD200" Action="None" />                       <!-- Naming styles                              Task Open()                                         Task OpenAsync()                      -->
+    <Rule Id="VSTHRD010" Action="None" />                       <!-- Visual Studio service should be used on main thread explicitly.-->
+    <Rule Id="VSTHRD103" Action="None" />                       <!-- Call async methods when in an async method.-->
+  </Rules>
 </RuleSet>

--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -123,6 +123,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.3.0-beta3-61808-05" Condition="'$(UseRoslynAnalyzers)' == 'true'" />
     <PackageReference Include="Microsoft.Net.RoslynDiagnostics" Version="2.3.0-beta1" Condition="'$(UseRoslynAnalyzers)' == 'true'" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="15.3.23" Condition="'$(UseRoslynAnalyzers)' == 'true'" />
   </ItemGroup>
 
   <!-- Common project settings -->

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/DebugProfileEnumValuesGeneratorTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/DebugProfileEnumValuesGeneratorTests.cs
@@ -32,8 +32,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             Mock<ILaunchSettingsProvider> moqProfileProvider = new Mock<ILaunchSettingsProvider>();
             moqProfileProvider.Setup(p => p.CurrentSnapshot).Returns(testProfiles.Object);
+            var moqThreadingService = new Mock<IProjectThreadingService>();
+            moqThreadingService
+                .Setup(p => p.JoinableTaskFactory)
+                .Returns(new Threading.JoinableTaskFactory(new Threading.JoinableTaskContext()));
 
-            DebugProfileEnumValuesGenerator generator =  new DebugProfileEnumValuesGenerator(moqProfileProvider.Object); 
+            DebugProfileEnumValuesGenerator generator =  
+                new DebugProfileEnumValuesGenerator(moqProfileProvider.Object, moqThreadingService.Object); 
             ICollection<IEnumValue> results = await generator.GetListedValuesAsync();
             Assert.True(results.Count == 4);
             Assert.True(results.ElementAt(0).Name == "Profile1" &&  results.ElementAt(0).DisplayName == "Profile1" );
@@ -54,8 +59,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             Mock<ILaunchSettingsProvider> moqProfileProvider = new Mock<ILaunchSettingsProvider>();
             moqProfileProvider.Setup(p => p.CurrentSnapshot).Returns(testProfiles.Object);
+            var moqThreadingService = new Mock<IProjectThreadingService>();
+            moqThreadingService
+                .Setup(p => p.JoinableTaskFactory)
+                .Returns(new Threading.JoinableTaskFactory(new Threading.JoinableTaskContext()));
 
-            DebugProfileEnumValuesGenerator generator =  new DebugProfileEnumValuesGenerator(moqProfileProvider.Object); 
+            DebugProfileEnumValuesGenerator generator = 
+                new DebugProfileEnumValuesGenerator(moqProfileProvider.Object, moqThreadingService.Object); 
 
             Assert.False(generator.AllowCustomValues);
             IEnumValue result = await generator.TryCreateEnumValueAsync("Profile1");

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/DebugProfileEnumValuesGeneratorTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/DebugProfileEnumValuesGeneratorTests.cs
@@ -32,13 +32,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             Mock<ILaunchSettingsProvider> moqProfileProvider = new Mock<ILaunchSettingsProvider>();
             moqProfileProvider.Setup(p => p.CurrentSnapshot).Returns(testProfiles.Object);
-            var moqThreadingService = new Mock<IProjectThreadingService>();
-            moqThreadingService
-                .Setup(p => p.JoinableTaskFactory)
-                .Returns(new Threading.JoinableTaskFactory(new Threading.JoinableTaskContext()));
+            var threadingService = new IProjectThreadingServiceMock();
 
             DebugProfileEnumValuesGenerator generator =  
-                new DebugProfileEnumValuesGenerator(moqProfileProvider.Object, moqThreadingService.Object); 
+                new DebugProfileEnumValuesGenerator(moqProfileProvider.Object, threadingService); 
             ICollection<IEnumValue> results = await generator.GetListedValuesAsync();
             Assert.True(results.Count == 4);
             Assert.True(results.ElementAt(0).Name == "Profile1" &&  results.ElementAt(0).DisplayName == "Profile1" );
@@ -59,13 +56,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             Mock<ILaunchSettingsProvider> moqProfileProvider = new Mock<ILaunchSettingsProvider>();
             moqProfileProvider.Setup(p => p.CurrentSnapshot).Returns(testProfiles.Object);
-            var moqThreadingService = new Mock<IProjectThreadingService>();
-            moqThreadingService
-                .Setup(p => p.JoinableTaskFactory)
-                .Returns(new Threading.JoinableTaskFactory(new Threading.JoinableTaskContext()));
+            var threadingService = new IProjectThreadingServiceMock();
 
             DebugProfileEnumValuesGenerator generator = 
-                new DebugProfileEnumValuesGenerator(moqProfileProvider.Object, moqThreadingService.Object); 
+                new DebugProfileEnumValuesGenerator(moqProfileProvider.Object, threadingService); 
 
             Assert.False(generator.AllowCustomValues);
             IEnumValue result = await generator.TryCreateEnumValueAsync("Profile1");

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileDebugTargetGenerator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileDebugTargetGenerator.cs
@@ -33,10 +33,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         private IDisposable _debugProviderLink;
 
         [ImportingConstructor]
-        public DebugProfileDebugTargetGenerator(UnconfiguredProject unconfiguredProject, ILaunchSettingsProvider launchSettingProvider)
+        public DebugProfileDebugTargetGenerator(
+            UnconfiguredProject unconfiguredProject, 
+            ILaunchSettingsProvider launchSettingProvider,
+            IProjectThreadingService threadingService)
             : base(unconfiguredProject.Services)
         {
             LaunchSettingProvider = launchSettingProvider;
+            ProjectThreadingService = threadingService;
         }
 
         private NamedIdentity _dataSourceKey = new NamedIdentity();
@@ -63,15 +67,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         }
 
         private ILaunchSettingsProvider LaunchSettingProvider{ get; }
+        private IProjectThreadingService ProjectThreadingService { get; }
 
 
         /// <summary>
         /// This provides access to the class which creates the list of debugger values..
         /// </summary>
         public Task<IDynamicEnumValuesGenerator> GetProviderAsync(IList<NameValuePair> options)
-        {
-            return Task.FromResult<IDynamicEnumValuesGenerator>(new DebugProfileEnumValuesGenerator(LaunchSettingProvider));
-        }
+            => Task.FromResult<IDynamicEnumValuesGenerator>(
+                new DebugProfileEnumValuesGenerator(LaunchSettingProvider, ProjectThreadingService));
 
 
         protected override void Initialize()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileEnumValuesGenerator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileEnumValuesGenerator.cs
@@ -28,7 +28,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// <summary>
         /// Create a new instance of the class.
         /// </summary>
-        internal DebugProfileEnumValuesGenerator(ILaunchSettingsProvider profileProvider)
+        internal DebugProfileEnumValuesGenerator(
+            ILaunchSettingsProvider profileProvider,
+            IProjectThreadingService threadingService)
         {
             this.listedValues = new AsyncLazy<ICollection<IEnumValue>>(delegate
             {
@@ -40,22 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
                 ICollection<IEnumValue> emptyCollection = new List<IEnumValue>();
                 return Task.FromResult(emptyCollection);
-            }, TryGetJoinableTaskFactory());
-        }
-
-        private static JoinableTaskFactory TryGetJoinableTaskFactory()
-        {
-            JoinableTaskFactory factory = null;
-            try
-            {
-                factory = ThreadHelper.JoinableTaskFactory;
-            }
-            catch (System.NullReferenceException)
-            {
-                // we are not running inside Visual Studio, so there is no JoinableTaskFactory
-            }
-
-            return factory;
+            }, threadingService.JoinableTaskFactory);
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileEnumValuesGenerator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileEnumValuesGenerator.cs
@@ -32,6 +32,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             ILaunchSettingsProvider profileProvider,
             IProjectThreadingService threadingService)
         {
+            Requires.NotNull(profileProvider, nameof(profileProvider));
+            Requires.NotNull(threadingService, nameof(threadingService));
+
             this.listedValues = new AsyncLazy<ICollection<IEnumValue>>(delegate
             {
                 var curSnapshot = profileProvider.CurrentSnapshot;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowProjectLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowProjectLogger.cs
@@ -41,17 +41,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
                 string text = format.Text + Environment.NewLine;
 
                 // Extremely naive implementation of a Windows Pane logger - the assumption here is that text is rarely written,
-                // so transitions to the UI thread are uncommon and are fire and forget. If we start writing to this a lot (such 
+                // so transitions to the UI thread are uncommon and are fire and forget. If we start writing to this a lot (such
                 // as via build), then we'll need to implement a better queueing mechanism.
                 _threadingService.Fork(async () =>
                 {
 
                     IVsOutputWindowPane pane = await _outputWindowProvider.GetOutputWindowPaneAsync()
                                                                           .ConfigureAwait(true);
-                                                                          
+
                     pane.OutputStringNoPump(text);
 
-                }, options: ForkOptions.HideLocks | ForkOptions.StartOnMainThread);
+                }, options: ForkOptions.HideLocks | ForkOptions.StartOnMainThread,
+                   factory: _threadingService.JoinableTaskFactory);
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         {
             EnsureInitialized();
         }
-        
+
         /// <summary>
         /// Initialize the watcher.
         /// </summary>
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             var projectUpdate = dataFlowUpdate.Value.Item2;
             var projectLockFilePath = GetProjectAssetsFilePath(newTree, projectUpdate);
 
-            // project.json may have been renamed to {projectName}.project.json or in the case of the project.assets.json, 
+            // project.json may have been renamed to {projectName}.project.json or in the case of the project.assets.json,
             // the immediate path could have changed. In either case, change the file watcher.
             if (!PathHelper.IsSamePath(projectLockFilePath, _fileBeingWatched))
             {
@@ -113,7 +113,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         {
             var projectFilePath = projectUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildProjectFullPathProperty, null);
 
-            // First check to see if the project has a project.json. 
+            // First check to see if the project has a project.json.
             IProjectTree projectJsonNode = FindProjectJsonNode(newTree, projectFilePath);
             if (projectJsonNode != null)
             {
@@ -129,7 +129,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             if (string.IsNullOrEmpty(objDirectory))
             {   // Don't have an intermdiate directory set, probably missing SDK attribute or Microsoft.Common.props
 
-                return null; 
+                return null;
             }
 
             objDirectory = PathHelper.MakeRooted(projectFilePath, objDirectory);
@@ -152,7 +152,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
 
             return null;
         }
-        
+
         private void RegisterFileWatcherAsync(string projectLockJsonFilePath)
         {
             // Note file change service is free-threaded
@@ -215,7 +215,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
                 {
                     // Project is already unloaded
                 }
-            }, unconfiguredProject: _projectServices.Project);
+            }, unconfiguredProject: _projectServices.Project,
+               factory: _projectServices.ThreadingService.JoinableTaskFactory);
 
             return VSConstants.S_OK;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikerValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikerValueProvider.cs
@@ -47,12 +47,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
                 // This causes the project to be reloaded after changing the values.
                 // Since the property providers are called under a write-lock, trying to reload the project on the same context fails saying it can't load the project
                 // if a lock is held. We are not going to write to the file under this lock (we return null from this method) and so we fork execution here to schedule
-                // a lambda on the UI thread and we don't pass the lock information from this context to the new one. 
+                // a lambda on the UI thread and we don't pass the lock information from this context to the new one.
                 _unconfiguredProjectVsServices.ThreadingService.Fork(() =>
                 {
                     _unconfiguredProjectVsServices.VsHierarchy.SetProperty(HierarchyId.Root, (int)VsHierarchyPropID.TargetFrameworkMoniker, unevaluatedPropertyValue);
                     return System.Threading.Tasks.Task.CompletedTask;
-                }, options: ForkOptions.HideLocks | ForkOptions.StartOnMainThread);
+                }, options: ForkOptions.HideLocks | ForkOptions.StartOnMainThread,
+                   factory: _unconfiguredProjectVsServices.ThreadingService.JoinableTaskFactory);
             }
             return await System.Threading.Tasks.Task.FromResult<string>(null).ConfigureAwait(false);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml.cs
@@ -5,8 +5,8 @@ using System.Linq;
 using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Threading;
 using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
+using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 {
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 DebugPageViewModel viewModel = e.OldValue as DebugPageViewModel;
                 viewModel.FocusEnvironmentVariablesGridRow -= OnFocusEnvironmentVariableGridRow;
                 viewModel.ClearEnvironmentVariablesGridError -= OnClearEnvironmentVariableGridError;
-                viewModel.PropertyChanged -= ViewModel_PropertyChanged; 
+                viewModel.PropertyChanged -= ViewModel_PropertyChanged;
             }
 
             if (e.NewValue != null && e.NewValue is DebugPageViewModel)
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 DebugPageViewModel viewModel = e.NewValue as DebugPageViewModel;
                 viewModel.FocusEnvironmentVariablesGridRow += OnFocusEnvironmentVariableGridRow;
                 viewModel.ClearEnvironmentVariablesGridError += OnClearEnvironmentVariableGridError;
-                viewModel.PropertyChanged += ViewModel_PropertyChanged; 
+                viewModel.PropertyChanged += ViewModel_PropertyChanged;
             }
         }
 
@@ -48,21 +48,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             ClearGridError(dataGridEnvironmentVariables);
         }
 
-        private void OnFocusEnvironmentVariableGridRow(object sender, EventArgs e)
+        private async void OnFocusEnvironmentVariableGridRow(object sender, EventArgs e)
         {
             if (DataContext != null && DataContext is DebugPageViewModel)
             {
-                Dispatcher.BeginInvoke(new DispatcherOperationCallback((param) =>
+                await ThreadHelper.JoinableTaskFactory
+                    .WithPriority(VsTaskRunContext.UIThreadBackgroundPriority)
+                    .SwitchToMainThreadAsync();
+                if ((DataContext as DebugPageViewModel).EnvironmentVariables.Count > 0)
                 {
-                    if ((DataContext as DebugPageViewModel).EnvironmentVariables.Count > 0)
-                    {
-                        // get the new cell, set focus, then open for edit
-                        var cell = WpfHelper.GetCell(dataGridEnvironmentVariables, (DataContext as DebugPageViewModel).EnvironmentVariables.Count - 1, 0);
-                        cell.Focus();
-                        dataGridEnvironmentVariables.BeginEdit();
-                    }
-                    return null;
-                }), DispatcherPriority.Background, new object[] { null });
+                    // get the new cell, set focus, then open for edit
+                    var cell = WpfHelper.GetCell(dataGridEnvironmentVariables, (DataContext as DebugPageViewModel).EnvironmentVariables.Count - 1, 0);
+                    cell.Focus();
+                    dataGridEnvironmentVariables.BeginEdit();
+                }
             }
         }
 
@@ -76,18 +75,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 cellErrorInfo.SetValue(dataGrid, false, null);
                 rowErrorInfo.SetValue(dataGrid, false, null);
             }
-            catch (Exception) 
-            { 
+            catch (Exception)
+            {
             }
         }
-        
+
         /// <summary>
         /// Called when a property changes on the view model. Used to detect when the custom UI changes so that
         /// the size of its grids can be determined
         /// </summary>
         private void ViewModel_PropertyChanged(Object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
-            if(e.PropertyName.Equals(nameof(DebugPageViewModel.ActiveProviderUserControl)))
+            if (e.PropertyName.Equals(nameof(DebugPageViewModel.ActiveProviderUserControl)))
             {
                 _customControlLayoutUpdateRequired = true;
             }
@@ -99,13 +98,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         /// </summary>
         private void DebugPageControl_LayoutUpdated(Object sender, EventArgs e)
         {
-            if(_customControlLayoutUpdateRequired && _mainGrid != null && DataContext != null)
+            if (_customControlLayoutUpdateRequired && _mainGrid != null && DataContext != null)
             {
                 _customControlLayoutUpdateRequired = false;
 
                 // Get the control that was added to the grid
                 var customControl = ((DebugPageViewModel)DataContext).ActiveProviderUserControl;
-                if(customControl != null)
+                if (customControl != null)
                 {
                     if (customControl.Content is Grid childGrid && childGrid.ColumnDefinitions.Count == _mainGrid.ColumnDefinitions.Count)
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml.cs
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                         cell.Focus();
                         dataGridEnvironmentVariables.BeginEdit();
                     }
-                });
+                }).FileAndForget(TelemetryEvents.ProjectSystemRootPath);
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml.cs
@@ -48,20 +48,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             ClearGridError(dataGridEnvironmentVariables);
         }
 
-        private async void OnFocusEnvironmentVariableGridRow(object sender, EventArgs e)
+        private void OnFocusEnvironmentVariableGridRow(object sender, EventArgs e)
         {
             if (DataContext != null && DataContext is DebugPageViewModel)
             {
-                await ThreadHelper.JoinableTaskFactory
-                    .WithPriority(VsTaskRunContext.UIThreadBackgroundPriority)
-                    .SwitchToMainThreadAsync();
-                if ((DataContext as DebugPageViewModel).EnvironmentVariables.Count > 0)
+                ThreadHelper.JoinableTaskFactory.StartOnIdle(async () =>
                 {
-                    // get the new cell, set focus, then open for edit
-                    var cell = WpfHelper.GetCell(dataGridEnvironmentVariables, (DataContext as DebugPageViewModel).EnvironmentVariables.Count - 1, 0);
-                    cell.Focus();
-                    dataGridEnvironmentVariables.BeginEdit();
-                }
+                    await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+                    if ((DataContext as DebugPageViewModel).EnvironmentVariables.Count > 0)
+                    {
+                        // get the new cell, set focus, then open for edit
+                        var cell = WpfHelper.GetCell(dataGridEnvironmentVariables, (DataContext as DebugPageViewModel).EnvironmentVariables.Count - 1, 0);
+                        cell.Focus();
+                        dataGridEnvironmentVariables.BeginEdit();
+                    }
+                });
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/GetProfileNameDialog.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/GetProfileNameDialog.xaml.cs
@@ -74,7 +74,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             // We need to schedule this to occur later after databinding has completed, otherwise
             // focus appears in the textbox, but at the start of the suggested name rather than at
             // the end.
-#pragma warning disable VSTHRD001 // Avoid legacy threading switching APIs
+#pragma warning disable VSTHRD001 // Avoid legacy threading switching APIs. 
+                                  // see https://github.com/Microsoft/vs-threading/issues/138
+                                  // There is currently no better way to queue an item on 
+                                  // DispatcherPriority.DataBind until the above issue is fixed
             Dispatcher.BeginInvoke(
                     (SetFocusCallback)delegate ()
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/GetProfileNameDialog.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/GetProfileNameDialog.xaml.cs
@@ -74,12 +74,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             // We need to schedule this to occur later after databinding has completed, otherwise
             // focus appears in the textbox, but at the start of the suggested name rather than at
             // the end.
+#pragma warning disable VSTHRD001 // Avoid legacy threading switching APIs
             Dispatcher.BeginInvoke(
                     (SetFocusCallback)delegate ()
                     {
                         ProfileNameTextBox.Select(0, ProfileNameTextBox.Text.Length);
                         ProfileNameTextBox.Focus();
                     }, System.Windows.Threading.DispatcherPriority.DataBind, null);
+#pragma warning restore VSTHRD001 // Avoid legacy threading switching APIs
         }
     }
 }


### PR DESCRIPTION
Tuned off the following in our codebase:

- VSTHRD010 this analyzer has a list of vs services that it believes must be called on the UI thread.  Perhaps this is the true, in which case our codebase has a major problem

- VSTHRD103 analysis here seems faulty.  The only cases it caught were false positives where we had named methods similarly but the async version was not equivalent to the sync version.

- VSTHRD200 we not follow this convention in the codebase so I left it off.