### PR TITLE
Fix problem with up-to-date check and custom items

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CopyUpToDateMarker.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CopyUpToDateMarker.xaml
@@ -13,17 +13,5 @@
         <Category Name="Advanced" DisplayName="Advanced" />
         <Category Name="Misc" DisplayName="Misc" />
     </Rule.Categories>
-
-    <StringProperty
-      Name="FullPath"
-      DisplayName="Full Path"
-      ReadOnly="true"
-      Category="Misc"
-      Description="Location of the file.">
-        <StringProperty.DataSource>
-            <DataSource Persistence="Intrinsic" ItemType="CopyUpToDateMarker" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
-        </StringProperty.DataSource>
-    </StringProperty>
-
     <BoolProperty Name="Visible" Default="false" Visible="false" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckBuilt.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckBuilt.xaml
@@ -10,16 +10,6 @@
         <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="UpToDateCheckBuilt" SourceOfDefaultValue="AfterContext" 
                     SourceType="TargetResults" MSBuildTarget="CollectBuiltDesignTime"/>
     </Rule.DataSource>
-    <StringProperty
-        Name="Identity"
-        Visible="false"
-        ReadOnly="true"
-        Category="Misc"
-        Description="The item specified in the Include attribute.">
-        <StringProperty.DataSource>
-            <DataSource Persistence="Intrinsic" ItemType="UpToDateCheckBuilt" PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
-        </StringProperty.DataSource>
-    </StringProperty>
     <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
     <StringProperty
         Name="Original"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckInput.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckInput.xaml
@@ -13,15 +13,4 @@
         <Category Name="Advanced" DisplayName="Advanced" />
         <Category Name="Misc" DisplayName="Misc" />
     </Rule.Categories>
-
-    <StringProperty
-      Name="FullPath"
-      DisplayName="Full Path"
-      ReadOnly="true"
-      Category="Misc"
-      Description="Location of the file.">
-        <StringProperty.DataSource>
-            <DataSource Persistence="Intrinsic" ItemType="UpToDateCheckInput" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
-        </StringProperty.DataSource>
-    </StringProperty>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckOutput.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckOutput.xaml
@@ -13,15 +13,4 @@
         <Category Name="Advanced" DisplayName="Advanced" />
         <Category Name="Misc" DisplayName="Misc" />
     </Rule.Categories>
-
-    <StringProperty
-      Name="FullPath"
-      DisplayName="Full Path"
-      ReadOnly="true"
-      Category="Misc"
-      Description="Location of the file.">
-        <StringProperty.DataSource>
-            <DataSource Persistence="Intrinsic" ItemType="UpToDateCheckOutput" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
-        </StringProperty.DataSource>
-    </StringProperty>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CopyUpToDateMarker.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CopyUpToDateMarker.xaml.cs.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Různé</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">Úplná cesta</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">Umístění souboru</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CopyUpToDateMarker.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CopyUpToDateMarker.xaml.de.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Sonst.</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">Vollständiger Pfad</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">Speicherort der Datei.</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CopyUpToDateMarker.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CopyUpToDateMarker.xaml.es.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Varios</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">Ruta de acceso completa</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">Ubicación del archivo.</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CopyUpToDateMarker.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CopyUpToDateMarker.xaml.fr.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Divers</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">Chemin d'accès complet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">Emplacement du fichier.</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CopyUpToDateMarker.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CopyUpToDateMarker.xaml.it.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Varie</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">Percorso completo</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">Percorso del file.</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CopyUpToDateMarker.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CopyUpToDateMarker.xaml.ja.xlf
@@ -22,16 +22,6 @@
         <target state="translated">その他</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">完全パス</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">ファイルの場所。</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CopyUpToDateMarker.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CopyUpToDateMarker.xaml.ko.xlf
@@ -22,16 +22,6 @@
         <target state="translated">기타</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">전체 경로</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">파일의 위치입니다.</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CopyUpToDateMarker.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CopyUpToDateMarker.xaml.pl.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Różne</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">Pełna ścieżka</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">Lokalizacja pliku.</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CopyUpToDateMarker.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CopyUpToDateMarker.xaml.pt-BR.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Diversos</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">Caminho Completo</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">Localização do arquivo.</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CopyUpToDateMarker.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CopyUpToDateMarker.xaml.ru.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Прочее</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">Полный путь</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">Расположение файла.</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CopyUpToDateMarker.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CopyUpToDateMarker.xaml.tr.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Çeşitli</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">Tam Yol</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">Dosyanın konumu.</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CopyUpToDateMarker.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CopyUpToDateMarker.xaml.zh-Hans.xlf
