### PR TITLE
Re-enable CA1825 - Don't allocate zero length arrays

### DIFF
--- a/build/Default.ruleset
+++ b/build/Default.ruleset
@@ -99,9 +99,7 @@
     <Rule Id="CA1308" Action="None" />
     <Rule Id="CA1810" Action="None" />
     <Rule Id="CA1816" Action="None" />
-
-    <!--CA1825 has a bug that fires on compiler generated code and is very noisy in this repo. Reenable this rule when we move to a new version of analyzers.' -->
-    <Rule Id="CA1825" Action="None" />
+    <Rule Id="CA1825" Action="Warning" />
     <Rule Id="CA2002" Action="None" />
     <Rule Id="CA2207" Action="None" />
     <Rule Id="CA2208" Action="None" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectDebuggerProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectDebuggerProvider.cs
@@ -188,7 +188,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             VsDebugTargetInfo4[] launchSettingsNative = launchSettings.Select(GetDebuggerStruct4).ToArray();
             if (launchSettingsNative.Length == 0)
             {
-                return new VsDebugTargetProcessInfo[0];
+                return Array.Empty<VsDebugTargetProcessInfo>();
             }
 
             try

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageElementHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageElementHost.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 filterKeys.TranslateAcceleratorEx(new OLE.Interop.MSG[] { oleMSG },
                                                   (uint)(__VSTRANSACCELEXFLAGS.VSTAEXF_NoFireCommand | __VSTRANSACCELEXFLAGS.VSTAEXF_UseGlobalKBScope | __VSTRANSACCELEXFLAGS.VSTAEXF_AllowModalState),
                                                   0 /*scope count*/,
-                                                  new Guid[0] /*scopes*/,
+                                                  Array.Empty<Guid>() /*scopes*/,
                                                   out Guid cmdGuid,
                                                   out uint cmdId,
                                                   out int fTranslated,


### PR DESCRIPTION
Fixes #241.

<details>**Customer scenario**

What does the customer do to get into this situation, and why do we think this
is common enough to address in Escrow.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

**Bugs this fixes:** 

(either VSO or GitHub links)

**Workarounds, if any**

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

**Risk**

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

**Is this a regression from a previous update?**

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

(E.g. customer reported it vs. ad hoc testing)
</details>