### PR TITLE
Remove type name from test methods

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/GlobalJsonRemoverTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/GlobalJsonRemoverTests.cs
@@ -18,19 +18,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         private const string Directory = @"C:\Temp";
 
         [Fact]
-        public void GlobalJsonRemover_InvalidServiceProvider_Throws()
+        public void InvalidServiceProvider_Throws()
         {
             Assert.Throws<ArgumentNullException>("serviceProvider", () => new GlobalJsonRemover(null, IFileSystemFactory.Create()));
         }
 
         [Fact]
-        public void GlobalJsonRemover_NullFileSystem_Throws()
+        public void NullFileSystem_Throws()
         {
             Assert.Throws<ArgumentNullException>("fileSystem", () => new GlobalJsonRemover(IServiceProviderFactory.Create(), null));
         }
 
         [Fact]
-        public void GlobalJsonRemover_RemovesJson_WhenExists()
+        public void RemovesJson_WhenExists()
         {
             UnitTestHelper.IsRunningUnitTests = true;
             var globalJsonPath = Path.Combine(Directory, "global.json");
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         }
 
         [Fact]
-        public void GlobalJsonRemover_NoJson_DoesntCrash()
+        public void NoJson_DoesntCrash()
         {
             UnitTestHelper.IsRunningUnitTests = true;
             var solution = IVsSolutionFactory.CreateWithSolutionDirectory(DirectoryInfoCallback);
@@ -103,7 +103,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         }
 
         [Fact]
