### PR TITLE
Change how the up to date check calculates outputs

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -1,6 +1,6 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\HostAgnostic.props"/>
+  <Import Project="..\HostAgnostic.props" />
   <PropertyGroup>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
     <!-- The value of RuleInjectionClassName of XamlPropertyRule items defined by this project -->
@@ -28,7 +28,7 @@
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests" />
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)"/>
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="ProjectSystem\Rules\AnalyzerReference.xaml.cs">
@@ -96,6 +96,9 @@
     </Compile>
     <Compile Update="ProjectSystem\Rules\UpToDateCheckOutput.cs">
       <DependentUpon>UpToDateCheckOutput.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="ProjectSystem\Rules\UpToDateCheckBuilt.cs">
+      <DependentUpon>UpToDateCheckBuilt.xaml</DependentUpon>
     </Compile>
     <Compile Update="ProjectSystem\Rules\CopyUpToDateMarker.cs">
       <DependentUpon>CopyUpToDateMarker.xaml</DependentUpon>
@@ -182,6 +185,10 @@
       <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\UpToDateCheckOutput.xaml">
+      <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
+      <SubType>Designer</SubType>
+    </XamlPropertyRule>
+    <XamlPropertyRule Include="ProjectSystem\Rules\UpToDateCheckBuilt.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
       <SubType>Designer</SubType>
     </XamlPropertyRule>
@@ -310,6 +317,6 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <DesignTimeTargetsFile Include="ProjectSystem\DesignTimeTargets\*.targets"/>
+    <DesignTimeTargetsFile Include="ProjectSystem\DesignTimeTargets\*.targets" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -132,6 +132,10 @@
       <Context>File</Context>
     </PropertyPageSchema>
 
+    <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)UpToDateCheckBuilt.xaml">
+      <Context>File</Context>
+    </PropertyPageSchema>
+
     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)CopyUpToDateMarker.xaml">
       <Context>File</Context>
     </PropertyPageSchema>
@@ -292,5 +296,23 @@
   
   <!-- This target collects all the resolved references that are used to actually compile. -->
   <Target Name="CollectResolvedCompilationReferencesDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(ReferencePathWithRefAssemblies)" />
+  
+  <!-- This target collects all the things built by the project for the up to date check. -->
+  <!-- See CopyFileToOutputDirectory target -->
+  <Target Name="CollectBuiltDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(UpToDateCheckBuilt)">
+    <ItemGroup>
+      <!-- Assembly output, bin and obj -->
+      <UpToDateCheckBuilt Condition="'$(CopyBuildOutputToOutputDirectory)' != 'false' and '$(SkipCopyBuildProduct)' != 'true'" Include="$(TargetPath)"/>
+      <UpToDateCheckBuilt Include="@(IntermediateAssembly)"/>
+
+      <!-- Documentation file, bin and obj -->
+      <UpToDateCheckBuilt Condition="'$(_DocumentationFileProduced)'=='true'" Include="@(FinalDocFile)"/>
+      <UpToDateCheckBuilt Condition="'$(_DocumentationFileProduced)'=='true'" Include="@(DocFileItem)"/>
+
+      <!-- Symbols, bin and obj -->
+      <UpToDateCheckBuilt Condition="'$(_DebugSymbolsProduced)'=='true'" Include="@(_DebugSymbolsIntermediatePath)"/>
+      <UpToDateCheckBuilt Condition="'$(_DebugSymbolsProduced)'=='true' and '$(SkipCopyingSymbolsToOutputDirectory)' != 'true' and '$(CopyOutputSymbolsToOutputDirectory)' != 'false'" Include="@(_DebugSymbolsOutputPath)"/>
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -312,6 +312,9 @@
       <!-- Symbols, bin and obj -->
       <UpToDateCheckBuilt Condition="'$(_DebugSymbolsProduced)'=='true'" Include="@(_DebugSymbolsIntermediatePath)"/>
       <UpToDateCheckBuilt Condition="'$(_DebugSymbolsProduced)'=='true' and '$(SkipCopyingSymbolsToOutputDirectory)' != 'true' and '$(CopyOutputSymbolsToOutputDirectory)' != 'false'" Include="@(_DebugSymbolsOutputPath)"/>
