### PR TITLE
Fix strong name and certificate for Editors, AppDesigner

### DIFF
--- a/build/SignToolData.json
+++ b/build/SignToolData.json
@@ -4,10 +4,6 @@
       "certificate": "MicrosoftSHA2",
       "strongName": "MsSharedLib72",
       "values": [
-        "bin/Dlls/Microsoft.VisualStudio.AppDesigner.dll",
-        "bin/Dlls/*/Microsoft.VisualStudio.AppDesigner.resources.dll",
-        "bin/Dlls/Microsoft.VisualStudio.Editors.dll",
-        "bin/Dlls/*/Microsoft.VisualStudio.Editors.resources.dll",
         "bin/Dlls/Microsoft.VisualStudio.ProjectSystem.CSharp.dll",
         "bin/Dlls/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.dll",
         "bin/Dlls/*/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.resources.dll",
@@ -21,6 +17,16 @@
         "bin/Dlls/Microsoft.VisualStudio.ProjectSystem.VisualBasic.dll",
         "bin/Dlls/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.dll",
         "bin/Dlls/*/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.resources.dll"
+      ]
+    },
+    {
+      "certificate": "MicrosoftSHA2",
+      "strongName": "67",
+      "values": [
+        "bin/Dlls/Microsoft.VisualStudio.AppDesigner.dll",
+        "bin/Dlls/*/Microsoft.VisualStudio.AppDesigner.resources.dll",
+        "bin/Dlls/Microsoft.VisualStudio.Editors.dll",
+        "bin/Dlls/*/Microsoft.VisualStudio.Editors.resources.dll"
       ]
     },
     {

--- a/src/Microsoft.VisualStudio.AppDesigner/Directory.Build.props
+++ b/src/Microsoft.VisualStudio.AppDesigner/Directory.Build.props
@@ -2,10 +2,9 @@
 <Project>
   <PropertyGroup>
     <!-- 
-      Components in this directory are versioned based on the VS version and signed with Microsoft key
+      Components in this directory are versioned based on the VS version
     -->
     <UseVisualStudioVersion>true</UseVisualStudioVersion>
-    <StrongNameKeyId>Microsoft</StrongNameKeyId>
   </PropertyGroup>
   
   <Import Project="..\Directory.Build.props"/>  

--- a/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
+++ b/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
@@ -4,7 +4,8 @@
   <PropertyGroup>
     <!-- TODO: Function doesn't return a value on all code paths (https://github.com/dotnet/project-system/issues/2592) -->
     <NoWarn>$(NoWarn);42353</NoWarn>
-    
+    <StrongNameKeyId>Microsoft</StrongNameKeyId>
+
     <!-- Nuget -->
     <IsPackable>true</IsPackable>
     <Description>This package implements the AppDesigner, which is the designer host used for project property pages among other things in Visual Studio</Description>

--- a/src/Microsoft.VisualStudio.Editors/Directory.Build.props
+++ b/src/Microsoft.VisualStudio.Editors/Directory.Build.props
@@ -2,10 +2,9 @@
 <Project>
   <PropertyGroup>
     <!-- 
-      Components in this directory are versioned based on the VS version and signed with Microsoft key
+      Components in this directory are versioned based on the VS version
     -->
     <UseVisualStudioVersion>true</UseVisualStudioVersion>
-    <StrongNameKeyId>Microsoft</StrongNameKeyId>
   </PropertyGroup>
   
   <Import Project="..\Directory.Build.props"/>  

--- a/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
+++ b/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
@@ -3,7 +3,8 @@
   <Import Project="..\VisualStudioDesigner.props"/>
   <PropertyGroup>
     <Prefer32Bit>false</Prefer32Bit>
-    
+    <StrongNameKeyId>Microsoft</StrongNameKeyId>
+
     <!-- TODO: Function/Property doesn't return a value on all code paths (https://github.com/dotnet/project-system/issues/2592) -->
     <NoWarn>$(NoWarn);42353;42355;42105</NoWarn>
     

--- a/src/VisualStudioEditorsSetup/Directory.Build.props
+++ b/src/VisualStudioEditorsSetup/Directory.Build.props
@@ -5,7 +5,6 @@
       Components in this directory are versioned based on the VS version and signed with Microsoft key
     -->
     <UseVisualStudioVersion>true</UseVisualStudioVersion>
-    <StrongNameKeyId>Microsoft</StrongNameKeyId>
   </PropertyGroup>
   
   <Import Project="..\Directory.Build.props"/>  


### PR DESCRIPTION
We used wrong certificate for signing Editors and AppDesigner assemblies.