### PR TITLE
Move project system to well defined path

### DIFF
--- a/src/ProjectSystemSetup/ProjectSystemSetup.csproj
+++ b/src/ProjectSystemSetup/ProjectSystemSetup.csproj
@@ -8,6 +8,8 @@
 
     <!-- VSIX -->
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
+    <ExtensionInstallationRoot>Extensions</ExtensionInstallationRoot>
+    <ExtensionInstallationFolder>Microsoft\ManagedProjectSystem</ExtensionInstallationFolder>
 
     <!-- VS Insertion -->
     <VisualStudioInsertionComponent>Microsoft.VisualStudio.ProjectSystem.Managed</VisualStudioInsertionComponent>


### PR DESCRIPTION
**Customer scenario**

Project system binaries are not profiled by Optprof, and later optimized, because they are not installed into a well defined path. Instead they are dropped into an anonymous path under  `Common7\IDE\Extensions`

**Bugs this fixes:** 

Fixes #2850 

**Workarounds, if any**

N/A

**Risk**

Low

**Performance impact**

Will eventually improve performance after profiling

**Is this a regression from a previous update?**

No

/cc @dotnet/project-system 
