### PR TITLE
Reduce allocations in OnOtherProjectDependenciesChanged significantly

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyFactory.cs
@@ -22,6 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                                             string id = null,
                                             string originalItemSpec = null,
                                             string path = null,
+                                            string fullPath = null,
                                             string name = null,
                                             string caption = null,
                                             string alias = null,
@@ -56,6 +57,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             if (originalItemSpec != null)
             {
                 mock.Setup(x => x.OriginalItemSpec).Returns(originalItemSpec);
+            }
+
+            if (fullPath != null)
+            {
+                mock.Setup(x => x.FullPath).Returns(fullPath);
             }
 
             if (path != null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyExtensionsTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyExtensionsTests.cs
@@ -194,35 +194,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void GetActualPath()
-        {
-            const string projectPath = @"c:\somepath\someproject\project.csproj";
-            var dependency1 = IDependencyFactory.FromJson(@"
-{
-    ""Id"":""id1"",
-    ""ProviderType"": ""ProjectDependency""
-}");
-
-            Assert.Null(dependency1.GetActualPath(projectPath));
-
-            var dependency2 = IDependencyFactory.FromJson(@"
-{
-    ""Id"":""id1"",
-    ""OriginalItemSpec"": ""c:\\somerootedpath\\xxx""
-}");
-
-            Assert.Equal("c:\\somerootedpath\\xxx", dependency2.GetActualPath(projectPath));
-
-            var dependency3 = IDependencyFactory.FromJson(@"
-{
-    ""Id"":""id1"",
-    ""OriginalItemSpec"": ""subfolder\\xxx""
-}");
-
-            Assert.Equal(@"c:\somepath\someproject\subfolder\xxx", dependency3.GetActualPath(projectPath));
-        }
-
-        [Fact]
         public void GetTopLevelId()
         {
             var dependency1 = IDependencyFactory.FromJson(@"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyTests.cs
@@ -17,25 +17,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         {
             Assert.Throws<ArgumentNullException>("dependencyModel", () =>
             {
-                new Dependency(null, null);
+                new Dependency(null, null, null);
             });
 
             Assert.Throws<ArgumentNullException>("ProviderType", () =>
             {
                 var mockModel = IDependencyModelFactory.Create();
-                new Dependency(mockModel, null);
+                new Dependency(mockModel, null, null);
             });
 
             Assert.Throws<ArgumentNullException>("Id", () =>
             {
                 var mockModel = IDependencyModelFactory.Implement(providerType: "someprovider");
-                new Dependency(mockModel, null);
+                new Dependency(mockModel, null, null);
             });
 
             Assert.Throws<ArgumentNullException>("targetFramework", () =>
             {
                 var mockModel = IDependencyModelFactory.Implement(providerType: "someprovider", id: "id");
-                new Dependency(mockModel, null);
+                new Dependency(mockModel, null, null);
             });
         }
 
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 }";
             var mockModel = IDependencyModelFactory.FromJson(jsonModel);
 
-            var dependency = new Dependency(mockModel, ITargetFrameworkFactory.Implement("tfm1"));
+            var dependency = new Dependency(mockModel, ITargetFrameworkFactory.Implement("tfm1"), @"C:\Foo\Project.csproj");
 
             Assert.Equal(mockModel.ProviderType, dependency.ProviderType);
             Assert.Equal(string.Empty, dependency.Name);
@@ -98,7 +98,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             var targetFramework = ITargetFrameworkFactory.Implement("Tfm1");
 
-            var dependency = new Dependency(mockModel, targetFramework);
+            var dependency = new Dependency(mockModel, targetFramework, @"C:\Foo\Project.csproj");
 
             Assert.Equal(mockModel.ProviderType, dependency.ProviderType);
             Assert.Equal(mockModel.Name, dependency.Name);
@@ -130,7 +130,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var mockModel = IDependencyModelFactory.Implement(providerType: "xxx", id: modelId);
             var mockSnapshot = ITargetedDependenciesSnapshotFactory.Create();
 
-            var dependency = new Dependency(mockModel, ITargetFrameworkFactory.Implement("tfm1"));
+            var dependency = new Dependency(mockModel, ITargetFrameworkFactory.Implement("tfm1"), @"C:\Foo\Project.cspoj");
 
             Assert.Equal(mockModel.ProviderType, dependency.ProviderType);
             Assert.Equal(expectedId, dependency.Id);
@@ -145,7 +145,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var mockModel = IDependencyModelFactory.Implement(providerType: "providerType", id: modelId);
             var mockTargetFramework = ITargetFrameworkFactory.Implement(moniker: "tfm");
 
-            var dependency = new Dependency(mockModel, mockTargetFramework);
+            var dependency = new Dependency(mockModel, mockTargetFramework, @"C:\Foo\Project.csproj");
 
             Assert.Equal(mockModel.ProviderType, dependency.ProviderType);
             Assert.Equal(expectedId, dependency.Id);
@@ -166,7 +166,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 caption: caption);
             var mockTargetFramework = ITargetFrameworkFactory.Implement(moniker: "tfm");
 
-            var dependency = new Dependency(mockModel, mockTargetFramework);
+            var dependency = new Dependency(mockModel, mockTargetFramework, @"C:\Foo\Project.csproj");
 
             Assert.Equal(expectedAlias, dependency.Alias);
         }
@@ -185,9 +185,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 id: "someId_other");
 
             var targetFramework = ITargetFrameworkFactory.Implement("tfm1");
-            var dependency1 = new Dependency(mockModel1, targetFramework);
-            var dependency2 = new Dependency(mockModel2, targetFramework);
-            var dependency3 = new Dependency(mockModel3, targetFramework);
+            var dependency1 = new Dependency(mockModel1, targetFramework, @"C:\Foo\Project.csproj");
+            var dependency2 = new Dependency(mockModel2, targetFramework, @"C:\Foo\Project.csproj");
+            var dependency3 = new Dependency(mockModel3, targetFramework, @"C:\Foo\Project.csproj");
 
             Assert.Equal(dependency1, dependency2);
             Assert.NotEqual(dependency1, dependency3);
@@ -202,7 +202,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 providerType: "providerType",
                 id: "someId");
 
-            var dependency = new Dependency(mockModel, ITargetFrameworkFactory.Implement("tfm1"));
+            var dependency = new Dependency(mockModel, ITargetFrameworkFactory.Implement("tfm1"), @"C:\Foo\Project.csproj");
 
             var newDependency = dependency.SetProperties(
                 caption: "newcaption",
@@ -224,7 +224,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 providerType: "providerType",
                 id: "cube",
                 dependencyIDs: ImmutableList<string>.Empty.Add("glass"));
-            var dependency = new Dependency(mockModel, ITargetFrameworkFactory.Implement("tfm1"));
+            var dependency = new Dependency(mockModel, ITargetFrameworkFactory.Implement("tfm1"), @"C:\Foo\Project.csproj");
 
             var expectedId = "tfm1\\providerType\\cube";
             var expectedDependencyId = "tfm1\\providerType\\glass";
@@ -289,7 +289,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             var mockSnapshot = ITargetedDependenciesSnapshotFactory.ImplementHasUnresolvedDependency(@"tfm1\providerType\someid1", true);
 
-            var dependency = new Dependency(mockModel1, ITargetFrameworkFactory.Implement("tfm1"));
+            var dependency = new Dependency(mockModel1, ITargetFrameworkFactory.Implement("tfm1"), @"C:\Foo\Project.csproj");
 
             Assert.True(dependency.HasUnresolvedDependency(mockSnapshot));
             Assert.True(dependency.IsOrHasUnresolvedDependency(mockSnapshot));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependency.cs
@@ -19,6 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         public string Caption { get; set; }
         public string OriginalItemSpec { get; set; }
         public string Path { get; set; }
+        public string FullPath { get; set; }
         public string SchemaName { get; set; }
         public string SchemaItemType { get; set; }
         public string Version { get; set; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnsupportedProjectsSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnsupportedProjectsSnapshotFilterTests.cs
@@ -114,7 +114,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     topLevel: true,
                     resolved: true,
                     flags: DependencyTreeFlags.ProjectNodeFlags.Union(DependencyTreeFlags.ResolvedFlags),
-                    originalItemSpec:@"c:\myproject2\project.csproj",
+                    fullPath: @"c:\myproject1\project.csproj",
                     setPropertiesResolved:false,
                     setPropertiesSchemaName:ProjectReference.SchemaName,
                     setPropertiesFlags: DependencyTreeFlags.ProjectNodeFlags.Union(DependencyTreeFlags.UnresolvedFlags));
@@ -145,7 +145,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     topLevel: true,
                     resolved: true,
                     flags: DependencyTreeFlags.ProjectNodeFlags.Union(DependencyTreeFlags.ResolvedFlags),
-                    originalItemSpec: @"c:\myproject2\project.csproj");
+                    fullPath: @"c:\myproject1\project.csproj");
 
             var filter = new UnsupportedProjectsSnapshotFilter(aggregateSnapshotProvider, null);
 
