### PR TITLE
Add attribute persistence style to Resolved Package References

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedPackageReference.xaml
@@ -22,6 +22,9 @@
                     ReadOnly="True"
                     DisplayName="Version"
                     Description="Version of dependency.">
+        <StringProperty.DataSource>
+            <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
     </StringProperty>
 
     <StringProperty Name="Name" 


### PR DESCRIPTION
**Customer scenario**

Customers adding NuGet packages through the NuGet package manager see version in "Element" style instead of "Attribute" style. This is a regression from 15.4.

**Bugs this fixes:** 

[507675](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/507675)

**Workarounds, if any**

N/A

**Risk**

Low, just updates some data source properties for the Version rule, similar to what was done in https://github.com/dotnet/project-system/pull/728
 
**Performance impact**

None, and returns VS to 15.4 behavior

**Is this a regression from a previous update?**

Yes

**Root cause analysis:**

This is ultimately a limitation in CPS. It is not able to distinguish between PackageReference.xaml and ResolvedPackageReference.xaml for representing package references, and has just been selecting the first one, which is not deterministic. Up to now it has always selected PackageReference.xaml, but something has changed to affect the ordering and choice. We have determined that updating ResolvedPackageReference.xaml is the safest workaround to restore 15.4 behavior. Long term, CPS is tracking removing this non-determinism with [519807](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/519807).

**How was the bug found?**

Customer and Vendor team reported

/cc @dotnet/project-system @jviau 
