### PR TITLE
Add new optional interface which allows distinguishing query launch t…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             List<DebugLaunchSettings> launchSettings = new List<DebugLaunchSettings>();
 
             // Resolve the tokens in the profile
-            ILaunchProfile resolvedProfile = await TokenReplacer.ReplaceTokensInProfileAsync(activeProfile).ConfigureAwait(true);
+            ILaunchProfile resolvedProfile = await TokenReplacer.ReplaceTokensInProfileAsync(activeProfile).ConfigureAwait(false);
 
             // For "run project", we want to launch the process via the command shell when not debugging, except when this debug session is being
             // launched for profiling.
@@ -109,7 +109,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                     IsRunProjectCommand(resolvedProfile) &&
                     (launchOptions & (DebugLaunchOptions.NoDebug | DebugLaunchOptions.Profiling)) == DebugLaunchOptions.NoDebug;
 
-            var consoleTarget = await GetConsoleTargetForProfile(resolvedProfile, launchOptions, useCmdShell).ConfigureAwait(true);
+            var consoleTarget = await GetConsoleTargetForProfile(resolvedProfile, launchOptions, useCmdShell).ConfigureAwait(false);
 
             launchSettings.Add(consoleTarget);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/IDebugProfileLaunchTargetsProvider2.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/IDebugProfileLaunchTargetsProvider2.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
+{
+
+    /// <summary>
+    /// Optional interrface that can be casted from IDebugProfileLaunchTargetsProvider for those implementations which need to distinguish
+    /// calls to QueryDebugTargetsAsync that originate from IVsDebuggableProjectCfg:QueryDebugTargets, from calls that originate from 
+    /// IVsDebuggableProjectCfg:DebugLaunch. If this interface is implemented, calls that originate from a debugLaunch will call 
+    /// QueryDebugTargetsForDebugLaunchAsync(). Calls from QueryDebugTargets will call IDebugProfileLaunchTargetsProvider:QueryDebugTargetsAsync
+    /// </summary>
+    public interface IDebugProfileLaunchTargetsProvider2
+    {
+        /// <summary>
+        /// Called in response to an F5/Ctrl+F5 operation to get the debug launch settings to pass to the
+        /// debugger for the active profile.
+        /// </summary>
+        Task<IReadOnlyList<IDebugLaunchSettings>> QueryDebugTargetsForDebugLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile);
+    }
+}
+


### PR DESCRIPTION
The existing Debugger Provider extension does not distinguish QueryDebugTargetsAsync being 
called from IVSDebuggableProjectCfg.QueryDebugTargets,  from being called by IVsDebuggableProjectCfg.DebugLaunch.  For most project implementation this is fine, as the same work happens in both cases. However, with more complicated debugging setups, like supporting asp.net core, Docker, etc,   a debug launch requires processes to be started,  ports to open, etc before calling the debugger to attach, QueryingDebugTargets is called by tools like profiling in VS and don't expect processes to start, etc.
 
To remain compatible with the existing interface, I added a new, optional, IDebugProfileLaunchTargetsProvider2 interface which, if implemented, will called to get the debug launch targets when debugging. The existing interface will continue to be called in response to IVSDebuggableProjectCfg.QueryDebugTarget. Note that there is no changes if the project system doesn't implement the new interface, everything will continue to work as before.

In testing this, I noticed there were a lot of ConfigureAwait(true) calls in this code. I changed them to ConfigureAwait(false).  Since the entry point is on the UI thread this means the calls to the providers QueryDebugTargets may now occur on background thread instead of the UI thread. There was never any expectation that they would be called on the UI thread so the implementations should have handled this anyway (I verified console\asp.net projects still work fine). I need to follow up with the Docker tools teams as they provide an implementation of the interface.

Note that this is to address this issue: https://devdiv.visualstudio.com/web/wi.aspx?pcguid=011b8bdf-6d56-4f87-be0d-0092136884d9&id=396082