### PR TITLE
Use msbuild binlog in MicroBuild

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -110,15 +110,9 @@ function Build {
     $env:VSSDKInstall = Join-Path $vsInstallDir "VSSDK\"
   }
 
-  # Microbuild is on 15.1 which doesn't support binary log
   if ($ci -or $log) {
     Create-Directory($logDir)
-
-    if ($env:BUILD_BUILDNUMBER -eq $null) {
-      $logCmd = "/bl:" + (Join-Path $LogDir "Build.binlog")
-    } else {
-      $logCmd = "/flp1:Summary;Verbosity=diagnostic;Encoding=UTF-8;LogFile=" + (Join-Path $LogDir "Build.log")
-    }
+    $logCmd = "/bl:" + (Join-Path $LogDir "Build.binlog")
   } else {
     $logCmd = ""
   }


### PR DESCRIPTION
MicroBuild machines now have msbuild 15.3, which supports binary log.