### PR TITLE
Changing the debug dropdown does not run the correct debug target

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -189,14 +189,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                             
                 ProjectRuleSubscriptionLink = ProjectDataSources.SyncLinkTo(
                     ProjectSubscriptionService.ProjectRuleSource.SourceBlock.SyncLinkOptions(evaluationLinkOptions),
-                    CommonProjectServices.ActiveConfiguredProject.Capabilities.SourceBlock.SyncLinkOptions(),
+                    CommonProjectServices.Project.Capabilities.SourceBlock.SyncLinkOptions(),
                     projectChangesBlock,
                     linkOptions: new DataflowLinkOptions { PropagateCompletion = true });
 
                 var capabilitiesChangeBlock = new ActionBlock<IProjectVersionedValue<IProjectCapabilitiesSnapshot>>(
                             DataflowUtilities.CaptureAndApplyExecutionContext<IProjectVersionedValue<IProjectCapabilitiesSnapshot>>(Capabilities_ChangedAsync));
 
-                CapabilitiesSubscriptionLink = CommonProjectServices.ActiveConfiguredProject.Capabilities.SourceBlock.LinkTo(
+                CapabilitiesSubscriptionLink = CommonProjectServices.Project.Capabilities.SourceBlock.LinkTo(
                     capabilitiesChangeBlock,
                     linkOptions: new DataflowLinkOptions { PropagateCompletion = true });
             }
@@ -210,7 +210,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             // Updates need to be sequenced
             await _sequentialTaskQueue.ExecuteTask(async () =>
             {
-                using (ProjectCapabilitiesContext.CreateIsolatedContext(CommonProjectServices.ActiveConfiguredProject, capabilities.Value))
+                using (ProjectCapabilitiesContext.CreateIsolatedContext(CommonProjectServices.Project, capabilities.Value))
                 {
                     await UpdateProfilesAsync(null).ConfigureAwait(false);
                 }


### PR DESCRIPTION
**Customer scenario**
Changing the debug dropdown to run a different debug target does not work reliably. Even though the UI updates, the actual debug target doesn't change. This is a regression caused by this [PR](https://github.com/dotnet/project-system/pull/3174)

**Bugs this fixes:** 
https://devdiv.visualstudio.com/DevDiv/_workitems?id=560770

(either VSO or GitHub links)

**Workarounds, if any**

No real workaround other than to close and reopen the project after making the change. 

**Risk**

Low risk. The change is to link to the Unconfigured capabilities rather than the Configured capabilities. The previous PR mixed Unconfigured project level dataflow with Configured project level dataflow.

**Performance impact**

Low. 

**Is this a regression from a previous update?**
Yes.

**Root cause analysis:**

**How was the bug found?**
Test team manual walk throughs

(E.g. customer reported it vs. ad hoc testing)
