### PR TITLE
Remove project guid property usage from language service

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
@@ -27,15 +27,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Requires.NotNull(projectChange, nameof(projectChange));
             Requires.NotNull(logger, nameof(logger));
 
-            if (projectChange.Difference.ChangedProperties.Contains(ConfigurationGeneral.ProjectGuidProperty))
-            {
-                if (Guid.TryParse(projectChange.After.Properties[ConfigurationGeneral.ProjectGuidProperty], out Guid result))
-                {
-                    logger.WriteLine("ProjectGuid: {0}", result);
-                    _context.Guid = result;
-                }
-            }
-
             // The language service wants both the intermediate (bin\obj) and output (bin\debug)) paths
             // so that it can automatically hook up project-to-project references. It does this by matching the 
             // bin output path with the another project's /reference argument, if they match, then it automatically 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/UnconfiguredProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/UnconfiguredProjectContextProvider.cs
@@ -28,6 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         private readonly List<AggregateWorkspaceProjectContext> _contexts = new List<AggregateWorkspaceProjectContext>();
         private readonly IProjectHostProvider _projectHostProvider;
         private readonly IActiveConfiguredProjectsProvider _activeConfiguredProjectsProvider;
+        private readonly IProjectGuidService2 _projectGuidService;
         private readonly IUnconfiguredProjectHostObject _unconfiguredProjectHostObject;
         private readonly Dictionary<ConfiguredProject, IWorkspaceProjectContext> _configuredProjectContextsMap = new Dictionary<ConfiguredProject, IWorkspaceProjectContext>();
         private readonly Dictionary<ConfiguredProject, IConfiguredProjectHostObject> _configuredProjectHostObjectsMap = new Dictionary<ConfiguredProject, IConfiguredProjectHostObject>();
@@ -38,7 +39,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
                                                  IProjectAsyncLoadDashboard asyncLoadDashboard,
                                                  ITaskScheduler taskScheduler,
                                                  IProjectHostProvider projectHostProvider,
-                                                 IActiveConfiguredProjectsProvider activeConfiguredProjectsProvider)
+                                                 IActiveConfiguredProjectsProvider activeConfiguredProjectsProvider,
+                                                 [Import(typeof(IProjectGuidService))]IProjectGuidService2 projectGuidService)
         {
             Requires.NotNull(commonServices, nameof(commonServices));
             Requires.NotNull(contextFactory, nameof(contextFactory));
@@ -53,7 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             _taskScheduler = taskScheduler;
             _projectHostProvider = projectHostProvider;
             _activeConfiguredProjectsProvider = activeConfiguredProjectsProvider;
-
+            _projectGuidService = projectGuidService;
             _unconfiguredProjectHostObject = _projectHostProvider.UnconfiguredProjectHostObject;
         }
 
@@ -167,15 +169,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
                                                                .ConfigureAwait(false);
         }
 
-        private async Task<Guid> GetProjectGuidAsync()
-        {
-            ConfigurationGeneral properties = await _commonServices.ActiveConfiguredProjectProperties.GetConfigurationGeneralPropertiesAsync()
-                                                                                                     .ConfigureAwait(false);
-            Guid.TryParse((string)await properties.ProjectGuid.GetValueAsync().ConfigureAwait(false), out Guid guid);
-
-            return guid;
-        }
-
         private async Task<string> GetTargetPathAsync()
         {
             ConfigurationGeneral properties = await _commonServices.ActiveConfiguredProjectProperties.GetConfigurationGeneralPropertiesAsync()
@@ -228,7 +221,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             if (string.IsNullOrEmpty(languageName))
                 return null;
 
-            Guid projectGuid = await GetProjectGuidAsync().ConfigureAwait(false);
+            Guid projectGuid = await _projectGuidService.GetProjectGuidAsync()
+                                                        .ConfigureAwait(false);
+
             string targetPath = await GetTargetPathAsync().ConfigureAwait(false);
             if (string.IsNullOrEmpty(targetPath))
                 return null;


### PR DESCRIPTION
Partially fixes: #2940.

The actual removal of the rule property and taking a lock while setting the project guid will be in a followup change.