### PR TITLE
Make F# application and build prop pages work

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/ProjectSystem/VS/Properties/FSharpProjectDesignerPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/ProjectSystem/VS/Properties/FSharpProjectDesignerPage.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
     internal static class FSharpProjectDesignerPage
     {
         public static readonly ProjectDesignerPageMetadata Application = new ProjectDesignerPageMetadata(new Guid("{6D2D9B56-2691-4624-A1BF-D07A14594748}"), pageOrder: 0, hasConfigurationCondition: false);
-        public static readonly ProjectDesignerPageMetadata Build = new ProjectDesignerPageMetadata(new Guid("{FAC0A17E-2E70-4211-916A-0D34FB708BFF}"), pageOrder: 1, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata Build = new ProjectDesignerPageMetadata(new Guid("{FAC0A17E-2E70-4211-916A-0D34FB708BFF}"), pageOrder: 1, hasConfigurationCondition: true);
         public static readonly ProjectDesignerPageMetadata BuildEvents = new ProjectDesignerPageMetadata(new Guid("{DD84AA8F-71BB-462a-8EF8-C9992CB325B7}"), pageOrder: 2, hasConfigurationCondition: false);
         public static readonly ProjectDesignerPageMetadata Debug = new ProjectDesignerPageMetadata(new Guid("{0273C280-1882-4ED0-9308-52914672E3AA}"), pageOrder: 3, hasConfigurationCondition: false);
         public static readonly ProjectDesignerPageMetadata Package = new ProjectDesignerPageMetadata(new Guid("{21b78be8-3957-4caa-bf2f-e626107da58e}"), pageOrder: 4, hasConfigurationCondition: false);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -164,4 +164,8 @@
     </StringProperty>
 
     <DynamicEnumProperty Name="SupportedTargetFrameworks" DisplayName="Supported TargetFrameworks" EnumProvider="SupportedTargetFrameworksEnumProvider" Visible="False"/>
+    
+    <!-- F# specific properties-->
+    <BoolProperty Name="CanUseTargetFSharpCoreVersion" Visible="False"/>
+    <StringProperty Name="TargetFSharpCoreVersion" Visible="False" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
@@ -128,4 +128,6 @@
   <StringProperty Name="LangVersion" DisplayName="CSharp Language Version" Visible="False"/>
   <StringProperty Name="CodeAnalysisRuleSet" DisplayName=" Code Analysis Rule set" Visible="False"/>
 
+  <!-- F# specific properties-->
+  <BoolProperty Name="Tailcalls" Visible="False" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/GeneralBrowseObject.xaml
@@ -152,4 +152,7 @@
     </StringProperty.DataSource>
   </StringProperty>
   <DynamicEnumProperty Name="SupportedTargetFrameworks" DisplayName="Podporované cílové architektury" EnumProvider="SupportedTargetFrameworksEnumProvider" Visible="False" />
+  <!-- F# specific properties-->
+  <BoolProperty Name="CanUseTargetFSharpCoreVersion" Visible="False" />
+  <StringProperty Name="TargetFSharpCoreVersion" Visible="False" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/GeneralConfiguredBrowseObject.xaml
@@ -113,4 +113,6 @@
   <!-- CSharp Project Configuration Properties-->
   <StringProperty Name="LangVersion" DisplayName="Verze jazyka CSharp" Visible="False" />
   <StringProperty Name="CodeAnalysisRuleSet" DisplayName=" Sada pravidel analýzy kódu" Visible="False" />
+  <!-- F# specific properties-->
+  <BoolProperty Name="Tailcalls" Visible="False" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/GeneralBrowseObject.xaml
@@ -152,4 +152,7 @@
     </StringProperty.DataSource>
   </StringProperty>
   <DynamicEnumProperty Name="SupportedTargetFrameworks" DisplayName="Unterstützte TargetFrameworks" EnumProvider="SupportedTargetFrameworksEnumProvider" Visible="False" />
+  <!-- F# specific properties-->
+  <BoolProperty Name="CanUseTargetFSharpCoreVersion" Visible="False" />
+  <StringProperty Name="TargetFSharpCoreVersion" Visible="False" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/GeneralConfiguredBrowseObject.xaml
@@ -113,4 +113,6 @@
   <!-- CSharp Project Configuration Properties-->
   <StringProperty Name="LangVersion" DisplayName="CSharp-Sprachversion" Visible="False" />
   <StringProperty Name="CodeAnalysisRuleSet" DisplayName=" Codeanalyseregel festgelegt" Visible="False" />
+  <!-- F# specific properties-->
+  <BoolProperty Name="Tailcalls" Visible="False" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/GeneralBrowseObject.xaml
@@ -152,4 +152,7 @@
     </StringProperty.DataSource>
   </StringProperty>
   <DynamicEnumProperty Name="SupportedTargetFrameworks" DisplayName="Plataformas de destino admitidas" EnumProvider="SupportedTargetFrameworksEnumProvider" Visible="False" />
+  <!-- F# specific properties-->
+  <BoolProperty Name="CanUseTargetFSharpCoreVersion" Visible="False" />
+  <StringProperty Name="TargetFSharpCoreVersion" Visible="False" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/GeneralConfiguredBrowseObject.xaml
@@ -113,4 +113,6 @@
   <!-- CSharp Project Configuration Properties-->
   <StringProperty Name="LangVersion" DisplayName="Versión de lenguaje CSharp" Visible="False" />
   <StringProperty Name="CodeAnalysisRuleSet" DisplayName=" Conjunto de reglas de análisis de código" Visible="False" />
+  <!-- F# specific properties-->
+  <BoolProperty Name="Tailcalls" Visible="False" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/GeneralBrowseObject.xaml
@@ -152,4 +152,7 @@
     </StringProperty.DataSource>
   </StringProperty>
   <DynamicEnumProperty Name="SupportedTargetFrameworks" DisplayName="TargetFrameworks pris en charge" EnumProvider="SupportedTargetFrameworksEnumProvider" Visible="False" />
+  <!-- F# specific properties-->
+  <BoolProperty Name="CanUseTargetFSharpCoreVersion" Visible="False" />
+  <StringProperty Name="TargetFSharpCoreVersion" Visible="False" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/GeneralConfiguredBrowseObject.xaml
@@ -113,4 +113,6 @@
   <!-- CSharp Project Configuration Properties-->
   <StringProperty Name="LangVersion" DisplayName="Version du langage CSharp" Visible="False" />
   <StringProperty Name="CodeAnalysisRuleSet" DisplayName=" Ensemble de règles d'analyse du code" Visible="False" />
+  <!-- F# specific properties-->
+  <BoolProperty Name="Tailcalls" Visible="False" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/GeneralBrowseObject.xaml
@@ -152,4 +152,7 @@
     </StringProperty.DataSource>
   </StringProperty>
   <DynamicEnumProperty Name="SupportedTargetFrameworks" DisplayName="Framework di destinazione supportati" EnumProvider="SupportedTargetFrameworksEnumProvider" Visible="False" />
+  <!-- F# specific properties-->
+  <BoolProperty Name="CanUseTargetFSharpCoreVersion" Visible="False" />
+  <StringProperty Name="TargetFSharpCoreVersion" Visible="False" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/GeneralConfiguredBrowseObject.xaml
@@ -113,4 +113,6 @@
   <!-- CSharp Project Configuration Properties-->
   <StringProperty Name="LangVersion" DisplayName="Versione del linguaggio CSharp" Visible="False" />
   <StringProperty Name="CodeAnalysisRuleSet" DisplayName=" Set di regole di analisi codice" Visible="False" />
+  <!-- F# specific properties-->
+  <BoolProperty Name="Tailcalls" Visible="False" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/GeneralBrowseObject.xaml
@@ -152,4 +152,7 @@
     </StringProperty.DataSource>
   </StringProperty>
   <DynamicEnumProperty Name="SupportedTargetFrameworks" DisplayName="サポートされるターゲット フレームワーク" EnumProvider="SupportedTargetFrameworksEnumProvider" Visible="False" />
+  <!-- F# specific properties-->
+  <BoolProperty Name="CanUseTargetFSharpCoreVersion" Visible="False" />
+  <StringProperty Name="TargetFSharpCoreVersion" Visible="False" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/GeneralConfiguredBrowseObject.xaml
@@ -113,4 +113,6 @@
   <!-- CSharp Project Configuration Properties-->
   <StringProperty Name="LangVersion" DisplayName="CSharp 言語バージョン" Visible="False" />
   <StringProperty Name="CodeAnalysisRuleSet" DisplayName=" コード分析規則セット" Visible="False" />
+  <!-- F# specific properties-->
+  <BoolProperty Name="Tailcalls" Visible="False" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/GeneralBrowseObject.xaml
@@ -152,4 +152,7 @@
     </StringProperty.DataSource>
   </StringProperty>
   <DynamicEnumProperty Name="SupportedTargetFrameworks" DisplayName="지원되는 대상 프레임워크" EnumProvider="SupportedTargetFrameworksEnumProvider" Visible="False" />
+  <!-- F# specific properties-->
+  <BoolProperty Name="CanUseTargetFSharpCoreVersion" Visible="False" />
+  <StringProperty Name="TargetFSharpCoreVersion" Visible="False" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/GeneralConfiguredBrowseObject.xaml
@@ -113,4 +113,6 @@
   <!-- CSharp Project Configuration Properties-->
   <StringProperty Name="LangVersion" DisplayName="CSharp 언어 버전" Visible="False" />
   <StringProperty Name="CodeAnalysisRuleSet" DisplayName=" 코드 분석 규칙 집합" Visible="False" />
+  <!-- F# specific properties-->
+  <BoolProperty Name="Tailcalls" Visible="False" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/GeneralBrowseObject.xaml
@@ -152,4 +152,7 @@
     </StringProperty.DataSource>
   </StringProperty>
   <DynamicEnumProperty Name="SupportedTargetFrameworks" DisplayName="Obsługiwane platformy docelowe" EnumProvider="SupportedTargetFrameworksEnumProvider" Visible="False" />
+  <!-- F# specific properties-->
+  <BoolProperty Name="CanUseTargetFSharpCoreVersion" Visible="False" />
+  <StringProperty Name="TargetFSharpCoreVersion" Visible="False" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/GeneralConfiguredBrowseObject.xaml
@@ -113,4 +113,6 @@
   <!-- CSharp Project Configuration Properties-->
   <StringProperty Name="LangVersion" DisplayName="Wersja języka CSharp" Visible="False" />
   <StringProperty Name="CodeAnalysisRuleSet" DisplayName=" Zestaw reguł analizy kodu" Visible="False" />
+  <!-- F# specific properties-->
+  <BoolProperty Name="Tailcalls" Visible="False" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/GeneralBrowseObject.xaml
@@ -152,4 +152,7 @@
     </StringProperty.DataSource>
   </StringProperty>
   <DynamicEnumProperty Name="SupportedTargetFrameworks" DisplayName="TargetFrameworks com Suporte" EnumProvider="SupportedTargetFrameworksEnumProvider" Visible="False" />
+  <!-- F# specific properties-->
+  <BoolProperty Name="CanUseTargetFSharpCoreVersion" Visible="False" />
+  <StringProperty Name="TargetFSharpCoreVersion" Visible="False" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/GeneralConfiguredBrowseObject.xaml
@@ -113,4 +113,6 @@
   <!-- CSharp Project Configuration Properties-->
   <StringProperty Name="LangVersion" DisplayName="Versão da Linguagem CSharp" Visible="False" />
   <StringProperty Name="CodeAnalysisRuleSet" DisplayName=" Conjunto de Regras da Análise de Código" Visible="False" />
+  <!-- F# specific properties-->
+  <BoolProperty Name="Tailcalls" Visible="False" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/GeneralBrowseObject.xaml
@@ -152,4 +152,7 @@
     </StringProperty.DataSource>
   </StringProperty>
   <DynamicEnumProperty Name="SupportedTargetFrameworks" DisplayName="Поддерживаемые целевые платформы" EnumProvider="SupportedTargetFrameworksEnumProvider" Visible="False" />
+  <!-- F# specific properties-->
+  <BoolProperty Name="CanUseTargetFSharpCoreVersion" Visible="False" />
+  <StringProperty Name="TargetFSharpCoreVersion" Visible="False" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/GeneralConfiguredBrowseObject.xaml
@@ -113,4 +113,6 @@
   <!-- CSharp Project Configuration Properties-->
   <StringProperty Name="LangVersion" DisplayName="Версия языка CSharp" Visible="False" />
   <StringProperty Name="CodeAnalysisRuleSet" DisplayName="Набор правил анализа кода" Visible="False" />
+  <!-- F# specific properties-->
+  <BoolProperty Name="Tailcalls" Visible="False" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/GeneralBrowseObject.xaml
@@ -152,4 +152,7 @@
     </StringProperty.DataSource>
   </StringProperty>
   <DynamicEnumProperty Name="SupportedTargetFrameworks" DisplayName="Desteklenen Hedef Çerçeveler" EnumProvider="SupportedTargetFrameworksEnumProvider" Visible="False" />
+  <!-- F# specific properties-->
+  <BoolProperty Name="CanUseTargetFSharpCoreVersion" Visible="False" />
+  <StringProperty Name="TargetFSharpCoreVersion" Visible="False" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/GeneralConfiguredBrowseObject.xaml
@@ -113,4 +113,6 @@
   <!-- CSharp Project Configuration Properties-->
   <StringProperty Name="LangVersion" DisplayName="CSharp Dil Sürümü" Visible="False" />
   <StringProperty Name="CodeAnalysisRuleSet" DisplayName="Kod Analizi Kural Kümesi" Visible="False" />
+  <!-- F# specific properties-->
+  <BoolProperty Name="Tailcalls" Visible="False" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/GeneralBrowseObject.xaml
@@ -152,4 +152,7 @@
     </StringProperty.DataSource>
   </StringProperty>
   <DynamicEnumProperty Name="SupportedTargetFrameworks" DisplayName="支持的目标框架" EnumProvider="SupportedTargetFrameworksEnumProvider" Visible="False" />
+  <!-- F# specific properties-->
+  <BoolProperty Name="CanUseTargetFSharpCoreVersion" Visible="False" />
+  <StringProperty Name="TargetFSharpCoreVersion" Visible="False" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/GeneralConfiguredBrowseObject.xaml
@@ -113,4 +113,6 @@
   <!-- CSharp Project Configuration Properties-->
   <StringProperty Name="LangVersion" DisplayName="CSharp 语言版本" Visible="False" />
   <StringProperty Name="CodeAnalysisRuleSet" DisplayName="代码分析规则集" Visible="False" />
+  <!-- F# specific properties-->
+  <BoolProperty Name="Tailcalls" Visible="False" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/GeneralBrowseObject.xaml
@@ -152,4 +152,7 @@
     </StringProperty.DataSource>
   </StringProperty>
   <DynamicEnumProperty Name="SupportedTargetFrameworks" DisplayName="支援的 TargetFrameworks" EnumProvider="SupportedTargetFrameworksEnumProvider" Visible="False" />
+  <!-- F# specific properties-->
+  <BoolProperty Name="CanUseTargetFSharpCoreVersion" Visible="False" />
+  <StringProperty Name="TargetFSharpCoreVersion" Visible="False" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/GeneralConfiguredBrowseObject.xaml
@@ -113,4 +113,6 @@
   <!-- CSharp Project Configuration Properties-->
   <StringProperty Name="LangVersion" DisplayName="CSharp 語言版本" Visible="False" />
   <StringProperty Name="CodeAnalysisRuleSet" DisplayName=" 程式碼分析規則集" Visible="False" />
+  <!-- F# specific properties-->
+  <BoolProperty Name="Tailcalls" Visible="False" />
 </Rule>


### PR DESCRIPTION
The application page needs rules for a couple of F# specific properties around FSharp core versions.
The build page was not marked as configuration-specific and that was causing it to blow up. Also added a rule for Tailcalls which is the only F# specific property in that page.

There are still three things left to do but they all require changes outside of this repo:
 - https://github.com/Microsoft/visualfsharp/issues/3276 - The TargetFramework dropdown is empty in the application page. This is because it asks the multi-targeting service for the TFMs and the multi-targeting service doesn't know about .NET Core\Standard. We made a [change to C#\VB pages](https://github.com/dotnet/project-system/pull/2097/commits/aee40ba336d0b94a20f416060213e0b9cf6369a1) augment that list from the SDK. The same change needs to be repeated for the F# application page.
- https://github.com/Microsoft/visualfsharp/issues/3277 - The BuildEvents prop page is still broken. This [line](https://github.com/Microsoft/visualfsharp/blob/6afc4f9776a5dba903ca6b11965a206fb8bc23d8/vsintegration/src/FSharp.ProjectSystem.PropertyPages/PropertyPages/BuildEventsPropPage.vb#L215) needs to be fixed - when the RunPostBuildEvent property is not set, the old PS returned a special missing value where CPS returns an empty string. That code needs to account for the empty string. 
- The FSharp.props needs to set default values for the Tailcalls property and Prefer32Bit - if default values are not set the checkboxes become greyed out. @KevinRansom is looking into this.

**Customer scenario**

Opening the property pages for a F# .NET Core project fails to load the application or the build page.

**Bugs this fixes:** 

https://github.com/dotnet/project-system/issues/1854

**Workarounds, if any**

None

**Risk**

Low

**Performance impact**

Low - this just makes the pages work.

**Is this a regression from a previous update?**

No. This is part of bringing up F# .NET core support.
