### PR TITLE
Fix up-to-date for "Copy to output directory" items

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         private string _msBuildProjectFullPath;
         private string _msBuildProjectDirectory;
         private string _markerFile;
-        private string _outputPath;
+        private string _outputRelativeOrFullPath;
 
         private readonly HashSet<string> _imports = new HashSet<string>(StringComparers.Paths);
         private readonly HashSet<string> _itemTypes = new HashSet<string>(StringComparers.Paths);
@@ -116,7 +116,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             _msBuildProjectFullPath = e.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildProjectFullPathProperty, _msBuildProjectFullPath);
             _msBuildProjectDirectory = e.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildProjectDirectoryProperty, _msBuildProjectDirectory);
-            _outputPath = e.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.OutputPathProperty, _outputPath);
+            _outputRelativeOrFullPath = e.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.OutputPathProperty, _outputRelativeOrFullPath);
 
             if (e.ProjectChanges.TryGetValue(ResolvedAnalyzerReference.SchemaName, out var changes) &&
                 changes.Difference.AnyChanges)
@@ -476,7 +476,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var items = _items.SelectMany(kvp => kvp.Value).Where(item => item.CopyType == CopyToOutputDirectoryType.CopyIfNewer)
                 .Select(item => item.Path);
 
-            string outputFullPath = Path.Combine(_msBuildProjectDirectory, _outputPath);
+            string outputFullPath = Path.Combine(_msBuildProjectDirectory, _outputRelativeOrFullPath);
 
             foreach (var item in items)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -66,6 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         private bool _isDisabled = true;
         private bool _itemsChangedSinceLastCheck = true;
         private string _msBuildProjectFullPath;
+        private string _msBuildProjectDirectory;
         private string _markerFile;
         private string _outputPath;
 
@@ -114,7 +115,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             _isDisabled = disableFastUpToDateCheckString != null && string.Equals(disableFastUpToDateCheckString, TrueValue, StringComparison.OrdinalIgnoreCase);
 
             _msBuildProjectFullPath = e.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildProjectFullPathProperty, _msBuildProjectFullPath);
-
+            _msBuildProjectDirectory = e.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildProjectDirectoryProperty, _msBuildProjectDirectory);
             _outputPath = e.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.OutputPathProperty, _outputPath);
 
             if (e.ProjectChanges.TryGetValue(ResolvedAnalyzerReference.SchemaName, out var changes) &&
@@ -475,6 +476,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var items = _items.SelectMany(kvp => kvp.Value).Where(item => item.CopyType == CopyToOutputDirectoryType.CopyIfNewer)
                 .Select(item => item.Path);
 
+            string outputFullPath = Path.Combine(_msBuildProjectDirectory, _outputPath);
+
             foreach (var item in items)
             {
                 var filename = Path.GetFileName(item);
@@ -498,7 +501,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     return false;
                 }
 
-                var outputItem = Path.Combine(_outputPath, filename);
+                
+                var outputItem = Path.Combine(outputFullPath, filename);
                 var outputItemTime = GetTimestamp(outputItem, timestampCache);
 
                 if (outputItemTime != null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -515,7 +515,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     return false;
                 }
 
-                if (outputItemTime <= itemTime)
+                if (outputItemTime < itemTime)
                 {
                     return false;
                 }


### PR DESCRIPTION
**Customer scenario**

Customer builds a test project and it always shells out to MSBuild and is never considered up-to-date from within Visual Studio.
Customer adds an item to a project, and changes "Copy to Output Directory" to "Copy if Newer" and now the project always shells out to MSBuild and is never considered up-to-date from within Visual Studio.

**Bugs this fixes:** 

#2717
#2743

**Workarounds, if any**

No workarounds.

**Risk**

Low.

**Performance impact**

Low, and very little impact.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

Up-to-date is new and we missed a few cases in our implementation.

**How was the bug found?**

Customer bugs and we also found it in testing.
