### PR TITLE
Disable integration tests

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/CSharp/CSharpErrorListTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/CSharp/CSharpErrorListTests.cs
@@ -66,7 +66,7 @@ class C
             Assert.Equal(expectedContents, actualContents);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/project-system/issues/3286")]
         public void ErrorLevelWarning()
         {
             VisualStudio.Editor.SetText(@"

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/CSharp/CSharpErrorListTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/CSharp/CSharpErrorListTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
 {
     [Collection(nameof(SharedIntegrationHostFixture))]
+    [Trait("Integration", "ErrorList")]
     public class CSharpErrorListTests : AbstractIntegrationTest
     {
         protected override string DefaultLanguageName => LanguageNames.CSharp;
@@ -20,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
             VisualStudio.SolutionExplorer.OpenFile(Project, "Class1.cs");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/project-system/issues/2281"), Trait("Integration", "ErrorList")]
+        [Fact(Skip = "https://github.com/dotnet/project-system/issues/2281")]
         public void ErrorList()
         {
             VisualStudio.Editor.SetText(@"
@@ -65,7 +66,7 @@ class C
             Assert.Equal(expectedContents, actualContents);
         }
 
-        [Fact, Trait("Integration", "ErrorList")]
+        [Fact]
         public void ErrorLevelWarning()
         {
             VisualStudio.Editor.SetText(@"

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/CSharp/CSharpProjectFileEditTest.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/CSharp/CSharpProjectFileEditTest.cs
@@ -37,7 +37,7 @@ namespace ProjectFileEditTest
 ");
         }
 
-        [Fact, Trait("Integration", "ProjectFileEdit")]
+        [Fact(Skip = "https://github.com/dotnet/project-system/issues/3286")]
         public void EditNetCore10To11()
         {
             VisualStudio.SolutionExplorer.EditProjectFile(Project);
@@ -61,7 +61,7 @@ namespace ProjectFileEditTest
             VisualStudio.SolutionExplorer.BuildSolution(waitForBuildToFinish: true);
         }
 
-        [Fact, Trait("Integration", "ProjectFileEdit")]
+        [Fact(Skip = "https://github.com/dotnet/project-system/issues/3286")]
         public void AddPackageReference()
         {
             VisualStudio.SolutionExplorer.EditProjectFile(Project);

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/CSharp/CSharpProjectFileEditTest.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/CSharp/CSharpProjectFileEditTest.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
 {
     [Collection(nameof(SharedIntegrationHostFixture))]
+    [Trait("Integration", "ErrorList")]
     public class CSharpProjectFileEditTest : AbstractIntegrationTest
     {
         protected override string DefaultLanguageName => LanguageNames.CSharp;

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/CSharp/CSharpSquigglesTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/CSharp/CSharpSquigglesTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
 {
     [Collection(nameof(SharedIntegrationHostFixture))]
+    [Trait("Integration", "Squiggles")]
     public class CSharpSquigglesTests : AbstractIntegrationTest
     {
         protected override string DefaultLanguageName => LanguageNames.CSharp;
@@ -18,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
             VisualStudio.SolutionExplorer.OpenFile(Project, "Class1.cs");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/project-system/issues/2281"), Trait("Integration", "Squiggles")]
+        [Fact(Skip = "https://github.com/dotnet/project-system/issues/2281")]
         public void VerifySyntaxErrorSquiggles()
         {
             VisualStudio.Editor.SetText(@"using System;
@@ -52,7 +53,7 @@ namespace ConsoleApplication1
             Assert.Equal(expectedTags, actualTags);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/project-system/issues/2281"), Trait("Integration", "Squiggles")]
+        [Fact(Skip = "https://github.com/dotnet/project-system/issues/2281")]
         public void VerifySemanticErrorSquiggles()
         {
             VisualStudio.Editor.SetText(@"using System;

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/VisualBasic/VisualBasicErrorListTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/VisualBasic/VisualBasicErrorListTests.cs
@@ -61,7 +61,7 @@ End Module
             VisualStudio.Editor.Verify.CaretPosition(43);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/project-system/issues/3286")]
         public void ErrorsDuringMethodBodyEditing()
         {
             VisualStudio.Editor.SetText(@"

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/VisualBasic/VisualBasicErrorListTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/VisualBasic/VisualBasicErrorListTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
 {
     [Collection(nameof(SharedIntegrationHostFixture))]
+    [Trait("Integration", "ErrorList")]
     public class VisualBasicErrorListTests : AbstractIntegrationTest
     {
         protected override string DefaultLanguageName => LanguageNames.VisualBasic;
@@ -20,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
             VisualStudio.SolutionExplorer.OpenFile(Project, "Class1.vb");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/project-system/issues/2281"), Trait("Integration", "ErrorList")]
+        [Fact(Skip = "https://github.com/dotnet/project-system/issues/2281")]
         public void ErrorList()
         {
             VisualStudio.Editor.SetText(@"
@@ -60,7 +61,7 @@ End Module
             VisualStudio.Editor.Verify.CaretPosition(43);
         }
 
-        [Fact, Trait("Integration", "ErrorList")]
+        [Fact]
         public void ErrorsDuringMethodBodyEditing()
         {
             VisualStudio.Editor.SetText(@"

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/VisualBasic/VisualBasicSquigglesTest.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/VisualBasic/VisualBasicSquigglesTest.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
 {
     [Collection(nameof(SharedIntegrationHostFixture))]
+    [Trait("Integration", "Squiggles")]
     public class VisualBasicSquigglesTest : AbstractIntegrationTest
     {
         protected override string DefaultLanguageName => LanguageNames.VisualBasic;
@@ -18,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
             VisualStudio.SolutionExplorer.OpenFile(Project, "Class1.vb");
         }
 
-        [Fact(Skip = "Syntax squiggles not showing on VB"), Trait("Integration", "Squiggles")]
+        [Fact(Skip = "Syntax squiggles not showing on VB")]
         public void VerifySyntaxErrorSquiggles()
         {
             VisualStudio.Editor.SetText(@"Class A
@@ -37,7 +38,7 @@ End Class");
             actualTags.ShouldEqualWithDiff(expectedTags);
         }
 
-        [Fact, Trait("Integration", "Squiggles")]
+        [Fact]
         public void VerifySemanticErrorSquiggles()
         {
             VisualStudio.Editor.SetText(@"Class A

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/VisualBasic/VisualBasicSquigglesTest.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/VisualBasic/VisualBasicSquigglesTest.cs
@@ -38,7 +38,7 @@ End Class");
             actualTags.ShouldEqualWithDiff(expectedTags);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/project-system/issues/3286")]
         public void VerifySemanticErrorSquiggles()
         {
             VisualStudio.Editor.SetText(@"Class A

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/WorkspaceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/WorkspaceTests.cs
@@ -66,7 +66,7 @@ End Class");
             VisualStudio.Editor.Verify.CurrentTokenType("identifier");
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/project-system/issues/3286")]
         public void ProjectReference()
         {
             var project = new ProjectUtils.Project(ProjectName);

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/WorkspaceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/WorkspaceTests.cs
@@ -10,6 +10,7 @@ using ProjectUtils = Microsoft.VisualStudio.IntegrationTest.Utilities.Common.Pro
 namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
 {
     [Collection(nameof(SharedIntegrationHostFixture))]
+    [Trait("Integration", "Workspace")]
     public class WorkspaceTests : AbstractIntegrationTest
     {
         protected override string DefaultLanguageName => LanguageNames.CSharp;
@@ -20,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
             VisualStudio.SolutionExplorer.OpenFile(Project, "Class1.cs");
         }
 
-        [Fact(Skip = "Classification doesn't work when files are loaded in misc workspace"), Trait("Integration", "Workspace")]
+        [Fact(Skip = "Classification doesn't work when files are loaded in misc workspace")]
         public void OpenCSharpThenVBSolution()
         {
             VisualStudio.Editor.SetText(@"using System; class Program { Exception e; }");
@@ -41,7 +42,7 @@ End Class");
             VisualStudio.Editor.Verify.CurrentTokenType(tokenType: "class name");
         }
 
-        [Fact(Skip = "Unload/Reload does not work"), Trait("Integration", "Workspace")]
+        [Fact(Skip = "Unload/Reload does not work")]
         public void MetadataReference()
         {
             var project = new ProjectUtils.Project(ProjectName);
@@ -65,7 +66,7 @@ End Class");
             VisualStudio.Editor.Verify.CurrentTokenType("identifier");
         }
 
-        [Fact, Trait("Integration", "Workspace")]
+        [Fact]
         public void ProjectReference()
         {
             var project = new ProjectUtils.Project(ProjectName);
@@ -82,7 +83,7 @@ End Class");
             VisualStudio.Editor.Verify.CurrentTokenType("identifier");
         }
 
-        [Fact(Skip = "Cannot set 'option infer' from DTE for CPS projects"), Trait("Integration", "Workspace")]
+        [Fact(Skip = "Cannot set 'option infer' from DTE for CPS projects")]
         public void ProjectProperties()
         {
             VisualStudio.SolutionExplorer.CreateSolution(nameof(WorkspaceTests));


### PR DESCRIPTION
We've never enabled the integration tests as a check-in blocker - nor have they ever passed as far as I can see on the jenkins runs - every single build that it has history on has failed. Disable them to avoid reduced confidence by those that are new to the tree.

Filed https://github.com/dotnet/project-system/issues/3286 to track reenabling them.