### PR TITLE
Back out ruleset fix due to RPS regressions

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckInput.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckInput.xaml
@@ -7,7 +7,7 @@
     Description="File Properties"
     xmlns="http://schemas.microsoft.com/build/2009/properties">
     <Rule.DataSource>
-        <DataSource HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" SourceType="TargetResults" MSBuildTarget="CollectUpToDateInputsDesignTime"/>
+        <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="UpToDateCheckInput" SourceOfDefaultValue="AfterContext" />
     </Rule.DataSource>
     <Rule.Categories>
         <Category Name="Advanced" DisplayName="Advanced" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckOutput.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckOutput.xaml
@@ -7,7 +7,7 @@
     Description="File Properties"
     xmlns="http://schemas.microsoft.com/build/2009/properties">
     <Rule.DataSource>
-        <DataSource HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" SourceType="TargetResults" MSBuildTarget="CollectUpToDateOutputsDesignTime"/>
+        <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="UpToDateCheckOutput" SourceOfDefaultValue="AfterContext" />
     </Rule.DataSource>
     <Rule.Categories>
         <Category Name="Advanced" DisplayName="Advanced" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/ProjectItemsSchema.xaml
@@ -12,9 +12,13 @@
   <ContentType Name="EmbeddedResource" DisplayName="Vložený prostředek" ItemType="EmbeddedResource">
     <NameValuePair Name="DefaultMetadata_Generator" Value="ResXFileCodeGenerator" />
   </ContentType>
+  <ContentType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" ItemType="UpToDateCheckInput"></ContentType>
+  <ContentType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" ItemType="UpToDateCheckOutput"></ContentType>
   <ItemType Name="None" DisplayName="Žádné" />
   <ItemType Name="Content" DisplayName="Obsah" />
   <ItemType Name="EmbeddedResource" DisplayName="Vložený prostředek" />
+  <ItemType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" />
+  <ItemType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" UpToDateCheckInput="False" />
   <FileExtension Name=".asax" ContentType="Asax" />
   <FileExtension Name=".asmx" ContentType="HTML" />
   <FileExtension Name=".asp" ContentType="AspPage" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/ProjectItemsSchema.xaml
@@ -12,9 +12,13 @@
   <ContentType Name="EmbeddedResource" DisplayName="Eingebettete Ressource" ItemType="EmbeddedResource">
     <NameValuePair Name="DefaultMetadata_Generator" Value="ResXFileCodeGenerator" />
   </ContentType>
+  <ContentType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" ItemType="UpToDateCheckInput"></ContentType>
+  <ContentType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" ItemType="UpToDateCheckOutput"></ContentType>
   <ItemType Name="None" DisplayName="Keine" />
   <ItemType Name="Content" DisplayName="Inhalt" />
   <ItemType Name="EmbeddedResource" DisplayName="Eingebettete Ressource" />
+  <ItemType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" />
+  <ItemType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" UpToDateCheckInput="False" />
   <FileExtension Name=".asax" ContentType="Asax" />
   <FileExtension Name=".asmx" ContentType="HTML" />
   <FileExtension Name=".asp" ContentType="AspPage" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/ProjectItemsSchema.xaml
@@ -12,9 +12,13 @@
   <ContentType Name="EmbeddedResource" DisplayName="Recurso incrustado" ItemType="EmbeddedResource">
     <NameValuePair Name="DefaultMetadata_Generator" Value="ResXFileCodeGenerator" />
   </ContentType>
+  <ContentType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" ItemType="UpToDateCheckInput"></ContentType>
+  <ContentType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" ItemType="UpToDateCheckOutput"></ContentType>
   <ItemType Name="None" DisplayName="Ninguno" />
   <ItemType Name="Content" DisplayName="Contenido" />
   <ItemType Name="EmbeddedResource" DisplayName="Recurso incrustado" />
+  <ItemType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" />
+  <ItemType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" UpToDateCheckInput="False" />
   <FileExtension Name=".asax" ContentType="Asax" />
   <FileExtension Name=".asmx" ContentType="HTML" />
   <FileExtension Name=".asp" ContentType="AspPage" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/ProjectItemsSchema.xaml
