### PR TITLE
Fixed an ordering bug dealing with empty folders and adding multiple items

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelperTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelperTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using Microsoft.Build.Evaluation;
 using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
 
@@ -352,7 +353,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
     File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
     File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 2, ItemName: ""test3.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 3, ItemName: ""test3.fs""
 ");
 
             var projectRootElement = @"
@@ -398,7 +399,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
     File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
     File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 2, ItemName: ""test3.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 3, ItemName: ""test3.fs""
 ");
 
             var projectRootElement = @"
@@ -431,6 +432,195 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
     <Compile Include=""test2.fs"" />
     <Compile Include=""test3.fs"" />
     <Compile Include=""test1.fs"" />
+  </ItemGroup>
+</Project>";
+
+            AssertEqualProject(expected, project);
+        }
+
+        [Fact]
+        public void AddItem_IsSuccessful()
+        {
+            var tree = ProjectTreeParser.Parse(@"
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
+    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 3, ItemName: ""test3.fs""
+");
+
+            var updatedTree = ProjectTreeParser.Parse(@"
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
+    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 3, ItemName: ""test4.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 4, ItemName: ""test3.fs""
+");
+
+            var addedNodes = new List<IProjectTree>();
+            addedNodes.Add(updatedTree.Children[2]);
+
+            var projectRootElement = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include=""test1.fs"" />
+    <Compile Include=""test2.fs"" />
+    <Compile Include=""test4.fs"" />
+    <Compile Include=""test3.fs"" />
+  </ItemGroup>
+
+</Project>
+".AsProjectRootElement();
+
+            var project = new Project(projectRootElement);
+
+            Assert.True(OrderingHelper.TryMoveNodesToTop(project, addedNodes, tree), "TryMoveNodesToTop returned false.");
+            Assert.True(project.IsDirty);
+
+            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include=""test4.fs"" />
+    <Compile Include=""test1.fs"" />
+    <Compile Include=""test2.fs"" />
+    <Compile Include=""test3.fs"" />
+  </ItemGroup>
+</Project>";
+
+            AssertEqualProject(expected, project);
+        }
+
+        [Fact]
+        public void AddItems_IsSuccessful()
+        {
+            var tree = ProjectTreeParser.Parse(@"
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
+    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 3, ItemName: ""test3.fs""
+");
+
+            var updatedTree = ProjectTreeParser.Parse(@"
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
+    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 3, ItemName: ""test4.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test5.fs"", DisplayOrder: 4, ItemName: ""test5.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 5, ItemName: ""test3.fs""
+");
+
+            var addedNodes = new List<IProjectTree>();
+            addedNodes.Add(updatedTree.Children[2]);
+            addedNodes.Add(updatedTree.Children[3]);
+
+            var projectRootElement = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include=""test1.fs"" />
+    <Compile Include=""test2.fs"" />
+    <Compile Include=""test4.fs"" />
+    <Compile Include=""test5.fs"" />
+    <Compile Include=""test3.fs"" />
+  </ItemGroup>
+
+</Project>
+".AsProjectRootElement();
+
+            var project = new Project(projectRootElement);
+
+            Assert.True(OrderingHelper.TryMoveNodesToTop(project, addedNodes, tree), "TryMoveNodesToTop returned false.");
+            Assert.True(project.IsDirty);
+
+            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include=""test4.fs"" />
+    <Compile Include=""test5.fs"" />
+    <Compile Include=""test1.fs"" />
+    <Compile Include=""test2.fs"" />
+    <Compile Include=""test3.fs"" />
+  </ItemGroup>
+</Project>";
+
+            AssertEqualProject(expected, project);
+        }
+
+        [Fact]
+        public void AddItemsInNestedFolder_IsSuccessful()
+        {
+            var tree = ProjectTreeParser.Parse(@"
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
+    Folder (flags: {Folder}), FilePath: ""C:\Foo\test""
+        Folder (flags: {Folder}), FilePath: ""C:\Foo\test\nested""
+    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 3, ItemName: ""test3.fs""
+");
+
+            var updatedTree = ProjectTreeParser.Parse(@"
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
+    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
+    Folder (flags: {Folder}), FilePath: ""C:\Foo\test"", DisplayOrder: 3
+        Folder (flags: {Folder}), FilePath: ""C:\Foo\test\nested"", DisplayOrder: 4
+            File (flags: {}), FilePath: ""C:\Foo\test\nested\test4.fs"", DisplayOrder: 5, ItemName: ""test\nested\test4.fs""
+            File (flags: {}), FilePath: ""C:\Foo\test\tested\test5.fs"", DisplayOrder: 6, ItemName: ""test\nested\test5.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 7, ItemName: ""test3.fs""
+");
+
+            var addedNodes = new List<IProjectTree>();
+            addedNodes.Add(updatedTree.Children[2].Children[0].Children[0]);
+            addedNodes.Add(updatedTree.Children[2].Children[0].Children[1]);
+
+            var projectRootElement = @"
+<Project Sdk=""Microsoft.NET.Sdk"">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include=""test1.fs"" />
+    <Compile Include=""test2.fs"" />
+    <Compile Include=""test\nested\test4.fs"" />
+    <Compile Include=""test\nested\test5.fs"" />
+    <Compile Include=""test3.fs"" />
+  </ItemGroup>
+
+</Project>
+".AsProjectRootElement();
+
+            var project = new Project(projectRootElement);
+
+            Assert.True(OrderingHelper.TryMoveNodesToTop(project, addedNodes, tree.Children[0].Children[0]), "TryMoveNodesToTop returned false.");
+            Assert.True(project.IsDirty);
+
+            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include=""test\nested\test4.fs"" />
+    <Compile Include=""test\nested\test5.fs"" />
+    <Compile Include=""test1.fs"" />
+    <Compile Include=""test2.fs"" />
+    <Compile Include=""test3.fs"" />
   </ItemGroup>
 </Project>";
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemAboveCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemAboveCommand.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             return ShowAddExistingFilesDialogAsync(nodeToAddTo);
         }
 
-        protected override async Task OnAddedNodesAsync(ConfiguredProject configuredProject, IEnumerable<IProjectTree> addedNodes, IProjectTree target)
+        protected override async Task OnAddedNodesAsync(ConfiguredProject configuredProject, IProjectTree target, IEnumerable<IProjectTree> addedNodes, IProjectTree updatedTarget)
         {
             foreach (var addedNode in addedNodes)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemBelowCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemBelowCommand.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Linq;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 
@@ -30,9 +31,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             return ShowAddExistingFilesDialogAsync(nodeToAddTo);
         }
 
-        protected override async Task OnAddedNodesAsync(ConfiguredProject configuredProject, IEnumerable<IProjectTree> addedNodes, IProjectTree target)
+        protected override async Task OnAddedNodesAsync(ConfiguredProject configuredProject, IProjectTree target, IEnumerable<IProjectTree> addedNodes, IProjectTree updatedTarget)
         {
-            foreach (var addedNode in addedNodes)
+            foreach (var addedNode in addedNodes.Reverse())
             {
                 await OrderingHelper.TryMoveBelowAsync(configuredProject, addedNode, target).ConfigureAwait(true);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemCommand.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
-
 using Microsoft.VisualStudio.Input;
 using Microsoft.VisualStudio.ProjectSystem.Input;
 using Microsoft.VisualStudio.Shell;
@@ -29,19 +27,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         protected override Task OnAddingNodesAsync(IProjectTree nodeToAddTo)
         {
             return ShowAddExistingFilesDialogAsync(nodeToAddTo);
-        }
-
-        protected override async Task OnAddedNodesAsync(ConfiguredProject configuredProject, IEnumerable<IProjectTree> addedNodes, IProjectTree target)
-        {
-            // Move added nodes to the top.
-            var child = OrderingHelper.GetFirstChild(target);
-            foreach (var addedNode in addedNodes)
-            {
-                if (child != addedNode)
-                {
-                    await OrderingHelper.TryMoveAboveAsync(configuredProject, addedNode, child).ConfigureAwait(true);
-                }
-            }
         }
 
         protected override bool CanAdd(IProjectTree target)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemAboveCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemAboveCommand.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             return ShowAddNewFileDialogAsync(nodeToAddTo);
         }
 
-        protected override async Task OnAddedNodesAsync(ConfiguredProject configuredProject, IEnumerable<IProjectTree> addedNodes, IProjectTree target)
+        protected override async Task OnAddedNodesAsync(ConfiguredProject configuredProject, IProjectTree target, IEnumerable<IProjectTree> addedNodes, IProjectTree updatedTarget)
         {
             foreach (var addedNode in addedNodes)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemBelowCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemBelowCommand.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Linq;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 
@@ -30,9 +31,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             return ShowAddNewFileDialogAsync(nodeToAddTo);
         }
 
-        protected override async Task OnAddedNodesAsync(ConfiguredProject configuredProject, IEnumerable<IProjectTree> addedNodes, IProjectTree target)
+        protected override async Task OnAddedNodesAsync(ConfiguredProject configuredProject, IProjectTree target, IEnumerable<IProjectTree> addedNodes, IProjectTree updatedTarget)
         {
-            foreach (var addedNode in addedNodes)
+            foreach (var addedNode in addedNodes.Reverse())
             {
                 await OrderingHelper.TryMoveBelowAsync(configuredProject, addedNode, target).ConfigureAwait(true);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemCommand.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
-
 using Microsoft.VisualStudio.Input;
 using Microsoft.VisualStudio.ProjectSystem.Input;
 using Microsoft.VisualStudio.Shell;
@@ -29,19 +27,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         protected override Task OnAddingNodesAsync(IProjectTree nodeToAddTo)
         {
             return ShowAddNewFileDialogAsync(nodeToAddTo);
-        }
-
-        protected override async Task OnAddedNodesAsync(ConfiguredProject configuredProject, IEnumerable<IProjectTree> addedNodes, IProjectTree target)
-        {
-            // Move added nodes to the top.
-            var child = OrderingHelper.GetFirstChild(target);
-            foreach (var addedNode in addedNodes)
-            {
-                if (child != addedNode)
-                {
-                    await OrderingHelper.TryMoveAboveAsync(configuredProject, addedNode, child).ConfigureAwait(true);
-                }
-            }
         }
 
         protected override bool CanAdd(IProjectTree target)


### PR DESCRIPTION
**Customer scenario**

Adding items to empty folders. Adding multiple items to a folder. Currently, doing these actions can cause invalid ordering of files.

**Bugs this fixes:** 

(n/a)

**Workarounds, if any**

Modifying the .proj file directly.

**Risk**

Low risk. Modified the ordering code slightly.

**Performance impact**

None

**Is this a regression from a previous update?**

No

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?
Missed it due to lack of specific testing; the specifics were not defined in the file ordering spec.
We should add these scenarios in the file ordering spec.

**How was the bug found?**

When trying to implement paste ordering.
