### PR TITLE
Fix version of VisualStudioEditorsSetup.vsix

### DIFF
--- a/src/VisualStudioEditorsSetup/Directory.Build.props
+++ b/src/VisualStudioEditorsSetup/Directory.Build.props
@@ -1,0 +1,12 @@
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
+  <PropertyGroup>
+    <!-- 
+      Components in this directory are versioned based on the VS version and signed with Microsoft key
+    -->
+    <UseVisualStudioVersion>true</UseVisualStudioVersion>
+    <StrongNameKeyId>Microsoft</StrongNameKeyId>
+  </PropertyGroup>
+  
+  <Import Project="..\Directory.Build.props"/>  
+</Project>


### PR DESCRIPTION
The version of the VSIX was set to 2.5 instead of 15.5 - I forgot to add Directory.Build.props file when reverting src subdirectories.