### PR TITLE
Add logic to resolve non-rooted exe's specified in a profile

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
@@ -27,6 +27,8 @@ namespace Microsoft.VisualStudio.IO
         Dictionary<string, FileData> _files = new Dictionary<string, FileData>(StringComparer.OrdinalIgnoreCase);
         HashSet<string> _folders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
+        string _currentDirectory;
+
         public Dictionary<string, FileData> Files { get => _files; }
 
         public Stream Create(string path)
@@ -132,6 +134,17 @@ namespace Microsoft.VisualStudio.IO
             }
         }
 
+        public void SetCurrentDirectory(string directory)
+        {
+            CreateDirectory(directory);
+            _currentDirectory = directory;
+        }
+
+        public string GetCurrentDirectory()
+        {
+            return _currentDirectory;
+        }
+        
         public void RemoveFile(string path)
         {
             if (!FileExists(path))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
@@ -145,6 +145,16 @@ namespace Microsoft.VisualStudio.IO
             return _currentDirectory;
         }
         
+        public string GetFullPath(string path)
+        {
+            if(_currentDirectory != null && !Path.IsPathRooted(path))
+            {
+                return Path.Combine(_currentDirectory, path);
+            }
+
+            return path;
+        }
+
         public void RemoveFile(string path)
         {
             if (!FileExists(path))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
@@ -147,12 +147,20 @@ namespace Microsoft.VisualStudio.IO
         
         public string GetFullPath(string path)
         {
-            if(_currentDirectory != null && !Path.IsPathRooted(path))
+            if (_currentDirectory != null)
             {
-                return Path.Combine(_currentDirectory, path);
+                var pathRoot = Path.GetPathRoot(path);
+                if (pathRoot == @"\")
+                {
+                    return Path.GetPathRoot(_currentDirectory) + path.Substring(1);
+                }
+                else if (!Path.IsPathRooted(path))
+                {
+                    return Path.Combine(_currentDirectory, path);
+                }
             }
 
-            return path;
+            return Path.GetFullPath(path);
         }
 
         public void RemoveFile(string path)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
@@ -271,7 +271,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
         }
 
         [Fact]
-        public async Task QueryDebugTargets_ExeProfileAsyncExeRelativeTooWorkingDir()
+        public async Task QueryDebugTargets_ExeProfileAsyncExeRelativeToWorkingDir()
         {
             var debugger = GetDebugTargetsProvider();
 
@@ -283,6 +283,36 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
             Assert.Single(targets);
             Assert.Equal(@"c:\WorkingDir\mytest.exe", targets[0].Executable);
             Assert.Equal(@"c:\WorkingDir", targets[0].CurrentDirectory);
+        }
+
+        [Theory]
+        [InlineData("dotnet")]
+        [InlineData("dotnet.exe")]
+        public async Task QueryDebugTargets_ExeProfileExeRelativeToPath(string exeName)
+        {
+            var debugger = GetDebugTargetsProvider();
+
+            // Exe relative to path
+            var activeProfile = new LaunchProfile(){Name="run", ExecutablePath=exeName};
+            var targets = await debugger.QueryDebugTargetsAsync(0, activeProfile);
+            Assert.Single(targets);
+            Assert.Equal(@"c:\program files\dotnet\dotnet.exe", targets[0].Executable);
+        }
+
+        [Theory]
+        [InlineData("myexe")]
+        [InlineData("myexe.exe")]
+        public async Task QueryDebugTargets_ExeProfileExeRelativeToCurrentDirectory(string exeName)
+        {
+            var debugger = GetDebugTargetsProvider();
+            _mockFS.WriteAllText(@"c:\CurrentDirectory\myexe.exe", string.Empty);
+            _mockFS.SetCurrentDirectory(@"c:\CurrentDirectory");
+
+            // Exe relative to path
+            var activeProfile = new LaunchProfile(){Name="run", ExecutablePath=exeName};
+            var targets = await debugger.QueryDebugTargetsAsync(0, activeProfile);
+            Assert.Single(targets);
+            Assert.Equal(@"c:\CurrentDirectory\myexe.exe", targets[0].Executable);
         }
 
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
@@ -285,6 +285,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
             Assert.Equal(@"c:\WorkingDir", targets[0].CurrentDirectory);
         }
 
