### PR TITLE
Prevent blocking background thread to register image monikers in dependency node 

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
@@ -98,14 +98,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
             return Task.CompletedTask;
         }
 
-        private async Task EnsureInitializedAsync()
-        {
-            if (!IsInitializing || !IsInitialized)
-            {
-                await InitializeAsync().ConfigureAwait(false);
-            }
-        }
-
         /// <summary>
         /// IGraphProvider.BeginGetGraphData
         /// Entry point for progression. Gets called everytime when progression
@@ -152,7 +144,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
         {
             try
             {
-                await EnsureInitializedAsync().ConfigureAwait(false);
+                await InitializeAsync().ConfigureAwait(false);
 
                 var actionHandlers = GraphActionHandlers.Where(x => x.Value.CanHandleRequest(context));
                 var shouldTrackChanges = actionHandlers.Aggregate(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
@@ -265,13 +265,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
 
         private void RegisterIcons(IEnumerable<ImageMoniker> icons)
         {
+            Assumes.NotNull(icons);
+
             lock (_knownIconsLock)
             {
-                if (icons == null)
-                {
-                    return;
-                }
-
                 icons = icons.Where(x => !KnownIcons.Contains(x)).ToList();
                 if (!icons.Any())
                 {


### PR DESCRIPTION
Fixes: https://github.com/dotnet/project-system/issues/3054.

The image service is free-threaded and thread-safe for registration APIs, stop blocking a background thread to switch to the UI, instead grab the service during initialization and register in background.

Also simplified the way we register the icons to avoid requiring a lock and lots of intermediate objects.

~**Note**: This is currently blocked due to multiple instances of DependenciesGraphProvider being created due to progression importing the parts as non-shared, and so that the thing that registers the icons is actually a different instance from the thing that gets initialized by progression. Fixing this now.~ 
Fixed in https://github.com/dotnet/project-system/pull/3064.