### PR TITLE
Consume Locally built Roslyn Nuget for Integration tests

### DIFF
--- a/build/Targets/References.targets
+++ b/build/Targets/References.targets
@@ -70,7 +70,7 @@
         <PackageReference Include="System.Reflection.Metadata" Version="1.4.2" />
         <PackageReference Include="System.ValueTuple" Version="4.3.0" />
         <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-        <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="2.3.0-beta3-61808-05" />
+        <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="$(MicrosoftVisualStudioLanguageServicesVersion)" />
         <PackageReference Include="Microsoft.Build" Version="15.1.0-preview-000516-03" />
         <PackageReference Include="Microsoft.Build.Framework" Version="15.1.0-preview-000516-03" />
         <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.0-preview-000516-03" />

--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -149,13 +149,7 @@
     <OutDir>$(OutDir)\Samples\$(MSBuildProjectName)</OutDir>
   </PropertyGroup>
 
-  <!-- Setting UseLocalRoslynForIntegrationTests to true and LocalRoslynDebugDirectoryPath to the Debug path of Roslyn bits will enable using 
-  Locally built Roslyn bits for integration tests -->
-  <PropertyGroup>
-    <UseLocalRoslynForIntegrationTests>true</UseLocalRoslynForIntegrationTests>
-    <LocalRoslynDebugDirectoryPath>C:\repos\roslyn-internal\Open\Binaries\Debug\</LocalRoslynDebugDirectoryPath>
-    <LocalRoslynNugetPath>$(LocalRoslynDebugDirectoryPath)Nuget\PerBuildPreRelease</LocalRoslynNugetPath>
-  </PropertyGroup>
+
 
   <Choose>
     <When Condition="'$(UseLocalRoslynForIntegrationTests)' == 'true' AND Exists('$(LocalRoslynNugetPath)')">

--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -149,6 +149,14 @@
     <OutDir>$(OutDir)\Samples\$(MSBuildProjectName)</OutDir>
   </PropertyGroup>
 
+  <!-- Setting UseLocalRoslynForIntegrationTests to true and LocalRoslynDebugDirectoryPath to the Debug path of Roslyn bits will enable using 
+  Locally built Roslyn bits for integration tests -->
+  <PropertyGroup>
+    <UseLocalRoslynForIntegrationTests>true</UseLocalRoslynForIntegrationTests>
+    <LocalRoslynDebugDirectoryPath>C:\repos\roslyn-internal\Open\Binaries\Debug\</LocalRoslynDebugDirectoryPath>
+    <MicrosoftVisualStudioLanguageServicesVersion>2.3.0-dev-56735-00</MicrosoftVisualStudioLanguageServicesVersion>
+  </PropertyGroup>
+
   <PropertyGroup>
   <!-- Disable AppX packaging for the Roslyn source. Not setting this to false has the side effect
        that any builds of portable projects end up in a sub folder of $(OutDir). Search for this flag in

--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -149,8 +149,6 @@
     <OutDir>$(OutDir)\Samples\$(MSBuildProjectName)</OutDir>
   </PropertyGroup>
 
-
-
   <Choose>
     <When Condition="'$(UseLocalRoslynForIntegrationTests)' == 'true' AND Exists('$(LocalRoslynNugetPath)')">
       <PropertyGroup>

--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -154,8 +154,22 @@
   <PropertyGroup>
     <UseLocalRoslynForIntegrationTests>true</UseLocalRoslynForIntegrationTests>
     <LocalRoslynDebugDirectoryPath>C:\repos\roslyn-internal\Open\Binaries\Debug\</LocalRoslynDebugDirectoryPath>
-    <MicrosoftVisualStudioLanguageServicesVersion>2.3.0-dev-56735-00</MicrosoftVisualStudioLanguageServicesVersion>
+    <LocalRoslynNugetPath>$(LocalRoslynDebugDirectoryPath)Nuget\PerBuildPreRelease</LocalRoslynNugetPath>
   </PropertyGroup>
+
+  <Choose>
+    <When Condition="'$(UseLocalRoslynForIntegrationTests)' == 'true' AND Exists('$(LocalRoslynNugetPath)')">
+      <PropertyGroup>
+          <ListOfLocalNugetFiles>$([System.IO.Directory]::GetFiles(`$(LocalRoslynNugetPath)`))</ListOfLocalNugetFiles>
+
+          <!-- The first file will be Microsoft.CodeAnalysis Nupkg-->
+          <MSCANugetFileName>$(ListOfLocalNugetFiles.Split(';')[0])</MSCANugetFileName>
+
+          <!-- Get version from fullpath; <Path>\Microsoft.CodeAnalysis.2.3.0-dev-56735-00.nupkg-->
+          <MicrosoftVisualStudioLanguageServicesVersion>$(MSCANugetFileName.Split('.')[2]).$(MSCANugetFileName.Split('.')[3]).$(MSCANugetFileName.Split('.')[4])</MicrosoftVisualStudioLanguageServicesVersion>
+      </PropertyGroup>
+    </When>
+  </Choose>
 
   <PropertyGroup>
   <!-- Disable AppX packaging for the Roslyn source. Not setting this to false has the side effect

