### PR TITLE
Add support for native debugging

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
@@ -160,6 +160,33 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
             Assert.Equal(DebugLaunchOperation.CreateProcess, targets[0].LaunchOperation);
             Assert.Equal((DebugLaunchOptions.StopDebuggingOnEnd), targets[0].LaunchOptions);
             Assert.Equal(DebuggerEngines.ManagedCoreEngine, targets[0].LaunchDebugEngineGuid);
+            Assert.Equal(0, targets[0].AdditionalDebugEngines.Count);
+            Assert.Equal("exec \"c:\\test\\project\\bin\\project.dll\" --someArgs", targets[0].Arguments);
+        }
+
+        [Fact]
+        public async Task QueryDebugTargets_ProjectProfileAsyncF5_NativeDebugging()
+        {
+            var debugger = GetDebugTargetsProvider();
+
+            _mockFS.WriteAllText(@"c:\program files\dotnet\dotnet.exe", "");
+            _mockFS.CreateDirectory(@"c:\test\project");
+
+            LaunchProfile activeProfile = new LaunchProfile() 
+            { 
+                Name = "MyApplication", 
+                CommandName = "Project", 
+                CommandLineArgs = "--someArgs",
+                OtherSettings = ImmutableDictionary<string, object>.Empty.Add(LaunchProfileExtensions.NativeDebuggingProperty, true)
+            };
+            var targets = await debugger.QueryDebugTargetsAsync(0, activeProfile);
+            Assert.Equal(1, targets.Count);
+            Assert.Equal(@"c:\program files\dotnet\dotnet.exe", targets[0].Executable);
+            Assert.Equal(DebugLaunchOperation.CreateProcess, targets[0].LaunchOperation);
+            Assert.Equal((DebugLaunchOptions.StopDebuggingOnEnd), targets[0].LaunchOptions);
+            Assert.Equal(DebuggerEngines.ManagedCoreEngine, targets[0].LaunchDebugEngineGuid);
+            Assert.Equal(1, targets[0].AdditionalDebugEngines.Count);
+            Assert.Equal(DebuggerEngines.NativeOnlyEngine, targets[0].AdditionalDebugEngines[0]);
             Assert.Equal("exec \"c:\\test\\project\\bin\\project.dll\" --someArgs", targets[0].Arguments);
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
@@ -258,6 +258,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             settings.CurrentDirectory = workingDir;
             settings.LaunchOperation = DebugLaunchOperation.CreateProcess;
             settings.LaunchDebugEngineGuid = await GetDebuggingEngineAsync(configuredProject).ConfigureAwait(false);
+
+            if (resolvedProfile.NativeDebuggingIsEnabled())
+            {
+                settings.AdditionalDebugEngines.Add(DebuggerEngines.NativeOnlyEngine);
+            }
+
             settings.LaunchOptions = launchOptions | DebugLaunchOptions.StopDebuggingOnEnd;
             if (settings.Environment.Count > 0)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfile.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfile.cs
@@ -80,6 +80,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
     internal static class LaunchProfileExtensions
     {
+        public const string NativeDebuggingProperty = "nativeDebugging";
+
         /// <summary>
         /// Return a mutable instance
         /// </summary>
@@ -88,5 +90,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             return new WritableLaunchProfile(curProfile);
         }
 
+        /// <summary>
+        /// Returns true if nativeDebugging property is set to true
+        /// </summary>
+        public static bool NativeDebuggingIsEnabled(this ILaunchProfile profile)
+        {
+            if (profile.OtherSettings != null 
+                && profile.OtherSettings.TryGetValue(NativeDebuggingProperty,  out object nativeDebugging) 
+                && nativeDebugging is bool)
+            {
+                return (bool)nativeDebugging;
+            }
+
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Addresses issue: https://github.com/dotnet/project-system/issues/1125

Native debugging is enabled by adding "nativeDebugging" : true to the launch profile as follows

```
{
  "profiles": {
    "ConsoleApp3": {
      "commandName": "Project",
      "nativeDebugging": true
    }
  }
}
```
This property will automatically be picked up by the LaunchSettingsManager and added to the OtherProperties property bag. This change does not add any UI support. 