### PR TITLE
Inform UIProviders when profile changes

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
@@ -502,6 +502,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 
                 UpdateLaunchTypes();
 
+                ActiveProvider?.ProfileSelected(CurrentLaunchSettings);
+
                 OnPropertyChanged(nameof(IsProfileSelected));
                 OnPropertyChanged(nameof(DeleteProfileEnabled));
                 


### PR DESCRIPTION
This addresses issue: https://github.com/dotnet/project-system/issues/3139 

**Risk**
This is low risk. 

**Performance impact**
None

**Is this a regression from a previous update?**
No

**Root cause analysis:**
As described in the issue, this was not found before because all the custom UI controls were shared across the same launch type (IIS express in this case). IIS Express server bitness is per profile and why that showed up.

**How was the bug found?**
Found during ad-hoc testing