@@ -12,9 +12,13 @@
   <ContentType Name="EmbeddedResource" DisplayName="Ressource incorporée" ItemType="EmbeddedResource">
     <NameValuePair Name="DefaultMetadata_Generator" Value="ResXFileCodeGenerator" />
   </ContentType>
+  <ContentType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" ItemType="UpToDateCheckInput"></ContentType>
+  <ContentType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" ItemType="UpToDateCheckOutput"></ContentType>
   <ItemType Name="None" DisplayName="Aucun" />
   <ItemType Name="Content" DisplayName="Contenu" />
   <ItemType Name="EmbeddedResource" DisplayName="Ressource incorporée" />
+  <ItemType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" />
+  <ItemType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" UpToDateCheckInput="False" />
   <FileExtension Name=".asax" ContentType="Asax" />
   <FileExtension Name=".asmx" ContentType="HTML" />
   <FileExtension Name=".asp" ContentType="AspPage" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/ProjectItemsSchema.xaml
@@ -12,9 +12,13 @@
   <ContentType Name="EmbeddedResource" DisplayName="Risorsa incorporata" ItemType="EmbeddedResource">
     <NameValuePair Name="DefaultMetadata_Generator" Value="ResXFileCodeGenerator" />
   </ContentType>
+  <ContentType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" ItemType="UpToDateCheckInput"></ContentType>
+  <ContentType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" ItemType="UpToDateCheckOutput"></ContentType>
   <ItemType Name="None" DisplayName="Nessuno" />
   <ItemType Name="Content" DisplayName="Contenuto" />
   <ItemType Name="EmbeddedResource" DisplayName="Risorsa incorporata" />
+  <ItemType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" />
+  <ItemType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" UpToDateCheckInput="False" />
   <FileExtension Name=".asax" ContentType="Asax" />
   <FileExtension Name=".asmx" ContentType="HTML" />
   <FileExtension Name=".asp" ContentType="AspPage" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/ProjectItemsSchema.xaml
@@ -12,9 +12,13 @@
   <ContentType Name="EmbeddedResource" DisplayName="埋め込みリソース" ItemType="EmbeddedResource">
     <NameValuePair Name="DefaultMetadata_Generator" Value="ResXFileCodeGenerator" />
   </ContentType>
+  <ContentType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" ItemType="UpToDateCheckInput"></ContentType>
+  <ContentType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" ItemType="UpToDateCheckOutput"></ContentType>
   <ItemType Name="None" DisplayName="なし" />
   <ItemType Name="Content" DisplayName="コンテンツ" />
   <ItemType Name="EmbeddedResource" DisplayName="埋め込みリソース" />
+  <ItemType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" />
+  <ItemType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" UpToDateCheckInput="False" />
   <FileExtension Name=".asax" ContentType="Asax" />
   <FileExtension Name=".asmx" ContentType="HTML" />
   <FileExtension Name=".asp" ContentType="AspPage" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/ProjectItemsSchema.xaml
@@ -12,9 +12,13 @@
   <ContentType Name="EmbeddedResource" DisplayName="포함 리소스" ItemType="EmbeddedResource">
     <NameValuePair Name="DefaultMetadata_Generator" Value="ResXFileCodeGenerator" />
   </ContentType>
+  <ContentType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" ItemType="UpToDateCheckInput"></ContentType>
+  <ContentType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" ItemType="UpToDateCheckOutput"></ContentType>
   <ItemType Name="None" DisplayName="없음" />
   <ItemType Name="Content" DisplayName="내용" />
   <ItemType Name="EmbeddedResource" DisplayName="포함 리소스" />
+  <ItemType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" />
+  <ItemType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" UpToDateCheckInput="False" />
   <FileExtension Name=".asax" ContentType="Asax" />
   <FileExtension Name=".asmx" ContentType="HTML" />
   <FileExtension Name=".asp" ContentType="AspPage" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/ProjectItemsSchema.xaml
@@ -12,9 +12,13 @@
   <ContentType Name="EmbeddedResource" DisplayName="Osadzony zasób" ItemType="EmbeddedResource">
     <NameValuePair Name="DefaultMetadata_Generator" Value="ResXFileCodeGenerator" />
   </ContentType>