-        public void GlobalJsonRemover_AfterRemoval_UnadvisesEvents()
+        public void AfterRemoval_UnadvisesEvents()
         {
             UnitTestHelper.IsRunningUnitTests = true;
             var globalJsonPath = Path.Combine(Directory, "global.json");

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         private static readonly string GlobalJsonLocation = Path.Combine(SlnLocation, "global.json");
 
         [Fact]
-        public void MigrateXprojProjectFactory_NullProcessRunner_ThrowsArgumentNullException()
+        public void NullProcessRunner_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("runner", () => new MigrateXprojProjectFactory(
                 null,
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         }
 
         [Fact]
-        public void MigrateXprojProjectFactory_NullFileSystem_ThrowsArgumentNullException()
+        public void NullFileSystem_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("fileSystem", () => new MigrateXprojProjectFactory(
                 ProcessRunnerFactory.CreateRunner(),
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         }
 
         [Fact]
-        public void MigrateXprojProjectFactory_NullServiceProvider_ThrowsArgumentNullException()
+        public void NullServiceProvider_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("serviceProvider", () => new MigrateXprojProjectFactory(
                 ProcessRunnerFactory.CreateRunner(),
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         }
 
         [Fact]
-        public void MigrateXprojProjectFactory_NullGlobalJsonSetup_ThrowsArgumentNullException()
+        public void NullGlobalJsonSetup_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>("globalJsonSetup", () => new MigrateXprojProjectFactory(
                 ProcessRunnerFactory.CreateRunner(),
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         }
 
         [Fact]
-        public void MigrateXprojProjectFactory_ValidArgs_BackupsCorrectly()
+        public void ValidArgs_BackupsCorrectly()
         {
             var procRunner = ProcessRunnerFactory.CreateRunner();
             var fileSystem = CreateFileSystem();
@@ -112,7 +112,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         }
 
         [Fact]
-        public void MigrateXprojProjectFactory_WithXprojUser_BackupsCorrectly()
+        public void WithXprojUser_BackupsCorrectly()
         {
             var procRunner = ProcessRunnerFactory.CreateRunner();
             var fileSystem = CreateFileSystem(withXprojUser: true, withProjectLock: true);
@@ -153,7 +153,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
 
 
         [Fact]
-        public void MigrateXprojProjectFactory_NonExistantProjectJson_DoesNotBackUp()
+        public void NonExistantProjectJson_DoesNotBackUp()
         {
             var procRunner = ProcessRunnerFactory.CreateRunner();
             var migrator = CreateInstance(procRunner, CreateFileSystem(false));
@@ -171,7 +171,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         }
 
         [Fact]
-        public void MigrateXprojProjectFactory_ValidPaths_CallMigrateCorrectly()
+        public void ValidPaths_CallMigrateCorrectly()
         {
             // Runner returns valid response, standard exit code
             var procRunner = ProcessRunnerFactory.ImplementRunner(ProcessVerifier);
@@ -187,7 +187,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         }
 
         [Fact]
-        public void MigrateXprojProjectFactory_MigrateOutput_LoggedCorrectly()
+        public void MigrateOutput_LoggedCorrectly()
         {
             // Runner returns valid response, standard exit code
             var procRunner = ProcessRunnerFactory.ImplementRunner(ProcessVerifier, outputText: "Standard Output", errorText: "Standard Error");
@@ -215,7 +215,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         }
 
         [Fact]
-        public void MigrateXprojProjectFactory_MigrateError_ReturnsErrorCode()
+        public void MigrateError_ReturnsErrorCode()
         {
             // Runner returns valid response, standard exit code
             var procRunner = ProcessRunnerFactory.ImplementRunner(ProcessVerifier, exitCode: VSConstants.E_FAIL);
@@ -229,7 +229,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         }
 
         [Fact]
-        public void MigrateXprojProjectFactory_ValidCsproj_FindsCsproj()
+        public void ValidCsproj_FindsCsproj()
         {
             var fileSystem = CreateFileSystem();
 
@@ -244,7 +244,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         }
 
         [Fact]
-        public void MigrateXprojProjectFactory_NoLogFile_LogsError()
+        public void NoLogFile_LogsError()
         {
             var fileSystem = CreateFileSystem(withEntries: false);
 
@@ -273,7 +273,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         }
 
         [Fact]
-        public void MigrateXprojProjectFactory_InvalidLogFile_LogsError()
+        public void InvalidLogFile_LogsError()
         {
             var fileSystem = CreateFileSystem(withEntries: false);
             fileSystem.WriteAllText(LogFileLocation, string.Empty);
@@ -303,7 +303,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         }
 
         [Fact]
-        public void MigrateXprojProjectFactory_LogWithErrors_MessagesAreLoggedToVs()
+        public void LogWithErrors_MessagesAreLoggedToVs()
         {
             var fileSystem = CreateFileSystem(withEntries: false);
             var migrationReport = new MigrationReport(0, new List<ProjectMigrationReport>
@@ -365,7 +365,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         }
 
         [Fact]
-        public void MigrateXprojProjectFactory_ValidProject_IsUpgradable()
+        public void ValidProject_IsUpgradable()
         {
             var fileSystem = CreateFileSystem();
 
@@ -382,7 +382,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         }
 
         [Fact]
-        public void MigrateXprojProjectFactory_Cleanup_RemovesAllFiles()
+        public void Cleanup_RemovesAllFiles()
         {
             var fileSystem = CreateFileSystem(withEntries: true, withXprojUser: true, withProjectLock: true);
 
@@ -396,7 +396,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         }
 
         [Fact]
-        public void MigrateXprojProjectFactory_NoXprojUserOrProjectLock_CausesNoIssues()
+        public void NoXprojUserOrProjectLock_CausesNoIssues()
         {
             var fileSystem = CreateFileSystem(withEntries: true, withXprojUser: false, withProjectLock: false);
 
@@ -408,7 +408,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         }
 
         [Fact]
-        public void MigrateXprojProjectFactory_GlobalJsonExists_BacksUpAndRemovesGlobalJson()
+        public void GlobalJsonExists_BacksUpAndRemovesGlobalJson()
         {
             var fileSystem = CreateFileSystem(withEntries: true, withGlobalJson: true);
             var solution = IVsSolutionFactory.CreateWithSolutionDirectory(CreateSolutionInfo());
@@ -434,7 +434,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         }
 
         [Fact]
-        public void MigrateXprojProjectFactory_GlobalJsonHasSdkElement_ElementIsRemoved()
+        public void GlobalJsonHasSdkElement_ElementIsRemoved()
         {
             var fileSystem = CreateFileSystem(withEntries: true, withGlobalJson: true);
             var solution = IVsSolutionFactory.CreateWithSolutionDirectory(CreateSolutionInfo());
@@ -468,7 +468,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         }
 
         [Fact]
-        public void MigrateXprojProjectFactory_E2E_Works()
+        public void E2E_Works()
         {
             var fileSystem = CreateFileSystem(withEntries: true, withXprojUser: true, withProjectLock: true, withGlobalJson: true);
             var processRunner = ProcessRunnerFactory.ImplementRunner(pInfo =>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ConfigurationProjectConfigurationDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ConfigurationProjectConfigurationDimensionProviderTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
 </Project>";
 
         [Fact]
-        public async Task ConfigurationProjectConfigurationDimensionProvider_GetDefaultValuesForDimensionsAsync()
+        public async Task GetDefaultValuesForDimensionsAsync()
         {
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         }
 
         [Fact]
-        public async Task ConfigurationProjectConfigurationDimensionProvider_GetDefaultValuesForDimensionsAsync_NoPropertyValue()
+        public async Task GetDefaultValuesForDimensionsAsync_NoPropertyValue()
         {
             using (var projectFile = new MsBuildProjectFile())
             {
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         }
 
         [Fact]
-        public async Task ConfigurationProjectConfigurationDimensionProvider_GetProjectConfigurationDimensionsAsync()
+        public async Task GetProjectConfigurationDimensionsAsync()
         {
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
             }
         }
 
-        public async Task ConfigurationProjectConfigurationDimensionProvider_GetProjectConfigurationDimensionsAsync_NoPropertyValue()
+        public async Task GetProjectConfigurationDimensionsAsync_NoPropertyValue()
         {
             using (var projectFile = new MsBuildProjectFile())
             {
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         }
 
         [Fact]
-        public async Task ConfigurationProjectConfigurationDimensionProvider_OnDimensionValueChanged_Add()
+        public async Task OnDimensionValueChanged_Add()
         {
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
@@ -117,7 +117,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         }
 
         [Fact]
-        public async Task ConfigurationProjectConfigurationDimensionProvider_OnDimensionValueChanged_Remove()
+        public async Task OnDimensionValueChanged_Remove()
         {
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
@@ -152,7 +152,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         }
 
         [Fact]
-        public async Task ConfigurationProjectConfigurationDimensionProvider_OnDimensionValueChanged_Remove_MissingValue()
+        public async Task OnDimensionValueChanged_Remove_MissingValue()
         {
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
@@ -174,7 +174,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         }
 
         [Fact]
-        public async Task ConfigurationProjectConfigurationDimensionProvider_OnDimensionValueChanged_Rename()
+        public async Task OnDimensionValueChanged_Rename()
         {
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
@@ -211,7 +211,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         }
 
         [Fact]
-        public async Task ConfigurationProjectConfigurationDimensionProvider_OnDimensionValueChanged_Rename_MissingValue()
+        public async Task OnDimensionValueChanged_Rename_MissingValue()
         {
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/TargetFrameworkProjectConfigurationDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/TargetFrameworkProjectConfigurationDimensionProviderTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
 </Project>";
 
         [Fact]
-        public async Task TargetFrameworkProjectConfigurationDimensionProvider_GetDefaultValuesForDimensionsAsync_TFM()
+        public async Task GetDefaultValuesForDimensionsAsync_TFM()
         {
             using (var projectFile = new MsBuildProjectFile(ProjectXmlTFM))
             {
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         [Theory]
         [InlineData(ProjectXmlTFMs)]
         [InlineData(ProjectXmlTFMAndTFMs)]
-        public async Task TargetFrameworkProjectConfigurationDimensionProvider_GetDefaultValuesForDimensionsAsync_TFMs(string projectXml)
+        public async Task GetDefaultValuesForDimensionsAsync_TFMs(string projectXml)
         {
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         }
 
         [Fact]
-        public async Task TargetFrameworkProjectConfigurationDimensionProvider_GetProjectConfigurationDimensionsAsync_TFM()
+        public async Task GetProjectConfigurationDimensionsAsync_TFM()
         {
             using (var projectFile = new MsBuildProjectFile(ProjectXmlTFM))
             {
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         [Theory]
         [InlineData(ProjectXmlTFMs)]
         [InlineData(ProjectXmlTFMAndTFMs)]
-        public async Task TargetFrameworkProjectConfigurationDimensionProvider_GetProjectConfigurationDimensionsAsync_TFMs(string projectXml)
+        public async Task GetProjectConfigurationDimensionsAsync_TFMs(string projectXml)
         {
             using (var projectFile = new MsBuildProjectFile(projectXml))
             {
@@ -104,7 +104,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         [InlineData(ConfigurationDimensionChange.Rename, ChangeEventStage.After)]
         [InlineData(ConfigurationDimensionChange.Delete, ChangeEventStage.Before)]
         [InlineData(ConfigurationDimensionChange.Delete, ChangeEventStage.After)]
-        public async Task TargetFrameworkProjectConfigurationDimensionProvider_OnDimensionValueChanged(ConfigurationDimensionChange change, ChangeEventStage stage)
+        public async Task OnDimensionValueChanged(ConfigurationDimensionChange change, ChangeEventStage stage)
         {
             // No changes should happen for TFM so verify that the property is the same before and after
             using (var projectFile = new MsBuildProjectFile(ProjectXmlTFMs))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/DebugTokenReplacerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/DebugTokenReplacerTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public async Task DebugTokenReplacer_ReplaceTokensInProfileTests()
+        public async Task ReplaceTokensInProfileTests()
         {
             IUnconfiguredProjectCommonServices services = IUnconfiguredProjectCommonServicesFactory.Create();
 
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         [InlineData("this is msbuild: %env3% $(msbuildProperty2) $(msbuildProperty3)",  "this is msbuild: Property6 Property2 Property3", true)]
         [InlineData(null, null, true)]
         [InlineData(" ", " ", true)]
-        public async Task DebugTokenReplacer_ReplaceTokensInStringTests(string input, string expected, bool expandEnvVars)
+        public async Task ReplaceTokensInStringTests(string input, string expected, bool expandEnvVars)
         {
             IUnconfiguredProjectCommonServices services = IUnconfiguredProjectCommonServicesFactory.Create();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public void LaunchSettingsProvider_ActiveProfileTests()
+        public void ActiveProfileTests()
         { 
             string activeProfile = "MyCommand";
             var testProfiles = new Mock<ILaunchSettings>();
@@ -94,7 +94,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public async Task LaunchSettingsProvider_UpdateProfiles_NoSettingsFile()
+        public async Task UpdateProfiles_NoSettingsFile()
         {
 
             IFileSystemMock moqFS = new IFileSystemMock();
@@ -107,7 +107,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public async Task LaunchSettingsProvider_UpdateProfilesBasicSettingsFile()
+        public async Task UpdateProfilesBasicSettingsFile()
         {
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
@@ -120,7 +120,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public async Task LaunchSettingsProvider_UpdateProfilesSetActiveProfileFromProperty()
+        public async Task UpdateProfilesSetActiveProfileFromProperty()
         {
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
@@ -134,7 +134,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public async Task LaunchSettingsProvider_UpdateProfiles_ChangeActiveProfileOnly()
+        public async Task UpdateProfiles_ChangeActiveProfileOnly()
         {
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
@@ -149,7 +149,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public async Task LaunchSettingsProvider_UpdateProfiles_BadJsonShouldLeaveProfilesStable()
+        public async Task UpdateProfiles_BadJsonShouldLeaveProfilesStable()
         {
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
@@ -164,7 +164,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
             
         [Fact]
-        public async Task LaunchSettingsProvider_UpdateProfiles_SetsErrorProfileTests()
+        public async Task UpdateProfiles_SetsErrorProfileTests()
         {
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
@@ -176,7 +176,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public async Task LaunchSettingsProvider_SettingsFileHasChangedTests()
+        public async Task SettingsFileHasChangedTests()
         {
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
@@ -192,7 +192,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
 
         [Fact]
-        public async Task LaunchSettingsProvider_ReadProfilesFromDisk_NoFile()
+        public async Task ReadProfilesFromDisk_NoFile()
         {
 
             IFileSystemMock moqFS = new IFileSystemMock();
@@ -212,7 +212,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public async Task LaunchSettingsProvider_ReadProfilesFromDisk_GoodFile()
+        public async Task ReadProfilesFromDisk_GoodFile()
         {
 
             IFileSystemMock moqFS = new IFileSystemMock();
@@ -226,7 +226,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public async Task LaunchSettingsProvider_ReadProfilesFromDisk_BadJsonFile()
+        public async Task ReadProfilesFromDisk_BadJsonFile()
         {
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
@@ -243,7 +243,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public async Task LaunchSettingsProvider_ReadProfilesFromDisk_JsonWithExtensionsNoProvider()
+        public async Task ReadProfilesFromDisk_JsonWithExtensionsNoProvider()
         {
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
@@ -257,7 +257,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public async Task LaunchSettingsProvider_ReadProfilesFromDisk_JsonWithExtensionsWithProvider()
+        public async Task ReadProfilesFromDisk_JsonWithExtensionsWithProvider()
         {
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
@@ -275,7 +275,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public async Task LaunchSettingsProvider_SaveProfilesToDiskTests()
+        public async Task SaveProfilesToDiskTests()
         {
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
@@ -317,7 +317,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public async Task LaunchSettingsProvider_LaunchSettingsFile_Changed()
+        public async Task LaunchSettingsFile_Changed()
         {
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
@@ -334,7 +334,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public async Task LaunchSettingsProvider_LaunchSettingsFile_TestIgnoreFlag()
+        public async Task LaunchSettingsFile_TestIgnoreFlag()
         {
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
@@ -360,7 +360,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public async Task LaunchSettingsProvider_LaunchSettingsFile_TestTimeStampFlag()
+        public async Task LaunchSettingsFile_TestTimeStampFlag()
         {
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
@@ -386,7 +386,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
         
         [Fact]
-        public void LaunchSettingsProvider_DisposeTests()
+        public void DisposeTests()
         {
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
@@ -397,7 +397,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public async Task LaunchSettingsProvider_UpdateAndSaveProfilesAsync()
+        public async Task UpdateAndSaveProfilesAsync()
         {
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
@@ -444,7 +444,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public async Task LaunchSettingsProvider_UpdateAndSaveProfilesAsync_ActiveProfilePreserved()
+        public async Task UpdateAndSaveProfilesAsync_ActiveProfilePreserved()
         {
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS, "Properties", "bar");
@@ -476,7 +476,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         [Theory]
         [InlineData(true, 0)]
         [InlineData(false, 2)]
-        public async Task LaunchSettingsProvider_AddOrUpdateProfileAsync_ProfileDoesntExist(bool addToFront, int expectedIndex)
+        public async Task AddOrUpdateProfileAsync_ProfileDoesntExist(bool addToFront, int expectedIndex)
         {
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
@@ -508,7 +508,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         [Theory]
         [InlineData(true, 0)]
         [InlineData(false, 1)]
-        public async Task LaunchSettingsProvider_AddOrUpdateProfileAsync_ProfileExists(bool addToFront, int expectedIndex)
+        public async Task AddOrUpdateProfileAsync_ProfileExists(bool addToFront, int expectedIndex)
         {
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
@@ -540,7 +540,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public async Task LaunchSettingsProvider_RemoveProfileAsync_ProfileExists()
+        public async Task RemoveProfileAsync_ProfileExists()
         {
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
@@ -568,7 +568,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public async Task LaunchSettingsProvider_RemoveProfileAsync_ProfileDoesntExists()
+        public async Task RemoveProfileAsync_ProfileDoesntExists()
         {
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
@@ -594,7 +594,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public async Task LaunchSettingsProvider_AddOrUpdateGlobalSettingAsync_SettingDoesntExist()
+        public async Task AddOrUpdateGlobalSettingAsync_SettingDoesntExist()
         {
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
@@ -623,7 +623,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public async Task LaunchSettingsProvider_AddOrUpdateGlobalSettingAsync_SettingExists()
+        public async Task AddOrUpdateGlobalSettingAsync_SettingExists()
         {
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
@@ -653,7 +653,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             Assert.True(((IISSettingsData)updatedSettings).WindowsAuthentication);
         }
         [Fact]
-        public async Task LaunchSettingsProvider_RemoveGlobalSettingAsync_SettingDoesntExist()
+        public async Task RemoveGlobalSettingAsync_SettingDoesntExist()
         {
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
@@ -679,7 +679,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public async Task LaunchSettingsProvider_RemoveGlobalSettingAsync_SettingExists()
+        public async Task RemoveGlobalSettingAsync_SettingExists()
         {
             IFileSystemMock moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviderTests.cs
@@ -368,7 +368,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.csproj""
     Properties (flags: {Folder AppDesignerFolder}), FilePath: ""C:\Foo\Properties""
     myapp.manifest, FilePath: ""C:\Foo\myapp.manifest""
 ", "NoManifest", @"C:\Foo\Properties\app.manifest")]
-        public async Task AppManifestSpecialFileProvider_Test(string input, string appManifestPropertyValue, string expectedFilePath)
+        public async Task Test(string input, string appManifestPropertyValue, string expectedFilePath)
         {
             var inputTree = ProjectTreeParser.Parse(input);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Automation/VsLangProjectPropertiesTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Automation/VsLangProjectPropertiesTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
         }
 
         [Fact]
-        public void VsLangProjectProperties_NotNull()
+        public void NotNull()
         {
             var unconfiguredProjectMock = new Mock<UnconfiguredProject>();
             unconfiguredProjectMock.Setup(p => p.Capabilities)
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
         }
 
         [Fact]
-        public void VsLangProjectProperties_ImportsAndEventsAsNull()
+        public void ImportsAndEventsAsNull()
         {
             var imports = Mock.Of<Imports>();
             var events = Mock.Of<VSProjectEvents>();
@@ -93,7 +93,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
 
 
         [Fact]
-        public void VsLangProjectProperties_ImportsAndEventsAsNonNull()
+        public void ImportsAndEventsAsNonNull()
         {
             var imports = Mock.Of<Imports>();
             var importsImpl = new OrderPrecedenceImportCollection<Imports>(ImportOrderPrecedenceComparer.PreferenceOrder.PreferredComesFirst, (UnconfiguredProject)null)
@@ -127,7 +127,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
         }
 
         [Fact]
-        public void VsLangProjectProperties_OutputTypeEx()
+        public void OutputTypeEx()
         {
             var setValues = new List<object>();
             var project = UnconfiguredProjectFactory.Create();
@@ -150,7 +150,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
         }
 
         [Fact]
-        public void VsLangProjectProperties_OutputType()
+        public void OutputType()
         {
             var setValues = new List<object>();
             var project = UnconfiguredProjectFactory.Create();
@@ -173,7 +173,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
         }
 
         [Fact]
-        public void VsLangProjectProperties_AssemblyName()
+        public void AssemblyName()
         {
             var setValues = new List<object>();
             var project = UnconfiguredProjectFactory.Create();
@@ -197,7 +197,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
         }
 
         [Fact]
-        public void VsLangProjectProperties_FullPath()
+        public void FullPath()
         {
             var project = UnconfiguredProjectFactory.Create();
             var data = new PropertyPageData()
@@ -215,7 +215,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
         }
 
         [Fact]
-        public void VsLangProjectProperties_AbsoluteProjectDirectory()
+        public void AbsoluteProjectDirectory()
         {
             var project = UnconfiguredProjectFactory.Create();
             var data = new PropertyPageData()
@@ -233,7 +233,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
         }
 
         [Fact]
-        public void VsLangProjectProperties_ExtenderCATID()
+        public void ExtenderCATID()
         {
             var vsproject = CreateInstance(
                 Mock.Of<VSLangProj.VSProject>(),

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
         }
 
         [Fact]
-        public void ConsoleDebugLaunchProvider_GetExeAndArguments()
+        public void GetExeAndArguments()
         {
             var debugger = GetDebugTargetsProvider();
 
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
         }
 
         [Fact]
-        public void ConsoleDebugLaunchProvider_GetExeAndArgumentsWithEscapedArgs()
+        public void GetExeAndArgumentsWithEscapedArgs()
         {
             var debugger = GetDebugTargetsProvider();
 
@@ -118,7 +118,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
         }
 
         [Fact]
-        public void ConsoleDebugLaunchProvider_GetExeAndArgumentsWithNullArgs()
+        public void GetExeAndArgumentsWithNullArgs()
         {
             var debugger = GetDebugTargetsProvider();
 
@@ -132,7 +132,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
         }
 
         [Fact]
-        public void ConsoleDebugLaunchProvider_GetExeAndArgumentsWithEmptyArgs()
+        public void GetExeAndArgumentsWithEmptyArgs()
         {
             var debugger = GetDebugTargetsProvider();
 
@@ -146,7 +146,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
         }
 
         [Fact]
-        public async Task ConsoleDebugLaunchProvider_QueryDebugTargets_ProjectProfileAsyncF5()
+        public async Task QueryDebugTargets_ProjectProfileAsyncF5()
         {
             var debugger = GetDebugTargetsProvider();
 
@@ -164,7 +164,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
         }
 
         [Fact]
-        public async Task ConsoleDebugLaunchProvider_QueryDebugTargets_ProjectProfileAsyncCtrlF5()
+        public async Task QueryDebugTargets_ProjectProfileAsyncCtrlF5()
         {
             var debugger = GetDebugTargetsProvider();
 
@@ -183,7 +183,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
         }
 
         [Fact]
-        public async Task ConsoleDebugLaunchProvider_QueryDebugTargets_ProjectProfileAsyncProfile()
+        public async Task QueryDebugTargets_ProjectProfileAsyncProfile()
         {
             var debugger = GetDebugTargetsProvider();
 
@@ -197,7 +197,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
         }
 
         [Fact]
-        public async Task ConsoleDebugLaunchProvider_QueryDebugTargets_ExeProfileAsyncF5()
+        public async Task QueryDebugTargets_ExeProfileAsyncF5()
         {
             var debugger = GetDebugTargetsProvider();
 
@@ -212,7 +212,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
         }
 
         [Fact]
-        public async Task ConsoleDebugLaunchProvider_QueryDebugTargets_ExeProfileAsyncCtrlF5()
+        public async Task QueryDebugTargets_ExeProfileAsyncCtrlF5()
         {
             var debugger = GetDebugTargetsProvider();
 
@@ -230,7 +230,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
         }
 
         [Fact]
-        public async Task ConsoleDebugLaunchProvider_QueryDebugTargets_ExeProfileAsyncExeRelativeNoWorkingDir()
+        public async Task QueryDebugTargets_ExeProfileAsyncExeRelativeNoWorkingDir()
         {
             var debugger = GetDebugTargetsProvider();
 
@@ -244,7 +244,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
         }
 
         [Fact]
-        public async Task ConsoleDebugLaunchProvider_QueryDebugTargets_ExeProfileAsyncExeRelativeTooWorkingDir()
+        public async Task QueryDebugTargets_ExeProfileAsyncExeRelativeTooWorkingDir()
         {
             var debugger = GetDebugTargetsProvider();
 
@@ -259,7 +259,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
         }
 
         [Fact]
-        public void ConsoleDebugLaunchProvider_ValidateSettingsNoExe()
+        public void ValidateSettingsNoExe()
         {
             string executable = null;
             string workingDir= null;
@@ -278,7 +278,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
         }
 
         [Fact]
-        public void ConsoleDebugLaunchProvider_ValidateSettingsExeNotFound()
+        public void ValidateSettingsExeNotFound()
         {
             string executable = null;
             string workingDir= null;
@@ -301,7 +301,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
         }
 
         [Fact]
-        public void ConsoleDebugLaunchProvider_ValidateSettingsWorkingDir()
+        public void ValidateSettingsWorkingDir()
         {
             string executable = null;
             string workingDir= null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectDebuggerProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectDebuggerProviderTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         
         
         [Fact]
-        public void ProjectDebuggerProvider_GetDebugEngineForFrameworkTests()
+        public void GetDebugEngineForFrameworkTests()
         {
 
             Assert.Equal(DebuggerEngines.ManagedCoreEngine, ProjectDebuggerProvider.GetManagedDebugEngineForFramework(".NetStandardApp"));
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         }        
 
         [Fact]
-        public async Task ProjectDebuggerProvider_CanLaunchAsyncTests()
+        public async Task CanLaunchAsyncTests()
         {
             Mock<ConfiguredProject> configuredProjectMoq = new Mock<ConfiguredProject>();
             var debugger = new ProjectDebuggerProvider(configuredProjectMoq.Object, new Mock<ILaunchSettingsProvider>().Object);
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         }
            
         [Fact]
-        public void ProjectDebuggerProvider_GetLaunchTargetsProviderForProfileTests()
+        public void GetLaunchTargetsProviderForProfileTests()
         {
             var debugger = new ProjectDebuggerProvider(_configuredProjectMoq.Object, _LaunchSettingsProviderMoq.Object, _launchProviders);
             Assert.Equal(_mockWebProvider.Object, debugger.GetLaunchTargetsProvider(new LaunchProfile() {Name = "test", CommandName = "IISExpress"}));
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         }
 
         [Fact]
-        public async Task ProjectDebuggerProvider_QueryDebugTargetsAsyncCorrectProvider()
+        public async Task QueryDebugTargetsAsyncCorrectProvider()
         {
             var debugger = new ProjectDebuggerProvider(_configuredProjectMoq.Object, _LaunchSettingsProviderMoq.Object, _launchProviders);
 
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         }
 
         [Fact]
-        public async Task ProjectDebuggerProvider_QueryDebugTargetsNoLaunchProfiler()
+        public async Task QueryDebugTargetsNoLaunchProfiler()
         {
             var debugger = new ProjectDebuggerProvider(_configuredProjectMoq.Object, _LaunchSettingsProviderMoq.Object, _launchProviders);
             _activeProfile = null;
@@ -122,7 +122,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         }
 
         [Fact]
-        public async Task ProjectDebuggerProvider_QueryDebugTargetsNoInstalledProvider()
+        public async Task QueryDebugTargetsNoInstalledProvider()
         {
             var debugger = new ProjectDebuggerProvider(_configuredProjectMoq.Object, _LaunchSettingsProviderMoq.Object, _launchProviders);
             _activeProfile = new LaunchProfile() {Name="NoActionProfile", CommandName = "SomeOtherExtension"};

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Editor/Listeners/TempFileBufferStateListenerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Editor/Listeners/TempFileBufferStateListenerTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor.Listeners
     public class TempFileBufferStateListenerTests
     {
         [Fact]
-        public void TempFileBufferStateListener_NullEditorState_Throws()
+        public void NullEditorState_Throws()
         {
             Assert.Throws<ArgumentNullException>("editorState", () => new TempFileBufferStateListener(null,
                 IVsEditorAdaptersFactoryServiceFactory.Create(),
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor.Listeners
         }
 
         [Fact]
-        public void TempFileBufferStateListener_NullEditorAdaptersFactory_Throws()
+        public void NullEditorAdaptersFactory_Throws()
         {
             Assert.Throws<ArgumentNullException>("editorAdaptersService", () => new TempFileBufferStateListener(
                 IProjectFileEditorPresenterFactory.Create(),
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor.Listeners
         }
 
         [Fact]
-        public void TempFileBufferStateListener_NullTextDocumentFactoryService_Throws()
+        public void NullTextDocumentFactoryService_Throws()
         {
             Assert.Throws<ArgumentNullException>("textDocumentFactoryService", () => new TempFileBufferStateListener(
                 IProjectFileEditorPresenterFactory.Create(),
@@ -51,7 +51,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor.Listeners
         }
 
         [Fact]
-        public void TempFileBufferStateListener_NullThreadingService_Throws()
+        public void NullThreadingService_Throws()
         {
             Assert.Throws<ArgumentNullException>("threadingService", () => new TempFileBufferStateListener(
                 IProjectFileEditorPresenterFactory.Create(),
@@ -63,7 +63,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor.Listeners
         }
 
         [Fact]
-        public void TempFileBufferStateListener_NullShellUtilities_Throws()
+        public void NullShellUtilities_Throws()
         {
             Assert.Throws<ArgumentNullException>("shellUtilities", () => new TempFileBufferStateListener(
                 IProjectFileEditorPresenterFactory.Create(),
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor.Listeners
         }
 
         [Fact]
-        public async Task TempFileBufferStateListener_Initialize_SubscribesToTextChangedEvents()
+        public async Task Initialize_SubscribesToTextChangedEvents()
         {
             var tempFile = @"C:\Temp\ConsoleApp1.csproj";
             var docData = IVsPersistDocDataFactory.ImplementAsIVsTextBuffer();
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor.Listeners
         }
 
         [Fact]
-        public async Task TempFileBufferStateListener_Dispose_UnsubscribtesFromTextChangedEvents()
+        public async Task Dispose_UnsubscribtesFromTextChangedEvents()
         {
             var tempFile = @"C:\Temp\ConsoleApp1.csproj";
             var docData = IVsPersistDocDataFactory.ImplementAsIVsTextBuffer();
@@ -133,7 +133,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor.Listeners
         [Theory]
         [InlineData(FileActionTypes.ContentLoadedFromDisk)]
         [InlineData(FileActionTypes.DocumentRenamed)]
-        public async Task TempFileBufferStateListener_NonFileSavedToDisk_DoesNotSaveProjectFile(FileActionTypes action)
+        public async Task NonFileSavedToDisk_DoesNotSaveProjectFile(FileActionTypes action)
         {
             var tempFile = @"C:\Temp\ConsoleApp1.csproj";
             var docData = IVsPersistDocDataFactory.ImplementAsIVsTextBuffer();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Editor/ProjectFileEditorPresenterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Editor/ProjectFileEditorPresenterTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         private static readonly Guid XmlFactoryGuid = Guid.Parse("{fa3cd31e-987b-443a-9b81-186104e8dac1}");
 
         [Fact]
-        public void ProjectFileEditorPresenter_NullThreadingService_Throws()
+        public void NullThreadingService_Throws()
         {
             Assert.Throws<ArgumentNullException>("threadingService", () => new ProjectFileEditorPresenter(
                 null,
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         }
 
         [Fact]
-        public void ProjectFileEditorPresenter_NullUnconfiguredProject_Throws()
+        public void NullUnconfiguredProject_Throws()
         {
             Assert.Throws<ArgumentNullException>("unconfiguredProject", () => new ProjectFileEditorPresenter(
                 IProjectThreadingServiceFactory.Create(),
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         }
 
         [Fact]
-        public void ProjectFileEditorPresenter_NullServiceProvider_Throws()
+        public void NullServiceProvider_Throws()
         {
             Assert.Throws<ArgumentNullException>("serviceProvider", () => new ProjectFileEditorPresenter(
                 IProjectThreadingServiceFactory.Create(),
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         }
 
         [Fact]
-        public void ProjectFileEditorPresenter_NullShellHelper_Throws()
+        public void NullShellHelper_Throws()
         {
             Assert.Throws<ArgumentNullException>("shellHelper", () => new ProjectFileEditorPresenter(
                 IProjectThreadingServiceFactory.Create(),
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         }
 
         [Fact]
-        public void ProjectFileEditorPresenter_NullProjectFileModelWatcherFactory_Throws()
+        public void NullProjectFileModelWatcherFactory_Throws()
         {
             Assert.Throws<ArgumentNullException>("projectFileModelWatcherFactory", () => new ProjectFileEditorPresenter(
                 IProjectThreadingServiceFactory.Create(),
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         }
 
         [Fact]
-        public void ProjectFileEditorPresenter_NullTextBufferListenerFactory_Throws()
+        public void NullTextBufferListenerFactory_Throws()
         {
             Assert.Throws<ArgumentNullException>("textBufferListenerFactory", () => new ProjectFileEditorPresenter(
                 IProjectThreadingServiceFactory.Create(),
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         }
 
         [Fact]
-        public void ProjectFileEditorPresenter_NullFrameEventsListenerFactory_Throws()
+        public void NullFrameEventsListenerFactory_Throws()
         {
             Assert.Throws<ArgumentNullException>("frameEventsListenerFactory", () => new ProjectFileEditorPresenter(
                 IProjectThreadingServiceFactory.Create(),
@@ -115,7 +115,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         }
 
         [Fact]
-        public void ProjectFileEditorPresenter_NullTextBufferManagerFactory_Throws()
+        public void NullTextBufferManagerFactory_Throws()
         {
             Assert.Throws<ArgumentNullException>("textBufferManagerFactory", () => new ProjectFileEditorPresenter(
                 IProjectThreadingServiceFactory.Create(),
@@ -129,7 +129,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         }
 
         [Fact]
-        public async Task ProjectFileEditorPresenter_OpenEditor_SetsUpListeners()
+        public async Task OpenEditor_SetsUpListeners()
         {
             var filePath = @"C:\Temp\ConsoleApp1.csproj";
             var textBufferManager = ITextBufferManagerFactory.ImplementFilePath(filePath);
@@ -170,7 +170,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         }
 
         [Fact]
-        public async Task ProjectFileEditorPresenter_MultipleOpen_CallsShowSecondTime()
+        public async Task MultipleOpen_CallsShowSecondTime()
         {
             var filePath = @"C:\Temp\ConsoleApp1.csproj";
             var textBufferManager = ITextBufferManagerFactory.ImplementFilePath(filePath);
@@ -212,7 +212,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         }
 
         [Fact]
-        public async Task ProjectFileEditorPresenter_CloseWindowSuccess_ReturnsContinueClose()
+        public async Task CloseWindowSuccess_ReturnsContinueClose()
         {
             var filePath = @"C:\Temp\ConsoleApp1.csproj";
             var textBufferManager = ITextBufferManagerFactory.ImplementFilePath(filePath);
@@ -250,7 +250,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         }
 
         [Fact]
-        public async Task ProjectFileEditorPresenter_CloseWindowFail_ReturnsStopClose()
+        public async Task CloseWindowFail_ReturnsStopClose()
         {
             var filePath = @"C:\Temp\ConsoleApp1.csproj";
             var textBufferManager = ITextBufferManagerFactory.ImplementFilePath(filePath);
@@ -288,7 +288,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         }
 
         [Fact]
-        public async Task ProjectFileEditorPresenter_DisposeWithoutOpen_DoesNothing()
+        public async Task DisposeWithoutOpen_DoesNothing()
         {
             var filePath = @"C:\Temp\ConsoleApp1.csproj";
             var textBufferManager = ITextBufferManagerFactory.ImplementFilePath(filePath);
@@ -328,7 +328,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         }
 
         [Fact]
-        public async Task ProjectFileEditorPresenter_DisposeWithOpen_DisposesListeners()
+        public async Task DisposeWithOpen_DisposesListeners()
         {
             var filePath = @"C:\Temp\ConsoleApp1.csproj";
             var textBufferManager = ITextBufferManagerFactory.ImplementFilePath(filePath);
@@ -374,7 +374,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         }
 
         [Fact]
-        public async Task ProjectFileEditorPresenter_UpdateProjectFile_SchedulesUpdate()
+        public async Task UpdateProjectFile_SchedulesUpdate()
         {
             var filePath = @"C:\Temp\ConsoleApp1.csproj";
             var textBufferManager = ITextBufferManagerFactory.ImplementFilePath(filePath);
@@ -428,7 +428,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         [InlineData((int)ProjectFileEditorPresenter.EditorState.NoEditor)]
         [InlineData((int)ProjectFileEditorPresenter.EditorState.EditorClosing)]
         [InlineData((int)ProjectFileEditorPresenter.EditorState.WritingProjectFile)]
-        public void ProjectFileEditorPresenter_UpdateProjectFileIncorrectEditorState_DoesNothing(int state)
+        public void UpdateProjectFileIncorrectEditorState_DoesNothing(int state)
         {
             var editorState = new ProjectFileEditorPresenterTester(
                 IProjectThreadingServiceFactory.Create(),
@@ -447,7 +447,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         }
 
         [Fact]
-        public async Task ProjectFileEditorPresenter_SaveProjectFile_SavesFile()
+        public async Task SaveProjectFile_SavesFile()
         {
             var filePath = @"C:\Temp\ConsoleApp1.csproj";
             var textBufferManager = ITextBufferManagerFactory.ImplementFilePath(filePath);
@@ -499,7 +499,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         [InlineData((int)ProjectFileEditorPresenter.EditorState.Initializing)]
         [InlineData((int)ProjectFileEditorPresenter.EditorState.NoEditor)]
         [InlineData((int)ProjectFileEditorPresenter.EditorState.WritingProjectFile)]
-        public async Task ProjectFileEditorPresenter_SaveProjectFile_OnlySavesInEditorOpen(int state)
+        public async Task SaveProjectFile_OnlySavesInEditorOpen(int state)
         {
             var filePath = @"C:\Temp\ConsoleApp1.csproj";
             var textBufferManager = ITextBufferManagerFactory.ImplementFilePath(filePath);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Editor/TempFileTextBufferManagerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Editor/TempFileTextBufferManagerTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
     public class TempFileTextBufferManagerTests
     {
         [Fact]
-        public void TempFileTextBufferManager_NullProject_Throws()
+        public void NullProject_Throws()
         {
             Assert.Throws<ArgumentNullException>("unconfiguredProject", () => new TempFileTextBufferManager(
                 null,
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         }
 
         [Fact]
-        public void TempFileTextBufferManager_NullMsBuildAccessor_Throws()
+        public void NullMsBuildAccessor_Throws()
         {
             Assert.Throws<ArgumentNullException>("projectXmlAccessor", () => new TempFileTextBufferManager(
                 UnconfiguredProjectFactory.Create(),
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         }
 
         [Fact]
-        public void TempFileTextBufferManager_NullEditorService_Throws()
+        public void NullEditorService_Throws()
         {
             Assert.Throws<ArgumentNullException>("editorAdaptersService", () => new TempFileTextBufferManager(
                 UnconfiguredProjectFactory.Create(),
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         }
 
         [Fact]
-        public void TempFileTextBufferManager_NullTextDocumentService_Throws()
+        public void NullTextDocumentService_Throws()
         {
             Assert.Throws<ArgumentNullException>("textDocumentService", () => new TempFileTextBufferManager(
                 UnconfiguredProjectFactory.Create(),
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         }
 
         [Fact]
-        public void TempFileTextBufferManager_NullShellUtilities_Throws()
+        public void NullShellUtilities_Throws()
         {
             Assert.Throws<ArgumentNullException>("shellUtilities", () => new TempFileTextBufferManager(
                 UnconfiguredProjectFactory.Create(),
@@ -90,7 +90,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         }
 
         [Fact]
-        public void TempFileTextBufferManager_NullFileSystem_Throws()
+        public void NullFileSystem_Throws()
         {
             Assert.Throws<ArgumentNullException>("fileSystem", () => new TempFileTextBufferManager(
                 UnconfiguredProjectFactory.Create(),
@@ -104,7 +104,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         }
 
         [Fact]
-        public void TempFileTextBufferManager_NullThreadingService_Throws()
+        public void NullThreadingService_Throws()
         {
             Assert.Throws<ArgumentNullException>("threadingService", () => new TempFileTextBufferManager(
                 UnconfiguredProjectFactory.Create(),
@@ -118,7 +118,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         }
 
         [Fact]
-        public void TempFileTextBufferManager_NullServiceProvider_Throws()
+        public void NullServiceProvider_Throws()
         {
             Assert.Throws<ArgumentNullException>("serviceProvider", () => new TempFileTextBufferManager(
                 UnconfiguredProjectFactory.Create(),
@@ -132,7 +132,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         }
 
         [Fact]
-        public async Task TempFileTextBufferManager_Initialize_CreatesTempFile()
+        public async Task Initialize_CreatesTempFile()
         {
             var projectFilePath = @"C:\ConsoleApp\ConsoleApp1\ConsoleApp1.csproj";
             var unconfiguredProject = UnconfiguredProjectFactory.Create(filePath: projectFilePath, projectEncoding: Encoding.Default);
@@ -158,7 +158,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
             Assert.Equal("<Project />", fileSystem.ReadAllText(tempProjectPath));
         }
 
-        public async Task TempFileTextBufferManager_NonStandardEncoding_UsesProjectEncoding()
+        public async Task NonStandardEncoding_UsesProjectEncoding()
         {
             var projectFilePath = @"C:\ConsoleApp\ConsoleApp1\ConsoleApp1.csproj";
             // Use some file encoding that's not the default
@@ -187,7 +187,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         }
 
         [Fact]
-        public async Task TempFileTextBufferManager_ResetBufferCleanDocData_UpdatesBufferNotFileSystem()
+        public async Task ResetBufferCleanDocData_UpdatesBufferNotFileSystem()
         {
             var projectFilePath = @"C:\ConsoleApp\ConsoleApp1\ConsoleApp1.csproj";
             // Use some file encoding that's not the default
@@ -232,7 +232,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         }
 
         [Fact]
-        public async Task TempFileTextBufferManager_ResetBufferDirtyDocData_UpdatesFileNotBuffer()
+        public async Task ResetBufferDirtyDocData_UpdatesFileNotBuffer()
         {
             var projectFilePath = @"C:\ConsoleApp\ConsoleApp1\ConsoleApp1.csproj";
             // Use some file encoding that's not the default
@@ -277,7 +277,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         }
 
         [Fact]
-        public async Task TempFileTextBufferManager_SaveAsync_SavesXmlToProject()
+        public async Task SaveAsync_SavesXmlToProject()
         {
             var projectFilePath = @"C:\ConsoleApp\ConsoleApp1\ConsoleApp1.csproj";
             // Use some file encoding that's not the default
@@ -319,7 +319,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         }
 
         [Fact]
-        public async Task TempFileTextBufferManager_SetReadonly_SetsOnlyReadonlyFlag()
+        public async Task SetReadonly_SetsOnlyReadonlyFlag()
         {
             var projectFilePath = @"C:\ConsoleApp\ConsoleApp1\ConsoleApp1.csproj";
             // Use some file encoding that's not the default
@@ -361,7 +361,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         }
 
         [Fact]
-        public async Task TempFileTextBufferManager_Dispose_RemovesTempFile()
+        public async Task Dispose_RemovesTempFile()
         {
             var projectFilePath = @"C:\ConsoleApp\ConsoleApp1\ConsoleApp1.csproj";
             // Use some file encoding that's not the default
@@ -402,7 +402,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Editor
         }
 
         [Fact]
-        public async Task TempFileTextBufferManager_NoChangesFrom_DoesNotOverwriteNewChanges()
+        public async Task NoChangesFrom_DoesNotOverwriteNewChanges()
         {
             var projectFilePath = @"C:\ConsoleApp\ConsoleApp1\ConsoleApp1.csproj";
             // Use some file encoding that's not the default

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Generators/GeneratorExtensionRegistrationAttributeTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Generators/GeneratorExtensionRegistrationAttributeTests.cs
@@ -14,20 +14,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Generators
         private const string testGuid3 = "CEE02EE1-D8DD-4D41-9D38-A23132643BA4";
 
         [Fact]
-        public void GeneratorExtensionRegistrationAttribute_NullAsExtension_ThrowsArgumentNull()
+        public void NullAsExtension_ThrowsArgumentNull()
         {
             Assert.Throws<ArgumentNullException>("extension", () => new GeneratorExtensionRegistrationAttribute(null, "ResXFileCodeGenerator", testGuid));
         }
 
 
         [Fact]
-        public void GeneratorExtensionRegistrationAttribute_NullAsGenerator_ThrowsArgumentNull()
+        public void NullAsGenerator_ThrowsArgumentNull()
         {
             Assert.Throws<ArgumentNullException>("generator", () => new GeneratorExtensionRegistrationAttribute(".resx", null, testGuid));
         }
 
         [Fact]
-        public void GeneratorExtensionRegistrationAttribute_NullAsContextGuid_ThrowsArgumentNull()
+        public void NullAsContextGuid_ThrowsArgumentNull()
         {
             Assert.Throws<ArgumentNullException>("contextGuid", () => new GeneratorExtensionRegistrationAttribute(".resx", "ResXFileCodeGenerator", null));
         }
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Generators
         [InlineData(".resx", "ResXCodeFileGenerator", testGuid)]
         [InlineData(".resx",  "PublicResXCodeFileGenerator", testGuid2)]
         [InlineData(".tt", "TextTemplateFileGenerator", testGuid3)]
-        public void GeneratorExtensionRegistrationAttribute_ValidRegistration_CreatesCorrectKeys(string extension, string generator, string contextGuid)
+        public void ValidRegistration_CreatesCorrectKeys(string extension, string generator, string contextGuid)
         {
             var numTimesCreateKeyCalled = 0;
             var numTimesSetupValueCalled = 0;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Generators/RemoteCodeGenerationRegistrationAttributeTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Generators/RemoteCodeGenerationRegistrationAttributeTests.cs
@@ -17,32 +17,32 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Generators
         private const string testGuid4 = "B8026ED7-DA10-4AFA-BD7B-157AAAEE0719";
 
         [Fact]
-        public void RemoteCodeGeneratorRegistrationAttribute_NullAsGeneratorGuid_ThrowsArgumentNull()
+        public void NullAsGeneratorGuid_ThrowsArgumentNull()
         {
             Assert.Throws<ArgumentNullException>("generatorGuid", () => new RemoteCodeGeneratorRegistrationAttribute(null, "ResXFileCodeGenerator", testGuid));
         }
 
 
         [Fact]
-        public void RemoteCodeGeneratorRegistrationAttribute_NullAsGeneratorClassName_ThrowsArgumentNull()
+        public void NullAsGeneratorClassName_ThrowsArgumentNull()
         {
             Assert.Throws<ArgumentNullException>("generatorClassName", () => new RemoteCodeGeneratorRegistrationAttribute(testGuid2, null, "ResXFileCodeGenerator", testGuid));
         }
 
         [Fact]
-        public void RemoteCodeGeneratorRegistrationAttribute_NullAsGeneratorName_ThrowsArgumentNull()
+        public void NullAsGeneratorName_ThrowsArgumentNull()
         {
             Assert.Throws<ArgumentNullException>("generatorName", () => new RemoteCodeGeneratorRegistrationAttribute(testGuid2, "ResXFileCodeGenerator", null, testGuid));
         }
 
         [Fact]
-        public void RemoteCodeGeneratorRegistrationAttribute_NullAsContextGuid_ThrowsArgumentNull()
+        public void NullAsContextGuid_ThrowsArgumentNull()
         {
             Assert.Throws<ArgumentNullException>("contextGuid", () => new RemoteCodeGeneratorRegistrationAttribute(testGuid, "ResXFileCodeGenerator", null));
         }
 
         [Fact]
-        public void RemoteCodeGeneratorRegistrationAttribute_BadGuidAsContextGuid_ThrowsArgument()
+        public void BadGuidAsContextGuid_ThrowsArgument()
         {
             Assert.Throws<ArgumentException>(() => new RemoteCodeGeneratorRegistrationAttribute(".resx", "ResXFileCodeGenerator",
                 "Not a guid"));
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Generators
         [InlineData(testGuid2, "PublicResXCodeFileGenerator", testGuid3, true, false)]
         [InlineData(testGuid4, "TextTemplateCodeFileGenerator", testGuid3, false, true)]
         [InlineData(testGuid4, "TextTemplateCodeFilePreprocessor", testGuid2, true, true)]
-        public void RemoteCodeGeneratorRegistrationAttribute_ValidRegistration_CreatesCorrectKeys(string generatorGuid, string generatorName, string contextGuid, bool generatesDesignTimeSource, bool generatesSharedDesignTimeSource)
+        public void ValidRegistration_CreatesCorrectKeys(string generatorGuid, string generatorName, string contextGuid, bool generatesDesignTimeSource, bool generatesSharedDesignTimeSource)
         {
             var numTimesCreateKeyCalled = 0;
             var createdKey = "";

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/EditProjectFileCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/EditProjectFileCommandTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         private const long CommandId = VisualStudioStandard2kCommandId.EditProjectFile;
 
         [Fact]
-        public void EditProjectFileCommand_NullAsUnconfiguredProject_Throws()
+        public void NullAsUnconfiguredProject_Throws()
         {
             var editorPresenter = IProjectFileEditorPresenterFactory.CreateLazy();
 
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         }
 
         [Fact]
-        public void EditProjectFileCommand_NullAsPresenter_Throws()
+        public void NullAsPresenter_Throws()
         {
             var unconfiguredProject = UnconfiguredProjectFactory.Create();
 
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         }
 
         [Fact]
-        public async Task EditProjectFileCommand_RootNode_ShouldHandle()
+        public async Task RootNode_ShouldHandle()
         {
             var tree = ProjectTreeParser.Parse(@"
 Root (flags: {ProjectRoot})
@@ -51,7 +51,7 @@ Root (flags: {ProjectRoot})
         }
 
         [Fact]
-        public async Task EditProjectFileCommand_NonRootNode_ShouldHandle()
+        public async Task NonRootNode_ShouldHandle()
         {
             var tree = ProjectTreeParser.Parse(@"
 Root (flags: {ProjectRoot})
@@ -71,7 +71,7 @@ Root (flags: {ProjectRoot})
         }
 
         [Fact]
-        public async Task EditProjectFileCommand_MultipleNodes_ShouldHandle()
+        public async Task MultipleNodes_ShouldHandle()
         {
             var tree = ProjectTreeParser.Parse(@"
 Root (flags: {ProjectRoot})
@@ -91,7 +91,7 @@ Root (flags: {ProjectRoot})
         }
 
         [Fact]
-        public async Task EditProjectFileCommand_RootNode_CallsOpenAsync()
+        public async Task RootNode_CallsOpenAsync()
         {
             var tree = ProjectTreeParser.Parse(@"
 Root (flags: {ProjectRoot})
@@ -110,7 +110,7 @@ Root (flags: {ProjectRoot})
         }
 
         [Fact]
-        public async Task EditProjectFileCommand_NonRootNode_CallsOpenAsync()
+        public async Task NonRootNode_CallsOpenAsync()
         {
             var tree = ProjectTreeParser.Parse(@"
 Root (flags: {ProjectRoot})
@@ -131,7 +131,7 @@ Root (flags: {ProjectRoot})
         }
 
         [Fact]
-        public async Task EditProjectFileCommand_MultipleNodes_CallsOpenAsync()
+        public async Task MultipleNodes_CallsOpenAsync()
         {
             var tree = ProjectTreeParser.Parse(@"
 Root (flags: {ProjectRoot})

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/NuGet/ProjectRestoreInfoBuilderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/NuGet/ProjectRestoreInfoBuilderTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
     public class ProjectRestoreInfoBuilderTests
     {
         [Fact]
-        public void ProjectRestoreInfoBuilder_NullUpdate_ThrowsArgumentNull()
+        public void NullUpdate_ThrowsArgumentNull()
         {
             Assert.Throws<ArgumentNullException>("updates", () => {
                 ProjectRestoreInfoBuilder.Build(null, GetMockProject());
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         }
 
         [Fact]
-        public void ProjectRestoreInfoBuilder_NullProject_ThrowsArgumentNull()
+        public void NullProject_ThrowsArgumentNull()
         {
             Assert.Throws<ArgumentNullException>("project", () => {
                 var projectSubscriptionUpdates = GetVersionedUpdatesFromJson(_sampleSubscriptionUpdate);
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         }
 
         [Fact]
-        public void ProjectRestoreInfoBuilder_NoProjectChanges_ReturnsNull()
+        public void NoProjectChanges_ReturnsNull()
         {
             var projectSubscriptionUpdates = GetVersionedUpdatesFromJson(@"{
     ""ProjectChanges"": {
@@ -57,7 +57,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         }
 
         [Fact]
-        public void ProjectRestoreInfoBuilder_WithAnyChanges_ReturnsFullRestoreInfo()
+        public void WithAnyChanges_ReturnsFullRestoreInfo()
         {
             var projectSubscriptionUpdates = GetVersionedUpdatesFromJson(_sampleSubscriptionUpdate);
             var restoreInfo = ProjectRestoreInfoBuilder.Build(projectSubscriptionUpdates, GetMockProject());
@@ -117,7 +117,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         }
 
         [Fact]
-        public void ProjectRestoreInfoBuilder_WithNoTargetFrameworkDimension_UsesPropertiesInstead()
+        public void WithNoTargetFrameworkDimension_UsesPropertiesInstead()
         {
             var projectSubscriptionUpdates = GetVersionedUpdatesFromJson(@"{
     ""ProjectConfiguration"": {
@@ -175,7 +175,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         }
 
         [Fact]
-        public void ProjectRestoreInfoBuilder_WithEmptyTargetFramework_ReturnsNull()
+        public void WithEmptyTargetFramework_ReturnsNull()
         {
             var projectSubscriptionUpdates = GetVersionedUpdatesFromJson(@"{
     ""ProjectConfiguration"": {
@@ -230,7 +230,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         }
 
         [Fact]
-        public void ProjectRestoreInfoBuilder_WithTwoIdenticalUpdates_ReturnsSingleTFM()
+        public void WithTwoIdenticalUpdates_ReturnsSingleTFM()
         {
             var projectSubscriptionUpdates = GetVersionedUpdatesFromJson(
                 _sampleSubscriptionUpdate,
@@ -244,7 +244,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         }
 
         [Fact]
-        public void ProjectRestoreInfoBuilder_WithTwoDifferentUpdates_ReturnsTwoTFMs()
+        public void WithTwoDifferentUpdates_ReturnsTwoTFMs()
         {
             var projectSubscriptionUpdates = GetVersionedUpdatesFromJson(@"{
     ""ProjectConfiguration"": {
@@ -350,7 +350,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         }
 
         [Fact]
-        public void ProjectRestoreInfoBuilder_WithRepeatedToolReference_ReturnsJustOne()
+        public void WithRepeatedToolReference_ReturnsJustOne()
         {
             var projectSubscriptionUpdates = GetVersionedUpdatesFromJson(@"{
     ""ProjectConfiguration"": {
@@ -471,7 +471,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         }
 
         [Fact]
-        public void ProjectRestoreInfoBuilder_WithoutDefiningProjectDirectory_UsesUnconfiguredProjectRoot()
+        public void WithoutDefiningProjectDirectory_UsesUnconfiguredProjectRoot()
         {
             var projectSubscriptionUpdates = GetVersionedUpdatesFromJson(@"{
     ""ProjectConfiguration"": {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/PropertyPageControlTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/PropertyPageControlTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
     public class PropertyPageControlTests
     {
         [Fact]
-        public void PropertyPageControl_Test()
+        public void Test()
         {
 
             var thread = new Thread(new ThreadStart(CallPropertyPageControl));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/PropertyPageTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/PropertyPageTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test.PropertyPages
     public class PropertyPageTests
     {
         [Fact]
-        public void PropertyPage_GetPageInfoAndHelp()
+        public void GetPageInfoAndHelp()
         {
             Castle.DynamicProxy.Generators.AttributesToAvoidReplicating.Add(typeof(System.Security.Permissions.UIPermissionAttribute));
 
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test.PropertyPages
         }
 
         [Fact]
-        public void PropertyPage_Move()
+        public void Move()
         {
             Castle.DynamicProxy.Generators.AttributesToAvoidReplicating.Add(typeof(System.Security.Permissions.UIPermissionAttribute));
 
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test.PropertyPages
         }
 
         [Fact]
-        public void PropertyPage_MoveThrowsArgumentExceptionIfNullRect()
+        public void MoveThrowsArgumentExceptionIfNullRect()
         {
             Assert.Throws<ArgumentNullException>(() =>
             {
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test.PropertyPages
         }
 
         [Fact]
-        public void PropertyPage_MoveThrowsArgumentExceptionIfEmptyRect()
+        public void MoveThrowsArgumentExceptionIfEmptyRect()
         {
             Assert.Throws<ArgumentNullException>(() =>
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/AnalyzerDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/AnalyzerDependencyModelTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     public class AnalyzerDependencyModelTests
     {
         [Fact]
-        public void AnalyzerDependencyModelTests_Resolved()
+        public void Resolved()
         {
             var properties = ImmutableDictionary<string, string>.Empty.Add("myProp", "myVal");
 
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void AnalyzerDependencyModelTests_Unresolved()
+        public void Unresolved()
         {
             var properties = ImmutableDictionary<string, string>.Empty.Add("myProp", "myVal");
 
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void AnalyzerDependencyModelTests_Implicit()
+        public void Implicit()
         {
             var properties = ImmutableDictionary<string, string>.Empty.Add("myProp", "myVal");
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/AssemblyDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/AssemblyDependencyModelTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     public class AssemblyDependencyModelTests
     {
         [Fact]
-        public void AssemblyDependencyModelTests_Resolved_NoFusionName()
+        public void Resolved_NoFusionName()
         {
             var properties = ImmutableDictionary<string, string>.Empty.Add("myProp", "myVal");
 
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void AssemblyDependencyModelTests_Resolved_WithFusionName()
+        public void Resolved_WithFusionName()
         {
             var properties = ImmutableDictionary<string, string>.Empty.Add(ResolvedAssemblyReference.FusionNameProperty, "myAssembly.dll");
 
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void AssemblyDependencyModelTests_Unresolved()
+        public void Unresolved()
         {
             var properties = ImmutableDictionary<string, string>.Empty.Add("myProp", "myVal");
 
@@ -108,7 +108,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void AssemblyDependencyModelTests_Implicit()
+        public void Implicit()
         {
             var properties = ImmutableDictionary<string, string>.Empty.Add("myProp", "myVal");
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/ComDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/ComDependencyModelTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     public class ComDependencyModelTests
     {
         [Fact]
-        public void ComDependencyModelTests_Resolved()
+        public void Resolved()
         {
             var properties = ImmutableDictionary<string, string>.Empty.Add("myProp", "myVal");
 
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void ComDependencyModelTests_Unresolved()
+        public void Unresolved()
         {
             var properties = ImmutableDictionary<string, string>.Empty.Add("myProp", "myVal");
 
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void ComDependencyModelTests_Implicit()
+        public void Implicit()
         {
             var properties = ImmutableDictionary<string, string>.Empty.Add("myProp", "myVal");
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DependencyModelTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     public class DependencyModelTests
     {
         [Fact]
-        public void DependencyModel_Constructor_WhenRequiredParamsNotProvided_ShouldThrow()
+        public void Constructor_WhenRequiredParamsNotProvided_ShouldThrow()
         {
             Assert.Throws<ArgumentNullException>("providerType", () =>
             {
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void DependencyModel_Constructor_WhenOptionalValuesNotProvided_ShouldSetDefaults()
+        public void Constructor_WhenOptionalValuesNotProvided_ShouldSetDefaults()
         {
             var model = new DependencyModel(
                 providerType: "somProvider", 
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void DependencyModel_Constructor_WhenValidParametersProvided_UnresolvedAndNotImplicit()
+        public void Constructor_WhenValidParametersProvided_UnresolvedAndNotImplicit()
         {
             var model = new TestableDependencyModel(
                 providerType: "somProvider",
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void DependencyModel_Constructor_WhenValidParametersProvided_ResolvedAndNotImplicit()
+        public void Constructor_WhenValidParametersProvided_ResolvedAndNotImplicit()
         {
             var model = new TestableDependencyModel(
                 providerType: "somProvider",
@@ -89,7 +89,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void DependencyModel_Constructor_WhenValidParametersProvided_ResolvedAndImplicit()
+        public void Constructor_WhenValidParametersProvided_ResolvedAndImplicit()
         {
             var model = new TestableDependencyModel(
                 providerType: "somProvider",
@@ -114,7 +114,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void DependencyModel_EqualsAndGetHashCode()
+        public void EqualsAndGetHashCode()
         {
             var model1 = new TestableDependencyModel(
                 providerType: "somProvider",
@@ -154,7 +154,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void DependencyModel_Visible_True()
+        public void Visible_True()
         {
             var dependencyModel = new DependencyModel(
                 providerType: "someProvider",
@@ -169,7 +169,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void DependencyModel_Visible_False()
+        public void Visible_False()
         {
             var dependencyModel = new DependencyModel(
                 providerType: "someProvider",
@@ -184,7 +184,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void DependencyModel_Visible_TrueWhenNotSpecified()
+        public void Visible_TrueWhenNotSpecified()
         {
             var dependencyModel = new DependencyModel(
                 providerType: "someProvider",

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DiagnosticDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DiagnosticDependencyModelTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     public class DiagnosticDependencyModelTests
     {
         [Fact]
-        public void DiagnosticDependencyModelTests_Error()
+        public void Error()
         {
             var properties = ImmutableDictionary<string, string>.Empty.Add("myProp", "myVal");
 
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void DiagnosticDependencyModelTests_Warning()
+        public void Warning()
         {
             var properties = ImmutableDictionary<string, string>.Empty.Add("myProp", "myVal");
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageAnalyzerAssemblyDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageAnalyzerAssemblyDependencyModelTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     public class PackageAnalyzerAssemblyDependencyModelTests
     {
         [Fact]
-        public void PackageAnalyzerAssemblyDependencyModelTests_Resolved()
+        public void Resolved()
         {
             var properties = ImmutableDictionary<string, string>.Empty.Add("myProp", "myVal");
             var dependencyIDs = new[] { "id1", "id2" };
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void PackageAnalyzerAssemblyDependencyModelTests_Unresolved()
+        public void Unresolved()
         {
             var properties = ImmutableDictionary<string, string>.Empty.Add("myProp", "myVal");
             var dependencyIDs = new[] { "id1", "id2" };

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageDependencyModelTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     public class PackageDependencyModelTests
     {
         [Fact]
-        public void PackageDependencyModelTests_Resolved()
+        public void Resolved()
         {
             var properties = ImmutableDictionary<string, string>.Empty.Add("myProp", "myVal");
             var dependencyIDs = new[] { "id1", "id2" };
@@ -57,7 +57,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void PackageDependencyModelTests_Unresolved()
+        public void Unresolved()
         {
             var properties = ImmutableDictionary<string, string>.Empty.Add("myProp", "myVal");
             var dependencyIDs = new[] { "id1", "id2" };
@@ -103,7 +103,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void PackageDependencyModelTests_Implicit()
+        public void Implicit()
         {
             var properties = ImmutableDictionary<string, string>.Empty.Add("myProp", "myVal");
             var dependencyIDs = new[] { "id1", "id2" };

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageFrameworkAssembliesViewModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageFrameworkAssembliesViewModelTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     public class PackageFrameworkAssembliesViewModelTests
     {
         [Fact]
-        public void PackageFrameworkAssembliesViewModelTests_Resolved()
+        public void Resolved()
         {
             var model = new PackageFrameworkAssembliesViewModel();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageUnknownDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageUnknownDependencyModelTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     public class PackageUnknownDependencyModelTests
     {
         [Fact]
-        public void PackageUnknownDependencyModelTests_Resolved()
+        public void Resolved()
         {
             var properties = ImmutableDictionary<string, string>.Empty.Add("myProp", "myVal");
             var dependencyIDs = new[] { "id1", "id2" };

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/ProjectDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/ProjectDependencyModelTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     public class ProjectDependencyModelTests
     {
         [Fact]
-        public void ProjectDependencyModelTests_Resolved()
+        public void Resolved()
         {
             var properties = ImmutableDictionary<string, string>.Empty.Add("myProp", "myVal");
 
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void ProjectDependencyModelTests_Unresolved()
+        public void Unresolved()
         {
             var properties = ImmutableDictionary<string, string>.Empty.Add("myProp", "myVal");
 
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void ProjectDependencyModelTests_Implicit()
+        public void Implicit()
         {
             var properties = ImmutableDictionary<string, string>.Empty.Add("myProp", "myVal");
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SharedProjectDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SharedProjectDependencyModelTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     public class SharedSharedProjectDependencyModelTests
     {
         [Fact]
-        public void SharedSharedProjectDependencyModelTests_Resolved()
+        public void SharedResolved()
         {
             var properties = ImmutableDictionary<string, string>.Empty.Add("myProp", "myVal");
 
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void SharedProjectDependencyModelTests_Unresolved()
+        public void Unresolved()
         {
             var properties = ImmutableDictionary<string, string>.Empty.Add("myProp", "myVal");
 
@@ -80,7 +80,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void SharedProjectDependencyModelTests_Implicit()
+        public void Implicit()
         {
             var properties = ImmutableDictionary<string, string>.Empty.Add("myProp", "myVal");
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyExtensionsTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyExtensionsTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     public class DependencyExtensionsTests
     {
         [Fact]
-        public void DependencyExtensionsTests_IsOrHasUnresolvedDependency()
+        public void IsOrHasUnresolvedDependency()
         {
             var dependency1 = IDependencyFactory.FromJson(@"
 {
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void DependencyExtensionsTests_ToViewModel()
+        public void ToViewModel()
         {
             var dependencyResolved = IDependencyFactory.FromJson(@"
 {
@@ -115,7 +115,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void DependencyExtensionsTests_GetIcons()
+        public void GetIcons()
         {
             var dependency = IDependencyFactory.FromJson(@"
 {
@@ -143,7 +143,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void DependencyExtensionsTests_IsPackage()
+        public void IsPackage()
         {
             var dependency = IDependencyFactory.FromJson(@"
 {
@@ -161,7 +161,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void DependencyExtensionsTests_IsProject()
+        public void IsProject()
         {
             var dependency = IDependencyFactory.FromJson(@"
 {
@@ -179,7 +179,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void DependencyExtensionsTests_HasSameTarget()
+        public void HasSameTarget()
         {
             var targetFramework1 = ITargetFrameworkFactory.Implement("tfm1");
             var targetFramework2 = ITargetFrameworkFactory.Implement("tfm2");
@@ -194,7 +194,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void DependencyExtensionsTests_GetActualPath()
+        public void GetActualPath()
         {
             const string projectPath = @"c:\somepath\someproject\project.csproj";
             var dependency1 = IDependencyFactory.FromJson(@"
@@ -223,7 +223,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void DependencyExtensionsTests_GetTopLevelId()
+        public void GetTopLevelId()
         {
             var dependency1 = IDependencyFactory.FromJson(@"
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DuplicatedDependenciesSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DuplicatedDependenciesSnapshotFilterTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     public class DuplicatedDependenciesSnapshotFilterTests
     {
         [Fact]
-        public void DuplicatedDependenciesSnapshotFilter_WhenThereNoMatchingDependencies_ShouldNotUpdateCaption()
+        public void WhenThereNoMatchingDependencies_ShouldNotUpdateCaption()
         {
             const string caption = "MyCaption";
             var dependency = IDependencyFactory.Implement(
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void DuplicatedDependenciesSnapshotFilter_WhenThereIsMatchingDependencies_ShouldUpdateCaptionForAll()
+        public void WhenThereIsMatchingDependencies_ShouldUpdateCaptionForAll()
         {
             const string caption = "MyCaption";
             var dependency = IDependencyFactory.Implement(
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void DuplicatedDependenciesSnapshotFilter_WhenThereIsMatchingDependencyWithAliasApplied_ShouldUpdateCaptionForCurrentDependency()
+        public void WhenThereIsMatchingDependencyWithAliasApplied_ShouldUpdateCaptionForCurrentDependency()
         {
             const string caption = "MyCaption";
             var dependency = IDependencyFactory.Implement(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/ImplicitTopLevelDependenciesSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/ImplicitTopLevelDependenciesSnapshotFilterTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     public class ImplicitTopLevelDependenciesSnapshotFilterTests
     {
         [Fact]
-        public void ImplicitTopLevelDependenciesSnapshotFilter_WhenNotTopLevel_ShouldDoNothing()
+        public void WhenNotTopLevel_ShouldDoNothing()
         {
             var dependency = IDependencyFactory.Implement(
                 id: "mydependency2",
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void ImplicitTopLevelDependenciesSnapshotFilter_WhenImplicitAlready_ShouldDoNothing()
+        public void WhenImplicitAlready_ShouldDoNothing()
         {
             var dependency = IDependencyFactory.Implement(
                 id: "mydependency2",
@@ -74,7 +74,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void ImplicitTopLevelDependenciesSnapshotFilter_WhenUnresolved_ShouldDoNothing()
+        public void WhenUnresolved_ShouldDoNothing()
         {
             var dependency = IDependencyFactory.Implement(
                 id: "mydependency2",
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void ImplicitTopLevelDependenciesSnapshotFilter_WhenNotGenericDependency_ShouldDoNothing()
+        public void WhenNotGenericDependency_ShouldDoNothing()
         {
             var dependency = IDependencyFactory.Implement(
                 id: "mydependency2",
@@ -139,7 +139,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void ImplicitTopLevelDependenciesSnapshotFilter_WhenCanApplyImplicitProjectContainsItem_ShouldDoNothing()
+        public void WhenCanApplyImplicitProjectContainsItem_ShouldDoNothing()
         {
             var dependency = IDependencyFactory.Implement(
                 id: "mydependency2",
@@ -173,7 +173,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void ImplicitTopLevelDependenciesSnapshotFilter_WhenNeedToApplyImplicit_ShouldSetProperties()
+        public void WhenNeedToApplyImplicit_ShouldSetProperties()
         {
             var dependency = IDependencyFactory.Implement(
                 id: "mydependency2",

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/SdkAndPackagesDependenciesSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/SdkAndPackagesDependenciesSnapshotFilterTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     public class SdkAndPackagesDependenciesSnapshotFilterTests
     {
         [Fact]
-        public void SdkAndPackagesDependenciesSnapshotFilter_WhenNotTopLevelOrResolved_ShouldDoNothing()
+        public void WhenNotTopLevelOrResolved_ShouldDoNothing()
         {
             var dependency = IDependencyFactory.Implement(
                 id: "mydependency1",
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void SdkAndPackagesDependenciesSnapshotFilter_WhenSdk_ShouldFindMatchingPackageAndSetProperties()
+        public void WhenSdk_ShouldFindMatchingPackageAndSetProperties()
         {
             var dependencyIDs = new List<string> { "id1", "id2" }.ToImmutableList();
 
@@ -89,7 +89,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void SdkAndPackagesDependenciesSnapshotFilter_WhenSdkAndPackageUnresolved_ShouldDoNothing()
+        public void WhenSdkAndPackageUnresolved_ShouldDoNothing()
         {
             var dependencyIDs = new List<string> { "id1", "id2" }.ToImmutableList();
 
@@ -128,7 +128,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void SdkAndPackagesDependenciesSnapshotFilter_WhenPackage_ShouldFindMatchingSdkAndSetProperties()
+        public void WhenPackage_ShouldFindMatchingSdkAndSetProperties()
         {
             var dependencyIDs = new List<string> { "id1", "id2" }.ToImmutableList();
 
@@ -180,7 +180,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void SdkAndPackagesDependenciesSnapshotFilter_WhenPackageRemoving_ShouldCleanupSdk()
+        public void WhenPackageRemoving_ShouldCleanupSdk()
         {
             var dependencyIDs = ImmutableList<string>.Empty;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     public class TargetedDependenciesSnapshotTests
     {
         [Fact]
-        public void TargetedDependenciesSnapshot_Constructor_WhenRequiredParamsNotProvided_ShouldThrow()
+        public void TConstructor_WhenRequiredParamsNotProvided_ShouldThrow()
         {
             Assert.Throws<ArgumentNullException>("projectPath", () =>
             {
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void TargetedDependenciesSnapshot_Constructor()
+        public void TConstructor()
         {
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var targetFramework = ITargetFrameworkFactory.Implement("tfm1");
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void TargetedDependenciesSnapshot_FromChanges_Empty()
+        public void TFromChanges_Empty()
         {
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var targetFramework = ITargetFrameworkFactory.Implement("tfm1");
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void TargetedDependenciesSnapshot_FromChanges_NoChanges()
+        public void TFromChanges_NoChanges()
         {
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var targetFramework = ITargetFrameworkFactory.Implement("tfm1");
@@ -152,7 +152,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void TargetedDependenciesSnapshot_FromChanges_NoChangesAfterBeforeRemoveFilterDeclinedChange()
+        public void TFromChanges_NoChangesAfterBeforeRemoveFilterDeclinedChange()
         {
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var targetFramework = ITargetFrameworkFactory.Implement("tfm1");
@@ -214,7 +214,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void TargetedDependenciesSnapshot_FromChanges_ReportedChangesAfterBeforeRemoveFilterDeclinedChange()
+        public void TFromChanges_ReportedChangesAfterBeforeRemoveFilterDeclinedChange()
         {
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var targetFramework = ITargetFrameworkFactory.Implement("tfm1");
@@ -287,7 +287,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void TargetedDependenciesSnapshot_FromChanges_NoChangesAfterBeforeAddFilterDeclinedChange()
+        public void TFromChanges_NoChangesAfterBeforeAddFilterDeclinedChange()
         {
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var targetFramework = ITargetFrameworkFactory.Implement("tfm1");
@@ -358,7 +358,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void TargetedDependenciesSnapshot_FromChanges_ReportedChangesAfterBeforeAddFilterDeclinedChange()
+        public void TFromChanges_ReportedChangesAfterBeforeAddFilterDeclinedChange()
         {
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var targetFramework = ITargetFrameworkFactory.Implement("tfm1");
@@ -430,7 +430,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void TargetedDependenciesSnapshot_FromChanges_RemovedAndAddedChanges()
+        public void TFromChanges_RemovedAndAddedChanges()
         {
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var targetFramework = ITargetFrameworkFactory.Implement("tfm1");

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnresolvedDependenciesSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnresolvedDependenciesSnapshotFilterTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     public class UnresolvedDependenciesSnapshotFilterTests
     {
         [Fact]
-        public void UnresolvedDependenciesSnapshotFilter_WhenUnresolvedAndExistsResolvedInSnapshot_ShouldReturnNull()
+        public void WhenUnresolvedAndExistsResolvedInSnapshot_ShouldReturnNull()
         {
             var dependency = IDependencyFactory.Implement(
                 id: "mydependency2",
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void UnresolvedDependenciesSnapshotFilter_WhenUnresolvedAndNotExistsResolvedInSnapshot_ShouldReturnDependency()
+        public void WhenUnresolvedAndNotExistsResolvedInSnapshot_ShouldReturnDependency()
         {
             var dependency = IDependencyFactory.Implement(
                 id: "mydependency2",
@@ -74,7 +74,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void UnresolvedDependenciesSnapshotFilter_WhenResolved_ShouldReturnDependency()
+        public void WhenResolved_ShouldReturnDependency()
         {
             var dependency = IDependencyFactory.Implement(
                 id: "mydependency2",

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/GroupedByTargetTreeViewProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/GroupedByTargetTreeViewProviderTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     public class GroupedByTargetTreeViewProviderTests
     {
         [Fact]
-        public async Task GrouppedByTargetTreeViewProvider_WhenEmptySnapshot_ShouldJustUpdateDependencyRootNode()
+        public async Task WhenEmptySnapshot_ShouldJustUpdateDependencyRootNode()
         {
             // Arrange
             var treeServices = new MockIDependenciesTreeServices();
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public async Task GrouppedByTargetTreeViewProvider_WhenOneTargetSnapshotWithExistingDependencies_ShouldApplyChanges()
+        public async Task WhenOneTargetSnapshotWithExistingDependencies_ShouldApplyChanges()
         {
             var tfm1 = ITargetFrameworkFactory.Implement(moniker: "tfm1");
             var dependencyRootXxx = IDependencyFactory.FromJson(@"
@@ -166,7 +166,7 @@ Caption=Dependency1, FilePath=tfm1\Xxx\dependencyXxxpath, IconHash=325249260, Ex
         }
 
         [Fact]
-        public async Task GrouppedByTargetTreeViewProvider_WhenOneTargetSnapshotAndDependencySupportsHierarchyAndIsResolved_ShouldReadd()
+        public async Task WhenOneTargetSnapshotAndDependencySupportsHierarchyAndIsResolved_ShouldReadd()
         {
             var tfm1 = ITargetFrameworkFactory.Implement(moniker: "tfm1");
             var dependencyRootYyy = IDependencyFactory.FromJson(@"
@@ -249,7 +249,7 @@ Caption=DependencyExisting, FilePath=tfm1\Yyy\dependencyExistingpath, IconHash=3
         }
 
         [Fact]
-        public async Task GrouppedByTargetTreeViewProvider_WhenOneTargetSnapshotAndDependencySupportsHierarchyAndIsUnresolved_ShouldReadd()
+        public async Task WhenOneTargetSnapshotAndDependencySupportsHierarchyAndIsUnresolved_ShouldReadd()
         {
             var dependencyRootYyy = IDependencyFactory.FromJson(@"
 {
@@ -331,7 +331,7 @@ Caption=DependencyExisting, FilePath=tfm1\yyy\dependencyExisting, IconHash=32524
         }
 
         [Fact]
-        public async Task GrouppedByTargetTreeViewProvider_WhenOneTargetSnapshotAndDependencySupportsRule_ShouldCreateRule()
+        public async Task WhenOneTargetSnapshotAndDependencySupportsRule_ShouldCreateRule()
         {
             var dependencyRootYyy = IDependencyFactory.FromJson(@"
 {
@@ -410,7 +410,7 @@ Caption=DependencyExisting, FilePath=tfm1\yyy\dependencyExisting, IconHash=32524
         }
 
         [Fact]
-        public async Task GrouppedByTargetTreeViewProvider_WheEmptySnapshotAndVisibilityMarkerProvided_ShouldDisplaySubTreeRoot()
+        public async Task WheEmptySnapshotAndVisibilityMarkerProvided_ShouldDisplaySubTreeRoot()
         {
             var dependencyRootYyy = IDependencyFactory.FromJson(@"
 {
@@ -478,7 +478,7 @@ Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconH
         }
 
         [Fact]
-        public async Task GrouppedByTargetTreeViewProvider_WheEmptySnapshotAndVisibilityMarkerNotProvided_ShouldHideSubTreeRoot()
+        public async Task WheEmptySnapshotAndVisibilityMarkerNotProvided_ShouldHideSubTreeRoot()
         {
             var dependencyRootYyy = IDependencyFactory.FromJson(@"
 {
@@ -545,7 +545,7 @@ Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconH
         }
 
         [Fact]
-        public async Task GrouppedByTargetTreeViewProvider_WhenMultipleTargetSnapshotsWithExistingDependencies_ShouldApplyChanges()
+        public async Task WhenMultipleTargetSnapshotsWithExistingDependencies_ShouldApplyChanges()
         {
             var tfm1 = ITargetFrameworkFactory.Implement(moniker: "tfm1");
             var tfm2 = ITargetFrameworkFactory.Implement(moniker: "tfm2");
@@ -722,7 +722,7 @@ Caption=Dependency1, FilePath=tfm1\Xxx\dependencyxxxpath, IconHash=325249260, Ex
         }
 
         [Fact]
-        public void GrouppedByTargetTreeViewProvider_WhenFindByPathAndNoolNode_ShouldDoNothing()
+        public void WhenFindByPathAndNoolNode_ShouldDoNothing()
         {
             // Arrange
             const string projectPath = @"c:\myfolder\mysubfolder\myproject.csproj";
@@ -749,7 +749,7 @@ Caption=Dependency1, FilePath=tfm1\Xxx\dependencyxxxpath, IconHash=325249260, Ex
         }
 
         [Fact]
-        public void GrouppedByTargetTreeViewProvider_WhenFindByPathAndNotDependenciesRoot_ShouldDoNothing()
+        public void WhenFindByPathAndNotDependenciesRoot_ShouldDoNothing()
         {
             // Arrange
             const string projectPath = @"c:\myfolder\mysubfolder\myproject.csproj";
@@ -776,7 +776,7 @@ Caption=Dependency1, FilePath=tfm1\Xxx\dependencyxxxpath, IconHash=325249260, Ex
         }
 
         [Fact]
-        public void GrouppedByTargetTreeViewProvider_WhenFindByPathAndAbsoluteNodePath_ShouldFind()
+        public void WhenFindByPathAndAbsoluteNodePath_ShouldFind()
         {
             // Arrange
             const string projectPath = @"c:\myfolder\mysubfolder\myproject.csproj";
@@ -855,7 +855,7 @@ Caption=Dependency1, FilePath=tfm1\Xxx\dependencyxxxpath, IconHash=325249260, Ex
         }
 
         [Fact]
-        public void GrouppedByTargetTreeViewProvider_WhenFindByPathAndRelativeNodePath_ShouldFind()
+        public void WhenFindByPathAndRelativeNodePath_ShouldFind()
         {
             // Arrange
             const string projectPath = @"c:\myfolder\mysubfolder\myproject.csproj";
@@ -934,7 +934,7 @@ Caption=Dependency1, FilePath=tfm1\Xxx\dependencyxxxpath, IconHash=325249260, Ex
         }
 
         [Fact]
-        public void GrouppedByTargetTreeViewProvider_WhenFindByPathAndNeedToFindDependenciesRoot_ShouldFind()
+        public void WhenFindByPathAndNeedToFindDependenciesRoot_ShouldFind()
         {
             // Arrange
             const string projectPath = @"c:\myfolder\mysubfolder\myproject.csproj";


### PR DESCRIPTION
Remove type name from test methods.

Some unit tests prepended the same type that they are testing, in the name of the test method; that's what the class name is for. Consistently applied it across the tree.