### PR TITLE
Added support for SemVer 2.0.0 metadata in package version.

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/AssemblyInfoUtils.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AssemblyInfoUtils.vb
@@ -38,7 +38,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="Version">[Out] the resulting combined version string, if valid.</param>
         Public Sub ValidateVersion(VersionTextBox As Windows.Forms.TextBox, MaxVersionPartValue As UInteger, PropertyName As String, WildcardsAllowed As Boolean, ByRef version As String)
             ' Validate the semantic version prefix (i.e. "1.0.0" prefix of "1.0.0-beta1")
-            Dim CombinedVersion = Split(VersionTextBox.Text, Delimiter:="-")(0).TrimStart()
+            Dim CombinedVersion = Split(Split(VersionTextBox.Text, "+")(0), "-")(0).TrimStart()
             InternalParseVersion(CombinedVersion, PropertyName, MaxVersionPartValue, WildcardsAllowed, version)
         End Sub
 


### PR DESCRIPTION
**Customer scenario**

SemVer 2.0.0 package versions should be supported, but an error is shown when saving the project properties, if the package version has build metadata.

**Bugs this fixes:** 

Fixes #2591

**Workarounds, if any**

N/A

**Risk**

Low

**Performance impact**

Low, this PR only adds an additional Split operation on package version validation.

**Is this a regression from a previous update?**

No

**Root cause analysis:**

Packages didn't support SemVer 2.0.0 versioning.

**How was the bug found?**

Customer reported
