### PR TITLE
Update CPS SDK, enabling parallel load for .netcore projects

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -62,7 +62,7 @@
     <VsWebSiteInteropVersion>8.0.0-alpha</VsWebSiteInteropVersion>
     
     <!-- CPS -->
-    <MicrosoftVisualStudioProjectSystemSDKVersion>15.5.293-pre</MicrosoftVisualStudioProjectSystemSDKVersion>
+    <MicrosoftVisualStudioProjectSystemSDKVersion>15.6.98-pre</MicrosoftVisualStudioProjectSystemSDKVersion>
     
     <!-- Roslyn -->
     <MicrosoftVisualStudioLanguageServicesVersion>2.6.0-beta1-62113-02</MicrosoftVisualStudioLanguageServicesVersion>
@@ -75,7 +75,7 @@
     <NuGetVisualStudioVersion>4.3.0</NuGetVisualStudioVersion>
     
     <!-- Msbuild -->
-    <MicrosoftBuildVersion>15.3.409</MicrosoftBuildVersion>
+    <MicrosoftBuildVersion>15.6.0-preview-000010-1174357</MicrosoftBuildVersion>
     
     <!-- Libs -->
     <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>


### PR DESCRIPTION
**Customer scenario**

This enables parallel project load for .netcore projects (our ProjectTypeRegistrationAttribute will generate a new key in the pkgdef to point to the CPS prefetch factory). Parallel loading is a new feature in 15.6 that gives project system authors a chance to pre-load their projects before the solution calls CreateProject. How it works is the solution will call into CPS with the information of all projects we will be loading for a given solution (that say they enable prefetch support). CPS will then begin loading all projects on the background in parallel (we will limit it to 1-4 projects at a time). In testing Roslyn.sln, this provided a ~5s improvement during solution load.

I hope to bring this change into 15.6 preview 2 (escrow)

**Bugs this fixes:** 

N/A - I can open a bug or issue if it is needed for escrow.

**Workarounds, if any**

No workaround, not a bug. Enabling a feature.

**Risk**

While parallel project load offers a performance improvement (that we will continue to refine), it does make solution load susceptible to thread-pool exhaustion. During parallel load, extension points will not be able to get to the UI thread until post solution load. This means any fire & forget tasks that use JTF.Run + SwitchToMainThreadAsync will almost certainly cause threadpool exhaustion. In my testing, this ended up _slowing_ Roslyn.sln load by 20 seconds. If users encounter this, there is a check-box in tools/options to disable this feature. JTF.Run + SwitchToMainThreadAsync should ideally *not* be used from a BG thread anyways, as it can cause thread-pool exhaustion in so many other scenarios.

**Performance impact**

Improves solution load performance.

**Is this a regression from a previous update?**

No

**Root cause analysis:**

N/A

**How was the bug found?**

N/A
