### PR TITLE
Mark "target framework" as a variant dimension

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -62,7 +62,7 @@
     <VsWebSiteInteropVersion>8.0.0-alpha</VsWebSiteInteropVersion>
     
     <!-- CPS -->
-    <MicrosoftVisualStudioProjectSystemSDKVersion>15.5.293-pre</MicrosoftVisualStudioProjectSystemSDKVersion>
+    <MicrosoftVisualStudioProjectSystemSDKVersion>15.6.57-pre</MicrosoftVisualStudioProjectSystemSDKVersion>
     
     <!-- Roslyn -->
     <MicrosoftVisualStudioLanguageServicesVersion>2.6.0-beta1-62113-02</MicrosoftVisualStudioLanguageServicesVersion>
@@ -75,7 +75,7 @@
     <NuGetVisualStudioVersion>4.3.0</NuGetVisualStudioVersion>
     
     <!-- Msbuild -->
-    <MicrosoftBuildVersion>15.3.409</MicrosoftBuildVersion>
+    <MicrosoftBuildVersion>15.5.0-preview-000153-1054696</MicrosoftBuildVersion>
     
     <!-- Libs -->
     <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/TargetFrameworkProjectConfigurationDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/TargetFrameworkProjectConfigurationDimensionProvider.cs
@@ -20,6 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
     [Export(typeof(IActiveConfiguredProjectsDimensionProvider))]
     [AppliesTo(ProjectCapabilities.ProjectConfigurationsDeclaredDimensions)]
     [Order(DimensionProviderOrder.TargetFramework)]
+    [ConfigurationDimensionDescription(ConfigurationGeneral.TargetFrameworkProperty, isVariantDimension:true)]
     internal class TargetFrameworkProjectConfigurationDimensionProvider : BaseProjectConfigurationDimensionProvider, IActiveConfiguredProjectsDimensionProvider
     {
         [ImportingConstructor]


### PR DESCRIPTION
One of many changes as we move to using the new IActiveConfigurationGroupService which returns all the configurations that we consider "active" for a multi-targeting scenarios (replacing IActiveConfiguredProjectsProvider).


- Mark "target framework" as a variant dimension
This marks "target framework" dimension as a variant dimension; ie a configuration dimension that when present is effectively ignored when calculating "active configurations" returned by IActiveConfigurationGroupService:

For example, given the following multi-targeting project:

      -> All known project configurations:

          Configuration Platform    TargetFramework
          -------------------------------------------
                  Debug |   AnyCPU  |           net45
                  Debug |   AnyCPU  |           net46
                Release |   AnyCPU  |           net45
                Release |   AnyCPU  |           net46

      -> Active solution configuration:

                  Debug |   AnyCPU  |           net45

      -> Target framework dimension is ignored, and active configurations returned by IActiveConfigurationGroupService:

                  Debug |   AnyCPU  |           net45
                  Debug |   AnyCPU  |           net46

 Whereas, given the following non-multi-targeting project:

      -> All known project configurations:

          Configuration   Platform
          ------------------------
                  Debug |   AnyCPU
                Release |   AnyCPU

      -> Active solution configuration:

                  Debug |   AnyCPU

      -> Active configurations return active configurations returned by IActiveConfigurationGroupService:

                  Debug |   AnyCPU