### PR TITLE
Stop walking dependency tree twice

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/GroupedByTargetTreeViewProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/GroupedByTargetTreeViewProviderTests.cs
@@ -855,7 +855,7 @@ Caption=Dependency1, FilePath=tfm1\Xxx\dependencyxxxpath, IconHash=325249260, Ex
         }
 
         [Fact]
-        public void GrouppedByTargetTreeViewProvider_WhenFindByPathAndRelativeNodePath_ShouldFind()
+        public void GrouppedByTargetTreeViewProvider_WhenFindByPathAndRelativeNodePath_ShouldNotFind()
         {
             // Arrange
             const string projectPath = @"c:\myfolder\mysubfolder\myproject.csproj";
@@ -929,12 +929,11 @@ Caption=Dependency1, FilePath=tfm1\Xxx\dependencyxxxpath, IconHash=325249260, Ex
             var resultTree = provider.FindByPath(dependenciesRoot, Path.Combine(projectFolder, @"level3Child32"));
 
             // Assert
-            Assert.NotNull(resultTree);
-            Assert.Equal("level3Child32", resultTree.Caption);
+            Assert.Null(resultTree);
         }
 
         [Fact]
-        public void GrouppedByTargetTreeViewProvider_WhenFindByPathAndNeedToFindDependenciesRoot_ShouldFind()
+        public void GroupedByTargetTreeViewProvider_WhenFindByPathAndNeedToFindDependenciesRoot_ShouldNotFind()
         {
             // Arrange
             const string projectPath = @"c:\myfolder\mysubfolder\myproject.csproj";
@@ -1014,11 +1013,11 @@ Caption=Dependency1, FilePath=tfm1\Xxx\dependencyxxxpath, IconHash=325249260, Ex
 
             // Act
             var provider = new GroupedByTargetTreeViewProvider(treeServices, treeViewModelFactory, commonServices);
-            var resultTree = provider.FindByPath(projectRoot, Path.Combine(projectFolder, @"level3Child32"));
+
+            var result = provider.FindByPath(projectRoot, Path.Combine(projectFolder, @"level3Child32"));
 
             // Assert
-            Assert.NotNull(resultTree);
-            Assert.Equal("level3Child32", resultTree.Caption);
+            Assert.Null(result);
         }
 
         private IDependenciesSnapshot GetSnapshot(Dictionary<ITargetFramework, List<IDependency>> testData)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GroupedByTargetTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GroupedByTargetTreeViewProvider.cs
@@ -147,13 +147,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 return null;
             }
 
-            var result = FindByPathInternal(dependenciesNode, path);
-            if (result != null)
-            {
-                return result;
-            }
-
-            return FindByPathInternal(dependenciesNode, CommonServices.Project.GetRelativePath(path));
+            return FindByPathInternal(dependenciesNode, path);
         }
 
         private IProjectTree FindByPathInternal(IProjectTree root, string path)


### PR DESCRIPTION
When called via IVsProject.IsDocumentInProject/ParseCanonicalName/IProjectTreeProvider.FindByPath, we walking the tree twice:

- Once with the path we were passed (ie C:\Project\Foo.cs")
- Once with the path we were passed, but relative to the project directory (Foo.cs, or ..\Analyzer.dll)

The later will never result in a match as we were comparing against "IProjectTree.FilePath" which is always a rooted path.