### PR TITLE
Turn off "var" enforcement in tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -142,3 +142,8 @@ csharp_new_line_before_catch = true
 csharp_new_line_before_finally = true
 csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
+
+[src/*Tests/**/*.cs]
+# We allow usage of "var" inside tests as it reduces churn as we remove/rename types
+csharp_style_var_for_built_in_types = true:none
+csharp_style_var_elsewhere = true:none


### PR DESCRIPTION
For the product code we only allow `var` usage when the type is apparent. However, this is too strict in our tests which make heavy use of `var` to reduce test churn as we remove/rename/change types. Turn off enforcement, and favor `var`.