### PR TITLE
Add dependency tree telemetry service

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITelemetryServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITelemetryServiceFactory.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.Telemetry
         {
             public string EventName { get; set; }
 
-            public IEnumerable<(string propertyName, string propertyValue)> Properties { get; set; }
+            public IEnumerable<(string propertyName, object propertyValue)> Properties { get; set; }
         }
 
         public static ITelemetryService Create() => Mock.Of<ITelemetryService>();
@@ -23,18 +23,18 @@ namespace Microsoft.VisualStudio.Telemetry
             telemetryService.Setup(t => t.PostEvent(It.IsAny<string>()))
                 .Callback((string name) => callParameters.EventName = name);
 
-            telemetryService.Setup(t => t.PostProperty(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-                .Callback((string e, string p, string v) => 
+            telemetryService.Setup(t => t.PostProperty(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<object>()))
+                .Callback((string e, string p, object v) => 
                 {
                     callParameters.EventName = e;
-                    callParameters.Properties = new List<(string, string)>
+                    callParameters.Properties = new List<(string, object)>
                     {
                         (p, v)
                     };
                 });
 
-            telemetryService.Setup(t => t.PostProperties(It.IsAny<string>(), It.IsAny<IEnumerable<(string propertyName, string propertyValue)>>()))
-                .Callback((string e, IEnumerable<(string propertyName, string propertyValue)> p) =>
+            telemetryService.Setup(t => t.PostProperties(It.IsAny<string>(), It.IsAny<IEnumerable<(string propertyName, object propertyValue)>>()))
+                .Callback((string e, IEnumerable<(string propertyName, object propertyValue)> p) =>
                 {
                     callParameters.EventName = e;
                     callParameters.Properties = p;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITelemetryServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITelemetryServiceFactory.cs
@@ -1,11 +1,46 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using Moq;
 
 namespace Microsoft.VisualStudio.Telemetry
 {
     internal static class ITelemetryServiceFactory
     {
+        public class TelemetryParameters
+        {
+            public string EventName { get; set; }
+
+            public IEnumerable<(string propertyName, string propertyValue)> Properties { get; set; }
+        }
+
         public static ITelemetryService Create() => Mock.Of<ITelemetryService>();
+
+        public static ITelemetryService Create(TelemetryParameters callParameters)
+        {
+            var telemetryService = new Mock<ITelemetryService>();
+
+            telemetryService.Setup(t => t.PostEvent(It.IsAny<string>()))
+                .Callback((string name) => callParameters.EventName = name);
+
+            telemetryService.Setup(t => t.PostProperty(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Callback((string e, string p, string v) => 
+                {
+                    callParameters.EventName = e;
+                    callParameters.Properties = new List<(string, string)>
+                    {
+                        (p, v)
+                    };
+                });
+
+            telemetryService.Setup(t => t.PostProperties(It.IsAny<string>(), It.IsAny<IEnumerable<(string propertyName, string propertyValue)>>()))
+                .Callback((string e, IEnumerable<(string propertyName, string propertyValue)> p) =>
+                {
+                    callParameters.EventName = e;
+                    callParameters.Properties = p;
+                });
+
+            return telemetryService.Object;
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryServiceTests.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Telemetry;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
+{
+    [ProjectSystemTrait]
+    public class DependencyTreeTelemetryServiceTests
+    {
+        private const string TestFilePath = @"C:\Path\To\Project.csproj";
+
+        private static ITelemetryServiceFactory.TelemetryParameters CalledParameters;
+
+        [Fact]
+        public void ObserveUnresolvedRules_LeavesTreeUpdateUnresolved()
+        {
+            var telemetryService = CreateInstance();
+
+            telemetryService.ObserveUnresolvedRules(
+                ITargetFrameworkFactory.Implement("tfm1"), 
+                new string[] { "Rule1", "Rule2" });
+
+            telemetryService.ObserveTreeUpdateCompleted();
+
+            Assert.Equal("TreeUpdated/Unresolved", CalledParameters.EventName);
+        }
+
+        static DependencyTreeTelemetryService CreateInstance()
+        {
+            CalledParameters = new ITelemetryServiceFactory.TelemetryParameters();
+
+            return new DependencyTreeTelemetryService(
+                UnconfiguredProjectFactory.Create(filePath: TestFilePath), 
+                ITelemetryServiceFactory.Create(CalledParameters));
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryServiceTests.cs
@@ -1,5 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 using Microsoft.VisualStudio.Telemetry;
 using Xunit;
 
@@ -12,8 +16,69 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
         private static ITelemetryServiceFactory.TelemetryParameters CalledParameters;
 
+        /// <summary>
+        /// This is a general end-to-end test of expected common flow
+        /// </summary>
+        [Fact]        
+        public void DesignTimeWithAllChanges_TreeUpdateResolved_MultiTFM()
+        {            
+            var tfNames = new string[] { "tfm1", "tfm2" };
+            var targetFrameworks = tfNames.Select(tfm => ITargetFrameworkFactory.Implement(tfm));
+            var evalRules = new List<string> { "eval1", "eval2", "eval3" };
+            var dtRules = new List<string> { "dt1", "dt2", "dt3" };
+            var allRules = evalRules.Concat(dtRules);
+            var withChanges = IProjectChangeDescriptionFactory.Implement(difference: IProjectChangeDiffFactory.Implement(anyChanges: true));
+            var noChanges = IProjectChangeDescriptionFactory.Implement(difference: IProjectChangeDiffFactory.Implement(anyChanges: false));
+
+            var telemetryService = CreateInstance();
+
+            // Initialization
+            foreach (var tf in targetFrameworks)
+            {
+                telemetryService.ObserveUnresolvedRules(tf, evalRules);
+            }
+
+            // Observe Evaluation
+            foreach (var tf in targetFrameworks)
+            {
+                var builder = ImmutableDictionary.CreateBuilder<string, IProjectChangeDescription>(StringComparers.RuleNames);
+                evalRules.ForEach(rule => builder.Add(rule, withChanges));
+                dtRules.ForEach(rule => builder.Add(rule, noChanges));
+
+                telemetryService.ObserveHandlerRulesChanges(tf, allRules, builder.ToImmutable());
+                telemetryService.ObserveCompleteHandlers(tf, RuleHandlerType.Evaluation);
+
+                telemetryService.ObserveTreeUpdateCompleted();
+                Assert.Equal("TreeUpdated/Unresolved", CalledParameters.EventName);
+                ResetTestCallParameters();
+            }
+
+            // Observe Design Time
+            var count = 0;
+            foreach (var tf in targetFrameworks)
+            {
+                var builder = ImmutableDictionary.CreateBuilder<string, IProjectChangeDescription>(StringComparers.RuleNames);
+                evalRules.ForEach(rule => builder.Add(rule, noChanges));
+                dtRules.ForEach(rule => builder.Add(rule, withChanges));
+
+                telemetryService.ObserveHandlerRulesChanges(tf, allRules, builder.ToImmutable());
+                telemetryService.ObserveCompleteHandlers(tf, RuleHandlerType.DesignTimeBuild);
+
+                telemetryService.ObserveTreeUpdateCompleted();
+
+                // only resolved after the last target framework
+                Assert.Equal(++count < targetFrameworks.Count() ? "TreeUpdated/Unresolved" : "TreeUpdated/Resolved", 
+                    CalledParameters.EventName);
+                ResetTestCallParameters();
+            }
+
+            // subsequent tree updates should not fire telemetry
+            telemetryService.ObserveTreeUpdateCompleted();
+            Assert.Null(CalledParameters.EventName);
+        }
+
         [Fact]
-        public void ObserveUnresolvedRules_LeavesTreeUpdateUnresolved()
+        public void ObserveUnresolvedRules_TreeUpdateUnresolved()
         {
             var telemetryService = CreateInstance();
 
@@ -24,6 +89,69 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             telemetryService.ObserveTreeUpdateCompleted();
 
             Assert.Equal("TreeUpdated/Unresolved", CalledParameters.EventName);
+        }
+
+        /// <summary>
+        /// Evaluation after Design Time stops telemetry even if no Resolved yet
+        /// </summary>
+        [Fact]
+        public void EvaluationAfterDesignTime_StopsTelemetry()
+        {
+            var targetFramework = ITargetFrameworkFactory.Implement("tfm1");
+            var evalRules = new List<string> { "eval1", "eval2", "eval3" };
+            var dtRules = new List<string> { "dt1", "dt2", "dt3" };
+            var allRules = evalRules.Concat(dtRules);
+            var withChanges = IProjectChangeDescriptionFactory.Implement(difference: IProjectChangeDiffFactory.Implement(anyChanges: true));
+            var noChanges = IProjectChangeDescriptionFactory.Implement(difference: IProjectChangeDiffFactory.Implement(anyChanges: false));
+
+            var telemetryService = CreateInstance();
+
+            // Initialization
+            telemetryService.ObserveUnresolvedRules(targetFramework, evalRules);
+
+            // Observe Evaluation
+            var builder = ImmutableDictionary.CreateBuilder<string, IProjectChangeDescription>(StringComparers.RuleNames);
+            evalRules.ForEach(rule => builder.Add(rule, withChanges));
+            dtRules.ForEach(rule => builder.Add(rule, noChanges));
+
+            telemetryService.ObserveHandlerRulesChanges(targetFramework, allRules, builder.ToImmutable());
+            telemetryService.ObserveCompleteHandlers(targetFramework, RuleHandlerType.Evaluation);
+
+            telemetryService.ObserveTreeUpdateCompleted();
+            Assert.Equal("TreeUpdated/Unresolved", CalledParameters.EventName);
+            ResetTestCallParameters();
+
+            // Observe Design Time
+            builder = ImmutableDictionary.CreateBuilder<string, IProjectChangeDescription>(StringComparers.RuleNames);
+            evalRules.ForEach(rule => builder.Add(rule, noChanges));
+            dtRules.ForEach(rule => builder.Add(rule, rule != "dt3" ? withChanges : noChanges));
+
+            telemetryService.ObserveHandlerRulesChanges(targetFramework, allRules, builder.ToImmutable());
+            telemetryService.ObserveCompleteHandlers(targetFramework, RuleHandlerType.DesignTimeBuild);
+
+            telemetryService.ObserveTreeUpdateCompleted();
+
+            // one of the design time rules has no changes hence this should not report resolved
+            Assert.Equal("TreeUpdated/Unresolved", CalledParameters.EventName);
+            ResetTestCallParameters();
+
+            // Observe another evaluation
+            builder = ImmutableDictionary.CreateBuilder<string, IProjectChangeDescription>(StringComparers.RuleNames);
+            evalRules.ForEach(rule => builder.Add(rule, withChanges));
+            dtRules.ForEach(rule => builder.Add(rule, noChanges));
+
+            telemetryService.ObserveHandlerRulesChanges(targetFramework, allRules, builder.ToImmutable());
+            telemetryService.ObserveCompleteHandlers(targetFramework, RuleHandlerType.Evaluation);
+
+            // no more telemetry events
+            telemetryService.ObserveTreeUpdateCompleted();
+            Assert.Null(CalledParameters.EventName);
+        }
+
+        private void ResetTestCallParameters()
+        {
+            CalledParameters.EventName = null;
+            CalledParameters.Properties = null;
         }
 
         static DependencyTreeTelemetryService CreateInstance()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -13,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     public class DependencyTreeTelemetryServiceTests
     {
         private const string TestFilePath = @"C:\Path\To\Project.csproj";
-
+        private static readonly Guid TestGuid = Guid.NewGuid();
         private static ITelemetryServiceFactory.TelemetryParameters CalledParameters;
 
         /// <summary>
@@ -158,9 +159,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         {
             CalledParameters = new ITelemetryServiceFactory.TelemetryParameters();
 
-            return new DependencyTreeTelemetryService(
+            var telemetryService = new DependencyTreeTelemetryService(
                 UnconfiguredProjectFactory.Create(filePath: TestFilePath), 
                 ITelemetryServiceFactory.Create(CalledParameters));
+
+            // set id directly because ExportProvider.GetExportedValueOrDefault() is an extension
+            // method and cannot be mocked.
+            telemetryService.SetProjectId(TestGuid.ToString());
+            return telemetryService;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryServiceTests.cs
@@ -22,7 +22,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// </summary>
         [Fact]        
         public void DesignTimeWithAllChanges_TreeUpdateResolved_MultiTFM()
-        {            
+        {
+            var handlerName = "TestHandler";
             var tfNames = new string[] { "tfm1", "tfm2" };
             var targetFrameworks = tfNames.Select(tfm => ITargetFrameworkFactory.Implement(tfm));
             var evalRules = new List<string> { "eval1", "eval2", "eval3" };
@@ -46,7 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 evalRules.ForEach(rule => builder.Add(rule, withChanges));
                 dtRules.ForEach(rule => builder.Add(rule, noChanges));
 
-                telemetryService.ObserveHandlerRulesChanges(tf, allRules, builder.ToImmutable());
+                telemetryService.ObserveHandlerRulesChanges(tf, handlerName, allRules, RuleHandlerType.Evaluation, builder.ToImmutable());
                 telemetryService.ObserveCompleteHandlers(tf, RuleHandlerType.Evaluation);
 
                 telemetryService.ObserveTreeUpdateCompleted();
@@ -62,7 +63,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 evalRules.ForEach(rule => builder.Add(rule, noChanges));
                 dtRules.ForEach(rule => builder.Add(rule, withChanges));
 
-                telemetryService.ObserveHandlerRulesChanges(tf, allRules, builder.ToImmutable());
+                telemetryService.ObserveHandlerRulesChanges(tf, handlerName, allRules, RuleHandlerType.DesignTimeBuild, builder.ToImmutable());
                 telemetryService.ObserveCompleteHandlers(tf, RuleHandlerType.DesignTimeBuild);
 
                 telemetryService.ObserveTreeUpdateCompleted();
@@ -96,6 +97,64 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             telemetryService.ObserveTreeUpdateCompleted();
 
             CheckForUnresolvedTreeUpdate();
+        }
+
+        /// <summary>
+        /// Evaluation after Design Time stops telemetry even if no Resolved yet
+        /// </summary>
+        [Fact]
+        public void EvaluationAfterDesignTime_StopsTelemetry()
+        {
+            var handlerName = "TestHandler";
+            var targetFramework = ITargetFrameworkFactory.Implement("tfm1");
+            var evalRules = new List<string> { "eval1", "eval2", "eval3" };
+            var dtRules = new List<string> { "dt1", "dt2", "dt3" };
+            var allRules = evalRules.Concat(dtRules);
+            var withChanges = IProjectChangeDescriptionFactory.Implement(difference: IProjectChangeDiffFactory.Implement(anyChanges: true));
+            var noChanges = IProjectChangeDescriptionFactory.Implement(difference: IProjectChangeDiffFactory.Implement(anyChanges: false));
+
+            var telemetryService = CreateInstance();
+
+            // Initialization
+            telemetryService.ObserveUnresolvedRules(targetFramework, evalRules);
+
+            // Observe Evaluation
+            var builder = ImmutableDictionary.CreateBuilder<string, IProjectChangeDescription>(StringComparers.RuleNames);
+            evalRules.ForEach(rule => builder.Add(rule, withChanges));
+            dtRules.ForEach(rule => builder.Add(rule, noChanges));
+
+            telemetryService.ObserveHandlerRulesChanges(targetFramework, handlerName, allRules, RuleHandlerType.Evaluation, builder.ToImmutable());
+            telemetryService.ObserveCompleteHandlers(targetFramework, RuleHandlerType.Evaluation);
+
+            telemetryService.ObserveTreeUpdateCompleted();
+            CheckForUnresolvedTreeUpdate();
+            ResetTestCallParameters();
+
+            // Observe Design Time
+            builder = ImmutableDictionary.CreateBuilder<string, IProjectChangeDescription>(StringComparers.RuleNames);
+            evalRules.ForEach(rule => builder.Add(rule, noChanges));
+            dtRules.ForEach(rule => builder.Add(rule, rule != "dt3" ? withChanges : noChanges));
+
+            telemetryService.ObserveHandlerRulesChanges(targetFramework, handlerName, allRules, RuleHandlerType.DesignTimeBuild, builder.ToImmutable());
+            telemetryService.ObserveCompleteHandlers(targetFramework, RuleHandlerType.DesignTimeBuild);
+
+            telemetryService.ObserveTreeUpdateCompleted();
+
+            // one of the design time rules has no changes hence this should not report resolved
+            CheckForUnresolvedTreeUpdate();
+            ResetTestCallParameters();
+
+            // Observe another evaluation
+            builder = ImmutableDictionary.CreateBuilder<string, IProjectChangeDescription>(StringComparers.RuleNames);
+            evalRules.ForEach(rule => builder.Add(rule, withChanges));
+            dtRules.ForEach(rule => builder.Add(rule, noChanges));
+
+            telemetryService.ObserveHandlerRulesChanges(targetFramework, handlerName, allRules, RuleHandlerType.Evaluation, builder.ToImmutable());
+            telemetryService.ObserveCompleteHandlers(targetFramework, RuleHandlerType.Evaluation);
+
+            // no more telemetry events
+            telemetryService.ObserveTreeUpdateCompleted();
+            Assert.Null(CalledParameters.EventName);
         }
 
         private void ResetTestCallParameters()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetRuleSubscriberBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetRuleSubscriberBase.cs
@@ -254,10 +254,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
                                                   ruleChangeContext)
                                      .ConfigureAwait(true);
 
-                        // check full set of handler rules for changes
+                        // check full set of handler rules for changes                        
+                        var allHandlerRules = handler.SupportsHandlerType(RuleHandlerType.DesignTimeBuild)
+                            ? handler.GetRuleNames(RuleHandlerType.DesignTimeBuild)
+                            : handlerRules;
+
                         _treeTelemetryService.ObserveHandlerRulesChanges(
                             projectContextToUpdate.TargetFramework,
-                            handler.GetRuleNames(RuleHandlerType.DesignTimeBuild), 
+                            allHandlerRules, 
                             projectChanges);
                     }
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetRuleSubscriberBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetRuleSubscriberBase.cs
@@ -261,7 +261,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 
                         _treeTelemetryService.ObserveHandlerRulesChanges(
                             projectContextToUpdate.TargetFramework,
+                            handler.GetType().ToString(),
                             allHandlerRules, 
+                            handlerType,
                             projectChanges);
                     }
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -32,6 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         IProjectTreeProvider,
         IDependenciesTreeServices
     {
+        private readonly IDependencyTreeTelemetryService _treeTelemetryService;
         private readonly object _treeUpdateLock = new object();
         private Task _treeUpdateQueueTask = null;
 
@@ -45,7 +46,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             IDependenciesSnapshotProvider dependenciesSnapshotProvider,
             [Import(DependencySubscriptionsHost.DependencySubscriptionsHostContract)]
             ICrossTargetSubscriptionsHost dependenciesHost,
-            [Import(ExportContractNames.Scopes.UnconfiguredProject)]IProjectAsynchronousTasksService tasksService)
+            [Import(ExportContractNames.Scopes.UnconfiguredProject)]IProjectAsynchronousTasksService tasksService,
+            IDependencyTreeTelemetryService treeTelemetryService)
             : base(threadingService, unconfiguredProject)
         {
             ProjectTreePropertiesProviders = new OrderPrecedenceImportCollection<IProjectTreePropertiesProvider>(
@@ -59,6 +61,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             DependenciesSnapshotProvider = dependenciesSnapshotProvider;
             DependenciesHost = dependenciesHost;
             TasksService = tasksService;
+            _treeTelemetryService = treeTelemetryService;
 
             unconfiguredProject.ProjectUnloading += OnUnconfiguredProjectUnloading;
         }
@@ -397,6 +400,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     {
                         dependenciesNode = await viewProvider.Value.BuildTreeAsync(dependenciesNode, snapshot, cancellationToken)
                                                                    .ConfigureAwait(false);
+
+                        _treeTelemetryService.ObserveTreeUpdateCompleted();
                     }
 
                     // TODO We still are getting mismatched data sources and need to figure out better 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Linq;
+using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
+using Microsoft.VisualStudio.Telemetry;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
+{
+    /// <summary>
+    /// Maintain light state to fire telemetry on dependency tree
+    /// </summary>
+    [Export(typeof(IDependencyTreeTelemetryService))]
+    [AppliesTo(ProjectCapability.DependenciesTree)]
+    internal class DependencyTreeTelemetryService : IDependencyTreeTelemetryService
+    {
+        private const string TelemetryEventName = "TreeUpdated";
+        private const string UnresolvedLabel = "Unresolved";
+        private const string ResolvedLabel = "Resolved";
+
+        private readonly IProjectAsynchronousTasksService _tasksService;
+        private readonly ITelemetryService _telemetryService;
+        private readonly Dictionary<string, bool> observedRuleChanges = new Dictionary<string, bool>();
+        private bool observedDesignTime = false;
+        private bool stopTelemetry = false;
+
+        [ImportingConstructor]
+        public DependencyTreeTelemetryService(
+            IUnconfiguredProjectCommonServices commonServices,
+            [Import(ExportContractNames.Scopes.UnconfiguredProject)]IProjectAsynchronousTasksService tasksService,
+            ITelemetryService telemetryService)
+        {
+            _tasksService = tasksService;
+            _telemetryService = telemetryService;
+        }
+
+        public void ObserveTreeUpdateCompleted()
+        {
+            if (stopTelemetry) return;
+
+            var notReady = !observedRuleChanges.Any() || !observedRuleChanges.All(entry => entry.Value);
+
+            _telemetryService.PostEvent($"{TelemetryEventName}/{(notReady ? UnresolvedLabel : ResolvedLabel)}");
+        }
+
+        public void ObserveUnresolvedRules(IEnumerable<string> rules)
+        {
+            if (stopTelemetry) return;
+
+            foreach (var rule in rules)
+            {
+                // observe all unresolved rules by default ignoring whether they have actual changes
+                UpdateObservedRuleChanges(rule);
+            }
+        }
+
+        public void ObserveHandlerRulesChanges(
+            IEnumerable<string> handlerRules, 
+            IImmutableDictionary<string, IProjectChangeDescription> projectChanges)
+        {
+            if (stopTelemetry) return;
+
+            foreach (var rule in handlerRules)
+            {
+                var hasChanges = projectChanges.ContainsKey(rule)
+                    && projectChanges[rule].Difference.AnyChanges;
+
+                UpdateObservedRuleChanges(rule, hasChanges);
+            }
+        }
+
+        public void ObserveCompleteHandlers(RuleHandlerType handlerType)
+        {
+            if (stopTelemetry) return;
+
+            observedDesignTime |= handlerType == RuleHandlerType.DesignTimeBuild;
+            stopTelemetry |= observedDesignTime && handlerType == RuleHandlerType.Evaluation;
+        }
+
+        private void UpdateObservedRuleChanges(string rule, bool hasChanges = true)
+        {
+            if (observedRuleChanges.TryGetValue(rule, out var anyChanges))
+            {
+                observedRuleChanges[rule] = anyChanges || hasChanges;
+            }
+            else
+            {
+                observedRuleChanges.Add(rule, hasChanges);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -60,16 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         {
             _telemetryService = telemetryService;
 
-            projectId = GetUniqueId(project);
-        }
-
-        private string GetUniqueId(UnconfiguredProject project)
-        {
-            using (var sha1 = SHA256.Create())
-            {
-                var hash = sha1.ComputeHash(Encoding.UTF8.GetBytes(project.FullPath));
-                return BitConverter.ToString(hash).Replace("-", string.Empty);
-            }
+            projectId = _telemetryService.HashValue(project.FullPath);
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -32,11 +32,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         internal class TelemetryState
         {
             public ConcurrentDictionary<string, bool> ObservedRuleChanges { get; } = new ConcurrentDictionary<string, bool>(StringComparers.RuleNames);
-            public bool ObservedDesignTime { get; set; }
             public bool StopTelemetry { get; set; }
 
-            public bool IsReadyToResolve() => ObservedDesignTime
-                && ObservedRuleChanges.Any()
+            public bool IsReadyToResolve() => ObservedRuleChanges.Any()
                 && ObservedRuleChanges.All(entry => entry.Value);            
         }
 
@@ -136,8 +134,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
                 if (_telemetryStates.TryGetValue(targetFramework, out var telemetryState))
                 {
-                    telemetryState.ObservedDesignTime |= handlerType == RuleHandlerType.DesignTimeBuild;
-                    telemetryState.StopTelemetry |= telemetryState.ObservedDesignTime && handlerType == RuleHandlerType.Evaluation;
+                    telemetryState.StopTelemetry |= telemetryState.IsReadyToResolve() 
+                        && handlerType == RuleHandlerType.Evaluation;
                 }
 
                 _isReadyToResolve = !_telemetryStates.IsEmpty && _telemetryStates.Values.All(s => s.IsReadyToResolve());

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -91,8 +91,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         {
             if (stopTelemetry) return;
 
-            stopTelemetry = isReadyToResolve ||
-                (!telemetryStates.IsEmpty && telemetryStates.Values.All(t => t.StopTelemetry));
+            stopTelemetry = isReadyToResolve || IsStopTelemetryInAllTargetFrameworks();
 
             _telemetryService.PostProperty($"{TelemetryEventName}/{(isReadyToResolve ? ResolvedLabel : UnresolvedLabel)}",
                 ProjectProperty, projectId);
@@ -140,7 +139,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             }
 
             isReadyToResolve = !telemetryStates.IsEmpty && telemetryStates.Values.All(s => s.IsReadyToResolve());
+
+            // if isReadyToResolve, wait until atleast one Resolved telemetry event has fired before stopping telemetry
+            stopTelemetry = !isReadyToResolve && IsStopTelemetryInAllTargetFrameworks();
         }
+
+        private bool IsStopTelemetryInAllTargetFrameworks() => 
+            !telemetryStates.IsEmpty && telemetryStates.Values.All(t => t.StopTelemetry);
 
         private void UpdateObservedRuleChanges(TelemetryState telemetryState, string rule, bool hasChanges = true)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Linq;
 using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 using Microsoft.VisualStudio.Telemetry;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
@@ -19,11 +20,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         private const string TelemetryEventName = "TreeUpdated";
         private const string UnresolvedLabel = "Unresolved";
         private const string ResolvedLabel = "Resolved";
+        private const string ProjectProperty = "Project";
+
+        public class TelemetryState
+        {
+            public Dictionary<string, bool> ObservedRuleChanges { get; } = new Dictionary<string, bool>();
+            public bool ObservedDesignTime { get; set; } = false;
+            public bool StopTelemetry { get; set; } = false;
+
+            public bool NotReady()
+            {
+                return !ObservedRuleChanges.Any() || !ObservedRuleChanges.All(entry => entry.Value);
+            }
+        }
 
         private readonly IProjectAsynchronousTasksService _tasksService;
         private readonly ITelemetryService _telemetryService;
-        private readonly Dictionary<string, bool> observedRuleChanges = new Dictionary<string, bool>();
-        private bool observedDesignTime = false;
+        private readonly Dictionary<ITargetFramework, TelemetryState> telemetryStates = 
+            new Dictionary<ITargetFramework, TelemetryState>();
+        private readonly string projectHash;
         private bool stopTelemetry = false;
 
         [ImportingConstructor]
@@ -34,60 +49,91 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         {
             _tasksService = tasksService;
             _telemetryService = telemetryService;
+
+            projectHash = GetHash(commonServices.Project.FullPath);
         }
 
+        private string GetHash(string fullPath)
+        {
+            return fullPath;
+        }
+
+        /// <summary>
+        /// This is fired when Tree is complete based on three heuristics:
+        /// - Marked 'Unresolved' until all TFMs have fired at least 1 Design Time build
+        /// - Marked 'Unresolved' if any relevant Resolved Rules are yet to report AnyChanges.
+        ///   Relevant Resolved rules are determined based on the handlers that have fired.
+        /// - Stops firing completely after an Evaluation is received following the 
+        ///   first DT build for that TFM
+        /// </summary>
         public void ObserveTreeUpdateCompleted()
         {
             if (stopTelemetry) return;
 
-            var notReady = !observedRuleChanges.Any() || !observedRuleChanges.All(entry => entry.Value);
+            var notReady = !telemetryStates.Any() || telemetryStates.Values.Any(s => s.NotReady());
 
-            _telemetryService.PostEvent($"{TelemetryEventName}/{(notReady ? UnresolvedLabel : ResolvedLabel)}");
+            _telemetryService.PostProperty($"{TelemetryEventName}/{(notReady ? UnresolvedLabel : ResolvedLabel)}",
+                ProjectProperty, projectHash);
         }
 
-        public void ObserveUnresolvedRules(IEnumerable<string> rules)
+        public void ObserveUnresolvedRules(ITargetFramework targetFramework, IEnumerable<string> rules)
         {
             if (stopTelemetry) return;
+
+            if (!telemetryStates.TryGetValue(targetFramework, out var telemetryState))
+            {
+                telemetryState = new TelemetryState();
+                telemetryStates[targetFramework] = telemetryState;
+            }
 
             foreach (var rule in rules)
             {
                 // observe all unresolved rules by default ignoring whether they have actual changes
-                UpdateObservedRuleChanges(rule);
+                UpdateObservedRuleChanges(telemetryState, rule);
             }
         }
 
         public void ObserveHandlerRulesChanges(
+            ITargetFramework targetFramework,
             IEnumerable<string> handlerRules, 
             IImmutableDictionary<string, IProjectChangeDescription> projectChanges)
         {
             if (stopTelemetry) return;
 
-            foreach (var rule in handlerRules)
+            if (telemetryStates.TryGetValue(targetFramework, out var telemetryState))
             {
-                var hasChanges = projectChanges.ContainsKey(rule)
-                    && projectChanges[rule].Difference.AnyChanges;
+                foreach (var rule in handlerRules)
+                {
+                    var hasChanges = projectChanges.ContainsKey(rule)
+                        && projectChanges[rule].Difference.AnyChanges;
 
-                UpdateObservedRuleChanges(rule, hasChanges);
+                    UpdateObservedRuleChanges(telemetryState, rule, hasChanges);
+                }
             }
         }
 
-        public void ObserveCompleteHandlers(RuleHandlerType handlerType)
+        public void ObserveCompleteHandlers(ITargetFramework targetFramework, RuleHandlerType handlerType)
         {
             if (stopTelemetry) return;
 
-            observedDesignTime |= handlerType == RuleHandlerType.DesignTimeBuild;
-            stopTelemetry |= observedDesignTime && handlerType == RuleHandlerType.Evaluation;
+            if (telemetryStates.TryGetValue(targetFramework, out var telemetryState))
+            {
+                telemetryState.ObservedDesignTime |= handlerType == RuleHandlerType.DesignTimeBuild;
+                telemetryState.StopTelemetry |= telemetryState.ObservedDesignTime && handlerType == RuleHandlerType.Evaluation;
+            }
+
+            stopTelemetry = telemetryStates.Any() && telemetryStates.Values.All(t => t.StopTelemetry);
         }
 
-        private void UpdateObservedRuleChanges(string rule, bool hasChanges = true)
+        private void UpdateObservedRuleChanges(TelemetryState telemetryState, string rule, bool hasChanges = true)
         {
-            if (observedRuleChanges.TryGetValue(rule, out var anyChanges))
+            if (telemetryState.ObservedRuleChanges.TryGetValue(rule, out var anyChanges))
             {
-                observedRuleChanges[rule] = anyChanges || hasChanges;
+                telemetryState.ObservedRuleChanges[rule] = anyChanges || hasChanges;
             }
             else
             {
-                observedRuleChanges.Add(rule, hasChanges);
+                telemetryState.ObservedRuleChanges.Add(rule, hasChanges);
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependencyTreeTelemetryService.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
@@ -21,13 +22,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// ignored when determining whether all rules have resolved. Typically 
         /// these are "Evaluation-only" rules.
         /// </summary>
-        void ObserveUnresolvedRules(IEnumerable<string> rules);
+        void ObserveUnresolvedRules(ITargetFramework targetFramework, IEnumerable<string> rules);
 
         /// <summary>
         /// Observe the full set of rules processed by a handler, and determine 
         /// if they have any changes.
         /// </summary>
         void ObserveHandlerRulesChanges(
+            ITargetFramework targetFramework,
             IEnumerable<string> handlerRules,
             IImmutableDictionary<string, IProjectChangeDescription> projectChanges);
 
@@ -35,6 +37,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// Observe when a pass handling all changed rules has completed, indicating
         /// whether the pass covered Evaluation or DesignTimeBuild rules
         /// </summary>
-        void ObserveCompleteHandlers(RuleHandlerType handlerType);
+        void ObserveCompleteHandlers(ITargetFramework targetFramework, RuleHandlerType handlerType);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependencyTreeTelemetryService.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
+{
+    /// <summary>
+    /// For maintaining light state about dependency tree to generate telemetry
+    /// </summary>
+    internal interface IDependencyTreeTelemetryService
+    {
+        /// <summary>
+        /// Fire telemetry when dependency tree completes an update
+        /// </summary>
+        void ObserveTreeUpdateCompleted();
+
+        /// <summary>
+        /// Add rules to the list that is always unresolved and hence should be  
+        /// ignored when determining whether all rules have resolved. Typically 
+        /// these are "Evaluation-only" rules.
+        /// </summary>
+        void ObserveUnresolvedRules(IEnumerable<string> rules);
+
+        /// <summary>
+        /// Observe the full set of rules processed by a handler, and determine 
+        /// if they have any changes.
+        /// </summary>
+        void ObserveHandlerRulesChanges(
+            IEnumerable<string> handlerRules,
+            IImmutableDictionary<string, IProjectChangeDescription> projectChanges);
+
+        /// <summary>
+        /// Observe when a pass handling all changed rules has completed, indicating
+        /// whether the pass covered Evaluation or DesignTimeBuild rules
+        /// </summary>
+        void ObserveCompleteHandlers(RuleHandlerType handlerType);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependencyTreeTelemetryService.cs
@@ -30,7 +30,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// </summary>
         void ObserveHandlerRulesChanges(
             ITargetFramework targetFramework,
-            IEnumerable<string> handlerRules,
+            string handlerName,
+            IEnumerable<string> handlerRules, 
+            RuleHandlerType handlerType,
             IImmutableDictionary<string, IProjectChangeDescription> projectChanges);
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
@@ -17,8 +17,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
         [ImportingConstructor]
         public DependencyRulesSubscriber(
             IUnconfiguredProjectCommonServices commonServices,
-            [Import(ExportContractNames.Scopes.UnconfiguredProject)]IProjectAsynchronousTasksService tasksService)
-            : base(commonServices, tasksService)
+            [Import(ExportContractNames.Scopes.UnconfiguredProject)]IProjectAsynchronousTasksService tasksService,
+            IDependencyTreeTelemetryService treeTelemetryService)
+            : base(commonServices, tasksService, treeTelemetryService)
         {
             DependencyRuleHandlers = new OrderPrecedenceImportCollection<ICrossTargetRuleHandler<DependenciesRuleChangeContext>>(
                 projectCapabilityCheckProvider: commonServices.Project);


### PR DESCRIPTION
Signals when dependencies tree has finished loading using heuristics to account for multiple tree updates following Evaluation and Design time builds.

**Customer scenario**

Dependency node population can be slow in some solutions. This telemetry can be used to get statistical information about how long it takes to populate the Dependencies node. The telemetry will be used as part of planned A/B testing to determine the best configuration of internal settings

**Bugs this fixes:** 

https://github.com/dotnet/project-system/issues/2703

**Workarounds, if any**

N/A

**Risk**

Low, this PR does not change dependency tree behavior, primary risk would be incorrect new telemetry.

**Performance impact**

Low, telemetry state only measures whether rules have "any changes" (per target framework) i.e. it does not maintain state for every node in the dependencies tree 

**Is this a regression from a previous update?** No

**Root cause analysis:**

N/A Planned, Partner requested

**How was the bug found?**

Partner requested

**Developer Notes**
This fires two possible telemetry events when TreeUpdate completes: 
```
vs/projectsystem/managed/treeupdated/unresolved
vs/projectsystem/managed/treeupdated/resolved
```
Heuristics used to determine which one to fire are below. In general, the "resolved" event is fired once per project, and should be used to determine project load time. Certain errors may mean we never get a design time build with everything resolved, hence the last "unresolved" event may need to be used to estimate load time in those cases. The heuristics are:
1. Telemetry is fired with 'Unresolved' label if any target frameworks are yet to process Rules from a Design Time build. This is tracked by `TelemetryState.ObservedDesignTime`
2. Telemetry is fired with 'Unresolved' label if any relevant Rules from design time builds are yet to report any changes. Relevant Rules are determined based on the `ICrossTargetRuleHandlers` that have processed. This is tracked by `TelemetryState.ObservedRuleChanges`
3. Telemetry fires with 'Resolved' label when 1. and 2. are no longer true
4. Telemetry stops firing once all target frameworks observe an Evaluation following the first design time build, or once it has fired once with 'Resolved' label. This prevents telemetry events caused by project changes and tree updates after initial load has completed.

TODO
- [x] Add more tests

/cc @dotnet/project-system @abpiskunov @lifengl @adrianvmsft