### PR TITLE
Apply naming/code styles 

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/LanguageServices/CSharpLanguageFeaturesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/LanguageServices/CSharpLanguageFeaturesProvider.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
     [AppliesTo(ProjectCapabilities.CSharp)]
     internal class CSharpLanguageFeaturesProvider : ILanguageFeaturesProvider
     {
-        private static readonly ImmutableHashSet<UnicodeCategory> IdentifierCharCategories = ImmutableHashSet<UnicodeCategory>.Empty
+        private static readonly ImmutableHashSet<UnicodeCategory> s_identifierCharCategories = ImmutableHashSet<UnicodeCategory>.Empty
             .Add(UnicodeCategory.UppercaseLetter)
             .Add(UnicodeCategory.LowercaseLetter)
             .Add(UnicodeCategory.TitlecaseLetter)
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             .Add(UnicodeCategory.EnclosingMark)
             .Add(UnicodeCategory.NonSpacingMark);
 
-        private static readonly ImmutableHashSet<UnicodeCategory> FirstIdentifierCharCategories = ImmutableHashSet<UnicodeCategory>.Empty
+        private static readonly ImmutableHashSet<UnicodeCategory> s_firstIdentifierCharCategories = ImmutableHashSet<UnicodeCategory>.Empty
             .Add(UnicodeCategory.UppercaseLetter)
             .Add(UnicodeCategory.LowercaseLetter)
             .Add(UnicodeCategory.TitlecaseLetter)
@@ -123,13 +123,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         private static bool IsValidIdentifierChar(char c)
         {
             var category = CharUnicodeInfo.GetUnicodeCategory(c);
-            return IdentifierCharCategories.Contains(category);
+            return s_identifierCharCategories.Contains(category);
         }
 
         private static bool IsValidFirstIdentifierChar(char c)
         {
             var category = CharUnicodeInfo.GetUnicodeCategory(c);
-            return FirstIdentifierCharCategories.Contains(category);
+            return s_firstIdentifierCharCategories.Contains(category);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/ProjectSystem/VS/Imaging/FSharpSourcesIconProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/ProjectSystem/VS/Imaging/FSharpSourcesIconProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Imaging
     [Order(Order.Default)]
     internal class FSharpSourcesIconProvider : IProjectTreePropertiesProvider
     {
-        private static readonly Dictionary<string, ProjectImageMoniker> FileExtensionImageMap = new Dictionary<string, ProjectImageMoniker>(StringComparer.OrdinalIgnoreCase)
+        private static readonly Dictionary<string, ProjectImageMoniker> s_fileExtensionImageMap = new Dictionary<string, ProjectImageMoniker>(StringComparer.OrdinalIgnoreCase)
         {
             { ".fs",   KnownMonikers.FSFileNode.ToProjectSystemType() },
             { ".fsi",  KnownMonikers.FSSignatureFile.ToProjectSystemType() },
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Imaging
 
         private ProjectImageMoniker GetIconForItem(string itemName)
         {
-            if (FileExtensionImageMap.TryGetValue(Path.GetExtension(itemName), out ProjectImageMoniker moniker))
+            if (s_fileExtensionImageMap.TryGetValue(Path.GetExtension(itemName), out ProjectImageMoniker moniker))
             {
                 return moniker;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp/ProjectSystem/LanguageServices/FSharpParseBuildOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp/ProjectSystem/LanguageServices/FSharpParseBuildOptions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         private readonly UnconfiguredProject _project;
 
         [ImportMany]
-        IEnumerable<Action<string, ImmutableArray<CommandLineSourceFile>, ImmutableArray<CommandLineReference>, ImmutableArray<string>>> Handlers =  null;
+        IEnumerable<Action<string, ImmutableArray<CommandLineSourceFile>, ImmutableArray<CommandLineReference>, ImmutableArray<string>>> _handlers =  null;
 
         [ImportingConstructor]
         public FSharpParseBuildOptions(UnconfiguredProject project)
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         {
             if (added is FSharpBuildOptions fscAdded)
             {
-                foreach (var handler in Handlers)
+                foreach (var handler in _handlers)
                 {
                     handler?.Invoke(_project.FullPath, fscAdded.SourceFiles, fscAdded.MetadataReferences, fscAdded.CompileOptions);
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp/ProjectSystem/LanguageServices/FSharpParseBuildOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp/ProjectSystem/LanguageServices/FSharpParseBuildOptions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         private readonly UnconfiguredProject _project;
 
         [ImportMany]
-        IEnumerable<Action<string, ImmutableArray<CommandLineSourceFile>, ImmutableArray<CommandLineReference>, ImmutableArray<string>>> _handlers =  null;
+        private IEnumerable<Action<string, ImmutableArray<CommandLineSourceFile>, ImmutableArray<CommandLineReference>, ImmutableArray<string>>> _handlers =  null;
 
         [ImportingConstructor]
         public FSharpParseBuildOptions(UnconfiguredProject project)

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp/ProjectSystem/LanguageServices/FSharpParseBuildOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp/ProjectSystem/LanguageServices/FSharpParseBuildOptions.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         {
             var sourceFiles = new List<CommandLineSourceFile>();
             var metadataReferences = new List<CommandLineReference>();
-            var commandLineOptions = new List<String>();
+            var commandLineOptions = new List<string>();
 
             foreach (var commandLineArgument in commandLineArgs)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Utilities/xUnitExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Utilities/xUnitExtensions.cs
@@ -57,7 +57,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
 
         private static string ReplaceWhiteSpaceCharacters(this char c)
         {
-            if (Char.IsControl(c) || Char.IsWhiteSpace(c))
+            if (char.IsControl(c) || char.IsWhiteSpace(c))
             {
                 switch (c)
                 {
@@ -74,7 +74,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
                     case '\f':
                         return @"\f";
                     default:
-                        return String.Format("\\u{0:X};", (int)c);
+                        return string.Format("\\u{0:X};", (int)c);
                 }
             }
             return c.ToString(CultureInfo.InvariantCulture);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IActiveConfiguredProjectsProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IActiveConfiguredProjectsProviderFactory.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
     internal class IActiveConfiguredProjectsProviderFactory
     {
-        Mock<IActiveConfiguredProjectsProvider> _mock;
+        private Mock<IActiveConfiguredProjectsProvider> _mock;
         public IActiveConfiguredProjectsProviderFactory(MockBehavior mockBehavior = MockBehavior.Strict)
         {
             _mock = new Mock<IActiveConfiguredProjectsProvider>(mockBehavior);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
@@ -24,8 +24,8 @@ namespace Microsoft.VisualStudio.IO
             public Encoding FileEncoding = Encoding.Default;
         };
 
-        Dictionary<string, FileData> _files = new Dictionary<string, FileData>(StringComparer.OrdinalIgnoreCase);
-        HashSet<string> _folders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        private Dictionary<string, FileData> _files = new Dictionary<string, FileData>(StringComparer.OrdinalIgnoreCase);
+        private HashSet<string> _folders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         string _currentDirectory;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ConfigurationProjectConfigurationDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ConfigurationProjectConfigurationDimensionProviderTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
     [ProjectSystemTrait]
     public class ConfigurationProjectConfigurationDimensionProviderTests
     {
-        const string Configurations = nameof(Configurations);
+        private const string Configurations = nameof(Configurations);
 
         private string projectXml =
 @"<Project Sdk=""Microsoft.NET.Sdk"">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/PlatformProjectConfigurationDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/PlatformProjectConfigurationDimensionProviderTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
     [ProjectSystemTrait]
     public class PlatformProjectConfigurationDimensionProviderTests
     {
-        const string Platforms = nameof(Platforms);
+        private const string Platforms = nameof(Platforms);
 
         private string projectXml =
 @"<Project Sdk=""Microsoft.NET.Sdk"">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/DebugTokenReplacerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/DebugTokenReplacerTests.cs
@@ -16,13 +16,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     [ProjectSystemTrait]
     public class DebugTokenReplacerTests
     {
-        Dictionary<string, string> _envVars = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+        private Dictionary<string, string> _envVars = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
             { "%env1%","envVariable1" },
             { "%env2%","envVariable2" },
             { "%env3%","$(msbuildProperty6)" }
         };
-        
-        Mock<IEnvironmentHelper> _envHelper = new Mock<IEnvironmentHelper>();
+        private Mock<IEnvironmentHelper> _envHelper = new Mock<IEnvironmentHelper>();
         public DebugTokenReplacerTests()
         {
             _envHelper.Setup(x => x.ExpandEnvironmentVariables(It.IsAny<string>())).Returns<string>((str) =>
@@ -108,7 +107,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             return Task.FromResult((IProjectReadAccess)new TestProjectReadAccessor());
         }
 
-        class TestProjectReadAccessor : IProjectReadAccess
+        private class TestProjectReadAccessor : IProjectReadAccess
         {
             public TestProjectReadAccessor() { }
             public Task<Microsoft.Build.Evaluation.Project> GetProjectAsync() {return Task.FromResult(CreateMsBuildProject());}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfileDataTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfileDataTests.cs
@@ -157,7 +157,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         // Json string data
-string JsonString1 = @"{
+        private string JsonString1 = @"{
   ""profiles"": {
   ""IIS Express"" :
     {
@@ -192,8 +192,7 @@ string JsonString1 = @"{
     }
   }
 }";
-
-string JsonString2 = @"{
+        private string JsonString2 = @"{
   ""profiles"": {
   }
 }";

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -811,7 +811,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             Assert.False(provider.CurrentSnapshot.GlobalSettings.TryGetValue("iisSettings", out object updatedSettings));
         }
 
-string JsonString1 = @"{
+        private string JsonString1 = @"{
   ""profiles"": {
   ""IIS Express"":
     {
@@ -846,8 +846,7 @@ string JsonString1 = @"{
     }
   }
 }";
-
-        string JsonStringWithWebSettings = @"{
+        private string JsonStringWithWebSettings = @"{
   ""iisSettings"": {
     ""windowsAuthentication"": true,
     ""anonymousAuthentication"": false,
@@ -867,8 +866,7 @@ string JsonString1 = @"{
     }
   }
 }";
-
-        string BadJsonString = @"{
+        private string BadJsonString = @"{
   ""profiles"": {
     {
       ""name"": ""IIS Express"",

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/AssemblyInfoPropertiesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/AssemblyInfoPropertiesProviderTests.cs
@@ -98,7 +98,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             // Configure whether AssemblyInfo properties are generated in project file or not.
             var saveInProjectFileStr = saveInProjectFile.ToString();
-            foreach (var kvp in AssemblyInfoProperties.s_assemblyPropertyInfoMap)
+            foreach (var kvp in AssemblyInfoProperties.AssemblyPropertyInfoMap)
             {
                 var generatePropertyInProjectFileName = kvp.Value.GeneratePropertyInProjectFileName;
                 additionalProps[generatePropertyInProjectFileName] = saveInProjectFileStr;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IActiveDebugFrameworkServicesFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IActiveDebugFrameworkServicesFactory.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
     internal class IActiveDebugFrameworkServicesFactory
     {
-        Mock<IActiveDebugFrameworkServices> _mock;
+        private Mock<IActiveDebugFrameworkServices> _mock;
         public IActiveDebugFrameworkServicesFactory(MockBehavior mockBehavior = MockBehavior.Strict)
         {
             _mock = new Mock<IActiveDebugFrameworkServices>(mockBehavior);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
@@ -19,14 +19,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
     [ProjectSystemTrait]
     public class ConsoleDebugLaunchProviderTest
     {
-        string _ProjectFile = @"c:\test\project\project.csproj";
-        string _Path = @"c:\program files\dotnet;c:\program files\SomeDirectory";
+        private string _ProjectFile = @"c:\test\project\project.csproj";
+        private string _Path = @"c:\program files\dotnet;c:\program files\SomeDirectory";
+        private Mock<IEnvironmentHelper> _mockEnvironment = new Mock<IEnvironmentHelper>();
+        private IFileSystemMock _mockFS = new IFileSystemMock();
+        private Mock<IDebugTokenReplacer> _mockTokenReplace = new Mock<IDebugTokenReplacer>();
 
-        Mock<IEnvironmentHelper> _mockEnvironment = new Mock<IEnvironmentHelper>();
-        IFileSystemMock _mockFS = new IFileSystemMock();
-        Mock<IDebugTokenReplacer> _mockTokenReplace = new Mock<IDebugTokenReplacer>();
-
-        ConsoleDebugTargetsProvider GetDebugTargetsProvider(string outputType = "exe", Dictionary<string, string> properties = null)
+        private ConsoleDebugTargetsProvider GetDebugTargetsProvider(string outputType = "exe", Dictionary<string, string> properties = null)
         {
             _mockFS.WriteAllText(@"c:\test\Project\someapp.exe", "");
             _mockFS.CreateDirectory(@"c:\test\Project");

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/DebugProfileEnumValuesGeneratorTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/DebugProfileEnumValuesGeneratorTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     [ProjectSystemTrait]
     public class DebugProfileEnumValuesGenerator_Tests
     {
-        List<ILaunchProfile> _profiles = new List<ILaunchProfile>() {
+        private List<ILaunchProfile> _profiles = new List<ILaunchProfile>() {
             {new LaunchProfile() {Name="Profile1", LaunchBrowser=true}},
             {new LaunchProfile() { Name = "MyCommand"} },
             {new LaunchProfile() { Name = "Foo"} },

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectDebuggerProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectDebuggerProviderTests.cs
@@ -12,20 +12,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
     [ProjectSystemTrait]
     public class ProjectDebuggerProviderTests
     {
-        Mock<IDebugProfileLaunchTargetsProvider> _mockWebProvider =  new Mock<IDebugProfileLaunchTargetsProvider>();
-        Mock<IDebugProfileLaunchTargetsProvider> _mockDockerProvider =  new Mock<IDebugProfileLaunchTargetsProvider>();
-        Mock<IDebugProfileLaunchTargetsProvider> _mockExeProvider =  new Mock<IDebugProfileLaunchTargetsProvider>();
-        OrderPrecedenceImportCollection<IDebugProfileLaunchTargetsProvider> _launchProviders = 
+        private Mock<IDebugProfileLaunchTargetsProvider> _mockWebProvider =  new Mock<IDebugProfileLaunchTargetsProvider>();
+        private Mock<IDebugProfileLaunchTargetsProvider> _mockDockerProvider =  new Mock<IDebugProfileLaunchTargetsProvider>();
+        private Mock<IDebugProfileLaunchTargetsProvider> _mockExeProvider =  new Mock<IDebugProfileLaunchTargetsProvider>();
+        private OrderPrecedenceImportCollection<IDebugProfileLaunchTargetsProvider> _launchProviders = 
             new OrderPrecedenceImportCollection<IDebugProfileLaunchTargetsProvider>(ImportOrderPrecedenceComparer.PreferenceOrder.PreferredComesFirst);
-        Mock<ConfiguredProject> _configuredProjectMoq = new Mock<ConfiguredProject>();
-        Mock<ILaunchSettingsProvider> _LaunchSettingsProviderMoq = new Mock<ILaunchSettingsProvider>();
-
-        List<IDebugLaunchSettings> _webProviderSettings = new List<IDebugLaunchSettings>();
-        List<IDebugLaunchSettings> _dockerProviderSettings = new List<IDebugLaunchSettings>();
-        List<IDebugLaunchSettings> _exeProviderSettings = new List<IDebugLaunchSettings>();
+        private Mock<ConfiguredProject> _configuredProjectMoq = new Mock<ConfiguredProject>();
+        private Mock<ILaunchSettingsProvider> _LaunchSettingsProviderMoq = new Mock<ILaunchSettingsProvider>();
+        private List<IDebugLaunchSettings> _webProviderSettings = new List<IDebugLaunchSettings>();
+        private List<IDebugLaunchSettings> _dockerProviderSettings = new List<IDebugLaunchSettings>();
+        private List<IDebugLaunchSettings> _exeProviderSettings = new List<IDebugLaunchSettings>();
 
         // Set this to have ILaunchSettingsProvider return this profile (null by default)
-        ILaunchProfile _activeProfile;
+        private ILaunchProfile _activeProfile;
 
         public ProjectDebuggerProviderTests()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksDynamicMenuCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksDynamicMenuCommandTests.cs
@@ -132,7 +132,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
             activeDebugFrameworkSvcs.Verify();
         }
 
-        class TestDebugFrameworksDynamicMenuCommand : DebugFrameworksDynamicMenuCommand
+        private class TestDebugFrameworksDynamicMenuCommand : DebugFrameworksDynamicMenuCommand
         {
             public TestDebugFrameworksDynamicMenuCommand(IStartupProjectHelper startupHelper)
                 : base(startupHelper)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksMenuTextUpdaterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksMenuTextUpdaterTests.cs
@@ -127,7 +127,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
             Assert.True(command.Enabled);
         }
 
-        class TestDebugFrameworkPropertyMenuTextUpdater : DebugFrameworkPropertyMenuTextUpdater
+        private class TestDebugFrameworkPropertyMenuTextUpdater : DebugFrameworkPropertyMenuTextUpdater
         {
             public TestDebugFrameworkPropertyMenuTextUpdater(IStartupProjectHelper startupHelper)
                 : base(startupHelper)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.DebuggerTraceListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.DebuggerTraceListener.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.ProjectSystem;
 
 namespace Microsoft.VisualStudio.Packaging
 {
-    partial class ManagedProjectSystemPackage
+    internal partial class ManagedProjectSystemPackage
     {
         private class DebuggerTraceListener : TraceListener
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/LanguageServiceErrorListProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/LanguageServiceErrorListProvider.cs
@@ -18,8 +18,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
     [Order(Order.Default)]
     internal partial class LanguageServiceErrorListProvider : IVsErrorListProvider
     {
-        private readonly static Task<AddMessageResult> HandledAndStopProcessing = Task.FromResult(AddMessageResult.HandledAndStopProcessing);
-        private readonly static Task<AddMessageResult> NotHandled = Task.FromResult(AddMessageResult.NotHandled);
+        private readonly static Task<AddMessageResult> s_handledAndStopProcessing = Task.FromResult(AddMessageResult.HandledAndStopProcessing);
+        private readonly static Task<AddMessageResult> s_notHandled = Task.FromResult(AddMessageResult.NotHandled);
         private readonly ILanguageServiceHost _host;
         private IVsLanguageServiceBuildErrorReporter2 _languageServiceBuildErrorReporter;
 
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
             // We only want to pass compiler, analyzers, etc to the language 
             // service, so we skip tasks that do not have a code
             if (!TryExtractErrorListDetails(error.BuildEventArgs, out ErrorListDetails details) || string.IsNullOrEmpty(details.Code))
-                return await NotHandled.ConfigureAwait(false);
+                return await s_notHandled.ConfigureAwait(false);
 
             InitializeBuildErrorReporter();
 
@@ -77,7 +77,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
                 }
             }
 
-            return handled ? await HandledAndStopProcessing.ConfigureAwait(false) : await NotHandled.ConfigureAwait(false);
+            return handled ? await s_handledAndStopProcessing.ConfigureAwait(false) : await s_notHandled.ConfigureAwait(false);
         }
 
         public Task ClearMessageFromTargetAsync(string targetName)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ConnectionPoint/ConnectionPoint.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ConnectionPoint/ConnectionPoint.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.ConnectionPoint
         private readonly ConnectionPointContainer _container;
         private readonly IEventSource<TSinkType> _source;
 
-        private uint nextCookie;
+        private uint _nextCookie;
 
         internal ConnectionPoint(ConnectionPointContainer container, IEventSource<TSinkType> source)
         {
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.ConnectionPoint
 
             _container = container;
             _source = source;
-            nextCookie = 1;
+            _nextCookie = 1;
         }
 
         public void Advise(object pUnkSink, out uint pdwCookie)
@@ -37,10 +37,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.ConnectionPoint
                 Marshal.ThrowExceptionForHR(VSConstants.E_NOINTERFACE);
             }
 
-            _sinks.Add(nextCookie, sink);
-            pdwCookie = nextCookie;
+            _sinks.Add(_nextCookie, sink);
+            pdwCookie = _nextCookie;
             _source.OnSinkAdded(sink);
-            nextCookie += 1;
+            _nextCookie += 1;
         }
 
         public void EnumConnections(out IEnumConnections ppEnum)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
     [Order(Order.Default)] // The higher the number the higher priority and we want this one last
     internal class ConsoleDebugTargetsProvider : IDebugProfileLaunchTargetsProvider
     {
-        private static readonly char[] EscapedChars = new[] { '^', '<', '>', '&' };
+        private static readonly char[] s_escapedChars = new[] { '^', '<', '>', '&' };
 
         [ImportingConstructor]
         public ConsoleDebugTargetsProvider(ConfiguredProject configuredProject,
@@ -143,7 +143,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             if (useCmdShell)
             {
                 // Escape the characters ^<>& so that they are passed to the application rather than interpreted by cmd.exe.
-                string escapedArgs = EscapeString(debugArgs, EscapedChars);
+                string escapedArgs = EscapeString(debugArgs, s_escapedChars);
                 finalArguments = $"/c \"\"{debugExe}\" {escapedArgs} & pause\"";
                 finalExePath = Path.Combine(Environment.SystemDirectory, "cmd.exe");
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugPageGuidProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugPageGuidProvider.cs
@@ -12,11 +12,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
     internal class LaunchProfilesDebugPageGuidProvider : IDebugPageGuidProvider
     {
         // This is the Guid of C#, VB and F# Debug property page
-        private static readonly Task<Guid> Guid = Task.FromResult(new Guid("{0273C280-1882-4ED0-9308-52914672E3AA}"));
+        private static readonly Task<Guid> s_guid = Task.FromResult(new Guid("{0273C280-1882-4ED0-9308-52914672E3AA}"));
 
         public Task<Guid> GetDebugPropertyPageGuidAsync()
         {
-            return Guid;
+            return s_guid;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/EditAndContinue/EditAndContinueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/EditAndContinue/EditAndContinueProvider.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Managed.VS.EditAndContinue
         // AbstractProject implements IVsENCRebuildableProjectCfg2 and IVsENCRebuildableProjectCfg4 only
         [ExportProjectNodeComService(typeof(EncInterop.IVsENCRebuildableProjectCfg2), typeof(EncInterop.IVsENCRebuildableProjectCfg4))]
         [AppliesTo(ProjectCapability.EditAndContinue)]
-        internal Object EditAndContinueService
+        internal object EditAndContinueService
         {
             get
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AddClassProjectVBCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AddClassProjectVBCommand.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 {
     [ProjectCommand(CommandGroup.VisualStudioStandard97, VisualStudioStandard97CommandId.AddClass)]
     [AppliesTo(ProjectCapability.VisualBasic)]
-    class AddClassProjectVBCommand : AbstractAddClassProjectCommand
+    internal class AddClassProjectVBCommand : AbstractAddClassProjectCommand
     {
         [ImportingConstructor]
         public AddClassProjectVBCommand(IPhysicalProjectTree projectTree, IUnconfiguredProjectVsServices projectVsServices, SVsServiceProvider serviceProvider) : base(projectTree, projectVsServices, serviceProvider)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/DebugFrameworksDynamicMenuCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/DebugFrameworksDynamicMenuCommand.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
     [Export(typeof(DebugFrameworksDynamicMenuCommand))]
     internal class DebugFrameworksDynamicMenuCommand : DynamicMenuCommand
     {
-        const int MaxFrameworks = 20;
+        private const int MaxFrameworks = 20;
 
         [ImportingConstructor]
         public DebugFrameworksDynamicMenuCommand(IStartupProjectHelper startupProjectHelper)
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
             StartupProjectHelper = startupProjectHelper;
         }
 
-        IStartupProjectHelper StartupProjectHelper { get; }
+        private IStartupProjectHelper StartupProjectHelper { get; }
 
         /// <summary>
         /// CAlled by the base when one if our menu ids is clicked. Need to return true if the command was handled

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/DebugFrameworksMenuTextUpdater.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/DebugFrameworksMenuTextUpdater.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
             StartupProjectHelper = startupProjectHelper;
         }
 
-        IStartupProjectHelper StartupProjectHelper { get; }
+        private IStartupProjectHelper StartupProjectHelper { get; }
 
         /// <summary>
         /// Exec handler called when one of the menu items is selected. Does some

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/StartupProjectHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/StartupProjectHelper.cs
@@ -22,8 +22,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
             ProjectExportProvider = projectExportProvider;
         }
 
-        IProjectExportProvider ProjectExportProvider { get; }
-        IServiceProvider ServiceProvider { get; }
+        private IProjectExportProvider ProjectExportProvider { get; }
+        private IServiceProvider ServiceProvider { get; }
 
         /// <summary>
         /// Returns the export T of the startup project if that project supports the specified capabilities

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowPaneProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowPaneProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
     [Export(typeof(IProjectOutputWindowPaneProvider))]
     internal class ProjectOutputWindowPaneProvider : IProjectOutputWindowPaneProvider
     {
-        private static readonly Guid ProjectOutputWindowPaneGuid = new Guid("{A18568CC-CA90-4AEE-9D14-A7E9D753B544}");
+        private static readonly Guid s_projectOutputWindowPaneGuid = new Guid("{A18568CC-CA90-4AEE-9D14-A7E9D753B544}");
 
         private readonly IProjectThreadingService _threadingService;
         private readonly IVsOptionalService<IVsOutputWindow> _outputWindow;
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
 
         private IVsOutputWindowPane CreateProjectOutputWindowPane(IVsOutputWindow outputWindow)
         {
-            Guid paneGuid = ProjectOutputWindowPaneGuid;
+            Guid paneGuid = s_projectOutputWindowPaneGuid;
             HResult hr = outputWindow.CreatePane(ref paneGuid, VSResources.OutputWindowPaneTitle, fInitVisible: 1, fClearWithSolution: 0);
             if (hr.Failed)
                 throw hr.Exception;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
@@ -29,10 +29,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         private DisposableBag _designTimeBuildSubscriptionLink;
         
 
-        private static ImmutableHashSet<string> _targetFrameworkWatchedRules = Empty.OrdinalIgnoreCaseStringSet
+        private static ImmutableHashSet<string> s_targetFrameworkWatchedRules = Empty.OrdinalIgnoreCaseStringSet
             .Add(NuGetRestore.SchemaName);
 
-        private static ImmutableHashSet<string> _designTimeBuildWatchedRules = Empty.OrdinalIgnoreCaseStringSet
+        private static ImmutableHashSet<string> s_designTimeBuildWatchedRules = Empty.OrdinalIgnoreCaseStringSet
             .Add(NuGetRestore.SchemaName)
             .Add(ProjectReference.SchemaName)
             .Add(PackageReference.SchemaName)
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
 
         // Remove the ConfiguredProjectIdentity key because it is unique to each configured project - so it won't match across projects by design.
         // Remove the ConfiguredProjectVersion key because each configuredproject manages it's own version and generally they don't match. 
-        private readonly static ImmutableArray<NamedIdentity> _keysToDrop = ImmutableArray.Create(ProjectDataSources.ConfiguredProjectIdentity, ProjectDataSources.ConfiguredProjectVersion);
+        private readonly static ImmutableArray<NamedIdentity> s_keysToDrop = ImmutableArray.Create(ProjectDataSources.ConfiguredProjectIdentity, ProjectDataSources.ConfiguredProjectVersion);
 
         [ImportingConstructor]
         public NuGetRestorer(
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             var target = new ActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(e => OnProjectChangedAsync(e));
             _targetFrameworkSubscriptionLink = _activeConfiguredProjectSubscriptionService.ProjectRuleSource.SourceBlock.LinkTo(
                 target: target,
-                ruleNames: _targetFrameworkWatchedRules,
+                ruleNames: s_targetFrameworkWatchedRules,
                 initialDataAsNew: false, // only reset on subsequent changes
                 suppressVersionOnlyUpdates: true);
 
@@ -116,7 +116,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             {
                 var sourceLinkOptions = new StandardRuleDataflowLinkOptions
                 {
-                    RuleNames = _designTimeBuildWatchedRules,
+                    RuleNames = s_designTimeBuildWatchedRules,
                     PropagateCompletion = true
                 };
 
@@ -148,7 +148,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         {
             var transformBlock = new TransformBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>, IProjectVersionedValue<IProjectSubscriptionUpdate>>(data =>
             {
-                return new ProjectVersionedValue<IProjectSubscriptionUpdate>(data.Value, data.DataSourceVersions.RemoveRange(_keysToDrop));
+                return new ProjectVersionedValue<IProjectSubscriptionUpdate>(data.Value, data.DataSourceVersions.RemoveRange(s_keysToDrop));
             });
 
             return transformBlock;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml.cs
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         /// Called when a property changes on the view model. Used to detect when the custom UI changes so that
         /// the size of its grids can be determined
         /// </summary>
-        private void ViewModel_PropertyChanged(Object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        private void ViewModel_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
             if (e.PropertyName.Equals(nameof(DebugPageViewModel.ActiveProviderUserControl)))
             {
@@ -96,7 +96,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         /// Used to make sure the custom controls layout matches the rest of the dialog. Assumes the custom control has a 3 column
         /// grid just like the main dialog page. If it doesn't no layout update is done.
         /// </summary>
-        private void DebugPageControl_LayoutUpdated(Object sender, EventArgs e)
+        private void DebugPageControl_LayoutUpdated(object sender, EventArgs e)
         {
             if (_customControlLayoutUpdateRequired && _mainGrid != null && DataContext != null)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
@@ -1008,8 +1008,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 
             PropertyChanged -= ViewModel_PropertyChanged;
         }
-        
-        ILaunchSettingsProvider _launchSettingsProvider;
+
+        private ILaunchSettingsProvider _launchSettingsProvider;
         protected virtual ILaunchSettingsProvider GetDebugProfileProvider()
         {
             if(_launchSettingsProvider == null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/GetProfileNameDialog.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/GetProfileNameDialog.xaml.cs
@@ -65,10 +65,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 return PropertyPageResources.NewProfileCaption;
             }
         }
+
         //------------------------------------------------------------------------------
         // Called when window loads. Use it to set focus on the text box correctly.
         //------------------------------------------------------------------------------
-        delegate void SetFocusCallback();
+        private delegate void SetFocusCallback();
         private void GetProfileNameDialogWindow_Loaded(object sender, RoutedEventArgs e)
         {
             // We need to schedule this to occur later after databinding has completed, otherwise

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPage.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         private bool _useJoinableTaskFactory = true;
         private IVsDebugger _debugger;
         private uint _debuggerCookie;
-        private bool isActivated = false;
+        private bool _isActivated = false;
         internal IProjectThreadingService _threadHandling;
 
         // WIN32 Constants
@@ -112,7 +112,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             // any changes that happen during initialization
             Win32Methods.SetParent(Handle, hWndParent);
             ResumeLayout();
-            isActivated = true;
+            _isActivated = true;
 
         }
 
@@ -135,13 +135,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         ///--------------------------------------------------------------------------------------------
         public void Deactivate()
         {
-            if (isActivated)
+            if (_isActivated)
             {
                 WaitForAsync(OnDeactivate);
                 UnadviseDebugger();
             }
 
-            isActivated = false;
+            _isActivated = false;
             Dispose(true);
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WatermarkTextBox.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WatermarkTextBox.cs
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             set { SetValue(WatermarkProperty, value); }
         }
 
-        static readonly DependencyPropertyKey s_hasInputtedTextPropertyKey = DependencyProperty.RegisterReadOnly(
+        private static readonly DependencyPropertyKey s_hasInputtedTextPropertyKey = DependencyProperty.RegisterReadOnly(
             HasInputtedTextPropertyName,
             typeof(bool),
             typeof(WatermarkTextBox),
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="args"></param>
-        static void TextPropertyChanged(object sender, DependencyPropertyChangedEventArgs args)
+        private static void TextPropertyChanged(object sender, DependencyPropertyChangedEventArgs args)
         {
             WatermarkTextBox source = sender as WatermarkTextBox;
             if (source == null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WatermarkTextBox.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WatermarkTextBox.cs
@@ -58,13 +58,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             set { SetValue(WatermarkProperty, value); }
         }
 
-        static readonly DependencyPropertyKey HasInputtedTextPropertyKey = DependencyProperty.RegisterReadOnly(
+        static readonly DependencyPropertyKey s_hasInputtedTextPropertyKey = DependencyProperty.RegisterReadOnly(
             HasInputtedTextPropertyName,
             typeof(bool),
             typeof(WatermarkTextBox),
             new PropertyMetadata(false));
 
-        public static readonly DependencyProperty HasInputtedTextProperty = HasInputtedTextPropertyKey.DependencyProperty;
+        public static readonly DependencyProperty HasInputtedTextProperty = s_hasInputtedTextPropertyKey.DependencyProperty;
 
         /// <summary>
         /// If there is text, that has been inputted, then this value will change to indicate that
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             bool hasInputtedText = !string.IsNullOrEmpty(source.Text.Trim());
             if (hasInputtedText != source.HasInputtedText)
             {
-                source.SetValue(HasInputtedTextPropertyKey, hasInputtedText);
+                source.SetValue(s_hasInputtedTextPropertyKey, hasInputtedText);
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WatermarkTextBox.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WatermarkTextBox.cs
@@ -16,9 +16,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
     /// </summary>
     internal class WatermarkTextBox : TextBox
     {
-        private const string c_WatermarkPropertyName = "Watermark";
-        private const string c_HasInputtedTextPropertyName = "HasInputtedText";
-        private const string c_WatermarkVerticalAlignmentPropertyName = "WatermarkVerticalAlignment";
+        private const string WatermarkPropertyName = "Watermark";
+        private const string HasInputtedTextPropertyName = "HasInputtedText";
+        private const string WatermarkVerticalAlignmentPropertyName = "WatermarkVerticalAlignment";
 
         /// <summary>
         /// Primarily, this static constructor will register the metadata overrides, for such things as
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         }
 
         public static readonly DependencyProperty WatermarkVerticalAlignmentProperty = DependencyProperty.Register(
-            c_WatermarkVerticalAlignmentPropertyName,
+            WatermarkVerticalAlignmentPropertyName,
             typeof(VerticalAlignment),
             typeof(WatermarkTextBox),
             new PropertyMetadata(VerticalAlignment.Center));
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         }
 
         public static readonly DependencyProperty WatermarkProperty = DependencyProperty.Register(
-            c_WatermarkPropertyName,
+            WatermarkPropertyName,
             typeof(string),
             typeof(WatermarkTextBox),
             new PropertyMetadata(string.Empty));
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         }
 
         static readonly DependencyPropertyKey HasInputtedTextPropertyKey = DependencyProperty.RegisterReadOnly(
-            c_HasInputtedTextPropertyName,
+            HasInputtedTextPropertyName,
             typeof(bool),
             typeof(WatermarkTextBox),
             new PropertyMetadata(false));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WatermarkTextBox.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WatermarkTextBox.cs
@@ -16,9 +16,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
     /// </summary>
     internal class WatermarkTextBox : TextBox
     {
-        const string c_WatermarkPropertyName = "Watermark";
-        const string c_HasInputtedTextPropertyName = "HasInputtedText";
-        const string c_WatermarkVerticalAlignmentPropertyName = "WatermarkVerticalAlignment";
+        private const string c_WatermarkPropertyName = "Watermark";
+        private const string c_HasInputtedTextPropertyName = "HasInputtedText";
+        private const string c_WatermarkVerticalAlignmentPropertyName = "WatermarkVerticalAlignment";
 
         /// <summary>
         /// Primarily, this static constructor will register the metadata overrides, for such things as

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WpfBasedPropertyPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WpfBasedPropertyPage.cs
@@ -8,9 +8,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 {
     internal abstract partial class WpfBasedPropertyPage : PropertyPage
     {
-        private PropertyPageElementHost host;
-        private PropertyPageControl control;
-        private PropertyPageViewModel viewModel;
+        private PropertyPageElementHost _host;
+        private PropertyPageControl _control;
+        private PropertyPageViewModel _viewModel;
 
         public WpfBasedPropertyPage()
         {
@@ -31,27 +31,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         {
             if (isClosing)
             {
-                control.DetachViewModel();
+                _control.DetachViewModel();
                 return;
             }
             else
             {
                 //viewModel can be non-null when the configuration is chaged. 
-                if (control == null)
+                if (_control == null)
                 {
-                    control = CreatePropertyPageControl();
+                    _control = CreatePropertyPageControl();
                 }
             }
 
-            viewModel = CreatePropertyPageViewModel();
-            viewModel.UnconfiguredProject = UnconfiguredProject;
-            await viewModel.Initialize().ConfigureAwait(false);
-            control.InitializePropertyPage(viewModel);
+            _viewModel = CreatePropertyPageViewModel();
+            _viewModel.UnconfiguredProject = UnconfiguredProject;
+            await _viewModel.Initialize().ConfigureAwait(false);
+            _control.InitializePropertyPage(_viewModel);
         }
 
         protected async override Task<int> OnApply()
         {
-            return await control.Apply().ConfigureAwait(false);
+            return await _control.Apply().ConfigureAwait(false);
         }
 
         protected async override Task OnDeactivate()
@@ -66,13 +66,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         {
             SuspendLayout();
 
-            host = new PropertyPageElementHost();
-            host.AutoSize = false;
-            host.Dock = DockStyle.Fill;
+            _host = new PropertyPageElementHost();
+            _host.AutoSize = false;
+            _host.Dock = DockStyle.Fill;
 
-            if (control == null)
+            if (_control == null)
             {
-                control = CreatePropertyPageControl();
+                _control = CreatePropertyPageControl();
             }
 
             ScrollViewer viewer = new ScrollViewer
@@ -81,21 +81,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 HorizontalScrollBarVisibility = ScrollBarVisibility.Auto
             };
 
-            viewer.Content = control;
-            host.Child = viewer;
+            viewer.Content = _control;
+            _host.Child = viewer;
 
             wpfHostPanel.Dock = DockStyle.Fill;
-            wpfHostPanel.Controls.Add(host);
+            wpfHostPanel.Controls.Add(_host);
 
             ResumeLayout(true);
-            control.StatusChanged += OnControlStatusChanged;
+            _control.StatusChanged += OnControlStatusChanged;
         }
 
         private void OnControlStatusChanged(object sender, EventArgs e)
         {
-            if (IsDirty != control.IsDirty)
+            if (IsDirty != _control.IsDirty)
             {
-                IsDirty = control.IsDirty;
+                IsDirty = _control.IsDirty;
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/BaseReferenceContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/BaseReferenceContextProvider.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         /// <summary>
         /// Lazy instance of the next handler in the chain.
         /// </summary>
-        private Lazy<Lazy<IVsReferenceManagerUserAsync, IVsReferenceManagerUserComponentMetadataView>> nextHandler;
+        private Lazy<Lazy<IVsReferenceManagerUserAsync, IVsReferenceManagerUserComponentMetadataView>> _nextHandler;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BaseReferenceContextProvider"/> class.
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         {
             ConfiguredProject = configuredProject;
             VsReferenceManagerUsers = new OrderPrecedenceImportCollection<IVsReferenceManagerUserAsync, IVsReferenceManagerUserComponentMetadataView>(projectCapabilityCheckProvider: configuredProject);
-            nextHandler = new Lazy<Lazy<IVsReferenceManagerUserAsync, IVsReferenceManagerUserComponentMetadataView>>(() =>
+            _nextHandler = new Lazy<Lazy<IVsReferenceManagerUserAsync, IVsReferenceManagerUserComponentMetadataView>>(() =>
             {
                 Type provider = GetType();
                 var order = provider.GetCustomAttribute<OrderAttribute>();
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         /// <summary>
         /// Gets the next handler in the chain.
         /// </summary>
-        private IVsReferenceManagerUserAsync NextHandler => nextHandler?.Value?.Value;
+        private IVsReferenceManagerUserAsync NextHandler => _nextHandler?.Value?.Value;
 
         /// <summary>
         /// Gets the collection of reference provider contexts that can handle individual reference type operations.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         private readonly object _stateUpdateLock = new object();
         private string _projectId;
         private bool _stopTelemetry = false;
-        private int eventCount = 0;
+        private int _eventCount = 0;
 
         [ImportingConstructor]
         public DependencyTreeTelemetryService(
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             lock (_stateUpdateLock)
             {
                 if (_stopTelemetry) return;
-                _stopTelemetry = !hasUnresolvedDependency || (++eventCount >= MaxEventCount);
+                _stopTelemetry = !hasUnresolvedDependency || (++_eventCount >= MaxEventCount);
                 observedAllRules = ObservedAllRules();
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
                                     ImportOrderPrecedenceComparer.PreferenceOrder.PreferredComesLast);
         }
 
-        private static readonly GraphCommand[] ContainsGraphCommand = new[] { new GraphCommand(
+        private static readonly GraphCommand[] s_containsGraphCommand = new[] { new GraphCommand(
                 GraphCommandDefinition.Contains,
                 targetCategories: null,
                 linkCategories: new[] { GraphCommonSchema.Contains },
@@ -126,7 +126,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
         /// </summary>
         public IEnumerable<GraphCommand> GetCommands(IEnumerable<GraphNode> nodes)
         {
-            return ContainsGraphCommand;
+            return s_containsGraphCommand;
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/IDialogServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/IDialogServices.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UI
     /// Provides an abstraction over dialogs to make them unit testable. Each dialog will have its own abstraction which
     /// can be retrieved from this servcie. 
     /// </summary>
-    interface IDialogServices
+    internal interface IDialogServices
     {
         MultiChoiceMsgBoxResult ShowMultiChoiceMsgBox(string dialogTitle, string errorText, string[] buttons);
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/RelayCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/RelayCommand.cs
@@ -30,8 +30,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UI
             _canExecute = canExecute;
         }
 
-        readonly Action<object> _execute;
-        readonly Predicate<object> _canExecute;
+        private readonly Action<object> _execute;
+        private readonly Predicate<object> _canExecute;
 
         public void RequeryCanExecute()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/Converters.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/Converters.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
     [ValueConversion(typeof(bool), typeof(Visibility))]
     internal class InvertableBooleanToVisibilityConverter : IValueConverter
     {
-        enum Parameters
+        private enum Parameters
         {
             Normal, Inverted
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Resources/ManagedImagesMonikers.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Resources/ManagedImagesMonikers.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     /// </summary>
     public static class ManagedImageMonikers
     {
-        private static readonly Guid ManifestGuid = new Guid("{259567C1-AA6B-46BF-811C-C145DD9F3B48}");
+        private static readonly Guid s_manifestGuid = new Guid("{259567C1-AA6B-46BF-811C-C145DD9F3B48}");
 
         private const int ApplicationPrivateId = 0;
         private const int ApplicationWarningId = 1;
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             get
             {
-                return new ImageMoniker { Guid = ManifestGuid, Id = ApplicationPrivateId };
+                return new ImageMoniker { Guid = s_manifestGuid, Id = ApplicationPrivateId };
             }
         }
 
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             get
             {
-                return new ImageMoniker { Guid = ManifestGuid, Id = ApplicationWarningId };
+                return new ImageMoniker { Guid = s_manifestGuid, Id = ApplicationWarningId };
             }
         }
 
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             get
             {
-                return new ImageMoniker { Guid = ManifestGuid, Id = CodeInformationPrivateId };
+                return new ImageMoniker { Guid = s_manifestGuid, Id = CodeInformationPrivateId };
             }
         }
 
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             get
             {
-                return new ImageMoniker { Guid = ManifestGuid, Id = CodeInformationWarningId };
+                return new ImageMoniker { Guid = s_manifestGuid, Id = CodeInformationWarningId };
             }
         }
 
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             get
             {
-                return new ImageMoniker { Guid = ManifestGuid, Id = ComponentId };
+                return new ImageMoniker { Guid = s_manifestGuid, Id = ComponentId };
             }
         }
 
@@ -80,7 +80,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             get
             {
-                return new ImageMoniker { Guid = ManifestGuid, Id = ComponentPrivateId };
+                return new ImageMoniker { Guid = s_manifestGuid, Id = ComponentPrivateId };
             }
         }
 
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             get
             {
-                return new ImageMoniker { Guid = ManifestGuid, Id = ComponentWarningId };
+                return new ImageMoniker { Guid = s_manifestGuid, Id = ComponentWarningId };
             }
         }
 
@@ -96,7 +96,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             get
             {
-                return new ImageMoniker { Guid = ManifestGuid, Id = ErrorSmallId };
+                return new ImageMoniker { Guid = s_manifestGuid, Id = ErrorSmallId };
             }
         }
 
@@ -104,7 +104,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             get
             {
-                return new ImageMoniker { Guid = ManifestGuid, Id = LibraryWarningId };
+                return new ImageMoniker { Guid = s_manifestGuid, Id = LibraryWarningId };
             }
         }
 
@@ -112,7 +112,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             get
             {
-                return new ImageMoniker { Guid = ManifestGuid, Id = NuGetGreyId };
+                return new ImageMoniker { Guid = s_manifestGuid, Id = NuGetGreyId };
             }
         }
 
@@ -120,7 +120,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             get
             {
-                return new ImageMoniker { Guid = ManifestGuid, Id = NuGetGreyPrivateId };
+                return new ImageMoniker { Guid = s_manifestGuid, Id = NuGetGreyPrivateId };
             }
         }
 
@@ -128,7 +128,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             get
             {
-                return new ImageMoniker { Guid = ManifestGuid, Id = NuGetGreyWarningId };
+                return new ImageMoniker { Guid = s_manifestGuid, Id = NuGetGreyWarningId };
             }
         }
 
@@ -136,7 +136,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             get
             {
-                return new ImageMoniker { Guid = ManifestGuid, Id = ReferenceGroupId };
+                return new ImageMoniker { Guid = s_manifestGuid, Id = ReferenceGroupId };
             }
         }
 
@@ -144,7 +144,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             get
             {
-                return new ImageMoniker { Guid = ManifestGuid, Id = ReferencePrivateId };
+                return new ImageMoniker { Guid = s_manifestGuid, Id = ReferencePrivateId };
             }
         }
 
@@ -152,7 +152,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             get
             {
-                return new ImageMoniker { Guid = ManifestGuid, Id = ReferenceGroupWarningId };
+                return new ImageMoniker { Guid = s_manifestGuid, Id = ReferenceGroupWarningId };
             }
         }
 
@@ -160,7 +160,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             get
             {
-                return new ImageMoniker { Guid = ManifestGuid, Id = SdkId };
+                return new ImageMoniker { Guid = s_manifestGuid, Id = SdkId };
             }
         }
 
@@ -168,7 +168,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             get
             {
-                return new ImageMoniker { Guid = ManifestGuid, Id = SdkPrivateId };
+                return new ImageMoniker { Guid = s_manifestGuid, Id = SdkPrivateId };
             }
         }
 
@@ -176,7 +176,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             get
             {
-                return new ImageMoniker { Guid = ManifestGuid, Id = SdkWarningId };
+                return new ImageMoniker { Guid = s_manifestGuid, Id = SdkWarningId };
             }
         }
 
@@ -184,7 +184,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             get
             {
-                return new ImageMoniker { Guid = ManifestGuid, Id = SharedProjectId };
+                return new ImageMoniker { Guid = s_manifestGuid, Id = SharedProjectId };
             }
         }
 
@@ -192,7 +192,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             get
             {
-                return new ImageMoniker { Guid = ManifestGuid, Id = SharedProjectPrivateId };
+                return new ImageMoniker { Guid = s_manifestGuid, Id = SharedProjectPrivateId };
             }
         }
 
@@ -200,7 +200,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             get
             {
-                return new ImageMoniker { Guid = ManifestGuid, Id = SharedProjectWarningId };
+                return new ImageMoniker { Guid = s_manifestGuid, Id = SharedProjectWarningId };
             }
         }
 
@@ -208,7 +208,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             get
             {
-                return new ImageMoniker { Guid = ManifestGuid, Id = WarningSmallId };
+                return new ImageMoniker { Guid = s_manifestGuid, Id = WarningSmallId };
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Collections/DictionaryEqualityComparer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Collections/DictionaryEqualityComparer.cs
@@ -71,8 +71,7 @@ namespace Microsoft.VisualStudio.Collections
                 return true;
             }
 
-            var concreteDictionary1 = dictionary1 as ImmutableDictionary<TKey, TValue>;
-            IEqualityComparer<TValue> valueComparer = concreteDictionary1 != null ? concreteDictionary1.ValueComparer : EqualityComparer<TValue>.Default;
+            IEqualityComparer<TValue> valueComparer = dictionary1 is ImmutableDictionary<TKey, TValue> concreteDictionary1 ? concreteDictionary1.ValueComparer : EqualityComparer<TValue>.Default;
             return AreEquivalent((IReadOnlyDictionary<TKey, TValue>)dictionary1, (IReadOnlyDictionary<TKey, TValue>)dictionary2, valueComparer);
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.IO
     /// <summary>
     ///     Provides static methods for the creation, copying, deletion, moving of files and directories.
     /// </summary>
-    interface IFileSystem
+    internal interface IFileSystem
     {
         Stream Create(string path);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AppDesignerFolderProjectTreePropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AppDesignerFolderProjectTreePropertiesProvider.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
     [AppliesTo(ProjectCapability.AppDesigner)]
     internal class AppDesignerFolderProjectTreePropertiesProvider : AbstractSpecialFolderProjectTreePropertiesProvider, IProjectTreeSettingsProvider
     {
-        private static readonly ProjectTreeFlags DefaultFolderFlags = ProjectTreeFlags.Create(ProjectTreeFlags.Common.AppDesignerFolder | ProjectTreeFlags.Common.BubbleUp);
+        private static readonly ProjectTreeFlags s_defaultFolderFlags = ProjectTreeFlags.Create(ProjectTreeFlags.Common.AppDesignerFolder | ProjectTreeFlags.Common.BubbleUp);
 
         private readonly IProjectDesignerService _designerService;
 
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public override ProjectTreeFlags FolderFlags
         {
-            get { return DefaultFolderFlags; }
+            get { return s_defaultFolderFlags; }
         }
 
         public override string FolderImageKey

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/CommandLineDesignTimeBuildPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/CommandLineDesignTimeBuildPropertiesProvider.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Build
     [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     internal class CommandLineDesignTimeBuildPropertiesProvider : StaticGlobalPropertiesProviderBase
     {
-        private static readonly Task<IImmutableDictionary<string, string>> BuildProperties = Task.FromResult<IImmutableDictionary<string, string>>(
+        private static readonly Task<IImmutableDictionary<string, string>> s_buildProperties = Task.FromResult<IImmutableDictionary<string, string>>(
             Empty.PropertiesMap.Add(BuildProperty.SkipCompilerExecution, "true")     // Don't run the compiler
                                .Add(BuildProperty.ProvideCommandLineArgs, "true"));  // Get csc/vbc to output command-line args
 
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Build
 
         public override Task<IImmutableDictionary<string, string>> GetGlobalPropertiesAsync(CancellationToken cancellationToken)
         {
-            return BuildProperties;
+            return s_buildProperties;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/TurnOffUseHostCompilerIfAvailableBuildPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/TurnOffUseHostCompilerIfAvailableBuildPropertiesProvider.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Build
     [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharpLanguageService)]
     internal class TurnOffUseHostCompilerIfAvailableBuildPropertiesProvider : StaticGlobalPropertiesProviderBase
     {
-        private static readonly Task<IImmutableDictionary<string, string>> BuildProperties = Task.FromResult<IImmutableDictionary<string, string>>(
+        private static readonly Task<IImmutableDictionary<string, string>> s_buildProperties = Task.FromResult<IImmutableDictionary<string, string>>(
             Empty.PropertiesMap.Add(BuildProperty.UseHostCompilerIfAvailable, "false"));
 
         [ImportingConstructor]
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Build
 
         public override Task<IImmutableDictionary<string, string>> GetGlobalPropertiesAsync(CancellationToken cancellationToken)
         {
-            return BuildProperties;
+            return s_buildProperties;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugTokenReplacer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugTokenReplacer.cs
@@ -140,9 +140,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
     internal sealed class ProjectReadAccessor : IProjectReadAccess
     {
-        IProjectLockService ProjectLockService { get; set; }
-        ConfiguredProject ConfiguredProject { get; set; }
-        ProjectLockReleaser? Access { get; set; }
+        private IProjectLockService ProjectLockService { get; set; }
+        private ConfiguredProject ConfiguredProject { get; set; }
+        private ProjectLockReleaser? Access { get; set; }
 
         public ProjectReadAccessor(IProjectLockService lockService, ConfiguredProject configuredProject)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugTokenReplacer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugTokenReplacer.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         private IActiveDebugFrameworkServices ActiveDebugFrameworkService { get; }
 
         // Regular expression string to extract $(sometoken) elements from a string
-        private static Regex MatchTokenRegex = new Regex(@"(\$\((?<token>[^\)]+)\))", RegexOptions.IgnoreCase);
+        private static Regex s_matchTokenRegex = new Regex(@"(\$\((?<token>[^\)]+)\))", RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Walks the profile and returns a new one where all the tokens have been replaced. Tokens can consist of 
@@ -99,7 +99,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             string updatedString = expandEnvironmentVars? EnvironmentHelper.ExpandEnvironmentVariables(rawString) : rawString;
 
-            var matches = MatchTokenRegex.Matches(updatedString);
+            var matches = s_matchTokenRegex.Matches(updatedString);
             if(matches.Count > 0)
             {
                 using (var access = await AccessProject().ConfigureAwait(true))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileData.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileData.cs
@@ -15,13 +15,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     internal class LaunchProfileData
     {
         // Well known properties
-        const string Prop_commandName = "commandName";
-        const string Prop_executablePath = "executablePath";
-        const string Prop_commandLineArgs = "commandLineArgs";
-        const string Prop_workingDirectory = "workingDirectory";
-        const string Prop_launchBrowser = "launchBrowser";
-        const string Prop_launchUrl = "launchUrl";
-        const string Prop_environmentVariables = "environmentVariables";
+        private const string Prop_commandName = "commandName";
+        private const string Prop_executablePath = "executablePath";
+        private const string Prop_commandLineArgs = "commandLineArgs";
+        private const string Prop_workingDirectory = "workingDirectory";
+        private const string Prop_launchBrowser = "launchBrowser";
+        private const string Prop_launchUrl = "launchUrl";
+        private const string Prop_environmentVariables = "environmentVariables";
 
         private static readonly HashSet<string> s_knownProfileProperties = new HashSet<string>(StringComparer.Ordinal)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileData.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileData.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         const string Prop_launchUrl = "launchUrl";
         const string Prop_environmentVariables = "environmentVariables";
 
-        static readonly HashSet<string> KnownProfileProperties = new HashSet<string>(StringComparer.Ordinal)
+        private static readonly HashSet<string> s_knownProfileProperties = new HashSet<string>(StringComparer.Ordinal)
         {
             {Prop_commandName},
             {Prop_executablePath},
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
         public static bool IsKnownProfileProperty(string propertyName)
         {
-            return KnownProfileProperties.Contains(propertyName);
+            return s_knownProfileProperties.Contains(propertyName);
         }
 
         // We don't serialize the name as it the dictionary index

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/WritableLaunchSettings.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/WritableLaunchSettings.cs
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         public IWritableLaunchProfile ActiveProfile { get; set; }
 
         public List<IWritableLaunchProfile> Profiles { get; } = new List<IWritableLaunchProfile>();
-        public Dictionary<String, object> GlobalSettings { get; } = new Dictionary<string, object>(StringComparer.Ordinal);
+        public Dictionary<string, object> GlobalSettings { get; } = new Dictionary<string, object>(StringComparer.Ordinal);
 
         public ILaunchSettings ToLaunchSettings()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ContextHandlerProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ContextHandlerProvider.cs
@@ -12,8 +12,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     [Export(typeof(IContextHandlerProvider))]
     internal partial class ContextHandlerProvider : IContextHandlerProvider
     {
-        private static readonly ImmutableArray<(HandlerFactory Factory, string EvaluationRuleName)> HandlerFactories = CreateHandlerFactories();
-        private static readonly ImmutableArray<string> AllEvaluationRuleNames = GetEvaluationRuleNames();
+        private static readonly ImmutableArray<(HandlerFactory Factory, string EvaluationRuleName)> s_handlerFactories = CreateHandlerFactories();
+        private static readonly ImmutableArray<string> s_allEvaluationRuleNames = GetEvaluationRuleNames();
         private readonly ConcurrentDictionary<IWorkspaceProjectContext, Handlers> _contextToHandlers = new ConcurrentDictionary<IWorkspaceProjectContext, Handlers>();
         private readonly UnconfiguredProject _project;
 
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         public ImmutableArray<string> EvaluationRuleNames
         {
-            get { return AllEvaluationRuleNames; }
+            get { return s_allEvaluationRuleNames; }
         }
 
         public ImmutableArray<(IEvaluationHandler Value, string EvaluationRuleName)> GetEvaluationHandlers(IWorkspaceProjectContext context)
@@ -57,10 +57,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         private Handlers CreateHandlers(IWorkspaceProjectContext context)
         {
-            var evaluationHandlers = ImmutableArray.CreateBuilder<(IEvaluationHandler Value, string EvaluationRuleName)>(HandlerFactories.Length);
-            var commandLineHandlers = ImmutableArray.CreateBuilder<ICommandLineHandler>(HandlerFactories.Length);
+            var evaluationHandlers = ImmutableArray.CreateBuilder<(IEvaluationHandler Value, string EvaluationRuleName)>(s_handlerFactories.Length);
+            var commandLineHandlers = ImmutableArray.CreateBuilder<ICommandLineHandler>(s_handlerFactories.Length);
 
-            foreach (var factory in HandlerFactories)
+            foreach (var factory in s_handlerFactories)
             {
                 object handler = factory.Factory(_project, context);
 
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         private static ImmutableArray<string> GetEvaluationRuleNames()
         {
-            return HandlerFactories.Select(e => e.EvaluationRuleName)
+            return s_handlerFactories.Select(e => e.EvaluationRuleName)
                                    .Where(name => !string.IsNullOrEmpty(name))
                                    .Distinct(StringComparers.RuleNames)
                                    .ToImmutableArray();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/AssemblyInfoProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/AssemblyInfoProperties.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         private readonly ImmutableDictionary<string, SourceAssemblyAttributePropertyValueProvider> _attributeValueProviderMap;
 
         // See https://github.com/dotnet/sdk/blob/master/src/Tasks/Microsoft.NET.Build.Tasks/build/Microsoft.NET.GenerateAssemblyInfo.targets
-        internal static readonly ImmutableDictionary<string, (string AttributeName, string GeneratePropertyInProjectFileName)> s_assemblyPropertyInfoMap = new Dictionary<string, (string AttributeName, string GeneratePropertyInProjectFileName)>
+        internal static readonly ImmutableDictionary<string, (string AttributeName, string GeneratePropertyInProjectFileName)> AssemblyPropertyInfoMap = new Dictionary<string, (string AttributeName, string GeneratePropertyInProjectFileName)>
         {
             { "Description",           ( AttributeName: "System.Reflection.AssemblyDescriptionAttribute", GeneratePropertyInProjectFileName: "GenerateAssemblyDescriptionAttribute" ) },
             { "Company",               ( AttributeName: "System.Reflection.AssemblyCompanyAttribute", GeneratePropertyInProjectFileName: "GenerateAssemblyCompanyAttribute" ) },
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             IProjectThreadingService threadingService)
         {
             var builder = ImmutableDictionary.CreateBuilder<string, SourceAssemblyAttributePropertyValueProvider>();
-            foreach (var kvp in s_assemblyPropertyInfoMap)
+            foreach (var kvp in AssemblyPropertyInfoMap)
             {
                 var provider = new SourceAssemblyAttributePropertyValueProvider(kvp.Value.AttributeName, getActiveProjectId, workspace, threadingService);
                 builder.Add(kvp.Key, provider);
@@ -113,7 +113,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         private async Task<bool> IsAssemblyInfoPropertyGeneratedByBuild(string propertyName)
         {
-            var info = s_assemblyPropertyInfoMap[propertyName];
+            var info = AssemblyPropertyInfoMap[propertyName];
 
             // Generate property in project file only if:
             // 1. "GenerateAssemblyInfo" is true AND

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/AssemblyVersionValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/AssemblyVersionValueProvider.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
     [ExportInterceptingPropertyValueProvider(AssemblyVersionPropertyName, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
     internal sealed class AssemblyVersionValueProvider : BaseVersionValueProvider
     {
-        private static readonly Version s_DefaultAssemblyVersion = new Version(1, 0, 0, 0);
+        private static readonly Version s_defaultAssemblyVersion = new Version(1, 0, 0, 0);
         private const string AssemblyVersionPropertyName = "AssemblyVersion";
 
         protected override string PropertyName => AssemblyVersionPropertyName;
@@ -17,9 +17,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
         {
             // Default semantic/package version just has 3 fields, we need to append an additional Revision field with value "0".
             var defaultVersion = await base.GetDefaultVersionAsync(defaultProperties).ConfigureAwait(true);
-            if (ReferenceEquals(defaultVersion, s_DefaultVersion))
+            if (ReferenceEquals(defaultVersion, DefaultVersion))
             {
-                return s_DefaultAssemblyVersion;
+                return s_defaultAssemblyVersion;
             }
 
             return new Version(defaultVersion.Major, defaultVersion.Minor, Math.Max(defaultVersion.Build, 0), revision: Math.Max(defaultVersion.Revision, 0));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/BaseVersionValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/BaseVersionValueProvider.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
     internal abstract class BaseVersionValueProvider : InterceptingPropertyValueProviderBase
     {
         private const string PackageVersionMSBuildProperty = "Version";
-        protected static readonly Version s_DefaultVersion = new Version(1, 0, 0);
+        protected static readonly Version DefaultVersion = new Version(1, 0, 0);
 
         protected abstract string PropertyName { get; }
 
@@ -19,12 +19,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
             var versionStr = await defaultProperties.GetEvaluatedPropertyValueAsync(PackageVersionMSBuildProperty).ConfigureAwait(true);
             if (string.IsNullOrEmpty(versionStr))
             {
-                return s_DefaultVersion;
+                return DefaultVersion;
             }
 
             // Ignore the semantic version suffix (e.g. "1.0.0-beta1" => "1.0.0")
             versionStr = versionStr.Split('-')[0];
-            return Version.TryParse(versionStr, out Version version) ? version : s_DefaultVersion;
+            return Version.TryParse(versionStr, out Version version) ? version : DefaultVersion;
         }
 
         public override async Task<string> OnGetEvaluatedPropertyValueAsync(string evaluatedPropertyValue, IProjectProperties defaultProperties)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/FileVersionValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/FileVersionValueProvider.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
     internal sealed class FileVersionValueProvider : BaseVersionValueProvider
     {
         private const string FileVersionPropertyName = "FileVersion";
-        private static readonly Version s_DefaultFileVersion = new Version(1, 0, 0, 0);
+        private static readonly Version s_defaultFileVersion = new Version(1, 0, 0, 0);
 
         protected override string PropertyName => FileVersionPropertyName;
 
@@ -17,9 +17,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
         {
             // Default semantic/package version just has 3 fields, we need to append an additional Revision field with value "0".
             var defaultVersion = await base.GetDefaultVersionAsync(defaultProperties).ConfigureAwait(true);
-            if (ReferenceEquals(defaultVersion, s_DefaultVersion))
+            if (ReferenceEquals(defaultVersion, DefaultVersion))
             {
-                return s_DefaultFileVersion;
+                return s_defaultFileVersion;
             }
 
             return new Version(defaultVersion.Major, defaultVersion.Minor, Math.Max(defaultVersion.Build, 0), revision: Math.Max(defaultVersion.Revision, 0));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/UserFileInterceptedProjectPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/UserFileInterceptedProjectPropertiesProvider.cs
@@ -12,10 +12,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     internal class UserFileInterceptedProjectPropertiesProvider : InterceptedProjectPropertiesProviderBase
     {
-        private const string userSuffix = ".user";
+        private const string UserSuffix = ".user";
 
         public override string DefaultProjectPath {
-            get { return base.DefaultProjectPath + userSuffix; }
+            get { return base.DefaultProjectPath + UserSuffix; }
         }
 
         [ImportingConstructor]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/References/AlwaysAllowValidProjectReferenceChecker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/References/AlwaysAllowValidProjectReferenceChecker.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.References
     [Order(Order.Default)] // Before the default checker, which delegates onto normal P-2-P rules
     internal class AlwaysAllowValidProjectReferenceChecker : IValidProjectReferenceChecker
     {
-        private static readonly Task<SupportedCheckResult> Supported = Task.FromResult(SupportedCheckResult.Supported);
+        private static readonly Task<SupportedCheckResult> s_supported = Task.FromResult(SupportedCheckResult.Supported);
 
         [ImportingConstructor]
         public AlwaysAllowValidProjectReferenceChecker()
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.References
         {
             Requires.NotNull(referencedProject, nameof(referencedProject));
 
-            return Supported;
+            return s_supported;
         }
 
         public Task<CanAddProjectReferencesResult> CanAddProjectReferencesAsync(IImmutableSet<object> referencedProjects)
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.References
         {
             Requires.NotNull(referencingProject, nameof(referencingProject));
 
-            return Supported;
+            return s_supported;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         private const string TelemetryEventName = "UpToDateCheck";
         private const string Link = "Link";
 
-        private static readonly HashSet<string> KnownOutputGroups = new HashSet<string>
+        private static readonly HashSet<string> s_knownOutputGroups = new HashSet<string>
         {
             "Symbols",
             "Built",
@@ -230,7 +230,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
         private void OnOutputGroupChanged(IImmutableDictionary<string, IOutputGroup> e)
         {
-            foreach (var outputGroupPair in e.Where(pair => KnownOutputGroups.Contains(pair.Key)))
+            foreach (var outputGroupPair in e.Where(pair => s_knownOutputGroups.Contains(pair.Key)))
             {
                 var outputs = outputGroupPair.Value.Outputs.Select(output => output.Key);
                 _outputGroups[outputGroupPair.Key] = new HashSet<string>(outputs, StringComparers.Paths);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/IEnvironmentHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/IEnvironmentHelper.cs
@@ -5,7 +5,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
     /// <summary>
     /// Abstraction for System.Environment for unit testing
     /// </summary>
-    interface IEnvironmentHelper
+    internal interface IEnvironmentHelper
     {
         string GetEnvironmentVariable(string name);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/TraceUtilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/TraceUtilities.cs
@@ -24,8 +24,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
         /// <summary>
         /// Buffer to preserve lastest set of error messages to help diagnosing Watson bugs.
         /// </summary>
-        private static readonly string[] CriticalTraceBuffer = new string[CriticalTraceBufferSize];
-        private static volatile int currentTraceIndex = 0;
+        private static readonly string[] s_criticalTraceBuffer = new string[CriticalTraceBufferSize];
+        private static volatile int s_currentTraceIndex = 0;
 
         /// <summary>
         /// Gives the current Travel Level setting for the CPS tracing
@@ -136,13 +136,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
             // Allocate the next index.  We use CompareExchange here to prevent the race condition between two threads.
             do
             {
-                currentValue = currentTraceIndex;
+                currentValue = s_currentTraceIndex;
             }
-            while (Interlocked.CompareExchange(ref currentTraceIndex, currentValue, (currentValue + 1) % CriticalTraceBufferSize) != currentValue);
+            while (Interlocked.CompareExchange(ref s_currentTraceIndex, currentValue, (currentValue + 1) % CriticalTraceBufferSize) != currentValue);
 
             // possible to override, if the buffer is written heavily
             // but this is just to help us to gather information, so performance is more important here.
-            CriticalTraceBuffer[currentValue] = message;
+            s_criticalTraceBuffer[currentValue] = message;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/StringFormat.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/StringFormat.cs
@@ -13,10 +13,10 @@ namespace Microsoft.VisualStudio
         // Sentinel fixed-length arrays eliminate the need for a "count" field keeping this
         // struct down to just 4 fields. These are only used for their "Length" property,
         // that is, their elements are never set or referenced.
-        private static readonly object[] ZeroArgumentArray = Array.Empty<object>();
-        private static readonly object[] OneArgumentArray = new object[1];
-        private static readonly object[] TwoArgumentArray = new object[2];
-        private static readonly object[] ThreeArgumentArray = new object[3];
+        private static readonly object[] s_zeroArgumentArray = Array.Empty<object>();
+        private static readonly object[] s_oneArgumentArray = new object[1];
+        private static readonly object[] s_twoArgumentArray = new object[2];
+        private static readonly object[] s_threeArgumentArray = new object[3];
         private readonly string _format;
         private readonly object _argument1;
         private readonly object _argument2;
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio
             _argument1 = null;
             _argument2 = null;
             _argument3 = null;
-            _arguments = ZeroArgumentArray;
+            _arguments = s_zeroArgumentArray;
         }
 
         public StringFormat(string format, object argument)
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio
             _argument1 = argument;
             _argument2 = null;
             _argument3 = null;
-            _arguments = OneArgumentArray;
+            _arguments = s_oneArgumentArray;
         }
 
         public StringFormat(string format, object argument1, object argument2)
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio
             _argument1 = argument1;
             _argument2 = argument2;
             _argument3 = null;
-            _arguments = TwoArgumentArray;
+            _arguments = s_twoArgumentArray;
         }
 
         public StringFormat(string format, object argument1, object argument2, object argument3)
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio
             _argument1 = argument1;
             _argument2 = argument2;
             _argument3 = argument3;
-            _arguments = ThreeArgumentArray;
+            _arguments = s_threeArgumentArray;
         }
 
         public StringFormat(string format, object[] arguments)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/TaskDelayScheduler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/TaskDelayScheduler.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.Threading.Tasks
     /// </summary>
     internal sealed class TaskDelayScheduler : ITaskDelayScheduler
     {
-        private object SyncObject = new object();
+        private object _syncObject = new object();
         private readonly IProjectThreadingService _threadingService;
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.Threading.Tasks
         /// </summary>
         public JoinableTask ScheduleAsyncTask(Func<CancellationToken, Task> asyncFnctionToCall)
         {
-            lock (SyncObject)
+            lock (_syncObject)
             {
                 // A new submission is being requested to be scheduled, cancel previous
                 // submissions first.
@@ -81,7 +81,7 @@ namespace Microsoft.VisualStudio.Threading.Tasks
                 await Task.Delay(TaskDelayTime).ConfigureAwait(true);
 
                 bool isCanceled = token.IsCancellationRequested;
-                lock (SyncObject)
+                lock (_syncObject)
                 {
                     // We want to clear any existing cancelation token IF it matches our token
                     if (PendingUpdateTokenSource != null && PendingUpdateTokenSource.Token == token)
@@ -112,7 +112,7 @@ namespace Microsoft.VisualStudio.Threading.Tasks
         /// </summary>
         private void ClearPendingUpdates(bool cancel)
         {
-            lock (SyncObject)
+            lock (_syncObject)
             {
                 if (PendingUpdateTokenSource != null)
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Automation/VsProjectEventsTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Automation/VsProjectEventsTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             var referenceEvents = Mock.Of<ReferencesEvents>();
             var buildManagerEvents = Mock.Of<BuildManagerEvents>();
 
-            var projectEventsMock = new Mock<VSLangProj.VSProjectEvents>();
+            var projectEventsMock = new Mock<VSProjectEvents>();
             projectEventsMock.Setup(e => e.ReferencesEvents)
                              .Returns(referenceEvents);
             projectEventsMock.Setup(e => e.BuildManagerEvents)

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Automation/VisualBasicVSImports.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Automation/VisualBasicVSImports.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
                                Imports,
                                ImportsEvents
     {
-        private const string importItemTypeName = "Import";
+        private const string ImportItemTypeName = "Import";
 
         private readonly ActiveConfiguredProject<ConfiguredProject> _activeConfiguredProject;
         private readonly IProjectThreadingService _threadingService;
@@ -74,7 +74,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
                     {
                         var project = await access.GetProjectAsync(ConfiguredProject).ConfigureAwait(true);
                         await access.CheckoutAsync(project.Xml.ContainingProject.FullPath).ConfigureAwait(true);
-                        project.AddItem(importItemTypeName, bstrImport);
+                        project.AddItem(ImportItemTypeName, bstrImport);
                     }
                 });
 
@@ -102,12 +102,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
                         await access.CheckoutAsync(project.Xml.ContainingProject.FullPath).ConfigureAwait(true);
                         if (index is string removeImport1)
                         {
-                            importProjectItem = project.GetItems(importItemTypeName)
+                            importProjectItem = project.GetItems(ImportItemTypeName)
                                                        .First(i => string.Compare(removeImport1, i.EvaluatedInclude, StringComparison.OrdinalIgnoreCase) == 0);
                         }
                         else if (index is int indexInt1)
                         {
-                            importProjectItem = project.GetItems(importItemTypeName)
+                            importProjectItem = project.GetItems(ImportItemTypeName)
                                                        .OrderBy(i => i.EvaluatedInclude)
                                                        .ElementAt((indexInt1 - 1));
                         }


### PR DESCRIPTION
This depends on https://github.com/dotnet/project-system/pull/3035 - so ignore the editorconfig change.

This applies all the naming/coding style rules that show up as errors/warnings.
