### PR TITLE
Transmit command line arguments directly to the F# language service

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp/ProjectSystem/LanguageServices/CSharpParseBuildOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp/ProjectSystem/LanguageServices/CSharpParseBuildOptions.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.IO;
 using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
@@ -10,10 +11,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     [AppliesTo(ProjectCapability.CSharp)]
     internal class CSharpParseBuildOptions : IParseBuildOptions
     {
-        public BuildOptions Parse(IEnumerable<string> args, string baseDirectory)
+        public BuildOptions Parse(IEnumerable<string> args, string projectPath)
         {
             return BuildOptions.FromCommandLineArguments(
-                CSharpCommandLineParser.Default.Parse(args, baseDirectory, sdkDirectory: null, additionalReferenceDirectories: null));
+                CSharpCommandLineParser.Default.Parse(args, Path.GetDirectoryName(projectPath), sdkDirectory: null, additionalReferenceDirectories: null));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp/ProjectSystem/LanguageServices/FSharpParseBuildOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp/ProjectSystem/LanguageServices/FSharpParseBuildOptions.cs
@@ -18,54 +18,64 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         [ImportMany]
         IEnumerable<Action<string, ImmutableArray<CommandLineSourceFile>, ImmutableArray<CommandLineReference>>> Handlers =  null;
-        public BuildOptions Parse(IEnumerable<string> args, string projectPath)
+
+        public BuildOptions Parse(IEnumerable<string> commandLineArgs, string projectPath)
         {
             var sourceFiles = new List<CommandLineSourceFile>();
             var metadataReferences = new List<CommandLineReference>();
 
-            foreach (var arg in args)
+            foreach (var commandLineArgument in commandLineArgs)
             {
-                if (arg.StartsWith(ReferencePrefix))
+                var args = commandLineArgument.Split(';');
+                foreach (var arg in args)
                 {
-                    // e.g., -r:C:\Path\To\FSharp.Core.dll
-                    metadataReferences.Add(new CommandLineReference(arg.Substring(ReferencePrefix.Length), MetadataReferenceProperties.Assembly));
-                }
-                else if (arg.StartsWith(LongReferencePrefix))
-                {
-                    // e.g., --reference:C:\Path\To\FSharp.Core.dll
-                    metadataReferences.Add(new CommandLineReference(arg.Substring(LongReferencePrefix.Length), MetadataReferenceProperties.Assembly));
-                }
-                else if (!arg.StartsWith("-"))
-                {
-                    // not an option, should be a regular file
-                    var extension = Path.GetExtension(arg).ToLowerInvariant();
-                    switch (extension)
+                    if (arg.StartsWith(ReferencePrefix))
                     {
-                        case ".fs":
-                        case ".fsi":
-                        case ".fsx":
-                        case ".fsscript":
-                        case ".ml":
-                        case ".mli":
-                            sourceFiles.Add(new CommandLineSourceFile(arg, isScript: (extension == ".fsx") || (extension == ".fsscript")));
-                            break;
-                        default:
-                            break;
+                        // e.g., -r:C:\Path\To\FSharp.Core.dll
+                        metadataReferences.Add(new CommandLineReference(arg.Substring(ReferencePrefix.Length), MetadataReferenceProperties.Assembly));
+                    }
+                    else if (arg.StartsWith(LongReferencePrefix))
+                    {
+                        // e.g., --reference:C:\Path\To\FSharp.Core.dll
+                        metadataReferences.Add(new CommandLineReference(arg.Substring(LongReferencePrefix.Length), MetadataReferenceProperties.Assembly));
+                    }
+                    else if (!arg.StartsWith("-"))
+                    {
+                        // not an option, should be a regular file
+                        var extension = Path.GetExtension(arg).ToLowerInvariant();
+                        switch (extension)
+                        {
+                            case ".fs":
+                            case ".fsi":
+                            case ".fsx":
+                            case ".fsscript":
+                            case ".ml":
+                            case ".mli":
+                                sourceFiles.Add(new CommandLineSourceFile(arg, isScript: (extension == ".fsx") || (extension == ".fsscript")));
+                                break;
+                            default:
+                                break;
+                        }
                     }
                 }
             }
 
-            var buildOptions = new BuildOptions(
-                sourceFiles: sourceFiles.ToImmutableArray(),
-                additionalFiles: ImmutableArray<CommandLineSourceFile>.Empty,
-                metadataReferences: metadataReferences.ToImmutableArray(),
-                analyzerReferences: ImmutableArray<CommandLineAnalyzerReference>.Empty);
+            return new BuildOptions(
+                    sourceFiles: sourceFiles.ToImmutableArray(),
+                    additionalFiles: ImmutableArray<CommandLineSourceFile>.Empty,
+                    metadataReferences: metadataReferences.ToImmutableArray(),
+                    analyzerReferences: ImmutableArray<CommandLineAnalyzerReference>.Empty);
+        }
+
+        [Export]
+        [AppliesTo(ProjectCapability.FSharp)]
+        public void HandleCommandLineNotifications(string projectPath, BuildOptions addedOptions, BuildOptions removedOptions)
+        {
             foreach (var handler in Handlers)
             {
-                handler?.Invoke(projectPath, buildOptions.SourceFiles, buildOptions.MetadataReferences);
+                handler?.Invoke(projectPath, addedOptions.SourceFiles, addedOptions.MetadataReferences);
             }
-
-            return buildOptions;
         }
+
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/CommandLineParserService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/CommandLineParserService.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.IO;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
@@ -35,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             if (parser == null)
                 throw new InvalidOperationException();
 
-            return parser.Value.Parse(arguments, Path.GetDirectoryName(_project.FullPath));
+            return parser.Value.Parse(arguments, _project.FullPath);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/CommandLineParserService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/CommandLineParserService.cs
@@ -34,7 +34,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             if (parser == null)
                 throw new InvalidOperationException();
 
-            return parser.Value.Parse(arguments, _project.FullPath);
+            var buildOptions = parser.Value.Parse(arguments, _project.FullPath);
+
+            return buildOptions;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IParseBuildOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IParseBuildOptions.cs
@@ -6,6 +6,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
     internal interface IParseBuildOptions
     {
-        BuildOptions Parse(IEnumerable<string> args, string baseDirectory);
+        BuildOptions Parse(IEnumerable<string> args, string projectPath);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHandlerManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHandlerManager.cs
@@ -29,6 +29,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             _commandLineParser = commandLineParser;
             _handlerProvider = handlerProvider;
             _logger = logger;
+            CommandLineNotifications = new OrderPrecedenceImportCollection<Action<string, BuildOptions, BuildOptions>>(projectCapabilityCheckProvider: project);
+        }
+
+        [ImportMany]
+        public OrderPrecedenceImportCollection<Action<string, BuildOptions, BuildOptions>> CommandLineNotifications
+        {
+            get;
         }
 
         public void Handle(IProjectVersionedValue<IProjectSubscriptionUpdate> update, RuleHandlerType handlerType, IWorkspaceProjectContext context, bool isActiveContext)
@@ -174,6 +181,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             {
                 handler.Handle(version, addedItems, removedItems, isActiveContext, logger);
             }
+
+            var notification = CommandLineNotifications.FirstOrDefault();
+            if (notification != null)
+                notification.Value.Invoke(_project.FullPath, addedItems, removedItems);
         }
 
         private void WriteHeader(IProjectLoggerBatch logger, IProjectVersionedValue<IProjectSubscriptionUpdate> update, IComparable version, RuleHandlerType source, bool isActiveContext)

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic/ProjectSystem/LanguageServices/VisualBasicParseBuildOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic/ProjectSystem/LanguageServices/VisualBasicParseBuildOptions.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.IO;
 using Microsoft.CodeAnalysis.VisualBasic;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
