### PR TITLE
Portuptodate

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -1,6 +1,6 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\HostAgnostic.props"/>
+  <Import Project="..\HostAgnostic.props" />
   <PropertyGroup>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
     <!-- The value of RuleInjectionClassName of XamlPropertyRule items defined by this project -->
@@ -28,7 +28,7 @@
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests" />
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)"/>
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="ProjectSystem\Rules\AnalyzerReference.xaml.cs">
@@ -96,6 +96,9 @@
     </Compile>
     <Compile Update="ProjectSystem\Rules\UpToDateCheckOutput.cs">
       <DependentUpon>UpToDateCheckOutput.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="ProjectSystem\Rules\UpToDateCheckBuilt.cs">
+      <DependentUpon>UpToDateCheckBuilt.xaml</DependentUpon>
     </Compile>
     <Compile Update="ProjectSystem\Rules\CopyUpToDateMarker.cs">
       <DependentUpon>CopyUpToDateMarker.xaml</DependentUpon>
@@ -182,6 +185,10 @@
       <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\UpToDateCheckOutput.xaml">
+      <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
+      <SubType>Designer</SubType>
+    </XamlPropertyRule>
+    <XamlPropertyRule Include="ProjectSystem\Rules\UpToDateCheckBuilt.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
       <SubType>Designer</SubType>
     </XamlPropertyRule>
@@ -310,6 +317,6 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <DesignTimeTargetsFile Include="ProjectSystem\DesignTimeTargets\*.targets"/>
+    <DesignTimeTargetsFile Include="ProjectSystem\DesignTimeTargets\*.targets" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -132,6 +132,10 @@
       <Context>File</Context>
     </PropertyPageSchema>
 
+    <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)UpToDateCheckBuilt.xaml">
+      <Context>File</Context>
+    </PropertyPageSchema>
+
     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)CopyUpToDateMarker.xaml">
       <Context>File</Context>
     </PropertyPageSchema>
@@ -292,5 +296,23 @@
   
   <!-- This target collects all the resolved references that are used to actually compile. -->
   <Target Name="CollectResolvedCompilationReferencesDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(ReferencePathWithRefAssemblies)" />
+  
+  <!-- This target collects all the things built by the project for the up to date check. -->
+  <!-- See CopyFileToOutputDirectory target -->
+  <Target Name="CollectBuiltDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(UpToDateCheckBuilt)">
+    <ItemGroup>
+      <!-- Assembly output, bin and obj -->
+      <UpToDateCheckBuilt Condition="'$(CopyBuildOutputToOutputDirectory)' != 'false' and '$(SkipCopyBuildProduct)' != 'true'" Include="$(TargetPath)"/>
+      <UpToDateCheckBuilt Include="@(IntermediateAssembly)"/>
+
+      <!-- Documentation file, bin and obj -->
+      <UpToDateCheckBuilt Condition="'$(_DocumentationFileProduced)'=='true'" Include="@(FinalDocFile)"/>
+      <UpToDateCheckBuilt Condition="'$(_DocumentationFileProduced)'=='true'" Include="@(DocFileItem)"/>
+
+      <!-- Symbols, bin and obj -->
+      <UpToDateCheckBuilt Condition="'$(_DebugSymbolsProduced)'=='true'" Include="@(_DebugSymbolsIntermediatePath)"/>
+      <UpToDateCheckBuilt Condition="'$(_DebugSymbolsProduced)'=='true' and '$(SkipCopyingSymbolsToOutputDirectory)' != 'true' and '$(CopyOutputSymbolsToOutputDirectory)' != 'false'" Include="@(_DebugSymbolsOutputPath)"/>
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -312,6 +312,9 @@
       <!-- Symbols, bin and obj -->
       <UpToDateCheckBuilt Condition="'$(_DebugSymbolsProduced)'=='true'" Include="@(_DebugSymbolsIntermediatePath)"/>
       <UpToDateCheckBuilt Condition="'$(_DebugSymbolsProduced)'=='true' and '$(SkipCopyingSymbolsToOutputDirectory)' != 'true' and '$(CopyOutputSymbolsToOutputDirectory)' != 'false'" Include="@(_DebugSymbolsOutputPath)"/>
