### PR TITLE
[WIP] Make PackageReference metadata 'NoWarn' Editable in the properties panes 

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyModelFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyModelFactory.cs
@@ -135,6 +135,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             public string Path { get; set; }
             public string SchemaName { get; set; }
             public string SchemaItemType { get; set; }
+            public string BindableBrowseObjectSchemaName { get; set; } = null;
             public string Version { get; set; }
             public bool Resolved { get; set; } = false;
             public bool TopLevel { get; set; } = true;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependency.cs
@@ -21,6 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         public string Path { get; set; }
         public string SchemaName { get; set; }
         public string SchemaItemType { get; set; }
+        public string BindableBrowseObjectSchemaName { get; set; } = null;
         public string Version { get; set; }
         public bool Resolved { get; set; } = false;
         public bool TopLevel { get; set; } = true;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -582,7 +582,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Requires.NotNull(namedCatalogs, nameof(namedCatalogs));
 
             var browseObjectsCatalog = namedCatalogs[PropertyPageContexts.BrowseObject];
-            var schema = browseObjectsCatalog.GetSchema(dependency.SchemaName);
+            var schema = browseObjectsCatalog.GetSchema(dependency.BindableBrowseObjectSchemaName ?? dependency.SchemaName);
             var itemSpec = string.IsNullOrEmpty(dependency.OriginalItemSpec) ? dependency.Path : dependency.OriginalItemSpec;
             var context = ProjectPropertiesContext.GetContext(UnconfiguredProject,
                 itemType: dependency.SchemaItemType,
@@ -591,7 +591,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             IRule rule = null;
             if (schema != null)
             {
-                if (dependency.Resolved)
+                if (dependency.Resolved && dependency.BindableBrowseObjectSchemaName == null)
                 {
                     rule = configuredProjectExports.RuleFactory.CreateResolvedReferencePageRule(
                                 schema,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependencyModel.cs
@@ -52,6 +52,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         string SchemaItemType { get; }
 
         /// <summary>
+        /// Optional alternative schema name that can be bound to a context in the project file
+        /// to build a browse object rule. When provided, this should be used to build the browse
+        /// object rule directly from the dependency's project file context.
+        /// </summary>
+        string BindableBrowseObjectSchemaName { get; }
+
+        /// <summary>
         /// Version of the dependency
         /// </summary>
         string Version { get; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DependencyModel.cs
@@ -57,6 +57,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
         public string Path { get; protected set; }
         public string SchemaName { get; protected set; }
         public string SchemaItemType { get; protected set; }
+        public string BindableBrowseObjectSchemaName { get; protected set; } = null;
         public string Version { get; protected set; }
         public bool Resolved { get; protected set; } = false;
         public bool TopLevel { get; protected set; } = true;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageDependencyModel.cs
@@ -55,6 +55,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
                 Priority = Dependency.UnresolvedReferenceNodePriority;
                 SchemaName = PackageReference.SchemaName;
             }
+
+            // When building browse object rule, always use PackageReference schema and bind
+            // to the package reference item in the project file
+            BindableBrowseObjectSchemaName = PackageReference.SchemaName;
         }
 
         private string _id;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
@@ -42,6 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             OriginalItemSpec = dependencyModel.OriginalItemSpec ?? string.Empty;
             Path = dependencyModel.Path ?? string.Empty;
             SchemaName = dependencyModel.SchemaName ?? Folder.SchemaName;
+            BindableBrowseObjectSchemaName = dependencyModel.BindableBrowseObjectSchemaName;
             _schemaItemType = dependencyModel.SchemaItemType ?? Folder.PrimaryDataSourceItemType;            
             Resolved = dependencyModel.Resolved;
             TopLevel = dependencyModel.TopLevel;
@@ -120,6 +121,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         public string OriginalItemSpec { get; protected set; }
         public string Path { get; protected set; }
         public string SchemaName { get; protected set; }
+        public string BindableBrowseObjectSchemaName { get; protected set; } = null;
         private string _schemaItemType;
         public string SchemaItemType
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
@@ -42,8 +42,17 @@
                     DisplayName="PrivateAssets"
                     Description="Assets that are private in this reference" />
 
+    <StringProperty Name="Identity"
+                    Visible="True"
+                    ReadOnly="True"
+                    Description="The item specified in the Include attribute.">
+        <StringProperty.DataSource>
+            <DataSource Persistence="Intrinsic" ItemType="PackageReference" PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+
     <StringProperty Name="Name" 
-                    Visible="True" 
+                    Visible="False" 
                     ReadOnly="True" />
 
     <StringProperty Name="OriginalItemSpec" 


### PR DESCRIPTION
This work makes several PackageReference metadata editable. The change is to build the browse object for package references from the `PackageReference` schema bound to the item's project file context, instead of using the `ResolvedPackageReference` schema. This allows us to get and set metadata on PackageReference items, especially NoWarn. The updated properties window has more metadata, but also retains the unresolved properties (i.e. 'Version') from the package reference:

![image](https://user-images.githubusercontent.com/7732033/27416151-6e25515c-56c0-11e7-92ed-9200c90ec232.png)

We concluded this is OK, even useful, for users to know the original version number. But I haven't been able to figure out how to make this not ReadOnly.

I've also tested this with implicit package references. With implicit packages, editing a property results in an 'Update' package reference being added to the project file, as expected:

```xml
  <ItemGroup>
    <PackageReference Update="Newtonsoft.Json">
      <NoWarn>NU1603</NoWarn>
    </PackageReference>
  </ItemGroup>
```

Fixes #2362

Still TODO:
- update unit tests
- run xliff tool

/cc @dotnet/project-system 