### PR TITLE
Adding the 'ClassDesigner' capability to the C# and VB design time targets.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.CSharp.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.CSharp.DesignTime.targets
@@ -25,7 +25,7 @@
     <ItemGroup>
      <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)CSharp.ProjectItemsSchema.xaml;"/>
 
-     <ProjectCapability Include="CSharp;Managed"/>
+     <ProjectCapability Include="CSharp;Managed;ClassDesigner;"/>
     </ItemGroup>
 
     <!-- Targets -->

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.CSharp.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.CSharp.DesignTime.targets
@@ -22,25 +22,27 @@
     <DefineCSharpItemSchemas>false</DefineCSharpItemSchemas>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)CSharp.ProjectItemsSchema.xaml;"/>
+
+    <ProjectCapability Include="
+                          CSharp;
+                          Managed;
+                          ClassDesigner;" />
+  </ItemGroup>
+
+  <!-- Targets -->
+
+  <!-- Returns Csc command-line arguments for the language service -->
+  <Target Name="CompileDesignTime"
+          Returns="@(_CompilerCommandLineArgs)"
+          DependsOnTargets="_CheckCompileDesignTimePrerequisite;Compile"
+          Condition="'$(IsCrossTargetingBuild)' != 'true'">
+
     <ItemGroup>
-     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)CSharp.ProjectItemsSchema.xaml;"/>
-
-     <ProjectCapability Include="CSharp;Managed;ClassDesigner;"/>
+      <_CompilerCommandLineArgs Include="@(CscCommandLineArgs)"/>
     </ItemGroup>
-
-    <!-- Targets -->
-
-    <!-- Returns Csc command-line arguments for the language service -->
-    <Target Name="CompileDesignTime"
-            Returns="@(_CompilerCommandLineArgs)"
-            DependsOnTargets="_CheckCompileDesignTimePrerequisite;Compile"
-            Condition="'$(IsCrossTargetingBuild)' != 'true'"
-          >
-
-      <ItemGroup>
-        <_CompilerCommandLineArgs Include="@(CscCommandLineArgs)"/>
-      </ItemGroup>
       
-    </Target>
+  </Target>
 
 </Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.VisualBasic.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.VisualBasic.DesignTime.targets
@@ -30,7 +30,7 @@
         <Context>ProjectSubscriptionService</Context>
       </PropertyPageSchema>
 
-     <ProjectCapability Include="VB;Managed"/>
+     <ProjectCapability Include="VB;Managed;ClassDesigner;"/>
   </ItemGroup>
 
   <!-- Targets -->

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.VisualBasic.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.VisualBasic.DesignTime.targets
@@ -30,7 +30,10 @@
         <Context>ProjectSubscriptionService</Context>
       </PropertyPageSchema>
 
-     <ProjectCapability Include="VB;Managed;ClassDesigner;"/>
+     <ProjectCapability Include="
+                          VB;
+                          Managed;
+                          ClassDesigner;" />
   </ItemGroup>
 
   <!-- Targets -->
@@ -39,8 +42,7 @@
   <Target Name="CompileDesignTime"
           Returns="@(_CompilerCommandLineArgs)"
           DependsOnTargets="_CheckCompileDesignTimePrerequisite;Compile"
-          Condition="'$(IsCrossTargetingBuild)' != 'true'"
-        >
+          Condition="'$(IsCrossTargetingBuild)' != 'true'">
 
     <!-- VB Framework projects needs core library references. In the case of Command line scenario, the vbc injects this reference. -->
     <PropertyGroup Condition="'$(FrameworkPathOverride)' != ''">


### PR DESCRIPTION
FYI. @Pilchie, @davkean.

This resolves https://github.com/dotnet/project-system/issues/256.

I've also tagged you on the CPS side change.