### PR TITLE
Stop publishing to Cpvsbuild directly

### DIFF
--- a/build/Scripts/copyOutput.cmd
+++ b/build/Scripts/copyOutput.cmd
@@ -5,6 +5,3 @@ set BinariesDirectory=%1
 
 echo Copy the Modern Vsixes manifest into VsixV3
 robocopy %BinariesDirectory% %BinariesDirectory%VsixV3 Microsoft.VisualStudio.Editors.vsman Microsoft.VisualStudio.ProjectSystem.Managed.vsman Microsoft.VisualStudio.NetCore.ProjectTemplates.vsman Microsoft.VisualStudio.NetCore.ProjectTemplates.1.x.vsman /njh /njs /np /xx
-
-echo Copy the Nugets to CoreXT Share
-robocopy %BinariesDirectory%NuGetPackages \\cpvsbuild\drops\dd\nuget /njh /njs /np /xx 


### PR DESCRIPTION
Infrastructure Only change

Port #2642 to dev15.4.x to fix build break

/cc @dotnet/project-system 