### PR TITLE
Enforce naming styles via .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -47,6 +47,66 @@ dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_null_propagation = true:suggestion
 dotnet_style_explicit_tuple_names = true:suggestion
 
+# Naming Rules
+dotnet_naming_rule.interfaces_must_be_pascal_cased_and_prefixed_with_I.symbols                        = interface_symbols
+dotnet_naming_rule.interfaces_must_be_pascal_cased_and_prefixed_with_I.style                          = pascal_case_and_prefix_with_I_style
+dotnet_naming_rule.interfaces_must_be_pascal_cased_and_prefixed_with_I.severity                       = warning
+
+dotnet_naming_rule.externally_visible_members_must_be_pascal_cased.symbols                            = externally_visible_symbols
+dotnet_naming_rule.externally_visible_members_must_be_pascal_cased.style                              = pascal_case_style
+dotnet_naming_rule.externally_visible_members_must_be_pascal_cased.severity                           = warning
+
+dotnet_naming_rule.parameters_must_be_camel_cased.symbols                                             = parameter_symbols
+dotnet_naming_rule.parameters_must_be_camel_cased.style                                               = camel_case_style
+dotnet_naming_rule.parameters_must_be_camel_cased.severity                                            = warning
+
+dotnet_naming_rule.constants_must_be_pascal_cased.symbols                                             = constant_symbols
+dotnet_naming_rule.constants_must_be_pascal_cased.style                                               = pascal_case_style
+dotnet_naming_rule.constants_must_be_pascal_cased.severity                                            = warning
+
+dotnet_naming_rule.private_static_fields_must_be_camel_cased_and_prefixed_with_s_underscore.symbols   = private_static_field_symbols
+dotnet_naming_rule.private_static_fields_must_be_camel_cased_and_prefixed_with_s_underscore.style     = camel_case_and_prefix_with_s_underscore_style
+dotnet_naming_rule.private_static_fields_must_be_camel_cased_and_prefixed_with_s_underscore.severity  = warning
+
+dotnet_naming_rule.private_instance_fields_must_be_camel_cased_and_prefixed_with_underscore.symbols   = private_field_symbols
+dotnet_naming_rule.private_instance_fields_must_be_camel_cased_and_prefixed_with_underscore.style     = camel_case_and_prefix_with_underscore_style
+dotnet_naming_rule.private_instance_fields_must_be_camel_cased_and_prefixed_with_underscore.severity  = warning
+
+# Symbols
+dotnet_naming_symbols.externally_visible_symbols.applicable_kinds                                     = class,struct,interface,enum,property,method,field,event,delegate
+dotnet_naming_symbols.externally_visible_symbols.applicable_accessibilities                           = public,internal,friend,protected,protected_internal,protected_friend,private_protected
+
+dotnet_naming_symbols.interface_symbols.applicable_kinds                                              = interface
+dotnet_naming_symbols.interface_symbols.applicable_accessibilities                                    = *
+
+dotnet_naming_symbols.parameter_symbols.applicable_kinds                                              = parameter
+dotnet_naming_symbols.parameter_symbols.applicable_accessibilities                                    = *
+
+dotnet_naming_symbols.constant_symbols.applicable_kinds                                               = field
+dotnet_naming_symbols.constant_symbols.required_modifiers                                             = const
+dotnet_naming_symbols.constant_symbols.applicable_accessibilities                                     = *
+
+dotnet_naming_symbols.private_static_field_symbols.applicable_kinds                                   = field
+dotnet_naming_symbols.private_static_field_symbols.required_modifiers                                 = static,shared
+dotnet_naming_symbols.private_static_field_symbols.applicable_accessibilities                         = private
+
+dotnet_naming_symbols.private_field_symbols.applicable_kinds                                          = field
+dotnet_naming_symbols.private_field_symbols.applicable_accessibilities                                = private
+
+# Styles
+dotnet_naming_style.camel_case_style.capitalization                                                   = camel_case
+
+dotnet_naming_style.pascal_case_style.capitalization                                                  = pascal_case
+
+dotnet_naming_style.camel_case_and_prefix_with_s_underscore_style.required_prefix                     = s_
+dotnet_naming_style.camel_case_and_prefix_with_s_underscore_style.capitalization                      = camel_case
+
+dotnet_naming_style.camel_case_and_prefix_with_underscore_style.required_prefix                       = _
+dotnet_naming_style.camel_case_and_prefix_with_underscore_style.capitalization                        = camel_case
+
+dotnet_naming_style.pascal_case_and_prefix_with_I_style.required_prefix                               = I
+dotnet_naming_style.pascal_case_and_prefix_with_I_style.capitalization                                = pascal_case
+
 # CSharp code style settings:
 [*.cs]
 # Prefer "var" everywhere


### PR DESCRIPTION
Enforce our [current naming styles](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md) via .editorconfig.

Ended up filing the following bugs as result of this:
["pascal_case" capatilization style only enforces "first_word_upper"](https://github.com/dotnet/roslyn/issues/23706)
[Should be able to specify two naming styles for a given symbol](https://github.com/dotnet/roslyn/issues/23707)
[Cannot refer to "private protected" in "applicable_accessibilities"](https://github.com/dotnet/roslyn/issues/23709)
[Add a way to enforce naming of type parameters](https://github.com/dotnet/roslyn/issues/23710)
[Add real world examples to "Naming Conventions for EditorConfig" topic ](https://github.com/MicrosoftDocs/visualstudio-docs/issues/378)