### PR TITLE
Cleanup TargetFramework

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IMockDependenciesViewModelFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IMockDependenciesViewModelFactory.cs
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 {
                     mock.Setup(x => x.CreateTargetViewModel(
                             It.Is<ITargetedDependenciesSnapshot>(
-                                (t) => string.Equals(t.TargetFramework.Moniker, d.Caption, System.StringComparison.OrdinalIgnoreCase))))
+                                (t) => string.Equals(t.TargetFramework.FullName, d.Caption, System.StringComparison.OrdinalIgnoreCase))))
                         .Returns(((IDependencyModel)d).ToViewModel(false));
                 }
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DependenciesViewModelFactoryTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DependenciesViewModelFactoryTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var result = factory.CreateTargetViewModel(targetedSnapshot);
 
             Assert.NotNull(result);
-            Assert.Equal(targetFramework.Moniker, result.Caption);
+            Assert.Equal(targetFramework.FullName, result.Caption);
             Assert.Equal(KnownMonikers.Library, result.Icon);
             Assert.Equal(KnownMonikers.Library, result.ExpandedIcon);
             Assert.True(result.Flags.Contains(DependencyTreeFlags.TargetNodeFlags));
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var result = factory.CreateTargetViewModel(targetedSnapshot);
 
             Assert.NotNull(result);
-            Assert.Equal(targetFramework.Moniker, result.Caption);
+            Assert.Equal(targetFramework.FullName, result.Caption);
             Assert.Equal(ManagedImageMonikers.LibraryWarning, result.Icon);
             Assert.Equal(ManagedImageMonikers.LibraryWarning, result.ExpandedIcon);
             Assert.True(result.Flags.Contains(DependencyTreeFlags.TargetNodeFlags));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 catalogs);
 
             Assert.NotNull(snapshot.TargetFramework);
-            Assert.Equal("tfm1", snapshot.TargetFramework.Moniker);
+            Assert.Equal("tfm1", snapshot.TargetFramework.FullName);
             Assert.Equal(projectPath, snapshot.ProjectPath);
             Assert.Equal(catalogs, snapshot.Catalogs);
             Assert.Equal(previousSnapshot.TopLevelDependencies, snapshot.TopLevelDependencies);
@@ -81,7 +81,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 out bool anyChanges);
 
             Assert.NotNull(snapshot.TargetFramework);
-            Assert.Equal("tfm1", snapshot.TargetFramework.Moniker);
+            Assert.Equal("tfm1", snapshot.TargetFramework.FullName);
             Assert.Equal(projectPath, snapshot.ProjectPath);
             Assert.Equal(catalogs, snapshot.Catalogs);
             Assert.False(anyChanges);
@@ -142,7 +142,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 out bool anyChanges);
 
             Assert.NotNull(snapshot.TargetFramework);
-            Assert.Equal("tfm1", snapshot.TargetFramework.Moniker);
+            Assert.Equal("tfm1", snapshot.TargetFramework.FullName);
             Assert.Equal(projectPath, snapshot.ProjectPath);
             Assert.Equal(catalogs, snapshot.Catalogs);
             Assert.False(anyChanges);
@@ -204,7 +204,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 out bool anyChanges);
 
             Assert.NotNull(snapshot.TargetFramework);
-            Assert.Equal("tfm1", snapshot.TargetFramework.Moniker);
+            Assert.Equal("tfm1", snapshot.TargetFramework.FullName);
             Assert.Equal(projectPath, snapshot.ProjectPath);
             Assert.Equal(catalogs, snapshot.Catalogs);
             Assert.False(anyChanges);
@@ -277,7 +277,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 out bool anyChanges);
 
             Assert.NotNull(snapshot.TargetFramework);
-            Assert.Equal("tfm1", snapshot.TargetFramework.Moniker);
+            Assert.Equal("tfm1", snapshot.TargetFramework.FullName);
             Assert.Equal(projectPath, snapshot.ProjectPath);
             Assert.Equal(catalogs, snapshot.Catalogs);
             Assert.True(anyChanges);
@@ -348,7 +348,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 out bool anyChanges);
 
             Assert.NotNull(snapshot.TargetFramework);
