### PR TITLE
Make the F# icons show up in solution explorer for F# source files

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/ProjectSystem/VS/Imaging/FSharpProjectImageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/ProjectSystem/VS/Imaging/FSharpProjectImageProvider.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.ProjectSystem.Imaging;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Imaging
 {
     /// <summary>
-    ///     Provides C# project images.
+    ///     Provides F# project images.
     /// </summary>
     [Export(typeof(IProjectImageProvider))]
     [AppliesTo(ProjectCapability.FSharp)]

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/ProjectSystem/VS/Imaging/FSharpSourcesIconProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/ProjectSystem/VS/Imaging/FSharpSourcesIconProvider.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.IO;
+using Microsoft.VisualStudio.Imaging;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Imaging
+{
+    [Export(typeof(IProjectTreePropertiesProvider))]
+    [AppliesTo(ProjectCapability.FSharp)]
+    [Order(Order.Default)]
+    internal class FSharpSourcesIconProvider : IProjectTreePropertiesProvider
+    {
+        private static readonly Dictionary<string, ProjectImageMoniker> FileExtensionImageMap = new Dictionary<string, ProjectImageMoniker>(StringComparer.OrdinalIgnoreCase)
+        {
+            { ".fs",   KnownMonikers.FSFileNode.ToProjectSystemType() },
+            { ".fsi",  KnownMonikers.FSSignatureFile.ToProjectSystemType() },
+            { ".fsx",  KnownMonikers.FSScript.ToProjectSystemType() }
+        };
+
+        public void CalculatePropertyValues(IProjectTreeCustomizablePropertyContext propertyContext, IProjectTreeCustomizablePropertyValues propertyValues)
+        {
+            if (!propertyValues.Flags.Contains(ProjectTreeFlags.Common.Folder))
+            {
+                if (!propertyValues.Flags.Contains(ProjectTreeFlags.Common.SourceFile | ProjectTreeFlags.Common.FileSystemEntity))
+                {
+                    return;
+                }
+
+                propertyValues.Icon = GetIconForItem(propertyContext.ItemName);
+            }
+        }
+
+        private ProjectImageMoniker GetIconForItem(string itemName)
+        {
+            if (FileExtensionImageMap.TryGetValue(Path.GetExtension(itemName), out ProjectImageMoniker moniker))
+            {
+                return moniker;
+            }
+
+            // Return null so VS can supply the default icons.
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
**Customer scenario**

For F# NetCore projects, solution explorer doesn't show the F# icons - makes it hard to distinguish between fs and fsi files.

**Bugs this fixes:** 

(either VSO or GitHub links)

**Workarounds, if any**

None

**Risk**

Low - just adds an icon provider for the fs, fsi and fsx extensions

**Performance impact**

Low - just adds an icon provider for the fs, fsi and fsx extensions

**Is this a regression from a previous update?**

No, this is part of the F# .NET Core support.