@@ -181,7 +181,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     topLevel: true,
                     resolved: true,
                     flags: DependencyTreeFlags.ProjectNodeFlags.Union(DependencyTreeFlags.ResolvedFlags),
-                    originalItemSpec: @"c:\myproject2\project.csproj",
+                    fullPath: @"c:\myproject1\project.csproj",
                     targetFramework: targetFramework);
 
             var filter = new UnsupportedProjectsSnapshotFilter(aggregateSnapshotProvider, targetFrameworkProvider);
@@ -218,7 +218,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     topLevel: true,
                     resolved: true,
                     flags: DependencyTreeFlags.ProjectNodeFlags.Union(DependencyTreeFlags.ResolvedFlags),
-                    originalItemSpec: @"c:\myproject2\project.csproj",
+                    fullPath: @"c:\myproject1\project.csproj",
                     targetFramework: targetFramework
                  );
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/ProjectGraphViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/ProjectGraphViewProvider.cs
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
 
         private ITargetedDependenciesSnapshot GetSnapshot(string projectPath, IDependency dependency, out string dependencyProjectPath)
         {
-            dependencyProjectPath = dependency.GetActualPath(projectPath);
+            dependencyProjectPath = dependency.FullPath;
 
             var snapshotProvider = AggregateSnapshotProvider.GetSnapshotProvider(dependencyProjectPath);
             if (snapshotProvider == null)
@@ -102,7 +102,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
 
         public override bool ShouldTrackChanges(string projectPath, string updatedProjectPath, IDependency dependency)
         {
-            var dependencyProjectPath = dependency.GetActualPath(projectPath);
+            var dependencyProjectPath = dependency.FullPath;
             return !string.IsNullOrEmpty(dependencyProjectPath)
                     && dependencyProjectPath.Equals(updatedProjectPath, StringComparison.OrdinalIgnoreCase);
         }
@@ -171,7 +171,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
                 return true;
             }
 
