### PR TITLE
Show version number for "SDK" packages in Solution Explorer

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SdkDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SdkDependencyModelTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal("myProvider", model.ProviderType);
             Assert.Equal("c:\\myPath.dll", model.Path);
             Assert.Equal("myOriginalItemSpec", model.OriginalItemSpec);
-            Assert.Equal("c:\\myPath.dll", model.Caption);
+            Assert.Equal("c:\\myPath.dll (2.0.0)", model.Caption);
             Assert.Equal("2.0.0", model.Version);
             Assert.Equal(ResolvedSdkReference.SchemaName, model.SchemaName);
             Assert.Equal(true, model.Resolved);
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal("myProvider", model.ProviderType);
             Assert.Equal("c:\\myPath.dll", model.Path);
             Assert.Equal("myOriginalItemSpec", model.OriginalItemSpec);
-            Assert.Equal("c:\\myPath.dll", model.Caption);
+            Assert.Equal("c:\\myPath.dll (2.0.0)", model.Caption);
             Assert.Equal("2.0.0", model.Version);
             Assert.Equal(SdkReference.SchemaName, model.SchemaName);
             Assert.Equal(false, model.Resolved);
@@ -96,7 +96,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal("myProvider", model.ProviderType);
             Assert.Equal("c:\\myPath.dll", model.Path);
             Assert.Equal("myOriginalItemSpec", model.OriginalItemSpec);
-            Assert.Equal("c:\\myPath.dll", model.Caption);
+            Assert.Equal("c:\\myPath.dll (2.0.0)", model.Caption);
             Assert.Equal("2.0.0", model.Version);
             Assert.Equal(ResolvedSdkReference.SchemaName, model.SchemaName);
             Assert.Equal(true, model.Resolved);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/SdkDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/SdkDependencyModel.cs
@@ -31,8 +31,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
                 SchemaName = SdkReference.SchemaName;
             }
 
-            Caption = Path.Split(CommonConstants.CommaDelimiter, StringSplitOptions.RemoveEmptyEntries)
-                          .FirstOrDefault();
             SchemaItemType = SdkReference.PrimaryDataSourceItemType;
             Priority = Dependency.SdkNodePriority;
             Icon = isImplicit ? ManagedImageMonikers.SdkPrivate : ManagedImageMonikers.Sdk;
@@ -41,6 +39,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             UnresolvedExpandedIcon = UnresolvedIcon;
             Version = properties != null && properties.ContainsKey(ProjectItemMetadata.Version)
                         ? properties[ProjectItemMetadata.Version] : string.Empty;
+            var baseCaption = Path.Split(CommonConstants.CommaDelimiter, StringSplitOptions.RemoveEmptyEntries)
+                                .FirstOrDefault();
+            Caption = string.IsNullOrEmpty(Version) ? baseCaption : $"{baseCaption} ({Version})";
         }
     }
 }


### PR DESCRIPTION
Currently we include the version number in the caption for _package_ items under the Dependencies node in Solution Explorer, like this:

> StyleCop.Analyzers (1.0.2)

However, we don't do the same thing for items under the SDK node. In this case the model for SDK dependencies supports a version number; we just need to update the caption to show it.

Note that the SDK dependencies are ultimately backed by items produced by the `CollectSDKReferencesDesignTime` task in the [dotnet/sdk](https://github.com/dotnet/sdk) repo, and these items currently do not include `Version` metadata. That will go in as a separate change (see https://github.com/dotnet/sdk/pull/1572), and only once both of these changes come together will you see the version number in Solution Explorer.

**Customer scenario**

Customer wishes to see which version of NETStandard.Library or Microsoft.NETCore.App their project is using. The natural place to put this is on the node in the Solution Explorer, but we don't currently:

![image](https://cloud.githubusercontent.com/assets/95136/26286148/c15e603c-3e12-11e7-9858-e2b9bdb01365.png)

We _do_ show the version number for NuGet packages, though.

**Bugs this fixes:** 

Related to #2248.

**Workarounds, if any**

Examine the project file directly, or open the project properties.

**Risk**

Low.

**Performance impact**

Low; this is just a change to how we display the package name.

**Is this a regression from a previous update?**

No.

**Root cause analysis:**

Overlooked as part of the initial Dependencies node work, possibly because it requires changes in dotnet/SDK to light up.

**How was the bug found?**

Internal use.