--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -33,7 +33,7 @@
     <MicrosoftVisualStudioShellDesign>15.0.26507-alpha</MicrosoftVisualStudioShellDesign>
     <MicrosoftVisualStudioManagedInterfaces>8.0.50727</MicrosoftVisualStudioManagedInterfaces>
     <!-- NOTE: Both of these should be updated at once to reference the same roslyn build-->
-    <MicrosoftVisualStudioLanguageServicesVersion>2.3.0-beta3-61808-05</MicrosoftVisualStudioLanguageServicesVersion>
+    <MicrosoftVisualStudioLanguageServicesVersion Condition="'$(MicrosoftVisualStudioLanguageServicesVersion)' == ''">2.3.0-beta3-61808-05</MicrosoftVisualStudioLanguageServicesVersion>
     <RoslynIntegrationVsixVersion>2.3.0.6182805</RoslynIntegrationVsixVersion>
     <MoqVersion>4.2.1402.2112</MoqVersion>
     <MicrosoftVisualStudioTextLogicVersion>15.0.26507-alpha</MicrosoftVisualStudioTextLogicVersion>

--- a/src/DeployIntegrationDependencies/DeployIntegrationDependencies.csproj
+++ b/src/DeployIntegrationDependencies/DeployIntegrationDependencies.csproj
@@ -49,6 +49,7 @@
     <ProjectReference Include="..\Templates\Microsoft.NetStandard.FSharp.ProjectTemplates.Vsix\Microsoft.NetStandard.FSharp.ProjectTemplates.Vsix.csproj" />
     <ProjectReference Include="..\Templates\Microsoft.NetStandard.VB.ProjectTemplates.Vsix\Microsoft.NetStandard.VB.ProjectTemplates.Vsix.csproj" />
     <ProjectReference Include="..\VisualStudioEditorsSetup\VisualStudioEditorsSetup.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj" />
   </ItemGroup>
   <Import Project="..\..\build\Targets\ProducesNoOutput.Imports.targets" />
 
@@ -63,8 +64,16 @@
 
     <!-- Downloading Roslyn Vsixes -->
     <Exec Command="mkdir &quot;$(IntegrationDirectory)Roslyn\Vsixes&quot;" IgnoreExitCode="true"/>
-    <Exec Command="@powershell -NoProfile -ExecutionPolicy Bypass -Command &quot;((New-Object System.Net.WebClient).DownloadFile('https://dotnet.myget.org/F/roslyn/vsix/0b48e25b-9903-4d8b-ad39-d4cca196e3c7-$(RoslynIntegrationVsixVersion).vsix', '$(IntegrationDirectory)Roslyn\Roslyn.Deployment.Full.Next.zip'))&quot;" />
-    <Exec Command="@powershell -NoProfile -ExecutionPolicy Bypass -Command &quot;((New-Object System.Net.WebClient).DownloadFile('https://dotnet.myget.org/F/roslyn/vsix/d0122878-51f1-4b36-95ec-dec2079a2a84-$(RoslynIntegrationVsixVersion).vsix', '$(IntegrationDirectory)Roslyn\Vsixes\Microsoft.VisualStudio.IntegrationTest.Setup.vsix'))&quot;" />
+
+    <!-- Download Roslyn from web if we are not using Locally Built Roslyn -->
+    <Exec Command="@powershell -NoProfile -ExecutionPolicy Bypass -Command &quot;((New-Object System.Net.WebClient).DownloadFile('https://dotnet.myget.org/F/roslyn/vsix/0b48e25b-9903-4d8b-ad39-d4cca196e3c7-$(RoslynIntegrationVsixVersion).vsix', '$(IntegrationDirectory)Roslyn\Roslyn.Deployment.Full.Next.zip'))&quot;" Condition="'$(UseLocalRoslynForIntegrationTests)' != 'true'"/>
+    <Exec Command="@powershell -NoProfile -ExecutionPolicy Bypass -Command &quot;((New-Object System.Net.WebClient).DownloadFile('https://dotnet.myget.org/F/roslyn/vsix/d0122878-51f1-4b36-95ec-dec2079a2a84-$(RoslynIntegrationVsixVersion).vsix', '$(IntegrationDirectory)Roslyn\Vsixes\Microsoft.VisualStudio.IntegrationTest.Setup.vsix'))&quot;" Condition="'$(UseLocalRoslynForIntegrationTests)' != 'true'"/>
+
+    <!-- Copy the local Roslyn bits -->
+    <Copy SourceFiles="$(LocalRoslynDebugDirectoryPath)Vsix\Roslyn.Deployment.Full.Next\Roslyn.Deployment.Full.Next.vsix" DestinationFiles="$(IntegrationDirectory)Roslyn\Roslyn.Deployment.Full.Next.zip" Condition="'$(UseLocalRoslynForIntegrationTests)' == 'true'"/> 
+    <Copy SourceFiles="$(LocalRoslynDebugDirectoryPath)Vsix\VisualStudioIntegrationTestSetup\Microsoft.VisualStudio.IntegrationTest.Setup.vsix" DestinationFiles="$(IntegrationDirectory)Roslyn\Vsixes\Microsoft.VisualStudio.IntegrationTest.Setup.vsix" Condition="'$(UseLocalRoslynForIntegrationTests)' == 'true'"/> 
+
+    <!-- Unzip the Roslyn full deployment vsix into individual vsixes -->
     <Exec Command="@powershell -NoProfile -ExecutionPolicy Bypass -Command &quot;Expand-Archive -path $(IntegrationDirectory)Roslyn\Roslyn.Deployment.Full.Next.zip -destinationPath $(IntegrationDirectory)Roslyn -force" />
 
     <!-- Uninstall any old (locally-deployed) Roslyn Vsixes -->

