### PR TITLE
Add design time telemetry for managed project system

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Telemetry/VsTelemetryServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Telemetry/VsTelemetryServiceTests.cs
@@ -107,7 +107,7 @@ namespace Microsoft.VisualStudio.Telemetry
             var service = CreateInstance();
 
             Assert.Throws<ArgumentException>("properties", () => {
-                service.PostProperties("event1", new List<(string propertyName, string propertyValue)>());
+                service.PostProperties("event1", new List<(string propertyName, object propertyValue)>());
             });
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Telemetry/VsTelemetryServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Telemetry/VsTelemetryServiceTests.cs
@@ -60,18 +60,6 @@ namespace Microsoft.VisualStudio.Telemetry
         }
 
         [Fact]
-        public void PostProperty_EmptyAsPropertyValue_ThrowArgument()
-        {
-            var service = CreateInstance();
-
-            Assert.Throws<ArgumentException>("propertyValue", () => {
-                service.PostProperty("event1", "propName", string.Empty);
-
-            });
-        }
-
-
-        [Fact]
         public void PostProperties_NullAsEventName_ThrowArgumentNull()
         {
             var service = CreateInstance();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/DesignTimeTelemetryLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/DesignTimeTelemetryLogger.cs
@@ -10,24 +10,6 @@ namespace Microsoft.VisualStudio.Telemetry
 {
     internal sealed class DesignTimeTelemetryLogger : ILogger
     {
-        private sealed class TargetRecord
-        {
-            public TargetRecord(string targetName, DateTime started)
-            {
-                TargetName = targetName;
-                Started = started;
-                Ended = DateTime.MinValue;
-            }
-
-            public string TargetName { get; }
-
-            public DateTime Started { get; }
-
-            public DateTime Ended { get; set; }
-
-            public TimeSpan Elapsed => Ended - Started;
-        }
-
         private readonly ITelemetryService _telemetryService;
 
         private readonly Dictionary<int, TargetRecord> _targets = new Dictionary<int, TargetRecord>();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/DesignTimeTelemetryLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/DesignTimeTelemetryLogger.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.VisualStudio.Telemetry
+{
+    internal sealed class DesignTimeTelemetryLogger : ILogger
+    {
+        private sealed class TargetRecord
+        {
+            public TargetRecord(string targetName, DateTime started)
+            {
+                TargetName = targetName;
+                Started = started;
+                Ended = DateTime.MinValue;
+            }
+
+            public string TargetName { get; }
+
+            public DateTime Started { get; }
+
+            public DateTime Ended { get; set; }
+
+            public TimeSpan Elapsed => Ended - Started;
+        }
+
+        private readonly ITelemetryService _telemetryService;
+
+        private readonly Dictionary<int, TargetRecord> _targets = new Dictionary<int, TargetRecord>();
+        private bool _succeeded;
+
+        public DesignTimeTelemetryLogger(ITelemetryService telemetryService)
+        {
+            _telemetryService = telemetryService;
+        }
+
+        public LoggerVerbosity Verbosity { get; set; }
+
+        public string Parameters { get; set; }
+
+        public void Initialize(IEventSource eventSource)
+        {
+            eventSource.TargetStarted += TargetStarted;
+            eventSource.TargetFinished += TargetFinished;
+            eventSource.BuildFinished += BuildFinished;
+        }
+
+        private void BuildFinished(object sender, BuildFinishedEventArgs e)
+        {
+            _succeeded = e.Succeeded;
+        }
+
+        private void TargetStarted(object sender, TargetStartedEventArgs e)
+        {
+            _targets[e.BuildEventContext.TargetId] = new TargetRecord(e.TargetName, e.Timestamp);
+        }
+
+        private void TargetFinished(object sender, TargetFinishedEventArgs e)
+        {
+            if (_targets.TryGetValue(e.BuildEventContext.TargetId, out TargetRecord record))
+            {
+                record.Ended = e.Timestamp;
+            }
+        }
+
+        public void Shutdown()
+        {
+            var builder = new StringBuilder();
+
+            foreach (var target in _targets.Values
+                .Where(v => v.Elapsed != TimeSpan.Zero)
+                .OrderByDescending(v => v.Elapsed)
+                .Take(10))
+            {
+                builder.Append(_telemetryService.HashValue(target.TargetName));
+                builder.Append(':');
+                builder.Append(target.Elapsed.TotalMilliseconds);
+                builder.Append(';');
+            }
+
+            var targetResults = builder.ToString();
+
+            _telemetryService.PostProperties("DesignTimeBuildComplete", new[]
+            {
+                ("Succeeded", (object)_succeeded),
+                ("Targets", targetResults)
+            });
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/DesignTimeTelemetryLoggerProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/DesignTimeTelemetryLoggerProvider.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+using Microsoft.VisualStudio.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Build;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.VisualStudio.Telemetry
+{
+    [Export(typeof(IBuildLoggerProviderAsync))]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
+    internal sealed class DesignTimeTelemetryLoggerProvider : IBuildLoggerProviderAsync
+    {
+        [Import]
+        private ITelemetryService TelemetryService { get; set; }
+
+        public Task<IImmutableSet<ILogger>> GetLoggersAsync(IReadOnlyList<string> targets, IImmutableDictionary<string, string> properties, CancellationToken cancellationToken)
+        {
+            IImmutableSet<ILogger> loggers = ImmutableHashSet<ILogger>.Empty;
+
+            if (properties.TryGetValue("DesignTimeBuild", out var designTimeBuildValue) &&
+                string.Equals(designTimeBuildValue, "true", StringComparison.OrdinalIgnoreCase))
+            {
+                loggers = loggers.Add(new DesignTimeTelemetryLogger(TelemetryService));
+            }
+
+            return Task.FromResult(loggers);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/TargetRecord.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/TargetRecord.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.VisualStudio.Telemetry
+{
+    internal sealed class TargetRecord
+    {
+        public TargetRecord(string targetName, DateTime started)
+        {
+            TargetName = targetName;
+            Started = started;
+            Ended = DateTime.MinValue;
+        }
+
+        public string TargetName { get; }
+
+        public DateTime Started { get; }
+
+        public DateTime Ended { get; set; }
+
+        public TimeSpan Elapsed => Ended - Started;
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/VsTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/VsTelemetryService.cs
@@ -15,6 +15,10 @@ namespace Microsoft.VisualStudio.Telemetry
         private const string EventPrefix = "vs/projectsystem/managed/";
         private const string PropertyPrefix = "VS.ProjectSystem.Managed.";
 
+
+        // SHA1 is good enough here since we're just hashing PII names.
+        private readonly SHA256CryptoServiceProvider _cryptoService = new SHA256CryptoServiceProvider();
+
         private readonly ConcurrentDictionary<string, (string Event, ConcurrentDictionary<string, string> Properties)> _eventCache = new ConcurrentDictionary<string, (string, ConcurrentDictionary<string, string>)>();
 
         private (string Event, ConcurrentDictionary<string, string> Properties) GetEventInfo(string eventName)
@@ -60,11 +64,11 @@ namespace Microsoft.VisualStudio.Telemetry
         /// <param name="eventName">Name of the event.</param>
         /// <param name="propertyName">Property name to be reported.</param>
         /// <param name="propertyValue">Property value to be reported.</param>
-        public void PostProperty(string eventName, string propertyName, string propertyValue)
+        public void PostProperty(string eventName, string propertyName, object propertyValue)
         {
             Requires.NotNullOrEmpty(eventName, nameof(eventName));
             Requires.NotNullOrEmpty(propertyName, nameof(propertyName));
-            Requires.NotNullOrEmpty(propertyValue, nameof(propertyValue));
+            Requires.NotNull(propertyValue, nameof(propertyValue));
 
             TelemetryEvent telemetryEvent = new TelemetryEvent(GetEventName(eventName));
             telemetryEvent.Properties.Add(BuildPropertyName(eventName, propertyName), propertyValue);
@@ -76,7 +80,7 @@ namespace Microsoft.VisualStudio.Telemetry
         /// </summary>
         /// <param name="eventName">Name of the event.</param>
         /// <param name="properties">List of Property name and corresponding values. PropertyName and PropertyValue cannot be null or empty.</param>
-        public void PostProperties(string eventName, IEnumerable<(string propertyName, string propertyValue)> properties)
+        public void PostProperties(string eventName, IEnumerable<(string propertyName, object propertyValue)> properties)
         {
             Requires.NotNullOrEmpty(eventName, nameof(eventName));
             Requires.NotNullOrEmpty(properties, nameof(properties));
@@ -97,8 +101,14 @@ namespace Microsoft.VisualStudio.Telemetry
         /// <returns>Hashed value.</returns>
         public string HashValue(string value)
         {
+            // Don't hash PII for internal users since we don't need to.
+            if (TelemetryService.DefaultSession.IsUserMicrosoftInternal)
+            {
+                return value;
+            }
+
             var inputBytes = Encoding.UTF8.GetBytes(value);
-            var hashedBytes = new SHA256CryptoServiceProvider().ComputeHash(inputBytes);
+            var hashedBytes = _cryptoService.ComputeHash(inputBytes);
             return BitConverter.ToString(hashedBytes);
         }
         

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/VsTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/VsTelemetryService.cs
@@ -15,10 +15,6 @@ namespace Microsoft.VisualStudio.Telemetry
         private const string EventPrefix = "vs/projectsystem/managed/";
         private const string PropertyPrefix = "VS.ProjectSystem.Managed.";
 
-
-        // SHA1 is good enough here since we're just hashing PII names.
-        private readonly SHA256CryptoServiceProvider _cryptoService = new SHA256CryptoServiceProvider();
-
         private readonly ConcurrentDictionary<string, (string Event, ConcurrentDictionary<string, string> Properties)> _eventCache = new ConcurrentDictionary<string, (string, ConcurrentDictionary<string, string>)>();
 
         private (string Event, ConcurrentDictionary<string, string> Properties) GetEventInfo(string eventName)
@@ -108,7 +104,7 @@ namespace Microsoft.VisualStudio.Telemetry
             }
 
             var inputBytes = Encoding.UTF8.GetBytes(value);
-            var hashedBytes = _cryptoService.ComputeHash(inputBytes);
+            var hashedBytes = new SHA256CryptoServiceProvider().ComputeHash(inputBytes);
             return BitConverter.ToString(hashedBytes);
         }
         

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ITelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ITelemetryService.cs
@@ -7,8 +7,8 @@ namespace Microsoft.VisualStudio.Telemetry
     internal interface ITelemetryService
     {
         void PostEvent(string eventName);
-        void PostProperty(string eventName, string propertyName, string propertyValue);
-        void PostProperties(string eventName, IEnumerable<(string propertyName, string propertyValue)> properties);
+        void PostProperty(string eventName, string propertyName, object propertyValue);
+        void PostProperties(string eventName, IEnumerable<(string propertyName, object propertyValue)> properties);
         string HashValue(string value);
     }
 }


### PR DESCRIPTION
**Customer scenario**

This adds telemetry to record target performance for design-time builds. This helps us determine problems that customers are seeing with design-time builds.

**Bugs this fixes:** 

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/492017

**Workarounds, if any**

None.

**Risk**

Low. This adds a logger that matches the one that exists in the native project system (most the code is the same).

**Performance impact**

Low, the logger only listens to target events and sticks them in a dictionary. We already do this on the native side.

**Is this a regression from a previous update?**

No.
