### PR TITLE
Target .NET 4.6.1 instead of 4.6.0.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,13 +27,7 @@
     <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
 
     <!-- All projects in this repository target the same framework by default -->
-    <TargetFramework Condition="'$(IsTestProject)' != 'true'">net46</TargetFramework>
-
-    <!--
-      All tests projects in this repository target another. This includes the DeployTestDependencies
-      and DeployIntegrationDependencies projects which must be updated independently.
-    -->
-    <TargetFramework Condition="$(MSBuildProjectName.EndsWith('.UnitTests')) or $(MSBuildProjectName.EndsWith('.IntegrationTests'))">net461</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
 
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 

--- a/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
+++ b/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
@@ -5,7 +5,7 @@
     <!-- TODO: Function doesn't return a value on all code paths (https://github.com/dotnet/project-system/issues/2592) -->
     <NoWarn>$(NoWarn);42353</NoWarn>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-
+    <TargetFramework>net46</TargetFramework>
     <!-- Nuget -->
     <IsPackable>true</IsPackable>
     <Description>This package implements the AppDesigner, which is the designer host used for project property pages among other things in Visual Studio</Description>

--- a/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
+++ b/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
@@ -1,13 +1,13 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\VisualStudioDesigner.props"/>
+  <Import Project="..\VisualStudioDesigner.props" />
   <PropertyGroup>
     <Prefer32Bit>false</Prefer32Bit>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
-
+    <TargetFramework>net46</TargetFramework>
     <!-- TODO: Function/Property doesn't return a value on all code paths (https://github.com/dotnet/project-system/issues/2592) -->
     <NoWarn>$(NoWarn);42353;42355;42105</NoWarn>
-    
+
     <!-- Nuget -->
     <IsPackable>true</IsPackable>
     <Description>Implementation of some designers and project property page editors in VisualStudio.</Description>


### PR DESCRIPTION
The Roslyn Workspaces and above layers all depend on 4.6.1 already, and all
workloads that include the project system also require it.