+      
+      <!-- app.config -->
+      <UpToDateCheckBuilt Condition=" '@(AppConfigWithTargetPath)' != '' " Include="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')" Original="@(AppConfigWithTargetPath)"/>
     </ItemGroup>
   </Target>
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckBuilt.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckBuilt.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
+    partial class UpToDateCheckBuilt
+    {
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckBuilt.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckBuilt.xaml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
+<Rule
+    Name="UpToDateCheckBuilt"
+    DisplayName="Up-to-date check built artifact"
+    PageTemplate="generic"
+    Description="File Properties"
+    xmlns="http://schemas.microsoft.com/build/2009/properties">
+    <Rule.DataSource>
+        <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="UpToDateCheckBuilt" SourceOfDefaultValue="AfterContext" 
+                    SourceType="TargetResults" MSBuildTarget="CollectBuiltDesignTime"/>
+    </Rule.DataSource>
+    <StringProperty
+        Name="Identity"
+        Visible="false"
+        ReadOnly="true"
+        Category="Misc"
+        Description="The item specified in the Include attribute.">
+        <StringProperty.DataSource>
+            <DataSource Persistence="Intrinsic" ItemType="UpToDateCheckBuilt" PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+    <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
+</Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckBuilt.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckBuilt.xaml
@@ -21,4 +21,8 @@
         </StringProperty.DataSource>
     </StringProperty>
     <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
+    <StringProperty
+        Name="Original"
+        Category="Misc"
+        Description="If set, specifies that this built output comes from this source file." />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.cs.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../UpToDateCheckBuilt.xaml">
+    <body>
+      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
+        <source>Up-to-date check built artifact</source>
+        <target state="new">Up-to-date check built artifact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
+        <source>File Properties</source>
+        <target state="new">File Properties</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>The item specified in the Include attribute.</source>
+        <target state="new">The item specified in the Include attribute.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.cs.xlf
@@ -17,6 +17,11 @@
         <target state="new">The item specified in the Include attribute.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Original|Description">
+        <source>If set, specifies that this built output comes from this source file.</source>
+        <target state="new">If set, specifies that this built output comes from this source file.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.de.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../UpToDateCheckBuilt.xaml">
+    <body>
+      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
+        <source>Up-to-date check built artifact</source>
+        <target state="new">Up-to-date check built artifact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
+        <source>File Properties</source>
+        <target state="new">File Properties</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>The item specified in the Include attribute.</source>
+        <target state="new">The item specified in the Include attribute.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.de.xlf
@@ -17,6 +17,11 @@
         <target state="new">The item specified in the Include attribute.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Original|Description">
+        <source>If set, specifies that this built output comes from this source file.</source>
+        <target state="new">If set, specifies that this built output comes from this source file.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.es.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../UpToDateCheckBuilt.xaml">
+    <body>
+      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
+        <source>Up-to-date check built artifact</source>
+        <target state="new">Up-to-date check built artifact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
+        <source>File Properties</source>
+        <target state="new">File Properties</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>The item specified in the Include attribute.</source>
+        <target state="new">The item specified in the Include attribute.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.es.xlf
@@ -17,6 +17,11 @@
         <target state="new">The item specified in the Include attribute.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Original|Description">
+        <source>If set, specifies that this built output comes from this source file.</source>
+        <target state="new">If set, specifies that this built output comes from this source file.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.fr.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../UpToDateCheckBuilt.xaml">
+    <body>
+      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
+        <source>Up-to-date check built artifact</source>
+        <target state="new">Up-to-date check built artifact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
+        <source>File Properties</source>
+        <target state="new">File Properties</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>The item specified in the Include attribute.</source>
+        <target state="new">The item specified in the Include attribute.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.fr.xlf
@@ -17,6 +17,11 @@
         <target state="new">The item specified in the Include attribute.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Original|Description">
+        <source>If set, specifies that this built output comes from this source file.</source>
+        <target state="new">If set, specifies that this built output comes from this source file.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.it.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../UpToDateCheckBuilt.xaml">
+    <body>
+      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
+        <source>Up-to-date check built artifact</source>
+        <target state="new">Up-to-date check built artifact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
+        <source>File Properties</source>
+        <target state="new">File Properties</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>The item specified in the Include attribute.</source>
+        <target state="new">The item specified in the Include attribute.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.it.xlf
@@ -17,6 +17,11 @@
         <target state="new">The item specified in the Include attribute.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Original|Description">
+        <source>If set, specifies that this built output comes from this source file.</source>
+        <target state="new">If set, specifies that this built output comes from this source file.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ja.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../UpToDateCheckBuilt.xaml">
+    <body>
+      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
+        <source>Up-to-date check built artifact</source>
+        <target state="new">Up-to-date check built artifact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
+        <source>File Properties</source>
+        <target state="new">File Properties</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>The item specified in the Include attribute.</source>
+        <target state="new">The item specified in the Include attribute.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ja.xlf
@@ -17,6 +17,11 @@
         <target state="new">The item specified in the Include attribute.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Original|Description">
+        <source>If set, specifies that this built output comes from this source file.</source>
+        <target state="new">If set, specifies that this built output comes from this source file.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ko.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../UpToDateCheckBuilt.xaml">
+    <body>
+      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
+        <source>Up-to-date check built artifact</source>
+        <target state="new">Up-to-date check built artifact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
+        <source>File Properties</source>
+        <target state="new">File Properties</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>The item specified in the Include attribute.</source>
+        <target state="new">The item specified in the Include attribute.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ko.xlf
@@ -17,6 +17,11 @@
         <target state="new">The item specified in the Include attribute.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Original|Description">
+        <source>If set, specifies that this built output comes from this source file.</source>
+        <target state="new">If set, specifies that this built output comes from this source file.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.pl.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../UpToDateCheckBuilt.xaml">
+    <body>
+      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
+        <source>Up-to-date check built artifact</source>
+        <target state="new">Up-to-date check built artifact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
+        <source>File Properties</source>
+        <target state="new">File Properties</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>The item specified in the Include attribute.</source>
+        <target state="new">The item specified in the Include attribute.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.pl.xlf
@@ -17,6 +17,11 @@
         <target state="new">The item specified in the Include attribute.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Original|Description">
+        <source>If set, specifies that this built output comes from this source file.</source>
+        <target state="new">If set, specifies that this built output comes from this source file.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.pt-BR.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../UpToDateCheckBuilt.xaml">
+    <body>
+      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
+        <source>Up-to-date check built artifact</source>
+        <target state="new">Up-to-date check built artifact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
+        <source>File Properties</source>
+        <target state="new">File Properties</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>The item specified in the Include attribute.</source>
+        <target state="new">The item specified in the Include attribute.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.pt-BR.xlf
@@ -17,6 +17,11 @@
         <target state="new">The item specified in the Include attribute.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Original|Description">
+        <source>If set, specifies that this built output comes from this source file.</source>
+        <target state="new">If set, specifies that this built output comes from this source file.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ru.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../UpToDateCheckBuilt.xaml">
+    <body>
+      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
+        <source>Up-to-date check built artifact</source>
+        <target state="new">Up-to-date check built artifact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
+        <source>File Properties</source>
+        <target state="new">File Properties</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>The item specified in the Include attribute.</source>
+        <target state="new">The item specified in the Include attribute.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ru.xlf
@@ -17,6 +17,11 @@
         <target state="new">The item specified in the Include attribute.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Original|Description">
+        <source>If set, specifies that this built output comes from this source file.</source>
+        <target state="new">If set, specifies that this built output comes from this source file.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.tr.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../UpToDateCheckBuilt.xaml">
+    <body>
+      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
+        <source>Up-to-date check built artifact</source>
+        <target state="new">Up-to-date check built artifact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
+        <source>File Properties</source>
+        <target state="new">File Properties</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>The item specified in the Include attribute.</source>
+        <target state="new">The item specified in the Include attribute.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.tr.xlf
@@ -17,6 +17,11 @@
         <target state="new">The item specified in the Include attribute.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Original|Description">
+        <source>If set, specifies that this built output comes from this source file.</source>
+        <target state="new">If set, specifies that this built output comes from this source file.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.zh-Hans.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../UpToDateCheckBuilt.xaml">
+    <body>
+      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
+        <source>Up-to-date check built artifact</source>
+        <target state="new">Up-to-date check built artifact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
+        <source>File Properties</source>
+        <target state="new">File Properties</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>The item specified in the Include attribute.</source>
+        <target state="new">The item specified in the Include attribute.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.zh-Hans.xlf
@@ -17,6 +17,11 @@
         <target state="new">The item specified in the Include attribute.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Original|Description">
+        <source>If set, specifies that this built output comes from this source file.</source>
+        <target state="new">If set, specifies that this built output comes from this source file.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.zh-Hant.xlf
@@ -17,6 +17,11 @@
         <target state="new">The item specified in the Include attribute.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Original|Description">
+        <source>If set, specifies that this built output comes from this source file.</source>
+        <target state="new">If set, specifies that this built output comes from this source file.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.zh-Hant.xlf
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../UpToDateCheckBuilt.xaml">
+    <body>
+      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
+        <source>Up-to-date check built artifact</source>
+        <target state="new">Up-to-date check built artifact</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
+        <source>File Properties</source>
+        <target state="new">File Properties</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Identity|Description">
+        <source>The item specified in the Include attribute.</source>
+        <target state="new">The item specified in the Include attribute.</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -27,12 +27,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         private const string TelemetryEventName = "UpToDateCheck";
         private const string Link = "Link";
 
-        private static ImmutableHashSet<string> KnownOutputGroups => ImmutableHashSet<string>.Empty
-            .Add("Symbols")
-            .Add("Built")
-            .Add("Documentation")
-            .Add("LocalizedResourceDlls");
-
         private static ImmutableHashSet<string> ReferenceSchemas => ImmutableHashSet<string>.Empty
             .Add(ResolvedAnalyzerReference.SchemaName)
             .Add(ResolvedCompilationReference.SchemaName);
@@ -40,7 +34,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         private static ImmutableHashSet<string> UpToDateSchemas => ImmutableHashSet<string>.Empty
             .Add(CopyUpToDateMarker.SchemaName)
             .Add(UpToDateCheckInput.SchemaName)
-            .Add(UpToDateCheckOutput.SchemaName);
+            .Add(UpToDateCheckOutput.SchemaName)
+            .Add(UpToDateCheckBuilt.SchemaName);
 
         private static ImmutableHashSet<string> ProjectPropertiesSchemas => ImmutableHashSet<string>.Empty
             .Add(ConfigurationGeneral.SchemaName)
@@ -72,10 +67,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         private readonly Dictionary<string, HashSet<(string Path, string Link, CopyToOutputDirectoryType CopyType)>> _items = new Dictionary<string, HashSet<(string, string, CopyToOutputDirectoryType)>>();
         private readonly HashSet<string> _customInputs = new HashSet<string>(StringComparers.Paths);
         private readonly HashSet<string> _customOutputs = new HashSet<string>(StringComparers.Paths);
+        private readonly HashSet<string> _builtOutputs = new HashSet<string>(StringComparers.Paths);
         private readonly HashSet<string> _analyzerReferences = new HashSet<string>(StringComparers.Paths);
         private readonly HashSet<string> _compilationReferences = new HashSet<string>(StringComparers.Paths);
         private readonly HashSet<string> _copyReferenceInputs = new HashSet<string>(StringComparers.Paths);
-        private readonly Dictionary<string, HashSet<string>> _outputGroups = new Dictionary<string, HashSet<string>>();
 
         [ImportingConstructor]
         public BuildUpToDateCheck(
@@ -108,9 +103,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 _configuredProject.Services.ProjectSubscription.JointRuleSource.SourceBlock.SyncLinkOptions(new StandardRuleDataflowLinkOptions { RuleNames = ProjectPropertiesSchemas }),
                 _configuredProject.Services.ProjectSubscription.ImportTreeSource.SourceBlock.SyncLinkOptions(),
                 _configuredProject.Services.ProjectSubscription.SourceItemsRuleSource.SourceBlock.SyncLinkOptions(),
-                _configuredProject.Services.OutputGroups.SourceBlock.SyncLinkOptions(new OutputGroupDataflowLinkOptions {OutputGroupNames = KnownOutputGroups}),
                 _projectItemSchemaService.SourceBlock.SyncLinkOptions(),
-                target: new ActionBlock<IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectImportTreeSnapshot, IProjectSubscriptionUpdate, IImmutableDictionary<string, IOutputGroup>, IProjectItemSchema>>>(e => OnChanged(e)),
+                target: new ActionBlock<IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectImportTreeSnapshot, IProjectSubscriptionUpdate, IProjectItemSchema>>>(e => OnChanged(e)),
                 linkOptions: new DataflowLinkOptions { PropagateCompletion = true });
         }
 