+        [Fact]
+        public async Task QueryDebugTargets_ExeProfileAsyncExeRelativeToWorkingDir_AlternateSlash()
+        {
+            var debugger = GetDebugTargetsProvider();
+
+            // Exe relative to full working dir
+            _mockFS.WriteAllText(@"c:\WorkingDir\mytest.exe", string.Empty);
+            _mockFS.CreateDirectory(@"c:\WorkingDir");
+            var activeProfile = new LaunchProfile(){Name="run", ExecutablePath="./mytest.exe", WorkingDirectory=@"c:/WorkingDir"};
+            var targets = await debugger.QueryDebugTargetsAsync(0, activeProfile);
+            Assert.Single(targets);
+            Assert.Equal(@"c:\WorkingDir\mytest.exe", targets[0].Executable);
+            Assert.Equal(@"c:\WorkingDir", targets[0].CurrentDirectory);
+        }
+
         [Theory]
         [InlineData("dotnet")]
         [InlineData("dotnet.exe")]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
@@ -225,7 +225,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 }
                 else
                 {
-                    workingDir = Path.GetFullPath(Path.Combine(projectFolder, resolvedProfile.WorkingDirectory));
+                    workingDir = Path.GetFullPath(Path.Combine(projectFolder, resolvedProfile.WorkingDirectory.Replace("/", "\\")));
                 }
             }
 
