### PR TITLE
Move SupportedTargetFrameworksEnumValuesGenerator to use IProjectAccessor

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectAccessorFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectAccessorFactory.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class IProjectAccessorFactory
+    {
+        public static IProjectAccessor Create()
+        {
+            return Mock.Of<IProjectAccessor>();
+        }
+
+        public static IProjectAccessor ImplementOpenProjectForReadAsync<TResult>(string xml)
+        {
+            var rootElement = ProjectRootElementFactory.Create(xml);
+            var evaluationProject = ProjectFactory.Create(rootElement);
+
+            var mock = new Mock<IProjectAccessor>();
+            mock.Setup(a => a.OpenProjectForReadAsync(It.IsAny<ConfiguredProject>(), It.IsAny<Func<Project, TResult>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((ConfiguredProject project, Func<Project, TResult> action, CancellationToken cancellationToken) =>
+                {
+                    return action(evaluationProject);
+                });
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectXmlAccessorFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectXmlAccessorFactory.cs
@@ -16,15 +16,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public static IProjectXmlAccessor Create() => Mock.Of<IProjectXmlAccessor>();
 
-        public static IProjectXmlAccessor ImplementGetProjectXml(string xml) => Implement(() => xml);
-
-        public static IProjectXmlAccessor Implement(Func<string> xmlFunc)
-        {
-            var mock = new Mock<IProjectXmlAccessor>();
-            mock.Setup(m => m.GetProjectXmlAsync()).Returns(() => Task.FromResult(xmlFunc()));
-            return mock.Object;
-        }
-
         public static IProjectXmlAccessor Create(ProjectRootElement msbuildProject)
         {
             var mock = new Mock<IProjectXmlAccessor>();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectXmlAccessorFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectXmlAccessorFactory.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Build.Construction;
@@ -39,22 +38,5 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             return mock.Object;
         }
-
-        public static IProjectXmlAccessor WithItems(string itemType, string metadataName, ICollection<(string name, string metadataValue)> items)
-        {
-            var mock = new Mock<IProjectXmlAccessor>();
-
-            mock.Setup(m => m.GetItems(
-                It.IsAny<ConfiguredProject>(), 
-                It.Is<string>((t) => string.Equals(t, itemType)),
-                It.Is<string>((t) => string.Equals(t, metadataName))))
-                .Returns<ConfiguredProject, string, string>((configuredProject, innerItemType, innerMetadataName) =>
-                {
-                    return Task.FromResult(items);
-                });
-
-            return mock.Object;
-        }
-
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectFactory.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.Build.Construction;
+
+namespace Microsoft.Build.Evaluation
+{
+    internal static class ProjectFactory
+    {
+        public static Project Create(ProjectRootElement rootElement)
+        {
+            return new Project(rootElement);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/SupportedTargetFrameworksEnumProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/SupportedTargetFrameworksEnumProviderTests.cs
@@ -12,10 +12,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     public class SupportedTargetFrameworksEnumProviderTests
     {
         [Fact]
-        public void Constructor_NullProjectXmlAccessor_ThrowsArgumentNullException()
+        public void Constructor_NullProjectAccessor_ThrowsArgumentNullException()
         {
             var configuredProject = ConfiguredProjectFactory.Create();
-            Assert.Throws<ArgumentNullException>("projectXmlAccessor", () =>
+            Assert.Throws<ArgumentNullException>("projectAccessor", () =>
             {
                 new SupportedTargetFrameworksEnumProvider(null, configuredProject);
             });
@@ -24,21 +24,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [Fact]
         public void Constructor_NullConfiguredProject_ThrowsArgumentNullException()
         {
-            var projectXmlAccessor = IProjectXmlAccessorFactory.Create();
+            var projectAccessor = IProjectAccessorFactory.Create();
 
             Assert.Throws<ArgumentNullException>("configuredProject", () =>
             {
-                new SupportedTargetFrameworksEnumProvider(projectXmlAccessor, null);
+                new SupportedTargetFrameworksEnumProvider(projectAccessor, null);
             });
         }
 
         [Fact]
         public async Task Constructor()
         {
-            var projectXmlAccessor = IProjectXmlAccessorFactory.Create();
+            var projectAccessor = IProjectAccessorFactory.Create();
             var configuredProject = ConfiguredProjectFactory.Create();
 
-            var provider = new SupportedTargetFrameworksEnumProvider(projectXmlAccessor, configuredProject);
+            var provider = new SupportedTargetFrameworksEnumProvider(projectAccessor, configuredProject);
             var generator = await provider.GetProviderAsync(null);
 
             Assert.NotNull(generator);
@@ -47,14 +47,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [Fact]
         public async Task GetListedValues()
         {
-            var projectXmlAccessor = IProjectXmlAccessorFactory.WithItems("SupportedTargetFramework", "DisplayName", new[] {
-                (name: ".NETCoreApp,Version=v1.0", metadataValue: ".NET Core 1.0"),
-                (name: ".NETCoreApp,Version=v1.1", metadataValue: ".NET Core 1.1"),
-                (name: ".NETCoreApp,Version=v2.0", metadataValue: ".NET Core 2.0"),
-            });
+            string project = 
+@"<Project>
+    <ItemGroup>
+        <SupportedTargetFramework Include="".NETCoreApp,Version=v1.0"" DisplayName="".NET Core 1.0"" />
+        <SupportedTargetFramework Include="".NETCoreApp,Version=v1.1"" DisplayName="".NET Core 1.1"" />
+        <SupportedTargetFramework Include="".NETCoreApp,Version=v2.0"" DisplayName="".NET Core 2.0"" />
+    </ItemGroup>
+</Project>";
+
+            var projectAccessor = IProjectAccessorFactory.ImplementOpenProjectForReadAsync<ICollection<IEnumValue>>(project);
+
             var configuredProject = ConfiguredProjectFactory.Create();
 
-            var provider = new SupportedTargetFrameworksEnumProvider(projectXmlAccessor, configuredProject);
+            var provider = new SupportedTargetFrameworksEnumProvider(projectAccessor, configuredProject);
             var generator = await provider.GetProviderAsync(null);
             var values = await generator.GetListedValuesAsync();
 
@@ -66,10 +72,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [Fact]
         public async Task TryCreateEnumValue()
         {
-            var projectXmlAccessor = IProjectXmlAccessorFactory.Create();
+            var projectAccessor = IProjectAccessorFactory.Create();
             var configuredProject = ConfiguredProjectFactory.Create();
 
-            var provider = new SupportedTargetFrameworksEnumProvider(projectXmlAccessor, configuredProject);
+            var provider = new SupportedTargetFrameworksEnumProvider(projectAccessor, configuredProject);
             var generator = await provider.GetProviderAsync(null);
 
             Assert.Throws<NotImplementedException>(() =>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/SupportedTargetFrameworksEnumProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/SupportedTargetFrameworksEnumProviderTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     public class SupportedTargetFrameworksEnumProviderTests
     {
         [Fact]
-        public void Constructor_NullProjectAccessor_ThrowsArgumentNullException()
+        public void Constructor_NullProjectAccessor_ThrowsArgumentNull()
         {
             var configuredProject = ConfiguredProjectFactory.Create();
             Assert.Throws<ArgumentNullException>("projectAccessor", () =>
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         }
 
         [Fact]
-        public void Constructor_NullConfiguredProject_ThrowsArgumentNullException()
+        public void Constructor_NullConfiguredProject_ThrowsArgumentNull()
         {
             var projectAccessor = IProjectAccessorFactory.Create();
 
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         }
 
         [Fact]
-        public async Task Constructor()
+        public async Task GetProviderAsync_ReturnsNonNullGenerator()
         {
             var projectAccessor = IProjectAccessorFactory.Create();
             var configuredProject = ConfiguredProjectFactory.Create();
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         }
 
         [Fact]
-        public async Task GetListedValues()
+        public async Task GetListedValuesAsync_ReturnsSupportedTargetFrameworksItems()
         {
             string project = 
 @"<Project>
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         }
 
         [Fact]
-        public async Task TryCreateEnumValue()
+        public async Task TryCreateEnumValueAsync_ThrowsNotImplemented()
         {
             var projectAccessor = IProjectAccessorFactory.Create();
             var configuredProject = ConfiguredProjectFactory.Create();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectXmlAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectXmlAccessor.cs
@@ -13,12 +13,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
     internal interface IProjectXmlAccessor
     {
         /// <summary>
-        /// Gets the XML for a given unconfigured project.
-        /// </summary>
-        /// <returns>XML content of the project.</returns>
-        Task<string> GetProjectXmlAsync();
-
-        /// <summary>
         /// Gets the evaluated property value for the specified property.
         /// </summary>
         /// <param name="unconfiguredProject"></param>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectXmlAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectXmlAccessor.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Build.Construction;
 
@@ -26,14 +25,5 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// <param name="action">Operation to execute</param>
         /// <returns>A task for the async operation.</returns>
         Task ExecuteInWriteLock(Action<ProjectRootElement> action);
-
-        /// <summary>
-        /// Returns a collection of items.
-        /// </summary>
-        /// <param name="configuredProject">The configured project.</param>
-        /// <param name="itemType">The type of the items to get.</param>
-        /// <param name="metadataName">The name of the metadata to get.</param>
-        /// <returns></returns>
-        Task<ICollection<(string evaluatedInclude, string metadataValue)>> GetItems(ConfiguredProject configuredProject, string itemType, string metadataName);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/MSBuildXmlAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/MSBuildXmlAccessor.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Build.Construction;
 using Microsoft.VisualStudio.IO;
@@ -31,15 +29,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
             _fileSystem = fileSystem;
         }
 
-        public async Task<string> GetProjectXmlAsync()
-        {
-            using (var access = await _projectLockService.ReadLockAsync())
-            {
-                var projectXml = await access.GetProjectXmlAsync(_unconfiguredProject.FullPath).ConfigureAwait(true);
-                return projectXml.RawXml;
-            }
-        }
-
         public async Task<string> GetEvaluatedPropertyValue(UnconfiguredProject unconfiguredProject, string propertyName)
         {
             var configuredProject = await unconfiguredProject.GetSuggestedConfiguredProjectAsync().ConfigureAwait(false);
@@ -57,15 +46,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 await access.CheckoutAsync(_unconfiguredProject.FullPath).ConfigureAwait(true);
                 var msbuildProject = await access.GetProjectXmlAsync(_unconfiguredProject.FullPath).ConfigureAwait(false);
                 action.Invoke(msbuildProject);
-            }
-        }
-
-        public async Task<ICollection<(string evaluatedInclude, string metadataValue)>> GetItems(ConfiguredProject configuredProject, string itemType, string metadataName)
-        {
-            using (var access = await _projectLockService.ReadLockAsync())
-            {
-                var project = await access.GetProjectAsync(configuredProject).ConfigureAwait(true);
-                return project.GetItems(itemType: itemType).Select(i => (i.EvaluatedInclude, i.GetMetadataValue(metadataName))).ToArray();
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/SupportedTargetFrameworksEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/SupportedTargetFrameworksEnumProvider.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Threading.Tasks;
-using Microsoft.Build.Framework.XamlTypes;
-using System;
 using System.Linq;
+using System.Threading.Tasks;
+
+using Microsoft.Build.Framework.XamlTypes;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Properties
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/SupportedTargetFrameworksEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/SupportedTargetFrameworksEnumProvider.cs
@@ -3,6 +3,7 @@ using System.ComponentModel.Composition;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework.XamlTypes;
 using System;
+using System.Linq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Properties
 {
@@ -14,21 +15,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     internal class SupportedTargetFrameworksEnumProvider : IDynamicEnumValuesProvider
     {
-        private readonly IProjectXmlAccessor _projectXmlAccessor;
+        private readonly IProjectAccessor _projectAccessor;
         private readonly ConfiguredProject _configuredProject;
 
         [ImportingConstructor]
-        public SupportedTargetFrameworksEnumProvider(IProjectXmlAccessor projectXmlAccessor, ConfiguredProject configuredProject)
+        public SupportedTargetFrameworksEnumProvider(IProjectAccessor projectAccessor, ConfiguredProject configuredProject)
         {
-            Requires.NotNull(projectXmlAccessor, nameof(projectXmlAccessor));
+            Requires.NotNull(projectAccessor, nameof(projectAccessor));
             Requires.NotNull(configuredProject, nameof(configuredProject));
-            _projectXmlAccessor = projectXmlAccessor;
+
+            _projectAccessor = projectAccessor;
             _configuredProject = configuredProject;
         }
 
         public Task<IDynamicEnumValuesGenerator> GetProviderAsync(IList<NameValuePair> options)
         {
-            return Task.FromResult<IDynamicEnumValuesGenerator>(new SupportedTargetFrameworksEnumValuesGenerator(_projectXmlAccessor, _configuredProject));
+            return Task.FromResult<IDynamicEnumValuesGenerator>(new SupportedTargetFrameworksEnumValuesGenerator(_projectAccessor, _configuredProject));
         }
 
         internal class SupportedTargetFrameworksEnumValuesGenerator : IDynamicEnumValuesGenerator
@@ -36,29 +38,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             private const string SupportedTargetFrameworkItemName = "SupportedTargetFramework";
             private const string DisplayNameMetadataName = "DisplayName";
 
-            private readonly IProjectXmlAccessor _projectXmlAccessor;
+            private readonly IProjectAccessor _projectAccessor;
             private readonly ConfiguredProject _configuredProject;
 
-            public SupportedTargetFrameworksEnumValuesGenerator(IProjectXmlAccessor projectXmlAccessor, ConfiguredProject configuredProject)
+            public SupportedTargetFrameworksEnumValuesGenerator(IProjectAccessor projectAccessor, ConfiguredProject configuredProject)
             {
-                _projectXmlAccessor = projectXmlAccessor;
+                _projectAccessor = projectAccessor;
                 _configuredProject = configuredProject;
             }
 
             public bool AllowCustomValues => false;
 
-            public async Task<ICollection<IEnumValue>> GetListedValuesAsync()
+            public Task<ICollection<IEnumValue>> GetListedValuesAsync()
             {
-                var enumValues = new List<IEnumValue>();
-                var items = await _projectXmlAccessor.GetItems(_configuredProject, itemType: SupportedTargetFrameworkItemName, metadataName: DisplayNameMetadataName).ConfigureAwait(false);
-
-                foreach ((string evaluatedInclude, string metadataValue) in items)
+                return _projectAccessor.OpenProjectForReadAsync(_configuredProject, project =>
                 {
-                    var val = new PageEnumValue(new EnumValue { Name = evaluatedInclude, DisplayName = metadataValue });
-                    enumValues.Add(val);
-                }
-
-                return enumValues;
+                    return (ICollection<IEnumValue>)project.GetItems(itemType: SupportedTargetFrameworkItemName)
+                                                           .Select(i => new PageEnumValue(new EnumValue { Name = i.EvaluatedInclude,
+                                                                                                          DisplayName = i.GetMetadataValue(DisplayNameMetadataName)}))
+                                                           .ToArray<IEnumValue>();
+                });
             }
 
             /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/SupportedTargetFrameworksEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/SupportedTargetFrameworksEnumProvider.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework.XamlTypes;


### PR DESCRIPTION
Continuation of https://github.com/dotnet/project-system/pull/3107.