### PR TITLE
Handle non-compilations files correctly in up to date check

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.VisualStudio.ProjectSystem.Build;
-using Microsoft.VisualStudio.ProjectSystem.Properties;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -11,9 +9,10 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
-using Microsoft.VisualStudio.ProjectSystem.UpToDate;
+using Microsoft.VisualStudio.ProjectSystem.Build;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
 
-namespace Microsoft.VisualStudio.ProjectSystem
+namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 {
     [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     [Export(typeof(IBuildUpToDateCheckProvider))]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheckLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheckLogger.cs
@@ -2,7 +2,7 @@
 
 using System.IO;
 
-namespace Microsoft.VisualStudio.ProjectSystem
+namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 {
     internal sealed class BuildUpToDateCheckLogger
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheckLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheckLogger.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.IO;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal sealed class BuildUpToDateCheckLogger
+    {
+        private readonly TextWriter _logger;
+        private readonly LogLevel _requestedLogLevel;
+        private readonly string _fileName;
+
+        public BuildUpToDateCheckLogger(TextWriter logger, LogLevel requestedLogLevel, string projectPath)
+        {
+            _logger = logger;
+            _requestedLogLevel = requestedLogLevel;
+            _fileName = Path.GetFileNameWithoutExtension(projectPath);
+        }
+
+        private void Log(LogLevel level, string message, params object[] values)
+        {
+            if (level <= _requestedLogLevel)
+            {
+                _logger?.WriteLine($"FastUpToDate: {string.Format(message, values)} ({_fileName})");
+            }
+        }
+
+        public void Info(string message, params object[] values) => Log(LogLevel.Info, message, values);
+        public void Verbose(string message, params object[] values) => Log(LogLevel.Verbose, message, values);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/CopyToOutputDirectoryType.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/CopyToOutputDirectoryType.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal enum CopyToOutputDirectoryType
+    {
+        CopyNever,
+        CopyIfNewer,
+        CopyAlways
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/CopyToOutputDirectoryType.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/CopyToOutputDirectoryType.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-namespace Microsoft.VisualStudio.ProjectSystem
+namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 {
     internal enum CopyToOutputDirectoryType
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckItemComparer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckItemComparer.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+
+namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
+{
+    internal class UpToDateCheckItemComparer : IEqualityComparer<(string, CopyToOutputDirectoryType)>
+    {
+        public static UpToDateCheckItemComparer Instance = new UpToDateCheckItemComparer();
+
+        private UpToDateCheckItemComparer()
+        {
+        }
+
+        public bool Equals((string, CopyToOutputDirectoryType) x, (string, CopyToOutputDirectoryType) y) => StringComparers.Paths.Equals(x.Item1, y.Item1);
+
+        public int GetHashCode((string, CopyToOutputDirectoryType) obj) => StringComparers.Paths.GetHashCode(obj.Item1);
+    }
+}


### PR DESCRIPTION
**Customer scenario**

A project -- for example, Roslyn -- has files that are either Content or None. These files are not handled correctly and either cause up to date to fail when it shouldn't (more common), or cause up to date to succeed when it shouldn't (less common). Building Roslyn in an up-to-date state still results in about 12 projects getting MSBuild called when it should be 0.

**Description of fix**

This fix:

- No longer looks at the Content output group as it doesn't actually give any useful values.
- No longer looks at Content/None files when calculating the up-to-dateness of the project output (i.e. .dll or .exe) since they are not part of the build.
- If any kind of file is marked to always be copied to the output directory, we always fail the up to date check. This is consistent with the old project system.
- If a Content/None file is marked as "copy if newer," we check it's timestamp against the copied file in the output directory and fail if the source is newer.

Also cleans up the code a slight bit and makes the logging a little nicer.

**Bugs this fixes:** 

#2458

**Workarounds, if any**

Manually rebuild if a build should be happening but isn't, no workaround if a build shouldn't be happening but is.

**Risk**

Relatively low. This just affects up to date checks and errs on the side of failing the check, so the most likely problem is that a project builds when it could be skipped.

**Performance impact**

Low, we aren't checking any more files than we were before.

**Is this a regression from a previous update?**

No

