### PR TITLE
Adding "publish" capability to Roslyn project system

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -93,6 +93,9 @@
 
     <!-- Settings page capability -->
     <ProjectCapability Include="AppSettings" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'"/>
+  
+    <!-- Publish capability -->
+    <ProjectCapability Include="Publish"/>
   </ItemGroup>
 
   <!-- Common Project System rules that override rules defined in msbuild. These are exact copy of the rules defined in msbuild. -->

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -94,7 +94,7 @@
     <!-- Settings page capability -->
     <ProjectCapability Include="AppSettings" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'"/>
   
-    <!-- Publish capability -->
+    <!-- Publish capability enables the Publish command for the Project -->
     <ProjectCapability Include="Publish"/>
   </ItemGroup>
 


### PR DESCRIPTION
Adding the project capability "Publish" to Roslyn project system.

Looked at all the capabilities for .NET core project and 'Publish' is missing. VS will be using at this capability to determine whether the publish command should be displayed.

@BillHiebert @davkean 
/cc @mlorbetske