### PR TITLE
Extension results in deleted launch profile not updating…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -189,7 +189,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 return new List<ILaunchProfile>()
                 {
                     { new LaunchProfile() { Name = "IIS Express", CommandName="IISExpress", LaunchBrowser=true, DoNotPersist = true } },
-                    { new LaunchProfile() { Name = "InMemory1", DoNotPersist = true} }
+                    { new LaunchProfile() { Name = "InMemory1", DoNotPersist = true} },
+                    { new LaunchProfile() { Name = "ShouldNotBeIncluded", CommandName=LaunchSettingsProvider.ErrorProfileCommandName, DoNotPersist = true} }
                 }.ToImmutableList();
             });
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -245,8 +245,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 // If no active profile specified, try to get one
                 if (activeProfile == null)
                 {
-                    var props = await CommonProjectServices.ActiveConfiguredProjectProperties.GetProjectDebuggerPropertiesAsync().ConfigureAwait(true);
-                    if (await props.ActiveDebugProfile.GetValueAsync().ConfigureAwait(true) is IEnumValue activeProfileVal)
+                    var props = await CommonProjectServices.ActiveConfiguredProjectProperties.GetProjectDebuggerPropertiesAsync().ConfigureAwait(false);
+                    if (await props.ActiveDebugProfile.GetValueAsync().ConfigureAwait(false) is IEnumValue activeProfileVal)
                     {
                         activeProfile = activeProfileVal.Name;
                     }
@@ -363,12 +363,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             CurrentSnapshot = newSnapshot;
             if(ensureProfileProperty)
             {
-                var props = await CommonProjectServices.ActiveConfiguredProjectProperties.GetProjectDebuggerPropertiesAsync().ConfigureAwait(true);
-                if (await props.ActiveDebugProfile.GetValueAsync().ConfigureAwait(true) is IEnumValue activeProfileVal)
+                var props = await CommonProjectServices.ActiveConfiguredProjectProperties.GetProjectDebuggerPropertiesAsync().ConfigureAwait(false);
+                if (await props.ActiveDebugProfile.GetValueAsync().ConfigureAwait(false) is IEnumValue activeProfileVal)
                 {
                     if(newSnapshot.ActiveProfile?.Name != null && !string.Equals(newSnapshot.ActiveProfile?.Name, activeProfileVal.Name))
                     {
-                        await props.ActiveDebugProfile.SetValueAsync(newSnapshot.ActiveProfile.Name).ConfigureAwait(true);
+                        await props.ActiveDebugProfile.SetValueAsync(newSnapshot.ActiveProfile.Name).ConfigureAwait(false);
                     }
                 }
             }
@@ -944,7 +944,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         public async Task SetActiveProfileAsync(string profileName)
         {
             var props = await CommonProjectServices.ActiveConfiguredProjectProperties.GetProjectDebuggerPropertiesAsync().ConfigureAwait(false);
-            await props.ActiveDebugProfile.SetValueAsync(profileName).ConfigureAwait(true);
+            await props.ActiveDebugProfile.SetValueAsync(profileName).ConfigureAwait(false);
         }
 
         internal async Task<string> GetLaunchSettingsFilePathNoCacheAsync()


### PR DESCRIPTION
This addresses DEVDIV bug 516329 Extension results in deleted launch profile not updating toolstrip

Steps to reproduce:
1) Have an extension create and persist a launch profile on project load.
2) Select that launch profile using the toolstrip.
3) Open the project properties debug tab and click delete.  (Note: The extension should be coded such that the launch settings provider's SourceBlock has a linked ActionBlock that recreates a (non-persisted) launch option if it's ever removed.)
4) The project properties page will show IIS Express as the selected launch profile, but the toolstrip will not be updated to match.

The problem here is that the ActiveDebugProfile property is not being set when the profiles are updated. So the launch profiles dataflow snapshot has the new updated active profile, but the debug dropdown which is tied to the ActiveDebugProfile does not reflect it.

Change was to modify to make FinishUpdate async and do the property check there.

In the process of testing this change, I found a bug in the in-memory profile implementation. 
1. Create project, add a launchsettings.json file.
2. Make a typo in the file (add and extra curly brace somewhere)
3. Close project
4. Reopen project and press F5. You will see an error telling you to correct the json file
5. Correct the error and press F5 again. You still see an error regarding the json file. 

this is because the code which merges in-memory profiles (and the error profile is one of these) was not filtering this one out and was re-adding it to the front of the list and it becomes the default profile.

