### PR TITLE
Prevent reevaluations when project.lock.json is touched without changing on disk

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
@@ -279,9 +279,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
                 // Only notify the project if the contents of the watched file have changed.
                 // In the case if we fail to read the contents, we will opt to notify the project.
                 byte[] newHash = GetFileHashOrNull(_fileBeingWatched);
-                if (newHash == null || _previousContentsHash == null || newHash.SequenceEqual(_previousContentsHash))
+                if (newHash == null || _previousContentsHash == null || !newHash.SequenceEqual(_previousContentsHash))
                 {
                     _previousContentsHash = newHash;
+                    cancellationToken.ThrowIfCancellationRequested();
                     await _projectServices.Project.Services.ProjectAsynchronousTasks.LoadedProjectAsync(async () =>
                         {
                             using (var access = await _projectServices.ProjectLockService.WriteLockAsync(cancellationToken))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
@@ -281,6 +282,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
                 byte[] newHash = GetFileHashOrNull(_fileBeingWatched);
                 if (newHash == null || _previousContentsHash == null || !newHash.SequenceEqual(_previousContentsHash))
                 {
+                    TraceUtilities.TraceVerbose("{0} changed on disk. Marking project dirty", _fileBeingWatched);
                     _previousContentsHash = newHash;
                     cancellationToken.ThrowIfCancellationRequested();
                     await _projectServices.Project.Services.ProjectAsynchronousTasks.LoadedProjectAsync(async () =>
@@ -298,6 +300,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
                                 }
                             }
                         });
+                }
+                else
+                {
+                    TraceUtilities.TraceWarning("{0} changed on disk, but has no actual content change.", _fileBeingWatched);
                 }
             }
             catch (OperationCanceledException)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
@@ -241,8 +241,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         private CancellationToken CreateLinkedCancellationToken()
         {
             // we want to cancel when we switch what file is watched, or when the project is unloaded
-            _watchedFileResetCancellationToken = CancellationTokenSource.CreateLinkedTokenSource(
-                _projectServices.Project.Services.ProjectAsynchronousTasks.UnloadCancellationToken);
+            if (_projectServices?.Project?.Services?.ProjectAsynchronousTasks?.UnloadCancellationToken != null)
+            {
+                _watchedFileResetCancellationToken = CancellationTokenSource.CreateLinkedTokenSource(
+                    _projectServices.Project.Services.ProjectAsynchronousTasks.UnloadCancellationToken);
+            }
+            else
+            {
+                _watchedFileResetCancellationToken = new CancellationTokenSource();
+            }
 
             return _watchedFileResetCancellationToken.Token;
         }
@@ -286,7 +293,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         /// <summary>
         /// Called when a project.lock.json file changes.
         /// </summary>
-        int IVsFreeThreadedFileChangeEvents.FilesChanged(uint cChanges, string[] rgpszFile, uint[] rggrfChange)
+        public int FilesChanged(uint cChanges, string[] rgpszFile, uint[] rggrfChange)
         {
             // Kick off the operation to notify the project change in a different thread irregardless of
             // the kind of change since we are interested in all changes.
@@ -295,12 +302,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             return VSConstants.S_OK;
         }
 
-        int IVsFreeThreadedFileChangeEvents.DirectoryChanged(string pszDirectory)
+        public int DirectoryChanged(string pszDirectory)
         {
             return VSConstants.E_NOTIMPL;
         }
 
-        int IVsFreeThreadedFileChangeEvents.DirectoryChangedEx(string pszDirectory, string pszFile)
+        public int DirectoryChangedEx(string pszDirectory, string pszFile)
         {
             return VSConstants.E_NOTIMPL;
         }


### PR DESCRIPTION
I was debugging and saw multiple reevaluations right after project load due to this. I imagine it is a decent perf hit in large solutions. This will prevent unnecessary reevaluations by first comparing the contents of project.lock.json on disk before dirtying the project. Not sure what release or branch you want this in.

**Customer scenario**

Projects reevaluate multiple times (typically 2 additional times) after being loaded. In larger solutions this is a perf hit. I haven't measured the perf hit though, so no idea how big it is.

**Bugs this fixes:** 

Don't have one.

**Workarounds, if any**

None.

**Risk**

Low risk.

**Performance impact**

Perf improvement

**Is this a regression from a previous update?**

Not sure when this was first introduced.

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**
Noticed during debugging.
