### PR TITLE
Fix up to date check for linked files

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckItemComparer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckItemComparer.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 {
-    internal class UpToDateCheckItemComparer : IEqualityComparer<(string, CopyToOutputDirectoryType)>
+    internal class UpToDateCheckItemComparer : IEqualityComparer<(string, string, CopyToOutputDirectoryType)>
     {
         public static UpToDateCheckItemComparer Instance = new UpToDateCheckItemComparer();
 
@@ -10,8 +10,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         {
         }
 
-        public bool Equals((string, CopyToOutputDirectoryType) x, (string, CopyToOutputDirectoryType) y) => StringComparers.Paths.Equals(x.Item1, y.Item1);
+        public bool Equals((string, string, CopyToOutputDirectoryType) x, (string, string, CopyToOutputDirectoryType) y) => StringComparers.Paths.Equals(x.Item1, y.Item1);
 
-        public int GetHashCode((string, CopyToOutputDirectoryType) obj) => StringComparers.Paths.GetHashCode(obj.Item1);
+        public int GetHashCode((string, string, CopyToOutputDirectoryType) obj) => StringComparers.Paths.GetHashCode(obj.Item1);
     }
 }


### PR DESCRIPTION
**Customer scenario**

When a project has a content file that has the <Link> metadata, that metadata can change the file's relative path or name in the output directory. The fast-up-to-date check doesn't look at that metadata, so it always thinks such files are out of date. This causes ~23 projects in Roslyn never to be considered up to date.

**Bugs this fixes:** 

#2413 and #2518 

**Workarounds, if any**

None, short of removing the file from the build.

**Risk**

Low. Currently up-to-date checks don't work with these files, the worst that would happen is it still would not work.

**Performance impact**

None, we're still checking the same number of files.

**Is this a regression from a previous update?**

No.

**How was the bug found?**

Ad hoc testing.