### PR TITLE
Don't show analyzer assemblies that have no analyzers

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -74,6 +74,7 @@
     
     <!-- Libs -->
     <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
+    <SystemReflectionMetadataVersion>1.4.2</SystemReflectionMetadataVersion>
 
     <!-- Microsoft.DotNet.*.ProjectTemplates -->
     <MicrosoftDotNetProjectTemplatesVersion>1.0.0-beta2-20170425-203</MicrosoftDotNetProjectTemplatesVersion>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/AnalyzerDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/AnalyzerDependencyModelTests.cs
@@ -21,9 +21,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 "myProvider",
                 "c:\\myPath",
                 "myOriginalItemSpec",
-                flags:flag,
-                resolved:true,
-                isImplicit:false,
+                flags: flag,
+                resolved: true,
+                isImplicit: false,
+                hasDiagnosticAnalyzers: true,
                 properties: properties);
 
             Assert.Equal("myProvider", model.ProviderType);
@@ -41,6 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.CodeInformationWarning, model.UnresolvedIcon);
             Assert.Equal(ManagedImageMonikers.CodeInformationWarning, model.UnresolvedExpandedIcon);
             Assert.True(model.Flags.Contains(flag));
+            Assert.True(model.Visible);
         }
 
         [Fact]
@@ -56,6 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 flags: flag,
                 resolved: false,
                 isImplicit: false,
+                hasDiagnosticAnalyzers: true,
                 properties: properties);
 
             Assert.Equal("myProvider", model.ProviderType);
@@ -73,6 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.CodeInformationWarning, model.UnresolvedIcon);
             Assert.Equal(ManagedImageMonikers.CodeInformationWarning, model.UnresolvedExpandedIcon);
             Assert.True(model.Flags.Contains(flag));
+            Assert.True(model.Visible);
         }
 
         [Fact]
@@ -88,6 +92,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 flags: flag,
                 resolved: true,
                 isImplicit: true,
+                hasDiagnosticAnalyzers: true,
                 properties: properties);
 
             Assert.Equal("myProvider", model.ProviderType);
@@ -105,6 +110,41 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.CodeInformationWarning, model.UnresolvedIcon);
             Assert.Equal(ManagedImageMonikers.CodeInformationWarning, model.UnresolvedExpandedIcon);
             Assert.True(model.Flags.Contains(flag));