+  <ContentType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" ItemType="UpToDateCheckInput"></ContentType>
+  <ContentType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" ItemType="UpToDateCheckOutput"></ContentType>
   <ItemType Name="None" DisplayName="Brak" />
   <ItemType Name="Content" DisplayName="Zawartość" />
   <ItemType Name="EmbeddedResource" DisplayName="Osadzony zasób" />
+  <ItemType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" />
+  <ItemType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" UpToDateCheckInput="False" />
   <FileExtension Name=".asax" ContentType="Asax" />
   <FileExtension Name=".asmx" ContentType="HTML" />
   <FileExtension Name=".asp" ContentType="AspPage" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/ProjectItemsSchema.xaml
@@ -12,9 +12,13 @@
   <ContentType Name="EmbeddedResource" DisplayName="Recurso inserido" ItemType="EmbeddedResource">
     <NameValuePair Name="DefaultMetadata_Generator" Value="ResXFileCodeGenerator" />
   </ContentType>
+  <ContentType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" ItemType="UpToDateCheckInput"></ContentType>
+  <ContentType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" ItemType="UpToDateCheckOutput"></ContentType>
   <ItemType Name="None" DisplayName="Nenhum" />
   <ItemType Name="Content" DisplayName="Conteúdo" />
   <ItemType Name="EmbeddedResource" DisplayName="Recurso inserido" />
+  <ItemType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" />
+  <ItemType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" UpToDateCheckInput="False" />
   <FileExtension Name=".asax" ContentType="Asax" />
   <FileExtension Name=".asmx" ContentType="HTML" />
   <FileExtension Name=".asp" ContentType="AspPage" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/ProjectItemsSchema.xaml
@@ -12,9 +12,13 @@
   <ContentType Name="EmbeddedResource" DisplayName="Внедренный ресурс" ItemType="EmbeddedResource">
     <NameValuePair Name="DefaultMetadata_Generator" Value="ResXFileCodeGenerator" />
   </ContentType>
+  <ContentType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" ItemType="UpToDateCheckInput"></ContentType>
+  <ContentType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" ItemType="UpToDateCheckOutput"></ContentType>
   <ItemType Name="None" DisplayName="Нет" />
   <ItemType Name="Content" DisplayName="Содержимое" />
   <ItemType Name="EmbeddedResource" DisplayName="Внедренный ресурс" />
+  <ItemType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" />
+  <ItemType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" UpToDateCheckInput="False" />
   <FileExtension Name=".asax" ContentType="Asax" />
   <FileExtension Name=".asmx" ContentType="HTML" />
   <FileExtension Name=".asp" ContentType="AspPage" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/ProjectItemsSchema.xaml
@@ -12,9 +12,13 @@
   <ContentType Name="EmbeddedResource" DisplayName="Eklenmiş kaynak" ItemType="EmbeddedResource">
     <NameValuePair Name="DefaultMetadata_Generator" Value="ResXFileCodeGenerator" />
   </ContentType>
+  <ContentType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" ItemType="UpToDateCheckInput"></ContentType>
+  <ContentType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" ItemType="UpToDateCheckOutput"></ContentType>
   <ItemType Name="None" DisplayName="Hiçbiri" />
   <ItemType Name="Content" DisplayName="İçerik" />
   <ItemType Name="EmbeddedResource" DisplayName="Eklenmiş kaynak" />
+  <ItemType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" />
+  <ItemType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" UpToDateCheckInput="False" />
   <FileExtension Name=".asax" ContentType="Asax" />
   <FileExtension Name=".asmx" ContentType="HTML" />
   <FileExtension Name=".asp" ContentType="AspPage" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.cs.xlf
@@ -63,6 +63,26 @@
         <target state="translated">Vložený prostředek</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.de.xlf
@@ -63,6 +63,26 @@
         <target state="translated">Eingebettete Ressource</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.es.xlf
@@ -63,6 +63,26 @@
         <target state="translated">Recurso incrustado</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.fr.xlf
@@ -63,6 +63,26 @@
         <target state="translated">Ressource incorporée</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.it.xlf
@@ -63,6 +63,26 @@
         <target state="translated">Risorsa incorporata</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.ja.xlf
@@ -63,6 +63,26 @@
         <target state="translated">埋め込みリソース</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.ko.xlf
@@ -63,6 +63,26 @@
         <target state="translated">포함 리소스</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.pl.xlf