@@ -236,16 +236,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             {
                 if (!Path.IsPathRooted(executable))
                 {
-                    if (executable.IndexOf(Path.DirectorySeparatorChar) != -1)
+                    if (executable.Contains("/") || executable.Contains("\\"))
                     {
                         // Combine with the working directory used by the profile
-                        executable = Path.GetFullPath(Path.Combine(workingDir, executable));
+                        executable = Path.GetFullPath(Path.Combine(workingDir, executable.Replace("/", "\\")));
                     }
                     else
                     {
                         // Try to resolve against the current working directory (for compat) and failing that, the environment path.
                         var exeName = executable.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)? executable : executable + ".exe";
-                        var fullPath = Path.Combine(TheFileSystem.GetCurrentDirectory(), exeName);
+                        var fullPath = TheFileSystem.GetFullPath(exeName);
                         if (TheFileSystem.FileExists(fullPath))
                         {
                             executable = fullPath;
@@ -265,7 +265,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             // Now validate the executable path and working directory exist
             ValidateSettings(executable, workingDir, resolvedProfile.Name);
             GetExeAndArguments(useCmdShell, executable, arguments, out string finalExecutable, out string finalArguments);
-
 
             // Apply environment variables.
             if (resolvedProfile.EnvironmentVariables != null && resolvedProfile.EnvironmentVariables.Count > 0)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
@@ -219,16 +219,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             else
             {
                 // If the working directory is not rooted we assume it is relative to the project directory
-                workingDir = resolvedProfile.WorkingDirectory.Replace("/", "\\");
-                if (Path.GetPathRoot(workingDir) == "\\")
-                {
-                    // Root of current drive, no drive specified
-                    workingDir = TheFileSystem.GetFullPath(workingDir);
-                }
-                else if (!Path.IsPathRooted(workingDir))
-                {
-                    workingDir = TheFileSystem.GetFullPath(Path.Combine(projectFolder, workingDir));
-                }
+                workingDir = TheFileSystem.GetFullPath(Path.Combine(projectFolder, resolvedProfile.WorkingDirectory.Replace("/", "\\")));
             }
 
             // IF the executable is not rooted, we want to make is relative to the workingDir unless is doesn't contain

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
@@ -219,13 +219,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             else
             {
                 // If the working directory is not rooted we assume it is relative to the project directory
-                if (Path.IsPathRooted(resolvedProfile.WorkingDirectory))
+                workingDir = resolvedProfile.WorkingDirectory.Replace("/", "\\");
+                if (Path.GetPathRoot(workingDir) == "\\")
                 {
-                    workingDir = resolvedProfile.WorkingDirectory.Replace("/", "\\");
+                    // Root of current drive, no drive specified
+                    workingDir = TheFileSystem.GetFullPath(workingDir);
                 }
-                else
+                else if (!Path.IsPathRooted(workingDir))
                 {
-                    workingDir = Path.GetFullPath(Path.Combine(projectFolder, resolvedProfile.WorkingDirectory.Replace("/", "\\")));
+                    workingDir = TheFileSystem.GetFullPath(Path.Combine(projectFolder, workingDir));
                 }
             }
 
@@ -234,12 +236,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             // the environment path. If we can't find it, we just launch it as before.
             if (!string.IsNullOrWhiteSpace(executable))
             {
-                if (!Path.IsPathRooted(executable))
+                executable = executable.Replace("/", "\\");
+                if (Path.GetPathRoot(executable) == "\\")
                 {
-                    if (executable.Contains("/") || executable.Contains("\\"))
+                    // Root of current drive
+                    executable = TheFileSystem.GetFullPath(executable);
+                }
+                else if (!Path.IsPathRooted(executable))
+                {
+                    if (executable.Contains("\\"))
                     {
                         // Combine with the working directory used by the profile
-                        executable = Path.GetFullPath(Path.Combine(workingDir, executable.Replace("/", "\\")));
+                        executable = TheFileSystem.GetFullPath(Path.Combine(workingDir, executable));
                     }
                     else
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
@@ -221,7 +221,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 // If the working directory is not rooted we assume it is relative to the project directory
                 if (Path.IsPathRooted(resolvedProfile.WorkingDirectory))
                 {
-                    workingDir = resolvedProfile.WorkingDirectory;
+                    workingDir = resolvedProfile.WorkingDirectory.Replace("/", "\\");
                 }
                 else
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
@@ -31,6 +31,7 @@ namespace Microsoft.VisualStudio.IO
         void SetDirectoryAttribute(string path, FileAttributes newAttribute);
         string GetCurrentDirectory();
         void SetCurrentDirectory(string directory);
+        string GetFullPath(string path);
 
         IEnumerable<string> EnumerateDirectories(string path);
         IEnumerable<string> EnumerateDirectories(string path, string searchPattern, SearchOption searchOption);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
@@ -29,6 +29,9 @@ namespace Microsoft.VisualStudio.IO
         void CreateDirectory(string path);
         void RemoveDirectory(string path, bool recursive);
         void SetDirectoryAttribute(string path, FileAttributes newAttribute);
+        string GetCurrentDirectory();
+        void SetCurrentDirectory(string directory);
+
         IEnumerable<string> EnumerateDirectories(string path);
         IEnumerable<string> EnumerateDirectories(string path, string searchPattern, SearchOption searchOption);
         IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
@@ -107,6 +107,11 @@ namespace Microsoft.VisualStudio.IO
             Directory.SetCurrentDirectory(directory);
         }
 
+        public string GetFullPath(string path)
+        {
+            return Path.GetFullPath(path);
+        }
+
         public IEnumerable<string> EnumerateDirectories(string path)
         {
             return Directory.EnumerateDirectories(path);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
@@ -97,6 +97,16 @@ namespace Microsoft.VisualStudio.IO
             }
         }
 
+        public string GetCurrentDirectory()
+        {
+            return Directory.GetCurrentDirectory();
+        }
+
+        public void SetCurrentDirectory(string directory)
+        {
+            Directory.SetCurrentDirectory(directory);
+        }
+
         public IEnumerable<string> EnumerateDirectories(string path)
         {
             return Directory.EnumerateDirectories(path);


### PR DESCRIPTION
**Customer scenario**

This is in response to this customer feedback item: https://developercommunity.visualstudio.com/content/problem/145118/specifying-dotnet-for-the-executablepath-in-launch.html

From my investigation this could never have worked reliably in Visual Studio as there was no code to resolve where to find non-rooted exes.  To support cross-platform solutions, it is necessary to avoid putting in paths or file extensions when specifying the executable.

So, the change is if the specified exe has no path separator elements, it will append .exe if not already specified, and check the current working directory first (I verified that if the VS process working directory contains the exe, it works today), otherwise search the path for the exe. If the exe can't be found it does what it did before.

To be testable I updated IFileSystem to support SetCurrentDirectory\GetCurrentDirecotory and added unit tests to cover the new scenario.

Note that I am not sure if this is the correct branch. This is a 15.6 code fix 

