### PR TITLE
Updating the property pages to follow the recommended keyboard navigation behavior for 'Navigating Between Window Panes'.

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabButton.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabButton.vb
@@ -151,28 +151,42 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                     If parent IsNot Nothing Then
                         parent.OnItemClick(Me, reactivatePage:=True)
                     End If
-                Case Keys.Tab, Keys.Up, Keys.Down
-
-                    If keyCode <> Keys.Tab OrElse (keyData And Keys.Control) <> Keys.Control Then                                   ' Don't process if Ctrl+Tab, but do Process for Ctrl+Up and Ctrl+Down
+                Case Keys.Up
+                    Dim parent As ProjectDesignerTabControl = ParentTabControl
+                    If parent IsNot Nothing Then
+                        Dim nextIndex As Int32 = ButtonIndex - 1
+                        If nextIndex < 0 Then
+                            nextIndex = parent.TabButtonCount - 1
+                        End If
+                        Dim nextButton = parent.GetTabButton(nextIndex)
+                        nextButton.Focus()
+                        nextButton.FocusedFromKeyboardNav = True
+                        Return True
+                    End If
+                Case Keys.Down
+                    Dim parent As ProjectDesignerTabControl = ParentTabControl
+                    If parent IsNot Nothing Then
+                        Dim nextIndex As Int32 = ButtonIndex + 1
+                        If nextIndex >= parent.TabButtonCount Then
+                            nextIndex = 0
+                        End If
+                        Dim nextButton = parent.GetTabButton(nextIndex)
+                        nextButton.Focus()
+                        nextButton.FocusedFromKeyboardNav = True
+                        Return True
+                    End If
+                Case Keys.Left, Keys.Right
+                    ' Don't move focus for left or right
+                    Return True
+                Case Keys.Tab
+                    ' Don't process if Ctrl+Tab, it is reserved for navigation between editor pages
+                    If (keyData And Keys.Control) <> Keys.Control Then
                         Dim parent As ProjectDesignerTabControl = ParentTabControl
                         If parent IsNot Nothing Then
-                            Dim nextIndex As Int32 = ButtonIndex
-                            If (keyCode = Keys.Tab AndAlso (keyData And Keys.Shift) = Keys.Shift) OrElse keyCode = Keys.Up Then     ' Process if Shift+Tab or Up
-                                nextIndex -= 1
-                                If nextIndex < 0 Then
-                                    nextIndex = parent.TabButtonCount - 1
-                                End If
-                            Else
-                                nextIndex += 1
-                                If nextIndex >= parent.TabButtonCount Then
-                                    nextIndex = 0
-                                End If
-                            End If
-                            Dim nextButton = parent.GetTabButton(nextIndex)
-                            nextButton.Focus()
-                            nextButton.FocusedFromKeyboardNav = True
-                            Return True
+                            ' Return focus back to the active property page
+                            parent.OnItemClick(parent.SelectedItem, reactivatePage:=True)
                         End If
+                        Return True
                     End If
             End Select
             Return MyBase.ProcessDialogKey(keyData)


### PR DESCRIPTION
**Customer scenario**

Customer attempts to navigate using the keyboard

**Bugs this fixes:** 

https://devdiv.visualstudio.com/DevDiv/_queries?id=470148

~~https://github.com/dotnet/project-system/issues/2650 and https://github.com/dotnet/project-system/issues/2651~~

**Workarounds, if any**

None

**Risk**

Low. This just modifies a code path to reactivate the page rather than transfer focus to the next button

**Performance impact**

Low.

**Is this a regression from a previous update?**

Not a regression. This was new code fixing accessibility issues.

**Root cause analysis:**

The focus order was not done in consideration to the guidelines set here: https://msdn.microsoft.com/en-us/library/ms971323.aspx

**How was the bug found?**

Ad-hoc testing
