### PR TITLE
Show contents of implicit package references (regression)

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyFactory.cs
@@ -121,6 +121,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                             setPropertiesSchemaName, 
                             setPropertiesDependencyIDs,
                             It.IsAny<ImageMoniker>(),
+                            It.IsAny<ImageMoniker>(),
                             setPropertiesImplicit))
                     .Returns(mock.Object);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyTests.cs
@@ -213,6 +213,33 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(true, newDependency.Resolved);
             Assert.True(newDependency.Flags.Equals(DependencyTreeFlags.BaseReferenceFlags));
             Assert.True(newDependency.DependencyIDs.Count == 1);
+            Assert.Equal("aaa", newDependency.DependencyIDs[0]);
+        }
+
+        [Fact]
+        public void Dependency_SetProperties_PreservesDependencyIDs()
+        {
+            var mockModel = IDependencyModelFactory.Implement(
+                providerType: "providerType",
+                id: "cube",
+                dependencyIDs: ImmutableList<string>.Empty.Add("glass"));
+            var dependency = new Dependency(mockModel, ITargetFrameworkFactory.Implement("tfm1"));
+
+            var expectedId = "tfm1\\providerType\\cube";
+            var expectedDependencyId = "tfm1\\providerType\\glass";
+
+            Assert.Equal(expectedId, dependency.Id);
+            Assert.True(dependency.DependencyIDs.Count == 1);
+            Assert.Equal(expectedDependencyId, dependency.DependencyIDs[0]);
+
+            var newDependency = dependency.SetProperties(
+                caption: "newcaption");
+
+            Assert.Equal("newcaption", newDependency.Caption);
+
+            Assert.Equal(expectedId, newDependency.Id);
+            Assert.True(newDependency.DependencyIDs.Count == 1);
+            Assert.Equal(expectedDependencyId, newDependency.DependencyIDs[0]);
         }
 
         //[Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependency.cs
@@ -44,7 +44,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             ProjectTreeFlags? flags = null,
             string schemaName = null,
             IImmutableList<string> dependencyIDs = null,
-            ImageMoniker icon = new ImageMoniker(),
+            ImageMoniker icon = default(ImageMoniker),
+            ImageMoniker expandedIcon = default(ImageMoniker),
             bool? isImplicit = null)
         {
             return this;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
+using System.Linq;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 
@@ -96,7 +97,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             // since this is a clone make the modelId and dependencyIds match the original model
             _modelId = modelId;
 
-            if (model.DependencyIDs != null)
+            if (model.DependencyIDs != null && model.DependencyIDs.Any())
             {
                 DependencyIDs = ImmutableList.CreateRange(model.DependencyIDs);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
@@ -87,10 +87,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             }
         }
 
+        /// <summary>
+        /// Private constructor used to clone Dependency
+        /// </summary>
         private Dependency(IDependency model, string modelId)
             : this(model, model.TargetFramework)
         {
+            // since this is a clone make the modelId and dependencyIds match the original model
             _modelId = modelId;
+
+            if (model.DependencyIDs != null)
+            {
+                DependencyIDs = ImmutableList.CreateRange(model.DependencyIDs);
+            }
         }
 
         #region IDependencyModel
@@ -146,7 +155,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         public bool Implicit { get; private set; }
         public bool Visible { get; }
         public ImageMoniker Icon { get; private set; }
-        public ImageMoniker ExpandedIcon { get; }
+        public ImageMoniker ExpandedIcon { get; private set; }
         public ImageMoniker UnresolvedIcon { get; }
         public ImageMoniker UnresolvedExpandedIcon { get; }
         public int Priority { get; }
@@ -168,7 +177,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             ProjectTreeFlags? flags = null,
             string schemaName = null,
             IImmutableList<string> dependencyIDs = null,
-            ImageMoniker icon = new ImageMoniker(),
+            ImageMoniker icon = default(ImageMoniker),
+            ImageMoniker expandedIcon = default(ImageMoniker),
             bool? isImplicit = null)
         {
             var clone = new Dependency(this, _modelId);
@@ -201,6 +211,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             if (icon.Id != 0 && icon.Guid != Guid.Empty)
             {
                 clone.Icon = icon;
+            }
+
+            if (expandedIcon.Id != 0 && expandedIcon.Guid != Guid.Empty)
+            {
+                clone.ExpandedIcon = expandedIcon;
             }
 
             if (isImplicit != null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/ImplicitTopLevelDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/ImplicitTopLevelDependenciesSnapshotFilter.cs
@@ -63,6 +63,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
 
                 resultDependency = resultDependency.SetProperties(
                     icon: internalProvider.GetImplicitIcon(),
+                    expandedIcon: internalProvider.GetImplicitIcon(),
                     isImplicit: true);
                 filterAnyChanges = true;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependency.cs
@@ -35,7 +35,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             ProjectTreeFlags? flags = null,
             string schemaName = null,
             IImmutableList<string> dependencyIDs = null,
-            ImageMoniker icon = new ImageMoniker(),
+            ImageMoniker icon = default(ImageMoniker),
+            ImageMoniker expandedIcon = default(ImageMoniker),
             bool? isImplicit = null);
     }
 }


### PR DESCRIPTION
**Customer scenario**

Implicit package references show up in the dependency tree with an expander arrow:

![image](https://user-images.githubusercontent.com/7732033/27459921-9721a4e8-5765-11e7-9c6f-f6e985d14aa4.png)

However the package does not expand to reveal its dependencies/contents as other package references do. 

This specifically applies to implicit package references that are set in an imported target file -- the dependency node makes them implicit by cloning the original dependency and changing some properties in the model. A bug in the cloning process meant that the resulting dependency IDs were of the form `tfm\provider\tfm\provider\modelId` instead of `tfm\provider\modelId`. This bug would also affect any other places where this cloning occurs, such as when a package reference is aliased.

Additionally, fixing this bug revealed that making a node implicit changes the icon (to a locked NuGet package) when it is closed, but not when it is expanded. This fix also corrects the "ExpandedIcon"

**Bugs this fixes:** 

Fixes #2351 

**Workarounds, if any**

N/A

**Risk**

Low. Previous Ids are incorrect and were being ignored

**Performance impact**

This bug effectively prevents the dependency node from recursing through implicit package references. Some large projects may make many of their common package references implicit (by placing them in a common targets file) -- so fixing the bug could lead to more work building these nodes.

However after doing some experiments timing the load of a large project with lots of implicit references, both with and without the fix, I do not see any discernable difference. This is probably because this recursion is at the model layer and each unique nested package is only computed once and stored in a cache.

**Is this a regression from a previous update?**

Regression when dependencies node was rewritten for 15.3

**Root cause analysis:**

Implementation correctly caught this for each model's Id but not for its children (dependency Ids). Additionally, in the most prominent use of this cloning method (when changing a node from unresolved to resolved) the children dependency Ids are always overwritten with new Ids which masked this bug.

**How was the bug found?**

Dogfooding

/cc @dotnet/project-system 

