### PR TITLE
Simplify FindByPathInternal

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GroupedByTargetTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GroupedByTargetTreeViewProvider.cs
@@ -158,28 +158,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
         private IProjectTree FindByPathInternal(IProjectTree root, string path)
         {
-            var node = root.FindImmediateChildByPath(path);
-            if (node != null)
+            foreach (IProjectTree node in root.GetSelfAndDescendentsBreadthFirst())
             {
-                return node;
-            }
-
-            foreach (var child in root.Children)
-            {
-                node = child.FindImmediateChildByPath(path);
-                if (node != null)
-                {
+                if (string.Equals(node.FilePath, path, StringComparison.OrdinalIgnoreCase))
                     return node;
-                }
-
-                foreach (var thirdLevelNode in child.Children)
-                {
-                    node = thirdLevelNode.FindImmediateChildByPath(path);
-                    if (node != null)
-                    {
-                        return node;
-                    }
-                }
             }
 
             return null;


### PR DESCRIPTION
Simplify FindByPathInternal  …

In CPS project tree terms, the dependency node looks like this (with only ever 3 nodes deep)

    Dependencies
        Analyzers
            Analyzer
        Projects
            Reference

We were attempting to walk into the children of Analyzer and Reference - even though that code never gets hit.

Replaced this walk with just a call to GetSelfAndDescendentsBreadthFirst - it's simpler and ends up resulting in the exact same number of allocations (5) as we're not walking each child's children twice.