### PR TITLE
Only look at projects when updating Dependencies -> Projects

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ProjectRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ProjectRuleHandler.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
@@ -114,7 +115,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             var dependencyThatNeedChange = new List<IDependency>();
             foreach(var target in projectSnapshot.Targets)
             {
-                foreach (var dependency in target.Value.TopLevelDependencies)
+                foreach (var dependency in target.Value.TopLevelDependencies.Where(d => StringComparers.DependencyProviderTypes.Equals(d.ProviderType, ProviderTypeString)))
                 {
                     if (otherProjectPath.Equals(dependency.GetActualPath(projectPath)))
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/StringComparers.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/StringComparers.cs
@@ -29,5 +29,10 @@ namespace Microsoft.VisualStudio
         {
             get { return StringComparer.Ordinal; }
         }
+
+        public static IEqualityComparer<string> DependencyProviderTypes
+        {
+            get { return StringComparer.OrdinalIgnoreCase; }
+        }
     }
 }


### PR DESCRIPTION
We were searching all project's top-level dependencies to determine if we need to update the toplevel dependency. In some projects in Roslyn and ProjectSystem, this can be up to hundred dependencies and can result in a lot of garbage due to the allocations in GetActualPath.

Fixes part of https://github.com/dotnet/project-system/issues/2533.

This reduces the amount of allocations in this path from 500 KB -> 100 KB opening ProjectSystem.sln.

Note, there's still a lot of wins to be had in GetActualPath which allocates a lot for what it's doing, I'm tracking that via: https://github.com/dotnet/project-system/issues/2536.
