### PR TITLE
Fix missing "Clean" command in new projects

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/ImplicitlyActiveConfiguredProjectReadyToBuild.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/ImplicitlyActiveConfiguredProjectReadyToBuild.cs
@@ -1,29 +1,76 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Build
 {
-    /// <summary>
-    ///     Provides an implementation of <see cref="IConfiguredProjectReadyToBuild"/> that allows
-    ///     implicitly active <see cref="ConfiguredProject"/> objects to perform design-time builds.
-    /// </summary>
     [Export(typeof(IConfiguredProjectReadyToBuild))]
     [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharpLanguageService)]
     [Order(Order.Default)]
-    internal sealed class ImplicitlyActiveConfiguredProjectReadyToBuild : IConfiguredProjectReadyToBuild
+    internal sealed class ImplicitlyActiveConfiguredProjectReadyToBuild : IConfiguredProjectReadyToBuild, IDisposable
     {
-        private readonly IConfiguredProjectImplicitActivationTracking _implicitActivationTracking;
+        private readonly ConfiguredProject _configuredProject;
+        private readonly IActiveConfiguredProjectProvider _activeConfiguredProjectProvider;
+
+        private TaskCompletionSource<object> _activationTask;
 
         [ImportingConstructor]
-        public ImplicitlyActiveConfiguredProjectReadyToBuild(IConfiguredProjectImplicitActivationTracking implicitActivationTracking)
+        public ImplicitlyActiveConfiguredProjectReadyToBuild(
+            ConfiguredProject configuredProject,
+            IActiveConfiguredProjectProvider activeConfiguredProjectProvider)
         {
-            _implicitActivationTracking = implicitActivationTracking;
+            Requires.NotNull(configuredProject, nameof(configuredProject));
+            Requires.NotNull(activeConfiguredProjectProvider, nameof(activeConfiguredProjectProvider));
+
+            _configuredProject = configuredProject;
+            _activeConfiguredProjectProvider = activeConfiguredProjectProvider;
+            _activationTask = new TaskCompletionSource<object>();
+
+            _activeConfiguredProjectProvider.Changed += ActiveConfiguredProject_Changed;
         }
 
-        public bool IsValidToBuild => _implicitActivationTracking.IsImplicitlyActive;
+        private void ActiveConfiguredProject_Changed(object sender, ActiveConfigurationChangedEventArgs e) => GetLatestActivationTask();
 
-        public Task WaitReadyToBuildAsync() => _implicitActivationTracking.IsImplicitlyActiveTask;
+        public bool IsValidToBuild => GetLatestActivationTask().IsCompleted;
+        public async Task WaitReadyToBuildAsync() => await GetLatestActivationTask().ConfigureAwait(false);
+
+        private Task GetLatestActivationTask()
+        {
+            lock (_configuredProject)
+            {
+                var previouslyActive = _activationTask.Task.IsCompleted;
+                var nowActive = IsActive();
+                if (previouslyActive)
+                {
+                    if (!nowActive)
+                    {
+                        _activationTask = new TaskCompletionSource<object>();
+                    }
+                }
+                else if (nowActive)
+                {
+                    _activationTask.TrySetResult(null);
+                }
+
+                return _activationTask.Task;
+            }
+        }
+
+        public void Dispose()
+        {
+            _activationTask.TrySetCanceled();
+            _activeConfiguredProjectProvider.Changed -= ActiveConfiguredProject_Changed;
+        }
+
+        private bool IsActive()
+        {
+            ProjectConfiguration activeConfig = _activeConfiguredProjectProvider.ActiveProjectConfiguration;
+            if (activeConfig == null)
+                return false;
+
+            return _configuredProject.ProjectConfiguration.EqualIgnoringTargetFramework(activeConfig);
+        }
     }
 }


### PR DESCRIPTION
It seems that Clean is hidden if the project isn't ready to build, but VS only
asks once. Having switched to using dataflow, we would return false on the very
first call.

Reverts the changes in 36e5c6c2.

**Customer scenario**

Create a new ASP.NET Core project.  The "Clean" button will be missing until the solution is reloaded.

**Bugs this fixes:** 

[VSTS Bug 550183](https://devdiv.visualstudio.com/DevDiv/Managed%20Project%20System/_workitems/edit/550183)

**Workarounds, if any**

Reload the solution.

**Risk**

Low - reverts to previous implementation used for 15.5.

**Performance impact**

Low - just tracking configuration changed events.

**Is this a regression from a previous update?**

Yes, it's a regression from 15.5, related to moving the service to use DataFlow.

**Root cause analysis:**

It seems that Clean is hidden if the project isn't ready to build, but VS only
asks once. Having switched to using dataflow, we would return false on the very
first call.

**How was the bug found?**

Internal automated tests.
