### PR TITLE
Remove a duplicate test

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Logging/ProjectOutputWindowProjectLoggerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Logging/ProjectOutputWindowProjectLoggerTests.cs
@@ -160,7 +160,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
 
         [Theory] // Format               Arguments                                          Expected
         [InlineData("",                  new object[] { null },                             "")]
-        [InlineData("",                  new object[] { null },                             "")]
         [InlineData("{0}",               new object[] { null },                             "")]
         [InlineData("{0}{1}",            new object[] { null, null },                       "")]
         [InlineData("{0}{1}{2}",         new object[] { null, null, null },                 "")]


### PR DESCRIPTION
This was resulting in a warning during test runs.