### PR TITLE
RepoToolset v36 - fix vsman hashes

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -9,8 +9,7 @@
     <UsingToolIbcOptimization>true</UsingToolIbcOptimization>
 
     <!-- Toolset -->
-    <RoslynToolsMicrosoftRepoToolsetVersion>1.0.0-alpha35</RoslynToolsMicrosoftRepoToolsetVersion>
-    <RoslynToolsMicrosoftModifyVsixManifestVersion>0.3.3-beta</RoslynToolsMicrosoftModifyVsixManifestVersion>
+    <RoslynToolsMicrosoftRepoToolsetVersion>1.0.0-alpha36</RoslynToolsMicrosoftRepoToolsetVersion>
     <RoslynDependenciesOptimizationDataVersion>2.0.0-rc-61101-17</RoslynDependenciesOptimizationDataVersion>
     <RoslynToolsMicrosoftVsixExpInstallerVersion>0.2.4-beta</RoslynToolsMicrosoftVsixExpInstallerVersion>
     <VSWhereVersion>1.0.47</VSWhereVersion>


### PR DESCRIPTION
VSIX hashes in vsman files need to be calculated after signing. Fixes insertion validation failure.

Change in RepoToolset: https://github.com/dotnet/roslyn-tools/pull/51