+      
+      <!-- app.config -->
+      <UpToDateCheckBuilt Condition=" '@(AppConfigWithTargetPath)' != '' " Include="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')" Original="@(AppConfigWithTargetPath)"/>
     </ItemGroup>
   </Target>
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckBuilt.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckBuilt.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
+    partial class UpToDateCheckBuilt
+    {
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckBuilt.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckBuilt.xaml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
+<Rule
+    Name="UpToDateCheckBuilt"
+    DisplayName="Up-to-date check built artifact"
+    PageTemplate="generic"
+    Description="File Properties"
+    xmlns="http://schemas.microsoft.com/build/2009/properties">
+    <Rule.DataSource>
+        <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="UpToDateCheckBuilt" SourceOfDefaultValue="AfterContext" 
+                    SourceType="TargetResults" MSBuildTarget="CollectBuiltDesignTime"/>
+    </Rule.DataSource>
+    <StringProperty
+        Name="Identity"
+        Visible="false"
+        ReadOnly="true"
+        Category="Misc"
+        Description="The item specified in the Include attribute.">
+        <StringProperty.DataSource>
+            <DataSource Persistence="Intrinsic" ItemType="UpToDateCheckBuilt" PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+    <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
+</Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckBuilt.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckBuilt.xaml
@@ -21,4 +21,8 @@
         </StringProperty.DataSource>
     </StringProperty>
     <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
+    <StringProperty
+        Name="Original"
+        Category="Misc"
+        Description="If set, specifies that this built output comes from this source file." />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.cs.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../UpToDateCheckBuilt.xaml">
+    <body>
+      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
+        <source>Up-to-date check built artifact</source>
+        <target state="new">Up-to-date check built artifact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
+        <source>File Properties</source>
+        <target state="new">File Properties</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>The item specified in the Include attribute.</source>
+        <target state="new">The item specified in the Include attribute.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.cs.xlf
@@ -17,6 +17,11 @@
         <target state="new">The item specified in the Include attribute.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Original|Description">
+        <source>If set, specifies that this built output comes from this source file.</source>
+        <target state="new">If set, specifies that this built output comes from this source file.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.de.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../UpToDateCheckBuilt.xaml">
+    <body>
+      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
+        <source>Up-to-date check built artifact</source>
+        <target state="new">Up-to-date check built artifact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
+        <source>File Properties</source>
+        <target state="new">File Properties</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>The item specified in the Include attribute.</source>
+        <target state="new">The item specified in the Include attribute.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.de.xlf
@@ -17,6 +17,11 @@
         <target state="new">The item specified in the Include attribute.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Original|Description">
+        <source>If set, specifies that this built output comes from this source file.</source>
+        <target state="new">If set, specifies that this built output comes from this source file.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.es.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../UpToDateCheckBuilt.xaml">
+    <body>
+      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
+        <source>Up-to-date check built artifact</source>
+        <target state="new">Up-to-date check built artifact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
+        <source>File Properties</source>
+        <target state="new">File Properties</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>The item specified in the Include attribute.</source>
+        <target state="new">The item specified in the Include attribute.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.es.xlf
@@ -17,6 +17,11 @@
         <target state="new">The item specified in the Include attribute.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Original|Description">
+        <source>If set, specifies that this built output comes from this source file.</source>
+        <target state="new">If set, specifies that this built output comes from this source file.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.fr.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../UpToDateCheckBuilt.xaml">
+    <body>
+      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
+        <source>Up-to-date check built artifact</source>
+        <target state="new">Up-to-date check built artifact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
+        <source>File Properties</source>
+        <target state="new">File Properties</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>The item specified in the Include attribute.</source>
+        <target state="new">The item specified in the Include attribute.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.fr.xlf
@@ -17,6 +17,11 @@
         <target state="new">The item specified in the Include attribute.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Original|Description">
+        <source>If set, specifies that this built output comes from this source file.</source>
+        <target state="new">If set, specifies that this built output comes from this source file.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.it.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../UpToDateCheckBuilt.xaml">
+    <body>
+      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
+        <source>Up-to-date check built artifact</source>
+        <target state="new">Up-to-date check built artifact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
+        <source>File Properties</source>
+        <target state="new">File Properties</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>The item specified in the Include attribute.</source>
+        <target state="new">The item specified in the Include attribute.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.it.xlf
@@ -17,6 +17,11 @@
         <target state="new">The item specified in the Include attribute.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Original|Description">
+        <source>If set, specifies that this built output comes from this source file.</source>
+        <target state="new">If set, specifies that this built output comes from this source file.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ja.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../UpToDateCheckBuilt.xaml">
+    <body>
+      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
+        <source>Up-to-date check built artifact</source>
+        <target state="new">Up-to-date check built artifact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
+        <source>File Properties</source>
+        <target state="new">File Properties</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>The item specified in the Include attribute.</source>
+        <target state="new">The item specified in the Include attribute.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ja.xlf
@@ -17,6 +17,11 @@
         <target state="new">The item specified in the Include attribute.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Original|Description">
+        <source>If set, specifies that this built output comes from this source file.</source>
+        <target state="new">If set, specifies that this built output comes from this source file.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ko.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../UpToDateCheckBuilt.xaml">
+    <body>
+      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
+        <source>Up-to-date check built artifact</source>
+        <target state="new">Up-to-date check built artifact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
+        <source>File Properties</source>
+        <target state="new">File Properties</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>The item specified in the Include attribute.</source>
+        <target state="new">The item specified in the Include attribute.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ko.xlf
@@ -17,6 +17,11 @@
         <target state="new">The item specified in the Include attribute.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Original|Description">
+        <source>If set, specifies that this built output comes from this source file.</source>
+        <target state="new">If set, specifies that this built output comes from this source file.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.pl.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../UpToDateCheckBuilt.xaml">
+    <body>
+      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
+        <source>Up-to-date check built artifact</source>
+        <target state="new">Up-to-date check built artifact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
+        <source>File Properties</source>
+        <target state="new">File Properties</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>The item specified in the Include attribute.</source>
+        <target state="new">The item specified in the Include attribute.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.pl.xlf
@@ -17,6 +17,11 @@
         <target state="new">The item specified in the Include attribute.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Original|Description">
+        <source>If set, specifies that this built output comes from this source file.</source>
+        <target state="new">If set, specifies that this built output comes from this source file.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.pt-BR.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../UpToDateCheckBuilt.xaml">
+    <body>
+      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
+        <source>Up-to-date check built artifact</source>
+        <target state="new">Up-to-date check built artifact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
+        <source>File Properties</source>
+        <target state="new">File Properties</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>The item specified in the Include attribute.</source>
+        <target state="new">The item specified in the Include attribute.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.pt-BR.xlf
@@ -17,6 +17,11 @@
         <target state="new">The item specified in the Include attribute.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Original|Description">
+        <source>If set, specifies that this built output comes from this source file.</source>
+        <target state="new">If set, specifies that this built output comes from this source file.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ru.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../UpToDateCheckBuilt.xaml">
+    <body>
+      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
+        <source>Up-to-date check built artifact</source>
+        <target state="new">Up-to-date check built artifact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
+        <source>File Properties</source>
+        <target state="new">File Properties</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>The item specified in the Include attribute.</source>
+        <target state="new">The item specified in the Include attribute.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ru.xlf
@@ -17,6 +17,11 @@
         <target state="new">The item specified in the Include attribute.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Original|Description">
+        <source>If set, specifies that this built output comes from this source file.</source>
+        <target state="new">If set, specifies that this built output comes from this source file.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.tr.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../UpToDateCheckBuilt.xaml">
+    <body>
+      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
+        <source>Up-to-date check built artifact</source>
+        <target state="new">Up-to-date check built artifact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
+        <source>File Properties</source>
+        <target state="new">File Properties</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>The item specified in the Include attribute.</source>
+        <target state="new">The item specified in the Include attribute.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.tr.xlf
@@ -17,6 +17,11 @@
         <target state="new">The item specified in the Include attribute.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Original|Description">
+        <source>If set, specifies that this built output comes from this source file.</source>
+        <target state="new">If set, specifies that this built output comes from this source file.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.zh-Hans.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../UpToDateCheckBuilt.xaml">
+    <body>
+      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
+        <source>Up-to-date check built artifact</source>
+        <target state="new">Up-to-date check built artifact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
+        <source>File Properties</source>
+        <target state="new">File Properties</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>The item specified in the Include attribute.</source>
+        <target state="new">The item specified in the Include attribute.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.zh-Hans.xlf
@@ -17,6 +17,11 @@
         <target state="new">The item specified in the Include attribute.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Original|Description">
+        <source>If set, specifies that this built output comes from this source file.</source>
+        <target state="new">If set, specifies that this built output comes from this source file.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.zh-Hant.xlf
@@ -17,6 +17,11 @@
         <target state="new">The item specified in the Include attribute.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Original|Description">
+        <source>If set, specifies that this built output comes from this source file.</source>
+        <target state="new">If set, specifies that this built output comes from this source file.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.zh-Hant.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../UpToDateCheckBuilt.xaml">
+    <body>
+      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
+        <source>Up-to-date check built artifact</source>
+        <target state="new">Up-to-date check built artifact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
+        <source>File Properties</source>
+        <target state="new">File Properties</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>The item specified in the Include attribute.</source>
+        <target state="new">The item specified in the Include attribute.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -53,7 +53,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
         private readonly IProjectSystemOptions _projectSystemOptions;
         private readonly ConfiguredProject _configuredProject;
-        private readonly Lazy<IFileTimestampCache> _fileTimestampCache;
         private readonly IProjectAsynchronousTasksService _tasksService;
         private readonly IProjectItemSchemaService _projectItemSchemaService;
         private readonly ITelemetryService _telemetryService;
@@ -82,14 +81,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         public BuildUpToDateCheck(
             IProjectSystemOptions projectSystemOptions,
             ConfiguredProject configuredProject,
-            Lazy<IFileTimestampCache> fileTimestampCache,
             [Import(ExportContractNames.Scopes.ConfiguredProject)] IProjectAsynchronousTasksService tasksService,
             IProjectItemSchemaService projectItemSchemaService,
             ITelemetryService telemetryService)
         {
             _projectSystemOptions = projectSystemOptions;
             _configuredProject = configuredProject;
-            _fileTimestampCache = fileTimestampCache;
             _tasksService = tasksService;
             _projectItemSchemaService = projectItemSchemaService;
             _telemetryService = telemetryService;
@@ -549,8 +546,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 return false;
             }
 
-            var timestampCache = _fileTimestampCache.Value.TimestampCache ??
-                    new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
+            var timestampCache = new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
             (DateTime? inputTime, string inputPath) = GetLatestInput(CollectInputs(logger), timestampCache);
             (DateTime? outputTime, string outputPath) = GetEarliestOutput(CollectOutputs(logger), timestampCache);
             


### PR DESCRIPTION
**Customer scenario**

There are a number of scenarios where the up to date check fails for projects that are actually up to date (see bugs listed below). This is because the up to date check uses the Built output group to determine the outputs of the build. However, the Built output group: a) includes things that are not always built by the projects (used to include things in the pack), and b) does not include things in the bin directory, only the obj. So, instead of using the more general mechanism, we need to fall back to the csproj strategy of hardcoding the things we're looking for: output assembly, pdb, and xml doc file.

This is done in this PR by hooking up a new DT build target that will collect the outputs and return them to the up to date checker.

**Bugs this fixes:** 

#2695, #2945, #3018, #2922

**Workarounds, if any**

User would have to rebuild the project by hand.

**Risk**

This is a non-trivial change to the way the up to date check works. The worst case is that things that shouldn't be considered up to date might be considered up to date. The user can always fix by rebuilding.

**Performance impact**

Negligible, we're already running a DT build and collecting outputs.

**Is this a regression from a previous update?**

No.

**How was the bug found?**

Customer reports