### PR TITLE
Stop filtering dependencies twice

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ProjectRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ProjectRuleHandler.cs
@@ -115,7 +115,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             var dependencyThatNeedChange = new List<IDependency>();
             foreach(var target in projectSnapshot.Targets)
             {
-                foreach (var dependency in target.Value.TopLevelDependencies.Where(d => StringComparers.DependencyProviderTypes.Equals(d.ProviderType, ProviderTypeString)))
+                foreach (var dependency in target.Value.TopLevelDependencies)
                 {
                     // We're only interested in project dependencies
                     if (!StringComparers.DependencyProviderTypes.Equals(dependency.ProviderType, ProviderTypeString))


### PR DESCRIPTION
A bad merge from 15.3 -> master resulted in us filtering twice. Taking the change rom 15.3 as it removed two allocations.