### PR TITLE
Force load active configured projects

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IActiveConfigurationGroupServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IActiveConfigurationGroupServiceFactory.cs
@@ -1,0 +1,18 @@
+﻿// Copyright(c) Microsoft.All Rights Reserved.Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class IActiveConfigurationGroupServiceFactory
+    {
+        public static IActiveConfigurationGroupService Implement(IProjectValueDataSource<IConfigurationGroup<ProjectConfiguration>> source)
+        {
+            var mock = new Mock<IActiveConfigurationGroupService>();
+            mock.SetupGet(s => s.ActiveConfigurationGroupSource)
+                .Returns(source);
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IConfigurationGroupFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IConfigurationGroupFactory.cs
@@ -1,0 +1,37 @@
+﻿// Copyright(c) Microsoft.All Rights Reserved.Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class IConfigurationGroupFactory
+    {
+        public static IConfigurationGroup<ProjectConfiguration> CreateFromConfigurationNames(params string[] configurationNames)
+        {
+            IEnumerable<StandardProjectConfiguration> configurations = configurationNames.Select(name => new StandardProjectConfiguration(name, ImmutableDictionary<string, string>.Empty));
+
+            return Create(configurations);
+        }
+
+        public static IConfigurationGroup<T> Create<T>(IEnumerable<T> values)
+        {
+            var group = new ConfigurationGroup<T>();
+
+            group.AddRange(values);
+
+            return group;
+        }
+
+
+        private class ConfigurationGroup<T> : List<T>, IConfigurationGroup<T>
+        {
+            public ConfigurationGroup()
+            {
+            }
+
+            public IReadOnlyCollection<string> VariantDimensionNames => throw new System.NotImplementedException();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectCommonServicesFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectCommonServicesFactory.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class IProjectCommonServicesFactory
+    {
+        public static IProjectCommonServices CreateWithDefaultThreadingPolicy()
+        {
+            return ImplementThreadingPolicy(new IProjectThreadingServiceMock());
+        }
+
+        public static IProjectCommonServices ImplementThreadingPolicy(IProjectThreadingService threadingPolicy)
+        {
+            var services = IProjectServicesFactory.Create(threadingPolicy);
+            var projectService = IProjectServiceFactory.Create(services);
+
+            var mock = new Mock<IProjectCommonServices>();
+
+            mock.SetupGet(s => s.ProjectService)
+                .Returns(projectService);
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IUnconfiguredProjectTasksServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IUnconfiguredProjectTasksServiceFactory.cs
@@ -1,0 +1,41 @@
+﻿// Copyright(c) Microsoft.All Rights Reserved.Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class IUnconfiguredProjectTasksServiceFactory
+    {
+        public static IUnconfiguredProjectTasksService CreateWithUnloadedProject<T>()
+        {
+            var mock = new Mock<IUnconfiguredProjectTasksService>();
+            mock.Setup(t => t.LoadedProjectAsync(It.IsAny<Func<Task>>()))
+                .Throws(new OperationCanceledException());
+
+            mock.Setup(t => t.LoadedProjectAsync(It.IsAny<Func<Task<T>>>()))
+                .Throws(new OperationCanceledException());
+
+            return mock.Object;
+        }
+
+        public static IUnconfiguredProjectTasksService ImplementLoadedProjectAsync(Func<Func<Task>, Task> action)
+        {
+            var mock = new Mock<IUnconfiguredProjectTasksService>();
+            mock.Setup(t => t.LoadedProjectAsync(It.IsAny<Func<Task>>()))
+                .Returns(action);
+
+            return mock.Object;
+        }
+
+        public static IUnconfiguredProjectTasksService ImplementLoadedProjectAsync<T>(Func<Func<Task<T>>, Task<T>> action)
+        {
+            var mock = new Mock<IUnconfiguredProjectTasksService>();
+            mock.Setup(t => t.LoadedProjectAsync(It.IsAny<Func<Task<T>>>()))
+                .Returns(action);
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectValueDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectValueDataSource.cs
@@ -1,0 +1,62 @@
+﻿// Copyright(c) Microsoft.All Rights Reserved.Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal class ProjectValueDataSource<T> : ProjectValueDataSourceBase<T> 
+        where T : class
+    {
+        private BroadcastBlock<IProjectVersionedValue<T>> _broadcastBlock;
+        private int _version;
+
+        public ProjectValueDataSource(IProjectCommonServices services)
+            : base(services)
+        {
+        }
+
+        public override NamedIdentity DataSourceKey { get; } = new NamedIdentity("DataSurce");
+
+        public override IComparable DataSourceVersion
+        {
+            get { return _version; }
+        }
+
+        public override IReceivableSourceBlock<IProjectVersionedValue<T>> SourceBlock
+        {
+            get
+            {
+                EnsureInitialized(true);
+
+                return _broadcastBlock;
+            }
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+
+            _broadcastBlock = new BroadcastBlock<IProjectVersionedValue<T>>(null);
+        }
+
+        public async Task SendAndCompleteAsync(T value, ITargetBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>> targetBlock)
+        {
+            EnsureInitialized(true);
+
+            _version++;
+            await _broadcastBlock.SendAsync(new ProjectVersionedValue<T>(
+                     value,
+                     ImmutableDictionary<NamedIdentity, IComparable>.Empty.Add(DataSourceKey, _version)));
+
+            _broadcastBlock.Complete();
+
+            // Note, we have to wait for both the source *and* target block as 
+            // the Completion of the source block doesn't mean that the target 
+            // block has finished.
+            await Task.WhenAll(_broadcastBlock.Completion, targetBlock.Completion);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectValueDataSourceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectValueDataSourceFactory.cs
@@ -1,0 +1,13 @@
+﻿// Copyright(c) Microsoft.All Rights Reserved.Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class ProjectValueDataSourceFactory
+    {
+        public static ProjectValueDataSource<T> Create<T>(IProjectCommonServices services)
+            where T : class
+        {
+            return new ProjectValueDataSource<T>(services);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsLoaderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsLoaderTests.cs
@@ -1,0 +1,85 @@
+﻿// Copyright(c) Microsoft.All Rights Reserved.Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    public class ActiveConfiguredProjectsLoaderTests
+    {
+        [Theory]
+        [InlineData(new object[] { new[] { "Debug|x86" } })]
+        [InlineData(new object[] { new[] { "Debug|x86", "Release|x86" } })]
+        [InlineData(new object[] { new[] { "Debug|x86", "Release|x86", "Release|AnyCPU" } })]
+        public async Task WhenActiveConfigurationChanges_LoadsConfiguredProject(string[] configurationNames)
+        {
+            var configurationGroups = IConfigurationGroupFactory.CreateFromConfigurationNames(configurationNames);
+
+            var results = new List<string>();
+            var project = UnconfiguredProjectFactory.ImplementLoadConfiguredProjectAsync(configuration =>  {
+
+                results.Add(configuration.Name);
+                return Task.FromResult<ConfiguredProject>(null);
+            });
+            
+            var loader = CreateInstance(project, out ProjectValueDataSource<IConfigurationGroup<ProjectConfiguration>> source);
+            await loader.InitializeAsync();
+
+            // Change the active configurations
+            await source.SendAndCompleteAsync(configurationGroups, loader.TargetBlock);
+
+            Assert.Equal(configurationNames, results);
+        }
+
+        [Fact]
+        public void Dispose_WhenNotInitialized_DoesNotThrow()
+        {
+            var project = UnconfiguredProjectFactory.Create();
+
+            var loader = CreateInstance(project, out _);
+            loader.Dispose();
+
+            Assert.True(loader.IsDisposed);
+        }
+
+        [Fact]
+        public async Task Dispose_WhenInitialized_DisposesSubscription()
+        {
+            int callCount = 0;
+            UnconfiguredProject project = UnconfiguredProjectFactory.ImplementLoadConfiguredProjectAsync(configuration => {
+
+                callCount++;
+                return Task.FromResult<ConfiguredProject>(null);
+            });
+
+            var loader = CreateInstance(project, out ProjectValueDataSource<IConfigurationGroup<ProjectConfiguration>> source);
+            await loader.InitializeAsync();
+            loader.Dispose();
+
+            var configurationGroups = IConfigurationGroupFactory.CreateFromConfigurationNames("Debug|AnyCPU");
+            
+            // Change the active configurations
+            await source.SendAndCompleteAsync(configurationGroups, loader.TargetBlock);
+
+            // Should not be listening
+            Assert.Equal(0, callCount);
+        }
+
+        private static ActiveConfiguredProjectsLoader CreateInstance(UnconfiguredProject project, out ProjectValueDataSource<IConfigurationGroup<ProjectConfiguration>> source)
+        {
+            var services = IProjectCommonServicesFactory.CreateWithDefaultThreadingPolicy();
+            source = ProjectValueDataSourceFactory.Create<IConfigurationGroup<ProjectConfiguration>>(services);
+            var activeConfigurationGroupService = IActiveConfigurationGroupServiceFactory.Implement(source);
+
+            var loader = CreateInstance(project, activeConfigurationGroupService);
+
+            return loader;
+        }
+
+        private static ActiveConfiguredProjectsLoader CreateInstance(UnconfiguredProject project, IActiveConfigurationGroupService activeConfigurationGroupService)
+        {
+            return new ActiveConfiguredProjectsLoader(project, activeConfigurationGroupService);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsLoaderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsLoaderTests.cs
@@ -17,8 +17,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var configurationGroups = IConfigurationGroupFactory.CreateFromConfigurationNames(configurationNames);
 
             var results = new List<string>();
-            var project = UnconfiguredProjectFactory.ImplementLoadConfiguredProjectAsync(configuration =>  {
-
+            var project = UnconfiguredProjectFactory.ImplementLoadConfiguredProjectAsync(configuration =>  
+            {
                 results.Add(configuration.Name);
                 return Task.FromResult<ConfiguredProject>(null);
             });

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsLoaderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsLoaderTests.cs
@@ -31,6 +31,30 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             Assert.Equal(configurationNames, results);
         }
+        
+        [Fact]
+        public async Task InitializeAsync_CanNotInitializeTwice()
+        {
+            var results = new List<string>();
+            var project = UnconfiguredProjectFactory.ImplementLoadConfiguredProjectAsync(configuration => {
+
+                results.Add(configuration.Name);
+                return Task.FromResult<ConfiguredProject>(null);
+            });
+
+            var loader = CreateInstance(project, out var source);
+
+            await loader.InitializeAsync();
+            await loader.InitializeAsync();
+
+            var configurationGroups = IConfigurationGroupFactory.CreateFromConfigurationNames("Debug|AnyCPU");
+
+            // Change the active configurations
+            await source.SendAndCompleteAsync(configurationGroups, loader.TargetBlock);
+
+            Assert.Equal(new string[] { "Debug|AnyCPU" }, results);
+        }
+
 
         [Fact]
         public void Dispose_WhenNotInitialized_DoesNotThrow()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
@@ -52,6 +52,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             if (disposing)
             {
                 _subscription?.Dispose();
+                _targetBlock.Complete();
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
@@ -37,10 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return Task.CompletedTask;
         }
 
-        public ITargetBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>> TargetBlock
-        {
-            get { return _targetBlock; }
-        }
+        public ITargetBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>> TargetBlock => _targetBlock;
 
         protected override void Initialize()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
@@ -11,14 +11,14 @@ namespace Microsoft.VisualStudio.ProjectSystem
     ///     Force loads the active <see cref="ConfiguredProject"/> objects so that any configured project-level 
     ///     services, such as evaluation and build services, are started.
     /// </summary>
-    internal class ForceLoadActiveConfiguredProjects : OnceInitializedOnceDisposed
+    internal class ActiveConfiguredProjectsLoader : OnceInitializedOnceDisposed
     {
         private readonly IActiveConfigurationGroupService _activeConfigurationGroupService;
         private readonly UnconfiguredProject _project;
         private IDisposable _subscription;
 
         [ImportingConstructor]
-        public ForceLoadActiveConfiguredProjects(UnconfiguredProject project, IActiveConfigurationGroupService activeConfigurationGroupService)
+        public ActiveConfiguredProjectsLoader(UnconfiguredProject project, IActiveConfigurationGroupService activeConfigurationGroupService)
         {
             _project = project;
             _activeConfigurationGroupService = activeConfigurationGroupService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
@@ -20,6 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         [ImportingConstructor]
         public ActiveConfiguredProjectsLoader(UnconfiguredProject project, IActiveConfigurationGroupService activeConfigurationGroupService)
+            : base(synchronousDisposal:true)
         {
             _project = project;
             _activeConfigurationGroupService = activeConfigurationGroupService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharpLanguageService)]
         public Task InitializeAsync()
         {
-            Initialize();
+            EnsureInitialized();
             return Task.CompletedTask;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ForceLoadActiveConfiguredProjects.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ForceLoadActiveConfiguredProjects.cs
@@ -1,0 +1,60 @@
+﻿// Copyright(c) Microsoft.All Rights Reserved.Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    /// <summary>
+    ///     Force loads the active <see cref="ConfiguredProject"/> objects so that any configured project-level 
+    ///     services, such as evaluation and build services, are started.
+    /// </summary>
+    internal class ForceLoadActiveConfiguredProjects : OnceInitializedOnceDisposed
+    {
+        private readonly IActiveConfigurationGroupService _activeConfigurationGroupService;
+        private readonly UnconfiguredProject _project;
+        private IDisposable _subscription;
+
+        [ImportingConstructor]
+        public ForceLoadActiveConfiguredProjects(UnconfiguredProject project, IActiveConfigurationGroupService activeConfigurationGroupService)
+        {
+            _project = project;
+            _activeConfigurationGroupService = activeConfigurationGroupService;
+        }
+
+        [ProjectAutoLoad(ProjectLoadCheckpoint.ProjectInitialCapabilitiesEstablished)]
+        [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharpLanguageService)]
+        private Task OnProjectFactoryCompletedAsync()
+        {
+            Initialize();
+            return Task.CompletedTask;
+        }
+
+        protected override void Initialize()
+        {
+            Action<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>> target = OnActiveConfigurationsChanged;
+
+            _subscription = _activeConfigurationGroupService.ActiveConfigurationGroupSource.SourceBlock.LinkTo(
+                target: new ActionBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>>(target),
+                linkOptions: new DataflowLinkOptions() { PropagateCompletion = true });
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _subscription?.Dispose();
+            }
+        }
+
+        private void OnActiveConfigurationsChanged(IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>> e)
+        {
+            foreach (ProjectConfiguration configuration in e.Value)
+            {
+                _project.LoadConfiguredProjectAsync(configuration);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IUnconfiguredProjectTasksService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IUnconfiguredProjectTasksService.cs
@@ -1,0 +1,40 @@
+﻿// Copyright(c) Microsoft.All Rights Reserved.Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    /// <summary>
+    ///     Provides methods for that assist in managing project-related background tasks. 
+    /// </summary>
+    [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Private)]
+    internal interface IUnconfiguredProjectTasksService
+    {   // Provides unit testable versions of CommonProjectSystemTools.LoadedProjectAsync
+
+        /// <summary>
+        ///     Provides protection for an operation that the project will not close before the completion of some task.
+        /// </summary>
+        /// <param name="action">
+        ///     The action to execute within the context of a loaded project.
+        /// </param>
+        /// <exception cref="OperationCanceledException">
+        ///     Thrown if the project was already unloaded before this method was invoked.
+        /// </exception>
+        Task LoadedProjectAsync(Func<Task> action);
+
+        /// <summary>
+        ///     Provides protection for an operation that the project will not close before the completion of some task.
+        /// </summary>
+        /// <typeparam name="T">
+        ///     The type of value returned by the joinable.
+        /// </typeparam>
+        /// <param name="action">
+        ///     The action to execute within the context of a loaded project.
+        /// </param>
+        /// <exception cref="OperationCanceledException">
+        ///     Thrown if the project was already unloaded before this method was invoked.
+        /// </exception>
+        Task<T> LoadedProjectAsync<T>(Func<Task<T>> action);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectTasksService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectTasksService.cs
@@ -1,0 +1,35 @@
+﻿// Copyright(c) Microsoft.All Rights Reserved.Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    [Export(typeof(IUnconfiguredProjectTasksService))]
+    internal class UnconfiguredProjectTasksService : IUnconfiguredProjectTasksService
+    {
+        private readonly IProjectAsynchronousTasksService _tasksService;
+
+        [ImportingConstructor]
+        public UnconfiguredProjectTasksService([Import(ExportContractNames.Scopes.UnconfiguredProject)]IProjectAsynchronousTasksService tasksService)
+        {
+            _tasksService = tasksService;
+        }
+
+        public Task LoadedProjectAsync(Func<Task> action)
+        {
+            JoinableTask joinable = _tasksService.LoadedProjectAsync(action);
+
+            return joinable.Task;
+        }
+
+        public Task<T> LoadedProjectAsync<T>(Func<Task<T>> action)
+        {
+            JoinableTask<T> joinable = _tasksService.LoadedProjectAsync(action);
+
+            return joinable.Task;
+        }
+    }
+}


### PR DESCRIPTION
(this depends on and includes https://github.com/dotnet/project-system/pull/3020, just look at the last commit)

CPS always force loads the _active_ configuration during project initialization and when the active configuration changes. This makes sure that any `ConfiguredProjectAutoLoad` services are created and run.

This is the equivalent, except for all configurations that we consider "active".  For example in the following multi-targeted project:

```
 -> All known project configurations:

      Configuration Platform    TargetFramework
      -------------------------------------------
              Debug |   AnyCPU  |           net45
              Debug |   AnyCPU  |           net46
            Release |   AnyCPU  |           net45
            Release |   AnyCPU  |           net46

  -> Active solution configuration:

              Debug |   AnyCPU
```
These configurations are explicitly loaded:
```
              Debug |   AnyCPU  |           net45
              Debug |   AnyCPU  |           net46
```

When active solution configuration changes to:

```
            Release |   AnyCPU
```

These configurations are explicitly loaded:

```
            Release |   AnyCPU  |           net45
            Release |   AnyCPU  |           net46
```

Previously, these configurations were implicitly loaded when an auto-load component (typically language service) happened to call through IActiveConfiguredProjectsProvider. This makes loading of configurations deliberate and explicit, and always occur regardless of the auto-load component that is run.

This basically moves loading these configs from implicit model when a random component calls IActiveConfiguredProjectsProvider.GetActiveConfiguredProjectsAsync (which is being replaced) to a more explicit and predictable model. 