### PR TITLE
Reduce 20% of allocations opening ProjectSystem.sln

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
@@ -112,8 +112,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
             if (!ManagedPathHelper.IsRooted(dependency.OriginalItemSpec))
             {
-                var projectFolder = Path.GetDirectoryName(containingProjectPath);
-                dependencyProjectPath = ManagedPathHelper.TryMakeRooted(projectFolder, dependency.OriginalItemSpec);
+                dependencyProjectPath = ManagedPathHelper.TryMakeRooted(containingProjectPath, dependency.OriginalItemSpec);
             }
 
             return dependencyProjectPath;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/ManagedPathHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/ManagedPathHelper.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
 
             try
             {
-                return PathHelper.MakeRooted(PathHelper.EnsureTrailingSlash(basePath), path);
+                return PathHelper.MakeRooted(basePath, path);
             }
             catch (ArgumentException)
             {


### PR DESCRIPTION
We were making two allocations (GetDirectoryName, EnsureTrailingSlash) calling PathHelper.MakeRooted to handle a case it already handles for us.

Given a base path, "C:\Project\Project.csproj" and path "Foo.cs", it already returns "C:\Project\Foo.cs"

- There are already unit tests for these cases.
- Partially fixes: https://github.com/dotnet/project-system/issues/2533. There are still more wins to be made inside of MakeRooted itself.