### PR TITLE
Use a pooled StringBuilder in Dependency.GetID

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
@@ -1,17 +1,22 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
+using System.Text;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
+using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 {
     internal class Dependency : IDependency
     {
+        private static ConcurrentBag<StringBuilder> s_builderPool = new ConcurrentBag<StringBuilder>();
+
         // These priorities are for graph nodes only and are used to group graph nodes 
         // appropriatelly in order groups predefined order instead of alphabetically.
         // Order is not changed for top dependency nodes only for grpah hierarchies.
@@ -331,7 +336,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             Requires.NotNullOrEmpty(providerType, nameof(providerType));
             Requires.NotNullOrEmpty(modelId, nameof(modelId));
 
-            return $"{targetFramework.ShortName}\\{providerType}\\{Normalize(modelId)}".TrimEnd(CommonConstants.BackSlashDelimiter);
+            StringBuilder sb = null;
+            try
+            {
+                int length = targetFramework.ShortName.Length + providerType.Length + 2;
+                if (!s_builderPool.TryTake(out sb))
+                {
+                    sb = new StringBuilder(length);
+                }
+
+                sb.Append(targetFramework.ShortName).Append('\\');
+                sb.Append(providerType).Append('\\');
+                sb.Append(Normalize(modelId));
+                sb.TrimEnd(CommonConstants.BackSlashDelimiter);
+                return sb.ToString();
+            }
+            finally
+            {
+                s_builderPool.Add(sb);
+            }
         }
 
         private static string GetFullPath(string originalItemSpec, string containingProjectPath)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
@@ -353,7 +353,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             }
             finally
             {
-                s_builderPool.Add(sb);
+                sb.Clear();
+
+                // Prevent holding on to large builders
+                if (sb.Length < 1000)
+                {
+                    s_builderPool.Add(sb);
+                }
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Text/StringBuilderExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Text/StringBuilderExtensions.cs
@@ -46,5 +46,29 @@ namespace Microsoft.VisualStudio.Text
                 builder.AppendFormat(format.Format, format.Arguments);
             }
         }
+
+        public static StringBuilder TrimEnd(this StringBuilder builder, params char[] trimChars)
+        {
+            while (builder.Length > 0)
+            {
+                var match = false;
+                foreach (var c in trimChars)
+                {
+                    if (builder[builder.Length - 1] == c)
+                    {
+                        match = true;
+                        builder.Length--;
+                        break;
+                    }
+                }
+
+                if (!match)
+                {
+                    return builder;
+                }
+            }
+
+            return builder;
+        }
     }
 }


### PR DESCRIPTION
Traces showed this taking upward of 1% of allocations of opening a solution.

Fixes #2918.

<details>**Customer scenario**

What does the customer do to get into this situation, and why do we think this
is common enough to address in Escrow.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

**Bugs this fixes:** 

(either VSO or GitHub links)

**Workarounds, if any**

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

**Risk**

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

**Is this a regression from a previous update?**

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

(E.g. customer reported it vs. ad hoc testing)
</details>