### PR TITLE
Update RepoToolset to 1.0.0-beta-62506-01

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -9,7 +9,7 @@
     <UsingToolIbcOptimization>true</UsingToolIbcOptimization>
 
     <!-- Toolset -->
-    <RoslynToolsRepoToolsetVersion>1.0.0-beta-62503-02</RoslynToolsRepoToolsetVersion>
+    <RoslynToolsRepoToolsetVersion>1.0.0-beta-62506-01</RoslynToolsRepoToolsetVersion>
     <RoslynToolsVsixExpInstallerVersion>1.0.0-beta-62503-02</RoslynToolsVsixExpInstallerVersion>
     <RoslynDependenciesProjectSystemOptimizationDataVersion>2.6.0-beta1-62205-02</RoslynDependenciesProjectSystemOptimizationDataVersion>
     <VSWhereVersion>2.1.4</VSWhereVersion>


### PR DESCRIPTION
**Customer scenario**

1) Fixes issue with publishing insertion manifests, which is blocking insertion.

2) Updates PDB converter to the latest version. This new version includes SourceLink in the converted Windows PDBs along with legacy srcsvr info. The former is picked up by VS Debugger the latter by WinDBG (which ignores SourceLink). This change will allow to debug Roslyn with Windows PDBs without enabling legacy srcsvr in VS debugger options.

**Bugs this fixes:** 

**Workarounds, if any**

**Risk**

Small.

**Performance impact**

None.

**Is this a regression from a previous update?**

**Root cause analysis:**

**How was the bug found?**

