### PR TITLE
Allow Project settings AppDesigner tabs to be activated via UI automation

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabButton.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabButton.vb
@@ -280,6 +280,20 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                 _button.PerformClick()
             End Sub
 
+            ''' <summary>
+            ''' Calls default action when select is called. Checks for correct flag
+            ''' </summary>
+            Public Overrides Sub [Select](flags As AccessibleSelection)
+                '''AccessibleSelection.TakeSelection is the flag set when an object is selected,
+                '''specfically from SelectionItem.Select If this flag is set, we call the default
+                '''action on the PageTab, which gives the desired behavior of selecting the item.
+                If (flags And AccessibleSelection.TakeSelection) = AccessibleSelection.TakeSelection Then
+                    DoDefaultAction()
+                Else
+                    MyBase.Select(flags)
+                End If
+            End Sub
+
         End Class
 
     End Class


### PR DESCRIPTION
**Customer scenario**

@Pilchie 
"Pulling back into 15.6 based on Accessibility team's recommendation."

**Bugs this fixes:** 

https://devdiv.visualstudio.com/DevDiv/Managed%20Project%20System/_queries?id=433488&_a=edit&triage=true

**Workarounds, if any**

None

**Risk**

Low

**Performance impact**

None

**Is this a regression from a previous update?**

No

**Root cause analysis:**

We missed a scenario for Accessibility  

**How was the bug found?**

Originally found through Integration Tests
