### PR TITLE
Fix VS consumes large amount of CPU 

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContext.cs
@@ -97,41 +97,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         }
 
         /// <summary>
-        /// Returns true if this cross-targeting aggregate project context has the same set of target frameworks and active target framework as the given TargetFrameworks property value.
-        /// </summary>
-        /// <param name="targetFrameworksProperty">Property value for MSBuild property "TargetsFramework"</param>
-        public bool HasMatchingTargetFrameworks(string targetFrameworksProperty)
-        {
-            Requires.NotNull(targetFrameworksProperty, nameof(targetFrameworksProperty));
-            Requires.Range(IsCrossTargeting, nameof(targetFrameworksProperty), "This method should only be invoked for Cross targeting projects");
-
-            ImmutableArray<string> parsedTargetFrameworks = BuildUtilities.GetPropertyValues(targetFrameworksProperty);
-            if (parsedTargetFrameworks.Length != _configuredProjectContextsByTargetFramework.Count)
-            {
-                // Different number of target frameworks.
-                return false;
-            }
-
-            if (!_activeTargetFramework.Equals(parsedTargetFrameworks[0]))
-            {
-                // Active target framework is different.
-                return false;
-            }
-
-            foreach (var targetFrameworkMoniker in parsedTargetFrameworks.Skip(1))
-            {
-                var targetFramework = TargetFrameworkProvider.GetTargetFramework(targetFrameworkMoniker);
-                if (!_configuredProjectContextsByTargetFramework.ContainsKey(targetFramework))
-                {
-                    // Differing TargetFramework
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        /// <summary>
         /// Returns true if this cross-targeting aggregate project context has the same set of target frameworks and active target framework as the given active and known configurations.
         /// </summary>
         public bool HasMatchingTargetFrameworks(ProjectConfiguration activeProjectConfiguration, 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContext.cs
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             Assumes.True(activeProjectConfiguration.IsCrossTargeting());
             Assumes.True(knownProjectConfigurations.All(c => c.IsCrossTargeting()));
 
-            var activeTargetFramework = activeProjectConfiguration.Dimensions[ConfigurationGeneral.TargetFrameworkProperty];
+            var activeTargetFramework = TargetFrameworkProvider.GetTargetFramework(activeProjectConfiguration.Dimensions[ConfigurationGeneral.TargetFrameworkProperty]);
             if (!_activeTargetFramework.Equals(activeTargetFramework))
             {
                 // Active target framework is different.


### PR DESCRIPTION
**Customer scenario**

Certain projects consumes large amount of CPU while the project is open.

There are many ways to represent a "friendly name" of a target framework in the `<TargetFrameworks>` element. For example, .NET Framework 4.0, can be represented as:

``` XML
<TargetFrameworks>net4</TargetFrameworks>
```
-or-

``` XML
<TargetFrameworks>net4.0</TargetFrameworks>
```

-or-

``` XML
<TargetFrameworks>net40</TargetFrameworks>
```

If you enter a form that is not canonical from what we get from NuGet (ie the first two), we continually process data forever, consuming larges amounts of CPU. 

**Bugs this fixes:** 

Fixes https://github.com/dotnet/project-system/issues/2388

**Workarounds, if any**

Change the element to be in the canonical form. It is not obvious this is the cause.

**Risk**

Low

**Performance impact**

None - we're effectively pulling a name from a cache.

**Is this a regression from a previous update?**

Yes, from 15.2.

**Root cause analysis:**

We have internal guidance not to parse or reason able these values, which we consider to be "user written" - but this was overlooked in this case. Right now the smallest, least risky change was made, but in the future (int #2525) we're centralizing all understanding of this error prone code in a single location.

**How was the bug found?**

Customer reported. We have external reports that I've yet to verify if they have the same underlying cause.

**Dev Notes**

We were making the assumption that the literal user written short name, matched the canonical version of the short name. This wasn't the case:

The project file had:

    portable-net4+win8+wpa81

Our "canonical" version had:

    portable-net40+win8+wpa81

This was causing us to continually reset our subscriptions to the data flow, and constantly process the same data over and over again.

After my fix, we still do not handle the portable versions correctly in the project, in that we only show one of them in the dependencies tree, filed #2524 to track that. I've confirmed this this wasn't regressed in this change.

Note also that this code shouldn't even be looking at TFMs, filed: #2525 to track that.