### PR TITLE
Clean up the logic to save the imports in the VB references page.

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePropPage.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel
 Imports System.ComponentModel.Design
@@ -791,7 +791,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 Dim componentModel = DirectCast(ServiceProvider.GetService(GetType(SComponentModel)), IComponentModel)
                 Dim visualStudioWorkspace = componentModel.GetService(Of VisualStudioWorkspace)
                 Dim solution = visualStudioWorkspace.CurrentSolution
-                Dim CurrentImportNames As New List(Of String)
 
                 For Each project In solution.Projects
 
@@ -802,12 +801,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                         Dim compilation = compilationTask.Result
                         Dim compilationOptions = CType(compilation.Options, VisualBasicCompilationOptions)
                         If (compilationOptions IsNot Nothing) Then
-                            For Each globalImport In compilationOptions.GlobalImports
-                                CurrentImportNames.Add(globalImport.Name)
-                            Next
-                            CurrentImportNames.Sort(CaseInsensitiveComparison.Comparer)
+                            Dim result As New List(Of String)(compilationOptions.GlobalImports.Length)
+                            result.AddRange(compilationOptions.GlobalImports.Select(Function(gi) gi.Name))
+                            result.Sort(CaseInsensitiveComparison.Comparer)
+                            Return result.ToArray()
                         End If
-                        Return CurrentImportNames.ToArray()
                     End If
                 Next
 
@@ -1404,91 +1402,73 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Imported namespaces are currently added/removed one at a time
         '''    All removes are processed first, and then adds 
         '''</summary>
