### PR TITLE
Rename ProjectGuidProvider -> ProjectTypeGuidProvider

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Properties/CSharpProjectTypeGuidProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Properties/CSharpProjectTypeGuidProviderTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 {
     [Trait("UnitTest", "ProjectSystem")]
-    public class CSharpProjectGuidProviderTests
+    public class CSharpProjectTypeGuidProviderTests
     {
         [Fact]
         public void ProjectTypeGuid_ReturnsNonEmptyGuid()
@@ -19,11 +19,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             Assert.NotEqual(Guid.Empty, provider.ProjectTypeGuid);
         }
 
-        private static CSharpProjectGuidProvider CreateInstance()
+        private static CSharpProjectTypeGuidProvider CreateInstance()
         {
             var unconfiguedProject = UnconfiguredProjectFactory.Create();
 
-            return new CSharpProjectGuidProvider(unconfiguedProject);
+            return new CSharpProjectTypeGuidProvider(unconfiguedProject);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/CSharpProjectTypeGuidProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/CSharpProjectTypeGuidProvider.cs
@@ -12,12 +12,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     /// </summary>
     [Export(typeof(IItemTypeGuidProvider))]
     [AppliesTo(ProjectCapabilities.CSharp)]
-    internal class CSharpProjectGuidProvider : IItemTypeGuidProvider
+    internal class CSharpProjectTypeGuidProvider : IItemTypeGuidProvider
     {
         private static readonly Guid s_csharpProjectType = new Guid(CSharpProjectSystemPackage.LegacyProjectTypeGuid);
 
         [ImportingConstructor]
-        public CSharpProjectGuidProvider(UnconfiguredProject project)
+        public CSharpProjectTypeGuidProvider(UnconfiguredProject project)
         {
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/ProjectSystem/VS/FSharpProjectTypeGuidProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/ProjectSystem/VS/FSharpProjectTypeGuidProvider.cs
@@ -11,19 +11,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     ///     Provides the Visual Basic implementation of <see cref="IItemTypeGuidProvider"/>.
     /// </summary>
     [Export(typeof(IItemTypeGuidProvider))]
-    [AppliesTo(ProjectCapabilities.VB)]
-    internal class VisualBasicProjectGuidProvider : IItemTypeGuidProvider
+    [AppliesTo(ProjectCapability.FSharp)]
+    internal class FSharpProjectTypeGuidProvider : IItemTypeGuidProvider
     {
-        private static readonly Guid s_visualBasicProjectType = new Guid(VisualBasicProjectSystemPackage.LegacyProjectTypeGuid);
+        private static readonly Guid s_fsharpProjectType = new Guid(FSharpProjectSystemPackage.LegacyProjectTypeGuid);
 
         [ImportingConstructor]
-        public VisualBasicProjectGuidProvider(UnconfiguredProject project)
+        public FSharpProjectTypeGuidProvider(UnconfiguredProject project)
         {
         }
 
         public Guid ProjectTypeGuid
         {
-            get { return s_visualBasicProjectType; }
+            get { return s_fsharpProjectType; }
         }
+
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/VisualBasicProjectTypeGuidProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/VisualBasicProjectTypeGuidProviderTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
     [Trait("UnitTest", "ProjectSystem")]
-    public class VisualBasicProjectGuidProviderTests
+    public class VisualBasicProjectTypeGuidProviderTests
     {
         [Fact]
         public void ProjectTypeGuid_ReturnsNonEmptyGuid()
@@ -19,11 +19,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             Assert.NotEqual(Guid.Empty, provider.ProjectTypeGuid);
         }
 
-        private static VisualBasicProjectGuidProvider CreateInstance()
+        private static VisualBasicProjectTypeGuidProvider CreateInstance()
         {
             var unconfiguedProject = UnconfiguredProjectFactory.Create();
 
-            return new VisualBasicProjectGuidProvider(unconfiguedProject);
+            return new VisualBasicProjectTypeGuidProvider(unconfiguedProject);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/VisualBasicProjectTypeGuidProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/VisualBasicProjectTypeGuidProvider.cs
@@ -11,20 +11,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     ///     Provides the Visual Basic implementation of <see cref="IItemTypeGuidProvider"/>.
     /// </summary>
     [Export(typeof(IItemTypeGuidProvider))]
-    [AppliesTo(ProjectCapability.FSharp)]
-    internal class FSharpProjectGuidProvider : IItemTypeGuidProvider
+    [AppliesTo(ProjectCapabilities.VB)]
+    internal class VisualBasicProjectTypeGuidProvider : IItemTypeGuidProvider
     {
-        private static readonly Guid s_fsharpProjectType = new Guid(FSharpProjectSystemPackage.LegacyProjectTypeGuid);
+        private static readonly Guid s_visualBasicProjectType = new Guid(VisualBasicProjectSystemPackage.LegacyProjectTypeGuid);
 
         [ImportingConstructor]
-        public FSharpProjectGuidProvider(UnconfiguredProject project)
+        public VisualBasicProjectTypeGuidProvider(UnconfiguredProject project)
         {
         }
 
         public Guid ProjectTypeGuid
         {
-            get { return s_fsharpProjectType; }
+            get { return s_visualBasicProjectType; }
         }
-
     }
 }


### PR DESCRIPTION
This better describes what it returns; it returns Project's *Type GUID*, not a Project's GUID.