### PR TITLE
Target .NET 4.6 instead of a mix 4.6 and 4.6.1.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,13 +27,7 @@
     <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
 
     <!-- All projects in this repository target the same framework by default -->
-    <TargetFramework Condition="'$(IsTestProject)' != 'true'">net46</TargetFramework>
-
-    <!--
-      All tests projects in this repository target another. This includes the DeployTestDependencies
-      and DeployIntegrationDependencies projects which must be updated independently.
-    -->
-    <TargetFramework Condition="$(MSBuildProjectName.EndsWith('.UnitTests')) or $(MSBuildProjectName.EndsWith('.IntegrationTests'))">net461</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
 
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 


### PR DESCRIPTION
The Roslyn Workspaces and above layers all depend on 4.6.1 already, and all
workloads that include the project system also require it.
