### PR TITLE
Remove hardcoded generator

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectItemsSchema.xaml
@@ -55,7 +55,6 @@
       Name="EmbeddedResource"
       DisplayName="Embedded resource"
       ItemType="EmbeddedResource">
-      <NameValuePair Name="DefaultMetadata_Generator" Value="ResXFileCodeGenerator" />
     </ContentType>
 
     <ContentType


### PR DESCRIPTION
The presence of the generator in the item schema for embedded resources, overrides the extensibility point in CPS which allows project extenders to block adding a single file generator, or change the generator which is used.

Verified C# and VB projects continue to apply the generator with this entry removed. 

F# didn't apply the generator before this change and I verified it continued to work as before.