@@ -63,6 +63,26 @@
         <target state="translated">Osadzony zasób</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.pt-BR.xlf
@@ -63,6 +63,26 @@
         <target state="translated">Recurso inserido</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.ru.xlf
@@ -63,6 +63,26 @@
         <target state="translated">Внедренный ресурс</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.tr.xlf
@@ -63,6 +63,26 @@
         <target state="translated">Eklenmiş kaynak</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.xlf
@@ -51,6 +51,22 @@
         <source>Embedded resource</source>
         <note />
       </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.zh-Hans.xlf
@@ -63,6 +63,26 @@
         <target state="translated">嵌入的资源</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectItemsSchema.xaml.zh-Hant.xlf
@@ -63,6 +63,26 @@
         <target state="translated">內嵌資源</target>
         <note />
       </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ContentType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckInput|DisplayName">
+        <source>Up-to-date check input</source>
+        <target state="new">Up-to-date check input</target>
+        <note></note>
+      </trans-unit>
+      <trans-unit id="ItemType|UpToDateCheckOutput|DisplayName">
+        <source>Up-to-date check output</source>
+        <target state="new">Up-to-date check output</target>
+        <note></note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/ProjectItemsSchema.xaml
@@ -12,9 +12,13 @@
   <ContentType Name="EmbeddedResource" DisplayName="嵌入的资源" ItemType="EmbeddedResource">
     <NameValuePair Name="DefaultMetadata_Generator" Value="ResXFileCodeGenerator" />
   </ContentType>
+  <ContentType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" ItemType="UpToDateCheckInput"></ContentType>
+  <ContentType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" ItemType="UpToDateCheckOutput"></ContentType>
   <ItemType Name="None" DisplayName="无" />
   <ItemType Name="Content" DisplayName="内容" />
   <ItemType Name="EmbeddedResource" DisplayName="嵌入的资源" />
+  <ItemType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" />
+  <ItemType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" UpToDateCheckInput="False" />
   <FileExtension Name=".asax" ContentType="Asax" />
   <FileExtension Name=".asmx" ContentType="HTML" />
   <FileExtension Name=".asp" ContentType="AspPage" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/ProjectItemsSchema.xaml
@@ -12,9 +12,13 @@
   <ContentType Name="EmbeddedResource" DisplayName="內嵌資源" ItemType="EmbeddedResource">
     <NameValuePair Name="DefaultMetadata_Generator" Value="ResXFileCodeGenerator" />
   </ContentType>
+  <ContentType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" ItemType="UpToDateCheckInput"></ContentType>
+  <ContentType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" ItemType="UpToDateCheckOutput"></ContentType>
   <ItemType Name="None" DisplayName="無" />
   <ItemType Name="Content" DisplayName="內容" />
   <ItemType Name="EmbeddedResource" DisplayName="內嵌資源" />
+  <ItemType Name="UpToDateCheckInput" DisplayName="Up-to-date check input" />
+  <ItemType Name="UpToDateCheckOutput" DisplayName="Up-to-date check output" UpToDateCheckInput="False" />
   <FileExtension Name=".asax" ContentType="Asax" />
   <FileExtension Name=".asmx" ContentType="HTML" />
   <FileExtension Name=".asp" ContentType="AspPage" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -216,6 +216,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 _items[itemType.Key] = new HashSet<(string Path, CopyToOutputDirectoryType CopyType)>(items, UpToDateCheckItemComparer.Instance);
                 _itemsChangedSinceLastCheck = true;
             }
+
+            if (e.ProjectChanges.TryGetValue(UpToDateCheckOutput.SchemaName, out var outputs) &&
+                outputs.Difference.AnyChanges)
+            {
+                _customOutputs.Clear();
+                _customOutputs.AddRange(outputs.After.Items.Select(item => item.Value[UpToDateCheckOutput.FullPathProperty]));
+            }
         }
 
         private void OnOutputGroupChanged(IImmutableDictionary<string, IOutputGroup> e)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -504,7 +504,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     return false;
                 }
 
-                if (outputItemTime < itemTime)
+                if (outputItemTime <= itemTime)
                 {
                     return false;
                 }
