### PR TITLE
Added fix for FSharp hotkeys in legacy projects

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Menus.vsct
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Menus.vsct
@@ -97,30 +97,6 @@
     </Groups>
 
     <Buttons>
-      <Button guid="guidManagedProjectSystemOrderCommandSet" id="cmdidMoveUp" priority="0x100">
-        <Parent guid="guidManagedProjectSystemOrderCommandSet" id="OrderingGroup" />
-        <CommandFlag>TextChanges</CommandFlag>
-        <CommandFlag>DynamicVisibility</CommandFlag>
-        <CommandFlag>DefaultInvisible</CommandFlag>
-        <CommandFlag>DefaultDisabled</CommandFlag>
-        <Strings>
-          <ButtonText>&amp;Move Up</ButtonText>
-          <CommandName>MoveUp</CommandName>
-        </Strings>
-      </Button>
-
-      <Button guid="guidManagedProjectSystemOrderCommandSet" id="cmdidMoveDown" priority="0x101">
-        <Parent guid="guidManagedProjectSystemOrderCommandSet" id="OrderingGroup" />
-        <CommandFlag>TextChanges</CommandFlag>
-        <CommandFlag>DynamicVisibility</CommandFlag>
-        <CommandFlag>DefaultInvisible</CommandFlag>
-        <CommandFlag>DefaultDisabled</CommandFlag>
-        <Strings>
-          <ButtonText>&amp;Move Down</ButtonText>
-          <CommandName>MoveDown</CommandName>
-        </Strings>
-      </Button>
-
       <Button guid="guidManagedProjectSystemOrderCommandSet" id="cmdidAddNewItemAbove" priority="0x102">
         <Parent guid="guidManagedProjectSystemOrderCommandSet" id="AddAboveGroup"/>
         <Icon guid="guidSHLMainMenu" id="1"/>
@@ -212,11 +188,6 @@
       </Button>
     </Buttons>
   </Commands>
-
-  <KeyBindings>
-    <KeyBinding guid="guidManagedProjectSystemOrderCommandSet" id="cmdidMoveUp" editor="SlnExplorerGuid" key1="VK_UP" mod1="Alt" />
-    <KeyBinding guid="guidManagedProjectSystemOrderCommandSet" id="cmdidMoveDown" editor="SlnExplorerGuid" key1="VK_DOWN" mod1="Alt" />    
-  </KeyBindings>
 
   <Symbols>
     <!-- This is out managed package guid. -->

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
@@ -35,12 +35,15 @@ namespace Microsoft.VisualStudio.Packaging
         public const int DebugFrameworksCmdId = 0x3050;
 
         public const string ManagedProjectSystemOrderCommandSet = "{6C4806E9-034E-4B64-99DE-29A6F837B993}";
-        public const int MoveUpCmdId = 0x2000;
-        public const int MoveDownCmdId = 0x2001;
         public const int AddNewItemAboveCmdId = 0x2002;
         public const int AddExistingItemAboveCmdId = 0x2003;
         public const int AddNewItemBelowCmdId = 0x2004;
         public const int AddExistingItemBelowCmdId = 0x2005;
+
+        // The guid and values are from the old F# project system, don't change them.
+        public const string FSharpProjectCmdSet = "{75AC5611-A912-4195-8A65-457AE17416FB}";
+        public const int MoveUpCmdId = 0x3002;
+        public const int MoveDownCmdId = 0x3007;
 
         public const string SolutionExplorerGuid = "{3AE79031-E1BC-11D0-8F78-00A0C9110057}";
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/MoveDownCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/MoveDownCommand.cs
@@ -8,7 +8,7 @@ using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
-    [ProjectCommand(ManagedProjectSystemPackage.ManagedProjectSystemOrderCommandSet, ManagedProjectSystemPackage.MoveDownCmdId)]
+    [ProjectCommand(ManagedProjectSystemPackage.FSharpProjectCmdSet, ManagedProjectSystemPackage.MoveDownCmdId)]
     [AppliesTo(ProjectCapability.SortByDisplayOrder)]
     internal class MoveDownCommand : AbstractMoveCommand
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/MoveUpCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/MoveUpCommand.cs
@@ -8,7 +8,7 @@ using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
-    [ProjectCommand(ManagedProjectSystemPackage.ManagedProjectSystemOrderCommandSet, ManagedProjectSystemPackage.MoveUpCmdId)]
+    [ProjectCommand(ManagedProjectSystemPackage.FSharpProjectCmdSet, ManagedProjectSystemPackage.MoveUpCmdId)]
     [AppliesTo(ProjectCapability.SortByDisplayOrder)]
     internal class MoveUpCommand : AbstractMoveCommand
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.cs.xlf
@@ -47,26 +47,6 @@
         <target state="translated">Architektura</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidMoveUp|ButtonText">
