### PR TITLE
Add IProjectAccessor as replacement for IProjectXmlAccessor

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectAccessor.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
+using Microsoft.VisualStudio.Composition;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    /// <summary>
+    ///     A project-service level component that provides methods for accessing the MSBuild evaluation and 
+    ///     construction models for a <see cref="UnconfiguredProject"/> or <see cref="ConfiguredProject"/>.
+    /// </summary>
+    [ProjectSystemContract(ProjectSystemContractScope.ProjectService, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
+    internal interface IProjectAccessor
+    {
+        /// <summary>
+        ///     Opens the MSBuild project construction model for the specified project, passing it to the specified action for reading.
+        /// </summary>
+        /// <param name="project">
+        ///     The <see cref="UnconfiguredProject"/> whose underlying MSBuild object model is required.
+        /// </param>
+        /// <param name="action">
+        ///     The <see cref="Func{T, TResult}"/> to run while holding the lock.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A token whose cancellation signals lost interest in the result.
+        /// </param>
+        /// <returns>
+        ///     The result of executing <paramref name="action"/> over the <see cref="ProjectRootElement"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="project"/> is <see langword="null"/>.
+        ///     <para>
+        ///         -or-
+        ///     </para>
+        ///     <paramref name="action"/> is <see langword="null"/>.
+        /// </exception>
+        Task<TResult> OpenProjectXmlForReadAsync<TResult>(UnconfiguredProject project, Func<ProjectRootElement, TResult> action, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        ///     Opens the MSBuild project construction model for the specified project, passing it to the specified action for writing.
+        /// </summary>
+        /// <param name="project">
+        ///     The <see cref="UnconfiguredProject"/> whose underlying MSBuild object model is required.
+        /// </param>
+        /// <param name="action">
+        ///     The <see cref="Action{T}"/> to run while holding the lock.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A token whose cancellation signals lost interest in the result.
+        /// </param>
+        /// <returns>
+        ///     The result of executing <paramref name="action"/> over the <see cref="ProjectRootElement"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="project"/> is <see langword="null"/>.
+        ///     <para>
+        ///         -or-
+        ///     </para>
+        ///     <paramref name="action"/> is <see langword="null"/>.
+        /// </exception>
+        Task OpenProjectXmlForWriteAsync(UnconfiguredProject project, Action<ProjectRootElement> action, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        ///     Opens the MSBuild project evaluation model for the specified project, passing it to the specified action for reading.
+        /// </summary>
+        /// <param name="project">
+        ///     The <see cref="ConfiguredProject"/> whose underlying MSBuild object model is required.
+        /// </param>
+        /// <param name="action">
+        ///     The <see cref="Func{T, TResult}"/> to run while holding the lock.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A token whose cancellation signals lost interest in the result.
+        /// </param>
+        /// <returns>
+        ///     The result of executing <paramref name="action"/> over the <see cref="Project"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="project"/> is <see langword="null"/>.
+        ///     <para>
+        ///         -or-
+        ///     </para>
+        ///     <paramref name="action"/> is <see langword="null"/>.
+        /// </exception>
+        Task<TResult> OpenProjectForReadAsync<TResult>(ConfiguredProject project, Func<Project, TResult> action, CancellationToken cancellationToken = default(CancellationToken));
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectAccessor.cs
@@ -38,6 +38,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
         ///     </para>
         ///     <paramref name="action"/> is <see langword="null"/>.
         /// </exception>
+        /// <remarks>
+        ///     NOTE: To avoid deadlocks, do not call arbitrary services or asynchronous code within <paramref name="action"/>.
+        /// </remarks>
         Task<TResult> OpenProjectXmlForReadAsync<TResult>(UnconfiguredProject project, Func<ProjectRootElement, TResult> action, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
@@ -62,6 +65,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
         ///     </para>
         ///     <paramref name="action"/> is <see langword="null"/>.
         /// </exception>
+        /// <remarks>
+        ///     NOTE: To avoid deadlocks, do not call arbitrary services or asynchronous code within <paramref name="action"/>.
+        /// </remarks>
         Task OpenProjectXmlForWriteAsync(UnconfiguredProject project, Action<ProjectRootElement> action, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
@@ -86,6 +92,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
         ///     </para>
         ///     <paramref name="action"/> is <see langword="null"/>.
         /// </exception>
+        /// <remarks>
+        ///     NOTE: To avoid deadlocks, do not call arbitrary services or asynchronous code within <paramref name="action"/>.
+        /// </remarks>
         Task<TResult> OpenProjectForReadAsync<TResult>(ConfiguredProject project, Func<Project, TResult> action, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectAccessor.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    /// <summary>
+    ///     Provides an implementation of <see cref="IProjectAccessor"/> that delegates onto
+    ///     the <see cref="IProjectLockService"/>.
+    /// </summary>
+    [Export(typeof(IProjectAccessor))]
+    internal class ProjectAccessor : IProjectAccessor
+    {
+        // NOTE: It is very deliberate that we ConfigureAwait(true) in this class to switch 
+        // back to the thread type ("threadpool") where XXXLockAsync switched us too.
+
+        private readonly IProjectLockService _projectLockService;
+
+        [ImportingConstructor]
+        public ProjectAccessor(IProjectLockService projectLockService)
+        {
+            _projectLockService = projectLockService;
+        }
+
+        public async Task<TResult> OpenProjectForReadAsync<TResult>(ConfiguredProject project, Func<Project, TResult> action, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Requires.NotNull(project, nameof(project));
+            Requires.NotNull(project, nameof(action));
+
+            using (ProjectLockReleaser access = await _projectLockService.ReadLockAsync(cancellationToken))
+            {
+                Project evaluatedProject = await access.GetProjectAsync(project, cancellationToken)
+                                                       .ConfigureAwait(true);
+
+                // Deliberately not async to reduce the type of
+                // code you can run while holding the lock.
+                return action(evaluatedProject);
+            }
+        }
+
+        public async Task<TResult> OpenProjectXmlForReadAsync<TResult>(UnconfiguredProject project, Func<ProjectRootElement, TResult> action, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Requires.NotNull(project, nameof(project));
+            Requires.NotNull(project, nameof(action));
+
+            using (ProjectLockReleaser access = await _projectLockService.ReadLockAsync(cancellationToken))
+            {
+                ProjectRootElement rootElement = await access.GetProjectXmlAsync(project.FullPath, cancellationToken)
+                                                             .ConfigureAwait(true);
+
+                // Deliberately not async to reduce the type of
+                // code you can run while holding the lock.
+                return action(rootElement);
+            }
+        }
+
+        public async Task OpenProjectXmlForWriteAsync(UnconfiguredProject project, Action<ProjectRootElement> action, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Requires.NotNull(project, nameof(project));
+            Requires.NotNull(project, nameof(action));
+
+            using (ProjectWriteLockReleaser access = await _projectLockService.WriteLockAsync(cancellationToken))
+            {
+                await access.CheckoutAsync(project.FullPath)
+                            .ConfigureAwait(true);
+
+                ProjectRootElement rootElement = await access.GetProjectXmlAsync(project.FullPath, cancellationToken)
+                                                             .ConfigureAwait(true);
+
+                // Deliberately not async to reduce the type of
+                // code you can run while holding the lock.
+                action(rootElement);
+            }
+        }
+    }
+}


### PR DESCRIPTION
IProjectXmlAccessor is an unconfigured project service that also acts upon other different unconfigured projects, as well as a grab bag of methods that should just be extension methods on a core API. It was added so that we could unit test taking a lock and has organically grown. This API is stab at pulling out the core pieces of which extension methods/helpers can be built on top.

Future PRs will replace IProjectXmlAccessor usage.

NOTE: This helper exists because the APIs are not unit testable, hence there are no unit tests.
  
  