### PR TITLE
Hide EmbeddedFiles

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -255,6 +255,16 @@
     </PropertyPageSchema>
   </ItemGroup>
 
+  <!--
+    EmbeddedFiles are source files to be embedded to the PDB. 
+    We need to set Visible to false in order to not display duplicate entries in project UI.
+  -->
+  <ItemDefinitionGroup>
+    <EmbeddedFiles>
+      <Visible>false</Visible>
+    </EmbeddedFiles>
+  </ItemDefinitionGroup>
+
   <!-- Targets -->
 
   <!-- For a newly created project with no packages restored, Design time build complains that there is no ResolvePackageDependenciesDesignTime


### PR DESCRIPTION
### Customer scenario

Legacy project system displays duplicate items in solution explorer for files that are included in EmbeddedFiles item group in order to be embedded to the PDB.

### Bugs this fixes

VSO [490111](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/490111)

### Workarounds, if any

Set the Visible attribute manually in .csproj file

### Risk

Small.

### Performance impact

None.

### Is this a regression from a previous update?

### Root cause analysis

### How was the bug found?

Customer reported.

### Test documentation updated?

N/A