-        <source>&amp;Move Up</source>
-        <target state="translated">Přesunout &amp;nahoru</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveUp|CommandName">
-        <source>MoveUp</source>
-        <target state="translated">MoveUp</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveDown|ButtonText">
-        <source>&amp;Move Down</source>
-        <target state="translated">Přesunout &amp;dolů</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveDown|CommandName">
-        <source>MoveDown</source>
-        <target state="translated">MoveDown</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddAboveMenu|ButtonText">
         <source>&amp;Add Above</source>
         <target state="translated">&amp;Přidat výše</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.de.xlf
@@ -47,26 +47,6 @@
         <target state="translated">Framework</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidMoveUp|ButtonText">
-        <source>&amp;Move Up</source>
-        <target state="translated">&amp;Nach oben</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveUp|CommandName">
-        <source>MoveUp</source>
-        <target state="translated">MoveUp</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveDown|ButtonText">
-        <source>&amp;Move Down</source>
-        <target state="translated">&amp;Nach unten</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveDown|CommandName">
-        <source>MoveDown</source>
-        <target state="translated">MoveDown</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddAboveMenu|ButtonText">
         <source>&amp;Add Above</source>
         <target state="translated">Oberh&amp;alb hinzufügen</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.es.xlf
@@ -47,26 +47,6 @@
         <target state="translated">Plataforma</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidMoveUp|ButtonText">
-        <source>&amp;Move Up</source>
-        <target state="translated">&amp;Subir</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveUp|CommandName">
-        <source>MoveUp</source>
-        <target state="translated">Subir</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveDown|ButtonText">
-        <source>&amp;Move Down</source>
-        <target state="translated">&amp;Bajar</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveDown|CommandName">
-        <source>MoveDown</source>
-        <target state="translated">Bajar</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddAboveMenu|ButtonText">
         <source>&amp;Add Above</source>
         <target state="translated">Agregar &amp;encima</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.fr.xlf
@@ -47,26 +47,6 @@
         <target state="translated">Framework</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidMoveUp|ButtonText">
-        <source>&amp;Move Up</source>
-        <target state="translated">&amp;Monter</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveUp|CommandName">
-        <source>MoveUp</source>
-        <target state="translated">MoveUp</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveDown|ButtonText">
-        <source>&amp;Move Down</source>
-        <target state="translated">&amp;Descendre</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveDown|CommandName">
-        <source>MoveDown</source>
-        <target state="translated">MoveDown</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddAboveMenu|ButtonText">
         <source>&amp;Add Above</source>
         <target state="translated">&amp;Ajouter au-dessus</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.it.xlf
@@ -47,26 +47,6 @@
         <target state="translated">Framework</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidMoveUp|ButtonText">
-        <source>&amp;Move Up</source>
-        <target state="translated">Sposta &amp;su</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveUp|CommandName">
-        <source>MoveUp</source>
-        <target state="translated">MoveUp</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveDown|ButtonText">
-        <source>&amp;Move Down</source>
-        <target state="translated">Sposta &amp;giù</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveDown|CommandName">
-        <source>MoveDown</source>
-        <target state="translated">MoveDown</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddAboveMenu|ButtonText">
         <source>&amp;Add Above</source>
         <target state="translated">&amp;Aggiungi sopra</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.ja.xlf
@@ -47,26 +47,6 @@
         <target state="translated">フレームワーク</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidMoveUp|ButtonText">
-        <source>&amp;Move Up</source>
-        <target state="translated">上へ移動(&amp;M)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveUp|CommandName">
-        <source>MoveUp</source>
-        <target state="translated">MoveUp</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveDown|ButtonText">
-        <source>&amp;Move Down</source>
-        <target state="translated">下へ移動(&amp;M)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveDown|CommandName">
-        <source>MoveDown</source>
-        <target state="translated">MoveDown</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddAboveMenu|ButtonText">
         <source>&amp;Add Above</source>
         <target state="translated">上に追加(&amp;A)</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.ko.xlf
@@ -47,26 +47,6 @@
         <target state="translated">프레임워크</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidMoveUp|ButtonText">
-        <source>&amp;Move Up</source>
-        <target state="translated">위로 이동(&amp;M)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveUp|CommandName">
-        <source>MoveUp</source>
-        <target state="translated">MoveUp</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveDown|ButtonText">
-        <source>&amp;Move Down</source>
-        <target state="translated">아래로 이동(&amp;M)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveDown|CommandName">
-        <source>MoveDown</source>
-        <target state="translated">MoveDown</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddAboveMenu|ButtonText">
         <source>&amp;Add Above</source>
         <target state="translated">위에 추가(&amp;A)</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.pl.xlf
@@ -47,26 +47,6 @@
         <target state="translated">Platforma</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidMoveUp|ButtonText">
