### PR TITLE
Implement dataflow to order solution tree by display order property.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿ <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\VisualStudio.props"/>
+  <Import Project="..\VisualStudio.props" />
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj" />
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj" />
@@ -15,6 +15,6 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests" />
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)"/>
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectTreeCustomizablePropertyContextFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectTreeCustomizablePropertyContextFactory.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Immutable;
 using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
@@ -22,6 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             mock.Setup(x => x.ItemType).Returns(itemType);
             mock.Setup(x => x.IsFolder).Returns(isFolder);
             mock.Setup(x => x.ParentNodeFlags).Returns(flags);
+            mock.Setup(x => x.Metadata).Returns(ImmutableDictionary<string,string>.Empty);
             return mock.Object;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectTreeCustomizablePropertyContextFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectTreeCustomizablePropertyContextFactory.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    internal class IProjectTreeCustomizablePropertyContextFactory
+    {
+        public static IProjectTreeCustomizablePropertyContext Create()
+        {
+            return Mock.Of<IProjectTreeCustomizablePropertyContext>();
+        }
+
+        public static IProjectTreeCustomizablePropertyContext Implement(
+            string itemName = null,
+            string itemType = null,
+            bool isFolder = false,
+            ProjectTreeFlags flags = default(ProjectTreeFlags))
+        {
+            var mock = new Mock<IProjectTreeCustomizablePropertyContext>();
+            mock.Setup(x => x.ItemName).Returns(itemName ?? string.Empty);
+            mock.Setup(x => x.ItemType).Returns(itemType);
+            mock.Setup(x => x.IsFolder).Returns(isFolder);
+            mock.Setup(x => x.ParentNodeFlags).Returns(flags);
+            return mock.Object;
+        }
+
+        public static ProjectTreeFlags CreateNewProjectRoot() =>
+            ProjectTreeFlags.Create(ProjectTreeFlags.Common.ProjectRoot);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectTreeCustomizablePropertyContextFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectTreeCustomizablePropertyContextFactory.cs
@@ -16,14 +16,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             string itemName = null,
             string itemType = null,
             bool isFolder = false,
-            ProjectTreeFlags flags = default(ProjectTreeFlags))
+            ProjectTreeFlags flags = default(ProjectTreeFlags),
+            IImmutableDictionary<string,string> metadata = null)
         {
             var mock = new Mock<IProjectTreeCustomizablePropertyContext>();
             mock.Setup(x => x.ItemName).Returns(itemName ?? string.Empty);
             mock.Setup(x => x.ItemType).Returns(itemType);
             mock.Setup(x => x.IsFolder).Returns(isFolder);
             mock.Setup(x => x.ParentNodeFlags).Returns(flags);
-            mock.Setup(x => x.Metadata).Returns(ImmutableDictionary<string,string>.Empty);
+            mock.Setup(x => x.Metadata).Returns(metadata ?? ImmutableDictionary<string,string>.Empty);
             return mock.Object;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProviderTests.cs
@@ -1,0 +1,172 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
+{
+    [ProjectSystemTrait]
+    public class TreeItemOrderPropertyProviderTests
+    {
+        private List<(string type, string include)> _simpleOrderFile = new List<(string type, string include)>
+        {
+            ("Compile", "Order.fs"),
+            ("Compile", "Customer.fs"),
+            ("Compile", "Program.fs")
+        };
+
+        [Theory]
+        [InlineData("Customer.fs", "Compile", false, 2)]
+        [InlineData("order.fs", "Compile", false, 1)] // case insensitive
+        [InlineData("Program.fs", "Compile", false, 3)] 
+        [InlineData("Misc.txt", "Content", false, 4)] // unknown type
+        [InlineData("ordered.fsproj", null, false, 4)] // hidden file
+        [InlineData("Debug", null, true, 0)] // unknown folder
+        public void VerifySimpleOrderedUnderProjectRoot(string itemName, string itemType, bool isFolder, int expectedOrder)
+        {
+            var orderedItems = _simpleOrderFile
+                .Select(p => new ProjectItemIdentity(p.type, p.include))
+                .ToList();
+
+            var provider = new TreeItemOrderPropertyProvider(orderedItems);
+
+            var context = GetContext(itemName, itemType, isFolder, ProjectTreeFlags.ProjectRoot);
+            var values = GetInitialValues();
+
+            provider.CalculatePropertyValues(context, values);
+
+            Assert.Equal(values.DisplayOrder, expectedOrder);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestTreeItems))]
+        public void VerifyOrderIncreasesMonotonically(
+            List<(string type, string include)> orderedFileInput,
+            List<(string itemName, string itemType, bool isFolder, bool isUnderProjectRoot)> solutionTree)
+        {
+            var orderedItems = orderedFileInput
+                .Select(p => new ProjectItemIdentity(p.type, p.include))
+                .ToList();
+
+            var provider = new TreeItemOrderPropertyProvider(orderedItems);
+
+            var lastOrder = 0;
+            solutionTree.ForEach(item =>
+            {
+                var context = GetContext(item.itemName, item.itemType, item.isFolder, item.isUnderProjectRoot ? ProjectTreeFlags.ProjectRoot : ProjectTreeFlags.Empty);
+                var values = GetInitialValues();
+
+                provider.CalculatePropertyValues(context, values);
+
+                Assert.True(values.DisplayOrder >= lastOrder);
+                lastOrder = values.DisplayOrder;
+            });
+
+            Assert.True(lastOrder >= orderedFileInput.Count);
+        }
+
+        public static IEnumerable<object[]> TestTreeItems
+        {
+            get
+            {
+                return new[]
+                {
+                    // 1. simple ordering with no folders in evaluated include
+                    new object[]
+                    {
+                        new List<(string type, string include)>
+                        {
+                            ("Compile", "Order.fs"),
+                            ("Compile", "Customer.fs"),
+                            ("Compile", "Program.fs")
+                        },
+                        new List<(string itemName, string itemType, bool isFolder, bool isUnderProjectRoot)>
+                        {
+                            // unknown folders and their nested items
+                            ("Debug", null, true, true),
+                            ("bin", null, true, false),
+                            ("app.exe", null, false, false),
+
+                            // included items
+                            ("Order.fs", "Compile", false, true),
+                            ("Customer.fs", "Compile", false, true),
+                            ("Program.fs", "Compile", false, true),
+
+                            // hidden or other items under project root
+                            ("profile.png", "Content", false, true),
+                            ("app.fsproj", null, false, true),
+                            ("app.sln", null, false, true)
+                        }
+                    },
+
+                    // 2. nested ordering with folders that should also be ordered
+                    new object[]
+                    {
+                        new List<(string type, string include)>
+                        {
+                            ("Compile", "Order/Order.fs"),
+                            ("Compile", "Customer/Postcode.fs"),
+                            ("Compile", "Customer\\Customer.fs"),
+                            ("Compile", "Customer/Telemetry/Data.fs"),
+                            ("Compile", "Customer/Address.fs"),
+                            ("Content", "Bio.png"),
+                            ("Compile", "Program.fs"),
+                        },
+                        new List<(string itemName, string itemType, bool isFolder, bool isUnderProjectRoot)>
+                        {
+                            // unknown folders and their nested items
+                            (".vs", "Folder", true, false),
+                            ("bin", "Folder", true, true),
+                            (".suo", null, false, false),
+                            ("netcoreapp2.0", "Folder", true, false),
+                            ("obj", "Folder", true, true),
+                            (".suo", null, false, false),
+                            ("app.fsproj.nuget.g.props", null, false, false),
+                            ("app.fsproj.nuget.g.targets", null, false, false),
+
+                            // included items
+                            ("Order", "Folder", true, true),
+                                ("Order.fs", "Compile", false, false),
+                            ("Customer", "Folder", true, true),
+                                ("Postcode.fs", "Compile", false, false),
+                                ("Customer.fs", "Compile", false, false),
+                                ("Telemetry", "Folder", true, false),
+                                    ("Data.fs", "Compile", false, false),
+                                ("Address.fs", "Compile", false, false),
+                            ("Bio.png", "Content", false, true),
+                            ("Program.fs", "Compile", false, true),
+
+                            // hidden or other items under project root
+                            ("app.fsproj", null, false, true),
+                            ("app.sln", null, false, true)
+                        }
+                    }
+                };
+            }
+        }
+
+        private static IProjectTreeCustomizablePropertyContext GetContext(
+            string itemName = null,
+            string itemType = null,
+            bool isFolder = false,
+            ProjectTreeFlags flags = default(ProjectTreeFlags))
+            => IProjectTreeCustomizablePropertyContextFactory.Implement(itemName, itemType, isFolder, flags);
+
+        private static ProjectTreeCustomizablePropertyValues GetInitialValues() =>
+            new ProjectTreeCustomizablePropertyValues { DisplayOrder = 0 };
+
+        private class ProjectTreeCustomizablePropertyValues : 
+            IProjectTreeCustomizablePropertyValues, 
+            IProjectTreeCustomizablePropertyValues2
+        {
+            public ProjectTreeFlags Flags { get; set; }
+
+            public ProjectImageMoniker Icon { get; set; }
+
+            public ProjectImageMoniker ExpandedIcon { get; set; }
+
+            public int DisplayOrder { get; set; }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProviderTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
                 .Select(p => new ProjectItemIdentity(p.type, p.include))
                 .ToList();
 
-            var provider = new TreeItemOrderPropertyProvider(orderedItems);
+            var provider = new TreeItemOrderPropertyProvider(orderedItems, UnconfiguredProjectFactory.Create());
 
             var context = GetContext(itemName, itemType, isFolder, ProjectTreeFlags.ProjectRoot);
             var values = GetInitialValues();
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
                 .Select(p => new ProjectItemIdentity(p.type, p.include))
                 .ToList();
 
-            var provider = new TreeItemOrderPropertyProvider(orderedItems);
+            var provider = new TreeItemOrderPropertyProvider(orderedItems, UnconfiguredProjectFactory.Create());
 
             var lastOrder = 0;
             solutionTree.ForEach(item =>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProviderTests.cs
@@ -21,8 +21,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
         [InlineData("Customer.fs", "Compile", false, 2)]
         [InlineData("order.fs", "Compile", false, 1)] // case insensitive
         [InlineData("Program.fs", "Compile", false, 3)] 
-        [InlineData("Misc.txt", "Content", false, 4)] // unknown type
-        [InlineData("ordered.fsproj", null, false, 4)] // hidden file
+        [InlineData("Misc.txt", "Content", false, int.MaxValue)] // unknown type
+        [InlineData("ordered.fsproj", null, false, int.MaxValue)] // hidden file
         [InlineData("Debug", null, true, 0)] // unknown folder
         public void VerifySimpleOrderedUnderProjectRoot(string itemName, string itemType, bool isFolder, int expectedOrder)
         {
@@ -88,7 +88,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
                             // unknown folders and their nested items
                             ("Debug", null, true, true),
                             ("bin", null, true, false),
-                            ("app.exe", null, false, false),
 
                             // included items
                             ("Order.fs", "Compile", false, true),
@@ -117,15 +116,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
                         },
                         new List<(string itemName, string itemType, bool isFolder, bool isUnderProjectRoot)>
                         {
-                            // unknown folders and their nested items
+                            // unknown folders 
                             (".vs", "Folder", true, false),
                             ("bin", "Folder", true, true),
-                            (".suo", null, false, false),
                             ("netcoreapp2.0", "Folder", true, false),
                             ("obj", "Folder", true, true),
-                            (".suo", null, false, false),
-                            ("app.fsproj.nuget.g.props", null, false, false),
-                            ("app.fsproj.nuget.g.targets", null, false, false),
 
                             // included items
                             ("Order", "Folder", true, true),

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -1,6 +1,6 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\VisualStudio.props"/>
+  <Import Project="..\VisualStudio.props" />
   <PropertyGroup>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
     
@@ -41,7 +41,7 @@
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests" />
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)"/>
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="ProjectSystem\VS\PropertyPages\DebugPageControl.xaml.cs">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProvider.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
+{
+    /// <summary>
+    /// Provider that computes display order of tree items based on input ordering of
+    /// evaluated includes from the project file.
+    /// </summary>
+    internal class TreeItemOrderPropertyProvider : IProjectTreePropertiesProvider
+    {
+        private readonly char[] _separators = new char[]
+        {
+            Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar
+        };
+
+        public IReadOnlyCollection<ProjectItemIdentity> OrderedItems { get; }
+
+        public ImmutableHashSet<string> AllowedItemTypes { get; }
+
+        public Dictionary<string, int> DisplayOrderMap { get; } = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+        public TreeItemOrderPropertyProvider(IReadOnlyCollection<ProjectItemIdentity> orderedItems)
+        {
+            OrderedItems = orderedItems;
+
+            AllowedItemTypes = OrderedItems.Select(p => p.ItemType).ToImmutableHashSet();
+
+            ComputeIndices(orderedItems);
+        }
+
+        /// <summary>
+        /// Preorder folders and items that are provided as ordered evaluated includes
+        /// </summary>
+        /// <param name="orderedItems">ordered evaluated includes</param>
+        private void ComputeIndices(IReadOnlyCollection<ProjectItemIdentity> orderedItems)
+        {
+            var index = 1;
+            var parts = OrderedItems.SelectMany(p => p.EvaluatedInclude.Split(_separators));
+
+            foreach (var item in parts)
+            {
+                if (!DisplayOrderMap.ContainsKey(item))
+                {
+                    DisplayOrderMap.Add(item, index++);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Assign a display order property to items that have previously been preordered
+        /// or other (hidden) items under the project root that are not folders
+        /// </summary>
+        /// <param name="propertyContext"></param>
+        /// <param name="propertyValues"></param>
+        public void CalculatePropertyValues(
+            IProjectTreeCustomizablePropertyContext propertyContext, 
+            IProjectTreeCustomizablePropertyValues propertyValues)
+        {
+            if (propertyValues is IProjectTreeCustomizablePropertyValues2 propertyValues2)
+            {
+                var isAllowedItemType = propertyContext.ItemType != null 
+                    && AllowedItemTypes.Contains(propertyContext.ItemType);
+
+                // assign disply order to folders and items that have a recognized 
+                // item type and appear in order map
+                if ((isAllowedItemType || propertyContext.IsFolder) 
+                    && DisplayOrderMap.TryGetValue(propertyContext.ItemName, out var index))
+                {
+                    propertyValues2.DisplayOrder = index;
+                }
+                else if (propertyContext.ParentNodeFlags.Contains(ProjectTreeFlags.ProjectRoot) && !propertyContext.IsFolder)
+                {
+                    // move unordered non-folder items at project root to the end 
+                    // (this will typically be hidden items visible on "Show All Files")
+                    propertyValues2.DisplayOrder = DisplayOrderMap.Count + 1;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProvider.cs
@@ -15,14 +15,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
     internal class TreeItemOrderPropertyProvider : IProjectTreePropertiesProvider
     {
         private const string FullPathProperty = "FullPath";
-        private readonly char[] _separators = new char[]
-        {
-            Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar
-        };
-        private Dictionary<string, int> _displayOrderMap = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-        private Dictionary<string, int> _rootedOrderMap = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-        private UnconfiguredProject _project;
-        private ImmutableHashSet<string> _allowedItemTypes;
+        private readonly Dictionary<string, int> _displayOrderMap = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, int> _rootedOrderMap = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        private readonly UnconfiguredProject _project;
+        private readonly ImmutableHashSet<string> _allowedItemTypes;
 
         public TreeItemOrderPropertyProvider(IReadOnlyCollection<ProjectItemIdentity> orderedItems, UnconfiguredProject project)
         {
@@ -48,10 +44,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
                 .Select(g => g.Key).ToImmutableHashSet();
 
             var index = 1;
-            
+
+            // This enumerates all the folder names and file names and maps them
+            // against their assigned display index. Any file names that are duplicates
+            // are mapped in in _rootedOrderMap only; everything else is mapped in
+            // _displayOrderMap only.
             foreach (var item in OrderedItems)
             {
-                var includeParts = item.EvaluatedInclude.Split(_separators, StringSplitOptions.RemoveEmptyEntries);
+                var includeParts = item.EvaluatedInclude.Split(CommonConstants.PathSeparators, StringSplitOptions.RemoveEmptyEntries);
                 foreach (var part in includeParts)
                 {
                     var rootedPath = duplicateFiles.Contains(part) ? _project.MakeRooted(item.EvaluatedInclude) : null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProviderSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProviderSource.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks.Dataflow;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
+{
+    /// <summary>
+    /// Setup the dataflow for a provider that updates solution tree item properties with 
+    /// display order metadata derived from IOrderedSourceItemsDataSourceService
+    /// </summary>
+    [Export(typeof(IProjectTreePropertiesProviderDataSource))]
+    [AppliesTo(ProjectCapability.SortByDisplayOrder)]
+    internal class TreeItemOrderPropertyProviderSource : ChainedProjectValueDataSourceBase<IProjectTreePropertiesProvider>, IProjectTreePropertiesProviderDataSource
+    {
+        [Import(ExportContractNames.Scopes.UnconfiguredProject)]
+        private IOrderedSourceItemsDataSourceService OrderedItemSource { get; set; }
+
+        [ImportingConstructor]
+        public TreeItemOrderPropertyProviderSource(UnconfiguredProject project)
+            : base(project.Services)
+        {
+        }
+
+        protected override IDisposable LinkExternalInput(ITargetBlock<IProjectVersionedValue<IProjectTreePropertiesProvider>> targetBlock)
+        {
+            JoinUpstreamDataSources(OrderedItemSource);
+
+            TreeItemOrderPropertyProvider latestTreeItemOrderPropertyProvider = null;
+            var providerProducerBlock = new TransformBlock<IProjectVersionedValue<IReadOnlyCollection<ProjectItemIdentity>>, IProjectVersionedValue<IProjectTreePropertiesProvider>>(
+                orderedItems =>
+                {
+                    if (latestTreeItemOrderPropertyProvider?.OrderedItems != orderedItems.Value)
+                    {
+                        latestTreeItemOrderPropertyProvider = new TreeItemOrderPropertyProvider(orderedItems.Value);
+                    }
+
+                    return new ProjectVersionedValue<IProjectTreePropertiesProvider>(latestTreeItemOrderPropertyProvider, orderedItems.DataSourceVersions);
+                });
+
+            providerProducerBlock.LinkTo(targetBlock, new DataflowLinkOptions() { PropagateCompletion = true });
+            return OrderedItemSource.SourceBlock.LinkTo(providerProducerBlock, new DataflowLinkOptions() { PropagateCompletion = true });
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProviderSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProviderSource.cs
@@ -39,7 +39,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
             var providerProducerBlock = new TransformBlock<IProjectVersionedValue<IReadOnlyCollection<ProjectItemIdentity>>, IProjectVersionedValue<IProjectTreePropertiesProvider>>(
                 orderedItems =>
                 {
-                    if (latestTreeItemOrderPropertyProvider?.OrderedItems != orderedItems.Value)
+                    // Limit TreeItemOrderPropertyProvider to one instance for now
+                    // to fend off race conditions
+                    if (latestTreeItemOrderPropertyProvider == null)
                     {
                         latestTreeItemOrderPropertyProvider = new TreeItemOrderPropertyProvider(orderedItems.Value, _project);
                     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProviderSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProviderSource.cs
@@ -15,12 +15,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
     [AppliesTo(ProjectCapability.SortByDisplayOrder)]
     internal class TreeItemOrderPropertyProviderSource : ChainedProjectValueDataSourceBase<IProjectTreePropertiesProvider>, IProjectTreePropertiesProviderDataSource
     {
-        private TreeItemOrderPropertyProvider latestTreeItemOrderPropertyProvider = null;
+        private UnconfiguredProject _project;
+        private TreeItemOrderPropertyProvider latestTreeItemOrderPropertyProvider;
 
         [ImportingConstructor]
         public TreeItemOrderPropertyProviderSource(UnconfiguredProject project)
             : base(project.Services)
         {
+            _project = project;
         }
 
         [Import(ExportContractNames.Scopes.UnconfiguredProject)]
@@ -35,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
                 {
                     if (latestTreeItemOrderPropertyProvider?.OrderedItems != orderedItems.Value)
                     {
-                        latestTreeItemOrderPropertyProvider = new TreeItemOrderPropertyProvider(orderedItems.Value);
+                        latestTreeItemOrderPropertyProvider = new TreeItemOrderPropertyProvider(orderedItems.Value, _project);
                     }
 
                     return new ProjectVersionedValue<IProjectTreePropertiesProvider>(latestTreeItemOrderPropertyProvider, orderedItems.DataSourceVersions);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProviderSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProviderSource.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
     {
         private readonly UnconfiguredProject _project;
         private readonly IOrderedSourceItemsDataSourceService _orderedItemSource;
-        private TreeItemOrderPropertyProvider latestTreeItemOrderPropertyProvider;
+        private TreeItemOrderPropertyProvider _latestTreeItemOrderPropertyProvider;
 
         [ImportingConstructor]
         public TreeItemOrderPropertyProviderSource(
@@ -41,12 +41,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
                 {
                     // Limit TreeItemOrderPropertyProvider to one instance for now
                     // to fend off race conditions
-                    if (latestTreeItemOrderPropertyProvider == null)
+                    if (_latestTreeItemOrderPropertyProvider?.OrderedItems != orderedItems.Value)
                     {
-                        latestTreeItemOrderPropertyProvider = new TreeItemOrderPropertyProvider(orderedItems.Value, _project);
+                        _latestTreeItemOrderPropertyProvider = new TreeItemOrderPropertyProvider(orderedItems.Value, _project);
                     }
 
-                    return new ProjectVersionedValue<IProjectTreePropertiesProvider>(latestTreeItemOrderPropertyProvider, orderedItems.DataSourceVersions);
+                    return new ProjectVersionedValue<IProjectTreePropertiesProvider>(_latestTreeItemOrderPropertyProvider, orderedItems.DataSourceVersions);
                 }, 
                 new ExecutionDataflowBlockOptions() { NameFormat= "Ordered Tree Item Input: {1}" });
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/CommonConstants.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/CommonConstants.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.IO;
+
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal static class CommonConstants
@@ -28,5 +30,13 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// Single, static instance of an array that contains a back slash '\', which is used to split strings.
         /// </summary>
         internal static readonly char[] BackSlashDelimiter = new char[] { '\\' };
+
+        /// <summary>
+        /// Single, static instance of an array that contains platform-specific path separators
+        /// </summary>
+        internal static readonly char[] PathSeparators = new char[]
+        {
+            Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar
+        };
     }
 }


### PR DESCRIPTION
Needed for FSharp projects where the order of source files in the project file is significant, and should be reflected in the solution explorer. This implementation also accounts for folders by pre-ordering each sub folder and item. The limitation of this is that duplicate folders in different parts of the tree will receive the same ordering.

**Customer scenario**

FSharp .NET Core projects list source files in alphabetical order in the solution explorer. But the order in the project file is significant and should be preserved to facilitate program comprehension.

**Bugs this fixes:** 

#2793 
[517046](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/517046)

**Workarounds, if any**

N/A

**Risk**

Low, changes only applied to projects that declare the `SortByDisplayOrder` capability

**Is this a regression from a previous update?**

N/A

**How was the bug found?**

Known issue

/cc @dotnet/project-system @brettfo @KevinRansom 
