### PR TITLE
Add LanguageVersion for C# 7.3

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/CSharpLanguageVersion.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CSharpLanguageVersion.vb
@@ -27,6 +27,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Private Const s_languageVersion_DisplayNameFor7_1 As String = "C# 7.1"
         Private Const s_languageVersion_7_2 As String = "7.2"
         Private Const s_languageVersion_DisplayNameFor7_2 As String = "C# 7.2"
+        Private Const s_languageVersion_7_3 As String = "7.3"
+        Private Const s_languageVersion_DisplayNameFor7_3 As String = "C# 7.3"
 
         ''' <summary>
         ''' Stores the property value corresponding to the language version
@@ -170,6 +172,16 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Public Shared ReadOnly Property Version7_2() As CSharpLanguageVersion
             Get
                 Static value As New CSharpLanguageVersion(s_languageVersion_7_2, s_languageVersion_DisplayNameFor7_2)
+                Return value
+            End Get
+        End Property
+
+        ''' <summary>
+        ''' Return the C# 7.3 language version object
+        ''' </summary>
+        Public Shared ReadOnly Property Version7_3() As CSharpLanguageVersion
+            Get
+                Static value As New CSharpLanguageVersion(s_languageVersion_7_3, s_languageVersion_DisplayNameFor7_3)
                 Return value
             End Get
         End Property

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CSharpLanguageVersionUtilities.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CSharpLanguageVersionUtilities.vb
@@ -25,7 +25,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 CSharpLanguageVersion.Version6,
                 CSharpLanguageVersion.Version7,
                 CSharpLanguageVersion.Version7_1,
-                CSharpLanguageVersion.Version7_2}
+                CSharpLanguageVersion.Version7_2,
+                CSharpLanguageVersion.Version7_3}
 
         End Function
 


### PR DESCRIPTION
**Customer scenario**
Set the language version for a project to C# 7.3 (shipping in 15.7).
![image](https://user-images.githubusercontent.com/12466233/35650681-cc9ced5e-0691-11e8-9a3c-82baa70a1d09.png)

**Bugs this fixes:** 
Fixes https://github.com/dotnet/project-system/issues/3200

**Workarounds, if any**
Edit the csproj manually

**Risk**
**Performance impact**
Low. This is a trivial change following the same pattern we used for every point release (for example [7.2](https://github.com/dotnet/project-system/pull/2334)).