### PR TITLE
Simplify StartupProjectRegistrar and remove ProjectGuid property usage

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/OrderPrecedenceImportCollectionExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/OrderPrecedenceImportCollectionExtensions.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal static class OrderPrecedenceImportCollectionExtensions
     {
-        public static void Add<T>(this OrderPrecedenceImportCollection<T> collection, T value, string appliesTo, int orderPrecedence = 0)
+        public static void Add<T>(this OrderPrecedenceImportCollection<T> collection, T value, string appliesTo = null, int orderPrecedence = 0)
         {
             var metadata = IOrderPrecedenceMetadataViewFactory.Create(appliesTo, orderPrecedence);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IActiveConfiguredProjectSubscriptionServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IActiveConfiguredProjectSubscriptionServiceFactory.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     public class IActiveConfiguredProjectSubscriptionServiceFactory
     {
-        public static IActiveConfiguredProjectSubscriptionService CreateInstance()
+        public static IActiveConfiguredProjectSubscriptionService Create()
         {
             var mock = new Mock<IActiveConfiguredProjectSubscriptionService>();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IAsyncServiceProviderMoq.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IAsyncServiceProviderMoq.cs
@@ -14,19 +14,19 @@ namespace Microsoft.VisualStudio.ProjectSystem
     public class IAsyncServiceProviderMoq : IAsyncServiceProvider
     {
         // Usage. Create a new IAsyncServiceProviderMoq and add your service moqs to it.
-        private Dictionary<Type, object> _services = new Dictionary<Type, object>();
+        private Dictionary<Guid, object> _services = new Dictionary<Guid, object>();
 
         // Returns null if it can't get it
         public Task<object> GetServiceAsync(Type serviceType)
         {
-            _services.TryGetValue(serviceType, out object retVal);
+            _services.TryGetValue(serviceType.GUID, out object retVal);
 
             return Task.FromResult(retVal);
         }
 
         public void AddService<T>(Type serviceType, T serviceMock)
         {
-            _services.Add(serviceType, serviceMock);
+            _services.Add(serviceType.GUID, serviceMock);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IAsyncServiceProviderMoq.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IAsyncServiceProviderMoq.cs
@@ -14,23 +14,19 @@ namespace Microsoft.VisualStudio.ProjectSystem
     public class IAsyncServiceProviderMoq : IAsyncServiceProvider
     {
         // Usage. Create a new IAsyncServiceProviderMoq and add your service moqs to it.
-        private Dictionary<Type, object> Services = new Dictionary<Type, object>();
+        private Dictionary<Type, object> _services = new Dictionary<Type, object>();
 
         // Returns null if it can't get it
         public Task<object> GetServiceAsync(Type serviceType)
         {
-            Services.TryGetValue(serviceType, out object retVal);
+            _services.TryGetValue(serviceType, out object retVal);
 
             return Task.FromResult(retVal);
         }
 
-        public void AddService(Type interfaceType, Type serviceType, object serviceMock)
+        public void AddService<T>(Type serviceType, T serviceMock)
         {
-            Services.Add(serviceType, serviceMock);
-            if (serviceType != interfaceType)
-            {
-                Services.Add(interfaceType, serviceMock);
-            }
+            _services.Add(serviceType, serviceMock);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDebugLaunchProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDebugLaunchProviderFactory.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Threading.Tasks;
+using System;
 
 using Moq;
 
@@ -8,12 +8,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
     public class IDebugLaunchProviderFactory
     {
-        public static IDebugLaunchProvider ImplementCanLaunchAsync(bool result)
+        public static IDebugLaunchProvider ImplementCanLaunchAsync(Func<bool> action)
         {
             var mock = new Mock<IDebugLaunchProvider>();
 
             mock.Setup(d => d.CanLaunchAsync(It.IsAny<DebugLaunchOptions>()))
-                                .Returns(() => Task.FromResult(result));
+                                .ReturnsAsync(action);
 
             return mock.Object;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDebugLaunchProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDebugLaunchProviderFactory.cs
@@ -8,12 +8,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
     public class IDebugLaunchProviderFactory
     {
-        public static IDebugLaunchProvider ImplementCanLaunchAsync(bool debugs)
+        public static IDebugLaunchProvider ImplementCanLaunchAsync(bool result)
         {
             var mock = new Mock<IDebugLaunchProvider>();
 
             mock.Setup(d => d.CanLaunchAsync(It.IsAny<DebugLaunchOptions>()))
-                                .Returns(() => Task.FromResult(debugs));
+                                .Returns(() => Task.FromResult(result));
 
             return mock.Object;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectGuidService2Factory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectGuidService2Factory.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    internal static class IProjectGuidService2Factory
+    {
+        public static IProjectGuidService2 ImplementGetProjectGuidAsync(Guid result)
+        {
+            var mock = new Mock<IProjectGuidService2>();
+            mock.Setup(s => s.GetProjectGuidAsync())
+                .ReturnsAsync(result);
+
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectSubscriptionUpdateFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectSubscriptionUpdateFactory.cs
@@ -12,6 +12,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
     internal static class IProjectSubscriptionUpdateFactory
     {
+        public static IProjectVersionedValue<IProjectSubscriptionUpdate> CreateEmptyVersionedValue()
+        {
+            return IProjectVersionedValueFactory<IProjectSubscriptionUpdate>.Create(Mock.Of<IProjectSubscriptionUpdate>());
+        }
+
         public static IProjectSubscriptionUpdate Create()
         {
             return Mock.Of<IProjectSubscriptionUpdate>();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsStartupProjectsListServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsStartupProjectsListServiceFactory.cs
@@ -8,6 +8,11 @@ namespace Microsoft.VisualStudio.Shell.Interop
 {
     public static class IVsStartupProjectsListServiceFactory
     {
+        public static IVsStartupProjectsListService Create()
+        {
+            return Mock.Of<IVsStartupProjectsListService>();
+        }
+
         public static Mock<IVsStartupProjectsListService> CreateMockInstance(Guid projectGuid)
         {
             var mock = new Mock<IVsStartupProjectsListService>();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/VsStartupProjectsListService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/VsStartupProjectsListService.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.VisualStudio.Shell.Interop
+{
+    internal class VsStartupProjectsListService : IVsStartupProjectsListService
+    {
+        public VsStartupProjectsListService()
+        {
+        }
+
+        public Guid? ProjectGuid
+        {
+            get;
+            private set;
+        }
+
+        public void AddProject(ref Guid guidProject)
+        {
+            ProjectGuid = guidProject;
+        }
+
+        public void RemoveProject(ref Guid guidProject)
+        {
+            if (guidProject == ProjectGuid)
+                ProjectGuid = null;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/DebugTests/StartupProjectRegistrarTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/DebugTests/StartupProjectRegistrarTests.cs
@@ -1,15 +1,14 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.Shell.Interop;
-
-using Moq;
-
 using Xunit;
 
-using Tasks = System.Threading.Tasks;
+using static Microsoft.VisualStudio.ProjectSystem.VS.Debug.StartupProjectRegistrar;
+
+using IAsyncServiceProvider = Microsoft.VisualStudio.Shell.IAsyncServiceProvider;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 {
@@ -17,266 +16,191 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
     public class StartupProjectRegistrarTests
     {
         [Fact]
-        public async Tasks.Task VerifyProjectNotAdded()
+        public void Dispose_WhenNotInitialized_DoesNotThrow()
         {
-            var projectGuid = Guid.NewGuid();
+            var registrar = CreateInstance();
 
-            var mockIVsStartupProjectsListService = IVsStartupProjectsListServiceFactory.CreateMockInstance(projectGuid);
-            var iVsStartupProjectsListService = IVsServiceFactory.Create<SVsStartupProjectsListService, IVsStartupProjectsListService>(mockIVsStartupProjectsListService.Object);
+            registrar.Dispose();
 
-            var debuggerLaunchProvider = CreateDebuggerLaunchProviderInstance();
-            debuggerLaunchProvider.Debuggers.Add(GetLazyDebugLaunchProvider(debugs: false));
-            var activeConfiguredProjectWithLaunchProviders = ActiveConfiguredProjectFactory.ImplementValue(() => debuggerLaunchProvider);
-
-            var startupProjectRegistrar = CreateInstance(
-                iVsStartupProjectsListService,
-                activeConfiguredProjectWithLaunchProviders);
-
-            var projectSubscriptionUpdate = IProjectSubscriptionUpdateFactory.FromJson(@"{
-    ""ProjectChanges"": {
-        ""ConfigurationGeneral"": {
-            ""Difference"": {
-                ""ChangedProperties"": [ ""Something"" ]
-            }
-        }
-    }
-}");
-            await startupProjectRegistrar.ConfigurationGeneralRuleBlock_ChangedAsync(
-                IProjectVersionedValueFactory<IProjectSubscriptionUpdate>.Create(projectSubscriptionUpdate));
-
-            mockIVsStartupProjectsListService.Verify(s => s.RemoveProject(ref projectGuid), Times.Never);
-            mockIVsStartupProjectsListService.Verify(s => s.AddProject(ref projectGuid), Times.Never);
-
-            projectSubscriptionUpdate = IProjectSubscriptionUpdateFactory.FromJson(@"{
-    ""ProjectChanges"": {
-        ""ConfigurationGeneral"": {
-            ""Difference"": {
-                ""ChangedProperties"": [ ""ProjectGuid"" ]
-            },
-            ""After"": {
-                ""Properties"": {
-                   ""ProjectGuid"": ""GuidNotParsable""
-                }
-            }
-        }
-    }
-}");
-            await startupProjectRegistrar.ConfigurationGeneralRuleBlock_ChangedAsync(
-                IProjectVersionedValueFactory<IProjectSubscriptionUpdate>.Create(projectSubscriptionUpdate));
-
-            mockIVsStartupProjectsListService.Verify(s => s.RemoveProject(ref projectGuid), Times.Never);
-            mockIVsStartupProjectsListService.Verify(s => s.AddProject(ref projectGuid), Times.Never);
+            Assert.True(registrar.IsDisposed);
         }
 
         [Fact]
-        public async Tasks.Task VerifyProjectAdded()
+        public async Task Disposed_WhenInitialized_DoesNotThrow()
         {
-            var projectGuid = Guid.NewGuid();
+            var registrar = await CreateInitializedInstanceAsync();
 
-            var mockIVsStartupProjectsListService = IVsStartupProjectsListServiceFactory.CreateMockInstance(projectGuid);
+            registrar.Dispose();
 
-            var iVsStartupProjectsListService = IVsServiceFactory.Create<SVsStartupProjectsListService, IVsStartupProjectsListService>(mockIVsStartupProjectsListService.Object);
-
-            var debuggerLaunchProvider = CreateDebuggerLaunchProviderInstance();
-            debuggerLaunchProvider.Debuggers.Add(GetLazyDebugLaunchProvider(debugs: true));
-            var activeConfiguredProjectWithLaunchProviders = ActiveConfiguredProjectFactory.ImplementValue(() => debuggerLaunchProvider);
-
-            var startupProjectRegistrar = CreateInstance(
-                iVsStartupProjectsListService,
-                activeConfiguredProjectWithLaunchProviders);
-
-            var projectSubscriptionUpdate = IProjectSubscriptionUpdateFactory.FromJson(@"{
-    ""ProjectChanges"": {
-        ""ConfigurationGeneral"": {
-            ""Difference"": {
-                ""ChangedProperties"": [ ""ProjectGuid"" ]
-            },
-            ""After"": {
-                ""Properties"": {
-                   ""ProjectGuid"": """ + projectGuid + @"""
-                }
-            }
-        }
-    }
-}");
-            await startupProjectRegistrar.ConfigurationGeneralRuleBlock_ChangedAsync(
-                IProjectVersionedValueFactory<IProjectSubscriptionUpdate>.Create(projectSubscriptionUpdate));
-
-            mockIVsStartupProjectsListService.Verify(s => s.AddProject(ref projectGuid), Times.Once);
-            mockIVsStartupProjectsListService.Verify(s => s.RemoveProject(ref projectGuid), Times.Never);
+            Assert.True(registrar.IsDisposed);
         }
 
         [Fact]
-        public async Tasks.Task VerifyProjectAdded_DifferentProviders()
+        public async Task OnProjectChanged_WhenNotDebuggable_ProjectNotRegistered()
         {
-            var projectGuid = Guid.NewGuid();
+            var vsStartupProjectsListService = new VsStartupProjectsListService();
+            var debugProvider = IDebugLaunchProviderFactory.ImplementCanLaunchAsync(() => false);
+            var registrar = await CreateInitializedInstanceAsync(vsStartupProjectsListService, debugProvider);
 
-            var mockIVsStartupProjectsListService = IVsStartupProjectsListServiceFactory.CreateMockInstance(projectGuid);
-            var iVsStartupProjectsListService = IVsServiceFactory.Create<SVsStartupProjectsListService, IVsStartupProjectsListService>(mockIVsStartupProjectsListService.Object);
+            await registrar.OnProjectChangedAsync();
 
-            var debuggerLaunchProvider = CreateDebuggerLaunchProviderInstance();
-            debuggerLaunchProvider.Debuggers.Add(GetLazyDebugLaunchProvider(debugs: false));
-            debuggerLaunchProvider.Debuggers.Add(GetLazyDebugLaunchProvider(debugs: true));
-            var activeConfiguredProjectWithLaunchProviders = ActiveConfiguredProjectFactory.ImplementValue(() => debuggerLaunchProvider);
-
-            var startupProjectRegistrar = CreateInstance(
-                iVsStartupProjectsListService,
-                activeConfiguredProjectWithLaunchProviders);
-
-            var projectSubscriptionUpdate = IProjectSubscriptionUpdateFactory.FromJson(@"{
-    ""ProjectChanges"": {
-        ""ConfigurationGeneral"": {
-            ""Difference"": {
-                ""ChangedProperties"": [ ""ProjectGuid"" ]
-            },
-            ""After"": {
-                ""Properties"": {
-                   ""ProjectGuid"": """ + projectGuid + @"""
-                }
-            }
-        }
-    }
-}");
-            await startupProjectRegistrar.ConfigurationGeneralRuleBlock_ChangedAsync(
-                IProjectVersionedValueFactory<IProjectSubscriptionUpdate>.Create(projectSubscriptionUpdate));
-
-            mockIVsStartupProjectsListService.Verify(s => s.AddProject(ref projectGuid), Times.Once);
-            mockIVsStartupProjectsListService.Verify(s => s.RemoveProject(ref projectGuid), Times.Never);
+            Assert.Null(vsStartupProjectsListService.ProjectGuid);
         }
 
         [Fact]
-        public async Tasks.Task VerifyProjectAdded_RemovedWithChange()
+        public async Task OnProjectChanged_WhenDebuggable_ProjectRegistered()
         {
             var projectGuid = Guid.NewGuid();
+            var vsStartupProjectsListService = new VsStartupProjectsListService();
+            var debugProvider = IDebugLaunchProviderFactory.ImplementCanLaunchAsync(() => true);
+            var registrar = await CreateInitializedInstanceAsync(projectGuid, vsStartupProjectsListService, debugProvider);
 
-            var mockIVsStartupProjectsListService = IVsStartupProjectsListServiceFactory.CreateMockInstance(projectGuid);
-            var iVsStartupProjectsListService = IVsServiceFactory.Create<SVsStartupProjectsListService, IVsStartupProjectsListService>(mockIVsStartupProjectsListService.Object);
+            await registrar.OnProjectChangedAsync();
 
-            var serviceProvider = SVsServiceProviderFactory.Create(iVsStartupProjectsListService);
-
-            var debuggerLaunchProvider = CreateDebuggerLaunchProviderInstance();
-            debuggerLaunchProvider.Debuggers.Add(GetLazyDebugLaunchProvider(debugs: true));
-            var activeConfiguredProjectWithLaunchProviders = ActiveConfiguredProjectFactory.ImplementValue(() => debuggerLaunchProvider);
-
-            var startupProjectRegistrar = CreateInstance(
-                iVsStartupProjectsListService,
-                activeConfiguredProjectWithLaunchProviders);
-
-            var projectSubscriptionUpdate = IProjectSubscriptionUpdateFactory.FromJson(@"{
-    ""ProjectChanges"": {
-        ""ConfigurationGeneral"": {
-            ""Difference"": {
-                ""ChangedProperties"": [ ""ProjectGuid"" ]
-            },
-            ""After"": {
-                ""Properties"": {
-                   ""ProjectGuid"": """ + projectGuid + @"""
-                }
-            }
-        }
-    }
-}");
-            await startupProjectRegistrar.ConfigurationGeneralRuleBlock_ChangedAsync(
-                IProjectVersionedValueFactory<IProjectSubscriptionUpdate>.Create(projectSubscriptionUpdate));
-
-            mockIVsStartupProjectsListService.Verify(s => s.AddProject(ref projectGuid), Times.Once);
-            mockIVsStartupProjectsListService.Verify(s => s.RemoveProject(ref projectGuid), Times.Never);
-
-            debuggerLaunchProvider.Debuggers.Clear();
-            debuggerLaunchProvider.Debuggers.Add(GetLazyDebugLaunchProvider(debugs: false));
-
-            projectSubscriptionUpdate = IProjectSubscriptionUpdateFactory.FromJson(@"{
-    ""ProjectChanges"": {
-        ""ConfigurationGeneral"": {
-            ""Difference"": {
-                ""ChangedProperties"": [ ""OutputType"" ]
-            }
-        }
-    }
-}");
-
-            await startupProjectRegistrar.ConfigurationGeneralRuleBlock_ChangedAsync(
-                IProjectVersionedValueFactory<IProjectSubscriptionUpdate>.Create(projectSubscriptionUpdate));
-
-            mockIVsStartupProjectsListService.Verify(s => s.RemoveProject(ref projectGuid), Times.Once);
+            Assert.Equal(projectGuid, vsStartupProjectsListService.ProjectGuid);
         }
 
         [Fact]
-        public async Tasks.Task VerifyProjectRemoved_AddedWithChange()
+        public async Task OnProjectChanged_WhenProjectAlreadyRegisteredAndDebuggable_RemainsRegistered()
         {
             var projectGuid = Guid.NewGuid();
+            var vsStartupProjectsListService = new VsStartupProjectsListService();
+            var debugProvider = IDebugLaunchProviderFactory.ImplementCanLaunchAsync(() => true);
+            var registrar = await CreateInitializedInstanceAsync(projectGuid, vsStartupProjectsListService, debugProvider);
 
-            var mockIVsStartupProjectsListService = IVsStartupProjectsListServiceFactory.CreateMockInstance(projectGuid);
+            await registrar.OnProjectChangedAsync();
 
-            var iVsStartupProjectsListService = IVsServiceFactory.Create<SVsStartupProjectsListService, IVsStartupProjectsListService>(mockIVsStartupProjectsListService.Object);
+            Assert.Equal(projectGuid, vsStartupProjectsListService.ProjectGuid);
 
-            var debuggerLaunchProvider = CreateDebuggerLaunchProviderInstance();
-            debuggerLaunchProvider.Debuggers.Add(GetLazyDebugLaunchProvider(debugs: false));
-            var activeConfiguredProjectWithLaunchProviders = ActiveConfiguredProjectFactory.ImplementValue(() => debuggerLaunchProvider);
+            await registrar.OnProjectChangedAsync();
 
-            var startupProjectRegistrar = CreateInstance(
-                iVsStartupProjectsListService,
-                activeConfiguredProjectWithLaunchProviders);
-
-            var projectSubscriptionUpdate = IProjectSubscriptionUpdateFactory.FromJson(@"{
-    ""ProjectChanges"": {
-        ""ConfigurationGeneral"": {
-            ""Difference"": {
-                ""ChangedProperties"": [ ""ProjectGuid"" ]
-            },
-            ""After"": {
-                ""Properties"": {
-                   ""ProjectGuid"": """ + projectGuid + @"""
-                }
-            }
-        }
-    }
-}");
-            await startupProjectRegistrar.ConfigurationGeneralRuleBlock_ChangedAsync(
-                IProjectVersionedValueFactory<IProjectSubscriptionUpdate>.Create(projectSubscriptionUpdate));
-
-            mockIVsStartupProjectsListService.Verify(s => s.AddProject(ref projectGuid), Times.Never);
-            mockIVsStartupProjectsListService.Verify(s => s.RemoveProject(ref projectGuid), Times.Once);
-
-            debuggerLaunchProvider.Debuggers.Clear();
-            debuggerLaunchProvider.Debuggers.Add(GetLazyDebugLaunchProvider(debugs: true));
-
-            projectSubscriptionUpdate = IProjectSubscriptionUpdateFactory.FromJson(@"{
-    ""ProjectChanges"": {
-        ""ConfigurationGeneral"": {
-            ""Difference"": {
-                ""ChangedProperties"": [ ""OutputType"" ]
-            }
-        }
-    }
-}");
-
-            await startupProjectRegistrar.ConfigurationGeneralRuleBlock_ChangedAsync(
-                IProjectVersionedValueFactory<IProjectSubscriptionUpdate>.Create(projectSubscriptionUpdate));
-
-            mockIVsStartupProjectsListService.Verify(s => s.AddProject(ref projectGuid), Times.Once);
+            Assert.Equal(projectGuid, vsStartupProjectsListService.ProjectGuid);
         }
 
-        private StartupProjectRegistrar.DebuggerLaunchProviders CreateDebuggerLaunchProviderInstance()
+
+        [Fact]
+        public async Task OnProjectChanged_WhenProjectNotRegisteredAndNotDebuggable_RemainsUnregistered()
         {
-            return new StartupProjectRegistrar.DebuggerLaunchProviders(ConfiguredProjectFactory.Create());
+            var vsStartupProjectsListService = new VsStartupProjectsListService();
+            var debugProvider = IDebugLaunchProviderFactory.ImplementCanLaunchAsync(() => false);
+            var registrar = await CreateInitializedInstanceAsync(vsStartupProjectsListService, debugProvider);
+
+            await registrar.OnProjectChangedAsync();
+
+            Assert.Null(vsStartupProjectsListService.ProjectGuid);
+
+            await registrar.OnProjectChangedAsync();
+
+            Assert.Null(vsStartupProjectsListService.ProjectGuid);
         }
 
-        private Lazy<IDebugLaunchProvider, IDebugLaunchProviderMetadataView> GetLazyDebugLaunchProvider(bool debugs)
+        [Fact]
+        public async Task OnProjectChanged_WhenProjectAlreadyRegisteredAndNotDebuggable_ProjectUnregistered()
         {
-            return new Lazy<IDebugLaunchProvider, IDebugLaunchProviderMetadataView>(
-                () => IDebugLaunchProviderFactory.ImplementCanLaunchAsync(debugs),
-                IDebugLaunchProviderMetadataViewFactory.CreateInstance());
+            bool isDebuggable = true;
+            var projectGuid = Guid.NewGuid();
+            var vsStartupProjectsListService = new VsStartupProjectsListService();
+            var debugProvider = IDebugLaunchProviderFactory.ImplementCanLaunchAsync(() => isDebuggable);
+            var registrar = await CreateInitializedInstanceAsync(projectGuid, vsStartupProjectsListService, debugProvider);
+
+            await registrar.OnProjectChangedAsync();
+
+            isDebuggable = false;
+
+            await registrar.OnProjectChangedAsync();
+
+            Assert.Null(vsStartupProjectsListService.ProjectGuid);
+        }
+
+        [Fact]
+        public async Task OnProjectChanged_WhenProjectNotRegisteredAndDebuggable_ProjectRegistered()
+        {
+            bool isDebuggable = false;
+            var projectGuid = Guid.NewGuid();
+            var vsStartupProjectsListService = new VsStartupProjectsListService();
+            var debugProvider = IDebugLaunchProviderFactory.ImplementCanLaunchAsync(() => isDebuggable);
+            var registrar = await CreateInitializedInstanceAsync(projectGuid, vsStartupProjectsListService, debugProvider);
+
+            await registrar.OnProjectChangedAsync();
+
+            isDebuggable = true;
+
+            await registrar.OnProjectChangedAsync();
+
+            Assert.Equal(projectGuid, vsStartupProjectsListService.ProjectGuid);
+        }
+
+        [Fact]
+        public async Task OnProjectChanged_ConsultsAllDebugProviders()
+        {
+            var projectGuid = Guid.NewGuid();
+            var vsStartupProjectsListService = new VsStartupProjectsListService();
+            var debugProvider1 = IDebugLaunchProviderFactory.ImplementCanLaunchAsync(() => false);
+            var debugProvider2 = IDebugLaunchProviderFactory.ImplementCanLaunchAsync(() => true);
+
+            var registrar = await CreateInitializedInstanceAsync(projectGuid, vsStartupProjectsListService, debugProvider1, debugProvider2);
+
+            await registrar.OnProjectChangedAsync();
+
+            Assert.Equal(projectGuid, vsStartupProjectsListService.ProjectGuid);
+        }
+
+        private Task<StartupProjectRegistrar> CreateInitializedInstanceAsync(IVsStartupProjectsListService vsStartupProjectsListService, params IDebugLaunchProvider[] launchProviders)
+        {
+            return CreateInitializedInstanceAsync(Guid.NewGuid(), vsStartupProjectsListService, launchProviders);
+        }
+
+        private Task<StartupProjectRegistrar> CreateInitializedInstanceAsync(Guid projectGuid, IVsStartupProjectsListService vsStartupProjectsListService, params IDebugLaunchProvider[] launchProviders)
+        {
+            var projectGuidService = IProjectGuidService2Factory.ImplementGetProjectGuidAsync(projectGuid);
+            var debuggerLaunchProviders = new DebuggerLaunchProviders(ConfiguredProjectFactory.Create());
+
+            int orderPrecedence = 0;
+            foreach (IDebugLaunchProvider launchProvider in launchProviders)
+            {
+                debuggerLaunchProviders.Debuggers.Add(launchProvider, orderPrecedence: orderPrecedence++);
+            }
+            
+            return CreateInitializedInstanceAsync(vsStartupProjectsListService: vsStartupProjectsListService,
+                                                  projectGuidService: projectGuidService,
+                                                  launchProviders: ActiveConfiguredProjectFactory.ImplementValue(() => debuggerLaunchProviders));
+        }
+
+        private async Task<StartupProjectRegistrar> CreateInitializedInstanceAsync(
+           IAsyncServiceProvider serviceProvider = null,
+           IVsStartupProjectsListService vsStartupProjectsListService = null,
+           IProjectThreadingService threadingService = null,
+           IProjectGuidService2 projectGuidService = null,
+           IActiveConfiguredProjectSubscriptionService projectSubscriptionService = null,
+           ActiveConfiguredProject<DebuggerLaunchProviders> launchProviders = null)
+        {
+            var instance = CreateInstance(serviceProvider, vsStartupProjectsListService, threadingService, projectGuidService, projectSubscriptionService, launchProviders);
+            await instance.InitializeAsync();
+
+            return instance;
         }
 
         private StartupProjectRegistrar CreateInstance(
-            IVsService<SVsStartupProjectsListService, IVsStartupProjectsListService> startupProjectsListService,
-            ActiveConfiguredProject<StartupProjectRegistrar.DebuggerLaunchProviders> launchProviders)
+            IAsyncServiceProvider serviceProvider = null,
+            IVsStartupProjectsListService vsStartupProjectsListService = null,
+            IProjectThreadingService threadingService = null,
+            IProjectGuidService2 projectGuidService = null,
+            IActiveConfiguredProjectSubscriptionService projectSubscriptionService = null,
+            ActiveConfiguredProject<DebuggerLaunchProviders> launchProviders = null)
         {
+
+            if (serviceProvider == null)
+            {
+                var sp = new IAsyncServiceProviderMoq();
+                sp.AddService(typeof(SVsStartupProjectsListService), vsStartupProjectsListService ?? IVsStartupProjectsListServiceFactory.Create());
+                serviceProvider = sp;
+            }
+
             return new StartupProjectRegistrar(
-                startupProjectsListService,
-                IProjectThreadingServiceFactory.Create(),
-                IActiveConfiguredProjectSubscriptionServiceFactory.CreateInstance(),
+                serviceProvider,
+                threadingService ?? new IProjectThreadingServiceMock(),
+                projectGuidService ?? IProjectGuidService2Factory.ImplementGetProjectGuidAsync(Guid.NewGuid()),
+                projectSubscriptionService ?? IActiveConfiguredProjectSubscriptionServiceFactory.Create(),
                 launchProviders);
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/NuGet/ProjectAssetFileWatcherTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/NuGet/ProjectAssetFileWatcherTests.cs
@@ -46,7 +46,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\foo.proj""
                                                      IProjectTreeProviderFactory.Create(),
                                                      IUnconfiguredProjectCommonServicesFactory.Create(threadingService: new IProjectThreadingServiceMock()),
                                                      tasksService,
-                                                     IActiveConfiguredProjectSubscriptionServiceFactory.CreateInstance());
+                                                     IActiveConfiguredProjectSubscriptionServiceFactory.Create());
 
             var tree = ProjectTreeParser.Parse(inputTree);
             var projectUpdate = IProjectSubscriptionUpdateFactory.FromJson(ProjectCurrentStateJson);
@@ -101,7 +101,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\foo.proj""
                                                      IProjectTreeProviderFactory.Create(),
                                                      IUnconfiguredProjectCommonServicesFactory.Create(threadingService: new IProjectThreadingServiceMock()),
                                                      tasksService,
-                                                     IActiveConfiguredProjectSubscriptionServiceFactory.CreateInstance());
+                                                     IActiveConfiguredProjectSubscriptionServiceFactory.Create());
             watcher.Load();
             var projectUpdate = IProjectSubscriptionUpdateFactory.FromJson(ProjectCurrentStateJson);
 
@@ -130,7 +130,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\foo.proj""
                                                      IProjectTreeProviderFactory.Create(),
                                                      IUnconfiguredProjectCommonServicesFactory.Create(threadingService: new IProjectThreadingServiceMock()),
                                                      tasksService,
-                                                     IActiveConfiguredProjectSubscriptionServiceFactory.CreateInstance());
+                                                     IActiveConfiguredProjectSubscriptionServiceFactory.Create());
 
             var tree = ProjectTreeParser.Parse(@"Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\foo.proj""");
             var projectUpdate = IProjectSubscriptionUpdateFactory.FromJson(@"{

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/NuGet/ProjectAssetFileWatcherTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/NuGet/ProjectAssetFileWatcherTests.cs
@@ -39,7 +39,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\foo.proj""
             var spMock = new IAsyncServiceProviderMoq();
             uint adviseCookie = 100;
             var fileChangeService = IVsFileChangeExFactory.CreateWithAdviseUnadviseFileChange(adviseCookie);
-            spMock.AddService(typeof(IVsFileChangeEx), typeof(SVsFileChangeEx), fileChangeService);
+            spMock.AddService(typeof(SVsFileChangeEx), fileChangeService);
             var tasksService = IUnconfiguredProjectTasksServiceFactory.ImplementLoadedProjectAsync<ConfiguredProject>(t => t());
 
             var watcher = new ProjectAssetFileWatcher(spMock,
@@ -94,7 +94,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\foo.proj""
             var spMock = new IAsyncServiceProviderMoq();
             uint adviseCookie = 100;
             var fileChangeService = IVsFileChangeExFactory.CreateWithAdviseUnadviseFileChange(adviseCookie);
-            spMock.AddService(typeof(IVsFileChangeEx), typeof(SVsFileChangeEx), fileChangeService);
+            spMock.AddService(typeof(SVsFileChangeEx), fileChangeService);
             var tasksService = IUnconfiguredProjectTasksServiceFactory.ImplementLoadedProjectAsync<ConfiguredProject>(t => t());
 
             var watcher = new ProjectAssetFileWatcher(spMock,
@@ -123,7 +123,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\foo.proj""
         {
             var spMock = new IAsyncServiceProviderMoq();
             var fileChangeService = IVsFileChangeExFactory.CreateWithAdviseUnadviseFileChange(100);
-            spMock.AddService(typeof(IVsFileChangeEx), typeof(SVsFileChangeEx), fileChangeService);
+            spMock.AddService(typeof(SVsFileChangeEx), fileChangeService);
             var tasksService = IUnconfiguredProjectTasksServiceFactory.ImplementLoadedProjectAsync<ConfiguredProject>(t => t());
 
             var watcher = new ProjectAssetFileWatcher(spMock,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
@@ -89,7 +89,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             return Task.CompletedTask;
         }
 
-        internal async Task OnProjectChangedAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> e)
+        internal async Task OnProjectChangedAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> e = null)
         {
             bool isDebuggable = await _launchProviders.Value.IsDebuggableAsync()
                                                             .ConfigureAwait(false);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
         [ProjectAutoLoad(startAfter: ProjectLoadCheckpoint.ProjectFactoryCompleted)]
         [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
-        internal Task Load()
+        public Task OnProjectFactoryCompleted()
         {
             return InitializeAsync();
         }
@@ -71,9 +71,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             _startupProjectsListService = (IVsStartupProjectsListService)await _serviceProvider.GetServiceAsync(typeof(SVsStartupProjectsListService))
                                                                                                .ConfigureAwait(false);
 
+            Assumes.Present(_startupProjectsListService);
+
             _subscription = _projectSubscriptionService.ProjectRuleSource.SourceBlock.LinkTo(
                 target: new ActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(OnProjectChangedAsync),
-                suppressVersionOnlyUpdates: true);
+                suppressVersionOnlyUpdates: true,
+                linkOptions: new DataflowLinkOptions() { PropagateCompletion = true });
         }
 
         protected override Task DisposeCoreAsync(bool initialized)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
@@ -56,9 +56,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
         [ProjectAutoLoad(startAfter: ProjectLoadCheckpoint.ProjectFactoryCompleted)]
         [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
-        internal Task OnProjectFactoryCompleted()
+        public Task InitializeAsync()
         {
-            return InitializeAsync();
+            return InitializeAsync(CancellationToken.None);
         }
 
         protected override async Task InitializeCoreAsync(CancellationToken cancellationToken)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
@@ -2,43 +2,55 @@
 
 using System;
 using System.ComponentModel.Composition;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.Shell.Interop;
 
+using AsyncServiceProvider = Microsoft.VisualStudio.Shell.AsyncServiceProvider;
+using IAsyncServiceProvider = Microsoft.VisualStudio.Shell.IAsyncServiceProvider;
+
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 {
     /// <summary>
-    /// <see cref="StartupProjectRegistrar"/> is responsible for adding or removing a project from the Startup list
-    /// depending on whether the active configuration of the a project is debuggable or not.
+    ///     Responsible for adding or removing the project from the startup list based on whether the project
+    ///     is debuggable or not.
     /// </summary>
-    internal class StartupProjectRegistrar : OnceInitializedOnceDisposed
+    internal class StartupProjectRegistrar : OnceInitializedOnceDisposedAsync
     {
+        private readonly IAsyncServiceProvider _serviceProvider;
         private readonly IProjectThreadingService _threadingService;
-        private readonly IActiveConfiguredProjectSubscriptionService _activeConfiguredProjectSubscriptionService;
+        private readonly IActiveConfiguredProjectSubscriptionService _projectSubscriptionService;
         private readonly ActiveConfiguredProject<DebuggerLaunchProviders> _launchProviders;
-        private readonly IVsService<IVsStartupProjectsListService> _startupProjectsListService;
-        private Guid _guid = Guid.Empty;
-        private IDisposable _evaluationSubscriptionLink;
-        private bool _isDebuggable;
+        private readonly IProjectGuidService2 _projectGuidService;
+        private IVsStartupProjectsListService _startupProjectsListService;
+        private Guid _projectGuid;
+        private IDisposable _subscription;
 
         [ImportingConstructor]
         public StartupProjectRegistrar(
-            IVsService<SVsStartupProjectsListService, IVsStartupProjectsListService> startupProjectsListService,
             IProjectThreadingService threadingService,
-            IActiveConfiguredProjectSubscriptionService activeConfiguredProjectSubscriptionService,
+            [Import(typeof(IProjectGuidService))]IProjectGuidService2 projectGuidService,
+            IActiveConfiguredProjectSubscriptionService projectSubscriptionService,
             ActiveConfiguredProject<DebuggerLaunchProviders> launchProviders)
+            : this(AsyncServiceProvider.GlobalProvider, threadingService, projectGuidService, projectSubscriptionService, launchProviders)
         {
-            Requires.NotNull(startupProjectsListService, nameof(startupProjectsListService));
-            Requires.NotNull(threadingService, nameof(threadingService));
-            Requires.NotNull(activeConfiguredProjectSubscriptionService, nameof(activeConfiguredProjectSubscriptionService));
-            Requires.NotNull(launchProviders, nameof(launchProviders));
+        }
 
-            _startupProjectsListService = startupProjectsListService;
+        public StartupProjectRegistrar(
+            IAsyncServiceProvider serviceProvider,
+            IProjectThreadingService threadingService,
+            IProjectGuidService2 projectGuidService,
+            IActiveConfiguredProjectSubscriptionService projectSubscriptionService,
+            ActiveConfiguredProject<DebuggerLaunchProviders> launchProviders)
+        : base(threadingService.JoinableTaskContext)
+        {
+            _serviceProvider = serviceProvider;
             _threadingService = threadingService;
-            _activeConfiguredProjectSubscriptionService = activeConfiguredProjectSubscriptionService;
+            _projectGuidService = projectGuidService;
+            _projectSubscriptionService = projectSubscriptionService;
             _launchProviders = launchProviders;
         }
 
@@ -46,105 +58,78 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
         internal Task Load()
         {
-            EnsureInitialized();
+            return InitializeAsync();
+        }
+
+        protected override async Task InitializeCoreAsync(CancellationToken cancellationToken)
+        {
+            _projectGuid = await _projectGuidService.GetProjectGuidAsync()
+                                                    .ConfigureAwait(false);
+
+            Assumes.False(_projectGuid == Guid.Empty);
+
+            _startupProjectsListService = (IVsStartupProjectsListService)await _serviceProvider.GetServiceAsync(typeof(SVsStartupProjectsListService))
+                                                                                               .ConfigureAwait(false);
+
+            _subscription = _projectSubscriptionService.ProjectRuleSource.SourceBlock.LinkTo(
+                target: new ActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(OnProjectChangedAsync),
+                suppressVersionOnlyUpdates: true);
+        }
+
+        protected override Task DisposeCoreAsync(bool initialized)
+        {
+            if (initialized)
+            {
+                _subscription.Dispose();
+            }
+
             return Task.CompletedTask;
         }
 
-        protected override void Dispose(bool disposing)
+        private async Task OnProjectChangedAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> e)
         {
-            if (disposing)
+            bool isDebuggable = await _launchProviders.Value.IsDebuggableAsync()
+                                                            .ConfigureAwait(false);
+
+            if (isDebuggable)
             {
-                _evaluationSubscriptionLink?.Dispose();
+                // If we're already registered, the service no-ops
+                _startupProjectsListService.AddProject(ref _projectGuid);
+            }
+            else
+            {
+                // If we're already unregistered, the service no-ops
+                _startupProjectsListService.RemoveProject(ref _projectGuid);
             }
         }
 
-        protected override void Initialize()
-        {
-            var watchedEvaluationRules = Empty.OrdinalIgnoreCaseStringSet.Add(ConfigurationGeneral.SchemaName);
-            var evaluationBlock = new ActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(ConfigurationGeneralRuleBlock_ChangedAsync);
-            _evaluationSubscriptionLink = _activeConfiguredProjectSubscriptionService.ProjectRuleSource.SourceBlock
-                                            .LinkTo(target: evaluationBlock, ruleNames: watchedEvaluationRules, suppressVersionOnlyUpdates: true);
-        }
-
-        internal async Task ConfigurationGeneralRuleBlock_ChangedAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> e)
-        {
-            IProjectChangeDescription projectChange = e.Value.ProjectChanges[ConfigurationGeneral.SchemaName];
-
-            if (projectChange.Difference.ChangedProperties.Contains(ConfigurationGeneral.ProjectGuidProperty))
-            {
-                if (Guid.TryParse(projectChange.After.Properties[ConfigurationGeneral.ProjectGuidProperty], out Guid result))
-                {
-                    _guid = result;
-                    await AddOrRemoveProjectFromStartupProjectListAsync(initialize: true).ConfigureAwait(false);
-                }
-
-                return;
-            }
-
-            if (_guid == Guid.Empty)
-            {
-                return;
-            }
-
-            /* Currently  we watch for the change in the OutputType to check if a project is debuggable.
-               There are other cases where the OutputType will remain the same and still the ability to debuggable a project could change
-               For eg: A project's OutputType could be a Lib and an execution entry point could be added or removed
-               Tracking bug: https://github.com/dotnet/roslyn-project-system/issues/455
-               */
-            if (projectChange.Difference.ChangedProperties.Contains(ConfigurationGeneral.OutputTypeProperty))
-            {
-                await AddOrRemoveProjectFromStartupProjectListAsync().ConfigureAwait(false);
-            }
-        }
-
-        private async Task AddOrRemoveProjectFromStartupProjectListAsync(bool initialize = false)
-        {
-            bool isDebuggable = await IsDebuggableAsync().ConfigureAwait(false);
-            await _threadingService.SwitchToUIThread();
-
-            if (initialize || isDebuggable != _isDebuggable)
-            {
-                _isDebuggable = isDebuggable;
-                if (isDebuggable)
-                {
-                    _startupProjectsListService.Value.AddProject(ref _guid);
-                }
-                else
-                {
-                    _startupProjectsListService.Value.RemoveProject(ref _guid);
-                }
-            }
-        }
-
-        private async Task<bool> IsDebuggableAsync()
-        {
-            foreach (var provider in _launchProviders.Value.Debuggers)
-            {
-                if (await provider.Value.CanLaunchAsync(DebugLaunchOptions.DesignTimeExpressionEvaluation)
-                                        .ConfigureAwait(false))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        // Creating a class which provides the LaunchProviders is a workaround because importing ActiveConfiguredProject
-        // with 2 arguments does not work.
         [Export]
         internal class DebuggerLaunchProviders
         {
             [ImportingConstructor]
             public DebuggerLaunchProviders(ConfiguredProject project)
             {
-                Debuggers = new OrderPrecedenceImportCollection<IDebugLaunchProvider, IDebugLaunchProviderMetadataView>(projectCapabilityCheckProvider: project);
+                Debuggers = new OrderPrecedenceImportCollection<IDebugLaunchProvider>(projectCapabilityCheckProvider: project);
             }
 
             [ImportMany]
-            public OrderPrecedenceImportCollection<IDebugLaunchProvider, IDebugLaunchProviderMetadataView> Debuggers
+            public OrderPrecedenceImportCollection<IDebugLaunchProvider> Debuggers
             {
                 get;
+            }
+
+            public async Task<bool> IsDebuggableAsync()
+            {
+                foreach (Lazy<IDebugLaunchProvider> provider in Debuggers)
+                {
+                    if (await provider.Value.CanLaunchAsync(DebugLaunchOptions.DesignTimeExpressionEvaluation)
+                                            .ConfigureAwait(false))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
         [ProjectAutoLoad(startAfter: ProjectLoadCheckpoint.ProjectFactoryCompleted)]
         [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
-        public Task OnProjectFactoryCompleted()
+        internal Task OnProjectFactoryCompleted()
         {
             return InitializeAsync();
         }
@@ -89,7 +89,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             return Task.CompletedTask;
         }
 
-        private async Task OnProjectChangedAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> e)
+        internal async Task OnProjectChangedAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> e)
         {
             bool isDebuggable = await _launchProviders.Value.IsDebuggableAsync()
                                                             .ConfigureAwait(false);


### PR DESCRIPTION
- Removed need to keep state if the project is debuggable or not, IVsStartupProjectsListService is designed to no op if the project has already been added or removed.
- Removed need to switch to UI thread. IVsStartupProjectsListService is free-threaded.
- Stop listening to project GUID changes - the project GUID rule is being removed to fix https://github.com/dotnet/project-system/issues/2940.
- Listen to all properties not just output type. If not using launch profiles, output type doesn't actually influence whether you are debuggable or not. It's based on the debugger properties such as executable, etc.