### PR TITLE
Change default working directory to the output folder

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
@@ -256,6 +256,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
         [Theory]
         [InlineData(@"c:\test\project\bin\")]
         [InlineData(@"bin\")]
+        [InlineData(@"doesntExist\")]
+        [InlineData(null)]
         public async Task QueryDebugTargets_ExeProfileAsyncExeRelativeNoWorkingDir(string outdir)
         {
           var properties = new Dictionary<string, string>() {
@@ -270,11 +272,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
 
             // Exe relative, no working dir
             _mockFS.WriteAllText(@"c:\test\project\bin\test.exe", string.Empty);
+            _mockFS.WriteAllText(@"c:\test\project\test.exe", string.Empty);
             var activeProfile = new LaunchProfile(){Name="run", ExecutablePath=".\\test.exe"};
             var targets = await debugger.QueryDebugTargetsAsync(0, activeProfile);
             Assert.Single(targets);
-            Assert.Equal(@"c:\test\project\bin\test.exe", targets[0].Executable);
-            Assert.Equal(@"c:\test\project\bin\", targets[0].CurrentDirectory);
+            if(outdir == null || outdir == @"doesntExist\")
+            {
+                Assert.Equal(@"c:\test\project\test.exe", targets[0].Executable);
+                Assert.Equal(@"c:\test\project", targets[0].CurrentDirectory);
+            }
+            else
+            {
+                Assert.Equal(@"c:\test\project\bin\test.exe", targets[0].Executable);
+                Assert.Equal(@"c:\test\project\bin\", targets[0].CurrentDirectory);
+            }
         }
 
         [Theory]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
@@ -52,7 +52,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
                     {"RunCommand", @"dotnet"},
                     {"RunArguments", "exec " + "\"" + @"c:\test\project\bin\project.dll"+ "\""},
                     {"RunWorkingDirectory",  @"bin\"},
-                    { "TargetFrameworkIdentifier", @".NetCoreApp" }
+                    { "TargetFrameworkIdentifier", @".NetCoreApp" },
+                    { "OutDir", @"c:\test\project\bin\" }
                 };
             }
             var delegatePropertiesMock = IProjectPropertiesFactory
@@ -252,18 +253,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
             Assert.Equal("--someArgs", targets[0].Arguments);
         }
 
-        [Fact]
-        public async Task QueryDebugTargets_ExeProfileAsyncExeRelativeNoWorkingDir()
+        [Theory]
+        [InlineData(@"c:\test\project\bin\")]
+        [InlineData(@"bin\")]
+        public async Task QueryDebugTargets_ExeProfileAsyncExeRelativeNoWorkingDir(string outdir)
         {
-            var debugger = GetDebugTargetsProvider();
+          var properties = new Dictionary<string, string>() {
+                    {"RunCommand", @"dotnet"},
+                    {"RunArguments", "exec " + "\"" + @"c:\test\project\bin\project.dll"+ "\""},
+                    {"RunWorkingDirectory",  @"bin\"},
+                    { "TargetFrameworkIdentifier", @".NetCoreApp" },
+                    { "OutDir", outdir }
+                };
+
+            var debugger = GetDebugTargetsProvider("exe", properties);
 
             // Exe relative, no working dir
-            _mockFS.WriteAllText(@"c:\test\project\test.exe", string.Empty);
+            _mockFS.WriteAllText(@"c:\test\project\bin\test.exe", string.Empty);
             var activeProfile = new LaunchProfile(){Name="run", ExecutablePath=".\\test.exe"};
             var targets = await debugger.QueryDebugTargetsAsync(0, activeProfile);
             Assert.Single(targets);
-            Assert.Equal(@"c:\test\project\test.exe", targets[0].Executable);
-            Assert.Equal(@"c:\test\project", targets[0].CurrentDirectory);
+            Assert.Equal(@"c:\test\project\bin\test.exe", targets[0].Executable);
+            Assert.Equal(@"c:\test\project\bin\", targets[0].CurrentDirectory);
         }
 
         [Theory]


### PR DESCRIPTION
Changed the  default working directory to be the output folder rather than the project root.  This addresses issue https://github.com/dotnet/project-system/issues/2239.
Note that there is a very slight behavior change. If the executable path specified in the profile is a relative path, it is assumed to be relative to the working directory (whether is comes from msbuild, the profile, or the default). This means that if no working directory is specified, it is now relative to the output directory rather than the project root - which I think makes more sense anyway.