### PR TITLE
Updating the build scripts to supppot paths with spaces in the name

### DIFF
--- a/Test.cmd
+++ b/Test.cmd
@@ -1,3 +1,3 @@
 @echo off
-powershell -ExecutionPolicy ByPass %~dp0build\Build.ps1 -test %*
+powershell -ExecutionPolicy ByPass -Command "& """%~dp0build\Build.ps1""" -test %*"
 exit /b %ErrorLevel%

--- a/build.cmd
+++ b/build.cmd
@@ -30,7 +30,7 @@ if /I "%1" == "/rootsuffix" set PropRootSuffix=/p:RootSuffix=%2&&shift&&shift&& 
 call :Usage && exit /b 1
 :DoneParsing
 
-powershell -ExecutionPolicy ByPass %Root%build\Build.ps1 -configuration %BuildConfiguration% -restore -deployDeps:%OptDeployDeps% -build:%OptBuild% -rebuild:%OptRebuild% -deploy:%OptDeploy% -test:%OptTest% -integrationTest:%OptIntegrationTest% -log:%OptLog% %PropRootSuffix%
+powershell -ExecutionPolicy ByPass -Command "& """%Root%build\Build.ps1""" -configuration %BuildConfiguration% -restore -deployDeps:%OptDeployDeps% -build:%OptBuild% -rebuild:%OptRebuild% -deploy:%OptDeploy% -test:%OptTest% -integrationTest:%OptIntegrationTest% -log:%OptLog% %PropRootSuffix%"
 exit /b %ERRORLEVEL%
 
 :Usage


### PR DESCRIPTION
This resolves https://github.com/dotnet/project-system/issues/3187.

FYI. @tmat, @davkean, @jaredpar 