### PR TITLE
Added Add Above and Add Below commands for files

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/AbstractMoveCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/AbstractMoveCommandTests.cs
@@ -3,7 +3,7 @@
 using System;
 using Xunit;
 
-namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
     [Trait("UnitTest", "ProjectSystem")]
     public abstract class AbstractMoveCommandTests

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/MoveDownCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/MoveDownCommandTests.cs
@@ -5,10 +5,10 @@ using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
     [Trait("UnitTest", "ProjectSystem")]
-    public class MoveUpCommandTests : AbstractMoveCommandTests
+    public class MoveDownCommandTests : AbstractMoveCommandTests
     {
         [Fact]
         public async Task GetCommandStatusAsync_File_ReturnsStatusEnabled()
@@ -21,7 +21,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
     File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2
 ");
 
-            var nodes = ImmutableHashSet.Create(tree.Children[1]); // test2.fs
+            var nodes = ImmutableHashSet.Create(tree.Children[0]); // test1.fs
 
             var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
 
@@ -40,7 +40,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
     File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2
 ");
 
-            var nodes = ImmutableHashSet.Create(tree.Children[0]); // test1.fs
+            var nodes = ImmutableHashSet.Create(tree.Children[1]); // test2.fs
 
             var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
 
@@ -62,7 +62,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 5
 ");
 
-            var nodes = ImmutableHashSet.Create(tree.Children[2].Children[1]); // test4.fs
+            var nodes = ImmutableHashSet.Create(tree.Children[2].Children[0]); // test3.fs
 
             var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
 
@@ -84,7 +84,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 5
 ");
 
-            var nodes = ImmutableHashSet.Create(tree.Children[2].Children[0]); // test3.fs
+            var nodes = ImmutableHashSet.Create(tree.Children[2].Children[1]); // test4.fs
 
             var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
 
@@ -109,7 +109,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         File (flags: {}), FilePath: ""C:\Foo\test6.fs"", DisplayOrder: 8
 ");
 
-            var nodes = ImmutableHashSet.Create(tree.Children[3]); // second folder
+            var nodes = ImmutableHashSet.Create(tree.Children[2]); // first folder
 
             var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
 
@@ -124,17 +124,17 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 
             var tree = ProjectTreeParser.Parse(@"
 Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2
-    Folder (flags: {Folder}), DisplayOrder: 3
-        File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 4
-        File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 5
+    Folder (flags: {Folder}), DisplayOrder: 1
+        File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 2
+        File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 3
+    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 4
+    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 5
     Folder (flags: {Folder}), DisplayOrder: 6
         File (flags: {}), FilePath: ""C:\Foo\test5.fs"", DisplayOrder: 7
         File (flags: {}), FilePath: ""C:\Foo\test6.fs"", DisplayOrder: 8
 ");
 
-            var nodes = ImmutableHashSet.Create(tree.Children[2]); // first folder
+            var nodes = ImmutableHashSet.Create(tree.Children[0]); // first folder
 
             var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
 
@@ -157,7 +157,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         File (flags: {}), FilePath: ""C:\Foo\test6.fs"", DisplayOrder: 6
 ");
 
-            var nodes = ImmutableHashSet.Create(tree.Children[0]); // first folder
+            var nodes = ImmutableHashSet.Create(tree.Children[1]); // second folder
 
             var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
 
@@ -165,11 +165,11 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
             Assert.False(result.Status.HasFlag(CommandStatus.Enabled));
         }
 
-        override internal long GetCommandId() => ManagedProjectSystemPackage.MoveUpCmdId;
+        override internal long GetCommandId() => ManagedProjectSystemPackage.MoveDownCmdId;
 
         override internal AbstractMoveCommand CreateInstance(IPhysicalProjectTree projectTree, Shell.SVsServiceProvider serviceProvider, ConfiguredProject configuredProject)
         {
-            return new MoveUpCommand(projectTree, serviceProvider, configuredProject);
+            return new MoveDownCommand(projectTree, serviceProvider, configuredProject);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/MoveUpCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/MoveUpCommandTests.cs
@@ -5,10 +5,10 @@ using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
     [Trait("UnitTest", "ProjectSystem")]
-    public class MoveDownCommandTests : AbstractMoveCommandTests
+    public class MoveUpCommandTests : AbstractMoveCommandTests
     {
         [Fact]
         public async Task GetCommandStatusAsync_File_ReturnsStatusEnabled()
@@ -21,7 +21,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
     File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2
 ");
 
-            var nodes = ImmutableHashSet.Create(tree.Children[0]); // test1.fs
+            var nodes = ImmutableHashSet.Create(tree.Children[1]); // test2.fs
 
             var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
 
@@ -40,7 +40,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
     File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2
 ");
 
-            var nodes = ImmutableHashSet.Create(tree.Children[1]); // test2.fs
+            var nodes = ImmutableHashSet.Create(tree.Children[0]); // test1.fs
 
             var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
 
@@ -62,7 +62,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 5
 ");
 
-            var nodes = ImmutableHashSet.Create(tree.Children[2].Children[0]); // test3.fs
+            var nodes = ImmutableHashSet.Create(tree.Children[2].Children[1]); // test4.fs
 
             var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
 
@@ -84,7 +84,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 5
 ");
 
-            var nodes = ImmutableHashSet.Create(tree.Children[2].Children[1]); // test4.fs
+            var nodes = ImmutableHashSet.Create(tree.Children[2].Children[0]); // test3.fs
 
             var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
 
@@ -109,7 +109,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         File (flags: {}), FilePath: ""C:\Foo\test6.fs"", DisplayOrder: 8
 ");
 
-            var nodes = ImmutableHashSet.Create(tree.Children[2]); // first folder
+            var nodes = ImmutableHashSet.Create(tree.Children[3]); // second folder
 
             var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
 
@@ -124,17 +124,17 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 
             var tree = ProjectTreeParser.Parse(@"
 Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    Folder (flags: {Folder}), DisplayOrder: 1
-        File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 2
-        File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 3
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 4
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 5
+    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1
+    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2
+    Folder (flags: {Folder}), DisplayOrder: 3
+        File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 4
+        File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 5
     Folder (flags: {Folder}), DisplayOrder: 6
         File (flags: {}), FilePath: ""C:\Foo\test5.fs"", DisplayOrder: 7
         File (flags: {}), FilePath: ""C:\Foo\test6.fs"", DisplayOrder: 8
 ");
 
-            var nodes = ImmutableHashSet.Create(tree.Children[0]); // first folder
+            var nodes = ImmutableHashSet.Create(tree.Children[2]); // first folder
 
             var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
 
@@ -157,7 +157,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         File (flags: {}), FilePath: ""C:\Foo\test6.fs"", DisplayOrder: 6
 ");
 
-            var nodes = ImmutableHashSet.Create(tree.Children[1]); // second folder
+            var nodes = ImmutableHashSet.Create(tree.Children[0]); // first folder
 
             var result = await command.GetCommandStatusAsync(nodes, GetCommandId(), true, "commandText", (CommandStatus)0);
 
@@ -165,11 +165,11 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
             Assert.False(result.Status.HasFlag(CommandStatus.Enabled));
         }
 
-        override internal long GetCommandId() => ManagedProjectSystemPackage.MoveDownCmdId;
+        override internal long GetCommandId() => ManagedProjectSystemPackage.MoveUpCmdId;
 
         override internal AbstractMoveCommand CreateInstance(IPhysicalProjectTree projectTree, Shell.SVsServiceProvider serviceProvider, ConfiguredProject configuredProject)
         {
-            return new MoveDownCommand(projectTree, serviceProvider, configuredProject);
+            return new MoveUpCommand(projectTree, serviceProvider, configuredProject);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Menus.vsct
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Menus.vsct
@@ -52,6 +52,22 @@
             <ButtonText>Framework</ButtonText>
         </Strings>
       </Menu>
+
+      <Menu guid="guidManagedProjectSystemOrderCommandSet" id="AddAboveMenu" priority="0x300" type="Menu">
+        <Parent guid="guidManagedProjectSystemOrderCommandSet" id="OrderingGroup"/>
+        <CommandFlag>TextChanges</CommandFlag>
+        <Strings>
+          <ButtonText>&amp;Add Above</ButtonText>
+        </Strings>
+      </Menu>
+
+      <Menu guid="guidManagedProjectSystemOrderCommandSet" id="AddBelowMenu" priority="0x305" type="Menu">
+        <Parent guid="guidManagedProjectSystemOrderCommandSet" id="OrderingGroup"/>
+        <CommandFlag>TextChanges</CommandFlag>
+        <Strings>
+          <ButtonText>&amp;Add Below</ButtonText>
+        </Strings>
+      </Menu>  
     </Menus>
 
     <Groups>
@@ -71,6 +87,12 @@
       </Group>
       <Group guid="guidManagedProjectSystemOrderCommandSet" id="OrderingGroup" priority="0x100">
         <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_FOLDERNODE" />
+      </Group>
+      <Group guid="guidManagedProjectSystemOrderCommandSet" id="AddAboveGroup" priority="0x101">
+        <Parent guid="guidManagedProjectSystemOrderCommandSet" id="AddAboveMenu" />
+      </Group>
+      <Group guid="guidManagedProjectSystemOrderCommandSet" id="AddBelowGroup" priority="0x102">
+        <Parent guid="guidManagedProjectSystemOrderCommandSet" id="AddBelowMenu" />
       </Group>
     </Groups>
 
@@ -96,6 +118,58 @@
         <Strings>
           <ButtonText>&amp;Move Down</ButtonText>
           <CommandName>MoveDown</CommandName>
+        </Strings>
+      </Button>
+
+      <Button guid="guidManagedProjectSystemOrderCommandSet" id="cmdidAddNewItemAbove" priority="0x102">
+        <Parent guid="guidManagedProjectSystemOrderCommandSet" id="AddAboveGroup"/>
+        <Icon guid="guidSHLMainMenu" id="1"/>
+        <CommandFlag>TextChanges</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DefaultDisabled</CommandFlag>
+        <Strings>
+          <ButtonText>&amp;Add New Item...</ButtonText>
+          <CommandName>AddNewItemAbove</CommandName>
+        </Strings>
+      </Button>
+
+      <Button guid="guidManagedProjectSystemOrderCommandSet" id="cmdidAddExistingItemAbove" priority="0x103">
+        <Parent guid="guidManagedProjectSystemOrderCommandSet" id="AddAboveGroup"/>
+        <Icon guid="guidSHLMainMenu" id="16"/>
+        <CommandFlag>TextChanges</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DefaultDisabled</CommandFlag>
+        <Strings>
+          <ButtonText>&amp;Add Existing Item...</ButtonText>
+          <CommandName>AddExistingItemAbove</CommandName>
+        </Strings>
+      </Button>
+
+      <Button guid="guidManagedProjectSystemOrderCommandSet" id="cmdidAddNewItemBelow" priority="0x104">
+        <Parent guid="guidManagedProjectSystemOrderCommandSet" id="AddBelowGroup"/>
+        <Icon guid="guidSHLMainMenu" id="1"/>
+        <CommandFlag>TextChanges</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DefaultDisabled</CommandFlag>
+        <Strings>
+          <ButtonText>&amp;Add New Item...</ButtonText>
+          <CommandName>AddNewItemBelow</CommandName>
+        </Strings>
+      </Button>
+
+      <Button guid="guidManagedProjectSystemOrderCommandSet" id="cmdidAddExistingItemBelow" priority="0x105">
+        <Parent guid="guidManagedProjectSystemOrderCommandSet" id="AddBelowGroup"/>
+        <Icon guid="guidSHLMainMenu" id="16"/>
+        <CommandFlag>TextChanges</CommandFlag>
+        <CommandFlag>DynamicVisibility</CommandFlag>
+        <CommandFlag>DefaultInvisible</CommandFlag>
+        <CommandFlag>DefaultDisabled</CommandFlag>
+        <Strings>
+          <ButtonText>&amp;Add Existing Item...</ButtonText>
+          <CommandName>AddExistingItemBelow</CommandName>
         </Strings>
       </Button>
       
@@ -166,8 +240,16 @@
 
     <GuidSymbol name="guidManagedProjectSystemOrderCommandSet" value="{6C4806E9-034E-4B64-99DE-29A6F837B993}">
       <IDSymbol name="OrderingGroup" value="0x0100" />
+      <IDSymbol name="AddAboveGroup" value="0x0101" />
+      <IDSymbol name="AddBelowGroup" value="0x0102" />
+      <IDSymbol name="AddAboveMenu" value="0x0103" />
+      <IDSymbol name="AddBelowMenu" value="0x0104" />
       <IDSymbol name="cmdidMoveUp" value="0x2000" />
       <IDSymbol name="cmdidMoveDown" value="0x2001" />
+      <IDSymbol name="cmdidAddNewItemAbove" value="0x2002" />
+      <IDSymbol name="cmdidAddExistingItemAbove" value="0x2003" />
+      <IDSymbol name="cmdidAddNewItemBelow" value="0x2004" />
+      <IDSymbol name="cmdidAddExistingItemBelow" value="0x2005" />
     </GuidSymbol>
   
     <GuidSymbol name="SlnExplorerGuid" value="{3AE79031-E1BC-11D0-8F78-00A0C9110057}" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.Packaging
         new string[] {"SolutionHasProjectCapability:(CSharp | VB) & CPS"}
         )]
 
-    [ProvideMenuResource("Menus.ctmenu", 2)]
+    [ProvideMenuResource("Menus.ctmenu", 3)]
     internal partial class ManagedProjectSystemPackage : AsyncPackage
     {
         public const string ActivationContextGuid = "E7DF1626-44DD-4E8C-A8A0-92EAB6DDC16E";
@@ -36,6 +36,10 @@ namespace Microsoft.VisualStudio.Packaging
         public const string ManagedProjectSystemOrderCommandSet = "{6C4806E9-034E-4B64-99DE-29A6F837B993}";
         public const int MoveUpCmdId = 0x2000;
         public const int MoveDownCmdId = 0x2001;
+        public const int AddNewItemAboveCmdId = 0x2002;
+        public const int AddExistingItemAboveCmdId = 0x2003;
+        public const int AddNewItemBelowCmdId = 0x2004;
+        public const int AddExistingItemBelowCmdId = 0x2005;
 
         public const string SolutionExplorerGuid = "{3AE79031-E1BC-11D0-8F78-00A0C9110057}";
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AbstractAddItemCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AbstractAddItemCommand.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.ProjectSystem.Input;
+
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
+{
+    internal abstract class AbstractAddItemCommand : AbstractSingleNodeProjectCommand
+    {
+        private readonly IPhysicalProjectTree _projectTree;
+        private readonly IUnconfiguredProjectVsServices _projectVsServices;
+        private readonly SVsServiceProvider _serviceProvider;
+
+        public AbstractAddItemCommand(IPhysicalProjectTree projectTree, IUnconfiguredProjectVsServices projectVsServices, SVsServiceProvider serviceProvider)
+        {
+            Requires.NotNull(projectTree, nameof(IPhysicalProjectTree));
+            Requires.NotNull(projectVsServices, nameof(IUnconfiguredProjectVsServices));
+            Requires.NotNull(serviceProvider, nameof(SVsServiceProvider));
+
+            _projectTree = projectTree;
+            _projectVsServices = projectVsServices;
+            _serviceProvider = serviceProvider;
+        }
+
+        protected abstract bool CanAdd(IProjectTree target);
+
+        protected abstract IProjectTree GetNodeToAddTo(IProjectTree target);
+
+        protected abstract Task OnAddingNodesAsync(IProjectTree nodeToAddTo);
+
+        protected abstract Task OnAddedNodesAsync(ConfiguredProject configuredProject, IEnumerable<IProjectTree> addedNodes, IProjectTree target);
+
+        protected Task ShowAddNewFileDialogAsync(IProjectTree target)
+        {
+            return HACK_AddItemHelper.ShowAddNewFileDialogAsync(_projectTree, _projectVsServices, _serviceProvider, target);
+        }
+
+        protected Task ShowAddExistingFilesDialogAsync(IProjectTree target)
+        {
+            return HACK_AddItemHelper.ShowAddExistingFilesDialogAsync(_projectTree, _projectVsServices, _serviceProvider, target);
+        }
+
+        protected override Task<CommandStatusResult> GetCommandStatusAsync(IProjectTree node, bool focused, string commandText, CommandStatus progressiveStatus)
+        {
+            if (_projectTree.NodeCanHaveAdditions(GetNodeToAddTo(node)) && CanAdd(node))
+            {
+                return GetCommandStatusResult.Handled(commandText, CommandStatus.Enabled);
+            }
+            else
+            {
+                return GetCommandStatusResult.Unhandled;
+            }
+        }
+
+        protected override async Task<bool> TryHandleCommandAsync(IProjectTree node, bool focused, long commandExecuteOptions, IntPtr variantArgIn, IntPtr variantArgOut)
+        {
+            var nodeToAddTo = GetNodeToAddTo(node);
+
+            // Publish any existing changes that could potentially be here.
+            // Then call OnAddingNodesAsync.
+            // Then publish changes that could have taken place in OnAddingNodesAsync.
+            await _projectTree.TreeService.PublishLatestTreeAsync(waitForFileSystemUpdates: true).ConfigureAwait(true);
+            await OnAddingNodesAsync(nodeToAddTo).ConfigureAwait(true);
+            await _projectTree.TreeService.PublishLatestTreeAsync(waitForFileSystemUpdates: true).ConfigureAwait(true);
+
+            // Get the difference to see what was added.
+            // We do a sanity check to make sure they have a valid display order.
+            // We also order the added nodes by their display order.
+            var updatedNode = _projectTree.CurrentTree.Find(node.Identity);
+            var updatedNodeToAddTo = _projectTree.CurrentTree.Find(nodeToAddTo.Identity);
+            var addedNodes = 
+                updatedNodeToAddTo.Children.Where(x => !nodeToAddTo.TryFind(x.Identity, out var subtree) && OrderingHelper.HasValidDisplayOrder(x))
+                .OrderBy(OrderingHelper.GetDisplayOrder).ToList();
+
+            if (addedNodes.Any())
+            {
+                await OnAddedNodesAsync(_projectVsServices.ActiveConfiguredProject, addedNodes, updatedNode).ConfigureAwait(true);
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AbstractMoveCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AbstractMoveCommand.cs
@@ -2,12 +2,12 @@
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.Packaging;
-using Microsoft.VisualStudio.ProjectSystem.Input;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.ProjectSystem.Input;
 
-namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
     internal abstract class AbstractMoveCommand : AbstractSingleNodeProjectCommand
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemAboveCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemAboveCommand.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.ProjectSystem.Input;
+using Microsoft.VisualStudio.Shell;
+
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
+{
+    [ProjectCommand(ManagedProjectSystemPackage.ManagedProjectSystemOrderCommandSet, ManagedProjectSystemPackage.AddExistingItemAboveCmdId)]
+    [AppliesTo(ProjectCapability.SortByDisplayOrder)]
+    internal class AddExistingItemAboveCommand : AbstractAddItemCommand
+    {
+        [ImportingConstructor]
+        public AddExistingItemAboveCommand(IPhysicalProjectTree projectTree, IUnconfiguredProjectVsServices projectVsServices, SVsServiceProvider serviceProvider) : base(projectTree, projectVsServices, serviceProvider)
+        {
+        }
+
+        protected override IProjectTree GetNodeToAddTo(IProjectTree target)
+        {
+            return target.Parent;
+        }
+
+        protected override Task OnAddingNodesAsync(IProjectTree nodeToAddTo)
+        {
+            return ShowAddExistingFilesDialogAsync(nodeToAddTo);
+        }
+
+        protected override async Task OnAddedNodesAsync(ConfiguredProject configuredProject, IEnumerable<IProjectTree> addedNodes, IProjectTree target)
+        {
+            foreach (var addedNode in addedNodes)
+            {
+                await OrderingHelper.TryMoveAboveAsync(configuredProject, addedNode, target).ConfigureAwait(true);
+            }
+        }
+
+        protected override bool CanAdd(IProjectTree target)
+        {
+            return OrderingHelper.HasValidDisplayOrder(target);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemBelowCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemBelowCommand.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.ProjectSystem.Input;
+using Microsoft.VisualStudio.Shell;
+
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
+{
+    [ProjectCommand(ManagedProjectSystemPackage.ManagedProjectSystemOrderCommandSet, ManagedProjectSystemPackage.AddExistingItemBelowCmdId)]
+    [AppliesTo(ProjectCapability.SortByDisplayOrder)]
+    internal class AddExistingItemBelowCommand : AbstractAddItemCommand
+    {
+        [ImportingConstructor]
+        public AddExistingItemBelowCommand(IPhysicalProjectTree projectTree, IUnconfiguredProjectVsServices projectVsServices, SVsServiceProvider serviceProvider) : base(projectTree, projectVsServices, serviceProvider)
+        {
+        }
+
+        protected override IProjectTree GetNodeToAddTo(IProjectTree target)
+        {
+            return target.Parent;
+        }
+
+        protected override Task OnAddingNodesAsync(IProjectTree nodeToAddTo)
+        {
+            return ShowAddExistingFilesDialogAsync(nodeToAddTo);
+        }
+
+        protected override async Task OnAddedNodesAsync(ConfiguredProject configuredProject, IEnumerable<IProjectTree> addedNodes, IProjectTree target)
+        {
+            foreach (var addedNode in addedNodes)
+            {
+                await OrderingHelper.TryMoveBelowAsync(configuredProject, addedNode, target).ConfigureAwait(true);
+            }
+        }
+
+        protected override bool CanAdd(IProjectTree target)
+        {
+            return OrderingHelper.HasValidDisplayOrder(target);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemCommand.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.ProjectSystem.Input;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Input;
+using System.Collections.Generic;
+
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
+{
+    [ProjectCommand(CommandGroup.VisualStudioStandard97, (long)VSConstants.VSStd97CmdID.AddExistingItem)]
+    [AppliesTo(ProjectCapability.SortByDisplayOrder)]
+    [Order(5000)]
+    internal class AddExistingItemCommand : AbstractAddItemCommand
+    {
+        [ImportingConstructor]
+        public AddExistingItemCommand(IPhysicalProjectTree projectTree, IUnconfiguredProjectVsServices projectVsServices, SVsServiceProvider serviceProvider) : base(projectTree, projectVsServices, serviceProvider)
+        {
+        }
+
+        protected override IProjectTree GetNodeToAddTo(IProjectTree target)
+        {
+            return target;
+        }
+
+        protected override Task OnAddingNodesAsync(IProjectTree nodeToAddTo)
+        {
+            return ShowAddExistingFilesDialogAsync(nodeToAddTo);
+        }
+
+        protected override async Task OnAddedNodesAsync(ConfiguredProject configuredProject, IEnumerable<IProjectTree> addedNodes, IProjectTree target)
+        {
+            // Move added nodes to the top.
+            var child = OrderingHelper.GetFirstChild(target);
+            foreach (var addedNode in addedNodes)
+            {
+                if (child != addedNode)
+                {
+                    await OrderingHelper.TryMoveAboveAsync(configuredProject, addedNode, child).ConfigureAwait(true);
+                }
+            }
+        }
+
+        protected override bool CanAdd(IProjectTree target)
+        {
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemAboveCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemAboveCommand.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.ProjectSystem.Input;
+using Microsoft.VisualStudio.Shell;
+
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
+{
+    [ProjectCommand(ManagedProjectSystemPackage.ManagedProjectSystemOrderCommandSet, ManagedProjectSystemPackage.AddNewItemAboveCmdId)]
+    [AppliesTo(ProjectCapability.SortByDisplayOrder)]
+    internal class AddNewItemAboveCommand : AbstractAddItemCommand
+    {
+        [ImportingConstructor]
+        public AddNewItemAboveCommand(IPhysicalProjectTree projectTree, IUnconfiguredProjectVsServices projectVsServices, SVsServiceProvider serviceProvider) : base(projectTree, projectVsServices, serviceProvider)
+        {
+        }
+
+        protected override IProjectTree GetNodeToAddTo(IProjectTree target)
+        {
+            return target.Parent;
+        }
+
+        protected override Task OnAddingNodesAsync(IProjectTree nodeToAddTo)
+        {
+            return ShowAddNewFileDialogAsync(nodeToAddTo);
+        }
+
+        protected override async Task OnAddedNodesAsync(ConfiguredProject configuredProject, IEnumerable<IProjectTree> addedNodes, IProjectTree target)
+        {
+            foreach (var addedNode in addedNodes)
+            {
+                await OrderingHelper.TryMoveAboveAsync(configuredProject, addedNode, target).ConfigureAwait(true);
+            }
+        }
+
+        protected override bool CanAdd(IProjectTree target)
+        {
+            return OrderingHelper.HasValidDisplayOrder(target);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemBelowCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemBelowCommand.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.ProjectSystem.Input;
+using Microsoft.VisualStudio.Shell;
+
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
+{
+    [ProjectCommand(ManagedProjectSystemPackage.ManagedProjectSystemOrderCommandSet, ManagedProjectSystemPackage.AddNewItemBelowCmdId)]
+    [AppliesTo(ProjectCapability.SortByDisplayOrder)]
+    internal class AddNewItemBelowCommand : AbstractAddItemCommand
+    {
+        [ImportingConstructor]
+        public AddNewItemBelowCommand(IPhysicalProjectTree projectTree, IUnconfiguredProjectVsServices projectVsServices, SVsServiceProvider serviceProvider) : base(projectTree, projectVsServices, serviceProvider)
+        {
+        }
+
+        protected override IProjectTree GetNodeToAddTo(IProjectTree target)
+        {
+            return target.Parent;
+        }
+
+        protected override Task OnAddingNodesAsync(IProjectTree nodeToAddTo)
+        {
+            return ShowAddNewFileDialogAsync(nodeToAddTo);
+        }
+
+        protected override async Task OnAddedNodesAsync(ConfiguredProject configuredProject, IEnumerable<IProjectTree> addedNodes, IProjectTree target)
+        {
+            foreach (var addedNode in addedNodes)
+            {
+                await OrderingHelper.TryMoveBelowAsync(configuredProject, addedNode, target).ConfigureAwait(true);
+            }
+        }
+
+        protected override bool CanAdd(IProjectTree target)
+        {
+            return OrderingHelper.HasValidDisplayOrder(target);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemCommand.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.ProjectSystem.Input;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Input;
+using System.Collections.Generic;
+
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
+{
+    [ProjectCommand(CommandGroup.VisualStudioStandard97, (long)VSConstants.VSStd97CmdID.AddNewItem)]
+    [AppliesTo(ProjectCapability.SortByDisplayOrder)]
+    [Order(5000)]
+    internal class AddNewItemCommand : AbstractAddItemCommand
+    {
+        [ImportingConstructor]
+        public AddNewItemCommand(IPhysicalProjectTree projectTree, IUnconfiguredProjectVsServices projectVsServices, SVsServiceProvider serviceProvider) : base(projectTree, projectVsServices, serviceProvider)
+        {
+        }
+
+        protected override IProjectTree GetNodeToAddTo(IProjectTree target)
+        {
+            return target;
+        }
+
+        protected override Task OnAddingNodesAsync(IProjectTree nodeToAddTo)
+        {
+            return ShowAddNewFileDialogAsync(nodeToAddTo);
+        }
+
+        protected override async Task OnAddedNodesAsync(ConfiguredProject configuredProject, IEnumerable<IProjectTree> addedNodes, IProjectTree target)
+        {
+            // Move added nodes to the top.
+            var child = OrderingHelper.GetFirstChild(target);
+            foreach (var addedNode in addedNodes)
+            {
+                if (child != addedNode)
+                {
+                    await OrderingHelper.TryMoveAboveAsync(configuredProject, addedNode, child).ConfigureAwait(true);
+                }
+            }
+        }
+
+        protected override bool CanAdd(IProjectTree target)
+        {
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/HACK_AddItemHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/HACK_AddItemHelper.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
+{
+    /// <summary>
+    /// This is a HACK due to having to call Vs directly to show a dialog.
+    /// Ideally, we should be able to show a dialog from CPS, but we can't at the moment.
+    /// </summary>
+    internal static class HACK_AddItemHelper
+    {
+        /// <summary>
+        /// Show the item dialog window to add new items.
+        /// </summary>
+        public static Task ShowAddNewFileDialogAsync(
+            IPhysicalProjectTree projectTree,
+            IUnconfiguredProjectVsServices projectVsServices,
+            SVsServiceProvider serviceProvider,
+            IProjectTree target)
+        {
+            return ShowAddItemDialogAsync(projectTree, projectVsServices, serviceProvider, target, AddItemAction.NewItem);
+        }
+
+        /// <summary>
+        /// Show the item dialog window to add existing items.
+        /// </summary>
+        public static Task ShowAddExistingFilesDialogAsync(
+            IPhysicalProjectTree projectTree,
+            IUnconfiguredProjectVsServices projectVsServices,
+            SVsServiceProvider serviceProvider,
+            IProjectTree target)
+        {
+            return ShowAddItemDialogAsync(projectTree, projectVsServices, serviceProvider, target,AddItemAction.ExistingItem);
+        }
+
+        /// <summary>
+        /// Show the item dialog window to add new/existing items.
+        /// </summary>
+        private static async Task ShowAddItemDialogAsync(
+            IPhysicalProjectTree projectTree, 
+            IUnconfiguredProjectVsServices projectVsServices, 
+            SVsServiceProvider serviceProvider, 
+            IProjectTree target,
+            AddItemAction addItemAction)
+        {
+            Requires.NotNull(projectTree, nameof(projectTree));
+            Requires.NotNull(projectVsServices, nameof(projectVsServices));
+            Requires.NotNull(serviceProvider, nameof(serviceProvider));
+            Requires.NotNull(target, nameof(target));
+
+            await projectVsServices.ThreadingService.SwitchToUIThread();
+
+            var strBrowseLocations = projectTree.TreeProvider.GetAddNewItemDirectory(target);
+            ShowAddItemDialog(serviceProvider, target, projectVsServices.VsProject, strBrowseLocations, addItemAction);
+        }
+
+        private enum AddItemAction { NewItem=0, ExistingItem=1 }
+
+        /// <summary>
+        /// Direct Vs call to show the add item dialog.
+        /// </summary>
+        private static int ShowAddItemDialog(SVsServiceProvider serviceProvider, IProjectTree target, IVsProject vsProject, string strBrowseLocations, AddItemAction addItemAction)
+        {
+            var addItemDialog = serviceProvider.GetService<IVsAddProjectItemDlg, SVsAddProjectItemDlg>();
+            Assumes.Present(addItemDialog);
+
+            var uiFlags = __VSADDITEMFLAGS.VSADDITEM_AddNewItems | __VSADDITEMFLAGS.VSADDITEM_SuggestTemplateName | __VSADDITEMFLAGS.VSADDITEM_AllowHiddenTreeView;
+            if (addItemAction == AddItemAction.ExistingItem)
+            {
+                uiFlags = __VSADDITEMFLAGS.VSADDITEM_AddExistingItems | __VSADDITEMFLAGS.VSADDITEM_AllowMultiSelect | __VSADDITEMFLAGS.VSADDITEM_AllowStickyFilter | __VSADDITEMFLAGS.VSADDITEM_ProjectHandlesLinks;
+            }
+
+            var strFilter = string.Empty;
+            Guid addItemTemplateGuid = Guid.Empty;  // Let the dialog ask the hierarchy itself
+
+            return addItemDialog.AddProjectItemDlg(target.GetHierarchyId(), ref addItemTemplateGuid, vsProject, (uint)uiFlags,
+                null, null, ref strBrowseLocations, ref strFilter, out int iDontShowAgain);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/MoveDownCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/MoveDownCommand.cs
@@ -6,25 +6,25 @@ using Microsoft.VisualStudio.Packaging;
 using Microsoft.VisualStudio.ProjectSystem.Input;
 using Microsoft.VisualStudio.Shell;
 
-namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
-    [ProjectCommand(ManagedProjectSystemPackage.ManagedProjectSystemOrderCommandSet, ManagedProjectSystemPackage.MoveUpCmdId)]
-    [AppliesTo(ProjectCapability.FSharp)]
-    internal class MoveUpCommand : AbstractMoveCommand
+    [ProjectCommand(ManagedProjectSystemPackage.ManagedProjectSystemOrderCommandSet, ManagedProjectSystemPackage.MoveDownCmdId)]
+    [AppliesTo(ProjectCapability.SortByDisplayOrder)]
+    internal class MoveDownCommand : AbstractMoveCommand
     {
         [ImportingConstructor]
-        public MoveUpCommand(IPhysicalProjectTree projectTree, SVsServiceProvider serviceProvider, ConfiguredProject configuredProject) : base(projectTree, serviceProvider, configuredProject)
+        public MoveDownCommand(IPhysicalProjectTree projectTree, SVsServiceProvider serviceProvider, ConfiguredProject configuredProject) : base(projectTree, serviceProvider, configuredProject)
         {
         }
 
         protected override bool CanMove(IProjectTree node)
         {
-            return OrderingHelper.CanMoveUp(node);
+            return OrderingHelper.CanMoveDown(node);
         }
 
         protected override Task<bool> TryMoveAsync(ConfiguredProject configuredProject, IProjectTree node)
         {
-            return OrderingHelper.TryMoveUpAsync(configuredProject, node);
+            return OrderingHelper.TryMoveDownAsync(configuredProject, node);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/MoveUpCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/MoveUpCommand.cs
@@ -6,25 +6,25 @@ using Microsoft.VisualStudio.Packaging;
 using Microsoft.VisualStudio.ProjectSystem.Input;
 using Microsoft.VisualStudio.Shell;
 
-namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
-    [ProjectCommand(ManagedProjectSystemPackage.ManagedProjectSystemOrderCommandSet, ManagedProjectSystemPackage.MoveDownCmdId)]
-    [AppliesTo(ProjectCapability.FSharp)]
-    internal class MoveDownCommand : AbstractMoveCommand
+    [ProjectCommand(ManagedProjectSystemPackage.ManagedProjectSystemOrderCommandSet, ManagedProjectSystemPackage.MoveUpCmdId)]
+    [AppliesTo(ProjectCapability.SortByDisplayOrder)]
+    internal class MoveUpCommand : AbstractMoveCommand
     {
         [ImportingConstructor]
-        public MoveDownCommand(IPhysicalProjectTree projectTree, SVsServiceProvider serviceProvider, ConfiguredProject configuredProject) : base(projectTree, serviceProvider, configuredProject)
+        public MoveUpCommand(IPhysicalProjectTree projectTree, SVsServiceProvider serviceProvider, ConfiguredProject configuredProject) : base(projectTree, serviceProvider, configuredProject)
         {
         }
 
         protected override bool CanMove(IProjectTree node)
         {
-            return OrderingHelper.CanMoveDown(node);
+            return OrderingHelper.CanMoveUp(node);
         }
 
         protected override Task<bool> TryMoveAsync(ConfiguredProject configuredProject, IProjectTree node)
         {
-            return OrderingHelper.TryMoveDownAsync(configuredProject, node);
+            return OrderingHelper.TryMoveUpAsync(configuredProject, node);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
@@ -8,10 +8,34 @@ using System.Collections.ObjectModel;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
 
-namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
+    /// <summary>
+    /// Helper methods to interact with a project tree that have items with a valid display order.
+    /// </summary>
     internal static class OrderingHelper
     {
+        /// <summary>
+        /// Checks to see if the project tree has a valid display order.
+        /// </summary>
+        public static bool HasValidDisplayOrder(IProjectTree projectTree)
+        {
+            return IsValidDisplayOrder(GetDisplayOrder(projectTree));
+        }
+
+        /// <summary>
+        /// Gets the display order for a project tree.
+        /// </summary>
+        public static int GetDisplayOrder(IProjectTree projectTree)
+        {
+            if (projectTree is IProjectTree2 projectTree2)
+            {
+                return projectTree2.DisplayOrder;
+            }
+            // It's safe to return zero here. Project trees that do not have a display order are always assumed zero.
+            return 0;
+        }
+
         /// <summary>
         /// Checks if the given project tree can move up over one of its siblings.
         /// </summary>
@@ -42,6 +66,30 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
             Requires.NotNull(projectTree, nameof(projectTree));
 
             return TryMoveAsync(configuredProject, projectTree, MoveAction.Up);
+        }
+
+        /// <summary>
+        /// Move a project tree above the target project tree.
+        /// </summary>
+        public static bool TryMoveAbove(Project project, IProjectTree projectTree, IProjectTree target)
+        {
+            Requires.NotNull(project, nameof(project));
+            Requires.NotNull(projectTree, nameof(projectTree));
+            Requires.NotNull(target, nameof(target));
+
+            return TryMove(project, projectTree, target, MoveAction.Up);
+        }
+
+        /// <summary>
+        /// Move a project tree above the target project tree.
+        /// </summary>
+        public static Task<bool> TryMoveAboveAsync(ConfiguredProject configuredProject, IProjectTree projectTree, IProjectTree target)
+        {
+            Requires.NotNull(configuredProject, nameof(configuredProject));
+            Requires.NotNull(projectTree, nameof(projectTree));
+            Requires.NotNull(target, nameof(target));
+
+            return TryMoveAsync(configuredProject, projectTree, target, MoveAction.Up);
         }
 
         /// <summary>
@@ -77,6 +125,50 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         }
 
         /// <summary>
+        /// Move a project tree below the target project tree.
+        /// </summary>
+        public static bool TryMoveBelow(Project project, IProjectTree projectTree, IProjectTree target)
+        {
+            Requires.NotNull(project, nameof(project));
+            Requires.NotNull(projectTree, nameof(projectTree));
+            Requires.NotNull(target, nameof(target));
+
+            return TryMove(project, projectTree, target, MoveAction.Down);
+        }
+
+        /// <summary>
+        /// Move a project tree below the project tree.
+        /// </summary>
+        public static Task<bool> TryMoveBelowAsync(ConfiguredProject configuredProject, IProjectTree projectTree, IProjectTree target)
+        {
+            Requires.NotNull(configuredProject, nameof(configuredProject));
+            Requires.NotNull(projectTree, nameof(projectTree));
+            Requires.NotNull(target, nameof(target));
+
+            return TryMoveAsync(configuredProject, projectTree, target, MoveAction.Down);
+        }
+
+        /// <summary>
+        /// Gets the last child of a project tree.
+        /// The child will have a valid display order.
+        /// Returns null if there are no children, or no children with a valid display order.
+        /// </summary>
+        public static IProjectTree GetLastChild(IProjectTree projectTree)
+        {
+            return GetChildren(projectTree).LastOrDefault();
+        }
+
+        /// <summary>
+        /// Gets the first child of a project tree.
+        /// The child will have a valid display order.
+        /// Returns null if there are no children, or no children with a valid display order.
+        /// </summary>
+        public static IProjectTree GetFirstChild(IProjectTree projectTree)
+        {
+            return GetChildren(projectTree).FirstOrDefault();
+        }
+
+        /// <summary>
         /// Determines if we are moving up or down files or folders.
         /// </summary>
         private enum MoveAction { Up=0, Down=1 }
@@ -99,24 +191,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
             {
                 var tree = treeQueue.Dequeue();
 
-                if (tree.IsFolder)
+                if (tree is IProjectItemTree2 tree2 && IsValidDisplayOrder(tree2.DisplayOrder))
+                {
+                    // Technically it is possible to have more than one of the same item names.
+                    // We only want to add one of them.
+                    // Sanity check
+                    if (hashSet.Add(tree2.Item.ItemName))
+                    {
+                        includes.Add(tree2.DisplayOrder, tree2.Item.ItemName);
+                    }
+                }
+
+                if (tree.IsFolder || tree.Flags.HasFlag(ProjectTreeFlags.Common.ProjectRoot))
                 {
                     foreach (var childTree in tree.Children)
                     {
                         treeQueue.Enqueue(childTree);
-                    }
-                }
-                else
-                {
-                    if (tree is IProjectItemTree2 tree2 && IsValidDisplayOrder(tree2.DisplayOrder))
-                    {
-                        // Technically it is possible to have more than one of the same item names.
-                        // We only want to add one of them.
-                        // Sanity check
-                        if (hashSet.Add(tree2.Item.ItemName))
-                        {
-                            includes.Add(tree2.DisplayOrder, tree2.Item.ItemName);
-                        }
                     }
                 }
             }
@@ -151,24 +241,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         }
 
         /// <summary>
-        /// Gets the display order for a project tree.
-        /// </summary>
-        private static int GetDisplayOrder(IProjectTree projectTree)
-        {
-            if (projectTree is IProjectTree2 projectTree2)
-            {
-                return projectTree2.DisplayOrder;
-            }
-            // It's safe to return zero here. Project trees that do not have a display order are always assumed zero.
-            return 0;
-        }
-
-        /// <summary>
         /// Checks to see if the display order is valid.
         /// </summary>
         private static bool IsValidDisplayOrder(int displayOrder)
         {
             return displayOrder > 0 && displayOrder != int.MaxValue;
+        }
+
+        /// <summary>
+        /// Gets a collection a project tree's children. 
+        /// The children will only have a valid display order, and the collection will be in order by their display order.
+        /// </summary>
+        private static ReadOnlyCollection<IProjectTree> GetChildren(IProjectTree projectTree)
+        {
+            return projectTree.Children.Where(x => HasValidDisplayOrder(x)).OrderBy(x => GetDisplayOrder(x)).ToList().AsReadOnly();
         }
 
         /// <summary>
@@ -186,7 +272,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
                 return null;
             }
 
-            var orderedChildren = parent.Children.Where(x => IsValidDisplayOrder(GetDisplayOrder(x))).OrderBy(x => GetDisplayOrder(x)).ToList().AsReadOnly();
+            var orderedChildren = GetChildren(parent);
 
             for (var i = 0; i < orderedChildren.Count; ++i)
             {
@@ -319,18 +405,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         }
 
         /// <summary>
-        /// Move project elements based on the given project tree and move action. 
+        /// Move project elements based on the given project tree, reference project tree and move action. 
         /// Will modify the project if successful, but not save; only dirty.
         /// </summary>
-        private static bool TryMove(Project project, IProjectTree projectTree, MoveAction moveAction)
+        private static bool TryMove(Project project, IProjectTree projectTree, IProjectTree referenceProjectTree, MoveAction moveAction)
         {
-            // Determine what sibling we want to look at based on if we are moving up or down.
-            var sibling = GetSiblingByMoveAction(projectTree, moveAction);
+            if (!HasValidDisplayOrder(projectTree) || !HasValidDisplayOrder(referenceProjectTree))
+            {
+                return false;
+            }
 
-            if (sibling != null)
+            if (projectTree == referenceProjectTree)
+            {
+                return false;
+            }
+
+            if (referenceProjectTree != null)
             {
                 // The reference element is the element for which moved items will be above or below it.
-                var referenceElement = GetReferenceElement(project, sibling, moveAction);
+                var referenceElement = GetReferenceElement(project, referenceProjectTree, moveAction);
 
                 if (referenceElement != null)
                 {
@@ -344,8 +437,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 
         /// <summary>
         /// Move project elements based on the given project tree and move action. 
+        /// Will modify the project if successful, but not save; only dirty.
         /// </summary>
-        private static async Task<bool> TryMoveAsync(ConfiguredProject configuredProject, IProjectTree projectTree, MoveAction moveAction)
+        private static bool TryMove(Project project, IProjectTree projectTree, MoveAction moveAction)
+        {
+            // Determine what sibling we want to look at based on if we are moving up or down.
+            var sibling = GetSiblingByMoveAction(projectTree, moveAction);
+            return TryMove(project, projectTree, sibling, moveAction);
+        }
+
+        /// <summary>
+        /// Call to get a callback that allows modifying the project.
+        /// </summary>
+        private static async Task<bool> ModifyProjectAsync(ConfiguredProject configuredProject, Func<Project, bool> modify)
         {
             var projectLockService = configuredProject.UnconfiguredProject.ProjectService.Services.ProjectLockService;
 
@@ -358,8 +462,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
                 // We must perform a checkout of the project file before we can modify it.
                 await writeLock.CheckoutAsync(project.FullPath).ConfigureAwait(true);
 
-                return TryMove(project, projectTree, moveAction);
+                return modify(project);
             }
+        }
+
+        /// <summary>
+        /// Move project elements based on the given project tree and move action. 
+        /// </summary>
+        private static Task<bool> TryMoveAsync(ConfiguredProject configuredProject, IProjectTree projectTree, MoveAction moveAction)
+        {
+            return ModifyProjectAsync(configuredProject, project => TryMove(project, projectTree, moveAction));
+        }
+
+
+        /// <summary>
+        /// Move project elements based on the given project tree and move action. 
+        /// </summary>
+        private static Task<bool> TryMoveAsync(ConfiguredProject configuredProject, IProjectTree projectTree, IProjectTree referenceProjectTree, MoveAction moveAction)
+        {
+            return ModifyProjectAsync(configuredProject, project => TryMove(project, projectTree, referenceProjectTree, moveAction));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.cs.xlf
@@ -67,6 +67,56 @@
         <target state="new">MoveDown</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddAboveMenu|ButtonText">
+        <source>&amp;Add Above</source>
+        <target state="new">&amp;Add Above</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemAbove|ButtonText">
+        <source>&amp;Add New Item...</source>
+        <target state="new">&amp;Add New Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemAbove|CommandName">
+        <source>AddNewItemAbove</source>
+        <target state="new">AddNewItemAbove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AddBelowMenu|ButtonText">
+        <source>&amp;Add Below</source>
+        <target state="new">&amp;Add Below</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemAbove|ButtonText">
+        <source>&amp;Add Existing Item...</source>
+        <target state="new">&amp;Add Existing Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemAbove|CommandName">
+        <source>AddExistingItemAbove</source>
+        <target state="new">AddExistingItemAbove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemBelow|ButtonText">
+        <source>&amp;Add New Item...</source>
+        <target state="new">&amp;Add New Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemBelow|CommandName">
+        <source>AddNewItemBelow</source>
+        <target state="new">AddNewItemBelow</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemBelow|ButtonText">
+        <source>&amp;Add Existing Item...</source>
+        <target state="new">&amp;Add Existing Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemBelow|CommandName">
+        <source>AddExistingItemBelow</source>
+        <target state="new">AddExistingItemBelow</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.de.xlf
@@ -67,6 +67,56 @@
         <target state="new">MoveDown</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddAboveMenu|ButtonText">
+        <source>&amp;Add Above</source>
+        <target state="new">&amp;Add Above</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemAbove|ButtonText">
+        <source>&amp;Add New Item...</source>
+        <target state="new">&amp;Add New Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemAbove|CommandName">
+        <source>AddNewItemAbove</source>
+        <target state="new">AddNewItemAbove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AddBelowMenu|ButtonText">
+        <source>&amp;Add Below</source>
+        <target state="new">&amp;Add Below</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemAbove|ButtonText">
+        <source>&amp;Add Existing Item...</source>
+        <target state="new">&amp;Add Existing Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemAbove|CommandName">
+        <source>AddExistingItemAbove</source>
+        <target state="new">AddExistingItemAbove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemBelow|ButtonText">
+        <source>&amp;Add New Item...</source>
+        <target state="new">&amp;Add New Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemBelow|CommandName">
+        <source>AddNewItemBelow</source>
+        <target state="new">AddNewItemBelow</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemBelow|ButtonText">
+        <source>&amp;Add Existing Item...</source>
+        <target state="new">&amp;Add Existing Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemBelow|CommandName">
+        <source>AddExistingItemBelow</source>
+        <target state="new">AddExistingItemBelow</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.es.xlf
@@ -67,6 +67,56 @@
         <target state="new">MoveDown</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddAboveMenu|ButtonText">
+        <source>&amp;Add Above</source>
+        <target state="new">&amp;Add Above</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemAbove|ButtonText">
+        <source>&amp;Add New Item...</source>
+        <target state="new">&amp;Add New Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemAbove|CommandName">
+        <source>AddNewItemAbove</source>
+        <target state="new">AddNewItemAbove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AddBelowMenu|ButtonText">
+        <source>&amp;Add Below</source>
+        <target state="new">&amp;Add Below</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemAbove|ButtonText">
+        <source>&amp;Add Existing Item...</source>
+        <target state="new">&amp;Add Existing Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemAbove|CommandName">
+        <source>AddExistingItemAbove</source>
+        <target state="new">AddExistingItemAbove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemBelow|ButtonText">
+        <source>&amp;Add New Item...</source>
+        <target state="new">&amp;Add New Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemBelow|CommandName">
+        <source>AddNewItemBelow</source>
+        <target state="new">AddNewItemBelow</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemBelow|ButtonText">
+        <source>&amp;Add Existing Item...</source>
+        <target state="new">&amp;Add Existing Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemBelow|CommandName">
+        <source>AddExistingItemBelow</source>
+        <target state="new">AddExistingItemBelow</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.fr.xlf
@@ -67,6 +67,56 @@
         <target state="new">MoveDown</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddAboveMenu|ButtonText">
+        <source>&amp;Add Above</source>
+        <target state="new">&amp;Add Above</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemAbove|ButtonText">
+        <source>&amp;Add New Item...</source>
+        <target state="new">&amp;Add New Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemAbove|CommandName">
+        <source>AddNewItemAbove</source>
+        <target state="new">AddNewItemAbove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AddBelowMenu|ButtonText">
+        <source>&amp;Add Below</source>
+        <target state="new">&amp;Add Below</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemAbove|ButtonText">
+        <source>&amp;Add Existing Item...</source>
+        <target state="new">&amp;Add Existing Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemAbove|CommandName">
+        <source>AddExistingItemAbove</source>
+        <target state="new">AddExistingItemAbove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemBelow|ButtonText">
+        <source>&amp;Add New Item...</source>
+        <target state="new">&amp;Add New Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemBelow|CommandName">
+        <source>AddNewItemBelow</source>
+        <target state="new">AddNewItemBelow</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemBelow|ButtonText">
+        <source>&amp;Add Existing Item...</source>
+        <target state="new">&amp;Add Existing Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemBelow|CommandName">
+        <source>AddExistingItemBelow</source>
+        <target state="new">AddExistingItemBelow</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.it.xlf
@@ -67,6 +67,56 @@
         <target state="new">MoveDown</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddAboveMenu|ButtonText">
+        <source>&amp;Add Above</source>
+        <target state="new">&amp;Add Above</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemAbove|ButtonText">
+        <source>&amp;Add New Item...</source>
+        <target state="new">&amp;Add New Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemAbove|CommandName">
+        <source>AddNewItemAbove</source>
+        <target state="new">AddNewItemAbove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AddBelowMenu|ButtonText">
+        <source>&amp;Add Below</source>
+        <target state="new">&amp;Add Below</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemAbove|ButtonText">
+        <source>&amp;Add Existing Item...</source>
+        <target state="new">&amp;Add Existing Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemAbove|CommandName">
+        <source>AddExistingItemAbove</source>
+        <target state="new">AddExistingItemAbove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemBelow|ButtonText">
+        <source>&amp;Add New Item...</source>
+        <target state="new">&amp;Add New Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemBelow|CommandName">
+        <source>AddNewItemBelow</source>
+        <target state="new">AddNewItemBelow</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemBelow|ButtonText">
+        <source>&amp;Add Existing Item...</source>
+        <target state="new">&amp;Add Existing Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemBelow|CommandName">
+        <source>AddExistingItemBelow</source>
+        <target state="new">AddExistingItemBelow</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.ja.xlf
@@ -67,6 +67,56 @@
         <target state="new">MoveDown</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddAboveMenu|ButtonText">
+        <source>&amp;Add Above</source>
+        <target state="new">&amp;Add Above</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemAbove|ButtonText">
+        <source>&amp;Add New Item...</source>
+        <target state="new">&amp;Add New Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemAbove|CommandName">
+        <source>AddNewItemAbove</source>
+        <target state="new">AddNewItemAbove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AddBelowMenu|ButtonText">
+        <source>&amp;Add Below</source>
+        <target state="new">&amp;Add Below</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemAbove|ButtonText">
+        <source>&amp;Add Existing Item...</source>
+        <target state="new">&amp;Add Existing Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemAbove|CommandName">
+        <source>AddExistingItemAbove</source>
+        <target state="new">AddExistingItemAbove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemBelow|ButtonText">
+        <source>&amp;Add New Item...</source>
+        <target state="new">&amp;Add New Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemBelow|CommandName">
+        <source>AddNewItemBelow</source>
+        <target state="new">AddNewItemBelow</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemBelow|ButtonText">
+        <source>&amp;Add Existing Item...</source>
+        <target state="new">&amp;Add Existing Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemBelow|CommandName">
+        <source>AddExistingItemBelow</source>
+        <target state="new">AddExistingItemBelow</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.ko.xlf
@@ -67,6 +67,56 @@
         <target state="new">MoveDown</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddAboveMenu|ButtonText">
+        <source>&amp;Add Above</source>
+        <target state="new">&amp;Add Above</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemAbove|ButtonText">
+        <source>&amp;Add New Item...</source>
+        <target state="new">&amp;Add New Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemAbove|CommandName">
+        <source>AddNewItemAbove</source>
+        <target state="new">AddNewItemAbove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AddBelowMenu|ButtonText">
+        <source>&amp;Add Below</source>
+        <target state="new">&amp;Add Below</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemAbove|ButtonText">
+        <source>&amp;Add Existing Item...</source>
+        <target state="new">&amp;Add Existing Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemAbove|CommandName">
+        <source>AddExistingItemAbove</source>
+        <target state="new">AddExistingItemAbove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemBelow|ButtonText">
+        <source>&amp;Add New Item...</source>
+        <target state="new">&amp;Add New Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemBelow|CommandName">
+        <source>AddNewItemBelow</source>
+        <target state="new">AddNewItemBelow</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemBelow|ButtonText">
+        <source>&amp;Add Existing Item...</source>
+        <target state="new">&amp;Add Existing Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemBelow|CommandName">
+        <source>AddExistingItemBelow</source>
+        <target state="new">AddExistingItemBelow</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.pl.xlf
@@ -67,6 +67,56 @@
         <target state="new">MoveDown</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddAboveMenu|ButtonText">
+        <source>&amp;Add Above</source>
+        <target state="new">&amp;Add Above</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemAbove|ButtonText">
+        <source>&amp;Add New Item...</source>
+        <target state="new">&amp;Add New Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemAbove|CommandName">
+        <source>AddNewItemAbove</source>
+        <target state="new">AddNewItemAbove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AddBelowMenu|ButtonText">
+        <source>&amp;Add Below</source>
+        <target state="new">&amp;Add Below</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemAbove|ButtonText">
+        <source>&amp;Add Existing Item...</source>
+        <target state="new">&amp;Add Existing Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemAbove|CommandName">
+        <source>AddExistingItemAbove</source>
+        <target state="new">AddExistingItemAbove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemBelow|ButtonText">
+        <source>&amp;Add New Item...</source>
+        <target state="new">&amp;Add New Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemBelow|CommandName">
+        <source>AddNewItemBelow</source>
+        <target state="new">AddNewItemBelow</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemBelow|ButtonText">
+        <source>&amp;Add Existing Item...</source>
+        <target state="new">&amp;Add Existing Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemBelow|CommandName">
+        <source>AddExistingItemBelow</source>
+        <target state="new">AddExistingItemBelow</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.pt-BR.xlf
@@ -67,6 +67,56 @@
         <target state="new">MoveDown</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddAboveMenu|ButtonText">
+        <source>&amp;Add Above</source>
+        <target state="new">&amp;Add Above</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemAbove|ButtonText">
+        <source>&amp;Add New Item...</source>
+        <target state="new">&amp;Add New Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemAbove|CommandName">
+        <source>AddNewItemAbove</source>
+        <target state="new">AddNewItemAbove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AddBelowMenu|ButtonText">
+        <source>&amp;Add Below</source>
+        <target state="new">&amp;Add Below</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemAbove|ButtonText">
+        <source>&amp;Add Existing Item...</source>
+        <target state="new">&amp;Add Existing Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemAbove|CommandName">
+        <source>AddExistingItemAbove</source>
+        <target state="new">AddExistingItemAbove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemBelow|ButtonText">
+        <source>&amp;Add New Item...</source>
+        <target state="new">&amp;Add New Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemBelow|CommandName">
+        <source>AddNewItemBelow</source>
+        <target state="new">AddNewItemBelow</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemBelow|ButtonText">
+        <source>&amp;Add Existing Item...</source>
+        <target state="new">&amp;Add Existing Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemBelow|CommandName">
+        <source>AddExistingItemBelow</source>
+        <target state="new">AddExistingItemBelow</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.ru.xlf
@@ -67,6 +67,56 @@
         <target state="new">MoveDown</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddAboveMenu|ButtonText">
+        <source>&amp;Add Above</source>
+        <target state="new">&amp;Add Above</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemAbove|ButtonText">
+        <source>&amp;Add New Item...</source>
+        <target state="new">&amp;Add New Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemAbove|CommandName">
+        <source>AddNewItemAbove</source>
+        <target state="new">AddNewItemAbove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AddBelowMenu|ButtonText">
+        <source>&amp;Add Below</source>
+        <target state="new">&amp;Add Below</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemAbove|ButtonText">
+        <source>&amp;Add Existing Item...</source>
+        <target state="new">&amp;Add Existing Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemAbove|CommandName">
+        <source>AddExistingItemAbove</source>
+        <target state="new">AddExistingItemAbove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemBelow|ButtonText">
+        <source>&amp;Add New Item...</source>
+        <target state="new">&amp;Add New Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemBelow|CommandName">
+        <source>AddNewItemBelow</source>
+        <target state="new">AddNewItemBelow</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemBelow|ButtonText">
+        <source>&amp;Add Existing Item...</source>
+        <target state="new">&amp;Add Existing Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemBelow|CommandName">
+        <source>AddExistingItemBelow</source>
+        <target state="new">AddExistingItemBelow</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.tr.xlf
@@ -67,6 +67,56 @@
         <target state="new">MoveDown</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddAboveMenu|ButtonText">
+        <source>&amp;Add Above</source>
+        <target state="new">&amp;Add Above</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemAbove|ButtonText">
+        <source>&amp;Add New Item...</source>
+        <target state="new">&amp;Add New Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemAbove|CommandName">
+        <source>AddNewItemAbove</source>
+        <target state="new">AddNewItemAbove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AddBelowMenu|ButtonText">
+        <source>&amp;Add Below</source>
+        <target state="new">&amp;Add Below</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemAbove|ButtonText">
+        <source>&amp;Add Existing Item...</source>
+        <target state="new">&amp;Add Existing Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemAbove|CommandName">
+        <source>AddExistingItemAbove</source>
+        <target state="new">AddExistingItemAbove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemBelow|ButtonText">
+        <source>&amp;Add New Item...</source>
+        <target state="new">&amp;Add New Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemBelow|CommandName">
+        <source>AddNewItemBelow</source>
+        <target state="new">AddNewItemBelow</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemBelow|ButtonText">
+        <source>&amp;Add Existing Item...</source>
+        <target state="new">&amp;Add Existing Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemBelow|CommandName">
+        <source>AddExistingItemBelow</source>
+        <target state="new">AddExistingItemBelow</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.zh-Hans.xlf
@@ -67,6 +67,56 @@
         <target state="new">MoveDown</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddAboveMenu|ButtonText">
+        <source>&amp;Add Above</source>
+        <target state="new">&amp;Add Above</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemAbove|ButtonText">
+        <source>&amp;Add New Item...</source>
+        <target state="new">&amp;Add New Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemAbove|CommandName">
+        <source>AddNewItemAbove</source>
+        <target state="new">AddNewItemAbove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AddBelowMenu|ButtonText">
+        <source>&amp;Add Below</source>
+        <target state="new">&amp;Add Below</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemAbove|ButtonText">
+        <source>&amp;Add Existing Item...</source>
+        <target state="new">&amp;Add Existing Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemAbove|CommandName">
+        <source>AddExistingItemAbove</source>
+        <target state="new">AddExistingItemAbove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemBelow|ButtonText">
+        <source>&amp;Add New Item...</source>
+        <target state="new">&amp;Add New Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemBelow|CommandName">
+        <source>AddNewItemBelow</source>
+        <target state="new">AddNewItemBelow</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemBelow|ButtonText">
+        <source>&amp;Add Existing Item...</source>
+        <target state="new">&amp;Add Existing Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemBelow|CommandName">
+        <source>AddExistingItemBelow</source>
+        <target state="new">AddExistingItemBelow</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.zh-Hant.xlf
@@ -67,6 +67,56 @@
         <target state="new">MoveDown</target>
         <note />
       </trans-unit>
+      <trans-unit id="AddAboveMenu|ButtonText">
+        <source>&amp;Add Above</source>
+        <target state="new">&amp;Add Above</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemAbove|ButtonText">
+        <source>&amp;Add New Item...</source>
+        <target state="new">&amp;Add New Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemAbove|CommandName">
+        <source>AddNewItemAbove</source>
+        <target state="new">AddNewItemAbove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="AddBelowMenu|ButtonText">
+        <source>&amp;Add Below</source>
+        <target state="new">&amp;Add Below</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemAbove|ButtonText">
+        <source>&amp;Add Existing Item...</source>
+        <target state="new">&amp;Add Existing Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemAbove|CommandName">
+        <source>AddExistingItemAbove</source>
+        <target state="new">AddExistingItemAbove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemBelow|ButtonText">
+        <source>&amp;Add New Item...</source>
+        <target state="new">&amp;Add New Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddNewItemBelow|CommandName">
+        <source>AddNewItemBelow</source>
+        <target state="new">AddNewItemBelow</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemBelow|ButtonText">
+        <source>&amp;Add Existing Item...</source>
+        <target state="new">&amp;Add Existing Item...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidAddExistingItemBelow|CommandName">
+        <source>AddExistingItemBelow</source>
+        <target state="new">AddExistingItemBelow</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
**Customer scenario**

Users need to be able to add files above and below existing files in solution explorer for languages that need file ordering, such as F#.

**Bugs this fixes:** 

https://github.com/dotnet/project-system/issues/2887

**Workarounds, if any**

Add a file and move it using solution explorer or editing the proj file.

**Risk**

Adds some changes to existing ordering for moving up and down, but nothing significant. Ordering work is self contained.

**Performance impact**

No performance impact.

**Is this a regression from a previous update?**

No

**Root cause analysis:**

Feature was not implemented to begin with.

**How was the bug found?**

Feature was not implemented to begin with.

---

A few comments:

These changes are only just for adding files above and below other files or folders. It also overrides the behavior for the standard add new item/add existing item for languages that need file ordering, F#.

The commands for ordering are in their own folder to keep everything organized.