@@ -161,6 +155,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 _customOutputs.Clear();
                 _customOutputs.AddRange(outputs.After.Items.Select(item => item.Value[UpToDateCheckOutput.FullPathProperty]));
+            }
+
+            if (e.ProjectChanges.TryGetValue(UpToDateCheckBuilt.SchemaName, out var built) &&
+                built.Difference.AnyChanges)
+            {
+                _builtOutputs.Clear();
+                _builtOutputs.AddRange(built.After.Items.Select(item => item.Value[UpToDateCheckBuilt.IdentityProperty]));
             }
 
             if (e.ProjectChanges.TryGetValue(CopyUpToDateMarker.SchemaName, out var upToDateMarkers) &&
@@ -233,21 +234,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             }
         }
 
-        private void OnOutputGroupChanged(IImmutableDictionary<string, IOutputGroup> e)
-        {
-            foreach (var outputGroupPair in e)
-            {
-                var outputs = outputGroupPair.Value.Outputs.Select(output => output.Key);
-                _outputGroups[outputGroupPair.Key] = new HashSet<string>(outputs, StringComparers.Paths);
-            }
-        }
-
-        private void OnChanged(IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectImportTreeSnapshot, IProjectSubscriptionUpdate, IImmutableDictionary<string, IOutputGroup>, IProjectItemSchema>> e)
+        private void OnChanged(IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectImportTreeSnapshot, IProjectSubscriptionUpdate, IProjectItemSchema>> e)
         {
             OnProjectChanged(e.Value.Item1);
             OnProjectImportsChanged(e.Value.Item2);
-            OnSourceItemChanged(e.Value.Item3, e.Value.Item5);
-            OnOutputGroupChanged(e.Value.Item4);
+            OnSourceItemChanged(e.Value.Item3, e.Value.Item4);
             _lastVersionSeen = e.DataSourceVersions[ProjectDataSources.ConfiguredProjectVersion];
         }
 
