### PR TITLE
Avoid crash when loading profile without executable

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
@@ -828,7 +828,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                         using (var dialog = new System.Windows.Forms.OpenFileDialog())
                         {
                             var file = ExecutablePath;
-                            if ((file.IndexOfAny(Path.GetInvalidPathChars()) == -1) && Path.IsPathRooted(file))
+                            if (!string.IsNullOrEmpty(file) && (file.IndexOfAny(Path.GetInvalidPathChars()) == -1) && Path.IsPathRooted(file))
                             {
                                 dialog.InitialDirectory = Path.GetDirectoryName(file);
                                 dialog.FileName = file;


### PR DESCRIPTION
Fixes: #3253

Avoids crash when browse for an executable when we load a profile without an executable path. This can occur when the user didn't set an initial one, or removed it explicitly from the file.

All launch profile properties can be null - searched the code base for other similar usages, and this was the only one that didn't handle null.