-        <source>&amp;Move Up</source>
-        <target state="translated">Przenieś &amp;w górę</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveUp|CommandName">
-        <source>MoveUp</source>
-        <target state="translated">MoveUp</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveDown|ButtonText">
-        <source>&amp;Move Down</source>
-        <target state="translated">Przeni&amp;eś w dół</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveDown|CommandName">
-        <source>MoveDown</source>
-        <target state="translated">MoveDown</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddAboveMenu|ButtonText">
         <source>&amp;Add Above</source>
         <target state="translated">&amp;Dodaj powyżej</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.pt-BR.xlf
@@ -47,26 +47,6 @@
         <target state="translated">Estrutura</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidMoveUp|ButtonText">
-        <source>&amp;Move Up</source>
-        <target state="translated">&amp;Move Up</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveUp|CommandName">
-        <source>MoveUp</source>
-        <target state="translated">MoveUp</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveDown|ButtonText">
-        <source>&amp;Move Down</source>
-        <target state="translated">&amp;Move Down</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveDown|CommandName">
-        <source>MoveDown</source>
-        <target state="translated">MoveDown</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddAboveMenu|ButtonText">
         <source>&amp;Add Above</source>
         <target state="translated">&amp;Adicionar acima</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.ru.xlf
@@ -47,26 +47,6 @@
         <target state="translated">Платформа</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidMoveUp|ButtonText">
-        <source>&amp;Move Up</source>
-        <target state="translated">&amp;Переместить вверх</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveUp|CommandName">
-        <source>MoveUp</source>
-        <target state="translated">MoveUp</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveDown|ButtonText">
-        <source>&amp;Move Down</source>
-        <target state="translated">&amp;Переместить вниз</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveDown|CommandName">
-        <source>MoveDown</source>
-        <target state="translated">MoveDown</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddAboveMenu|ButtonText">
         <source>&amp;Add Above</source>
         <target state="translated">&amp;Добавить выше</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.tr.xlf
@@ -47,26 +47,6 @@
         <target state="translated">Çerçeve</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidMoveUp|ButtonText">
-        <source>&amp;Move Up</source>
-        <target state="translated">&amp;Yukarı Taşı</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveUp|CommandName">
-        <source>MoveUp</source>
-        <target state="translated">MoveUp</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveDown|ButtonText">
-        <source>&amp;Move Down</source>
-        <target state="translated">&amp;Aşağı Taşı</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveDown|CommandName">
-        <source>MoveDown</source>
-        <target state="translated">MoveDown</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddAboveMenu|ButtonText">
         <source>&amp;Add Above</source>
         <target state="translated">&amp;Yukarı Ekle</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.zh-Hans.xlf
@@ -47,26 +47,6 @@
         <target state="translated">框架</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidMoveUp|ButtonText">
-        <source>&amp;Move Up</source>
-        <target state="translated">上移(&amp;M)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveUp|CommandName">
-        <source>MoveUp</source>
-        <target state="translated">MoveUp</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveDown|ButtonText">
-        <source>&amp;Move Down</source>
-        <target state="translated">下移(&amp;M)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveDown|CommandName">
-        <source>MoveDown</source>
-        <target state="translated">MoveDown</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddAboveMenu|ButtonText">
         <source>&amp;Add Above</source>
         <target state="translated">在上方添加(&amp;A)</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.zh-Hant.xlf
@@ -47,26 +47,6 @@
         <target state="translated">架構</target>
         <note />
       </trans-unit>
-      <trans-unit id="cmdidMoveUp|ButtonText">
-        <source>&amp;Move Up</source>
-        <target state="translated">上移(&amp;M)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveUp|CommandName">
-        <source>MoveUp</source>
-        <target state="translated">MoveUp</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveDown|ButtonText">
-        <source>&amp;Move Down</source>
-        <target state="translated">下移(&amp;M)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="cmdidMoveDown|CommandName">
-        <source>MoveDown</source>
-        <target state="translated">MoveDown</target>
-        <note />
-      </trans-unit>
       <trans-unit id="AddAboveMenu|ButtonText">
         <source>&amp;Add Above</source>
         <target state="translated">在上方新增(&amp;A)</target>


### PR DESCRIPTION
**Customer scenario**

This fixes an issue where alt+up/down hotkeys for legacy F# projects wasn't working anymore.

**Bugs this fixes:** 

https://github.com/Microsoft/visualfsharp/issues/4405

**Workarounds, if any**

Don't use hotkeys, or use Tools\Options\Environment\Keyboard and remap them (but this means you need to use different keybinding for non-Core and Core F#.

**Risk**

Low risk.

**Performance impact**

None.

**Is this a regression from a previous update?**

Yes.

**Root cause analysis:**

How did we miss it?
Didn't check legacy projects for F#.

**How was the bug found?**

https://developercommunity.visualstudio.com/content/problem/204016/vs-156-preview6-alt-updown-arrows-do-not-repositio.html
