### PR TITLE
Adding Rule files and ProjectItemsSchema entries for 'ApplicationDefinition' and 'Page' files.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -37,6 +37,12 @@
     <Compile Update="ProjectSystem\Rules\AdditionalFiles.cs">
       <DependentUpon>AdditionalFiles.xaml</DependentUpon>
     </Compile>
+    <Compile Update="ProjectSystem\Rules\ApplicationDefinition.cs">
+      <DependentUpon>ApplicationDefinition.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="ProjectSystem\Rules\Page.cs">
+      <DependentUpon>Page.xaml</DependentUpon>
+    </Compile>
     <Compile Update="ProjectSystem\Rules\ProjectDebugger.xaml.cs">
       <DependentUpon>ProjectDebugger.xaml</DependentUpon>
     </Compile>
@@ -161,6 +167,14 @@
     <XamlPropertyRule Include="ProjectSystem\Rules\Content.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
       <SubType>Designer</SubType>
+    </XamlPropertyRule>
+    <XamlPropertyRule Include="ProjectSystem\Rules\ApplicationDefinition.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
+    </XamlPropertyRule>
+    <XamlPropertyRule Include="ProjectSystem\Rules\Page.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\EmbeddedResource.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ApplicationDefinition.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ApplicationDefinition.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
+    partial class ApplicationDefinition
+    {
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ApplicationDefinition.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ApplicationDefinition.xaml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
+<Rule
+    Name="ApplicationDefinition"
+    DisplayName="ApplicationDefinition"
+    PageTemplate="generic"
+    Description="File Properties"
+    xmlns="http://schemas.microsoft.com/build/2009/properties">
+    <Rule.DataSource>
+        <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="ApplicationDefinition" SourceOfDefaultValue="AfterContext" />
+    </Rule.DataSource>
+    <Rule.Categories>
+        <Category Name="Advanced" DisplayName="Advanced" />
+        <Category Name="Misc" DisplayName="Misc" />
+    </Rule.Categories>
+
+    <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Build Action"  Category="Advanced"
+                     Description="How the file relates to the build and deployment processes."
+                     EnumProvider="ItemTypes" />
+    <EnumProperty
+      Name="CopyToOutputDirectory"
+      DisplayName="Copy to Output Directory"
+      Category="Advanced"
+      Description="Specifies the source file will be copied to the output directory.">
+        <EnumValue Name="Never" DisplayName="Do not copy" />
+        <EnumValue Name="Always" DisplayName="Copy always" />
+        <EnumValue Name="PreserveNewest" DisplayName="Copy if newer" />
+    </EnumProperty>
+
+    <StringProperty
+      Name="Generator"
+      Category="Advanced"
+      DisplayName="Custom Tool"
+      Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+    <StringProperty
+      Name="CustomToolNamespace"
+      Category="Advanced"
+      DisplayName="Custom Tool Namespace"
+      Description="The namespace into which the output of the custom tool is placed." />
+
+    <StringProperty
+      Name="Identity"
+      Visible="false"
+      ReadOnly="true"
+      Category="Misc"
+      Description="The item specified in the Include attribute.">
+        <StringProperty.DataSource>
+            <DataSource Persistence="Intrinsic" ItemType="ApplicationDefinition" PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+
+    <StringProperty
+      Name="FullPath"
+      DisplayName="Full Path"
+      ReadOnly="true"
+      Category="Misc"
+      Description="Location of the file.">
+        <StringProperty.DataSource>
+            <DataSource Persistence="Intrinsic" ItemType="ApplicationDefinition" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+
+    <StringProperty
+      Name="FileNameAndExtension"
+      DisplayName="File Name"
+      ReadOnly="true"
+      Category="Misc"
+      Description="Name of the file or folder.">
+        <StringProperty.DataSource>
+            <DataSource Persistence="Intrinsic" ItemType="ApplicationDefinition" PersistedName="FileNameAndExtension" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+
+    <StringProperty Name="URL" ReadOnly="true" Visible="false">
+        <StringProperty.DataSource>
+            <DataSource Persistence="Intrinsic" ItemType="ApplicationDefinition" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+    <BoolProperty Name="Visible" Visible="false" />
+    <StringProperty Name="DependentUpon" Visible="false" />
+    <StringProperty Name="Link" Visible="false">
+        <StringProperty.DataSource>
+            <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+    <StringProperty Name="Extension" Visible="False" ReadOnly="true">
+        <StringProperty.DataSource>
+            <DataSource Persistence="Intrinsic" ItemType="ApplicationDefinition" PersistedName="Extension" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+    <StringProperty Name="LastGenOutput" Visible="false" Description="The filename of the last file generated as a result of the SFG." />
+    <BoolProperty Name="DesignTime" Visible="false" Description="A value indicating whether this file has a designer." />
+    <BoolProperty Name="AutoGen" Visible="false" Description="A value indicating whether this is a generated file." />
+    <StringProperty Name="CustomTool" Visible="false" Description="DTE Property for accessing the Generator property.">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFile" ItemType="ApplicationDefinition" PersistedName="Generator" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+</Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Page.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Page.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
+    partial class Page
+    {
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Page.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Page.xaml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
+<Rule
+    Name="Page"
+    DisplayName="Page"
+    PageTemplate="generic"
+    Description="File Properties"
+    xmlns="http://schemas.microsoft.com/build/2009/properties">
+    <Rule.DataSource>
+        <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="Page" SourceOfDefaultValue="AfterContext" />
+    </Rule.DataSource>
+    <Rule.Categories>
+        <Category Name="Advanced" DisplayName="Advanced" />
+        <Category Name="Misc" DisplayName="Misc" />
+    </Rule.Categories>
+
+    <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Build Action"  Category="Advanced"
+                     Description="How the file relates to the build and deployment processes."
+                     EnumProvider="ItemTypes" />
+    <EnumProperty
+      Name="CopyToOutputDirectory"
+      DisplayName="Copy to Output Directory"
+      Category="Advanced"
+      Description="Specifies the source file will be copied to the output directory.">
+        <EnumValue Name="Never" DisplayName="Do not copy" />
+        <EnumValue Name="Always" DisplayName="Copy always" />
+        <EnumValue Name="PreserveNewest" DisplayName="Copy if newer" />
+    </EnumProperty>
+
+    <StringProperty
+      Name="Generator"
+      Category="Advanced"
+      DisplayName="Custom Tool"
+      Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
+    <StringProperty
+      Name="CustomToolNamespace"
+      Category="Advanced"
+      DisplayName="Custom Tool Namespace"
+      Description="The namespace into which the output of the custom tool is placed." />
+
+    <StringProperty
+      Name="Identity"
+      Visible="false"
+      ReadOnly="true"
+      Category="Misc"
+      Description="The item specified in the Include attribute.">
+        <StringProperty.DataSource>
+            <DataSource Persistence="Intrinsic" ItemType="Page" PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+
+    <StringProperty
+      Name="FullPath"
+      DisplayName="Full Path"
+      ReadOnly="true"
+      Category="Misc"
+      Description="Location of the file.">
+        <StringProperty.DataSource>
+            <DataSource Persistence="Intrinsic" ItemType="Page" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+
+    <StringProperty
+      Name="FileNameAndExtension"
+      DisplayName="File Name"
+      ReadOnly="true"
+      Category="Misc"
+      Description="Name of the file or folder.">
+        <StringProperty.DataSource>
+            <DataSource Persistence="Intrinsic" ItemType="Page" PersistedName="FileNameAndExtension" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+
+    <StringProperty Name="URL" ReadOnly="true" Visible="false">
+        <StringProperty.DataSource>
+            <DataSource Persistence="Intrinsic" ItemType="Page" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+    <BoolProperty Name="Visible" Visible="false" />
+    <StringProperty Name="DependentUpon" Visible="false" />
+    <StringProperty Name="Link" Visible="false">
+        <StringProperty.DataSource>
+            <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+    <StringProperty Name="Extension" Visible="False" ReadOnly="true">
+        <StringProperty.DataSource>
+            <DataSource Persistence="Intrinsic" ItemType="Page" PersistedName="Extension" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+    <StringProperty Name="LastGenOutput" Visible="false" Description="The filename of the last file generated as a result of the SFG." />
+    <BoolProperty Name="DesignTime" Visible="false" Description="A value indicating whether this file has a designer." />
+    <BoolProperty Name="AutoGen" Visible="false" Description="A value indicating whether this is a generated file." />
+    <StringProperty Name="CustomTool" Visible="false" Description="DTE Property for accessing the Generator property.">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFile" ItemType="Page" PersistedName="Generator" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+</Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectItemsSchema.xaml
@@ -44,13 +44,13 @@
       DisplayName="Media file"
       ItemType="Content">
     </ContentType>
-    
+
     <ContentType
       Name="Image"
       DisplayName="Image file"
       ItemType="Content">
     </ContentType>
-    
+
     <ContentType
       Name="EmbeddedResource"
       DisplayName="Embedded resource"
@@ -58,9 +58,18 @@
       <NameValuePair Name="DefaultMetadata_Generator" Value="ResXFileCodeGenerator" />
     </ContentType>
 
+    <ContentType
+      Name="Page"
+      DisplayName="Page file"
+      ItemType="Page">
+      <NameValuePair Name="DefaultMetadata_Generator" Value="MSBuild:Compile" />
+    </ContentType>
+
     <ItemType Name="None" DisplayName="None"/>
     <ItemType Name="Content" DisplayName="Content" />
-    <ItemType Name="EmbeddedResource" DisplayName="Embedded resource"/>
+    <ItemType Name="EmbeddedResource" DisplayName="Embedded resource" />
+    <ItemType Name="Page" DisplayName="Page" />
+    <ItemType Name="ApplicationDefinition" DisplayName="Application definition" />
 
     <FileExtension Name=".asax" ContentType="Asax" />
     <FileExtension Name=".asmx" ContentType="HTML" />
@@ -80,6 +89,7 @@
     <FileExtension Name=".cd" ContentType="ClassDiagram" />
     <FileExtension Name=".licenses" ContentType="Licenses" />
     <FileExtension Name=".json" ContentType="Json" />
+    <FileExtension Name=".xaml" ContentType="Page" />
 
     <!-- Image formats -->
     <FileExtension Name=".jpeg" ContentType="Image" />

--- a/src/Targets/Microsoft.Managed.DesignTime.targets
+++ b/src/Targets/Microsoft.Managed.DesignTime.targets
@@ -178,6 +178,14 @@
     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)ProjectDebugger.xaml">
       <Context>Project</Context>
     </PropertyPageSchema>
+
+    <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)ApplicationDefinition.xaml">
+      <Context>File;BrowseObject</Context>
+    </PropertyPageSchema>
+
+    <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)Page.xaml">
+      <Context>File;BrowseObject</Context>
+    </PropertyPageSchema>
   </ItemGroup>
 
   <ItemGroup Condition="'$(DefineCommonManagedReferenceSchemas)' == 'true'">


### PR DESCRIPTION
FYI. @Srivatsn, @dotnet/project-system 

Still waiting on final confirmation from the CPS guys, but it seems like the following is true:
 * For any item type to display in the solution explorer, you must define a rule file and have an 'ItemType' entry in a ProjectSchemaDefinition file.
 * For an extension to have a default item type (other than none) you must define a rule file and have a 'FileExtension' entry in a ProjectSchemaDefinition file.
