### PR TITLE
Add WinRTReferences Project capability

### DIFF
--- a/src/Targets/Microsoft.Managed.DesignTime.targets
+++ b/src/Targets/Microsoft.Managed.DesignTime.targets
@@ -73,6 +73,7 @@
                           ProjectReferences;
                           PackageReferences;
                           SharedProjectReferences;
+                          WinRTReferences;
                           OutputGroups;
                           AllTargetOutputGroups;
                           VisualStudioWellKnownOutputGroups;


### PR DESCRIPTION
Adding this capability enables the WinRT References service which knows
how to handle the WinRT assemblies

@dotnet/project-system for review

**Customer scenario**

Customer cannot add Winmd references to .Net Core/Standard projects through Reference Dialog

**Bugs this fixes:** 

#2495

**Workarounds, if any**

The users can hand edit the project file

**Risk**

The risk is low because the impact is localized

**Performance impact**

Should enable a few services in CPS but it should not affect perf significantly

**Is this a regression from a previous update?**

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

Customer reported