-            Assert.Equal("tfm1", snapshot.TargetFramework.Moniker);
+            Assert.Equal("tfm1", snapshot.TargetFramework.FullName);
             Assert.Equal(projectPath, snapshot.ProjectPath);
             Assert.Equal(catalogs, snapshot.Catalogs);
             Assert.False(anyChanges);
@@ -420,7 +420,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 out bool anyChanges);
 
             Assert.NotNull(snapshot.TargetFramework);
-            Assert.Equal("tfm1", snapshot.TargetFramework.Moniker);
+            Assert.Equal("tfm1", snapshot.TargetFramework.FullName);
             Assert.Equal(projectPath, snapshot.ProjectPath);
             Assert.Equal(catalogs, snapshot.Catalogs);
             Assert.True(anyChanges);
@@ -556,7 +556,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 out bool anyChanges);
 
             Assert.NotNull(snapshot.TargetFramework);
-            Assert.Equal("tfm1", snapshot.TargetFramework.Moniker);
+            Assert.Equal("tfm1", snapshot.TargetFramework.FullName);
             Assert.Equal(projectPath, snapshot.ProjectPath);
             Assert.Equal(catalogs, snapshot.Catalogs);
             Assert.True(anyChanges);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
@@ -227,7 +227,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
                     {
                         // Get the target path for the configured project.
                         var targetPath = (string)await configurationGeneralProperties.TargetPath.GetValueAsync().ConfigureAwait(true);
-                        var displayName = GetDisplayName(configuredProject, projectData, targetFramework.Moniker);
+                        var displayName = GetDisplayName(configuredProject, projectData, targetFramework.FullName);
 
                         targetedProjectContext = new TargetedProjectContext(targetFramework, projectData.FullPath, displayName, targetPath)
                         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/ITargetFramework.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/ITargetFramework.cs
@@ -28,7 +28,5 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         /// Gets the display name.
         /// </summary>
         string FriendlyName { get; }
-
-        string Version { get; }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/ITargetFramework.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/ITargetFramework.cs
@@ -5,8 +5,7 @@ using System.Runtime.Versioning;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 {
-    internal interface ITargetFramework : IComparable<ITargetFramework>, 
-                                          IEquatable<ITargetFramework>, 
+    internal interface ITargetFramework : IEquatable<ITargetFramework>, 
                                           IEquatable<string>
     {
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/ITargetFramework.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/ITargetFramework.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         /// <summary>
         /// Gets the full moniker (TFM).
         /// </summary>
-        string Moniker { get; }
+        string FullName { get; }
 
         /// <summary>
         /// Gets the short name.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetFramework.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetFramework.cs
@@ -103,18 +103,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         public static bool operator !=(TargetFramework left, TargetFramework right)
             => !(left == right);
 
-        public static bool operator <(TargetFramework left, TargetFramework right)
-            => left is null ? !(right is null) : left.CompareTo(right) < 0;
-
-        public static bool operator <=(TargetFramework left, TargetFramework right)
-            => left is null || left.CompareTo(right) <= 0;
-
-        public static bool operator >(TargetFramework left, TargetFramework right)
-            => !(left is null) && left.CompareTo(right) > 0;
-
-        public static bool operator >=(TargetFramework left, TargetFramework right)
-            => left is null ? right is null : left.CompareTo(right) >= 0;
-
         /// <summary>
         ///  Need to override this to ensure it can be hashed correctly
         /// </summary>
@@ -128,16 +116,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             {
                 return StringComparer.OrdinalIgnoreCase.GetHashCode(Moniker);
             }
-        }
-
-        public int CompareTo(ITargetFramework other)
-        {
-            if (other == null)
-            {
-                return 1;
-            }
-
-            return StringComparer.OrdinalIgnoreCase.Compare(Moniker, other.Moniker);
         }
 
         public override string ToString()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetFramework.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetFramework.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             Requires.NotNull(frameworkName, nameof(frameworkName));
 
             FrameworkName = frameworkName;
-            Moniker = frameworkName.FullName;
+            FullName = frameworkName.FullName;
             ShortName = shortName ?? string.Empty;
             FriendlyName = $"{frameworkName.Identifier} {frameworkName.Version}";
         }
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         {
             Requires.NotNull(moniker, nameof(moniker));
 
-            Moniker = moniker;
+            FullName = moniker;
             ShortName = moniker;
             FriendlyName = moniker;
         }
@@ -41,9 +41,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         public FrameworkName FrameworkName { get; }
 
         /// <summary>
-        /// Gets the full moniker (TFM).
+        /// Gets the full name of the target framework.
         /// </summary>
-        public string Moniker { get; }
+        public string FullName { get; }
 
         /// <summary>
         /// Gets the short name.
@@ -80,7 +80,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         {
             if (obj != null)
             {
-                return Moniker.Equals(obj.Moniker, StringComparison.OrdinalIgnoreCase);
+                return FullName.Equals(obj.FullName, StringComparison.OrdinalIgnoreCase);
             }
 
             return false;
@@ -90,7 +90,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         {
             if (obj != null)
             {
-                return string.Equals(Moniker, obj, StringComparison.OrdinalIgnoreCase)
+                return string.Equals(FullName, obj, StringComparison.OrdinalIgnoreCase)
                         || string.Equals(ShortName, obj, StringComparison.OrdinalIgnoreCase);
             }
 
@@ -108,19 +108,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         /// </summary>
         public override int GetHashCode()
         {
-            if (Moniker == null)
+            if (FullName == null)
             {
                 return string.Empty.GetHashCode();
             }
             else
             {
-                return StringComparer.OrdinalIgnoreCase.GetHashCode(Moniker);
+                return StringComparer.OrdinalIgnoreCase.GetHashCode(FullName);
             }
         }
 
         public override string ToString()
         {
-            return Moniker ?? string.Empty;
+            return FullName ?? string.Empty;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetFramework.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetFramework.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             FrameworkName = frameworkName;
             Moniker = frameworkName.FullName;
             ShortName = shortName ?? string.Empty;
-            FriendlyName = $"{frameworkName.Identifier} {Version}";
+            FriendlyName = $"{frameworkName.Identifier} {frameworkName.Version}";
         }
 
         /// <summary>
@@ -54,14 +54,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         /// Gets the display name.
         /// </summary>
         public string FriendlyName { get; }
-
-        public string Version
-        {
-            get
-            {
-                return FrameworkName?.Version.ToString();
-            }
-        }
 
         /// <summary>
         /// Override Equals to handle equivalency correctly. They are equal if the 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetFramework.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetFramework.cs
@@ -108,19 +108,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         /// </summary>
         public override int GetHashCode()
         {
-            if (FullName == null)
-            {
-                return string.Empty.GetHashCode();
-            }
-            else
-            {
-                return StringComparer.OrdinalIgnoreCase.GetHashCode(FullName);
-            }
+            return StringComparer.OrdinalIgnoreCase.GetHashCode(FullName);
         }
 
         public override string ToString()
         {
-            return FullName ?? string.Empty;
+            return FullName;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/TargetDependencyViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/TargetDependencyViewModel.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             Caption = snapshot.TargetFramework.FriendlyName;
             Icon = snapshot.HasUnresolvedDependency ? ManagedImageMonikers.LibraryWarning : KnownMonikers.Library;
             ExpandedIcon = Icon;
-            Flags = DependencyTreeFlags.TargetNodeFlags.Add($"$TFM:{snapshot.TargetFramework.Moniker}");
+            Flags = DependencyTreeFlags.TargetNodeFlags.Add($"$TFM:{snapshot.TargetFramework.FullName}");
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ProjectRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ProjectRuleHandler.cs
@@ -157,7 +157,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 FireDependenciesChanged(
                     new DependenciesChangedEventArgs(
                         this, 
-                        dependency.TargetFramework.Moniker, 
+                        dependency.TargetFramework.FullName, 
                         changes, 
                         catalogs:null, 
                         dataSourceVersions:null));


### PR DESCRIPTION
In preparation for removing short name comparisons (https://github.com/dotnet/project-system/issues/2795), clean up ITargetFramework to remove unused code.