### PR TITLE
Avoid COM interface in SupportsProjectDesigner

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsProjectDesignerPageService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsProjectDesignerPageService.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties
+{
+    internal static class IVsProjectDesignerPageServiceFactory
+    {
+        public static IVsProjectDesignerPageService Create()
+        {
+            return Mock.Of<IVsProjectDesignerPageService>();
+        }
+
+        public static IVsProjectDesignerPageService ImplementIsProjectDesignerSupported(Func<bool> action)
+        {
+            var mock = new Mock<IVsProjectDesignerPageService>();
+            mock.SetupGet(s => s.IsProjectDesignerSupported)
+                .Returns(action);
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/ProjectDesignerServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/ProjectDesignerServiceTests.cs
@@ -75,12 +75,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
             var designerService = CreateInstance(projectVsServices, vsProjectDesignerPageService);
 
-#pragma warning disable RS0003 // Do not directly await a Task (see https://github.com/dotnet/roslyn/issues/6770)
             await Assert.ThrowsAsync<COMException>(() => {
 
                 return designerService.ShowProjectDesignerAsync();
             });
-#pragma warning restore RS0003 // Do not directly await a Task
         }
 
         [Fact]
@@ -95,12 +93,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
             var designerService = CreateInstance(projectVsServices, vsProjectDesignerPageService);
 
-#pragma warning disable RS0003 // Do not directly await a Task (see https://github.com/dotnet/roslyn/issues/6770)
             await Assert.ThrowsAsync<COMException>(() => {
 
                 return designerService.ShowProjectDesignerAsync();
             });
-#pragma warning restore RS0003 // Do not directly await a Task
         }
 
         [Fact]
@@ -120,12 +116,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
             var designerService = CreateInstance(projectVsServices, vsProjectDesignerPageService);
 
-#pragma warning disable RS0003 // Do not directly await a Task (see https://github.com/dotnet/roslyn/issues/6770)
             await Assert.ThrowsAsync<COMException>(() => {
 
                 return designerService.ShowProjectDesignerAsync();
             });
-#pragma warning restore RS0003 // Do not directly await a Task
         }
 
         [Fact]
@@ -167,12 +161,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
             var designerService = CreateInstance(projectVsServices, vsProjectDesignerPageService);
 
-#pragma warning disable RS0003 // Do not directly await a Task (see https://github.com/dotnet/roslyn/issues/6770)
             await Assert.ThrowsAsync<COMException>(() => {
 
                 return designerService.ShowProjectDesignerAsync();
             });
-#pragma warning restore RS0003 // Do not directly await a Task
         }
 
         [Fact]
@@ -194,9 +186,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
             var designerService = CreateInstance(projectVsServices, vsProjectDesignerPageService);
 
-#pragma warning disable RS0003 // Do not directly await a Task (see https://github.com/dotnet/roslyn/issues/6770)
             await designerService.ShowProjectDesignerAsync();
-#pragma warning restore RS0003 // Do not directly await a Task
 
             Assert.Equal(1, callCount);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/ProjectDesignerService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/ProjectDesignerService.cs
@@ -16,18 +16,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
     internal class ProjectDesignerService : IProjectDesignerService
     {
         private readonly IUnconfiguredProjectVsServices _projectVsServices;
-        private readonly Lazy<bool> _lazySupportsProjectDesigner;
+        private readonly IVsProjectDesignerPageService _vsProjectDesignerPageService;
 
         [ImportingConstructor]
-        public ProjectDesignerService(IUnconfiguredProjectVsServices projectVsServices)
+        public ProjectDesignerService(IUnconfiguredProjectVsServices projectVsServices, IVsProjectDesignerPageService vsProjectDesignerPageService)
         {
             Requires.NotNull(projectVsServices, nameof(projectVsServices));
+            Requires.NotNull(vsProjectDesignerPageService, nameof(vsProjectDesignerPageService));
 
             _projectVsServices = projectVsServices;
-            _lazySupportsProjectDesigner = new Lazy<bool>(() => _projectVsServices.VsHierarchy.GetProperty(VsHierarchyPropID.SupportsProjectDesigner, defaultValue: false), mode: System.Threading.LazyThreadSafetyMode.PublicationOnly);
+            _vsProjectDesignerPageService = vsProjectDesignerPageService;
         }
 
-        public bool SupportsProjectDesigner => _lazySupportsProjectDesigner.Value;
+        public bool SupportsProjectDesigner => _vsProjectDesignerPageService.IsProjectDesignerSupported;
 
         public Task ShowProjectDesignerAsync()
         {


### PR DESCRIPTION
Avoid COM interface in SupportsProjectDesigner.

Avoiding calling through the COM interface in SupportsProjectDesigner to fix #2911.