### PR TITLE
Make sure product binaries are deployed when tests are built

### DIFF
--- a/src/DeployIntegrationDependencies/DeployIntegrationDependencies.csproj
+++ b/src/DeployIntegrationDependencies/DeployIntegrationDependencies.csproj
@@ -6,9 +6,6 @@
     <PublishOutputToSymStore>false</PublishOutputToSymStore>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.IntegrationTests\Microsoft.VisualStudio.ProjectSystem.IntegrationTests.csproj" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.IntegrationTest.Utilities" Version="$(MicrosoftVisualStudioIntegrationTestUtilitiesVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="$(MicrosoftVisualStudioLanguageServicesVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests.csproj
@@ -1,6 +1,9 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\HostAgnostic.props" />
+  <PropertyGroup>
+    <RootNamespace>Microsoft.VisualStudio</RootNamespace>
+  </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests.csproj
@@ -1,11 +1,12 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\HostAgnostic.props"/>
+  <Import Project="..\HostAgnostic.props" />
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests" />
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)"/>
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\DeployTestDependencies\DeployTestDependencies.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.CSharp\Microsoft.VisualStudio.ProjectSystem.CSharp.csproj" />
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj" />
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests.csproj
@@ -1,10 +1,11 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\VisualStudio.props"/>
+  <Import Project="..\VisualStudio.props" />
   <ItemGroup>
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)"/>
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\DeployTestDependencies\DeployTestDependencies.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.CSharp.VS\Microsoft.VisualStudio.ProjectSystem.CSharp.VS.csproj" />
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.CSharp\Microsoft.VisualStudio.ProjectSystem.CSharp.csproj" />
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests.csproj
@@ -1,6 +1,9 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\VisualStudio.props" />
+  <PropertyGroup>
+    <RootNamespace>Microsoft.VisualStudio</RootNamespace>
+  </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
   </ItemGroup>

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.UnitTests/Microsoft.VisualStudio.ProjectSystem.FSharp.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.UnitTests/Microsoft.VisualStudio.ProjectSystem.FSharp.UnitTests.csproj
@@ -1,6 +1,9 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\HostAgnostic.props" />
+  <PropertyGroup>
+    <RootNamespace>Microsoft.VisualStudio</RootNamespace>
+  </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.UnitTests/Microsoft.VisualStudio.ProjectSystem.FSharp.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.UnitTests/Microsoft.VisualStudio.ProjectSystem.FSharp.UnitTests.csproj
@@ -1,11 +1,12 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\HostAgnostic.props"/>
+  <Import Project="..\HostAgnostic.props" />
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests" />
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)"/>
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\DeployTestDependencies\DeployTestDependencies.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.FSharp\Microsoft.VisualStudio.ProjectSystem.FSharp.csproj" />
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj" />
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests.csproj
@@ -1,10 +1,11 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\VisualStudio.props"/>
+  <Import Project="..\VisualStudio.props" />
   <ItemGroup>
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)"/>
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\DeployTestDependencies\DeployTestDependencies.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.FSharp.VS\Microsoft.VisualStudio.ProjectSystem.FSharp.VS.csproj" />
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.FSharp\Microsoft.VisualStudio.ProjectSystem.FSharp.csproj" />
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests.csproj
@@ -1,6 +1,9 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\VisualStudio.props" />
+  <PropertyGroup>
+    <RootNamespace>Microsoft.VisualStudio</RootNamespace>
+  </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
   </ItemGroup>

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests.csproj
@@ -1,11 +1,12 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\VisualStudio.props"/>
+  <Import Project="..\VisualStudio.props" />
   <PropertyGroup>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\DeployIntegrationDependencies\DeployIntegrationDependencies.csproj" ReferenceOutputAssembly="false" />
     <PackageReference Include="Microsoft.VisualStudio.IntegrationTest.Utilities" Version="$(MicrosoftVisualStudioIntegrationTestUtilitiesVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests.csproj
@@ -1,15 +1,16 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\HostAgnostic.props"/>
+  <Import Project="..\HostAgnostic.props" />
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests" />
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)"/>
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\DeployTestDependencies\DeployTestDependencies.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj" />
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj" />
   </ItemGroup>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests.csproj
@@ -1,6 +1,9 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\HostAgnostic.props" />
+  <PropertyGroup>
+    <RootNamespace>Microsoft.VisualStudio</RootNamespace>
+  </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\HostAgnostic.props"/>
+  <Import Project="..\HostAgnostic.props" />
   <ItemGroup>
     <Reference Include="WindowsBase" />
   </ItemGroup>
@@ -12,9 +12,10 @@
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.FSharp.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests" />
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)"/>
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\DeployTestDependencies\DeployTestDependencies.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj" />
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj" />
  </ItemGroup>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
@@ -1,6 +1,9 @@
 ﻿ <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\VisualStudio.props" />
+  <PropertyGroup>
+    <RootNamespace>Microsoft.VisualStudio</RootNamespace>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\DeployTestDependencies\DeployTestDependencies.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\VisualStudio.props" />
   <ItemGroup>
+    <ProjectReference Include="..\DeployTestDependencies\DeployTestDependencies.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj" />
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj" />
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.VS\Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests.csproj
@@ -1,11 +1,12 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\HostAgnostic.props"/>
+  <Import Project="..\HostAgnostic.props" />
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\DeployTestDependencies\DeployTestDependencies.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj" />
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj" />
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests.csproj
@@ -1,6 +1,9 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\HostAgnostic.props" />
+  <PropertyGroup>
+    <RootNamespace>Microsoft.VisualStudio</RootNamespace>
+  </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests.csproj
@@ -1,10 +1,11 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\VisualStudio.props"/>
+  <Import Project="..\VisualStudio.props" />
   <ItemGroup>
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)"/>
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\DeployTestDependencies\DeployTestDependencies.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj" />
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj" />
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests\Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests.csproj
@@ -1,6 +1,9 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\VisualStudio.props" />
+  <PropertyGroup>
+    <RootNamespace>Microsoft.VisualStudio</RootNamespace>
+  </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
   </ItemGroup>


### PR DESCRIPTION
In the move to the new toolset (fcca201) two things changes;

- Tests no longer caused the product binaries to be deployed. This resulted in tests running against previous versions of the product. Add back references to the DeployXXXDependencies projects.
- Test projects had a default namespace that matched their project name. Add back the previous default namespace.