--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -14,6 +14,7 @@
     <add key="myget.org vs-devcore" value="http://www.myget.org/F/vs-devcore/api/v3/index.json" />
     <add key="dotnet.myget.org templating" value="https://dotnet.myget.org/F/templating/api/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="local Roslyn Feed" value="C:\repos\roslyn-internal\Open\Binaries\Debug\NuGet\PerBuildPreRelease" />
   </packageSources>
 
   <!-- Don't let user disabled sources in VS prevent us from restoring -->

--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -14,7 +14,6 @@
     <add key="myget.org vs-devcore" value="http://www.myget.org/F/vs-devcore/api/v3/index.json" />
     <add key="dotnet.myget.org templating" value="https://dotnet.myget.org/F/templating/api/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="local Roslyn Feed" value="C:\repos\roslyn-internal\Open\Binaries\Debug\NuGet\PerBuildPreRelease" />
   </packageSources>
 
   <!-- Don't let user disabled sources in VS prevent us from restoring -->


### PR DESCRIPTION
This is a test only change which enables the user to be able to target the locally built Roslyn Nuget which will contain changes made in the Roslyn side to improve the test utilities to support writing more integration tests on the project system side.

**Changes to Make:**

Apart from this change, 2 changes need to be made. One in Project System side  and the other in the Roslyn side. 

On the project system side,

1. Add the following properties to [Settings.Target](https://github.com/dotnet/project-system/blob/master/build/Targets/Settings.targets) file after the property `TargetFrameworkRootPath` is set. Note that `LocalRoslynDebugDirectoryPath` will change based on everyone's repo.

```XML
  <!-- Setting UseLocalRoslynForIntegrationTests to true and LocalRoslynDebugDirectoryPath to the Debug path of Roslyn bits will enable using 
  Locally built Roslyn bits for integration tests -->
  <PropertyGroup>
    <UseLocalRoslynForIntegrationTests>true</UseLocalRoslynForIntegrationTests>
    <LocalRoslynDebugDirectoryPath>C:\repos\roslyn-internal\Open\Binaries\Debug\</LocalRoslynDebugDirectoryPath><!-- Change this path appropriately-->
    <LocalRoslynNugetPath>$(LocalRoslynDebugDirectoryPath)Nuget\PerBuildPreRelease</LocalRoslynNugetPath>
  </PropertyGroup>
```

2. Add a local nuget feed in [Nuget.Config](https://github.com/dotnet/project-system/blob/master/src/NuGet.config) file to point to the locally created nuget packages.

```
<add key="local Roslyn Feed" value="C:\repos\roslyn-internal\Open\Binaries\Debug\NuGet\PerBuildPreRelease" />
```

3. On the Roslyn side, apply this commit [03e2956](https://github.com/basoundr/roslyn/commit/03e2956dce70c37e902f091fe509915532c2a9cd) 

**Working:**

Now, everytime a change is made on the Roslyn side, build Rolsyn with the UseLocalRoslynForIntegrationTests property set to true. This will create Local Roslyn Nuget packages with the current changes. Now, trigger Nuget restore on the Roslyn Project System solution. In a minute or 2(depending on nuget), Project system will point to the new nugets.

i.e.

msbuild src\Tools\MicroBuild\Build.proj /p:UseLocalRoslynForIntegrationTests=true
nuget restore project system solution

**_Few things to notice:_**

1. I am not pushing the changes for Roslyn to the repo because these changes are made to projects that are supposed to run in the microbuild environment where certain objects are precreated.

-------

Once these changes are through, I will make a detailed page with all the above information

@dotnet/project-system for review

**Customer scenario**

What does the customer do to get into this situation, and why do we think this
is common enough to address in Escrow.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

**Bugs this fixes:** 

(either VSO or GitHub links)

**Workarounds, if any**

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

**Risk**

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

**Is this a regression from a previous update?**

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

(E.g. customer reported it vs. ad hoc testing)