@@ -360,7 +351,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             return true;
         }
 
-        private HashSet<string> CollectInputs(BuildUpToDateCheckLogger logger)
+        private IEnumerable<string> CollectInputs(BuildUpToDateCheckLogger logger)
         {
             var inputs = new HashSet<string>(StringComparers.Paths);
 
@@ -381,21 +372,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             return inputs;
         }
 
-        private HashSet<string> CollectOutputs(BuildUpToDateCheckLogger logger)
+        private IEnumerable<string> CollectOutputs(BuildUpToDateCheckLogger logger)
         {
             var outputs = new HashSet<string>(StringComparers.Paths);
 
-            foreach (var pair in _outputGroups)
-            {
-                AddOutputs(logger, outputs, pair.Value, pair.Key);
-            }
-
             AddOutputs(logger, outputs, _customOutputs, UpToDateCheckOutput.SchemaName);
+
+            AddOutputs(logger, outputs, _builtOutputs.Select(_configuredProject.UnconfiguredProject.MakeRooted), UpToDateCheckBuilt.SchemaName);
 
             return outputs;
         }
 
-        private static (DateTime? time, string path) GetLatestInput(HashSet<string> inputs, IDictionary<string, DateTime> timestampCache, bool ignoreMissing = false)
+        private static (DateTime? time, string path) GetLatestInput(IEnumerable<string> inputs, IDictionary<string, DateTime> timestampCache, bool ignoreMissing = false)
         {
             DateTime? latest = DateTime.MinValue;
             string latestPath = null;
@@ -413,7 +401,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             return (latest, latestPath);
         }
 
