### PR TITLE
Added .fsi, .ml, .mli file extensions to F# schema

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/FSharp.ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/FSharp.ProjectItemsSchema.xaml
@@ -12,5 +12,8 @@
     <ItemType Name="Compile" DisplayName="F# compiler"/>
     
     <FileExtension Name=".fs" ContentType="FSharpFile"/>
+    <FileExtension Name=".fsi" ContentType="FSharpFile"/>
+    <FileExtension Name=".ml" ContentType="FSharpFile"/>
+    <FileExtension Name=".mli" ContentType="FSharpFile"/>
 </ProjectSchemaDefinitions>
 


### PR DESCRIPTION
**Customer scenario**

Customer adds a ".fsi", F# signature file, to their F# project and it by default will not be part of compilation.

**Bugs this fixes:** 

https://github.com/dotnet/project-system/issues/3207

**Workarounds, if any**

Edit the "fsproj" file to change the item type.

**Risk**

No risk

**Performance impact**

No performance impact

**Is this a regression from a previous update?**

No

**Root cause analysis:**

F# devs typically don't create ".fsi" a lot.

**How was the bug found?**

Testing adding files.

---

I haven't been able to get this to work, or be able to test this. I'm certain this change is what associates file extensions with item types, according to here: https://github.com/Microsoft/VSProjectSystem/blob/master/doc/extensibility/custom_item_types.md

I also followed the instructions for VS to respect the rules: https://github.com/dotnet/project-system/blob/master/docs/repo/getting-started.md#command-line-1