### PR TITLE
Updating the GetProfileNameDialog to support localization.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/GetProfileNameDialog.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/GetProfileNameDialog.xaml
@@ -3,6 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:ui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.15.0"
+    xmlns:local="clr-namespace:Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages"
     x:Uid="ProfileNameDialog"
     x:Class="Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages.GetProfileNameDialog"
     Name="GetProfileNameDialogWindow"
@@ -27,7 +28,7 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"></RowDefinition>
             </Grid.RowDefinitions>
-            <TextBlock x:Uid="NameLabel" Margin="10,10" Grid.Row="0" Grid.Column="0"  TextWrapping="NoWrap">Profile name:</TextBlock>
+            <TextBlock x:Uid="NameLabel" Margin="10,10" Grid.Row="0" Grid.Column="0"  TextWrapping="NoWrap" Text="{x:Static Member=local:PropertyPageResources.ProfileName}" />
             <TextBox x:Name="ProfileNameTextBox" Uid="ProfileNameTextBox" Margin="10,10" Grid.Row="0" Grid.Column="1" Text="{Binding UpdateSourceTrigger=PropertyChanged, Path=ProfileName}" />
         </Grid>
         <Grid x:Uid="ButtonGrid" Grid.Row="1" Margin="5" HorizontalAlignment="Right" >
@@ -38,8 +39,8 @@
                 <ColumnDefinition Width="Auto"></ColumnDefinition>
                 <ColumnDefinition Width="Auto"></ColumnDefinition>
             </Grid.ColumnDefinitions>
