### PR TITLE
Prevent ActiveConfiguredProjectsLoader tests from deadlocking

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectVersionedValueFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectVersionedValueFactory.cs
@@ -1,0 +1,15 @@
+﻿// Copyright(c) Microsoft.All Rights Reserved.Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class ProjectVersionedValueFactory
+    {
+        public static ProjectVersionedValue<T> Create<T>(T value)
+        {
+            return new ProjectVersionedValue<T>(value, ImmutableDictionary<NamedIdentity, IComparable>.Empty);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             _project = project;
             _activeConfigurationGroupService = activeConfigurationGroupService;
             _tasksService = tasksService;
-            _targetBlock = new ActionBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>>(OnActiveConfigurationsChanged);
+            _targetBlock = new ActionBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>>(OnActiveConfigurationsChangedAsync);
         }
 
         [ProjectAutoLoad(ProjectLoadCheckpoint.ProjectInitialCapabilitiesEstablished)]
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             }
         }
 
-        private async Task OnActiveConfigurationsChanged(IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>> e)
+        private async Task OnActiveConfigurationsChangedAsync(IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>> e)
         {
             foreach (ProjectConfiguration configuration in e.Value)
             {


### PR DESCRIPTION
Fixes: #3279

These tests were using dataflow messages to test the service which I believe were deadlocking due to blocks not completing. I've not been able to reproduce locally, but we've hitting a lot since 15.6 - and these are the only thread-related tests that we've added.

Move to a simpler model of just calling the event handler.