@@ -22,16 +22,6 @@
         <target state="translated">杂项</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">完整路径</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">文件位置。</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CopyUpToDateMarker.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/CopyUpToDateMarker.xaml.zh-Hant.xlf
@@ -22,16 +22,6 @@
         <target state="translated">其他</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">完整路徑</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">檔案的位置。</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.cs.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Vlastnosti souboru</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Identity|Description">
-        <source>The item specified in the Include attribute.</source>
-        <target state="translated">Položka zadaná v atributu Include</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Original|Description">
         <source>If set, specifies that this built output comes from this source file.</source>
         <target state="translated">Pokud je možnost nastavená, určuje, že tento sestavený výstup pochází z tohoto zdrojového souboru.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.de.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Dateieigenschaften</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Identity|Description">
-        <source>The item specified in the Include attribute.</source>
-        <target state="translated">Das im Include-Attribut angegebene Element.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Original|Description">
         <source>If set, specifies that this built output comes from this source file.</source>
         <target state="translated">Gibt bei Festlegung an, dass die Ausgabe aus dieser Quelldatei stammt.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.es.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Propiedades del archivo</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Identity|Description">
-        <source>The item specified in the Include attribute.</source>
-        <target state="translated">El elemento especificado en el atributo Include.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Original|Description">
         <source>If set, specifies that this built output comes from this source file.</source>
         <target state="translated">Si está configurado, especifica que esta salida de compilación procede de este archivo de origen.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.fr.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Propriétés du fichier</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Identity|Description">
-        <source>The item specified in the Include attribute.</source>
-        <target state="translated">Élément spécifié dans l'attribut Include.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Original|Description">
         <source>If set, specifies that this built output comes from this source file.</source>
         <target state="translated">Si cette option est définie, elle spécifie que la sortie de build provient de ce fichier source.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.it.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Proprietà file</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Identity|Description">
-        <source>The item specified in the Include attribute.</source>
-        <target state="translated">Elemento specificato nell'attributo Include.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Original|Description">
         <source>If set, specifies that this built output comes from this source file.</source>
         <target state="translated">Se impostata, specifica che questo output compilato deriva da questo file di origine.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ja.xlf
@@ -12,11 +12,6 @@
         <target state="translated">ファイルのプロパティ</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Identity|Description">
-        <source>The item specified in the Include attribute.</source>
-        <target state="translated">Include 属性に指定された項目です。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Original|Description">
         <source>If set, specifies that this built output comes from this source file.</source>
         <target state="translated">設定される場合、このビルド出力はこのソース ファイルから派生することを指定します。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ko.xlf
@@ -12,11 +12,6 @@
         <target state="translated">파일 속성</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Identity|Description">
-        <source>The item specified in the Include attribute.</source>
-        <target state="translated">Include 특성에 지정된 항목입니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Original|Description">
         <source>If set, specifies that this built output comes from this source file.</source>
         <target state="translated">설정하면 이 빌드된 출력이 이 소스 파일에서 나오도록 지정합니다.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.pl.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Właściwości pliku</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Identity|Description">
-        <source>The item specified in the Include attribute.</source>
-        <target state="translated">Element wskazany w atrybucie Include.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Original|Description">
         <source>If set, specifies that this built output comes from this source file.</source>
         <target state="translated">Jeśli ta opcja jest ustawiona, określa, że dane wyjściowe kompilacji pochodzą z tego pliku źródłowego.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.pt-BR.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Propriedades do Arquivo</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Identity|Description">
-        <source>The item specified in the Include attribute.</source>
-        <target state="translated">O item especificado no atributo Include.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Original|Description">
         <source>If set, specifies that this built output comes from this source file.</source>
         <target state="translated">Se definido, especifica que essa saída criada é proveniente desse arquivo de origem.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ru.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Свойства файла</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Identity|Description">
-        <source>The item specified in the Include attribute.</source>
-        <target state="translated">Элемент, заданный в атрибуте Include.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Original|Description">
         <source>If set, specifies that this built output comes from this source file.</source>
         <target state="translated">Если он задан, указывает, что сборка получена из этого файла исходного кода.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.tr.xlf
@@ -12,11 +12,6 @@
         <target state="translated">Dosya Özellikleri</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Identity|Description">
