### PR TITLE
Turn off "var" suggestion when not apparent

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -50,7 +50,7 @@ dotnet_style_explicit_tuple_names = true:suggestion
 # CSharp code style settings:
 [*.cs]
 # Prefer "var" everywhere
-csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_for_built_in_types = false:none
 csharp_style_var_when_type_is_apparent = true:suggestion
 csharp_style_var_elsewhere = false:none
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -49,10 +49,10 @@ dotnet_style_explicit_tuple_names = true:suggestion
 
 # CSharp code style settings:
 [*.cs]
-# Prefer "var" everywhere
-csharp_style_var_for_built_in_types = false:none
-csharp_style_var_when_type_is_apparent = true:suggestion
-csharp_style_var_elsewhere = false:none
+# Prefer "var" only when the type is apparent
+csharp_style_var_for_built_in_types = false:warning
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = false:warning
 
 # Prefer method-like constructs to have a block body
 csharp_style_expression_bodied_methods = false:none

--- a/.editorconfig
+++ b/.editorconfig
@@ -52,7 +52,7 @@ dotnet_style_explicit_tuple_names = true:suggestion
 # Prefer "var" everywhere
 csharp_style_var_for_built_in_types = true:suggestion
 csharp_style_var_when_type_is_apparent = true:suggestion
-csharp_style_var_elsewhere = true:suggestion
+csharp_style_var_elsewhere = false:none
 
 # Prefer method-like constructs to have a block body
 csharp_style_expression_bodied_methods = false:none

--- a/.editorconfig
+++ b/.editorconfig
@@ -50,9 +50,9 @@ dotnet_style_explicit_tuple_names = true:suggestion
 # CSharp code style settings:
 [*.cs]
 # Prefer "var" only when the type is apparent
-csharp_style_var_for_built_in_types = false:warning
-csharp_style_var_when_type_is_apparent = true:warning
-csharp_style_var_elsewhere = false:warning
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = false:suggestion
 
 # Prefer method-like constructs to have a block body
 csharp_style_expression_bodied_methods = false:none


### PR DESCRIPTION
See: https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md.

> We only use var when it's obvious what the variable type is (i.e. `var stream = new FileStream(...)` not `var stream = OpenStandardInput()`).