### PR TITLE
Fix for bug 565888 - [E2EBlocking] Create ASP.NET Core 2.0 Web Applic…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -101,7 +101,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         private TaskCompletionSource<bool> _firstSnapshotCompletionSource = new TaskCompletionSource<bool>();
 
         protected IDisposable ProjectRuleSubscriptionLink { get; set; }
-        protected IDisposable CapabilitiesSubscriptionLink { get; set; }
 
         private SequencialTaskExecutor _sequentialTaskQueue = new SequencialTaskExecutor();
 
@@ -749,12 +748,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 {
                     ProjectRuleSubscriptionLink.Dispose();
                     ProjectRuleSubscriptionLink = null;
-                }
-
-                if (CapabilitiesSubscriptionLink != null)
-                {
-                    CapabilitiesSubscriptionLink.Dispose();
-                    CapabilitiesSubscriptionLink = null;
                 }
             }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -192,29 +192,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                     CommonProjectServices.Project.Capabilities.SourceBlock.SyncLinkOptions(),
                     projectChangesBlock,
                     linkOptions: new DataflowLinkOptions { PropagateCompletion = true });
-
-                var capabilitiesChangeBlock = new ActionBlock<IProjectVersionedValue<IProjectCapabilitiesSnapshot>>(
-                            DataflowUtilities.CaptureAndApplyExecutionContext<IProjectVersionedValue<IProjectCapabilitiesSnapshot>>(Capabilities_ChangedAsync));
-
-                CapabilitiesSubscriptionLink = CommonProjectServices.Project.Capabilities.SourceBlock.LinkTo(
-                    capabilitiesChangeBlock,
-                    linkOptions: new DataflowLinkOptions { PropagateCompletion = true });
             }
 
             // Make sure we are watching the file at this point
             WatchLaunchSettingsFile();
-        }
-
-        private async Task Capabilities_ChangedAsync(IProjectVersionedValue<IProjectCapabilitiesSnapshot> capabilities)
-        {
-            // Updates need to be sequenced
-            await _sequentialTaskQueue.ExecuteTask(async () =>
-            {
-                using (ProjectCapabilitiesContext.CreateIsolatedContext(CommonProjectServices.Project, capabilities.Value))
-                {
-                    await UpdateProfilesAsync(null).ConfigureAwait(false);
-                }
-            }).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -232,7 +213,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                     // Updates need to be sequenced
                     await _sequentialTaskQueue.ExecuteTask(async () =>
                     {
-                        using (ProjectCapabilitiesContext.CreateIsolatedContext(CommonProjectServices.ActiveConfiguredProject, projectSnapshot.Value.Item2))
+                        using (ProjectCapabilitiesContext.CreateIsolatedContext(CommonProjectServices.Project, projectSnapshot.Value.Item2))
                         {
                             await UpdateActiveProfileInSnapshotAsync(activeProfile).ConfigureAwait(false);
                         }


### PR DESCRIPTION
**Customer scenario**
Create a new ASP.NET Core web application with individual authentication.  The sslport is set to 0 instead of the actual port value. When you F5, you'll see a page not found in the browser as it is configured to launch on the https url.l

**Bugs this fixes:** 
[565888](https://devdiv.visualstudio.com/DevDiv/_workitems?id=565888): Create ASP.NET Core 2.0 Web Application with IndAuth, the "ssIport" is 0 in launchSettings.json.


**Workarounds, if any**
Hand edit the launchsettings.json file to add the correct ssl port

**Risk**
Should be low. Removed the extra capabilities dataflow that was added by PR 3174 as it is completely unnecessary. The first snapshot from this dataflow does not contain the proper set of capabilities and unfortunately, the first launch settings snapshot is created from this data. When the web project system validates IIS Express settings later, it doesn't see any because the snapshot was created without the correct capabilities and overwrites the actual settings with its own.

**Performance impact**
Shouldn't be any perf impact

**Is this a regression from a previous update?**
Yes. A regression caused by [this ](https://github.com/dotnet/project-system/pull/3174) change and [this ](https://github.com/dotnet/project-system/pull/3227)one which incorrectly fixed the first one.

**Root cause analysis:**

Poor testing of related scenarios. There is pretty good unit test coverage, but no integration tests.

**How was the bug found?**
CTI team manual test walk throughs. 