-        private static (DateTime? time, string path) GetEarliestOutput(HashSet<string> outputs, IDictionary<string, DateTime> timestampCache)
+        private static (DateTime? time, string path) GetEarliestOutput(IEnumerable<string> outputs, IDictionary<string, DateTime> timestampCache)
         { 
             DateTime? earliest = DateTime.MaxValue;
             string earliestPath = null;
@@ -508,7 +496,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     logger.Info("    '{0}' does not exist.", item.Path);
                     return false;
                 }
-
                 
                 var outputItem = Path.Combine(outputFullPath, filename);
                 var outputItemTime = GetTimestamp(outputItem, timestampCache);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -53,7 +53,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
         private readonly IProjectSystemOptions _projectSystemOptions;
         private readonly ConfiguredProject _configuredProject;
-        private readonly Lazy<IFileTimestampCache> _fileTimestampCache;
         private readonly IProjectAsynchronousTasksService _tasksService;
         private readonly IProjectItemSchemaService _projectItemSchemaService;
         private readonly ITelemetryService _telemetryService;
@@ -82,14 +81,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         public BuildUpToDateCheck(
             IProjectSystemOptions projectSystemOptions,
             ConfiguredProject configuredProject,
-            Lazy<IFileTimestampCache> fileTimestampCache,
             [Import(ExportContractNames.Scopes.ConfiguredProject)] IProjectAsynchronousTasksService tasksService,
             IProjectItemSchemaService projectItemSchemaService,
             ITelemetryService telemetryService)
         {
             _projectSystemOptions = projectSystemOptions;
             _configuredProject = configuredProject;
-            _fileTimestampCache = fileTimestampCache;
             _tasksService = tasksService;
             _projectItemSchemaService = projectItemSchemaService;
             _telemetryService = telemetryService;
@@ -549,8 +546,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 return false;
             }
 