-            var projectFullPath = topLevelDependency.GetActualPath(projectPath);
+            var projectFullPath = topLevelDependency.FullPath;
             if (!searchResultsPerContext.TryGetValue(projectFullPath, out HashSet<IDependency> contextResults)
                 || contextResults.Count == 0)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/UnsupportedProjectsSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/UnsupportedProjectsSnapshotFilter.cs
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
                 && resultDependency.Flags.Contains(DependencyTreeFlags.ProjectNodeFlags)
                 && !resultDependency.Flags.Contains(DependencyTreeFlags.SharedProjectFlags))
             {
-                var snapshot = GetSnapshot(projectPath, resultDependency, out string dependencyProjectPath);
+                var snapshot = GetSnapshot(projectPath, resultDependency);
                 if (snapshot != null && snapshot.HasUnresolvedDependency)
                 {
                     filterAnyChanges = true;
@@ -60,12 +60,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             return resultDependency;
         }
 
-        private ITargetedDependenciesSnapshot GetSnapshot(
-            string projectPath, 
-            IDependency dependency, 
-            out string dependencyProjectPath)
+        private ITargetedDependenciesSnapshot GetSnapshot(string projectPath, IDependency dependency)
         {
-            dependencyProjectPath = dependency.GetActualPath(projectPath);
+            string dependencyProjectPath = dependency.GetActualPath(projectPath);
 
             var snapshotProvider = AggregateSnapshotProvider.GetSnapshotProvider(dependencyProjectPath);
             if (snapshotProvider == null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/UnsupportedProjectsSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/UnsupportedProjectsSnapshotFilter.cs
@@ -62,9 +62,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
 
         private ITargetedDependenciesSnapshot GetSnapshot(string projectPath, IDependency dependency)
         {
-            string dependencyProjectPath = dependency.GetActualPath(projectPath);
-
-            var snapshotProvider = AggregateSnapshotProvider.GetSnapshotProvider(dependencyProjectPath);
+            var snapshotProvider = AggregateSnapshotProvider.GetSnapshotProvider(dependency.FullPath);
             if (snapshotProvider == null)
             {
                 return null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependency.cs
@@ -19,6 +19,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         ITargetFramework TargetFramework { get; }
 
         /// <summary>
+        /// Get the full path of the dependency, if relevant, otherwise, <see langword="string.Empty"/>.
+        /// </summary>
+        string FullPath { get; }
+
+        /// <summary>
         /// Alias is used to de-dupe tree nodes in the CPS tree. If there are seberal nodes in the same
         /// folder with the same name, we replace them all with: Alias = "Caption (OriginalItemSpec)".
         /// </summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
@@ -3,11 +3,9 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.IO;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions;
-using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 {
@@ -97,27 +95,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             return self.TargetFramework.Equals(other.TargetFramework);
         }
 
-        /// <summary>
-        /// Tries to convert OriginalItemSpec to absolute path for given dependency. If OriginalItemSpec is 
-        /// absolute path, just returns OriginalItemSpec. If OriginalItemSpec is not absoulte, tries to make
-        /// OriginalItemSpec rooted to current project folder.
-        /// </summary>
-        public static string GetActualPath(this IDependency dependency, string containingProjectPath)
-        {
-            var dependencyProjectPath = dependency.OriginalItemSpec;
-            if (string.IsNullOrEmpty(dependency.OriginalItemSpec))
-            {
-                return null;
-            }
-
-            if (!ManagedPathHelper.IsRooted(dependency.OriginalItemSpec))
-            {
-                dependencyProjectPath = ManagedPathHelper.TryMakeRooted(containingProjectPath, dependency.OriginalItemSpec);
-            }
-
-            return dependencyProjectPath;
-        }
-        
         public static IDependency ToResolved(this IDependency dependency,
                                              string schemaName = null,
                                              IImmutableList<string> dependencyIDs = null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
@@ -203,7 +203,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
             foreach (var added in changes.AddedNodes)
             {
-                IDependency newDependency = new Dependency(added, TargetFramework);
+                IDependency newDependency = new Dependency(added, TargetFramework, ProjectPath);
 
                 if (snapshotFilters != null)
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ProjectRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ProjectRuleHandler.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
@@ -110,7 +109,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             }
 
             var otherProjectPath = otherProjectSnapshot.ProjectPath;
-            var projectPath = CommonServices.Project.FullPath;
 
             var dependencyThatNeedChange = new List<IDependency>();
             foreach(var target in projectSnapshot.Targets)
@@ -121,11 +119,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                     if (!StringComparers.DependencyProviderTypes.Equals(dependency.ProviderType, ProviderTypeString))
                         continue;
 
-                    if (otherProjectPath.Equals(dependency.GetActualPath(projectPath)))
-                    {
-                        dependencyThatNeedChange.Add(dependency);
-                        break;
-                    }
+                    if (!StringComparers.Paths.Equals(otherProjectPath, dependency.FullPath))
+                        continue;
+
+                    dependencyThatNeedChange.Add(dependency);
+                    break;
                 }
             }
 


### PR DESCRIPTION
This reduces the number of total allocations to TryMakeRooted from approx 9.1% (141 MB) of opening/closing solution -> 0.3% (2 MB), by introducing a new property called FullPath on IDependency that is cached and remembered between calls. This is called and only accessed for top level dependencies.

![image](https://user-images.githubusercontent.com/1103906/28414694-3a34c79c-6d90-11e7-8308-4932724e2046.png)

![image](https://user-images.githubusercontent.com/1103906/28414688-314fd8e2-6d90-11e7-830e-65b33861d766.png)
