### PR TITLE
Turn on native debugging

### DIFF
--- a/src/ProjectSystemSetup/Properties/launchSettings.json
+++ b/src/ProjectSystemSetup/Properties/launchSettings.json
@@ -9,6 +9,17 @@
         "FSharpDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.FSharp.DesignTime.targets",
         "CSharpDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.CSharp.DesignTime.targets"
       }
+    },
+    "ProjectSystemSetup (with native debugging)": {
+      "commandName": "Executable",
+      "executablePath": "$(DevEnvDir)devenv.exe",
+      "commandLineArgs": "/rootsuffix $(VSSDKTargetPlatformRegRootSuffix) /log",
+      "environmentVariables": {
+        "VisualBasicDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.VisualBasic.DesignTime.targets",
+        "FSharpDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.FSharp.DesignTime.targets",
+        "CSharpDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.CSharp.DesignTime.targets"
+      },
+      "nativeDebugging": true
     }
   }
 }


### PR DESCRIPTION
Turn on native debugging for the project system by default.