### PR TITLE
Use binpath for communication with IDE

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp/ProjectSystem/LanguageServices/FSharpParseBuildOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp/ProjectSystem/LanguageServices/FSharpParseBuildOptions.cs
@@ -17,17 +17,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         private const string SlashReferencePrefix  = "/r:";
         private const string LongReferencePrefix   = "--reference:";
 
-        private readonly UnconfiguredProject _project;
-
         [ImportMany]
         private IEnumerable<Action<string, ImmutableArray<CommandLineSourceFile>, ImmutableArray<CommandLineReference>, ImmutableArray<string>>> _handlers =  null;
 
         [ImportingConstructor]
-        public FSharpParseBuildOptions(UnconfiguredProject project)
-        {
-            Requires.NotNull(project, nameof(project));
-            _project = project;
-        }
+        public FSharpParseBuildOptions() { }
 
         public BuildOptions Parse(IEnumerable<string> commandLineArgs, string projectPath)
         {
@@ -91,13 +85,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         [Export]
         [AppliesTo(ProjectCapability.FSharp)]
-        public void HandleCommandLineNotifications(string projectPath, BuildOptions added, BuildOptions removed)
+        public void HandleCommandLineNotifications(string binPath, BuildOptions added, BuildOptions removed)
         {
             if (added is FSharpBuildOptions fscAdded)
             {
                 foreach (var handler in _handlers)
                 {
-                    handler?.Invoke(_project.FullPath, fscAdded.SourceFiles, fscAdded.MetadataReferences, fscAdded.CompileOptions);
+                    handler?.Invoke(binPath, fscAdded.SourceFiles, fscAdded.MetadataReferences, fscAdded.CompileOptions);
                 }
             }
             return;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHandlerManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHandlerManager.cs
@@ -182,7 +182,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 handler.Handle(version, addedItems, removedItems, isActiveContext, logger);
             }
 
-            CommandLineNotifications.FirstOrDefault()?.Value.Invoke(_project.FullPath, addedItems, removedItems);
+            CommandLineNotifications.FirstOrDefault()?.Value.Invoke(context.BinOutputPath, addedItems, removedItems);
         }
 
         private void WriteHeader(IProjectLoggerBatch logger, IProjectVersionedValue<IProjectSubscriptionUpdate> update, IComparable version, RuleHandlerType source, bool isActiveContext)


### PR DESCRIPTION
Multi-targeting doesn't work correctly in the F# IDE.

The reason is the IDE doesn't know how to identify the correct cached references and source files.  Currently it uses the project file name, this is insufficient because in a multi-targeting project there is in fact an in memory project for each target framework.

The project tracker can identify the correct in memory project using the binpath of the project output file.  In the project system the context object also identifies the binpath for the project being "design-time" built.

This change modifies the CommandLine notification to send the binpath rather than the project path.

/cc @Pilchie ,  can we see if this makes the bar for preview 4?

It also will require an F# update.

Thanks
