### PR TITLE
Remove ProjectGuid usage from tests

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractAddClassProjectCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractAddClassProjectCommandTests.cs
@@ -171,10 +171,6 @@ Root (flags: {ProjectRoot})
                 return 0;
             }, g, folder, string.Empty, 0);
 
-            var projectProperties = ProjectPropertiesFactory.Create(UnconfiguredProjectFactory.Create(), new[] {
-                    new PropertyPageData { Category = ConfigurationGeneral.SchemaName, PropertyName = ConfigurationGeneral.ProjectGuidProperty, Value = g.ToString() }
-                });
-
             var command = CreateInstance(provider: IProjectTreeProviderFactory.Create(folder), dlg: dlg);
 
             var tree = ProjectTreeParser.Parse(@"


### PR DESCRIPTION
This variable wasn't being used and left over previously removed code.