### PR TITLE
Fixing the DesignerTabButton to only use `Focused` and `GotFocusFromKeyboardNav` when determining whether to draw focus cues.

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabButton.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabButton.vb
@@ -180,7 +180,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
 
         Friend ReadOnly Property DrawFocusCues As Boolean
             Get
-                Return ShowFocusCues OrElse (Focused And FocusedFromKeyboardNav)
+                Return Focused And FocusedFromKeyboardNav
             End Get
         End Property
 


### PR DESCRIPTION
**Customer scenario**

Customer closes a solution with the property page still open, reopens the solution, and then tries to navigate to a new tab using the keyboard.

**Bugs this fixes:** 

Ticket: https://devdiv.visualstudio.com/DevDiv/_workitems?id=466671
Bug: https://devdiv.visualstudio.com/DevDiv/_workitems?id=467800

**Workarounds, if any**

User can close the property page, close and reopen the solution, and then reopen the property page.

**Risk**

Minimal

**Performance impact**

None

**Is this a regression from a previous update?**

New functionality which was fixing an accessibility bug

**Root cause analysis:**

It seems that the `System.Windows.Forms.Control.ShowFocusCues` property has some odd behavior, such as returning `true` if the underlying handle has not been created yet.

**How was the bug found?**

Scenario day bug