+            Assert.True(model.Visible);
+        }
+
+        [Fact]
+        public void NoDiagnosticAnalyzers()
+        {
+            var properties = ImmutableDictionary<string, string>.Empty.Add("myProp", "myVal");
+
+            var flag = ProjectTreeFlags.Create("MyCustomFlag");
+            var model = new AnalyzerDependencyModel(
+                "myProvider",
+                "c:\\myPath",
+                "myOriginalItemSpec",
+                flags: flag,
+                resolved: true,
+                isImplicit: false,
+                hasDiagnosticAnalyzers: false,
+                properties: properties);
+
+            Assert.Equal("myProvider", model.ProviderType);
+            Assert.Equal("c:\\myPath", model.Path);
+            Assert.Equal("myOriginalItemSpec", model.OriginalItemSpec);
+            Assert.Equal("myPath", model.Caption);
+            Assert.Equal(ResolvedAnalyzerReference.SchemaName, model.SchemaName);
+            Assert.Equal(true, model.Resolved);
+            Assert.Equal(false, model.Implicit);
+            Assert.Equal(properties, model.Properties);
+            Assert.Equal(Dependency.AnalyzerNodePriority, model.Priority);
+            Assert.Equal(AnalyzerReference.PrimaryDataSourceItemType, model.SchemaItemType);
+            Assert.Equal(KnownMonikers.CodeInformation, model.Icon);
+            Assert.Equal(KnownMonikers.CodeInformation, model.ExpandedIcon);
+            Assert.Equal(ManagedImageMonikers.CodeInformationWarning, model.UnresolvedIcon);
+            Assert.Equal(ManagedImageMonikers.CodeInformationWarning, model.UnresolvedExpandedIcon);
+            Assert.True(model.Flags.Contains(flag));
+            Assert.False(model.Visible);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -1,6 +1,6 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\VisualStudio.props"/>
+  <Import Project="..\VisualStudio.props" />
   <PropertyGroup>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
     
@@ -20,6 +20,7 @@
     
     <PackageReference Include="NuGet.SolutionRestoreManager.Interop" Version="$(NuGetSolutionRestoreManagerInteropVersion)" />
     <PackageReference Include="NuGet.VisualStudio" Version="$(NuGetVisualStudioVersion)" />
+    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj" />
@@ -41,7 +42,7 @@
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests" />
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)"/>
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="ProjectSystem\VS\PropertyPages\DebugPageControl.xaml.cs">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AnalyzerAssemblyService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AnalyzerAssemblyService.cs
@@ -1,0 +1,204 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
+{
+    [Export(typeof(IAnalyzerAssemblyService))]
+    [AppliesTo(ProjectCapability.DependenciesTree)]
+    internal class AnalyzerAssemblyService : IAnalyzerAssemblyService
+    {
+        private object _guard = new object();
+        private Dictionary<string, bool> _map = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+
+        public bool ContainsDiagnosticAnalyzers(string fullPathToAssembly)
+        {
+            lock (_guard)
+            {
+                if (!_map.TryGetValue(fullPathToAssembly, out bool containsDiagnosticAnalyzers))
+                {
+                    containsDiagnosticAnalyzers = ContainsDiagnosticAnalyzersCore(fullPathToAssembly);
+                    _map.Add(fullPathToAssembly, containsDiagnosticAnalyzers);
+                }
+
+                return containsDiagnosticAnalyzers;
+            }
+        }
+
+        private static bool ContainsDiagnosticAnalyzersCore(string path)
+        {
+            try
+            {
+                using (var assemblyStream = System.IO.File.OpenRead(path))
+                using (var peReader = new PEReader(assemblyStream, PEStreamOptions.LeaveOpen))
+                {
+                    var reader = peReader.GetMetadataReader();
+                    foreach (var typeDefinitionHandle in reader.TypeDefinitions)
+                    {
+                        var typeDefinition = reader.GetTypeDefinition(typeDefinitionHandle);
+                        foreach (var customAttributeHandle in typeDefinition.GetCustomAttributes())
+                        {
+                            if (IsTargetAttribute(reader,
+                                                  customAttributeHandle,
+                                                  namespaceName: "Microsoft.CodeAnalysis.Diagnostics",
+                                                  typeName: "DiagnosticAnalyzerAttribute"))
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // Ignore any errors in reading the assembly metadata.
+            }
+
+            return false;
+        }
+
+        private static bool IsTargetAttribute(
+            System.Reflection.Metadata.MetadataReader metadataReader,
+            CustomAttributeHandle customAttributeHandle,
+            string namespaceName,
+            string typeName)
+        {
+            if (!GetTypeAndConstructor(metadataReader, customAttributeHandle, out EntityHandle ctorTypeHandle, out EntityHandle ctorHandle))
+            {
+                return false;
+            }
+
+            if (!GetAttributeNamespaceAndName(metadataReader, ctorTypeHandle, out StringHandle ctorTypeNamespaceHandle, out StringHandle ctorTypeNameHandle))
+            {
+                return false;
+            }
+
+            try
+            {
+                return metadataReader.StringComparer.Equals(ctorTypeNameHandle, typeName)
+                    && metadataReader.StringComparer.Equals(ctorTypeNamespaceHandle, namespaceName);
+            }
+            catch (BadImageFormatException)
+            {
+                return false;
+            }
+        }
+
+        private static bool GetTypeAndConstructor(
+            System.Reflection.Metadata.MetadataReader metadataReader,
+            CustomAttributeHandle customAttributeHandle,
+            out EntityHandle ctorType,
+            out EntityHandle attributeCtor
+            )
+        {
+            try
+            {
+                ctorType = default(EntityHandle);
+
+                attributeCtor = metadataReader.GetCustomAttribute(customAttributeHandle).Constructor;
+
+                if (attributeCtor.Kind == HandleKind.MemberReference)
+                {
+                    var memberRef = metadataReader.GetMemberReference((MemberReferenceHandle)attributeCtor);
+                    var ctorName = memberRef.Name;
+
+                    if (!metadataReader.StringComparer.Equals(ctorName, ".ctor"))
+                    {
+                        // Not a constructor.
+                        return false;
+                    }
+
+                    ctorType = memberRef.Parent;
+                }
+                else if (attributeCtor.Kind == HandleKind.MethodDefinition)
+                {
+                    var methodDef = metadataReader.GetMethodDefinition((MethodDefinitionHandle)attributeCtor);
+                    var ctorName = methodDef.Name;
+
+                    if (!metadataReader.StringComparer.Equals(ctorName, ".ctor"))
+                    {
+                        // Not a constructor.
+                        return false;
+                    }
+
+                    ctorType = methodDef.GetDeclaringType();
+                }
+                else
+                {
+                    // Unsupported metadata.
+                    return false;
+                }
+
+                return true;
+            }
+            catch (BadImageFormatException)
+            {
+                ctorType = default(EntityHandle);
+                attributeCtor = default(EntityHandle);
+                return false;
+            }
+        }
+
+        private static bool GetAttributeNamespaceAndName(
+            System.Reflection.Metadata.MetadataReader metadataReader,
+            EntityHandle typeDefOrRef,
+            out StringHandle namespaceHandle,
+            out StringHandle nameHandle)
+        {
+            nameHandle = default(StringHandle);
+            namespaceHandle = default(StringHandle);
+
+            try
+            {
+                if (typeDefOrRef.Kind == HandleKind.TypeReference)
+                {
+                    var typeRefRow = metadataReader.GetTypeReference((TypeReferenceHandle)typeDefOrRef);
+                    var handleType = typeRefRow.ResolutionScope.Kind;
+
+                    if (handleType == HandleKind.TypeReference || handleType == HandleKind.TypeDefinition)
+                    {
+                        // TODO - Support nested types.
+                        return false;
+                    }
+
+                    nameHandle = typeRefRow.Name;
+                    namespaceHandle = typeRefRow.Namespace;
+                }
+                else if (typeDefOrRef.Kind == HandleKind.TypeDefinition)
+                {
+                    var def = metadataReader.GetTypeDefinition((TypeDefinitionHandle)typeDefOrRef);
+
+                    if (IsNested(def.Attributes))
+                    {
+                        // TODO - Support nested types.
+                        return false;
+                    }
+
+                    nameHandle = def.Name;
+                    namespaceHandle = def.Namespace;
+                }
+                else
+                {
+                    // Unsupported metadata.
+                    return false;
+                }
+
+                return true;
+            }
+            catch (BadImageFormatException)
+            {
+                return false;
+            }
+        }
+
+        private static bool IsNested(TypeAttributes flags)
+        {
+            return (flags & ((TypeAttributes)0x0000006)) != 0;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IAnalyzerAssemblyService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IAnalyzerAssemblyService.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
+{
+    internal interface IAnalyzerAssemblyService
+    {
+        /// <summary>
+        /// Checks if an assembly contains any diagnostic analyzers.
+        /// </summary>
+        /// <param name="fullPathToAssembly">Full path to the assembly to check.</param>
+        /// <returns><code>true</code> if the assembly contains any types tagged with the
+        /// <see cref="CodeAnalysis.Diagnostics.DiagnosticAnalyzerAttribute"/>.</returns>
+        bool ContainsDiagnosticAnalyzers(string fullPathToAssembly);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/AnalyzerDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/AnalyzerDependencyModel.cs
@@ -15,6 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             ProjectTreeFlags flags,
             bool resolved,
             bool isImplicit,
+            bool hasDiagnosticAnalyzers,
             IImmutableDictionary<string, string> properties)
             : base(providerType, path, originalItemSpec, flags, resolved, isImplicit, properties)
         {
@@ -35,6 +36,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             ExpandedIcon = Icon;
             UnresolvedIcon = ManagedImageMonikers.CodeInformationWarning;
             UnresolvedExpandedIcon = UnresolvedIcon;
+
+            if (!hasDiagnosticAnalyzers)
+            {
+                Visible = false;
+            }
         }
     }
 }


### PR DESCRIPTION
Currently the Dependencies/Analyzers node shows _all_ of the assemblies passed to the compiler as analyzers. This often includes assemblies that don't contain analyzers themselves, but are needed to satisfy a dependency of some sort: utility libraries, resource assemblies, assemblies with code fixes, etc. It is not useful to show these to the user, and the legacy project system hides them.

This change updates the new project system to hide them as well. To do this we crack the assembly, loop over all the types, and look for any tagged with the `DiagnosticAnalyzerAttribute`. If we find one we mark the analyzer's node as visible; otherwise, we hide it. The code to read the metadata and check fot the attribute is a simplified copy of what the compiler uses to find diagnostic analyzers in the assembly--down to a lack of support for nested types.

A cache has also been implemented to avoid repeatedly cracking the same assemblies over and over as the same analyzers are likely to be used by multiple projects within the same solution. We make no attempt to update this information if an analyzer assembly changes on disk; this is a rare occurrence, and the language service already handles this situation by asking the user to restart VS (since it won't be able to load the analyzer assembly a second time anyway).

**Customer scenario**

Customer adds an analyzer package to their .NET Standard or .NET Core package. When looking at the items under the Dependencies/Analyzers node for a project they will likely see a bunch of utility libraries, resource assemblies, and other things that don't actually have any diagnostics, cluttering up the view.

Example 1:
![1](https://cloud.githubusercontent.com/assets/1427284/26641161/ae3de0a8-45f7-11e7-87f2-7df2210354c3.png)

Example 2:
![Analyzers in VS 15.3.1](https://user-images.githubusercontent.com/1156571/29532815-d6d7d5e4-8663-11e7-9678-eeffbb1ae1b6.PNG)

**Bugs this fixes:** 

Fixes #2724 
Fixes #2338 

**Workarounds, if any**

None.

**Risk**

Low.

**Performance impact**

Low; the extra work of reading the assembly metadata will generally happen in the background, and the caching limits how often it needs to happen.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

This was a known limitation of the analyzer support in the new project system.

**How was the bug found?**

Customer reports.
