### PR TITLE
[WIP] FIX #189 - Set buildevent textinput font

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventsPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventsPropPage.vb
@@ -1,5 +1,6 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Drawing
 Imports System.Windows.Forms
 Imports Microsoft.VisualStudio.Editor
 Imports Microsoft.VisualStudio.Shell.Interop
@@ -78,8 +79,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 FontColorStorage.GetFont(Nothing, TextEditorFont)
 
                 ' Try to set the font..
-                Dim FontDisplayed As System.Drawing.Font
-                FontDisplayed = New System.Drawing.Font(TextEditorFont(0).bstrFaceName, CType(TextEditorFont(0).wPointSize, Single))
+                Dim FontDisplayed As Font
+                FontDisplayed = New Font(TextEditorFont(0).bstrFaceName, CType(TextEditorFont(0).wPointSize, Single))
                 txtPreBuildEventCommandLine.Font = FontDisplayed
                 txtPostBuildEventCommandLine.Font = FontDisplayed
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventsPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventsPropPage.vb
@@ -4,7 +4,6 @@ Imports System.Drawing
 Imports System.Windows.Forms
 Imports Microsoft.VisualStudio.Editor
 Imports Microsoft.VisualStudio.Shell.Interop
-Imports Microsoft.VisualStudio.TextManager.Interop
 Imports VSLangProj80
 
 Namespace Microsoft.VisualStudio.Editors.PropertyPages

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventsPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventsPropPage.vb
@@ -1,6 +1,7 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Windows.Forms
+Imports Microsoft.VisualStudio.Editor
 Imports Microsoft.VisualStudio.Shell.Interop
 Imports VSLangProj80
 
@@ -19,6 +20,22 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
             'Add any initialization after the InitializeComponent() call
             AddChangeHandlers()
+
+            Dim Flags As __FCSTORAGEFLAGS = __FCSTORAGEFLAGS.FCSF_READONLY
+
+            Dim FontColorStorage As IVsFontAndColorStorage = TryCast(GetService(GetType(IVsFontAndColorStorage)), IVsFontAndColorStorage)
+            If FontColorStorage IsNot Nothing Then
+                FontColorStorage.OpenCategory(DefGuidList.guidTextEditorFontCategory, CType(Flags, System.UInt32))
+                Dim TextEditorFont As FontInfo() = Nothing
+                FontColorStorage.GetFont(Nothing, TextEditorFont)
+
+                ' Try to set the font..
+                Dim FontDisplayed As System.Drawing.Font
+                FontDisplayed = New System.Drawing.Font(TextEditorFont(0).bstrFaceName, CType(TextEditorFont(0).wPointSize, Single))
+                txtPreBuildEventCommandLine.Font = FontDisplayed
+                txtPostBuildEventCommandLine.Font = FontDisplayed
+
+            End If
         End Sub
 
         Public Enum Tokens

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventsPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventsPropPage.vb
@@ -21,21 +21,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             'Add any initialization after the InitializeComponent() call
             AddChangeHandlers()
 
-            Dim Flags As __FCSTORAGEFLAGS = __FCSTORAGEFLAGS.FCSF_READONLY
-
-            Dim FontColorStorage As IVsFontAndColorStorage = TryCast(GetService(GetType(IVsFontAndColorStorage)), IVsFontAndColorStorage)
-            If FontColorStorage IsNot Nothing Then
-                FontColorStorage.OpenCategory(DefGuidList.guidTextEditorFontCategory, CType(Flags, System.UInt32))
-                Dim TextEditorFont As FontInfo() = Nothing
-                FontColorStorage.GetFont(Nothing, TextEditorFont)
-
-                ' Try to set the font..
-                Dim FontDisplayed As System.Drawing.Font
-                FontDisplayed = New System.Drawing.Font(TextEditorFont(0).bstrFaceName, CType(TextEditorFont(0).wPointSize, Single))
-                txtPreBuildEventCommandLine.Font = FontDisplayed
-                txtPostBuildEventCommandLine.Font = FontDisplayed
-
-            End If
         End Sub
 
         Public Enum Tokens
@@ -82,6 +67,25 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             "ProjectExt",
             "SolutionExt"
         }
+
+        Private Sub OnFontColorPreferencesChanged(sender As Object, e As EventArgs)
+            Dim Flags As __FCSTORAGEFLAGS = __FCSTORAGEFLAGS.FCSF_READONLY
+
+            Dim FontColorStorage As IVsFontAndColorStorage = TryCast(GetService(GetType(IVsFontAndColorStorage)), IVsFontAndColorStorage)
+            If FontColorStorage IsNot Nothing Then
+                FontColorStorage.OpenCategory(DefGuidList.guidTextEditorFontCategory, CType(Flags, System.UInt32))
+                Dim TextEditorFont As FontInfo() = Nothing
+                FontColorStorage.GetFont(Nothing, TextEditorFont)
+
+                ' Try to set the font..
+                Dim FontDisplayed As System.Drawing.Font
+                FontDisplayed = New System.Drawing.Font(TextEditorFont(0).bstrFaceName, CType(TextEditorFont(0).wPointSize, Single))
+                txtPreBuildEventCommandLine.Font = FontDisplayed
+                txtPostBuildEventCommandLine.Font = FontDisplayed
+
+            End If
+
+        End Sub
 
         Protected Overrides ReadOnly Property ControlData() As PropertyControlData()
             Get


### PR DESCRIPTION
**Customer scenario**

Customer wants to be able to change the default font for the text boxes in the "Build events" property page were monospace.

**Bugs this fixes:** 

It is not actually a bug. It is adding enhancement on Build events property page to respect Text Editor setting of Visual Studio's Font and Color setting

**Workarounds, if any**

None. The property page needs to check the Fonts and Color setting.

**Risk**

Low. It only adds checking of Font and Color setting.

**Performance impact**

Very low performance impact, because it only checks Font and Color setting using `IVsFontAndColorStorage`

**Is this a regression from a previous update?**
No.

**Root cause analysis:**

Since this is an additional enhancement, there's no root cause.

**How was the bug found?**

Customer reported in issue #189

**Partner requested**

@davkean 