### PR TITLE
Remove extension installation root and folder from ProjectSystemSetup

### DIFF
--- a/src/ProjectSystemSetup/ProjectSystemSetup.csproj
+++ b/src/ProjectSystemSetup/ProjectSystemSetup.csproj
@@ -7,8 +7,6 @@
     
     <!-- VSIX -->
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
-    <ExtensionInstallationRoot>CommonExtensions</ExtensionInstallationRoot>
-    <ExtensionInstallationFolder>Microsoft\VisualStudio\Editors</ExtensionInstallationFolder>
 
     <!-- VS Insertion -->
     <VisualStudioInsertionComponent>Microsoft.VisualStudio.ProjectSystem.Managed</VisualStudioInsertionComponent>


### PR DESCRIPTION
**Customer scenario**

.NET Core users cannot see icons in dependency tree. This is because the setup authoring of Project System changed to place its components in `Common7\IDE\CommonExtensions\Microsoft\VisualStudio\Editors`. This fixes the incorrect setup authoring.

![image](https://user-images.githubusercontent.com/7732033/30706054-178540c6-9eac-11e7-8cc2-d22121670de3.png)

**Bugs this fixes:** 

[495585](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/495585)

**Workarounds, if any**

None

**Risk**

Low, puts things back the way they were in 15.4

**Performance impact**

None, puts things back the way they were in 15.4

**Is this a regression from a previous update?**

Yes, from 15.4

**Root cause analysis:**

Likely copy-and-paste error from recent refactoring of our build system infrastructure to use https://github.com/dotnet/roslyn-tools.

**How was the bug found?**

Vendor validation

**Dev Notes**

- [x] Validate this change using a VAL build installation. Result: icons are displayed correctly

/cc @dotnet/project-system 