### PR TITLE
Reduce the amount of data we're allocating on project open by 39%

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
@@ -112,8 +112,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
             if (!ManagedPathHelper.IsRooted(dependency.OriginalItemSpec))
             {
-                var projectFolder = Path.GetDirectoryName(containingProjectPath);
-                dependencyProjectPath = ManagedPathHelper.TryMakeRooted(projectFolder, dependency.OriginalItemSpec);
+                dependencyProjectPath = ManagedPathHelper.TryMakeRooted(containingProjectPath, dependency.OriginalItemSpec);
             }
 
             return dependencyProjectPath;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ProjectRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ProjectRuleHandler.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
@@ -115,8 +114,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             var dependencyThatNeedChange = new List<IDependency>();
             foreach(var target in projectSnapshot.Targets)
             {
-                foreach (var dependency in target.Value.TopLevelDependencies.Where(d => StringComparers.DependencyProviderTypes.Equals(d.ProviderType, ProviderTypeString)))
+                foreach (var dependency in target.Value.TopLevelDependencies)
                 {
+                    // We're only interested in project dependencies
+                    if (!StringComparers.DependencyProviderTypes.Equals(dependency.ProviderType, ProviderTypeString))
+                        continue;
+
                     if (otherProjectPath.Equals(dependency.GetActualPath(projectPath)))
                     {
                         dependencyThatNeedChange.Add(dependency);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ProjectRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ProjectRuleHandler.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
@@ -114,7 +115,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             var dependencyThatNeedChange = new List<IDependency>();
             foreach(var target in projectSnapshot.Targets)
             {
-                foreach (var dependency in target.Value.TopLevelDependencies)
+                foreach (var dependency in target.Value.TopLevelDependencies.Where(d => StringComparers.DependencyProviderTypes.Equals(d.ProviderType, ProviderTypeString)))
                 {
                     if (otherProjectPath.Equals(dependency.GetActualPath(projectPath)))
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/ManagedPathHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/ManagedPathHelper.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
 
             try
             {
-                return PathHelper.MakeRooted(PathHelper.EnsureTrailingSlash(basePath), path);
+                return PathHelper.MakeRooted(basePath, path);
             }
             catch (ArgumentException)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/StringComparers.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/StringComparers.cs
@@ -29,5 +29,10 @@ namespace Microsoft.VisualStudio
         {
             get { return StringComparer.Ordinal; }
         }
+
+        public static IEqualityComparer<string> DependencyProviderTypes
+        {
+            get { return StringComparer.OrdinalIgnoreCase; }
+        }
     }
 }


### PR DESCRIPTION
**Customer scenario**

User experiences UI delays and general performance delays during solution load and for a short period afterwards. Changes to projects, such as changing branches or installing/changing NuGet packages can also cause delays.

**Bugs this fixes:** 

https://github.com/dotnet/project-system/issues/2533.

**Workarounds, if any**

No workaround.

**Risk**

Low.

**Performance impact**

This reduces the amount of data we allocate opening a solution and for a short period after we open by 39%.

Opening Roslyn.sln, and waiting for ~9 minutes after it has loaded (until we'd stopped processing data) this made the following improvements:

|Metric|Before Fix|After Fix|Reduction|
|----|---:|---:|---:|
|% CPU Time paused for GC|16%|10.5%|35%
|Total CPU Time paused for GC|82 secs|54 secs|34%
|# Gen 0 GCs|5467|2823|48%
|# Gen 1 GCs|4644|4059|13%
|Allocations|390 GB|239 GB|39%


**Is this a regression from a previous update?**

Yes. This was introduced as part of the dependency tree rewrite.

**Root cause analysis:**

When a project's dependencies change, it calls a call back into every project in the solution telling it that it needs to update. The calculation on whether a project needed to update allocated lots of strings, which increased based on how many references a project had and how many projects were in the solution.

We've been peeling the onion with the dependencies tree, this was the next one we found.

**How was the bug found?**

Dogfooding.

**Dev Notes** 

Note, this is just a port of https://github.com/dotnet/project-system/issues/2537 and https://github.com/dotnet/project-system/issues/2545 (already reviewed) to the 15.3 branch.