### PR TITLE
Update to RepoToolset 43

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -9,7 +9,7 @@
     <UsingToolIbcOptimization>true</UsingToolIbcOptimization>
 
     <!-- Toolset -->
-    <RoslynToolsMicrosoftRepoToolsetVersion>1.0.0-alpha40</RoslynToolsMicrosoftRepoToolsetVersion>
+    <RoslynToolsMicrosoftRepoToolsetVersion>1.0.0-alpha43</RoslynToolsMicrosoftRepoToolsetVersion>
     <RoslynDependenciesOptimizationDataVersion>2.6.0-beta1-62010-04</RoslynDependenciesOptimizationDataVersion>
     <RoslynToolsMicrosoftVsixExpInstallerVersion>0.4.1-beta</RoslynToolsMicrosoftVsixExpInstallerVersion>
     <VSWhereVersion>2.1.4</VSWhereVersion>

--- a/src/DeployIntegrationDependencies/DeployIntegrationDependencies.csproj
+++ b/src/DeployIntegrationDependencies/DeployIntegrationDependencies.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <PlatformTarget>x86</PlatformTarget>
     <TargetFramework>net461</TargetFramework>
+    <PublishOutputToSymStore>false</PublishOutputToSymStore>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.IntegrationTests\Microsoft.VisualStudio.ProjectSystem.IntegrationTests.csproj" />

--- a/src/DeployTestDependencies/DeployTestDependencies.csproj
+++ b/src/DeployTestDependencies/DeployTestDependencies.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
+    <PublishOutputToSymStore>false</PublishOutputToSymStore>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.AppDesigner\Microsoft.VisualStudio.AppDesigner.vbproj" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj
@@ -1,6 +1,9 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\HostAgnostic.props"/>
+  <PropertyGroup>    
+    <PublishOutputToSymStore>false</PublishOutputToSymStore>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
     <PackageReference Include="xunit.assert" Version="$(XunitVersion)" />

--- a/src/ProjectSystemSetup/ProjectSystemSetup.csproj
+++ b/src/ProjectSystemSetup/ProjectSystemSetup.csproj
@@ -4,7 +4,8 @@
   <PropertyGroup>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
     <AssemblyName>ProjectSystem</AssemblyName>
-    
+    <PublishOutputToSymStore>false</PublishOutputToSymStore>
+
     <!-- VSIX -->
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
 

--- a/src/Templates/Directory.Build.props
+++ b/src/Templates/Directory.Build.props
@@ -8,6 +8,7 @@
 
   <PropertyGroup>
     <DebugSymbols>false</DebugSymbols>
+    <PublishOutputToSymStore>false</PublishOutputToSymStore>
     
     <!-- VSIX -->
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>

--- a/src/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
+++ b/src/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
@@ -3,6 +3,7 @@
   <Import Project="..\VisualStudioDesigner.props"/>
   <PropertyGroup>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
+    <PublishOutputToSymStore>false</PublishOutputToSymStore>
     
     <!-- VSIX -->
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>


### PR DESCRIPTION
Infrastructure only change. 

The new version comes with a fix for including OptProf data and more efficient symbol store publishing.

It introduces PublishOutputToSymStore property that is true by default and can be set to false for projects whose outputs (DLL/EXE/PDB) should not be published to symbol server (non-shipping binaries).