### PR TITLE
Update documentation on how to diagnose design-time issues

### DIFF
--- a/docs/design-time-builds.md
+++ b/docs/design-time-builds.md
@@ -78,7 +78,7 @@ The following are symptoms of a design-time build that is taking too long:
 
 You can force Visual Studio to show the results of a design-time build using the following instructions:
 
-#### Visual Studio 2015 or below:
+#### Visual Studio 2015 or below
 
 1. Delete the `.vs` directory that sits alongside the solution that is experiencing the problem
 2. Start a Developer Command Prompt for VS2015
@@ -87,7 +87,7 @@ You can force Visual Studio to show the results of a design-time build using the
 5. Open the solution
 6. Under %TEMP%, look for [RANDOMGUID].designtime.log files, these will contain the results of the design-time build. If running Visual Studio 2015 Update 2 or higher, the name of the project and design-time target that is being called will also be included in the file name.
 
-#### Visual Studio 2017
+#### Visual Studio 2017 (version 15.3 or earlier)
 
 In Visual Studio 2017 there are two C# and Visual Basic project systems. By default the majority of projects (.NET Framework, UWP, etc) continue to open in the same project system as previous versions of Visual Studio, and hence the instructions are the same as above. 
 
@@ -109,6 +109,14 @@ To turn off this pane:
 ```
 DesignTimeBuildOutputPane.cmd disable
 ```
+
+#### Visual Studio 2017 (version 15.4 or later)
+
+1. Install the [Project System Tools](https://marketplace.visualstudio.com/items?itemName=VisualStudioProductTeam.ProjectSystemTools) extension
+2. In Visual Studio, choose the `View > Other Windows > Build Logging` menu item.
+3. Click on the "play" button.
+
+This will cause design time builds to show up in the build logging tool window. If you have the [MSBuild Binary and Structured Log Viewer](http://msbuildlog.com/) installed, you can double-click on a log to view it in the viewer, otherwise you can right-click and choose `Save As...` to save the log in the new [binary log format](https://github.com/Microsoft/msbuild/wiki/Binary-Log).
 
 ### Diagnosing why a design-time build is failing or taking too long
 


### PR DESCRIPTION
This is a documentation-only change but I wanted to run it by @davkean. This adds a pointer to the build log viewer for VS 2017 15.4+ in the design-time build recommendations.