### PR TITLE
Using non-canonical name results in high CPU usage

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetFramework.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetFramework.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Runtime.Versioning;
+using BCLDebug = System.Diagnostics.Debug;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 {
@@ -96,6 +97,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 
         public bool Equals(string obj)
         {
+            BCLDebug.Fail("This should never be called.");
+
             if (obj != null)
             {
                 return string.Equals(Moniker, obj, StringComparison.OrdinalIgnoreCase)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySubscriptionsHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySubscriptionsHost.cs
@@ -38,7 +38,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                    contextProvider,
                    tasksService,
                    activeConfiguredProjectSubscriptionService,
-                   activeProjectConfigurationRefreshService)
+                   activeProjectConfigurationRefreshService,
+                   targetFrameworkProvider)
         {
             CommonServices = commonServices;
             DependencySubscribers = new OrderPrecedenceImportCollection<IDependencyCrossTargetSubscriber>(


### PR DESCRIPTION
**Customer scenario**

Using a non-canonical name as your target framework (for example, net4.7 instead of net47) results in VS continually consuming CPU.

**Bugs this fixes:** 

https://github.com/dotnet/project-system/issues/2713
[VSFeedback](https://developercommunity.visualstudio.com/content/problem/105265/high-cpu-usage-with-a-tiny-project-opened.html) | [488045](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/488045)

**Workarounds, if any**

Use a canonical name in `<TargetFramework>` property, however, it is not an obvious workaround.

**Risk**

Low.

**Performance impact**

This stops CPU spinning forever - so improves performance a lot.

**Is this a regression from a previous update?**

Regression from 15.2 -> 15.3.

**Root cause analysis:**

Dependency tree was rewritten in 15.3, as with all rewrites they can introduce regressions - this is one of them.

I've added a debug only assert to catch additional hits of this, but I plan on removing all code that let's us compare non-canonical names in 15.5.

**How was the bug found?**

Customer reported.
