### PR TITLE
Don't set design time build flag until after processing changes

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHandlerManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHandlerManager.cs
@@ -104,9 +104,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 // If nothing changed (even another failed design-time build), don't do anything
                 if (projectChange.Difference.AnyChanges)
                 {
-                    ProcessDesignTimeBuildFailure(projectChange, context, logger);
                     ProcessOptions(projectChange, context, logger);
                     ProcessItems(version, projectChange, context, isActiveContext, logger);
+                    ProcessDesignTimeBuildFailure(projectChange, context, logger);
                 }
                 else
                 {


### PR DESCRIPTION
**Customer scenario**
Opens a solution with LUT enabled and CPS based projects, but LUT is unable to use it's cache, since projects don't have their references set yet.

**Bugs this fixes:** 
None directly in this repo.

**Workarounds, if any**
Manually restart LUT.

**Risk**
Low - just re-ordering some events.

**Performance impact**
Should improve LUT startup, since the cache should be able to be re-used more often.  This may also help support batching of events for initializing the language service during solution load .

**Is this a regression from a previous update?**
No

**Root cause analysis:**
Missing performance tests.

**How was the bug found?**
Performance investigations