-        <source>The item specified in the Include attribute.</source>
-        <target state="translated">Include özniteliğinde belirtilen öğe.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Original|Description">
         <source>If set, specifies that this built output comes from this source file.</source>
         <target state="translated">Ayarlanırsa, bu derleme çıkışının bu kaynak dosyadan geldiğini belirtir.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.zh-Hans.xlf
@@ -12,11 +12,6 @@
         <target state="translated">文件属性</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Identity|Description">
-        <source>The item specified in the Include attribute.</source>
-        <target state="translated">Include 特性中指定的项。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Original|Description">
         <source>If set, specifies that this built output comes from this source file.</source>
         <target state="translated">如果设置，则指定此生成的输出来自此源文件。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.zh-Hant.xlf
@@ -12,11 +12,6 @@
         <target state="translated">檔案屬性</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Identity|Description">
-        <source>The item specified in the Include attribute.</source>
-        <target state="translated">Include 屬性中指定的項目。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Original|Description">
         <source>If set, specifies that this built output comes from this source file.</source>
         <target state="translated">如有設定，會指定這個建置輸出來自這個來源檔案。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.cs.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Různé</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">Úplná cesta</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">Umístění souboru</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.de.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Sonst.</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">Vollständiger Pfad</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">Speicherort der Datei.</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.es.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Varios</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">Ruta de acceso completa</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">Ubicación del archivo.</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.fr.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Divers</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">Chemin d'accès complet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">Emplacement du fichier.</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.it.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Varie</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">Percorso completo</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">Percorso del file.</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.ja.xlf
@@ -22,16 +22,6 @@
         <target state="translated">その他</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">完全パス</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">ファイルの場所。</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.ko.xlf
@@ -22,16 +22,6 @@
         <target state="translated">기타</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">전체 경로</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">파일의 위치입니다.</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.pl.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Różne</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">Pełna ścieżka</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">Lokalizacja pliku.</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.pt-BR.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Diversos</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">Caminho Completo</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">Localização do arquivo.</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.ru.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Прочее</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">Полный путь</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">Расположение файла.</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.tr.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Çeşitli</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">Tam Yol</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">Dosyanın konumu.</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.zh-Hans.xlf
@@ -22,16 +22,6 @@
         <target state="translated">杂项</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">完整路径</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">文件位置。</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.zh-Hant.xlf
@@ -22,16 +22,6 @@
         <target state="translated">其他</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">完整路徑</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">檔案的位置。</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.cs.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Různé</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">Úplná cesta</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">Umístění souboru</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.de.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Sonst.</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">Vollständiger Pfad</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">Speicherort der Datei.</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.es.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Varios</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">Ruta de acceso completa</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">Ubicación del archivo.</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.fr.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Divers</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">Chemin d'accès complet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">Emplacement du fichier.</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.it.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Varie</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">Percorso completo</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">Percorso del file.</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.ja.xlf
@@ -22,16 +22,6 @@
         <target state="translated">その他</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">完全パス</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">ファイルの場所。</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.ko.xlf
@@ -22,16 +22,6 @@
         <target state="translated">기타</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">전체 경로</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">파일의 위치입니다.</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.pl.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Różne</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">Pełna ścieżka</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">Lokalizacja pliku.</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.pt-BR.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Diversos</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">Caminho Completo</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">Localização do arquivo.</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.ru.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Прочее</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">Полный путь</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">Расположение файла.</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.tr.xlf
@@ -22,16 +22,6 @@
         <target state="translated">Çeşitli</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">Tam Yol</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">Dosyanın konumu.</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.zh-Hans.xlf
@@ -22,16 +22,6 @@
         <target state="translated">杂项</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">完整路径</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">文件位置。</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.zh-Hant.xlf
@@ -22,16 +22,6 @@
         <target state="translated">其他</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|FullPath|DisplayName">
