### PR TITLE
Updating the Roslyn dependencies to 2.6.0-beta1-61907-05

### DIFF
--- a/build/Targets/References.targets
+++ b/build/Targets/References.targets
@@ -70,7 +70,7 @@
         <PackageReference Include="System.Reflection.Metadata" Version="1.4.2" />
         <PackageReference Include="System.ValueTuple" Version="4.3.0" />
         <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-        <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="2.3.0-beta3-61808-05" />
+        <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="2.6.0-beta1-61911-10" />
         <PackageReference Include="Microsoft.Build" Version="15.1.0-preview-000516-03" />
         <PackageReference Include="Microsoft.Build.Framework" Version="15.1.0-preview-000516-03" />
         <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.0-preview-000516-03" />

--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -122,7 +122,7 @@
   <!-- Import the global NuGet packages -->
   <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers" Version="2.6.0-beta1-61911-10" Condition="'$(UseRoslynAnalyzers)' == 'true'" />
-    <PackageReference Include="Microsoft.Net.RoslynDiagnostics" Version="2.3.0-beta1" Condition="'$(UseRoslynAnalyzers)' == 'true'" />
+    <PackageReference Include="Microsoft.Net.RoslynDiagnostics" Version="2.5.0-beta1-61911-01" Condition="'$(UseRoslynAnalyzers)' == 'true'" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="15.3.23" Condition="'$(UseRoslynAnalyzers)' == 'true'" />
   </ItemGroup>
 

--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -121,7 +121,7 @@
   
   <!-- Import the global NuGet packages -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers" Version="2.3.0-beta3-61808-05" Condition="'$(UseRoslynAnalyzers)' == 'true'" />
+    <PackageReference Include="Microsoft.Net.Compilers" Version="2.6.0-beta1-61911-10" Condition="'$(UseRoslynAnalyzers)' == 'true'" />
     <PackageReference Include="Microsoft.Net.RoslynDiagnostics" Version="2.3.0-beta1" Condition="'$(UseRoslynAnalyzers)' == 'true'" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="15.3.23" Condition="'$(UseRoslynAnalyzers)' == 'true'" />
   </ItemGroup>

--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -37,6 +37,7 @@
     <RoslynIntegrationVsixVersion>2.6.0.6191110</RoslynIntegrationVsixVersion>
     <MoqVersion>4.2.1402.2112</MoqVersion>
     <MicrosoftVisualStudioTextLogicVersion>15.0.26507-alpha</MicrosoftVisualStudioTextLogicVersion>
+    <RoslynDiagnosticsNugetPackageVersion>2.5.0-beta1-61911-01</RoslynDiagnosticsNugetPackageVersion>
     <RoslynToolsDownloadRoslynVsixesVersion>0.3.4-beta</RoslynToolsDownloadRoslynVsixesVersion>
     <RoslynToolsMicrosoftModifyVsixManifestVersion>0.2.4-beta</RoslynToolsMicrosoftModifyVsixManifestVersion>
     <RoslynToolsMicrosoftVSIXExpInstallerVersion>0.4.0-beta</RoslynToolsMicrosoftVSIXExpInstallerVersion>

--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -21,6 +21,7 @@
     <RoslynDependenciesOptimizationDataVersion>2.0.0-rc-61101-17</RoslynDependenciesOptimizationDataVersion>
     <ProjectSystemSDKVersion>15.3.178-pre-g209fb07c2e</ProjectSystemSDKVersion>
     <SystemCollectionsImmutableVersion>1.3.1</SystemCollectionsImmutableVersion>
+    <SystemDiagnosticsProcessVersion>4.3.0</SystemDiagnosticsProcessVersion>
     <SystemReflectionMetadataVersion>1.4.2</SystemReflectionMetadataVersion>
     <SystemRuntimeInteropServicesRuntimeInformationVersion>4.3.0</SystemRuntimeInteropServicesRuntimeInformationVersion>
     <MicrosoftDotNetIBCMergeVersion>4.7.1-alpha-00001</MicrosoftDotNetIBCMergeVersion>

--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -33,8 +33,8 @@
     <MicrosoftVisualStudioShellDesign>15.0.26507-alpha</MicrosoftVisualStudioShellDesign>
     <MicrosoftVisualStudioManagedInterfaces>8.0.50727</MicrosoftVisualStudioManagedInterfaces>
     <!-- NOTE: Both of these should be updated at once to reference the same roslyn build-->