-            <Button x:Uid="OKButton" Grid.Row="0"  Grid.Column="0" Margin="5" MinWidth="50" Padding="10,2" IsDefault="True" Click="OKButton_Click">OK</Button>
-            <Button x:Uid="CancelButton" Grid.Row="0"  Grid.Column="1" Margin="5" MinWidth="50" Padding="10,2" IsCancel="True">Cancel</Button>
+            <Button x:Uid="OKButton" Grid.Row="0"  Grid.Column="0" Margin="5" MinWidth="50" Padding="10,2" IsDefault="True" Click="OKButton_Click" Content="{x:Static Member=local:PropertyPageResources.OKBtn}" />
+            <Button x:Uid="CancelButton" Grid.Row="0"  Grid.Column="1" Margin="5" MinWidth="50" Padding="10,2" IsCancel="True" Content="{x:Static Member=local:PropertyPageResources.CancelBtn}" />
         </Grid>
     </Grid>
 </ui:DialogWindow>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class PropertyPageResources {
@@ -102,6 +102,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         public static string BrowseBtn {
             get {
                 return ResourceManager.GetString("BrowseBtn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cancel.
+        /// </summary>
+        public static string CancelBtn {
+            get {
+                return ResourceManager.GetString("CancelBtn", resourceCulture);
             }
         }
         
@@ -268,6 +277,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to OK.
+        /// </summary>
+        public static string OKBtn {
+            get {
+                return ResourceManager.GetString("OKBtn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Profile:.
         /// </summary>
         public static string Profile {
@@ -309,6 +327,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         public static string ProfileKindProjectName {
             get {
                 return ResourceManager.GetString("ProfileKindProjectName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Profile name:.
+        /// </summary>
+        public static string ProfileName {
+            get {
+                return ResourceManager.GetString("ProfileName", resourceCulture);
             }
         }
         

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.resx
@@ -222,4 +222,13 @@
   <data name="WorkingDirectory" xml:space="preserve">
     <value>Working directory:</value>
   </data>
+  <data name="CancelBtn" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="OKBtn" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="ProfileName" xml:space="preserve">
+    <value>Profile name:</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.cs.xlf
@@ -177,6 +177,21 @@
         <target state="translated">Pracovní adresář:</target>
         <note />
       </trans-unit>
+      <trans-unit id="CancelBtn">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OKBtn">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProfileName">
+        <source>Profile name:</source>
+        <target state="new">Profile name:</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.de.xlf
@@ -177,6 +177,21 @@
         <target state="translated">Arbeitsverzeichnis:</target>
         <note />
       </trans-unit>
+      <trans-unit id="CancelBtn">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OKBtn">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProfileName">
+        <source>Profile name:</source>
+        <target state="new">Profile name:</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.es.xlf
@@ -177,6 +177,21 @@
         <target state="translated">Directorio de trabajo:</target>
         <note />
       </trans-unit>
+      <trans-unit id="CancelBtn">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OKBtn">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProfileName">
+        <source>Profile name:</source>
+        <target state="new">Profile name:</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.fr.xlf
@@ -177,6 +177,21 @@
         <target state="translated">Répertoire de travail :</target>
         <note />
       </trans-unit>
+      <trans-unit id="CancelBtn">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OKBtn">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProfileName">
+        <source>Profile name:</source>
+        <target state="new">Profile name:</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.it.xlf
@@ -177,6 +177,21 @@
         <target state="translated">Directory di lavoro:</target>
         <note />
       </trans-unit>
+      <trans-unit id="CancelBtn">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OKBtn">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProfileName">
+        <source>Profile name:</source>
+        <target state="new">Profile name:</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ja.xlf
@@ -177,6 +177,21 @@
         <target state="translated">作業ディレクトリ:</target>
         <note />
       </trans-unit>
+      <trans-unit id="CancelBtn">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OKBtn">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProfileName">
+        <source>Profile name:</source>
+        <target state="new">Profile name:</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ko.xlf
@@ -177,6 +177,21 @@
         <target state="translated">작업 디렉터리:</target>
         <note />
       </trans-unit>
+      <trans-unit id="CancelBtn">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OKBtn">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProfileName">
+        <source>Profile name:</source>
+        <target state="new">Profile name:</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.pl.xlf
@@ -177,6 +177,21 @@
         <target state="translated">Katalog roboczy:</target>
         <note />
       </trans-unit>
+      <trans-unit id="CancelBtn">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OKBtn">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProfileName">
+        <source>Profile name:</source>
+        <target state="new">Profile name:</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.pt-BR.xlf
@@ -177,6 +177,21 @@
         <target state="translated">Diretório de trabalho:</target>
         <note />
       </trans-unit>
+      <trans-unit id="CancelBtn">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OKBtn">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProfileName">
+        <source>Profile name:</source>
+        <target state="new">Profile name:</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ru.xlf
@@ -177,6 +177,21 @@
         <target state="translated">Рабочий каталог:</target>
         <note />
       </trans-unit>
+      <trans-unit id="CancelBtn">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OKBtn">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProfileName">
+        <source>Profile name:</source>
+        <target state="new">Profile name:</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.tr.xlf
@@ -177,6 +177,21 @@
         <target state="translated">Çalışma dizini:</target>
         <note />
       </trans-unit>
+      <trans-unit id="CancelBtn">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OKBtn">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProfileName">
+        <source>Profile name:</source>
+        <target state="new">Profile name:</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.zh-Hans.xlf
@@ -177,6 +177,21 @@
         <target state="translated">工作目录:</target>
         <note />
       </trans-unit>
+      <trans-unit id="CancelBtn">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OKBtn">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProfileName">
+        <source>Profile name:</source>
+        <target state="new">Profile name:</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.zh-Hant.xlf
@@ -177,6 +177,21 @@
         <target state="translated">工作目錄:</target>
         <note />
       </trans-unit>
+      <trans-unit id="CancelBtn">
+        <source>Cancel</source>
+        <target state="new">Cancel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OKBtn">
+        <source>OK</source>
+        <target state="new">OK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ProfileName">
+        <source>Profile name:</source>
+        <target state="new">Profile name:</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
**Customer scenario**

Users who depend on localization may not be able to create new debug profiles.

**Bugs this fixes:** 

https://devdiv.visualstudio.com/DevDiv/_queries?id=473107&triage=true&_a=edit

**Workarounds, if any**

None.

**Risk**

Low.

**Performance impact**

Low

**Is this a regression from a previous update?**

No

**Root cause analysis:**

This was likely missed when the localization effort was done.

**How was the bug found?**

Customer reported