### PR TITLE
Set up Sdk Dependency Model Ids to ignore version information

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/SdkDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/SdkDependencyModel.cs
@@ -43,5 +43,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
                                 .FirstOrDefault();
             Caption = string.IsNullOrEmpty(Version) ? baseCaption : $"{baseCaption} ({Version})";
         }
+
+        private string _id;
+        public override string Id
+        {
+            get
+            {
+                if (_id == null)
+                {
+                    _id = OriginalItemSpec;
+                }
+
+                return _id;
+            }
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/SdkDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/SdkDependencyModel.cs
@@ -44,18 +44,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             Caption = string.IsNullOrEmpty(Version) ? baseCaption : $"{baseCaption} ({Version})";
         }
 
-        private string _id;
-        public override string Id
-        {
-            get
-            {
-                if (_id == null)
-                {
-                    _id = OriginalItemSpec;
-                }
-
-                return _id;
-            }
-        }
+        public override string Id => OriginalItemSpec;
     }
 }


### PR DESCRIPTION
Version was unset for earlier releases, but is set for the first time in .NET Core 2.1 (by https://github.com/dotnet/sdk/pull/1572) creating problems matching SdkDependencyModel to NuGet Package references. See https://github.com/dotnet/project-system/issues/3184#issuecomment-361791926 for more details

This fix overrides base class implementation and ignores version information. It turns out this approach is used in other derived classes as well. I also considered a fix in which the broken filter checks for SDK using an Id without version and one with version, but this approach seems more consistent with other models in this project. 

At this point, it is unclear why the base class implementation needs to include version in its ID since many of its derived classes ignore version or leave it empty. But since this is an escrow fix, I'll avoid making a sweeping change.

**Customer scenario**

Customers using .NET Core 2.1 SDK see unresolved warning in dependency node, and cannot expand SDK to see its packages

**Bugs this fixes:** 

Fixes #3184 
Fixes [556559](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/556559)

**Workarounds, if any**

Close and reopen solution often resolves this, but this depends on the order of dataflows

**Risk**

Low, previous SDKs did not include version information either

**Performance impact**

Low, this just overrides a base class implementation

**Is this a regression from a previous update?**

Regression from .NET Core 2.0 to .NET Core 2.1 SDK

**Root cause analysis:**

.NET Core SDK team probably noticed version was missing and added it. 2.1 is still in early preview so problems like this are being weeded out.

**How was the bug found?**

Test team

/cc @dotnet/project-system 
