### PR TITLE
Add exclude source and fallback folder properties to restore nomination

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -114,6 +114,10 @@
                     Visible="False" 
                     ReadOnly="True" />
                     
+    <StringProperty Name="RestoreAdditionalProjectFallbackFoldersExcludes" 
+                    Visible="False" 
+                    ReadOnly="True" />
+                    
     <StringProperty Name="DotnetCliToolTargetFramework" 
                     Visible="False" 
                     ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/cs/NuGetRestore.xaml
@@ -52,6 +52,7 @@
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectFallbackFoldersExcludes" Visible="False" ReadOnly="True" />
   <StringProperty Name="DotnetCliToolTargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/de/NuGetRestore.xaml
@@ -52,6 +52,7 @@
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectFallbackFoldersExcludes" Visible="False" ReadOnly="True" />
   <StringProperty Name="DotnetCliToolTargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/es/NuGetRestore.xaml
@@ -52,6 +52,7 @@
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectFallbackFoldersExcludes" Visible="False" ReadOnly="True" />
   <StringProperty Name="DotnetCliToolTargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/fr/NuGetRestore.xaml
@@ -52,6 +52,7 @@
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectFallbackFoldersExcludes" Visible="False" ReadOnly="True" />
   <StringProperty Name="DotnetCliToolTargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/it/NuGetRestore.xaml
@@ -52,6 +52,7 @@
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectFallbackFoldersExcludes" Visible="False" ReadOnly="True" />
   <StringProperty Name="DotnetCliToolTargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ja/NuGetRestore.xaml
@@ -52,6 +52,7 @@
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectFallbackFoldersExcludes" Visible="False" ReadOnly="True" />
   <StringProperty Name="DotnetCliToolTargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ko/NuGetRestore.xaml
@@ -52,6 +52,7 @@
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectFallbackFoldersExcludes" Visible="False" ReadOnly="True" />
   <StringProperty Name="DotnetCliToolTargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pl/NuGetRestore.xaml
@@ -52,6 +52,7 @@
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectFallbackFoldersExcludes" Visible="False" ReadOnly="True" />
   <StringProperty Name="DotnetCliToolTargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/pt-BR/NuGetRestore.xaml
@@ -52,6 +52,7 @@
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectFallbackFoldersExcludes" Visible="False" ReadOnly="True" />
   <StringProperty Name="DotnetCliToolTargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ru/NuGetRestore.xaml
@@ -52,6 +52,7 @@
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectFallbackFoldersExcludes" Visible="False" ReadOnly="True" />
   <StringProperty Name="DotnetCliToolTargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/tr/NuGetRestore.xaml
@@ -52,6 +52,7 @@
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectFallbackFoldersExcludes" Visible="False" ReadOnly="True" />
   <StringProperty Name="DotnetCliToolTargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hans/NuGetRestore.xaml
@@ -52,6 +52,7 @@
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectFallbackFoldersExcludes" Visible="False" ReadOnly="True" />
   <StringProperty Name="DotnetCliToolTargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/zh-Hant/NuGetRestore.xaml
@@ -52,6 +52,7 @@
   <StringProperty Name="RestorePackagesPath" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectSources" Visible="False" ReadOnly="True" />
   <StringProperty Name="RestoreAdditionalProjectFallbackFolders" Visible="False" ReadOnly="True" />
+  <StringProperty Name="RestoreAdditionalProjectFallbackFoldersExcludes" Visible="False" ReadOnly="True" />
   <StringProperty Name="DotnetCliToolTargetFramework" Visible="False" ReadOnly="True" />
   <StringProperty Name="TreatWarningsAsErrors" Visible="False" ReadOnly="True" />
   <StringProperty Name="WarningsAsErrors" Visible="False" ReadOnly="True" />


### PR DESCRIPTION
**Customer scenario**

Needed to support Escrow NuGet scenario

**Bugs this fixes:** 

#2605 

**Workarounds, if any**

N/A

**Risk**

Low

**Performance impact**

None, just adding another rule

**Is this a regression from a previous update?**

No

**How was the bug found?**

Requested by partner team

/cc @srivatsn 
/cc @emgarten