### PR TITLE
Return empty target framework when one is not found

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
@@ -273,7 +273,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
                 }
             }
 
-            return _targetFrameworkProvider.GetTargetFramework(shortOrFullName);
+            return _targetFrameworkProvider.GetTargetFramework(shortOrFullName) ?? TargetFramework.Empty;
         }
 
         private static string GetDisplayName(ConfiguredProject configuredProject, ProjectData projectData, string targetFramework)


### PR DESCRIPTION
Fixes NRE in AggregateCrossTargetProjectContextProvider

**Customer scenario**

Customers using barebones CPS projects without a TargetFramework do not see an expandable dependencies node. This fix unblocks some CTI team tests.

**Bugs this fixes:** 

[426406](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/426406)

**Workarounds, if any**

Add a target framework to the template

**Risk**

Low. This prevents a Null Reference Exception

**Performance impact**

Low, this is not a mainline scenario for us.

**Is this a regression from a previous update?**

Yes, Regressed in 15.3 after rewriting dependencies node

**Root cause analysis:**

`GetTargetFramework` can return null, but not all code paths accounted for this. I went through and looked at the other paths as well to confirm they all handle null.

**How was the bug found?**

Reported by CTI team (blocking some of their tests)

/cc @dotnet/project-system 