### PR TITLE
Avoid deadlock in DebugProfileDebugTargetGenerator

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/AppDesignerFolderSpecialFileProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/AppDesignerFolderSpecialFileProviderFactory.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Moq;
+using System.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
+{
+    internal class AppDesignerFolderSpecialFileProviderFactory
+    {
+        public static AppDesignerFolderSpecialFileProvider ImplementGetFile(string result)
+        {
+            var mock = new Mock<AppDesignerFolderSpecialFileProvider>();
+            mock.Setup(m => m.GetFileAsync(It.IsAny<SpecialFiles>(), It.IsAny<SpecialFileFlags>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(result);
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 Value = activeProfileValue.Object
             };
 
-            var specialFilesManager = ISpecialFilesManagerFactory.ImplementGetFile(appDesignerFolder);
+            var specialFilesManager = ActiveConfiguredProjectFactory.ImplementValue(() => AppDesignerFolderSpecialFileProviderFactory.ImplementGetFile(appDesignerFolder));
             var unconfiguredProject = UnconfiguredProjectFactory.Create(null, null, @"c:\test\Project1\Project1.csproj");
             var properties = ProjectPropertiesFactory.Create(unconfiguredProject, new[] { debuggerData  });
             var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(unconfiguredProject, null,  new IProjectThreadingServiceMock(), null, properties);
@@ -785,8 +785,8 @@ string JsonString1 = @"{
         // ECan pass null for all and a default will be crewated
         public LaunchSettingsUnderTest(UnconfiguredProject unconfiguredProject, IUnconfiguredProjectServices projectServices, 
                                       IFileSystem fileSystem,   IUnconfiguredProjectCommonServices commonProjectServices, 
-                                      IActiveConfiguredProjectSubscriptionService projectSubscriptionService, ISpecialFilesManager specialFilesManager)
-          : base(unconfiguredProject, projectServices, fileSystem, commonProjectServices, projectSubscriptionService, specialFilesManager)
+                                      IActiveConfiguredProjectSubscriptionService projectSubscriptionService, ActiveConfiguredProject<AppDesignerFolderSpecialFileProvider> appDesignerFolderSpecialFileProvider)
+          : base(unconfiguredProject, projectServices, fileSystem, commonProjectServices, projectSubscriptionService, appDesignerFolderSpecialFileProvider)
         {
             // Block the code from setting up one on the real file system. Since we block, it we need to set up the fileChange scheduler manually
             FileWatcher = new SimpleFileWatcher();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProvider.cs
@@ -14,6 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
     ///     called "Properties" in C# and "My Project" in Visual Basic.
     /// </summary>
     [ExportSpecialFileProvider(SpecialFiles.AppDesigner)]
+    [Export(typeof(AppDesignerFolderSpecialFileProvider))]
     [AppliesTo(ProjectCapability.AppDesigner)]
     internal class AppDesignerFolderSpecialFileProvider : ISpecialFileProvider
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProvider.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
             _properties = properties;
         }
 
-        public async Task<string> GetFileAsync(SpecialFiles fileId, SpecialFileFlags flags, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<string> GetFileAsync(SpecialFiles fileId, SpecialFileFlags flags, CancellationToken cancellationToken = default(CancellationToken))
         {
             // Make sure at least have a tree before we start searching it
             await _projectTree.Value.TreeService.PublishAnyNonLoadingTreeAsync(cancellationToken)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProvider.cs
@@ -31,6 +31,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
             _properties = properties;
         }
 
+        // For unit tests
+        protected AppDesignerFolderSpecialFileProvider()
+        {
+        }
+
         public virtual async Task<string> GetFileAsync(SpecialFiles fileId, SpecialFileFlags flags, CancellationToken cancellationToken = default(CancellationToken))
         {
             // Make sure at least have a tree before we start searching it


### PR DESCRIPTION
Fixes: 461771.

We were deadlocking by switching to the UI thread while DebugProfileDebugTargetGenerator is trying to calculate it's data. Avoid calling into SpecialFilesManager.GetFiles which goes via IVsProjectSpecialFiles on the UI thread, and just call the AppDesignerSpecialFileProvider directly.

This is just a targeted change, with the real change to be switching to an entirely dataflow chain of providing this data. See: #2316.