### PR TITLE
Reduce allocations in DuplicatedDependenciesSnapshotFilter.BeforeAdd

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DuplicatedDependenciesSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DuplicatedDependenciesSnapshotFilterTests.cs
@@ -141,5 +141,46 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             dependency.VerifyAll();
             otherDependency.VerifyAll();
         }
+
+        [Fact]
+        public void WhenThereIsMatchingDependency_WithSubstringCaption()
+        {
+            const string caption = "MyCaption";
+            var dependency = IDependencyFactory.Implement(
+                providerType: "myprovider",
+                id: "mydependency1",
+                caption: caption);
+
+            var otherDependency = IDependencyFactory.Implement(
+                    providerType: "myprovider",
+                    id: "mydependency2",
+                    caption: caption + "X");
+
+            var worldBuilder = new Dictionary<string, IDependency>()
+            {
+                { dependency.Object.Id, dependency.Object }
+            }.ToImmutableDictionary().ToBuilder();
+            var topLevelBuilder = ImmutableHashSet<IDependency>.Empty
+                                                               .Add(dependency.Object)
+                                                               .Add(otherDependency.Object)
+                                                               .ToBuilder();
+
+            var filter = new DuplicatedDependenciesSnapshotFilter();
+
+            var resultDependency = filter.BeforeAdd(
+                null,
+                null,
+                dependency.Object,
+                worldBuilder,
+                topLevelBuilder,
+                null,
+                null,
+                out bool filterAnyChanges);
+
+            Assert.False(worldBuilder.ContainsKey(otherDependency.Object.Id));
+
+            dependency.VerifyAll();
+            otherDependency.VerifyAll();
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DuplicatedDependenciesSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DuplicatedDependenciesSnapshotFilterTests.cs
@@ -23,8 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var otherDependency = IDependencyFactory.Implement(
                     providerType: "myprovider",
                     id: "mydependency2",
-                    caption: "otherCaption",
-                    originalItemSpec: "mydependency2ItemSpec");
+                    caption: "otherCaption");
 
             var worldBuilder = new Dictionary<string, IDependency>()
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DuplicatedDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DuplicatedDependenciesSnapshotFilter.cs
@@ -40,14 +40,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
                      && x.ProviderType.Equals(dependency.ProviderType, StringComparison.OrdinalIgnoreCase) 
                      && x.Caption.Equals(dependency.Caption, StringComparison.OrdinalIgnoreCase));
             
-            // if found node with same caption, or if there were nodes with same caption but with Alias already applied
+            // If found node with same caption, or if there were nodes with same caption but with Alias already applied
+            // NOTE: Performance sensitive, so avoid formatting the Caption with parens if it's possible to avoid it.
             var shouldApplyAlias = (matchingDependency == null)
                 ? topLevelBuilder.Any(
                     x => !x.Id.Equals(dependency.Id)
                          && x.ProviderType.Equals(dependency.ProviderType, StringComparison.OrdinalIgnoreCase)
-                         && x.Caption.Equals(
-                             string.Format(CultureInfo.CurrentCulture, "{0} ({1})", dependency.Caption, x.OriginalItemSpec),
-                                StringComparison.OrdinalIgnoreCase))
+                         && x.Caption.StartsWith(dependency.Caption, StringComparison.OrdinalIgnoreCase)
+                         && string.Compare(x.Caption, dependency.Caption.Length + " (".Length, x.OriginalItemSpec, 0, x.OriginalItemSpec.Length, StringComparison.OrdinalIgnoreCase) == 0)
                 : true;
 
             if (shouldApplyAlias)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DuplicatedDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DuplicatedDependenciesSnapshotFilter.cs
@@ -4,8 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
-using System.Globalization;
-using System.Linq;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Filters
@@ -48,27 +46,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             }
 
             // If found node with same caption, or if there were nodes with same caption but with Alias already applied
-            // NOTE: Performance sensitive, so avoid formatting the Caption with parens if it's possible to avoid it.
-            bool shouldApplyAlias;
-            if (matchingDependency == null)
+            // NOTE: Performance sensitive, so avoid formatting the Caption with parenthesis if it's possible to avoid it.
+            var shouldApplyAlias = matchingDependency != null;
+            if (!shouldApplyAlias)
             {
+                var adjustedLength = dependency.Caption.Length + " (".Length;
                 foreach (var x in topLevelBuilder)
                 {
                     if (!x.Id.Equals(dependency.Id)
                          && x.ProviderType.Equals(dependency.ProviderType, StringComparison.OrdinalIgnoreCase)
                          && x.Caption.StartsWith(dependency.Caption, StringComparison.OrdinalIgnoreCase)
-                         && string.Compare(x.Caption, dependency.Caption.Length + " (".Length, x.OriginalItemSpec, 0, x.OriginalItemSpec.Length, StringComparison.OrdinalIgnoreCase) == 0)
+                         && x.Caption.Length >= adjustedLength
+                         && string.Compare(x.Caption, adjustedLength, x.OriginalItemSpec, 0, x.OriginalItemSpec.Length, StringComparison.OrdinalIgnoreCase) == 0)
                     {
                         shouldApplyAlias = true;
                         break;
                     }
                 }
-
-                shouldApplyAlias = false;
-            }
-            else
-            {
-                shouldApplyAlias = true;
             }
 
             if (shouldApplyAlias)


### PR DESCRIPTION
NOTES: Look at last two commits only - the rest are just things from `master` that need to come into `post-dev15.5`.

**Customer scenario**

Opening a large solution a lot of entries in the dependencies nodes.

**Bugs this fixes:** 

#2596 

**Workarounds, if any**

none

**Risk**

Low - just re-wrote some code to avoid `string.Format` and Linq.

**Performance impact**

Currently this method is responsible for 6.6% of the allocations involved in opening the project-system repo. 

**Is this a regression from a previous update?**

No

**Root cause analysis:**

Need more performance tests for new project system

**How was the bug found?**

Profiling
