### PR TITLE
Make AppDesigner icon show outside of C#/VB

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Imaging/CSharpProjectImageProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Imaging/CSharpProjectImageProviderTests.cs
@@ -52,7 +52,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Imaging
         [InlineData(ProjectImageKey.ProjectRoot)]
         [InlineData(ProjectImageKey.SharedProjectRoot)]
         [InlineData(ProjectImageKey.SharedItemsImportFile)]
-        [InlineData(ProjectImageKey.AppDesignerFolder)]
         public void GetProjectImage_RecognizedKeyAsKey_ReturnsNonNull(string key)
         {
             var provider = CreateInstance();

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Imaging/CSharpProjectImageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Imaging/CSharpProjectImageProvider.cs
@@ -31,9 +31,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Imaging
                 case ProjectImageKey.SharedProjectRoot:
                     return KnownMonikers.CSSharedProject.ToProjectSystemType();
 
-                case ProjectImageKey.AppDesignerFolder:
-                    return KnownMonikers.Property.ToProjectSystemType();
-
                 default:
                     return null;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests/ProjectSystem/VS/Imaging/FSharpProjectImageProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests/ProjectSystem/VS/Imaging/FSharpProjectImageProviderTests.cs
@@ -50,7 +50,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Imaging
 
         [Theory]
         [InlineData(ProjectImageKey.ProjectRoot)]
-        [InlineData(ProjectImageKey.AppDesignerFolder)]
         public void GetProjectImage_RecognizedKeyAsKey_ReturnsNonNull(string key)
         {
             var provider = CreateInstance();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -1,6 +1,6 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\VisualStudio.props"/>
+  <Import Project="..\VisualStudio.props" />
   <PropertyGroup>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
     
@@ -41,7 +41,7 @@
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests" />
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)"/>
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="ProjectSystem\VS\PropertyPages\DebugPageControl.xaml.cs">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Imaging/AppDesignerFolderProjectImageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Imaging/AppDesignerFolderProjectImageProvider.cs
@@ -7,14 +7,14 @@ using Microsoft.VisualStudio.ProjectSystem.Imaging;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Imaging
 {
     /// <summary>
-    ///     Provides F# project images.
+    ///     Provides the AppDesigner folder image.
     /// </summary>
     [Export(typeof(IProjectImageProvider))]
-    [AppliesTo(ProjectCapability.FSharp)]
-    internal class FSharpProjectImageProvider : IProjectImageProvider
+    [AppliesTo(ProjectCapability.AppDesigner)]
+    internal class AppDesignerFolderProjectImageProvider : IProjectImageProvider
     {
         [ImportingConstructor]
-        public FSharpProjectImageProvider()
+        public AppDesignerFolderProjectImageProvider()
         {
         }
 
@@ -24,8 +24,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Imaging
 
             switch (key)
             {
-                case ProjectImageKey.ProjectRoot:
-                    return KnownMonikers.FSProjectNode.ToProjectSystemType();
+                case ProjectImageKey.AppDesignerFolder:
+                    return KnownMonikers.Property.ToProjectSystemType();
 
                 default:
                     return null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Imaging/VisualBasicProjectImageProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Imaging/VisualBasicProjectImageProviderTests.cs
@@ -52,7 +52,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Imaging
         [InlineData(ProjectImageKey.ProjectRoot)]
         [InlineData(ProjectImageKey.SharedProjectRoot)]
         [InlineData(ProjectImageKey.SharedItemsImportFile)]
-        [InlineData(ProjectImageKey.AppDesignerFolder)]
         public void GetProjectImage_RecognizedKeyAsKey_ReturnsNonNull(string key)
         {
             var provider = CreateInstance();

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Imaging/VisualBasicProjectImageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Imaging/VisualBasicProjectImageProvider.cs
@@ -31,9 +31,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Imaging
                 case ProjectImageKey.SharedProjectRoot:
                     return KnownMonikers.VBSharedProject.ToProjectSystemType();
 
-                case ProjectImageKey.AppDesignerFolder:
-                    return KnownMonikers.Property.ToProjectSystemType();
-
                 default:
                     return null;
             }


### PR DESCRIPTION
This lets non-managed projects opt-into the AppDesigner folder and have the correct icon show.

Fixes: #2948.