@@ -10,10 +11,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     [AppliesTo(ProjectCapability.VisualBasic)]
     internal class VisualBasicParseBuildOptions : IParseBuildOptions
     {
-        public BuildOptions Parse(IEnumerable<string> args, string baseDirectory)
+        public BuildOptions Parse(IEnumerable<string> args, string projectPath)
         {
             return BuildOptions.FromCommandLineArguments(
-                VisualBasicCommandLineParser.Default.Parse(args, baseDirectory, sdkDirectory: null, additionalReferenceDirectories: null));
+                VisualBasicCommandLineParser.Default.Parse(args, Path.GetDirectoryName(projectPath), sdkDirectory: null, additionalReferenceDirectories: null));
         }
     }
 }

--- a/src/Targets/Microsoft.FSharp.DesignTime.targets
+++ b/src/Targets/Microsoft.FSharp.DesignTime.targets
@@ -34,9 +34,24 @@
           >
 
     <ItemGroup>
+      <_CompilerCommandLineArgs Include="@(FscCommandLineArgs, ';');"/> 
+    </ItemGroup>
+
+  </Target>
+
+
+<!-- Saved
+  <Target Name="CompileDesignTime"
+          Returns="@(_CompilerCommandLineArgs)"
+          DependsOnTargets="_CheckCompileDesignTimePrerequisite;Compile"
+          Condition="'$(IsCrossTargetingBuild)' != 'true'"
+          >
+
+    <ItemGroup>
       <_CompilerCommandLineArgs Include="@(FscCommandLineArgs)"/>
     </ItemGroup>
 
   </Target>
+-->
 
 </Project>


### PR DESCRIPTION
This fixes command line ordering for F# CPS projects temporarily until CPS can provide a more complete fix.

* CPS / project system rearrange the order for command line arguments when importing them from the project file.
* This change modifies the targets file, to pass them in as a single string.  
* It also exposes a MEF import that can be exported by the F# language service to process the command line arguments.
* Currently supplies source files in compilation order and references in compilation order.  probably need to update build options to supply command line switches.

* The FSharpParser exports for F# Projects only an event handler to get added and removed build options.  In fact, only added are used at this time, until CPS can keep track of ordering.
* This handler notifies the language services which export a listener.

Portions of this were authored by @brettfo 

/cc:  @Srivatsn, @brettfo, @dsyme, @Pilchie 