-    <MicrosoftVisualStudioLanguageServicesVersion>2.3.0-beta3-61808-05</MicrosoftVisualStudioLanguageServicesVersion>
-    <RoslynIntegrationVsixVersion>2.3.0.6182805</RoslynIntegrationVsixVersion>
+    <MicrosoftVisualStudioLanguageServicesVersion>2.6.0-beta1-61911-10</MicrosoftVisualStudioLanguageServicesVersion>
+    <RoslynIntegrationVsixVersion>2.6.0.6191110</RoslynIntegrationVsixVersion>
     <MoqVersion>4.2.1402.2112</MoqVersion>
     <MicrosoftVisualStudioTextLogicVersion>15.0.26507-alpha</MicrosoftVisualStudioTextLogicVersion>
     <RoslynToolsDownloadRoslynVsixesVersion>0.3.4-beta</RoslynToolsDownloadRoslynVsixesVersion>

--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -40,7 +40,7 @@
     <RoslynDiagnosticsNugetPackageVersion>2.5.0-beta1-61911-01</RoslynDiagnosticsNugetPackageVersion>
     <RoslynToolsDownloadRoslynVsixesVersion>0.3.4-beta</RoslynToolsDownloadRoslynVsixesVersion>
     <RoslynToolsMicrosoftModifyVsixManifestVersion>0.2.4-beta</RoslynToolsMicrosoftModifyVsixManifestVersion>
-    <RoslynToolsMicrosoftVSIXExpInstallerVersion>0.4.0-beta</RoslynToolsMicrosoftVSIXExpInstallerVersion>
+    <RoslynToolsMicrosoftVSIXExpInstallerVersion>0.4.1-beta</RoslynToolsMicrosoftVSIXExpInstallerVersion>
     <XUnitVersion>2.2.0-beta4-build3444</XUnitVersion>
     <XUnitRunnerConsoleVersion>2.2.0</XUnitRunnerConsoleVersion>
     <XUnitRunnerVisualstudioVersion>2.2.0</XUnitRunnerVisualstudioVersion>

--- a/src/Common/Integration/App.config
+++ b/src/Common/Integration/App.config
@@ -34,6 +34,10 @@
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-1.2.1.0" newVersion="1.2.1.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO.FileSystem" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/DeployIntegrationDependencies/DeployIntegrationDependencies.csproj
+++ b/src/DeployIntegrationDependencies/DeployIntegrationDependencies.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="RoslynTools.DownloadRoslynVsixes" Version="$(RoslynToolsDownloadRoslynVsixesVersion)" />
     <PackageReference Include="RoslynTools.Microsoft.ModifyVsixManifest" Version="$(RoslynToolsMicrosoftModifyVsixManifestVersion)" />
     <PackageReference Include="RoslynTools.Microsoft.VSIXExpInstaller" Version="$(RoslynToolsMicrosoftVSIXExpInstallerVersion)" />
+    <PackageReference Include="System.Diagnostics.Process" Version="[$(SystemDiagnosticsProcessVersion)]" />
     <PackageReference Include="System.Reflection.Metadata" Version="[$(SystemReflectionMetadataVersion)]" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="$(SystemRuntimeInteropServicesRuntimeInformationVersion)" />
     <PackageReference Include="xunit.runner.console" Version="[$(XUnitRunnerConsoleVersion)]" />

--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -4,15 +4,14 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="myget.org roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
-    <add key="myget.org dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-    <add key="myget.org roslyn-master-nightly" value="https://dotnet.myget.org/F/roslyn-master-nightly/api/v3/index.json" />
-    <add key="myget.org roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
-    <add key="myget.org msbuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
-    <add key="myget.org nuget-build" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
+    <add key="dotnet.myget.org dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="dotnet.myget.org msbuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
+    <add key="dotnet.myget.org nuget-build" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
+    <add key="dotnet.myget.org roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
+    <add key="dotnet.myget.org roslyn-analyzers" value="https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json" />
     <add key="dotnet.myget.org roslyn-tools" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
-    <add key="myget.org vs-devcore" value="http://www.myget.org/F/vs-devcore/api/v3/index.json" />
     <add key="dotnet.myget.org templating" value="https://dotnet.myget.org/F/templating/api/v3/index.json" />
+    <add key="myget.org vs-devcore" value="http://www.myget.org/F/vs-devcore/api/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 


### PR DESCRIPTION
This resolves https://github.com/dotnet/project-system/issues/2528

I am waiting to hear back from @jasonmalinowski, @Pilchie, or @jaredpar on whether Roslyn is staying 2.6.0 or if it will be moving back to 2.5.0