### PR TITLE
Remove incorrect assert

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetFramework.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetFramework.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Runtime.Versioning;
-using BCLDebug = System.Diagnostics.Debug;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 {
@@ -97,8 +96,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 
         public bool Equals(string obj)
         {
-            BCLDebug.Fail("This should never be called.");
-
             if (obj != null)
             {
                 return string.Equals(Moniker, obj, StringComparison.OrdinalIgnoreCase)


### PR DESCRIPTION
Commit 409a3421 added a debug assertion that the `TargetFramework.Equals(string)` method is not called. However, it is called explicitly by the `TargetFrameworkProvider.GetTargetFramework(string)` method.

**Customer scenario**

Developers running debug builds of project-system are likely to run into dozens (if not more) assertion dialogs making it effectively impossible to test and debug other changes.

**Bugs this fixes:** 

No bug.

**Workarounds, if any**

Use release bits.

**Risk**

Low; just removing an assert.

**Performance impact**

None.

**Is this a regression from a previous update?**

This is a regression from a previous build.

**Root cause analysis:**

Not sure.

**How was the bug found?**

Development.
