### PR TITLE
Enumerate rather than GetDirectories/GetFiles

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesigner.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesigner.vb
@@ -414,8 +414,8 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 Return
             End If
 
-            For Each directory As IO.DirectoryInfo In applicationRootDirectoryInfo.GetDirectories()
-                For Each file As IO.FileInfo In directory.GetFiles("user.config")
+            For Each directory As IO.DirectoryInfo In applicationRootDirectoryInfo.EnumerateDirectories()
+                For Each file As IO.FileInfo In directory.EnumerateFiles("user.config")
                     files.Add(file.FullName)
                 Next
             Next

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
@@ -104,7 +104,7 @@ namespace Microsoft.VisualStudio.IO
 
         public IEnumerable<string> EnumerateDirectories(string path, string searchPattern, SearchOption searchOption)
         {
-            return Directory.GetDirectories(path, searchPattern, searchOption);
+            return Directory.EnumerateDirectories(path, searchPattern, searchOption);
         }
 
         public IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption)


### PR DESCRIPTION
`GetDirectories` and `GetFiles` call `Enumerate` -> `new List` -> `ToArray` to get the `string[]`

Since the result is then `foreach` over, just go direct to Enumerate.