-        ''' <param name="NewImportList">the imported list being saved</param>
+        ''' <param name="newImportList">the imported list being saved</param>
         ''' <return>return true if any value was changed...</return>
         ''' <remarks>
         ''' CONSIDER: This is how the msvbprj code did it, and it may not work well
         '''         for other compilers (assuming this page is later shared)
         '''</remarks>
-        Private Function SaveImportedNamespaces(NewImportList As String()) As Boolean
-            Dim theVSProject As VSLangProj.VSProject
-            Dim _Imports As VSLangProj.Imports
-            Dim index, ListIndex As Integer
-            Dim _Namespace As String
+        Private Function SaveImportedNamespaces(newImportList As String()) As Boolean
             Dim valueUpdated As Boolean = False
-
-            theVSProject = CType(DTEProject.Object, VSLangProj.VSProject)
-
-            _Imports = theVSProject.Imports
+            Dim vsImports As VSLangProj.Imports = CType(DTEProject.Object, VSLangProj.VSProject).Imports
 
             Debug.Assert(Not _ignoreImportEvent, "why m_ignoreImportEvent = TRUE?")
             Try
                 _ignoreImportEvent = True
 
                 'For backward compatibility we remove all non-imported ones from the current Imports before adding any new ones
-                Dim CurrentImports As String() = GetCurrentImports()
+                Dim currentImports = New List(Of String)(vsImports.Count)
 
-                index = CurrentImports.Length
-                For index = _Imports.Count To 1 Step -1
-                    _Namespace = CurrentImports(index - 1)
-                    ListIndex = LookupInStringArray(NewImportList, _Namespace)
-                    If ListIndex = -1 Then
-                        Debug.WriteLine("Removing reference: " & _Imports.Item(index))
-                        Try
-                            _Imports.Remove(index)
+                For index = vsImports.Count To 1 Step -1
+                    Dim namespaceName As String = String.Empty
+                    Try
+                        namespaceName = vsImports.Item(index)
+                        currentImports.Add(namespaceName)
+                        If Not newImportList.Contains(namespaceName) Then
+                            Debug.WriteLine("Removing reference: " & namespaceName)
+                            vsImports.Remove(index)
                             valueUpdated = True
-                        Catch ex As Exception When ReportWithoutCrash(ex, "Unexpected error when removing imports", NameOf(ReferencePropPage))
-                            If IsCheckoutCanceledException(ex) Then
-                                'Exit early - no need to show any UI, they've already seen it
-                                Return valueUpdated
-                            ElseIf TypeOf ex Is COMException Then
-                                ShowErrorMessage(My.Resources.Designer.GetString(My.Resources.Designer.PPG_Reference_RemoveImportsFailUnexpected, _Namespace, Hex(DirectCast(ex, COMException).ErrorCode)))
-                                Debug.Fail("Unexpected error when removing imports")
-                            Else
-                                ShowErrorMessage(My.Resources.Designer.GetString(My.Resources.Designer.PPG_Reference_RemoveImportsFailUnexpected, _Namespace, ex.Message))
-                                Debug.Fail("Unexpected error when removing imports")
-                            End If
-                        End Try
-                    End If
+                        End If
+                    Catch ex As Exception When ReportWithoutCrash(ex, "Unexpected error when removing imports", NameOf(ReferencePropPage))
+                        If IsCheckoutCanceledException(ex) Then
+                            'Exit early - no need to show any UI, they've already seen it
+                            Return valueUpdated
+                        ElseIf TypeOf ex Is COMException Then
+                            ShowErrorMessage(My.Resources.Designer.GetString(My.Resources.Designer.PPG_Reference_RemoveImportsFailUnexpected, namespaceName, Hex(DirectCast(ex, COMException).ErrorCode)))
+                            Debug.Fail("Unexpected error when removing imports")
+                        Else
+                            ShowErrorMessage(My.Resources.Designer.GetString(My.Resources.Designer.PPG_Reference_RemoveImportsFailUnexpected, namespaceName, ex.Message))
+                            Debug.Fail("Unexpected error when removing imports")
+                        End If
+                    End Try
                 Next index
 
                 'Now add anything new
-                For ListIndex = 0 To UBound(NewImportList)
-                    _Namespace = NewImportList(ListIndex)
-                    'Add it if not already in the list
-                    index = LookupInStringArray(CurrentImports, _Namespace)
-                    If index = -1 Then
-                        Debug.WriteLine("Adding reference: " & _Namespace)
-                        Try
-                            _Imports.Add(_Namespace)
+                For Each namespaceName As String In newImportList
+                    Try
+                        'Add it if not already in the list
+                        If Not currentImports.Contains(namespaceName) Then
+                            Debug.WriteLine("Adding reference: " & namespaceName)
+                            vsImports.Add(namespaceName)
                             valueUpdated = True
-                        Catch ex As Exception When ReportWithoutCrash(ex, "Unexpected error when removing imports", NameOf(ReferencePropPage))
-                            If IsCheckoutCanceledException(ex) Then
-                                'Exit early - no need to show any UI, they've already seen it
-                                Return valueUpdated
-                            ElseIf TypeOf ex Is COMException Then
-                                ShowErrorMessage(My.Resources.Designer.GetString(My.Resources.Designer.PPG_Reference_RemoveImportsFailUnexpected, _Namespace, Hex(DirectCast(ex, COMException).ErrorCode)))
-                                Debug.Fail("Unexpected error when removing imports")
-                            Else
-                                ShowErrorMessage(My.Resources.Designer.GetString(My.Resources.Designer.PPG_Reference_RemoveImportsFailUnexpected, _Namespace, ex.Message))
-                                Debug.Fail("Unexpected error when removing imports")
-                            End If
-                        End Try
-                    End If
+                        End If
+                    Catch ex As Exception When ReportWithoutCrash(ex, "Unexpected error when removing imports", NameOf(ReferencePropPage))
+                        If IsCheckoutCanceledException(ex) Then
+                            'Exit early - no need to show any UI, they've already seen it
+                            Return valueUpdated
+                        ElseIf TypeOf ex Is COMException Then
+                            ShowErrorMessage(My.Resources.Designer.GetString(My.Resources.Designer.PPG_Reference_RemoveImportsFailUnexpected, namespaceName, Hex(DirectCast(ex, COMException).ErrorCode)))
+                            Debug.Fail("Unexpected error when removing imports")
+                        Else
+                            ShowErrorMessage(My.Resources.Designer.GetString(My.Resources.Designer.PPG_Reference_RemoveImportsFailUnexpected, namespaceName, ex.Message))
+                            Debug.Fail("Unexpected error when removing imports")
+                        End If
+                    End Try
                 Next
             Finally
                 _ignoreImportEvent = False
             End Try
             Return valueUpdated
-        End Function
-
-        Private Function LookupInStringArray(StringArray As String(), Text As String) As Integer
-            For i As Integer = 0 To StringArray.Length - 1
-                If String.Compare(StringArray(i), Text) = 0 Then
-                    Return i
-                End If
-            Next
-            Return -1
         End Function
 
         'Get the user selected values and update the project's Imports list


### PR DESCRIPTION
Fixes internal bug 509520 - an automatic crash dump for an IndexOutOfRangeException.

I *suspect*, though can't tell from the crash dump I've been looking at that the issue here
is that the VSLangProj "Imports" collection has a different number of items than what is
passed to the compiler and retrieved from the compilation.

To fix, I cleaned up the logic, and stopped relying on the data from the compiler, instead
just collecting the items from the VSLangProj "Imports".

<details>
**Customer scenario**

What does the customer do to get into this situation, and why do we think this
is common enough to address in Escrow.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

**Bugs this fixes:** 

(either VSO or GitHub links)

**Workarounds, if any**

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

**Risk**

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

**Is this a regression from a previous update?**

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

(E.g. customer reported it vs. ad hoc testing)
</details>