### PR TITLE
Chain capabilities snapshot to nominate restore and dependency tree dataflows

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/ICrossTargetRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/ICrossTargetRuleHandler.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         ///     Handles the specified set of changes to a rule, and applies them
         ///     to the given <see cref="ITargetedProjectContext"/>.
         /// </summary>
-        Task HandleAsync(IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectCatalogSnapshot>> e, 
+        Task HandleAsync(IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectCatalogSnapshot, IProjectCapabilitiesSnapshot>> e, 
                          IImmutableDictionary<string, IProjectChangeDescription> projectChange, 
                          ITargetedProjectContext targetedProjectContext,
                          bool isActiveContext,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependenciesRuleHandlerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependenciesRuleHandlerBase.cs
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
         }
 
         public virtual Task HandleAsync(
-            IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectCatalogSnapshot>> e,
+            IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectCatalogSnapshot, IProjectCapabilitiesSnapshot>> e,
             IImmutableDictionary<string, IProjectChangeDescription> projectChanges,
             ITargetedProjectContext context,
             bool isActiveContext,
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
         {
             if (projectChanges.TryGetValue(UnresolvedRuleName, out IProjectChangeDescription unresolvedChanges))
             {
-                HandleChangesForRule(false /*resolved*/,
+                HandleChangesForRule(false /*unresolved*/,
                     unresolvedChanges, context, isActiveContext, ruleChangeContext,
                         (itemSpec) => { return true; });
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/PackageRuleHandler.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
         }
 
         public override Task HandleAsync(
-            IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectCatalogSnapshot>> e,
+            IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectCatalogSnapshot, IProjectCapabilitiesSnapshot>> e,
             IImmutableDictionary<string, IProjectChangeDescription> projectChanges,
             ITargetedProjectContext context,
             bool isActiveContext,


### PR DESCRIPTION
A race condition in CPS is resulting from data flow action blocks being executed in the wrong capabilities context. This race condition may have been around for a while but is occurring much more frequently. CPS expects us to explicitly chain dataflows to the right capability context, so we are doing so in a number of cases where the symptoms of this race condition have become more pronounced. This PR fixes two cases:
1. After opening .NET Core projects, NuGet restore fails to run, and all dependencies are unresolved. In this case, running in the wrong capabilities context causes a NuGet check for compatibility to fail so that it does not recognize .NET Core projects.
2. Opening .NET Core projects sometimes produces spurious warnings in the dependencies tree, or an empty dependencies tree node, and these warnings do not go away following a build. In this case, running in the wrong capabilities context causes `OrderPrecedenceImportCollection` (used to import rule handlers and tree view providers) to return an empty collection from `OrderPrecedenceImportCollection.GetFilteredSnapshot()`, breaking the dependencies tree.

**Customer scenario**

Customers opening .NET Core projects sometimes see spurious warnings in the dependencies tree, or an empty dependencies tree node, and sometimes restore fails to run. 

**Bugs this fixes:** 

Fixes #3111 
Fixes [553715](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/553715)

**Workarounds, if any**

Building the solution generally resolves case 1
Close and reopen solution sometimes resolves case 2

**Risk**

Should be low as the rest of the dataflow is unchanged

**Performance impact**

Low. Only change is to creating Isolated capabilities context, which is fast and necessary in any case

**Is this a regression from a previous update?**

Appears to have gotten worse in the latest bits, but its not clear why

**Root cause analysis:**

Pending: We are still trying to figure out the change that makes the race condition more frequent.

**How was the bug found?**

Numerous internal reports

**Notes**
I'm creating a signed build and VAL build to test this further.
