### PR TITLE
fix default target DebuggerFlavor property

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -51,7 +51,7 @@
 
   <PropertyGroup>
     <ManagedXamlResourcesDirectory Condition="!HasTrailingSlash('$(ManagedXamlResourcesDirectory)')">$(ManagedXamlResourcesDirectory)\</ManagedXamlResourcesDirectory>
-    <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
+    <DebuggerFlavor Condition = "'$(DebuggerFlavor)' == ''">ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
 
   <!-- Project Capabilities -->


### PR DESCRIPTION
This change fixes an issue when trying to add a custom debugger to an extension - the DebuggerFlavor property gets overridden by the default target.