### PR TITLE
Connection point support

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
@@ -4398,7 +4398,7 @@ NextControl:
             For Each Data As PropertyControlData In ControlData
                 If Data.DispId = DISPID OrElse DISPID = Interop.win.DISPID_UNKNOWN Then
                     OnExternalPropertyChanged(Data, Source)
-                    If Data.DispId <> Interop.win.DISPID_UNKNOWN Then
+                    If DISPID <> Interop.win.DISPID_UNKNOWN Then
                         'If the DISPID was a specific value, we only have one specific property to update, otherwise
                         '  we need to continue for all properties.
                         Return

--- a/src/Microsoft.VisualStudio.AppDesigner/interop/NativeMethods.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/interop/NativeMethods.vb
@@ -216,7 +216,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesInterop
             Protected Overrides Sub Finalize()
 
 #If DEBUG Then
-                Debug.Assert(_cookie = 0, "We should never finalize an active connection point. (Interface = " & _eventInterface.FullName & "), allocating code (see stack) is responsible for unhooking the ConnectionPoint by calling Disconnect.  Hookup Stack =" & vbNewLine & _callStack)
+                Debug.Assert(_cookie = 0, "We should never finalize an active connection point. (Interface = " & _eventInterface?.FullName & "), allocating code (see stack) is responsible for unhooking the ConnectionPoint by calling Disconnect.  Hookup Stack =" & vbNewLine & _callStack)
 #End If
                 ' We can't call Disconnect here, because connectionPoint could be finalized earlier
                 MyBase.Finalize()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsProject.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsProject.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.ComponentModel.Composition;
 using EnvDTE;
+using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.ProjectSystem.VS.ConnectionPoint;
 using VSLangProj;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
@@ -19,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
     [Export(ExportContractNames.VsTypes.VSProject, typeof(VSLangProj.VSProject))]
     [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
     [Order(Order.Default)]
-    public partial class VSProject : VSLangProj.VSProject
+    public partial class VSProject : VSLangProj.VSProject, IConnectionPointContainer, IEventSource<IPropertyNotifySink>
     {
         private readonly VSLangProj.VSProject _vsProject;
         private readonly IProjectThreadingService _threadingService;
@@ -131,5 +134,35 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
         {
             return _vsProject.GetUniqueFilename(pDispatch, bstrRoot, bstrDesiredExt);
         }
+
+        #region IConnectionPointContainer
+
+        public void EnumConnectionPoints(out IEnumConnectionPoints ppEnum)
+        {
+            ppEnum = null;
+            (_vsProject as IConnectionPointContainer)?.EnumConnectionPoints(out ppEnum);
+        }
+
+        public void FindConnectionPoint(ref Guid riid, out IConnectionPoint ppCP)
+        {
+            ppCP = null;
+            (_vsProject as IConnectionPointContainer)?.FindConnectionPoint(ref riid, out ppCP);
+        }
+
+        #endregion IConnectionPointContainer
+
+        #region IEventSource<IPropertyNotifySink>
+
+        public void OnSinkAdded(IPropertyNotifySink sink)
+        {
+            (_vsProject as IEventSource<IPropertyNotifySink>)?.OnSinkAdded(sink);
+        }
+
+        public void OnSinkRemoved(IPropertyNotifySink sink)
+        {
+            (_vsProject as IEventSource<IPropertyNotifySink>)?.OnSinkRemoved(sink);
+        }
+
+        #endregion IEventSource<IPropertyNotifySink>
     }
 }


### PR DESCRIPTION
**Customer scenario**

Implementing ConnectionPoint to enable AppDesigner to receive property change notifications. This works in combination with new implementation on the CPS side.

Current change delegates the connection point implementation to the CPS implementation.

Note that AppDesigner also expects that CSharpProjectConfigurationProperties implements connection point. This change does not address that additional work. 

**Bugs this fixes:** 
#1259

**Workarounds, if any**
Close and reopen app designer will usually refresh the values displayed.

**Risk**
Low

**Performance impact**
Performance impact is driven by the CPS implementation.
CPS doesn't specify which individual property has changed. That means, AppDesigner will refresh all properties. Also, for correctness, CPS may trigger the property change more often than needed.

**Is this a regression from a previous update?**
No

**Root cause analysis:**
Known missing feature

**How was the bug found?**
Known missing feature
