### PR TITLE
Fix 'Parameter is not valid' error when reopen Resource Editor

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
@@ -256,10 +256,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 DeleteTemporaryFolders(_deleteFoldersOnEditorExit)
                 _deleteFoldersOnEditorExit.Clear()
 
-                If _cachedResources IsNot Nothing Then
-                    _cachedResources.Dispose()
-                End If
-
                 _typeResolutionServiceCache = Nothing
 
             End If
@@ -4843,14 +4839,12 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 #Region "Private class - resources cached by this resource editor instance"
 
         Friend NotInheritable Class CachedResourcesForView
-            Implements IDisposable
 
             Private _errorGlyphLarge As Image
             Private _errorGlyphSmall As Image
             Private _errorGlyphState As Image
             Private _sortUpGlyph As Image
             Private _sortDownGlyph As Image
-            Private _imageService As IVsImageService2
             Private _backgroundColor As Color
 
             ''' <summary>
@@ -4864,45 +4858,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 _errorGlyphState = GetImageFromImageService(KnownMonikers.StatusError, 12, 12, background)
                 _sortUpGlyph = GetImageFromImageService(KnownMonikers.GlyphUp, 12, 12, background)
                 _sortDownGlyph = GetImageFromImageService(KnownMonikers.GlyphDown, 12, 12, background)
-            End Sub
-
-            ''' <summary>
-            ''' IDisposable.Dispose
-            ''' </summary>
-            ''' <remarks></remarks>
-            Public Overloads Sub Dispose() Implements IDisposable.Dispose
-                Dispose(Disposing:=True)
-            End Sub
-
-
-            ''' <summary>
-            ''' Dispose the instance.
-            ''' </summary>
-            ''' <param name="Disposing"></param>
-            ''' <remarks></remarks>
-            Public Overloads Sub Dispose(Disposing As Boolean)
-                If Disposing Then
-                    If _errorGlyphLarge IsNot Nothing Then
-                        _errorGlyphLarge.Dispose()
-                        _errorGlyphLarge = Nothing
-                    End If
-                    If _errorGlyphSmall IsNot Nothing Then
-                        _errorGlyphSmall.Dispose()
-                        _errorGlyphSmall = Nothing
-                    End If
-                    If _errorGlyphState IsNot Nothing Then
-                        _errorGlyphState.Dispose()
-                        _errorGlyphState = Nothing
-                    End If
-                    If _sortUpGlyph IsNot Nothing Then
-                        _sortUpGlyph.Dispose()
-                        _sortUpGlyph = Nothing
-                    End If
-                    If _sortDownGlyph IsNot Nothing Then
-                        _sortDownGlyph.Dispose()
-                        _sortDownGlyph = Nothing
-                    End If
-                End If
             End Sub
 
             ''' <summary>


### PR DESCRIPTION
**Customer scenario**
1. Add a new RESX resource file, add a new empty PNG image resource. Save and close Resource Editor.
2. Immediately double click on the RESX file to open Resource Editor.
3. Result: 'Parameter is not valid' error.

**Bugs this fixes:** 
https://devdiv.visualstudio.com/DevDiv/_workitems?id=452557

**Workarounds, if any**
Wait for a short period of time and launch Resource Editor again.

**Risk**
Low, this change affects a private class of Resource Editor View.

**Performance impact**
Low performance impact because the assets returned by Image Service may stay a little bit longer, but GC will collect them because Image Service only keeps weak references to them.

**Is this a regression from a previous update?**
Regression from VS 2015.

**Root cause analysis:**
- Resource Editor used to load its icons from embedded resources and dispose these icons when closed.
- A change was made (https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/902) to convert these icons to assets returned from Image Service. But the dispose code was not removed.
- Assets returned by Image Service are managed by Image Service and should not be disposed by consumers.
- The old code disposes assets when Resource Editor is closed. Next time Resource Editor is opened, Image Service may return disposed assets.
- This does not happen all the time because between Resource Editor launches, garbage collector may collect the assets (hold by weak-reference from Image Service) and next time new assets will be returned.

**How was the bug found?**
Customer feedback - https://developercommunity.visualstudio.com/content/problem/64136/parameter-is-not-valid.html
