### PR TITLE
Don't instantiate up to date for shared projects

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -99,7 +99,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         /// Called on project load.
         /// </summary>
         [ConfiguredProjectAutoLoad]
-        [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
+        [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp + "+ !" + ProjectCapabilities.SharedAssetsProject)]
         internal void Load()
         {
             EnsureInitialized();


### PR DESCRIPTION
**Customer scenario**

When creating a shared project, there is a NullReferenceException in the up to date checker.

**Bugs this fixes:** 

#3096

**Workarounds, if any**

None.

**Risk**

Low, fixes a null reference exception by not pre-loading the up to date checker for shared projects.

**Performance impact**

None.

**Is this a regression from a previous update?**

Yes,

**Root cause analysis:**

We have a work item to create a test for up to date. #2452 

**How was the bug found?**

Ad hoc testing.