-            var timestampCache = _fileTimestampCache.Value.TimestampCache ??
-                    new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
+            var timestampCache = new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
             (DateTime? inputTime, string inputPath) = GetLatestInput(CollectInputs(logger), timestampCache);
             (DateTime? outputTime, string outputPath) = GetEarliestOutput(CollectOutputs(logger), timestampCache);
             


### PR DESCRIPTION
NOTE: I just realized that these bug fixes were merged into `master`, not `dev15.6.x`, even though they were all marked for 15.6. This just ports those fixes to the correct branch.

**Customer scenario**

There are a number of scenarios where the up to date check fails for projects that are actually up to date (see bugs listed below). This is because the up to date check uses the Built output group to determine the outputs of the build. However, the Built output group: a) includes things that are not always built by the projects (used to include things in the pack), and b) does not include things in the bin directory, only the obj. So, instead of using the more general mechanism, we need to fall back to the csproj strategy of hardcoding the things we're looking for: output assembly, pdb, and xml doc file.

This is done in this PR by hooking up a new DT build target that will collect the outputs and return them to the up to date checker.

**Bugs this fixes:** 

#2695, #2945, #3018, #2922

**Workarounds, if any**

User would have to rebuild the project by hand.

**Risk**

This is a non-trivial change to the way the up to date check works. The worst case is that things that shouldn't be considered up to date might be considered up to date. The user can always fix by rebuilding.

**Performance impact**

Negligible, we're already running a DT build and collecting outputs.

**Is this a regression from a previous update?**

No.

**How was the bug found?**

Customer reports