### PR TITLE
Add IProjectAccessor.OpenProjectForWriteAsync (15.7)

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectAccessorFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectAccessorFactory.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class IProjectAccessorFactory
+    {
+        public static IProjectAccessor Create(string xml = null)
+        {
+            var rootElement = ProjectRootElementFactory.Create(xml);
+
+            return Create(rootElement);
+        }
+
+        public static IProjectAccessor Create(ProjectRootElement rootElement)
+        {
+            var evaluationProject = ProjectFactory.Create(rootElement);
+
+            return new ProjectAccessor(rootElement, evaluationProject);
+        }
+
+        private class ProjectAccessor : IProjectAccessor
+        {
+            private readonly ProjectRootElement _rootElement;
+            private readonly Project _evaluationProject;
+
+            public ProjectAccessor(ProjectRootElement element, Project project)
+            {
+                _rootElement = element;
+                _evaluationProject = project;
+            }
+
+            public Task<TResult> OpenProjectForReadAsync<TResult>(ConfiguredProject project, Func<Project, TResult> action, CancellationToken cancellationToken = default(CancellationToken))
+            {
+                var result = action(_evaluationProject);
+
+                return Task.FromResult(result);
+            }
+
+            public Task<TResult> OpenProjectXmlForReadAsync<TResult>(UnconfiguredProject project, Func<ProjectRootElement, TResult> action, CancellationToken cancellationToken = default(CancellationToken))
+            {
+                var result = action(_rootElement);
+
+                return Task.FromResult(result);
+            }
+
+            public Task OpenProjectXmlForWriteAsync(UnconfiguredProject project, Action<ProjectRootElement> action, CancellationToken cancellationToken = default(CancellationToken))
+            {
+                action(_rootElement);
+
+                return Task.CompletedTask;
+            }
+
+            public Task OpenProjectForWriteAsync(ConfiguredProject project, Action<Project> action, CancellationToken cancellationToken = default(CancellationToken))
+            {
+                action(_evaluationProject);
+
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectFactory.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.Build.Construction;
+
+namespace Microsoft.Build.Evaluation
+{
+    internal static class ProjectFactory
+    {
+        public static Project Create(ProjectRootElement rootElement)
+        {
+            return new Project(rootElement);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectAccessor.cs
@@ -97,5 +97,32 @@ namespace Microsoft.VisualStudio.ProjectSystem
         ///     NOTE: To avoid deadlocks, do not call arbitrary services or asynchronous code within <paramref name="action"/>.
         /// </remarks>
         Task<TResult> OpenProjectForReadAsync<TResult>(ConfiguredProject project, Func<Project, TResult> action, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        ///     Opens the MSBuild project evaluation model for the specified project, passing it to the specified action for writing.
+        /// </summary>
+        /// <param name="project">
+        ///     The <see cref="ConfiguredProject"/> whose underlying MSBuild object model is required.
+        /// </param>
+        /// <param name="action">
+        ///     The <see cref="Action{T}"/> to run while holding the lock.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A token whose cancellation signals lost interest in the result.
+        /// </param>
+        /// <returns>
+        ///     The result of executing <paramref name="action"/> over the <see cref="Project"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="project"/> is <see langword="null"/>.
+        ///     <para>
+        ///         -or-
+        ///     </para>
+        ///     <paramref name="action"/> is <see langword="null"/>.
+        /// </exception>
+        /// <remarks>
+        ///     NOTE: To avoid deadlocks, do not call arbitrary services or asynchronous code within <paramref name="action"/>.
+        /// </remarks>
+        Task OpenProjectForWriteAsync(ConfiguredProject project, Action<Project> action, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectAccessor.cs
@@ -78,5 +78,24 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 action(rootElement);
             }
         }
+
+        public async Task OpenProjectForWriteAsync(ConfiguredProject project, Action<Project> action, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Requires.NotNull(project, nameof(project));
+            Requires.NotNull(project, nameof(action));
+
+            using (ProjectWriteLockReleaser access = await _projectLockService.WriteLockAsync(cancellationToken))
+            {
+                await access.CheckoutAsync(project.UnconfiguredProject.FullPath)
+                            .ConfigureAwait(true);
+
+                Project evaluatedProject = await access.GetProjectAsync(project, cancellationToken)
+                                                       .ConfigureAwait(true);
+
+                // Deliberately not async to reduce the type of
+                // code you can run while holding the lock.
+                action(evaluatedProject);
+            }
+        }
     }
 }


### PR DESCRIPTION
Lets callers modify the evaluation project.

This is a straight cherry-pick of IProjectAccessor additions from master to 15.7 as they are required for the ProjectGuid changes.
