### PR TITLE
Update RepoToolset to 1.0.0-beta-62503-02

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -9,8 +9,8 @@
     <UsingToolIbcOptimization>true</UsingToolIbcOptimization>
 
     <!-- Toolset -->
-    <RoslynToolsRepoToolsetVersion>1.0.0-beta-62413-01</RoslynToolsRepoToolsetVersion>
-    <RoslynToolsVsixExpInstallerVersion>1.0.0-beta-62413-01</RoslynToolsVsixExpInstallerVersion>
+    <RoslynToolsRepoToolsetVersion>1.0.0-beta-62503-02</RoslynToolsRepoToolsetVersion>
+    <RoslynToolsVsixExpInstallerVersion>1.0.0-beta-62503-02</RoslynToolsVsixExpInstallerVersion>
     <RoslynDependenciesProjectSystemOptimizationDataVersion>2.6.0-beta1-62205-02</RoslynDependenciesProjectSystemOptimizationDataVersion>
     <VSWhereVersion>2.1.4</VSWhereVersion>
     <MicrosoftDotNetIBCMergeVersion>4.7.1-alpha-00001</MicrosoftDotNetIBCMergeVersion>


### PR DESCRIPTION
Fixes version overflow in signed build caused by new year.