### PR TITLE
Use NewTree overloads available prior to 15.5

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -425,6 +425,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
                 ApplyProjectTreePropertiesCustomization(null, values);
 
+                // Note that all the parameters are specified so we can force this call to an
+                // overload of NewTree available prior to 15.5 versions of CPS. Once a 15.5 build
+                // is publicly available we can move this to an overload with default values for
+                // most of the parameters, and we'll only need to pass the interesting ones.
                 return NewTree(
                          caption: values.Caption,
                          filePath: null,
@@ -535,6 +539,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             bool visible = true,
             ProjectTreeFlags? flags = default(ProjectTreeFlags?))
         {
+            // Note that all the parameters are specified so we can force this call to an
+            // overload of NewTree available prior to 15.5 versions of CPS. Once a 15.5 build
+            // is publicly available we can move this to an overload with default values for
+            // most of the parameters, and we'll only need to pass the interesting ones.
             return NewTree(
                 caption: caption,
                 item: itemContext,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -426,9 +426,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 ApplyProjectTreePropertiesCustomization(null, values);
 
                 return NewTree(
-                         values.Caption,
+                         caption: values.Caption,
+                         filePath: null,
+                         browseObjectProperties: null,
                          icon: values.Icon,
                          expandedIcon: values.ExpandedIcon,
+                         visible: true,
                          flags: values.Flags);
             }
             else
@@ -540,7 +543,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 icon: icon,
                 expandedIcon: expandedIcon,
                 visible: visible,
-                flags: flags);
+                flags: flags,
+                isLinked: false);
         }
 
         public IProjectTree CreateTree(


### PR DESCRIPTION
Commit 334dcf6a updated us to consume a 15.5 version of the CPS
binaries. This includes changes to support specifying a sort order on
tree nodes, needed by F#.

When we moved over our calls in the Dependencies tree code
to the `NewTree` method started binding to new overloads that can take
a value indicating a sort order, and return an instance of the new
`IProjectTree2` or `IProjectTreeItem2` interfaces. However, these new
overloads aren't available at runtime on VS builds prior to 15.5,
leading to "method not found" exceptions when trying to run locally
built project-system bits on top of a 15.4 Preview VS.

Since there are no publicly available 15.5 builds and the Dependencies
tree doesn't need to specify its own sort order, this commit updates
the calls so we will use the overloads available prior to 15.5.

**Customer scenario**

Affects developers, not customers. A developer using a publicly-available build of VS (e.g. a 15.4 Preview) will not be able to build the project-system repo and try out the bits; they'll immediately run into missing method exceptions and debug assertions, and the Dependencies node no longer shows up.

**Bugs this fixes:** 

No bug.

**Workarounds, if any**

None.

**Risk**

None; we're just going back to using the same method overloads we have in the past.

**Performance impact**

None.

**Is this a regression from a previous update?**

Not a previous update, but certainly a previous build.

**Root cause analysis:**

No idea how we missed this.

**How was the bug found?**

Development.
