### PR TITLE
Fix dataflow for up to date output groups

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -111,7 +111,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 _configuredProject.Services.ProjectSubscription.JointRuleSource.SourceBlock.SyncLinkOptions(new StandardRuleDataflowLinkOptions { RuleNames = ProjectPropertiesSchemas }),
                 _configuredProject.Services.ProjectSubscription.ImportTreeSource.SourceBlock.SyncLinkOptions(),
                 _configuredProject.Services.ProjectSubscription.SourceItemsRuleSource.SourceBlock.SyncLinkOptions(),
-                _configuredProject.Services.OutputGroups.SourceBlock.SyncLinkOptions(new StandardRuleDataflowLinkOptions {RuleNames = KnownOutputGroups}),
+                _configuredProject.Services.OutputGroups.SourceBlock.SyncLinkOptions(new OutputGroupDataflowLinkOptions {OutputGroupNames = KnownOutputGroups}),
                 _projectItemSchemaService.SourceBlock.SyncLinkOptions(),
                 target: new ActionBlock<IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectImportTreeSnapshot, IProjectSubscriptionUpdate, IImmutableDictionary<string, IOutputGroup>, IProjectItemSchema>>>(e => OnChanged(e)),
                 linkOptions: new DataflowLinkOptions { PropagateCompletion = true });


### PR DESCRIPTION
**Customer scenario**

The customer makes a change to their .NET Core project and runs. The project system thinks the project is up to date and doesn't rebuild, so the customer doesn't see their changes.

**Bugs this fixes:** 

#3050 

**Workarounds, if any**

Customer has to do a rebuild.

**Risk**

Low, this is correcting a call into CPS that was wrong.

**Performance impact**

None, makes things work the way they're supposed to.

**Is this a regression from a previous update?**

Yes.

**Root cause analysis:**

The underlying CPS code we call will sometimes return correct results even with incorrect parameters, so the fact we were passing in the wrong parameter was masked during testing.

**How was the bug found?**

Customer report
