### PR TITLE
Infrastructure/cleanup integration tests

### DIFF
--- a/src/DeployIntegrationDependencies/DeployIntegrationDependencies.csproj
+++ b/src/DeployIntegrationDependencies/DeployIntegrationDependencies.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
   <Import Project="..\..\build\Targets\ProducesNoOutput.Imports.targets" />
 
-  <Target Name="DeployIntegrationDependencies" Condition="'$(DesignTimeBuild)' == '' AND  ('$(DeployVsixExtension)' == 'true' OR '$(RunIntegrationTests)' == 'true')" AfterTargets="PostBuildEvent">
+  <Target Name="DeployIntegrationDependencies" Condition="'$(DesignTimeBuild)' == '' AND '$(RunIntegrationTests)' == 'true'" AfterTargets="PostBuildEvent">
     <PropertyGroup>
       <NUGET_PACKAGES Condition="'$(NUGET_PACKAGES)' == ''">$(UserProfile)\.nuget\packages</NUGET_PACKAGES>
       <RepositoryRootDirectory>$(MSBuildThisFileDirectory)..\..\</RepositoryRootDirectory>

--- a/src/DeployIntegrationDependencies/DeployIntegrationDependencies.csproj
+++ b/src/DeployIntegrationDependencies/DeployIntegrationDependencies.csproj
@@ -28,16 +28,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="[$(XUnitRunnerVisualstudioVersion)]" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.VisualStudio.AppDesigner\Microsoft.VisualStudio.AppDesigner.vbproj" />
-    <ProjectReference Include="..\Microsoft.VisualStudio.Editors\Microsoft.VisualStudio.Editors.vbproj" />
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.CSharp.VS\Microsoft.VisualStudio.ProjectSystem.CSharp.VS.csproj" />
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.CSharp\Microsoft.VisualStudio.ProjectSystem.CSharp.csproj" />
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.FSharp.VS\Microsoft.VisualStudio.ProjectSystem.FSharp.VS.csproj" />
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.FSharp\Microsoft.VisualStudio.ProjectSystem.FSharp.csproj" />
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.VS\Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj" />
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj" />
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS\Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.csproj" />
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.VisualBasic\Microsoft.VisualStudio.ProjectSystem.VisualBasic.csproj" />
     <ProjectReference Include="..\ProjectSystemSetup\ProjectSystemSetup.csproj" />
     <ProjectReference Include="..\Templates\Microsoft.NetCore.CSharp.ProjectTemplates.Test.Vsix\Microsoft.NetCore.CSharp.ProjectTemplates.Test.Vsix.csproj" />
     <ProjectReference Include="..\Templates\Microsoft.NetCore.CSharp.ProjectTemplates.Vsix\Microsoft.NetCore.CSharp.ProjectTemplates.Vsix.csproj" />


### PR DESCRIPTION
Test only change.  Developer will need to pass `/p:RunIntegrationTests=true` to deploy the integration dependencies
fixes https://github.com/dotnet/project-system/issues/2563
fixes https://github.com/dotnet/project-system/issues/2564
fixes https://github.com/dotnet/project-system/issues/2565