### PR TITLE
Sign VSIXes inserted into VS

### DIFF
--- a/build/SignToolData.json
+++ b/build/SignToolData.json
@@ -37,7 +37,18 @@
         "VSSetup/Microsoft.NetStandard.FSharp.ProjectTemplates.vsix",
         "VSSetup/Microsoft.NetStandard.VB.ProjectTemplates.vsix",
         "VSSetup/ProjectSystem.vsix",
-        "VSSetup/VisualStudioEditorsSetup.vsix"
+        "VSSetup/VisualStudioEditorsSetup.vsix",
+        "VSSetup/Insertion/Microsoft.NetCore.CSharp.ProjectTemplates.Test.vsix",
+        "VSSetup/Insertion/Microsoft.NetCore.CSharp.ProjectTemplates.vsix",
+        "VSSetup/Insertion/Microsoft.NetCore.FSharp.ProjectTemplates.Test.vsix",
+        "VSSetup/Insertion/Microsoft.NetCore.FSharp.ProjectTemplates.vsix",
+        "VSSetup/Insertion/Microsoft.NetCore.VB.ProjectTemplates.Test.vsix",
+        "VSSetup/Insertion/Microsoft.NetCore.VB.ProjectTemplates.vsix",
+        "VSSetup/Insertion/Microsoft.NetStandard.CSharp.ProjectTemplates.vsix",
+        "VSSetup/Insertion/Microsoft.NetStandard.FSharp.ProjectTemplates.vsix",
+        "VSSetup/Insertion/Microsoft.NetStandard.VB.ProjectTemplates.vsix",
+        "VSSetup/Insertion/ProjectSystem.vsix",
+        "VSSetup/Insertion/VisualStudioEditorsSetup.vsix"
       ]
     }
   ]

--- a/build/Versions.props
+++ b/build/Versions.props
@@ -9,7 +9,7 @@
     <UsingToolIbcOptimization>true</UsingToolIbcOptimization>
 
     <!-- Toolset -->
-    <RoslynToolsMicrosoftRepoToolsetVersion>1.0.0-alpha34</RoslynToolsMicrosoftRepoToolsetVersion>
+    <RoslynToolsMicrosoftRepoToolsetVersion>1.0.0-alpha35</RoslynToolsMicrosoftRepoToolsetVersion>
     <RoslynDependenciesOptimizationDataVersion>2.0.0-rc-61101-17</RoslynDependenciesOptimizationDataVersion>
     <RoslynToolsMicrosoftVsixExpInstallerVersion>0.2.4-beta</RoslynToolsMicrosoftVsixExpInstallerVersion>
     <VSWhereVersion>1.0.47</VSWhereVersion>


### PR DESCRIPTION
The build produces two kinds of VSIXes - ones marked "experimental" the others not. We need to sign both.

Fixes VS insertion.