### PR TITLE
Implement basic resolved dependency tree telemetry

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITelemetryServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITelemetryServiceFactory.cs
@@ -1,11 +1,46 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using Moq;
 
 namespace Microsoft.VisualStudio.Telemetry
 {
     internal static class ITelemetryServiceFactory
     {
+        public class TelemetryParameters
+        {
+            public string EventName { get; set; }
+
+            public IEnumerable<(string propertyName, object propertyValue)> Properties { get; set; }
+        }
+
         public static ITelemetryService Create() => Mock.Of<ITelemetryService>();
+
+        public static ITelemetryService Create(TelemetryParameters callParameters)
+        {
+            var telemetryService = new Mock<ITelemetryService>();
+
+            telemetryService.Setup(t => t.PostEvent(It.IsAny<string>()))
+                .Callback((string name) => callParameters.EventName = name);
+
+            telemetryService.Setup(t => t.PostProperty(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<object>()))
+                .Callback((string e, string p, object v) => 
+                {
+                    callParameters.EventName = e;
+                    callParameters.Properties = new List<(string, object)>
+                    {
+                        (p, v)
+                    };
+                });
+
+            telemetryService.Setup(t => t.PostProperties(It.IsAny<string>(), It.IsAny<IEnumerable<(string propertyName, object propertyValue)>>()))
+                .Callback((string e, IEnumerable<(string propertyName, object propertyValue)> p) =>
+                {
+                    callParameters.EventName = e;
+                    callParameters.Properties = p;
+                });
+
+            return telemetryService.Object;
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
@@ -14,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     /// It maintains some light state for each Target Framework to keep track
     /// whether all expected rules have been observed; this information is passed
     /// as a property of the telemetry event and can be used to determine if the
-    /// 'resolved' event is fired to early (so sessions can be appropriately filtered).
+    /// 'resolved' event is fired too early (so sessions can be appropriately filtered).
     /// </summary>
     [Export(typeof(IDependencyTreeTelemetryService))]
     [AppliesTo(ProjectCapability.DependenciesTree)]
@@ -105,8 +106,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             {
                 InitializeProjectId();
             }
-
-            _telemetryService.PostProperties($"{TelemetryEventName}/{(hasUnresolvedDependency ? UnresolvedLabel : ResolvedLabel)}",
+            
+            _telemetryService.PostProperties(
+                FormattableString.Invariant($"{TelemetryEventName}/{(hasUnresolvedDependency ? UnresolvedLabel : ResolvedLabel)}"),
                 new List<(string, object)>
                 {
                     (ProjectProperty, _projectId),

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -26,6 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         private const string ResolvedLabel = "Resolved";
         private const string ProjectProperty = "Project";
         private const string ObservedAllRulesProperty = "ObservedAllRules";
+        private const int MaxEventCount = 10;
 
         private readonly UnconfiguredProject _project;
         private readonly ITelemetryService _telemetryService;
@@ -34,6 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         private readonly object _stateUpdateLock = new object();
         private string _projectId;
         private bool _stopTelemetry = false;
+        private int eventCount = 0;
 
         [ImportingConstructor]
         public DependencyTreeTelemetryService(
@@ -98,7 +100,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             lock (_stateUpdateLock)
             {
                 if (_stopTelemetry) return;
-                _stopTelemetry = !hasUnresolvedDependency;
+                _stopTelemetry = !hasUnresolvedDependency || (++eventCount >= MaxEventCount);
                 observedAllRules = ObservedAllRules();
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -1,0 +1,153 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
+using Microsoft.VisualStudio.Telemetry;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
+{
+    /// <summary>
+    /// Model for creating telemetry events when dependency tree is updated.
+    /// It maintains some light state for each Target Framework to keep track
+    /// whether all expected rules have been observed; this information is passed
+    /// as a property of the telemetry event and can be used to determine if the
+    /// 'resolved' event is fired to early (so sessions can be appropriately filtered).
+    /// </summary>
+    [Export(typeof(IDependencyTreeTelemetryService))]
+    [AppliesTo(ProjectCapability.DependenciesTree)]
+    internal class DependencyTreeTelemetryService : IDependencyTreeTelemetryService
+    {
+        private const string TelemetryEventName = "TreeUpdated";
+        private const string UnresolvedLabel = "Unresolved";
+        private const string ResolvedLabel = "Resolved";
+        private const string ProjectProperty = "Project";
+        private const string ObservedAllRulesProperty = "ObservedAllRules";
+
+        private readonly UnconfiguredProject _project;
+        private readonly ITelemetryService _telemetryService;
+        private readonly ConcurrentDictionary<ITargetFramework, TelemetryState> _telemetryStates =
+            new ConcurrentDictionary<ITargetFramework, TelemetryState>();
+        private readonly object _stateUpdateLock = new object();
+        private string _projectId;
+        private bool _stopTelemetry = false;
+
+        [ImportingConstructor]
+        public DependencyTreeTelemetryService(
+            UnconfiguredProject project,
+            ITelemetryService telemetryService)
+        {
+            _project = project;
+            _telemetryService = telemetryService;
+        }
+
+        /// <summary>
+        /// Indicate whether we have seen all rules we initialized with, in all target frameworks
+        /// </summary>
+        public bool ObservedAllRules() => _telemetryStates.All(state => state.Value.ObservedAllRules());
+
+        /// <summary>
+        /// Initialize telemetry state with the set of rules we expect to observe for target framework
+        /// </summary>
+        public void InitializeTargetFrameworkRules(ITargetFramework targetFramework, IEnumerable<string> rules)
+        {
+            lock (_stateUpdateLock)
+            {
+                if (_stopTelemetry) return;
+
+                var telemetryState = _telemetryStates.GetOrAdd(targetFramework, (key) => new TelemetryState());
+
+                foreach (var rule in rules)
+                {
+                    telemetryState.InitializeRule(rule);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Indicate that a set of rules has been observed in either an Evaluation or Design Time pass.
+        /// This information is used when firing tree update telemetry events to indicate whether all rules
+        /// have been observed.
+        /// </summary>
+        public void ObserveTargetFrameworkRules(ITargetFramework targetFramework, IEnumerable<string> rules)
+        {
+            lock (_stateUpdateLock)
+            {
+                if (_stopTelemetry) return;
+
+                if (_telemetryStates.TryGetValue(targetFramework, out var telemetryState))
+                {
+                    foreach (var rule in rules)
+                    {
+                        telemetryState.ObserveRule(rule);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Fire telemetry when dependency tree completes an update
+        /// </summary>
+        /// <param name="hasUnresolvedDependency">indicates if the snapshot used for the update had any unresolved dependencies</param>
+        public void ObserveTreeUpdateCompleted(bool hasUnresolvedDependency)
+        {
+            bool observedAllRules;
+            lock (_stateUpdateLock)
+            {
+                if (_stopTelemetry) return;
+                _stopTelemetry = !hasUnresolvedDependency;
+                observedAllRules = ObservedAllRules();
+            }
+
+            if (_projectId == null)
+            {
+                InitializeProjectId();
+            }
+
+            _telemetryService.PostProperties($"{TelemetryEventName}/{(hasUnresolvedDependency ? UnresolvedLabel : ResolvedLabel)}",
+                new List<(string, object)>
+                {
+                    (ProjectProperty, _projectId),
+                    (ObservedAllRulesProperty, observedAllRules)
+                });
+        }
+
+        private void InitializeProjectId()
+        {
+            var projectGuidService = _project.Services.ExportProvider.GetExportedValueOrDefault<IProjectGuidService>();
+            if (projectGuidService != null)
+            {
+                SetProjectId(projectGuidService.ProjectGuid.ToString());
+            }
+            else
+            {
+                SetProjectId(_telemetryService.HashValue(_project.FullPath));
+            }
+        }
+
+        // helper to support testing
+        internal void SetProjectId(string projectId)
+        {
+            _projectId = projectId;
+        }
+
+        /// <summary>
+        /// Maintain state for each target framework
+        /// </summary>
+        internal class TelemetryState
+        {
+            private ConcurrentDictionary<string, bool> _observedRules = new ConcurrentDictionary<string, bool>(StringComparers.RuleNames);
+
+            internal bool InitializeRule(string rule) => 
+                _observedRules.TryAdd(rule, false);
+
+            internal bool ObserveRule(string rule) =>
+                _observedRules.TryUpdate(rule, true, false);
+
+            internal bool ObservedAllRules() =>
+                !_observedRules.IsEmpty && _observedRules.All(entry => entry.Value);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependencyTreeTelemetryService.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
+{
+    /// <summary>
+    /// For maintaining light state about dependency tree to generate telemetry
+    /// </summary>
+    internal interface IDependencyTreeTelemetryService
+    {
+        /// <summary>
+        /// Indicate whether we have seen all rules we initialized with, in all target frameworks
+        /// </summary>
+        bool ObservedAllRules();
+
+        /// <summary>
+        /// Initialize telemetry state with the set of rules we expect to observe for target framework
+        /// </summary>
+        void InitializeTargetFrameworkRules(ITargetFramework targetFramework, IEnumerable<string> rules);
+
+        /// <summary>
+        /// Indicate that a set of rules has been observed in either an Evaluation or Design Time pass.
+        /// This information is used when firing tree update telemetry events to indicate whether all rules
+        /// have been observed.
+        /// </summary>
+        void ObserveTargetFrameworkRules(ITargetFramework targetFramework, IEnumerable<string> rules);
+
+        /// <summary>
+        /// Fire telemetry when dependency tree completes an update
+        /// </summary>
+        /// <param name="hasUnresolvedDependency">indicates if the snapshot used for the update had any unresolved dependencies</param>
+        void ObserveTreeUpdateCompleted(bool hasUnresolvedDependency);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
@@ -17,8 +17,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
         [ImportingConstructor]
         public DependencyRulesSubscriber(
             IUnconfiguredProjectCommonServices commonServices,
-            [Import(ExportContractNames.Scopes.UnconfiguredProject)]IProjectAsynchronousTasksService tasksService)
-            : base(commonServices, tasksService)
+            [Import(ExportContractNames.Scopes.UnconfiguredProject)]IProjectAsynchronousTasksService tasksService,
+            IDependencyTreeTelemetryService treeTelemetryService)
+            : base(commonServices, tasksService, treeTelemetryService)
         {
             DependencyRuleHandlers = new OrderPrecedenceImportCollection<ICrossTargetRuleHandler<DependenciesRuleChangeContext>>(
                 projectCapabilityCheckProvider: commonServices.Project);


### PR DESCRIPTION
This change supercedes https://github.com/dotnet/project-system/pull/2879

This implements simplified telemetry to detect resolved dependency tree based on whether the corresponding snapshot has unresolved dependencies.  It includes a telemetry service that maintains some light state for each Target Framework to keep track whether all expected rules have been observed; this information is passed as a property of the telemetry event and can be used to determine if the 'resolved' event is fired too early (so sessions can be appropriately filtered).

**Customer scenario**

Dependency node population can be slow in some solutions. This telemetry can be used to get statistical information about how long it takes to populate the Dependencies node. The telemetry will be used as part of planned A/B testing to determine the best configuration of internal settings

**Bugs this fixes:** 

https://github.com/dotnet/project-system/issues/2703
[509162](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/509162)

**Workarounds, if any**

N/A

**Risk**

Low, this PR does not change dependency tree behavior, primary risk would be incorrect new telemetry.

**Performance impact**

Low, telemetry state only measures whether rules have been observed i.e. it does not maintain state for every node in the dependencies tree 

**Is this a regression from a previous update?** No

**Root cause analysis:**

N/A Planned, Partner requested

**How was the bug found?**

Partner requested

**Developer Notes**
This fires two possible telemetry events when TreeUpdate completes based on whether the corresponding snapshot has unresolved dependencies: 
```
vs/projectsystem/managed/treeupdated/unresolved
vs/projectsystem/managed/treeupdated/resolved
```
After resolved is fired, a flag is set that prevents anymore telemetry for that session (unless there is a reload). Hence sessions without reloads may have many "unresolved" events, and zero or one "resolved" event. Custom properties on the event are:
- Project: project guid
- ObservedAllRules: True | False

/cc @dotnet/project-system @abpiskunov @lifengl @adrianvmsft