### PR TITLE
Make NuGetRestorer a dynamic component

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.NuGetRestorerInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.NuGetRestorerInstance.cs
@@ -1,0 +1,240 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+using Microsoft.Internal.Performance;
+using Microsoft.VisualStudio.ProjectSystem.Logging;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.Utilities;
+using NuGet.SolutionRestoreManager;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
+{
+    using TIdentityDictionary = IImmutableDictionary<NamedIdentity, IComparable>;
+
+    partial class NuGetRestorer
+    {
+        private class NuGetRestorerInstance : AbstractProjectDynamicLoadInstance
+        {
+            private readonly IUnconfiguredProjectVsServices _projectVsServices;
+            private readonly IVsSolutionRestoreService _solutionRestoreService;
+            private readonly IActiveConfigurationGroupService _activeConfigurationGroupService;
+            private readonly IActiveConfiguredProjectSubscriptionService _activeConfiguredProjectSubscriptionService;
+            private readonly IProjectLogger _logger;
+            private IDisposable _configurationsSubscription;
+            private DisposableBag _designTimeBuildSubscriptionLink;
+
+            private static ImmutableHashSet<string> s_designTimeBuildWatchedRules = Empty.OrdinalIgnoreCaseStringSet
+                .Add(NuGetRestore.SchemaName)
+                .Add(ProjectReference.SchemaName)
+                .Add(PackageReference.SchemaName)
+                .Add(DotNetCliToolReference.SchemaName);
+
+            // Remove the ConfiguredProjectIdentity key because it is unique to each configured project - so it won't match across projects by design.
+            // Remove the ConfiguredProjectVersion key because each configuredproject manages it's own version and generally they don't match. 
+            private readonly static ImmutableArray<NamedIdentity> s_keysToDrop = ImmutableArray.Create(ProjectDataSources.ConfiguredProjectIdentity, ProjectDataSources.ConfiguredProjectVersion);
+
+            [ImportingConstructor]
+            public NuGetRestorerInstance(
+                IUnconfiguredProjectVsServices projectVsServices,
+                IVsSolutionRestoreService solutionRestoreService,
+                IActiveConfiguredProjectSubscriptionService activeConfiguredProjectSubscriptionService,
+                IActiveConfigurationGroupService activeConfigurationGroupService,
+                IProjectLogger logger)
+                : base(projectVsServices.ThreadingService.JoinableTaskContext)
+            {
+                _projectVsServices = projectVsServices;
+                _solutionRestoreService = solutionRestoreService;
+                _activeConfiguredProjectSubscriptionService = activeConfiguredProjectSubscriptionService;
+                _activeConfigurationGroupService = activeConfigurationGroupService;
+                _logger = logger;
+            }
+
+            protected override Task InitializeCoreAsync(CancellationToken cancellationToken)
+            {
+                Action<IProjectVersionedValue<IConfigurationGroup<ConfiguredProject>>> target = OnActiveConfigurationsChanged;
+
+                _configurationsSubscription = _activeConfigurationGroupService.ActiveConfiguredProjectGroupSource.SourceBlock.LinkTo(
+                    target: new ActionBlock<IProjectVersionedValue<IConfigurationGroup<ConfiguredProject>>>(target),
+                    linkOptions: new DataflowLinkOptions() { PropagateCompletion = true });
+
+                return Task.CompletedTask;
+            }
+
+            protected override Task DisposeCoreAsync(bool initialized)
+            {
+                _designTimeBuildSubscriptionLink?.Dispose();
+                _configurationsSubscription?.Dispose();
+                return Task.CompletedTask;
+            }
+
+            private void OnActiveConfigurationsChanged(IProjectVersionedValue<IConfigurationGroup<ConfiguredProject>> e)
+            {
+                if (IsDisposing || IsDisposed)
+                    return;
+
+                // Clean up past subscriptions
+                _designTimeBuildSubscriptionLink?.Dispose();
+
+                if (e.Value.Count > 0)
+                {
+                    var sourceLinkOptions = new StandardRuleDataflowLinkOptions
+                    {
+                        RuleNames = s_designTimeBuildWatchedRules,
+                        PropagateCompletion = true
+                    };
+
+                    var disposableBag = new DisposableBag(CancellationToken.None);
+                    // We are taking source blocks from multiple configured projects and creating a SyncLink to combine the sources.
+                    // The SyncLink will only publish data when the versions of the sources match. There is a problem with that.
+                    // The sources have some version components that will make this impossible to match across TFMs. We introduce a 
+                    // intermediate block here that will remove those version components so that the synclink can actually sync versions. 
+                    var sourceBlocks = e.Value.Select(
+                        cp =>
+                        {
+                            var sourceBlock = cp.Services.ProjectSubscription.JointRuleSource.SourceBlock;
+                            var versionDropper = CreateVersionDropperBlock();
+                            disposableBag.AddDisposable(sourceBlock.LinkTo(versionDropper, sourceLinkOptions));
+                            return versionDropper.SyncLinkOptions<IProjectValueVersions>(sourceLinkOptions);
+                        });
+
+                    var target = new ActionBlock<Tuple<ImmutableList<IProjectValueVersions>, TIdentityDictionary>>(ProjectPropertyChangedAsync);
+
+                    var targetLinkOptions = new DataflowLinkOptions { PropagateCompletion = true };
+
+                    disposableBag.AddDisposable(ProjectDataSources.SyncLinkTo(sourceBlocks.ToImmutableList(), target, targetLinkOptions));
+
+                    _designTimeBuildSubscriptionLink = disposableBag;
+                }
+            }
+
+            private static IPropagatorBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>, IProjectVersionedValue<IProjectSubscriptionUpdate>> CreateVersionDropperBlock()
+            {
+                var transformBlock = new TransformBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>, IProjectVersionedValue<IProjectSubscriptionUpdate>>(data =>
+                {
+                    return new ProjectVersionedValue<IProjectSubscriptionUpdate>(data.Value, data.DataSourceVersions.RemoveRange(s_keysToDrop));
+                });
+
+                return transformBlock;
+            }
+
+            private Task ProjectPropertyChangedAsync(Tuple<ImmutableList<IProjectValueVersions>, TIdentityDictionary> sources)
+            {
+                IVsProjectRestoreInfo projectRestoreInfo = ProjectRestoreInfoBuilder.Build(sources.Item1, _projectVsServices.Project);
+
+                if (projectRestoreInfo != null)
+                {
+                    _projectVsServices.Project.Services.ProjectAsynchronousTasks
+                        .RegisterAsyncTask(JoinableFactory.RunAsync(async () =>
+                        {
+                            LogProjectRestoreInfo(_projectVsServices.Project.FullPath, projectRestoreInfo);
+
+                            await _solutionRestoreService
+                                   .NominateProjectAsync(_projectVsServices.Project.FullPath, projectRestoreInfo,
+                                        _projectVsServices.Project.Services.ProjectAsynchronousTasks.UnloadCancellationToken)
+                                   .ConfigureAwait(false);
+
+                            CodeMarkers.Instance.CodeMarker(CodeMarkerTimerId.PerfPackageRestoreEnd);
+
+                            CompleteLogProjectRestoreInfo(_projectVsServices.Project.FullPath);
+                        }),
+                        ProjectCriticalOperation.Build | ProjectCriticalOperation.Unload | ProjectCriticalOperation.Rename,
+                        registerFaultHandler: true);
+                }
+
+                return Task.CompletedTask;
+            }
+
+            #region ProjectRestoreInfo Logging
+
+            private void LogProjectRestoreInfo(string fullPath, IVsProjectRestoreInfo projectRestoreInfo)
+            {
+                if (_logger.IsEnabled)
+                {
+                    using (IProjectLoggerBatch logger = _logger.BeginBatch())
+                    {
+                        logger.WriteLine();
+                        logger.WriteLine("------------------------------------------");
+                        logger.WriteLine($"BEGIN Nominate Restore for {fullPath}");
+                        logger.IndentLevel++;
+
+                        logger.WriteLine($"BaseIntermediatePath:     {projectRestoreInfo.BaseIntermediatePath}");
+                        logger.WriteLine($"OriginalTargetFrameworks: {projectRestoreInfo.OriginalTargetFrameworks}");
+                        LogTargetFrameworks(logger, projectRestoreInfo.TargetFrameworks as TargetFrameworks);
+                        LogReferenceItems(logger, "Tool References", projectRestoreInfo.ToolReferences as ReferenceItems);
+
+                        logger.IndentLevel--;
+                        logger.WriteLine();
+                    }
+                }
+            }
+
+            private void CompleteLogProjectRestoreInfo(string fullPath)
+            {
+                if (_logger.IsEnabled)
+                {
+                    using (IProjectLoggerBatch logger = _logger.BeginBatch())
+                    {
+                        logger.WriteLine();
+                        logger.WriteLine("------------------------------------------");
+                        logger.WriteLine($"COMPLETED Nominate Restore for {fullPath}");
+                        logger.WriteLine();
+                    }
+                }
+            }
+
+            private void LogTargetFrameworks(IProjectLoggerBatch logger, TargetFrameworks targetFrameworks)
+            {
+                logger.WriteLine($"Target Frameworks ({targetFrameworks.Count})");
+                logger.IndentLevel++;
+
+                foreach (var tf in targetFrameworks)
+                {
+                    LogTargetFramework(logger, tf as TargetFrameworkInfo);
+                }
+                logger.IndentLevel--;
+            }
+
+            private void LogTargetFramework(IProjectLoggerBatch logger, TargetFrameworkInfo targetFrameworkInfo)
+            {
+                logger.WriteLine(targetFrameworkInfo.TargetFrameworkMoniker);
+                logger.IndentLevel++;
+
+                LogReferenceItems(logger, "Project References", targetFrameworkInfo.ProjectReferences as ReferenceItems);
+                LogReferenceItems(logger, "Package References", targetFrameworkInfo.PackageReferences as ReferenceItems);
+                LogProperties(logger, "Target Framework Properties", targetFrameworkInfo.Properties as ProjectProperties);
+
+                logger.IndentLevel--;
+            }
+
+            private void LogProperties(IProjectLoggerBatch logger, string heading, ProjectProperties projectProperties)
+            {
+                var properties = projectProperties.Cast<ProjectProperty>()
+                        .Select(prop => $"{prop.Name}:{prop.Value}");
+                logger.WriteLine($"{heading} -- ({string.Join(" | ", properties)})");
+            }
+
+            private void LogReferenceItems(IProjectLoggerBatch logger, string heading, ReferenceItems references)
+            {
+                logger.WriteLine(heading);
+                logger.IndentLevel++;
+
+                foreach (var reference in references)
+                {
+                    var properties = reference.Properties.Cast<ReferenceProperty>()
+                        .Select(prop => $"{prop.Name}:{prop.Value}");
+                    logger.WriteLine($"{reference.Name} -- ({string.Join(" | ", properties)})");
+                }
+
+                logger.IndentLevel--;
+            }
+
+            #endregion
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
@@ -1,42 +1,21 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Immutable;
 using System.ComponentModel.Composition;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Threading.Tasks.Dataflow;
-using Microsoft.Internal.Performance;
 using Microsoft.VisualStudio.ProjectSystem.Logging;
-using Microsoft.VisualStudio.ProjectSystem.Properties;
-using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using NuGet.SolutionRestoreManager;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
 {
-    using TIdentityDictionary = IImmutableDictionary<NamedIdentity, IComparable>;
-
-    internal class NuGetRestorer : OnceInitializedOnceDisposedAsync
+    [Export(ExportContractNames.Scopes.UnconfiguredProject, typeof(IProjectDynamicLoadComponent))]
+    [AppliesTo(ProjectCapability.PackageReferences)]
+    internal partial class NuGetRestorer : AbstractProjectDynamicLoadComponent
     {
         private readonly IUnconfiguredProjectVsServices _projectVsServices;
         private readonly IVsSolutionRestoreService _solutionRestoreService;
         private readonly IActiveConfigurationGroupService _activeConfigurationGroupService;
         private readonly IActiveConfiguredProjectSubscriptionService _activeConfiguredProjectSubscriptionService;
         private readonly IProjectLogger _logger;
-        private IDisposable _configurationsSubscription;
-        private DisposableBag _designTimeBuildSubscriptionLink;
         
-        private static ImmutableHashSet<string> s_designTimeBuildWatchedRules = Empty.OrdinalIgnoreCaseStringSet
-            .Add(NuGetRestore.SchemaName)
-            .Add(ProjectReference.SchemaName)
-            .Add(PackageReference.SchemaName)
-            .Add(DotNetCliToolReference.SchemaName);
-
-        // Remove the ConfiguredProjectIdentity key because it is unique to each configured project - so it won't match across projects by design.
-        // Remove the ConfiguredProjectVersion key because each configuredproject manages it's own version and generally they don't match. 
-        private readonly static ImmutableArray<NamedIdentity> s_keysToDrop = ImmutableArray.Create(ProjectDataSources.ConfiguredProjectIdentity, ProjectDataSources.ConfiguredProjectVersion);
-
         [ImportingConstructor]
         public NuGetRestorer(
             IUnconfiguredProjectVsServices projectVsServices,
@@ -53,192 +32,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             _logger = logger;
         }
 
-        [ProjectAutoLoad(startAfter: ProjectLoadCheckpoint.ProjectFactoryCompleted)]
-        [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
-        internal Task OnProjectFactoryCompletedAsync()
+        protected override AbstractProjectDynamicLoadInstance CreateInstance()
         {
-            return InitializeAsync();
+            return new NuGetRestorerInstance(_projectVsServices, _solutionRestoreService, _activeConfiguredProjectSubscriptionService, _activeConfigurationGroupService, _logger);
         }
-
-        protected override Task InitializeCoreAsync(CancellationToken cancellationToken)
-        {
-            Action<IProjectVersionedValue<IConfigurationGroup<ConfiguredProject>>> target = OnActiveConfigurationsChanged;
-
-            _configurationsSubscription = _activeConfigurationGroupService.ActiveConfiguredProjectGroupSource.SourceBlock.LinkTo(
-                target: new ActionBlock<IProjectVersionedValue<IConfigurationGroup<ConfiguredProject>>>(target),
-                linkOptions: new DataflowLinkOptions() { PropagateCompletion = true });
-
-            return Task.CompletedTask;
-        }
-
-        protected override Task DisposeCoreAsync(bool initialized)
-        {
-            _designTimeBuildSubscriptionLink?.Dispose();
-            _configurationsSubscription?.Dispose();
-            return Task.CompletedTask;
-        }
-
-        private void OnActiveConfigurationsChanged(IProjectVersionedValue<IConfigurationGroup<ConfiguredProject>> e)
-        {
-            if (IsDisposing || IsDisposed)
-                return;
-  
-            // Clean up past subscriptions
-            _designTimeBuildSubscriptionLink?.Dispose();
-
-            if (e.Value.Count > 0)
-            {
-                var sourceLinkOptions = new StandardRuleDataflowLinkOptions
-                {
-                    RuleNames = s_designTimeBuildWatchedRules,
-                    PropagateCompletion = true
-                };
-
-                var disposableBag = new DisposableBag(CancellationToken.None);
-                // We are taking source blocks from multiple configured projects and creating a SyncLink to combine the sources.
-                // The SyncLink will only publish data when the versions of the sources match. There is a problem with that.
-                // The sources have some version components that will make this impossible to match across TFMs. We introduce a 
-                // intermediate block here that will remove those version components so that the synclink can actually sync versions. 
-                var sourceBlocks = e.Value.Select(
-                    cp =>
-                    {
-                        var sourceBlock = cp.Services.ProjectSubscription.JointRuleSource.SourceBlock;
-                        var versionDropper = CreateVersionDropperBlock();
-                        disposableBag.AddDisposable(sourceBlock.LinkTo(versionDropper, sourceLinkOptions));
-                        return versionDropper.SyncLinkOptions<IProjectValueVersions>(sourceLinkOptions);
-                    });
-
-                var target = new ActionBlock<Tuple<ImmutableList<IProjectValueVersions>, TIdentityDictionary>>(ProjectPropertyChangedAsync);
-
-                var targetLinkOptions = new DataflowLinkOptions { PropagateCompletion = true };
-
-                disposableBag.AddDisposable(ProjectDataSources.SyncLinkTo(sourceBlocks.ToImmutableList(), target, targetLinkOptions));
-
-                _designTimeBuildSubscriptionLink = disposableBag;
-            }
-        }
-
-        private static IPropagatorBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>, IProjectVersionedValue<IProjectSubscriptionUpdate>> CreateVersionDropperBlock()
-        {
-            var transformBlock = new TransformBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>, IProjectVersionedValue<IProjectSubscriptionUpdate>>(data =>
-            {
-                return new ProjectVersionedValue<IProjectSubscriptionUpdate>(data.Value, data.DataSourceVersions.RemoveRange(s_keysToDrop));
-            });
-
-            return transformBlock;
-        }
-
-        private Task ProjectPropertyChangedAsync(Tuple<ImmutableList<IProjectValueVersions>, TIdentityDictionary> sources)
-        {
-            IVsProjectRestoreInfo projectRestoreInfo = ProjectRestoreInfoBuilder.Build(sources.Item1, _projectVsServices.Project);
-
-            if (projectRestoreInfo != null)
-            {
-                _projectVsServices.Project.Services.ProjectAsynchronousTasks
-                    .RegisterAsyncTask(JoinableFactory.RunAsync(async () =>
-                    {
-                        LogProjectRestoreInfo(_projectVsServices.Project.FullPath, projectRestoreInfo);
-
-                        await _solutionRestoreService
-                               .NominateProjectAsync(_projectVsServices.Project.FullPath, projectRestoreInfo,
-                                    _projectVsServices.Project.Services.ProjectAsynchronousTasks.UnloadCancellationToken)
-                               .ConfigureAwait(false);
-
-                        CodeMarkers.Instance.CodeMarker(CodeMarkerTimerId.PerfPackageRestoreEnd);
-
-                        CompleteLogProjectRestoreInfo(_projectVsServices.Project.FullPath);
-                    }),
-                    ProjectCriticalOperation.Build | ProjectCriticalOperation.Unload | ProjectCriticalOperation.Rename,
-                    registerFaultHandler: true);
-            }
-
-            return Task.CompletedTask;
-        }
-
-        #region ProjectRestoreInfo Logging
-
-        private void LogProjectRestoreInfo(string fullPath, IVsProjectRestoreInfo projectRestoreInfo)
-        {
-            if (_logger.IsEnabled)
-            {
-                using (IProjectLoggerBatch logger = _logger.BeginBatch())
-                {
-                    logger.WriteLine();
-                    logger.WriteLine("------------------------------------------");
-                    logger.WriteLine($"BEGIN Nominate Restore for {fullPath}");
-                    logger.IndentLevel++;
-
-                    logger.WriteLine($"BaseIntermediatePath:     {projectRestoreInfo.BaseIntermediatePath}");
-                    logger.WriteLine($"OriginalTargetFrameworks: {projectRestoreInfo.OriginalTargetFrameworks}");
-                    LogTargetFrameworks(logger, projectRestoreInfo.TargetFrameworks as TargetFrameworks);
-                    LogReferenceItems(logger, "Tool References", projectRestoreInfo.ToolReferences as ReferenceItems);
-
-                    logger.IndentLevel--;
-                    logger.WriteLine();
-                }
-            }
-        }
-
-        private void CompleteLogProjectRestoreInfo(string fullPath)
-        {
-            if (_logger.IsEnabled)
-            {
-                using (IProjectLoggerBatch logger = _logger.BeginBatch())
-                {
-                    logger.WriteLine();
-                    logger.WriteLine("------------------------------------------");
-                    logger.WriteLine($"COMPLETED Nominate Restore for {fullPath}");
-                    logger.WriteLine();
-                }
-            }
-        }
-
-        private void LogTargetFrameworks(IProjectLoggerBatch logger, TargetFrameworks targetFrameworks)
-        {
-            logger.WriteLine($"Target Frameworks ({targetFrameworks.Count})");
-            logger.IndentLevel++;
-
-            foreach (var tf in targetFrameworks)
-            {
-                LogTargetFramework(logger, tf as TargetFrameworkInfo);
-            }
-            logger.IndentLevel--;
-        }
-
-        private void LogTargetFramework(IProjectLoggerBatch logger, TargetFrameworkInfo targetFrameworkInfo)
-        {
-            logger.WriteLine(targetFrameworkInfo.TargetFrameworkMoniker);
-            logger.IndentLevel++;
-
-            LogReferenceItems(logger, "Project References", targetFrameworkInfo.ProjectReferences as ReferenceItems);
-            LogReferenceItems(logger, "Package References", targetFrameworkInfo.PackageReferences as ReferenceItems);
-            LogProperties(logger, "Target Framework Properties", targetFrameworkInfo.Properties as ProjectProperties);
-
-            logger.IndentLevel--;
-        }
-
-        private void LogProperties(IProjectLoggerBatch logger, string heading, ProjectProperties projectProperties)
-        {
-            var properties = projectProperties.Cast<ProjectProperty>()
-                    .Select(prop => $"{prop.Name}:{prop.Value}");
-            logger.WriteLine($"{heading} -- ({string.Join(" | ", properties)})");
-        }
-
-        private void LogReferenceItems(IProjectLoggerBatch logger, string heading, ReferenceItems references)
-        {
-            logger.WriteLine(heading);
-            logger.IndentLevel++;
-
-            foreach (var reference in references)
-            {
-                var properties = reference.Properties.Cast<ReferenceProperty>()
-                    .Select(prop => $"{prop.Name}:{prop.Value}");
-                logger.WriteLine($"{reference.Name} -- ({string.Join(" | ", properties)})");
-            }
-
-            logger.IndentLevel--;
-        }
-
-        #endregion
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
@@ -21,11 +21,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
     {
         private readonly IUnconfiguredProjectVsServices _projectVsServices;
         private readonly IVsSolutionRestoreService _solutionRestoreService;
-        private readonly IActiveConfiguredProjectsProvider _activeConfiguredProjectsProvider;
+        private readonly IActiveConfigurationGroupService _activeConfigurationGroupService;
         private readonly IActiveConfiguredProjectSubscriptionService _activeConfiguredProjectSubscriptionService;
-        private readonly IActiveProjectConfigurationRefreshService _activeProjectConfigurationRefreshService;
         private readonly IProjectLogger _logger;
-        private IDisposable _targetFrameworkSubscriptionLink;
+        private IDisposable _configurationsSubscription;
         private DisposableBag _designTimeBuildSubscriptionLink;
         
 
@@ -47,16 +46,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             IUnconfiguredProjectVsServices projectVsServices,
             IVsSolutionRestoreService solutionRestoreService,
             IActiveConfiguredProjectSubscriptionService activeConfiguredProjectSubscriptionService,
-            IActiveProjectConfigurationRefreshService activeProjectConfigurationRefreshService,
-            IActiveConfiguredProjectsProvider activeConfiguredProjectsProvider,
+            IActiveConfigurationGroupService activeConfigurationGroupService,
             IProjectLogger logger) 
             : base(projectVsServices.ThreadingService.JoinableTaskContext)
         {
             _projectVsServices = projectVsServices;
             _solutionRestoreService = solutionRestoreService;
             _activeConfiguredProjectSubscriptionService = activeConfiguredProjectSubscriptionService;
-            _activeProjectConfigurationRefreshService = activeProjectConfigurationRefreshService;
-            _activeConfiguredProjectsProvider = activeConfiguredProjectsProvider;
+            _activeConfigurationGroupService = activeConfigurationGroupService;
             _logger = logger;
         }
 
@@ -64,55 +61,36 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
         internal Task OnProjectFactoryCompletedAsync()
         {
-            // set up a subscription to listen for target framework changes
-            var target = new ActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(e => OnProjectChangedAsync(e));
-            _targetFrameworkSubscriptionLink = _activeConfiguredProjectSubscriptionService.ProjectRuleSource.SourceBlock.LinkTo(
-                target: target,
-                ruleNames: s_targetFrameworkWatchedRules,
-                initialDataAsNew: false, // only reset on subsequent changes
-                suppressVersionOnlyUpdates: true);
+            return InitializeAsync();
+        }
+
+        protected override Task InitializeCoreAsync(CancellationToken cancellationToken)
+        {
+            Action<IProjectVersionedValue<IConfigurationGroup<ConfiguredProject>>> target = OnActiveConfigurationsChanged;
+
+            _configurationsSubscription = _activeConfigurationGroupService.ActiveConfiguredProjectGroupSource.SourceBlock.LinkTo(
+                target: new ActionBlock<IProjectVersionedValue<IConfigurationGroup<ConfiguredProject>>>(target),
+                linkOptions: new DataflowLinkOptions() { PropagateCompletion = true });
 
             return Task.CompletedTask;
-        }
-
-        private async Task OnProjectChangedAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update)
-        {
-            if (IsDisposing || IsDisposed)
-                return;
-
-            await InitializeAsync().ConfigureAwait(false);
-
-            // when TargetFrameworks or TargetFrameworkMoniker changes, reset subscriptions so that
-            // any new configured projects are picked up
-            if (HasTargetFrameworkChanged(update))
-            {
-                await ResetSubscriptionsAsync().ConfigureAwait(false);
-            }
-        }
-
-        protected override async Task InitializeCoreAsync(CancellationToken cancellationToken)
-        {
-            await ResetSubscriptionsAsync().ConfigureAwait(false);
         }
 
         protected override Task DisposeCoreAsync(bool initialized)
         {
             _designTimeBuildSubscriptionLink?.Dispose();
-            _targetFrameworkSubscriptionLink?.Dispose();
+            _configurationsSubscription?.Dispose();
             return Task.CompletedTask;
         }
 
-        private async Task ResetSubscriptionsAsync()
+        private void OnActiveConfigurationsChanged(IProjectVersionedValue<IConfigurationGroup<ConfiguredProject>> e)
         {
-            // active configuration should be updated before resetting subscriptions
-            await RefreshActiveConfigurationAsync().ConfigureAwait(false);
-
+            if (IsDisposing || IsDisposed)
+                return;
+  
+            // Clean up past subscriptions
             _designTimeBuildSubscriptionLink?.Dispose();
 
-            var currentProjects = await _activeConfiguredProjectsProvider.GetActiveConfiguredProjectsAsync()
-                                                                         .ConfigureAwait(false);
-
-            if (currentProjects != null)
+            if (e.Value.Count > 0)
             {
                 var sourceLinkOptions = new StandardRuleDataflowLinkOptions
                 {
@@ -125,8 +103,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
                 // The SyncLink will only publish data when the versions of the sources match. There is a problem with that.
                 // The sources have some version components that will make this impossible to match across TFMs. We introduce a 
                 // intermediate block here that will remove those version components so that the synclink can actually sync versions. 
-                var sourceBlocks = currentProjects.Objects.Select(
-                    cp => 
+                var sourceBlocks = e.Value.Select(
+                    cp =>
                     {
                         var sourceBlock = cp.Services.ProjectSubscription.JointRuleSource.SourceBlock;
                         var versionDropper = CreateVersionDropperBlock();
@@ -152,13 +130,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             });
 
             return transformBlock;
-        }
-        
-        private async Task RefreshActiveConfigurationAsync()
-        {
-            // Force refresh the CPS active project configuration (needs UI thread).
-            await _projectVsServices.ThreadingService.SwitchToUIThread();
-            await _activeProjectConfigurationRefreshService.RefreshActiveProjectConfigurationAsync().ConfigureAwait(false);
         }
 
         private Task ProjectPropertyChangedAsync(Tuple<ImmutableList<IProjectValueVersions>, TIdentityDictionary> sources)
@@ -186,18 +157,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             }
 
             return Task.CompletedTask;
-        }
-
-        private static bool HasTargetFrameworkChanged(IProjectVersionedValue<IProjectSubscriptionUpdate> update)
-        {
-            if (update.Value.ProjectChanges.TryGetValue(NuGetRestore.SchemaName, out IProjectChangeDescription projectChange))
-            {
-                var changedProperties = projectChange.Difference.ChangedProperties;
-                return changedProperties.Contains(NuGetRestore.TargetFrameworksProperty)
-                    || changedProperties.Contains(NuGetRestore.TargetFrameworkProperty)
-                    || changedProperties.Contains(NuGetRestore.TargetFrameworkMonikerProperty);
-            }
-            return false;
         }
 
         #region ProjectRestoreInfo Logging

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/NuGetRestorer.cs
@@ -27,10 +27,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         private IDisposable _configurationsSubscription;
         private DisposableBag _designTimeBuildSubscriptionLink;
         
-
-        private static ImmutableHashSet<string> s_targetFrameworkWatchedRules = Empty.OrdinalIgnoreCaseStringSet
-            .Add(NuGetRestore.SchemaName);
-
         private static ImmutableHashSet<string> s_designTimeBuildWatchedRules = Empty.OrdinalIgnoreCaseStringSet
             .Add(NuGetRestore.SchemaName)
             .Add(ProjectReference.SchemaName)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractProjectDynamicLoadComponent.AbstractProjectDynamicLoadInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractProjectDynamicLoadComponent.AbstractProjectDynamicLoadInstance.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    partial class AbstractProjectDynamicLoadComponent
+    {
+        /// <summary>
+        ///     Represents an instance that is automatically initialized when its parent
+        ///     <see cref="IProjectDynamicLoadComponent"/> instance's capabilities requirements are 
+        ///     satisfied, or disposed when they are not.
+        /// </summary>
+        protected abstract class AbstractProjectDynamicLoadInstance : OnceInitializedOnceDisposedAsync
+        {
+            protected AbstractProjectDynamicLoadInstance(JoinableTaskContextNode joinableTaskContextNode) 
+                : base(joinableTaskContextNode)
+            {
+            }
+
+            /// <summary>
+            ///     Initializes the <see cref="AbstractProjectDynamicLoadInstance"/>.
+            /// </summary>
+            public Task InitializeAsync()
+            {
+                return InitializeAsync(CancellationToken.None);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractProjectDynamicLoadComponent.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractProjectDynamicLoadComponent.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    /// <summary>
+    ///     An <see langword="abstract"/> base class that simplifies the lifetime of a
+    ///     <see cref="IProjectDynamicLoadComponent"/> implementation.
+    /// </summary>
+    internal abstract partial class AbstractProjectDynamicLoadComponent : IProjectDynamicLoadComponent
+    {
+        private readonly object _lock = new object();
+        private AbstractProjectDynamicLoadInstance _instance;
+
+        protected AbstractProjectDynamicLoadComponent()
+        {
+        }
+
+        public Task LoadAsync()
+        {
+            AbstractProjectDynamicLoadInstance instance;
+            lock (_lock)
+            {
+                if (_instance == null)
+                {
+                    _instance = CreateInstance();
+                }
+
+                instance = _instance;
+            }
+
+            return instance.InitializeAsync();
+        }
+
+        
+        public Task UnloadAsync()
+        {
+            AbstractProjectDynamicLoadInstance instance = null;
+
+            lock (_lock)
+            {
+                if (_instance != null)
+                {
+                    instance = _instance;
+                    _instance = null;
+                }
+            }
+
+            if (instance != null)
+            {
+                return instance.DisposeAsync();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        ///     Creates a new instance of the underlying <see cref="AbstractProjectDynamicLoadInstance"/>.
+        /// </summary>
+        protected abstract AbstractProjectDynamicLoadInstance CreateInstance();
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapability.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapability.cs
@@ -31,6 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public const string ReferenceManagerSharedProjects = nameof(ReferenceManagerSharedProjects);
         public const string ReferenceManagerWinRT = nameof(ReferenceManagerWinRT);
         public const string Pack = nameof(Pack); // Keep this in sync with Microsoft.VisualStudio.Editors.ProjectCapability.Pack
+        public const string PackageReferences = ProjectCapabilities.PackageReferences;
         public const string PreserveFormatting = nameof(PreserveFormatting);
         public const string ProjectConfigurationsDeclaredDimensions = ProjectCapabilities.ProjectConfigurationsDeclaredDimensions;
         public const string LanguageService = ProjectCapabilities.LanguageService;


### PR DESCRIPTION
Turns NuGetRestorer into a dynamic component based on the PackageReferences capability.

This is replacement of https://github.com/dotnet/project-system/pull/2479 by @jmarolf.

Fixes: #2231 and first item of #2491.

Note this includes https://github.com/dotnet/project-system/pull/3093, so only review from https://github.com/dotnet/project-system/pull/3097/commits/799fdabd1e5ff1619c60c2d5c497aa180f268a2c onwards.

  
  