### PR TITLE
Marking the ConfigurationGeneralFile.xaml PropertyPageSchema as Context=Invisible

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -109,7 +109,7 @@
     </PropertyPageSchema>
 
     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)ConfigurationGeneralFile.xaml">
-      <Context>File</Context>
+      <Context>Invisible</Context>
     </PropertyPageSchema>
 
     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)SourceControl.xaml">


### PR DESCRIPTION
FYI. @Pilchie, @davkean, @adrianvmsft 

This resolves https://github.com/dotnet/project-system/issues/2809 by marking the context as invisible. This was listed as the safer of the two changes.