### PR TITLE
Add new ".NET" capability

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
@@ -52,7 +52,8 @@ namespace Microsoft.VisualStudio.Packaging
                                                   ProjectCapability.OpenProjectFile + "; " +
                                                   ProjectCapability.PreserveFormatting + "; " +
                                                   ProjectCapability.ProjectConfigurationsDeclaredDimensions + "; " +
-                                                  ProjectCapability.LanguageService;
+                                                  ProjectCapability.LanguageService + "; " +
+                                                  ProjectCapability.DotNet;
 
         private IDotNetCoreProjectCompatibilityDetector _dotNetCoreCompatibilityDetector;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapability.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapability.cs
@@ -36,5 +36,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public const string ProjectConfigurationsDeclaredDimensions = ProjectCapabilities.ProjectConfigurationsDeclaredDimensions;
         public const string LanguageService = ProjectCapabilities.LanguageService;
         public const string SortByDisplayOrder = ProjectCapabilities.SortByDisplayOrder;
+        public const string DotNet = ".NET";
     }
 }


### PR DESCRIPTION
This is intended to replace the "Managed" capability to represent the primary .NET languages C#, VB and F# . "Managed" is overloaded and defined by C++, even though they support very little of the managed features that traditional .NET languages support.

This change, combined with https://github.com/dotnet/project-system/pull/3274, enables the Publish command for F# projects.