### PR TITLE
Update FWLinks for DotNet 2.1 detector learn more links

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DotNetCoreProjectCompatibilityDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DotNetCoreProjectCompatibilityDetector.cs
@@ -27,8 +27,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     [Export(typeof(IDotNetCoreProjectCompatibilityDetector))]
     internal sealed class DotNetCoreProjectCompatibilityDetector : IDotNetCoreProjectCompatibilityDetector, IVsSolutionEvents, IVsSolutionLoadEvents, IDisposable
     {
-        private const string SupportedLearnMoreFwlink = "https://go.microsoft.com/fwlink/?linkid=866848";
-        private const string UnsupportedLearnMoreFwlink = "https://go.microsoft.com/fwlink/?linkid=866796";
+        private const string SupportedLearnMoreFwlink = "https://go.microsoft.com/fwlink/?linkid=868064";
+        private const string UnsupportedLearnMoreFwlink = "https://go.microsoft.com/fwlink/?linkid=866797";
         private const string SuppressDotNewCoreWarningKey = @"ManagedProjectSystem\SuppressDotNewCoreWarning";
         private const string VersionCompatibilityDownloadFwlink = "https://go.microsoft.com/fwlink/?linkid=866798";
         private const string VersionDataFilename = "DotNetVersionCompatibility.json";


### PR DESCRIPTION
Simple change to update the FWLinks for the learn more links.

Addresses bug https://devdiv.visualstudio.com/web/wi.aspx?pcguid=011b8bdf-6d56-4f87-be0d-0092136884d9&id=566972