### PR TITLE
Fix Icon for F# templates and F# Test Templates

### DIFF
--- a/src/Templates/Microsoft.NetCore.FSharp.ProjectTemplates.Test/MSTest.vstemplate
+++ b/src/Templates/Microsoft.NetCore.FSharp.ProjectTemplates.Test/MSTest.vstemplate
@@ -3,7 +3,7 @@
   <TemplateData>
     <Name Package="{52CBD135-1F97-2580-011F-C7CD052E44DE}" ID="521"/>
     <Description Package="{52CBD135-1F97-2580-011F-C7CD052E44DE}" ID="522"/>
-    <Icon Package="{52CBD135-1F97-2580-011F-C7CD052E44DE}" ID="531"/>
+    <Icon Package="{91A04A73-4F2C-4E7C-AD38-C1A68E7DA05C}" ID="4018" />
     <ProjectType>FSharp</ProjectType>
     <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
     <SortOrder>15</SortOrder>

--- a/src/Templates/Microsoft.NetCore.FSharp.ProjectTemplates.Test/XUnitTest.vstemplate
+++ b/src/Templates/Microsoft.NetCore.FSharp.ProjectTemplates.Test/XUnitTest.vstemplate
@@ -3,7 +3,7 @@
   <TemplateData>
     <Name Package="{860A27C0-B665-47F3-BC12-637E16A1050A}" ID="11" />
     <Description Package="{860A27C0-B665-47F3-BC12-637E16A1050A}" ID="12" />
-    <Icon Package="{52CBD135-1F97-2580-011F-C7CD052E44DE}" ID="531"/>
+    <Icon Package="{91A04A73-4F2C-4E7C-AD38-C1A68E7DA05C}" ID="4018" />
     <ProjectType>FSharp</ProjectType>
     <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
     <SortOrder>16</SortOrder>

--- a/src/Templates/Microsoft.NetCore.FSharp.ProjectTemplates/ClassLibrary.vstemplate
+++ b/src/Templates/Microsoft.NetCore.FSharp.ProjectTemplates/ClassLibrary.vstemplate
@@ -3,7 +3,7 @@
   <TemplateData>
     <Name Package="{860A27C0-B665-47F3-BC12-637E16A1050A}" ID="9"/>
     <Description Package="{860A27C0-B665-47F3-BC12-637E16A1050A}" ID="10"/>
-    <Icon Package="{FAE04EC1-301F-11d3-BF4B-00C04F79EFBC}" ID="4547" />
+    <Icon Package="{91A04A73-4F2C-4E7C-AD38-C1A68E7DA05C}" ID="4002" />
     <ProjectType>FSharp</ProjectType>
     <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
     <SortOrder>14</SortOrder>

--- a/src/Templates/Microsoft.NetStandard.FSharp.ProjectTemplates/ClassLibrary.vstemplate
+++ b/src/Templates/Microsoft.NetStandard.FSharp.ProjectTemplates/ClassLibrary.vstemplate
@@ -3,7 +3,7 @@
   <TemplateData>
     <Name Package="{860A27C0-B665-47F3-BC12-637E16A1050A}" ID="5"/>
     <Description Package="{860A27C0-B665-47F3-BC12-637E16A1050A}" ID="6"/>
-    <Icon Package="{91A04A73-4F2C-4E7C-AD38-C1A68E7DA05C}" ID="4018" />
+    <Icon Package="{91A04A73-4F2C-4E7C-AD38-C1A68E7DA05C}" ID="4002" />
     <ProjectType>FSharp</ProjectType>
     <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
     <SortOrder>14</SortOrder>

--- a/src/Templates/Microsoft.NetStandard.FSharp.ProjectTemplates/ClassLibrary.vstemplate
+++ b/src/Templates/Microsoft.NetStandard.FSharp.ProjectTemplates/ClassLibrary.vstemplate
@@ -3,7 +3,7 @@
   <TemplateData>
     <Name Package="{860A27C0-B665-47F3-BC12-637E16A1050A}" ID="5"/>
     <Description Package="{860A27C0-B665-47F3-BC12-637E16A1050A}" ID="6"/>
-    <Icon Package="{FAE04EC1-301F-11d3-BF4B-00C04F79EFBC}" ID="4547" />
+    <Icon Package="{91A04A73-4F2C-4E7C-AD38-C1A68E7DA05C}" ID="4018" />
     <ProjectType>FSharp</ProjectType>
     <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
     <SortOrder>14</SortOrder>


### PR DESCRIPTION
The Icons for F# Net Sdk class library and test libraries. were wrong.

This gets them from the F# project system.