### PR TITLE
[WIP] Add a ProjectDefaultConfigurationProvider to guess the default configuration

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/IProjectConfigurationDimensionsProvider3.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/IProjectConfigurationDimensionsProvider3.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Configuration
+{
+    internal interface IProjectConfigurationDimensionsProvider3
+    {
+        /// <summary>
+        ///     Gets the default values for project configuration dimensions for the given unconfigured
+        ///     project.
+        /// </summary>
+        /// <param name="project">
+        ///     Unconfigured project.
+        /// </param>
+        /// <returns></returns>
+        /// <remarks>
+        ///     Implementors of this method must implement it without evaluating the project and it 
+        ///     results are not guaranteed to be accurate.
+        /// </remarks>
+        Task<IEnumerable<KeyValuePair<string, string>>> GetBestGuessDefaultValuesForDimensionsAsync(UnconfiguredProject project);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/ProjectDefaultConfigurationProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/ProjectDefaultConfigurationProvider.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Linq;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Configuration
+{
+    /// <summary>
+    ///     Attempts to calculate the default configuration of a project without evaluating or loading any unneeded configurations.
+    /// </summary>
+    [Export(typeof(IProjectDefaultConfigurationProvider))]
+    [AppliesTo(ProjectCapabilities.ProjectConfigurationsDeclaredDimensions)]
+    [Order(Order.Default)]
+    internal class ProjectDefaultConfigurationProvider : IProjectDefaultConfigurationProvider
+    {
+        private readonly UnconfiguredProject _project;
+        private readonly IProjectThreadingService _threadingService;
+
+        [ImportingConstructor]
+        public ProjectDefaultConfigurationProvider(UnconfiguredProject project, IProjectThreadingService threadingService)
+        {
+            _project = project;
+            _threadingService = threadingService;
+
+            DimensionsProviders = new OrderPrecedenceImportCollection<IProjectConfigurationDimensionsProvider>(projectCapabilityCheckProvider: project);
+        }
+
+        [ImportMany]
+        public OrderPrecedenceImportCollection<IProjectConfigurationDimensionsProvider> DimensionsProviders
+        {
+            get;
+        }
+
+        public ProjectConfiguration GetDefaultConfiguration(IMinimalProjectConfiguration projectConfiguration)
+        {
+            return _threadingService.ExecuteSynchronously(() => GetDefaultConfigurationAsync(projectConfiguration));
+        }
+
+        private async Task<ProjectConfiguration> GetDefaultConfigurationAsync(IMinimalProjectConfiguration projectConfiguration)
+        {
+            IEnumerable<KeyValuePair<string, string>> defaultValues = await GetDefaultValuesForDimensionsAsync().ConfigureAwait(false);
+
+            string name = string.Join("|", defaultValues.Select(defaultValue => defaultValue.Value));
+            IImmutableDictionary<string, string> dimensions = ConvertDefaultValuesToDimensionsMap(defaultValues, projectConfiguration);
+
+            return new StandardProjectConfiguration(name, dimensions);
+        }
+
+        private async Task<IEnumerable<KeyValuePair<string, string>>> GetDefaultValuesForDimensionsAsync()
+        {
+            // Walk through each dimension provider and get them provide their best guess of 
+            // the defaults of their dimensions without actually evaluating the project
+            
+            var allDefaultValues = new List<KeyValuePair<string, string>>();
+
+            IEnumerable<IProjectConfigurationDimensionsProvider3> providers = DimensionsProviders.Select(p => p.Value)
+                                                                                                 .OfType<IProjectConfigurationDimensionsProvider3>();
+
+            foreach (IProjectConfigurationDimensionsProvider3 provider in providers)
+            {
+                IEnumerable<KeyValuePair<string, string>> defaultValues = await provider.GetBestGuessDefaultValuesForDimensionsAsync(_project)
+                                                                                        .ConfigureAwait(false);
+
+                allDefaultValues.AddRange(defaultValues);
+            }
+
+            return allDefaultValues;
+        }
+
+        private static IImmutableDictionary<string, string> ConvertDefaultValuesToDimensionsMap(IEnumerable<KeyValuePair<string, string>> defaultValues, IMinimalProjectConfiguration projectConfiguration)
+        {
+            ImmutableDictionary<string, string> dimensions = Empty.PropertiesMap;
+
+            foreach (KeyValuePair<string, string> defaultValue in defaultValues)
+            {
+                dimensions = dimensions.SetItem(defaultValue.Key, defaultValue.Value);
+            }
+
+            if (projectConfiguration != null)
+            {   // Solution provided a default configuration based on what it was when the solution closed, use its
+                // version of the configuration/platform which is likely more accurate than our providers' defaults
+
+                dimensions = dimensions.SetItem(ConfigurationGeneral.ConfigurationProperty, projectConfiguration.Configuration)
+                                       .SetItem(ConfigurationGeneral.PlatformProperty, projectConfiguration.Platform);
+            }
+
+            return dimensions;
+        }
+    }
+}


### PR DESCRIPTION
To determine the configurations when loading a project, we need to read the project for the dimensions (the `<Configurations>`, `<Platforms>` and `<TargetFrameworks>` properties). This leads to a chicken and egg problem; to figure out all configurations for a given project you need to load at least one configuration to evaluate. This results us loading an empty configuration (called "NoVariablesDefault") just to grab the actual real configurations, see: https://github.com/dotnet/project-system/issues/2711.

To avoid unnecessarily loading this unneeded config, this class attempts to best guess what the default configuration will be based on two inputs;

- What the solution says is the current configuration
- The "default values" of the dimensions. For example, the default value of "Platform" would either be the first value in the  `<Platforms />` property or "AnyCPU" if inheriting configs from the SDK.

We want to attempt to do the second without actually evaluating a configuration, so I've introduced a new version of IProjectConfigurationDimensionsProvider3 that adds an additional method for "best guessing" the default without evaluating. The idea is that this takes raw XML value or if missing in the case of configuration/platform, just returns a hardcoded default.

TODO:

- [ ] Implement IProjectConfigurationDimensionsProvider3 for our existing providers
- [ ] Determine where this lives. I believe this is a CPS concept and should live in CPS. We'll likely move it there for 15.7.
- [ ] Tests