-        <source>Full Path</source>
-        <target state="translated">完整路徑</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|FullPath|Description">
-        <source>Location of the file.</source>
-        <target state="translated">檔案的位置。</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -344,28 +344,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             if (!_tasksService.IsTaskQueueEmpty(ProjectCriticalOperation.Build))
             {
-                return Fail(logger, "Critical build tasks are running, failed.", "CriticalTasks");
+                return Fail(logger, "Critical build tasks are running, not up to date.", "CriticalTasks");
             }
 
             if (_lastVersionSeen == null || _configuredProject.ProjectVersion.CompareTo(_lastVersionSeen) > 0)
             {
-                return Fail(logger, "Project information is older than current project version, failed.", "ProjectInfoOutOfDate");
+                return Fail(logger, "Project information is older than current project version, not up to date.", "ProjectInfoOutOfDate");
             }
 
             if (itemsChangedSinceLastCheck)
             {
-                return Fail(logger, "The list of source items has changed since the last build, failed.", "ItemInfoOutOfDate");
+                return Fail(logger, "The list of source items has changed since the last build, not up to date.", "ItemInfoOutOfDate");
             }
 
             if (_isDisabled)
             {
-                return Fail(logger, "The 'DisableFastUpToDateCheckProperty' property is true, failed.", "Disabled");
+                return Fail(logger, "The 'DisableFastUpToDateCheckProperty' property is true, not up to date.", "Disabled");
             }
 
             var copyAlwaysItem = _items.SelectMany(kvp => kvp.Value).FirstOrDefault(item => item.CopyType == CopyToOutputDirectoryType.CopyAlways);
             if (copyAlwaysItem.Path != null)
             {
-                logger.Info("Item '{0}' has CopyToOutputDirectory set to 'Always', failed.", copyAlwaysItem.Path);
+                logger.Info("Item '{0}' has CopyToOutputDirectory set to 'Always', not up to date.", copyAlwaysItem.Path);
             }
 
             return true;
@@ -484,7 +484,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             if (outputMarkerTime <= inputMarkerTime)
             {
-                logger.Info("Input marker is older than output marker, failed.");
+                logger.Info("Input marker is older than output marker, not up to date.");
             }
 
             return inputMarkerPath == null || outputMarkerTime == null || outputMarkerTime > inputMarkerTime;
@@ -507,7 +507,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 }
                 else
                 {
-                    logger.Info("Source '{0}' does not exist, failed.", source);
+                    logger.Info("Source '{0}' does not exist, not up to date.", source);
                     return false;
                 }
 
@@ -519,13 +519,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 }
                 else
                 {
-                    logger.Info("Destination '{0}' does not exist, failed.", destination);
+                    logger.Info("Destination '{0}' does not exist, not up to date.", destination);
                     return false;
                 }
 
                 if (outputItemTime < itemTime)
                 {
-                    logger.Info("Build output destination is newer than source, failed.");
+                    logger.Info("Build output destination is newer than source, not up to date.");
                     return false;
                 }
             }
@@ -560,7 +560,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 }
                 else
                 {
-                    logger.Info("Source '{0}' does not exist, failed.", item.Path);
+                    logger.Info("Source '{0}' does not exist, not up to date.", item.Path);
                     return false;
                 }
                 
@@ -573,13 +573,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 }
                 else
                 {
-                    logger.Info("Destination '{0}' does not exist, failed.", outputItem);
+                    logger.Info("Destination '{0}' does not exist, not up to date.", outputItem);
                     return false;
                 }
 
                 if (outputItemTime < itemTime)
                 {
-                    logger.Info("PreserveNewest destination is newer than source, failed.");
+                    logger.Info("PreserveNewest destination is newer than source, not up to date.");
                     return false;
                 }
             }
@@ -611,7 +611,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             }
             else
             {
-                logger.Info("Input '{0}' does not exist, failed.", inputPath);
+                logger.Info("Input '{0}' does not exist, not up to date.", inputPath);
             }
 
             if (outputTime != null)
@@ -620,12 +620,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             }
             else
             {
-                logger.Info("Output '{0}' does not exist, failed.", outputPath);
+                logger.Info("Output '{0}' does not exist, not up to date.", outputPath);
             }
 
             if (outputTime <= inputTime)
             {
-                logger.Info("Output is newer than input, failed.");
+                logger.Info("Output is newer than input, not up to date.");
             }
 
             // We are up to date if the earliest output write happened after the latest input write


### PR DESCRIPTION
**Customer scenario**

The customer adds a XAML file to their SDK project. From that point on, the up to date check believes the project is never up to date.

(This also improves the up to date check logging so it is more obvious why a check failed.)

**Bugs this fixes:** 

#2763

**Workarounds, if any**

Remove the XAML file.

**Risk**

Low. We're avoiding a previously unhandled exception.

**Performance impact**

Improves performance, avoids unhandled exception.

**Is this a regression from a previous update?**

No

**How was the bug found?**

Customer report