### PR TITLE
Fix VSIX manifest hashing

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -10,6 +10,7 @@
 
     <!-- Toolset -->
     <RoslynToolsMicrosoftRepoToolsetVersion>1.0.0-alpha35</RoslynToolsMicrosoftRepoToolsetVersion>
+    <RoslynToolsMicrosoftModifyVsixManifestVersion>0.3.3-beta</RoslynToolsMicrosoftModifyVsixManifestVersion>
     <RoslynDependenciesOptimizationDataVersion>2.0.0-rc-61101-17</RoslynDependenciesOptimizationDataVersion>
     <RoslynToolsMicrosoftVsixExpInstallerVersion>0.2.4-beta</RoslynToolsMicrosoftVsixExpInstallerVersion>
     <VSWhereVersion>1.0.47</VSWhereVersion>


### PR DESCRIPTION
Update to the latest version of ModifyVsixManifest that correctly updates hash in the patched VSIX. See https://github.com/dotnet/roslyn-tools/pull/50