### PR TITLE
Update CPS Sdk, removing uneeded pkgdef key

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -61,7 +61,7 @@
     <VsWebSiteInteropVersion>8.0.0-alpha</VsWebSiteInteropVersion>
     
     <!-- CPS -->
-    <MicrosoftVisualStudioProjectSystemSDKVersion>15.5.114-pre-gb992513730</MicrosoftVisualStudioProjectSystemSDKVersion>
+    <MicrosoftVisualStudioProjectSystemSDKVersion>15.5.293-pre</MicrosoftVisualStudioProjectSystemSDKVersion>
     
     <!-- Roslyn -->
     <MicrosoftVisualStudioLanguageServicesVersion>2.6.0-beta1-62113-02</MicrosoftVisualStudioLanguageServicesVersion>


### PR DESCRIPTION
We found an issue with the CPS SDK where `ProjectTypeRegistrationAttribute` would generate this key in the pkgdef: 

```
[$RootKey$\NewProjectTemplates\TemplateDirs\{3347bee8-d7a1-4082-95e4-38a439553cc2}\/1]
@="#1"
"SortPriority"=dword:00000064
```

This key is the old way of supplying project templates to VS, which has been replaced with assets in vsix manifest. It is causing an images loaded regression, and since the key is not needed we are removing it. See the CPS PR [here](https://mseng.visualstudio.com/VSIDEProj/_git/VSIDEProj.CPS/pullrequest/261699?_a=overview) which removes the key and explains all the issues with it.

**Customer scenario**

Regression in New Project. CPS assemblies are needlessly loaded.

**Bugs this fixes:** 

[Perf: ManagedLangs_CS_DDRIT.0800.Close Solution regressed VM_FileBytes_Total_devenv by 7,430,144.000 Bytes (1.3%). Baseline 26913.3006](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/495599)

**Workarounds, if any**

None

**Risk**

Low, removal of an unused registry key `ProjectTypeRegistrationAttribute` used to generate

**Performance impact**

Perf improvement

**Is this a regression from a previous update?**

Yes and no. Bug potential always present, but depends on VS install order. Didn't start happening until now.

**Root cause analysis:**

Issue with CPS.

**How was the bug found?**

RPS testing.