@@ -558,21 +558,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             if (!markersUpToDate)
             {
-                Fail(logger, "Project is not up to date due to markers being out of date.", "Marker");
+                _telemetryService.PostProperty($"{TelemetryEventName}/Fail", "Reason", "Marker");
             }
             else if (!outputsUpToDate)
             {
-                Fail(logger, "Project is not up to date due to outputs being out of date.", "Outputs");
+                _telemetryService.PostProperty($"{TelemetryEventName}/Fail", "Reason", "Outputs");
             }
             else if (!copyToOutputDirectoryUpToDate)
             {
-                Fail(logger, "Project is not up to date due to file copies being out of date.", "CopyToOutputDirectory");
+                _telemetryService.PostProperty($"{TelemetryEventName}/Fail", "Reason", "CopyToOutputDirectory");
             }
             else
             {
-                logger.Info("Project is up to date.");
                 _telemetryService.PostEvent($"{TelemetryEventName}/Success");
             }
+
+            logger.Info("Project is{0} up to date.", !isUpToDate ? " not" : "");
 
             return isUpToDate;
         }

--- a/src/Targets/Microsoft.Managed.DesignTime.targets
+++ b/src/Targets/Microsoft.Managed.DesignTime.targets
@@ -25,11 +25,6 @@
     <SuppressOutOfDateMessageOnBuild Condition="'$(SuppressOutOfDateMessageOnBuild)' == ''">true</SuppressOutOfDateMessageOnBuild>
   </PropertyGroup>
 
-  <!-- If the project we're compiling has a ruleset, make sure we check it for up-to-date checks. -->
-  <ItemGroup Condition="'$(CodeAnalysisRuleSet)' != ''">
-    <UpToDateCheckInput Include="$(CodeAnalysisRuleSet)" />
-  </ItemGroup>
-
   <!--
     Locate the approriate localized xaml resources based on the language ID or name.
 

--- a/src/Targets/Microsoft.Managed.DesignTime.targets
+++ b/src/Targets/Microsoft.Managed.DesignTime.targets
@@ -25,6 +25,11 @@
     <SuppressOutOfDateMessageOnBuild Condition="'$(SuppressOutOfDateMessageOnBuild)' == ''">true</SuppressOutOfDateMessageOnBuild>
   </PropertyGroup>
 
+  <!-- If the project we're compiling has a ruleset, make sure we check it for up-to-date checks. -->
+  <ItemGroup Condition="'$(CodeAnalysisRuleSet)' != ''">
+    <UpToDateCheckInput Include="$(CodeAnalysisRuleSet)" />
+  </ItemGroup>
+
   <!--
     Locate the approriate localized xaml resources based on the language ID or name.
 
@@ -277,16 +282,5 @@
   
   <!-- This target collects all the resolved references that are used to actually compile. -->
   <Target Name="CollectResolvedCompilationReferencesDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(ReferencePathWithRefAssemblies)" />
-
-  <!-- This target collects all up-to-date file additions. -->
-  <Target Name="CollectUpToDateInputsDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(UpToDateCheckInput)">
-    <!-- If the project we're compiling has a ruleset, make sure we check it for up-to-date checks. -->
-    <ItemGroup Condition="'$(ResolvedCodeAnalysisRuleSet)' != ''">
-      <UpToDateCheckInput Include="$([System.IO.Path]::GetFullPath($(ResolvedCodeAnalysisRuleSet)))" />
-    </ItemGroup>
-  </Target>
-
-  <!-- This target collects all up-to-date file additions. -->
-  <Target Name="CollectUpToDateOutputsDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(UpToDateCheckOutput)" />
 
 </Project>


### PR DESCRIPTION
**Customer scenario**

Pull request #2464 caused a performance regression bug (listed below) and has been integrated into d15rel. Pull request #2519 attempted to fix this regression but ended up causing a 40% regression in the F5 after edit scenario in the CSharp UAP scenario. The reason for this is still unclear, so we are backing out both fixes until we can figure out the problem. This will reopen issue #2374, which was the issue the original PR was designed to fix.

**Bugs this fixes:** 

https://devdiv.visualstudio.com/web/wi.aspx?pcguid=011b8bdf-6d56-4f87-be0d-0092136884d9&id=455561

**Workarounds, if any**

None.

**Risk**

Low, returns state to pre-fix.

**Performance impact**

Fixes RPS regressions.

**Is this a regression from a previous update?**

**How was the bug found?**

RPS