### PR TITLE
Prevent multiple DependenciesGraphProvider instances from being created 

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
@@ -27,8 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
     /// Note: when dependency has ProjectTreeFlags.Common.BrokenReference flag, GraphProvider API are not 
     /// called for that node.
     /// </summary>
-    [GraphProvider(Name = "Microsoft.VisualStudio.ProjectSystem.VS.Tree.DependenciesNodeGraphProvider",
-                   ProjectCapability = ProjectCapability.DependenciesTree)]
+    [Export(typeof(DependenciesGraphProvider))]
     [Export(typeof(IDependenciesGraphBuilder))]
     [AppliesTo(ProjectCapability.DependenciesTree)]
     internal class DependenciesGraphProvider : OnceInitializedOnceDisposedAsync, IGraphProvider, IDependenciesGraphBuilder
@@ -132,7 +131,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
         /// <summary>
         /// IGraphProvider.GetExtension
         /// </summary>
-        T IGraphProvider.GetExtension<T>(GraphObject graphObject, T previous)
+        public T GetExtension<T>(GraphObject graphObject, T previous) where T : class
         {
             return null;
         }
@@ -140,7 +139,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
         /// <summary>
         /// IGraphProvider.Schema
         /// </summary>
-        Graph IGraphProvider.Schema
+        public Graph Schema
         {
             get
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
@@ -310,6 +310,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
             GraphNode parentNode, 
             IDependencyViewModel viewModel)
         {
+            Assumes.True(IsInitialized);
+
             var modelId = viewModel.OriginalModel == null ? viewModel.Caption : viewModel.OriginalModel.Id;
             var newNodeId = GetGraphNodeId(projectPath, parentNode, modelId);
             return DoAddGraphNode(newNodeId, graphContext, projectPath, parentNode, viewModel);
@@ -320,6 +322,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
             string projectPath,
             IDependencyViewModel viewModel)
         {
+
+            Assumes.True(IsInitialized);
+
             var newNodeId = GetTopLevelGraphNodeId(projectPath, viewModel.OriginalModel.GetTopLevelId());
             return DoAddGraphNode(newNodeId, graphContext, projectPath, parentNode: null, viewModel:viewModel);
         }
@@ -361,6 +366,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
                                      string modelId,
                                      GraphNode parentNode)
         {
+            Assumes.True(IsInitialized);
+
             var id = GetGraphNodeId(projectPath, parentNode, modelId);
             var nodeToRemove = graphContext.Graph.Nodes.Get(id);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProviderFactory.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.GraphModel;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
+{
+    // Progression imports IGraphProviders as non-shared parts, which means if they themselves export other interfaces
+    // imports of those in the same scope/container will see a different instance to what progression sees. This class works 
+    // around that by importing DependenciesGraphProvider as shared and simply delegating onto it.
+
+    [GraphProvider(Name = "Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.DependenciesGraphProvider",
+                   ProjectCapability = ProjectCapability.DependenciesTree)]
+    internal class DependenciesGraphProviderFactory : IGraphProvider
+    {
+        private readonly DependenciesGraphProvider _provider;
+
+        [ImportingConstructor]
+        internal DependenciesGraphProviderFactory(DependenciesGraphProvider provider)
+        {
+            _provider = provider;
+        }
+
+        public Graph Schema => _provider.Schema;
+
+        public void BeginGetGraphData(IGraphContext context) => _provider.BeginGetGraphData(context);
+
+        public IEnumerable<GraphCommand> GetCommands(IEnumerable<GraphNode> nodes) => _provider.GetCommands(nodes);
+
+        public T GetExtension<T>(GraphObject graphObject, T previous) where T : class => _provider.GetExtension(graphObject, previous);
+    }
+}


### PR DESCRIPTION
Prevent multiple DependenciesGraphProvider instances from being created

Multiple DependenciesGraphProvider instances were being created because Progression imports IGraphProvider as non-shared, while IDependenciesGraphActionHandler were importing as shared. This resulted in IGraphProvider and IDependenciesGraphActionHandler  seeing different instances.

This was never issue because IDependenciesGraphActionHandler instances never relied on DependenciesGraphProvider being initialized when they called it. In #3063 this changed though and broke this.