### PR TITLE
Fix TargetFramework caching and comparison in PackageRuleHandler

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/PackageRuleHandler.cs
@@ -149,7 +149,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                                  && unresolvedChanges.Contains(metadata.Name));
                 isTarget = metadata.IsTarget;
                 var packageTargetFramework = TargetFrameworkProvider.GetTargetFramework(metadata.Target);
-                if (packageTargetFramework != targetFramework)
+                if (!(packageTargetFramework?.Equals(targetFramework) == true))
                 {
                     return null;
                 }


### PR DESCRIPTION
**Customer scenario**

Projects created with non-canonical target frameworks (e.g. netstandard20 instead of netstandard2.0) can leave dependency tree in unresolved state. Two bugs conspired to make this possible (1) TargetFrameworkProvider caches duplicate target frameworks in the face of non-canonical short names (2) comparison operator overload does not work with interfaces, hence in PackageRuleHandler two identical (i.e. duplicate) target frameworks are treated as unequal.

**Bugs this fixes:** 

Fixes #2772 

**Workarounds, if any**

N/A

**Risk**

Low

**Performance impact**

Slight improvement since cache is working

**Is this a regression from a previous update?**

No

**Root cause analysis:**

When caching, we use the canonical shortname, even if the input was non-canonical. This means future checks do not find anything in the cache, and create a duplicate. Fix is to also look for TargetFrameworks using the full name, and avoid the duplicate creation.

**How was the bug found?**

Customer reported