### PR TITLE
Fix second up to date build

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -97,6 +97,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             _telemetryService = telemetryService;
         }
 
+        /// <summary>
+        /// Called on project load.
+        /// </summary>
+        [ConfiguredProjectAutoLoad]
+        [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
+        internal void Load()
+        {
+            EnsureInitialized();
+        }
+
         protected override void Initialize()
         {
             _link = ProjectDataSources.SyncLinkTo(


### PR DESCRIPTION
**Customer scenario**

After opening a project, it takes two builds of a .NET Core/.NET Standard project before the fast up to date check will recognize the project is up to date.

**Bugs this fixes:** 

#2698 

**Workarounds, if any**

None. User has to build twice.

**Risk**

Low, this fix just loads the up to date checker when the project opens rather than when the project first builds.

**Performance impact**

This doesn't add any work but moves it slightly earlier (after project opens rather than after project first builds).

**Is this a regression from a previous update?**

No.

**How was the bug found?**

Ad hoc testing.
