### PR TITLE
Update analyzers

### DIFF
--- a/build/Default.ruleset
+++ b/build/Default.ruleset
@@ -10,7 +10,7 @@
     <Rule Id="CA1824" Action="None" />
     <Rule Id="CA2200" Action="None" />
   </Rules>
-  <Rules AnalyzerId="Microsoft.ApiDesignGuidelines.Analyzers" RuleNamespace="Microsoft.ApiDesignGuidelines.Analyzers">
+  <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
     <Rule Id="CA1000" Action="None" />
     <Rule Id="CA1001" Action="None" />
     <Rule Id="CA1010" Action="None" />

--- a/build/Default.ruleset
+++ b/build/Default.ruleset
@@ -129,15 +129,15 @@
     <Rule Id="IDE0012" Action="Error" />                      <!-- Simplify framework names                     System.Int32 value;                                 int value;                            -->
     <Rule Id="IDE0013" Action="Error" />                      <!-- Simplify framework names (member access)     Int32.Parse("1");                                   int.Parse("1");                       -->
     <Rule Id="IDE0018" Action="Error" />                      <!-- Inline variable declaration                  TryParse(value, out result)                         TryParse(value, out int result)       -->
-    <Rule Id="IDE0018WithoutSuggestion" Action="Error" />     
+    <Rule Id="IDE0018WithoutSuggestion" Action="Error" />
     <Rule Id="IDE0019" Action="Error" />                      <!-- Use pattern matching                         if (button != null)                                 if (control is Button button)         -->
     <Rule Id="IDE0019WithoutSuggestion" Action="Error" />
     <Rule Id="IDE0020" Action="Error" />                      <!-- Use pattern matching                         if (control is Button)                              if (control is Button button)         -->
     <Rule Id="IDE0020WithoutSuggestion" Action="Error" />
     <Rule Id="IDE0029" Action="Error" />                      <!-- Use coalesce expression                      string y = x == null ? string.Empty : x;            string y = x ?? string.Empty;         -->
-    <Rule Id="IDE0029WithoutSuggestion" Action="Error" />      
+    <Rule Id="IDE0029WithoutSuggestion" Action="Error" />
     <Rule Id="IDE0030" Action="Error" />                      <!-- Use coalesce expression (nullable)           int? y = x.HasValue ? x.Value : 0                   int? y = x ?? 0;                      -->
-    <Rule Id="IDE0030WithoutSuggestion" Action="Error" />     
+    <Rule Id="IDE0030WithoutSuggestion" Action="Error" />
     <Rule Id="IDE0031" Action="Error" />                      <!-- Use null propagation                         string y = x == null ? null : x.ToLower()           string y = x?.ToLower();              -->
     <Rule Id="IDE0031WithoutSuggestion" Action="Error" />
     <Rule Id="IDE1006" Action="Error" />                      <!-- Naming styles                                Task Open()                                         Task OpenAsync()                      -->
@@ -147,5 +147,6 @@
     <Rule Id="VSTHRD200" Action="None" />                       <!-- Naming styles                              Task Open()                                         Task OpenAsync()                      -->
     <Rule Id="VSTHRD010" Action="None" />                       <!-- Visual Studio service should be used on main thread explicitly.-->
     <Rule Id="VSTHRD103" Action="None" />                       <!-- Call async methods when in an async method.-->
+    <Rule Id="VSTHRD108" Action="None" />                       <!-- Thread affinity checks should be unconditional.-->
   </Rules>
 </RuleSet>

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RuleSet Name="Common diagnostic rules for all non-shipping projects" Description="Enables/disable rules specific to all non-shipping projects." ToolsVersion="14.0">
   <Include Path=".\Default.ruleset" Action="Default" />
-  <Rules AnalyzerId="Microsoft.ApiDesignGuidelines.Analyzers" RuleNamespace="Microsoft.ApiDesignGuidelines.Analyzers">
-    <!-- For tests, the ConfigureAwait(true) is good enough. Either they are already running on a thread pool 
-         thread where ConfigureAwait(false) does nothing, or we're running the workload from an STA thread 
+  <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
+    <!-- For tests, the ConfigureAwait(true) is good enough. Either they are already running on a thread pool
+         thread where ConfigureAwait(false) does nothing, or we're running the workload from an STA thread
          where we want to marshal the continuations back to it. -->
     <Rule Id="CA2007" Action="None" />
   </Rules>

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -6,7 +6,9 @@
          thread where ConfigureAwait(false) does nothing, or we're running the workload from an STA thread
          where we want to marshal the continuations back to it. -->
     <Rule Id="CA1822" Action="None" />
+    <Rule Id="CA2000" Action="None" />
     <Rule Id="CA2007" Action="None" />
+    <Rule Id="CA2009" Action="None" />
   </Rules>
   <Rules AnalyzerId="System.Runtime.Analyzers" RuleNamespace="System.Runtime.Analyzers">
     <!-- Avoid zero length allocations - suppress for non-shipping/test projects (originally RS0007) -->

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -5,9 +5,9 @@
     <!-- For tests, the ConfigureAwait(true) is good enough. Either they are already running on a thread pool
          thread where ConfigureAwait(false) does nothing, or we're running the workload from an STA thread
          where we want to marshal the continuations back to it. -->
+    <Rule Id="CA2007" Action="None" />
     <Rule Id="CA1822" Action="None" />
     <Rule Id="CA2000" Action="None" />
-    <Rule Id="CA2007" Action="None" />
     <Rule Id="CA2009" Action="None" />
   </Rules>
   <Rules AnalyzerId="System.Runtime.Analyzers" RuleNamespace="System.Runtime.Analyzers">

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -5,6 +5,7 @@
     <!-- For tests, the ConfigureAwait(true) is good enough. Either they are already running on a thread pool
          thread where ConfigureAwait(false) does nothing, or we're running the workload from an STA thread
          where we want to marshal the continuations back to it. -->
+    <Rule Id="CA1822" Action="None" />
     <Rule Id="CA2007" Action="None" />
   </Rules>
   <Rules AnalyzerId="System.Runtime.Analyzers" RuleNamespace="System.Runtime.Analyzers">

--- a/build/Versions.props
+++ b/build/Versions.props
@@ -60,10 +60,10 @@
     <MicrosoftVisualStudioXmlEditorVersion>15.0.26606-alpha</MicrosoftVisualStudioXmlEditorVersion>
     <MicrosoftVsDesignerVersion>15.0.26606-alpha</MicrosoftVsDesignerVersion>
     <VsWebSiteInteropVersion>8.0.0-alpha</VsWebSiteInteropVersion>
-    
+
     <!-- CPS -->
     <MicrosoftVisualStudioProjectSystemSDKVersion>15.6.128-pre</MicrosoftVisualStudioProjectSystemSDKVersion>
-    
+
     <!-- Roslyn -->
     <MicrosoftVisualStudioLanguageServicesVersion>2.6.0-beta1-62113-02</MicrosoftVisualStudioLanguageServicesVersion>
     <MicrosoftVisualStudioIntegrationTestUtilitiesVersion>2.6.0-beta1-62113-02</MicrosoftVisualStudioIntegrationTestUtilitiesVersion>
@@ -73,10 +73,10 @@
     <!-- NuGet -->
     <NuGetSolutionRestoreManagerInteropVersion>4.3.0</NuGetSolutionRestoreManagerInteropVersion>
     <NuGetVisualStudioVersion>4.3.0</NuGetVisualStudioVersion>
-    
+
     <!-- Msbuild -->
     <MicrosoftBuildVersion>15.6.0-preview-000010-1174357</MicrosoftBuildVersion>
-    
+
     <!-- Libs -->
     <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
 
@@ -85,7 +85,7 @@
 
     <!-- Tests -->
     <MoqVersion>4.7.99</MoqVersion>
-    <XUnitAnalyzersVersion>0.7.0</XUnitAnalyzersVersion>
+    <XUnitAnalyzersVersion>0.8.0</XUnitAnalyzersVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/build/Versions.props
+++ b/build/Versions.props
@@ -51,7 +51,7 @@
     <MicrosoftVisualStudioShellInterop153DesignTimeVersion>15.0.26606</MicrosoftVisualStudioShellInterop153DesignTimeVersion>
     <MicrosoftVisualStudioTemplateWizardInterfaceVersion>8.0.0-alpha</MicrosoftVisualStudioTemplateWizardInterfaceVersion>
     <MicrosoftVisualStudioThreadingVersion>15.5.13-beta</MicrosoftVisualStudioThreadingVersion>
-    <MicrosoftVisualStudioThreadingAnalyzersVersion>15.5.13-beta</MicrosoftVisualStudioThreadingAnalyzersVersion>
+    <MicrosoftVisualStudioThreadingAnalyzersVersion>15.6.46</MicrosoftVisualStudioThreadingAnalyzersVersion>
     <MicrosoftVisualStudioProjectSystemAnalyzersVersion>15.3.224</MicrosoftVisualStudioProjectSystemAnalyzersVersion>
     <MicrosoftVisualStudioUtilitiesVersion>15.0.26607</MicrosoftVisualStudioUtilitiesVersion>
     <MicrosoftVisualStudioValidationVersion>15.3.32</MicrosoftVisualStudioValidationVersion>

--- a/build/Versions.props
+++ b/build/Versions.props
@@ -14,7 +14,7 @@
     <RoslynDependenciesProjectSystemOptimizationDataVersion>2.6.0-beta1-62205-02</RoslynDependenciesProjectSystemOptimizationDataVersion>
     <VSWhereVersion>2.1.4</VSWhereVersion>
     <MicrosoftDotNetIBCMergeVersion>4.7.1-alpha-00001</MicrosoftDotNetIBCMergeVersion>
-    <MicrosoftNetCompilersVersion>2.6.0-beta3-62310-01</MicrosoftNetCompilersVersion>
+    <MicrosoftNetCompilersVersion>2.6.1</MicrosoftNetCompilersVersion>
 
     <!-- VS SDK -->
     <MicrosoftVisualStudioComponentModelHostVersion>15.0.26606</MicrosoftVisualStudioComponentModelHostVersion>
@@ -68,7 +68,7 @@
     <MicrosoftVisualStudioLanguageServicesVersion>2.6.0-beta1-62113-02</MicrosoftVisualStudioLanguageServicesVersion>
     <MicrosoftVisualStudioIntegrationTestUtilitiesVersion>2.6.0-beta1-62113-02</MicrosoftVisualStudioIntegrationTestUtilitiesVersion>
     <RoslynIntegrationVsixVersion>2.6.0.6211302</RoslynIntegrationVsixVersion>
-    <MicrosoftNetRoslynDiagnosticsVersion>2.6.0-beta1-62322-01</MicrosoftNetRoslynDiagnosticsVersion>
+    <MicrosoftNetRoslynDiagnosticsVersion>2.6.1-beta1-62702-01</MicrosoftNetRoslynDiagnosticsVersion>
 
     <!-- NuGet -->
     <NuGetSolutionRestoreManagerInteropVersion>4.3.0</NuGetSolutionRestoreManagerInteropVersion>

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
@@ -326,10 +326,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
             return VSConstants.S_OK;
         }
 
-        private string GetDotnetArguments(string xprojLocation, string projectDirectory, string logFile) =>
+        private static string GetDotnetArguments(string xprojLocation, string projectDirectory, string logFile) =>
             $"migrate --skip-backup -s -x \"{xprojLocation}\" \"{projectDirectory}\\project.json\" -r \"{logFile}\" --format-report-file-json";
 
-        private string GetDotnetGeneralErrorString(string projectName, string xprojLocation, string projectDirectory, string logFile, int exitCode) =>
+        private static string GetDotnetGeneralErrorString(string projectName, string xprojLocation, string projectDirectory, string logFile, int exitCode) =>
             string.Format(VSResources.XprojMigrationGeneralFailure,
                 projectName,
                 $"dotnet {GetDotnetArguments(xprojLocation, projectDirectory, logFile)}",

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/ProjectSystem/VS/Imaging/FSharpSourcesIconProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/ProjectSystem/VS/Imaging/FSharpSourcesIconProvider.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Imaging
             }
         }
 
-        private ProjectImageMoniker GetIconForItem(string itemName)
+        private static ProjectImageMoniker GetIconForItem(string itemName)
         {
             if (s_fileExtensionImageMap.TryGetValue(Path.GetExtension(itemName), out ProjectImageMoniker moniker))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.cs
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             if (parent == null)
 #pragma warning disable IDE0016 // Use 'throw' expression
-                throw _tokenizer.FormatException(ProjectTreeFormatError.MultipleRoots, "Encountered another project root, when tree can only have one.");
+                throw FormatException(ProjectTreeFormatError.MultipleRoots, "Encountered another project root, when tree can only have one.");
 #pragma warning restore IDE0016 // Use 'throw' expression
 
             var tree = ReadProjectItem();
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             }
 
             if (indentLevel > previousIndentLevel + 1)
-                throw _tokenizer.FormatException(ProjectTreeFormatError.IndentTooManyLevels, "Project item has been indented too many levels");
+                throw FormatException(ProjectTreeFormatError.IndentTooManyLevels, "Project item has been indented too many levels");
 
             return _indentLevel = indentLevel;
         }
@@ -191,7 +191,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                     break;
 
                 default:
-                    throw _tokenizer.FormatException(ProjectTreeFormatError.UnrecognizedPropertyName, $"Expected 'visibility' or 'flags', but encountered '{propertyName}'.");
+                    throw FormatException(ProjectTreeFormatError.UnrecognizedPropertyName, $"Expected 'visibility' or 'flags', but encountered '{propertyName}'.");
             }
         }
 
@@ -212,7 +212,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                     break;
 
                 default:
-                    throw _tokenizer.FormatException(ProjectTreeFormatError.UnrecognizedPropertyValue, $"Expected 'visible' or 'invisible', but encountered '{visibility}'.");
+                    throw FormatException(ProjectTreeFormatError.UnrecognizedPropertyValue, $"Expected 'visible' or 'invisible', but encountered '{visibility}'.");
             }
         }
 
@@ -288,7 +288,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                         break;
 
                     default:
-                        throw _tokenizer.FormatException(ProjectTreeFormatError.UnrecognizedPropertyName, $"Expected 'FilePath', 'Icon' or 'ExpandedIcon', but encountered '{fieldName}'.");
+                        throw FormatException(ProjectTreeFormatError.UnrecognizedPropertyName, $"Expected 'FilePath', 'Icon' or 'ExpandedIcon', but encountered '{fieldName}'.");
                 }
             }
         }
@@ -360,14 +360,14 @@ namespace Microsoft.VisualStudio.ProjectSystem
             string guidAsString = tokenizer.ReadIdentifier(IdentifierParseOptions.Required);
 
             if (!Guid.TryParseExact(guidAsString, "D", out Guid guid))
-                throw _tokenizer.FormatException(ProjectTreeFormatError.GuidExpected, $"Expected GUID, but encountered '{guidAsString}'");
+                throw FormatException(ProjectTreeFormatError.GuidExpected, $"Expected GUID, but encountered '{guidAsString}'");
 
             tokenizer.Skip(TokenType.WhiteSpace);
 
             string idAsString = tokenizer.ReadIdentifier(IdentifierParseOptions.Required);
 
             if (!int.TryParse(idAsString, out int id))
-                throw _tokenizer.FormatException(ProjectTreeFormatError.IntegerExpected, $"Expected integer, but encountered '{idAsString}'");
+                throw FormatException(ProjectTreeFormatError.IntegerExpected, $"Expected integer, but encountered '{idAsString}'");
 
             return new ProjectImageMoniker(guid, id);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/Tokenizer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/Tokenizer.cs
@@ -112,13 +112,13 @@ namespace Microsoft.VisualStudio.ProjectSystem
             throw FormatException(ProjectTreeFormatError.IdExpected_EncounteredDelimiter, $"Expected identifier, but encountered '{token.Value.Value}'.");
         }
 
-        private void CheckIdentifierAfterTrim(string identifier, IdentifierParseOptions options)
+        private static void CheckIdentifierAfterTrim(string identifier, IdentifierParseOptions options)
         {
             if (!IsValidIdentifier(identifier, options))
                 throw FormatException(ProjectTreeFormatError.IdExpected_EncounteredOnlyWhiteSpace, "Expected identifier, but encountered only white space.");
         }
 
-        private bool IsValidIdentifier(string identifier, IdentifierParseOptions options)
+        private static bool IsValidIdentifier(string identifier, IdentifierParseOptions options)
         {
             if ((options & IdentifierParseOptions.Required) == IdentifierParseOptions.Required)
             {
@@ -166,7 +166,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return _delimiters.Contains((TokenType)c);
         }
 
-        internal FormatException FormatException(ProjectTreeFormatError errorId, string message)
+        internal static FormatException FormatException(ProjectTreeFormatError errorId, string message)
         {
             return new ProjectTreeFormatException(message,
                                                   errorId);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
@@ -88,17 +88,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
         [Fact]
         public void GetExeAndArguments()
         {
-            var debugger = GetDebugTargetsProvider();
-
             string exeIn = @"c:\foo\bar.exe";
             string argsIn = "/foo /bar";
             string cmdExePath = Path.Combine(Environment.SystemDirectory, "cmd.exe");
 
-            debugger.GetExeAndArguments(false, exeIn, argsIn, out string finalExePath, out string finalArguments);
+            ConsoleDebugTargetsProvider.GetExeAndArguments(false, exeIn, argsIn, out string finalExePath, out string finalArguments);
             Assert.Equal(finalExePath, exeIn);
             Assert.Equal(finalArguments, argsIn);
 
-            debugger.GetExeAndArguments(true, exeIn, argsIn, out finalExePath, out finalArguments);
+            ConsoleDebugTargetsProvider.GetExeAndArguments(true, exeIn, argsIn, out finalExePath, out finalArguments);
             Assert.Equal(cmdExePath, finalExePath);
             Assert.Equal("/c \"\"c:\\foo\\bar.exe\" /foo /bar & pause\"", finalArguments);
         }
@@ -106,17 +104,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
         [Fact]
         public void GetExeAndArgumentsWithEscapedArgs()
         {
-            var debugger = GetDebugTargetsProvider();
-
             string exeIn = @"c:\foo\bar.exe";
             string argsInWithEscapes = "/foo /bar ^ < > &";
             string cmdExePath = Path.Combine(Environment.SystemDirectory, "cmd.exe");
 
-            debugger.GetExeAndArguments(true, exeIn, argsInWithEscapes, out string finalExePath, out string finalArguments);
+            ConsoleDebugTargetsProvider.GetExeAndArguments(true, exeIn, argsInWithEscapes, out string finalExePath, out string finalArguments);
             Assert.Equal(cmdExePath, finalExePath);
             Assert.Equal("/c \"\"c:\\foo\\bar.exe\" /foo /bar ^^ ^< ^> ^& & pause\"", finalArguments);
 
-            debugger.GetExeAndArguments(false, exeIn, argsInWithEscapes, out finalExePath, out finalArguments);
+            ConsoleDebugTargetsProvider.GetExeAndArguments(false, exeIn, argsInWithEscapes, out finalExePath, out finalArguments);
             Assert.Equal(exeIn, finalExePath);
             Assert.Equal(argsInWithEscapes, finalArguments);
         }
@@ -124,12 +120,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
         [Fact]
         public void GetExeAndArgumentsWithNullArgs()
         {
-            var debugger = GetDebugTargetsProvider();
-
             string exeIn = @"c:\foo\bar.exe";
             string cmdExePath = Path.Combine(Environment.SystemDirectory, "cmd.exe");
 
-            debugger.GetExeAndArguments(true, exeIn, null, out string finalExePath, out string finalArguments);
+            ConsoleDebugTargetsProvider.GetExeAndArguments(true, exeIn, null, out string finalExePath, out string finalArguments);
             Assert.Equal(cmdExePath, finalExePath);
             Assert.Equal("/c \"\"c:\\foo\\bar.exe\"  & pause\"", finalArguments);
 
@@ -138,13 +132,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
         [Fact]
         public void GetExeAndArgumentsWithEmptyArgs()
         {
-            var debugger = GetDebugTargetsProvider();
-
             string exeIn = @"c:\foo\bar.exe";
             string cmdExePath = Path.Combine(Environment.SystemDirectory, "cmd.exe");
 
             // empty string args
-            debugger.GetExeAndArguments(true, exeIn, null, out string finalExePath, out string finalArguments);
+            ConsoleDebugTargetsProvider.GetExeAndArguments(true, exeIn, null, out string finalExePath, out string finalArguments);
             Assert.Equal(cmdExePath, finalExePath);
             Assert.Equal("/c \"\"c:\\foo\\bar.exe\"  & pause\"", finalArguments);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
@@ -140,7 +140,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// <summary>
         /// Helper returns cmd.exe as the launcher for Ctrl-F5 (useCmdShell == true), otherwise just the exe and args passed in.
         /// </summary>
-        public void GetExeAndArguments(bool useCmdShell, string debugExe, string debugArgs, out string finalExePath, out string finalArguments)
+        public static void GetExeAndArguments(bool useCmdShell, string debugExe, string debugArgs, out string finalExePath, out string finalArguments)
         {
             if (useCmdShell)
             {
@@ -354,7 +354,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             return new Tuple<string, string, string>(runCommand, runArguments, runWorkingDirectory);
         }
 
-        private async Task<string> GetOutputDirectoryAsync(ConfiguredProject configuredProject)
+        private static async Task<string> GetOutputDirectoryAsync(ConfiguredProject configuredProject)
         {
             var properties = configuredProject.Services.ProjectPropertiesProvider.GetCommonProperties();
             var outdir = await properties.GetEvaluatedPropertyValueAsync("OutDir").ConfigureAwait(false);
@@ -362,7 +362,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             return outdir;
         }
 
-        private async Task<Guid> GetDebuggingEngineAsync(ConfiguredProject configuredProject)
+        private static async Task<Guid> GetDebuggingEngineAsync(ConfiguredProject configuredProject)
         {
             var properties = configuredProject.Services.ProjectPropertiesProvider.GetCommonProperties();
             var framework = await properties.GetEvaluatedPropertyValueAsync("TargetFrameworkIdentifier").ConfigureAwait(false);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
@@ -27,7 +27,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         private readonly IProjectGuidService2 _projectGuidService;
         private IVsStartupProjectsListService _startupProjectsListService;
         private Guid _projectGuid;
+#pragma warning disable CA2213 // OnceInitializedOnceDisposedAsync are not tracked corretly by the IDisposeable analyzer
         private IDisposable _subscription;
+#pragma warning restore CA2213
 
         [ImportingConstructor]
         public StartupProjectRegistrar(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DotNetCoreProjectCompatibilityDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DotNetCoreProjectCompatibilityDetector.cs
@@ -253,7 +253,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             }
         }
 
-        private async Task<CompatibilityLevel> GetProjectCompatibilityAsync(UnconfiguredProject project, VersionCompatibilityData compatData)
+        private static async Task<CompatibilityLevel> GetProjectCompatibilityAsync(UnconfiguredProject project, VersionCompatibilityData compatData)
         {
             if (project.Capabilities.AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp))
             {
@@ -304,7 +304,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         /// <summary>
         /// Compares the passed in version to the compatibility data to determine the compat level
         /// </summary>
-        private CompatibilityLevel GetCompatibilityLevelFromVersion(Version version, VersionCompatibilityData compatData)
+        private static CompatibilityLevel GetCompatibilityLevelFromVersion(Version version, VersionCompatibilityData compatData)
         {
             // Omly compare major, minor. The presence of build with change the comparison. ie: 2.0 != 2.0.0
             if (version.Build != -1)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ExportProjectNodeComServiceAttribute.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ExportProjectNodeComServiceAttribute.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             get;
         }
 
-        public bool IncludeInherited
+        public static bool IncludeInherited
         {
             get => false;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowPaneProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/ProjectOutputWindowPaneProvider.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
             return pane;
         }
 
-        private IVsOutputWindowPane CreateProjectOutputWindowPane(IVsOutputWindow outputWindow)
+        private static IVsOutputWindowPane CreateProjectOutputWindowPane(IVsOutputWindow outputWindow)
         {
             Guid paneGuid = s_projectOutputWindowPaneGuid;
             HResult hr = outputWindow.CreatePane(ref paneGuid, VSResources.OutputWindowPaneTitle, fInitVisible: 1, fClearWithSolution: 0);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/PackageRestoreInitiator.PackageRestoreInitiatorInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/PackageRestoreInitiator.PackageRestoreInitiatorInstance.cs
@@ -28,8 +28,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             private readonly IActiveConfigurationGroupService _activeConfigurationGroupService;
             private readonly IActiveConfiguredProjectSubscriptionService _activeConfiguredProjectSubscriptionService;
             private readonly IProjectLogger _logger;
+#pragma warning disable CA2213 // OnceInitializedOnceDisposedAsync are not tracked corretly by the IDisposeable analyzer
             private IDisposable _configurationsSubscription;
             private DisposableBag _designTimeBuildSubscriptionLink;
+#pragma warning restore CA2213
 
             private static ImmutableHashSet<string> s_designTimeBuildWatchedRules = Empty.OrdinalIgnoreCaseStringSet
                 .Add(NuGetRestore.SchemaName)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/PackageRestoreInitiator.PackageRestoreInitiatorInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/PackageRestoreInitiator.PackageRestoreInitiatorInstance.cs
@@ -201,7 +201,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
                 }
             }
 
-            private void LogTargetFrameworks(IProjectLoggerBatch logger, TargetFrameworks targetFrameworks)
+            private static void LogTargetFrameworks(IProjectLoggerBatch logger, TargetFrameworks targetFrameworks)
             {
                 logger.WriteLine($"Target Frameworks ({targetFrameworks.Count})");
                 logger.IndentLevel++;
@@ -213,7 +213,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
                 logger.IndentLevel--;
             }
 
-            private void LogTargetFramework(IProjectLoggerBatch logger, TargetFrameworkInfo targetFrameworkInfo)
+            private static void LogTargetFramework(IProjectLoggerBatch logger, TargetFrameworkInfo targetFrameworkInfo)
             {
                 logger.WriteLine(targetFrameworkInfo.TargetFrameworkMoniker);
                 logger.IndentLevel++;
@@ -225,14 +225,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
                 logger.IndentLevel--;
             }
 
-            private void LogProperties(IProjectLoggerBatch logger, string heading, ProjectProperties projectProperties)
+            private static void LogProperties(IProjectLoggerBatch logger, string heading, ProjectProperties projectProperties)
             {
                 var properties = projectProperties.Cast<ProjectProperty>()
                         .Select(prop => $"{prop.Name}:{prop.Value}");
                 logger.WriteLine($"{heading} -- ({string.Join(" | ", properties)})");
             }
 
-            private void LogReferenceItems(IProjectLoggerBatch logger, string heading, ReferenceItems references)
+            private static void LogReferenceItems(IProjectLoggerBatch logger, string heading, ReferenceItems references)
             {
                 logger.WriteLine(heading);
                 logger.IndentLevel++;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
@@ -183,7 +183,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             return hash;
         }
 
-        private string GetProjectAssetsFilePath(IProjectTree newTree, IProjectSubscriptionUpdate projectUpdate)
+        private static string GetProjectAssetsFilePath(IProjectTree newTree, IProjectSubscriptionUpdate projectUpdate)
         {
             var projectFilePath = projectUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildProjectFullPathProperty, null);
 
@@ -211,7 +211,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             return projectAssetsFilePath;
         }
 
-        private IProjectTree FindProjectJsonNode(IProjectTree newTree, string projectFilePath)
+        private static IProjectTree FindProjectJsonNode(IProjectTree newTree, string projectFilePath)
         {
             if (newTree.TryFindImmediateChild("project.json", out IProjectTree projectJsonNode))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
@@ -33,10 +33,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         private readonly IActiveConfiguredProjectSubscriptionService _activeConfiguredProjectSubscriptionService;
         private readonly IProjectTreeProvider _fileSystemTreeProvider;
 
+#pragma warning disable CA2213 // OnceInitializedOnceDisposedAsync are not tracked corretly by the IDisposeable analyzer
         private CancellationTokenSource _watchedFileResetCancellationToken;
         private ITaskDelayScheduler _taskDelayScheduler;
-        private IVsFileChangeEx _fileChangeService;
         private IDisposable _treeWatcher;
+#pragma warning restore CA2213
+        private IVsFileChangeEx _fileChangeService;
         private uint _filechangeCookie;
         private string _fileBeingWatched;
         private byte[] _previousContentsHash;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AbstractProjectConfigurationProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AbstractProjectConfigurationProperties.cs
@@ -137,6 +137,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         public string CodeAnalysisModuleSuppressionsFile { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
         public bool UseVSHostingProcess { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
         public sgenGenerationOption GenerateSerializationAssemblies { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+#pragma warning disable CA1822 // Mark members as static
         public bool CodeAnalysisIgnoreGeneratedCode { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
         public bool CodeAnalysisOverrideRuleVisibilities { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
         public string CodeAnalysisDictionaries { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
@@ -147,5 +148,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         public bool CodeAnalysisIgnoreBuiltInRules { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
         public bool CodeAnalysisFailOnMissingRules { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
         public bool Prefer32Bit { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
+#pragma warning restore CA1822 // Mark members as static
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.AbstractBuildEventHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.AbstractBuildEventHelper.cs
@@ -148,7 +148,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
                 }
             }
 
-            private void SetExecParameter(ProjectTaskElement execTask, string unevaluatedPropertyValue)
+            private static void SetExecParameter(ProjectTaskElement execTask, string unevaluatedPropertyValue)
                 => execTask.SetParameter(Command, unevaluatedPropertyValue);
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// <summary>
         /// When we implement WinForms support, we need to set this for VB winforms projects
         /// </summary>
-        private bool SearchForEntryPointsInFormsOnly => false;
+        private static bool SearchForEntryPointsInFormsOnly => false;
 
         [ImportingConstructor]
         public StartupObjectsEnumGenerator(Workspace workspace, UnconfiguredProject project)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml.cs
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             }
         }
 
-        private void ClearGridError(DataGrid dataGrid)
+        private static void ClearGridError(DataGrid dataGrid)
         {
             try
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
@@ -520,7 +520,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             }
         }
 
-        private void UpdateActiveProfile()
+        private static void UpdateActiveProfile()
         {
             // need to set it dirty so Apply() actually saves the profile
             // Billhie: this causes hangs. Disabling for now

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/GetProfileNameDialog.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/GetProfileNameDialog.xaml.cs
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         // Returns the name of the current product we are instantiated in from the appropriate resource
         // Used for dialog title binding
         //------------------------------------------------------------------------------
-        public string DialogCaption
+        public static string DialogCaption
         {
             get
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPage.cs
@@ -324,9 +324,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         /// </summary>
         internal static T GetExport<T>(IVsHierarchy hier)
         {
-            System.IServiceProvider sp = new Shell.ServiceProvider((OLE.Interop.IServiceProvider)hier.GetDTEProject().DTE);
-            IComponentModel compMode = sp.GetService<IComponentModel, SComponentModel>();
-            return compMode.DefaultExportProvider.GetExport<T>().Value;
+            using (var sp = new Shell.ServiceProvider((OLE.Interop.IServiceProvider)hier.GetDTEProject().DTE))
+            {
+                IComponentModel compMode = sp.GetService<IComponentModel, SComponentModel>();
+                return compMode.DefaultExportProvider.GetExport<T>().Value;
+            }
         }
 
         ///--------------------------------------------------------------------------------------------

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPage.cs
@@ -197,7 +197,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         public new void Move(RECT[] pRect)
         {
             if (pRect == null || pRect.Length <= 0)
-                throw new ArgumentNullException("pRect");
+                throw new ArgumentNullException(nameof(pRect));
 
             RECT r = pRect[0];
 
@@ -362,7 +362,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             }
 
             if (ppunk.Length < cObjects)
-                throw new ArgumentOutOfRangeException("cObjects");
+                throw new ArgumentOutOfRangeException(nameof(cObjects));
 
             var configurations = new List<string>();
             // Look for an IVsBrowseObject

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageElementHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageElementHost.cs
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             return base.PreProcessMessage(ref msg);
         }
 
-        private bool ShouldRouteCommandBackToVS(Guid cmdGuid, uint cmdId, bool translated, bool startsMultiKeyChord)
+        private static bool ShouldRouteCommandBackToVS(Guid cmdGuid, uint cmdId, bool translated, bool startsMultiKeyChord)
         {
             //Any command that wasn't translated by TranslateAccelleratorEx or has no VS handler in global scope should be routed to WPF
             if (!translated || cmdGuid == Guid.Empty)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WpfBasedPropertyPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WpfBasedPropertyPage.cs
@@ -8,7 +8,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 {
     internal abstract partial class WpfBasedPropertyPage : PropertyPage
     {
+#pragma warning disable CA2213 // WPF Controls implement IDisposable 
         private PropertyPageElementHost _host;
+#pragma warning restore CA2213
         private PropertyPageControl _control;
         private PropertyPageViewModel _viewModel;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/DesignTimeAssemblyResolution.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/DesignTimeAssemblyResolution.cs
@@ -107,7 +107,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             return resolvedReferencesCount;
         }
 
-        private string FindResolvedAssemblyPath(IDictionary<string, ResolvedReference> references, AssemblyName assemblyName)
+        private static string FindResolvedAssemblyPath(IDictionary<string, ResolvedReference> references, AssemblyName assemblyName)
         {
             // NOTE: We mimic the behavior of the legacy project system when in "DTARUseReferencesFromProject" mode, it matches 
             // only on version, and only against currently referenced assemblies, nothing more. 
@@ -158,7 +158,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             return project.Object as VSProject;
         }
 
-        private bool TryParseAssemblyNames(string[] assemblyNames, out AssemblyName[] result)
+        private static bool TryParseAssemblyNames(string[] assemblyNames, out AssemblyName[] result)
         {
             result = new AssemblyName[assemblyNames.Length];
 
@@ -182,7 +182,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             return true;
         }
 
-        private Version TryParseVersionOrNull(string version)
+        private static Version TryParseVersionOrNull(string version)
         {
             if (Version.TryParse(version, out Version result))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/AbstractRenameStrategy.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/AbstractRenameStrategy.cs
@@ -52,13 +52,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
             return _userConfirmedRename;
         }
 
-        protected Document GetDocument(Project project, string filePath) =>
+        protected static Document GetDocument(Project project, string filePath) =>
             (from d in project.Documents where StringComparers.Paths.Equals(d.FilePath, filePath) select d).FirstOrDefault();
 
-        protected async Task<SyntaxNode> GetRootNode(Document newDocument) =>
+        protected static async Task<SyntaxNode> GetRootNode(Document newDocument) =>
             await newDocument.GetSyntaxRootAsync().ConfigureAwait(false);
 
-        protected bool HasMatchingSyntaxNode(SemanticModel model, SyntaxNode syntaxNode, string name, bool isCaseSensitive)
+        protected static bool HasMatchingSyntaxNode(SemanticModel model, SyntaxNode syntaxNode, string name, bool isCaseSensitive)
         {
             if (model.GetDeclaredSymbol(syntaxNode) is INamedTypeSymbol symbol &&
                 (symbol.TypeKind == TypeKind.Class ||

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetRuleSubscriberBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetRuleSubscriberBase.cs
@@ -16,7 +16,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 {
     internal abstract class CrossTargetRuleSubscriberBase<T> : OnceInitializedOnceDisposedAsync, ICrossTargetSubscriber where T : IRuleChangeContext
     {
+#pragma warning disable CA2213 // OnceInitializedOnceDisposedAsync are not tracked corretly by the IDisposeable analyzer
         private readonly SemaphoreSlim _gate = new SemaphoreSlim(initialCount: 1);
+#pragma warning restore CA2213
         private readonly List<IDisposable> _evaluationSubscriptionLinks;
         private readonly List<IDisposable> _designTimeBuildSubscriptionLinks;
         private readonly IUnconfiguredProjectCommonServices _commonServices;
@@ -221,7 +223,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 
             // We need to process the update within a lock to ensure that we do not release this context during processing.
             // TODO: Enable concurrent execution of updates themeselves, i.e. two separate invocations of HandleAsync
-            //       should be able to run concurrently. 
+            //       should be able to run concurrently.
             using (await _gate.DisposableWaitAsync().ConfigureAwait(true))
             {
                 // Get the inner workspace project context to update for this change.
@@ -291,6 +293,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             if (initialized)
             {
                 await ReleaseSubscriptionsAsync().ConfigureAwait(false);
+                _gate?.Dispose();
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetRuleSubscriberBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetRuleSubscriberBase.cs
@@ -293,7 +293,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             if (initialized)
             {
                 await ReleaseSubscriptionsAsync().ConfigureAwait(false);
-                _gate?.Dispose();
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetSubscriptionHostBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetSubscriptionHostBase.cs
@@ -285,7 +285,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
                     suppressVersionOnlyUpdates: true));
         }
 
-        private bool HasTargetFrameworksChanged(IProjectVersionedValue<IProjectSubscriptionUpdate> e)
+        private static bool HasTargetFrameworksChanged(IProjectVersionedValue<IProjectSubscriptionUpdate> e)
         {
             // remember actual property value and compare
             return e.Value.ProjectChanges.TryGetValue(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetSubscriptionHostBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetSubscriptionHostBase.cs
@@ -309,8 +309,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
                         await _contextProvider.Value.ReleaseProjectContextAsync(_currentAggregateProjectContext).ConfigureAwait(false);
                     }
                 }).ConfigureAwait(false);
-
-                _gate?.Dispose();
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetSubscriptionHostBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetSubscriptionHostBase.cs
@@ -15,7 +15,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 {
     internal abstract class CrossTargetSubscriptionHostBase : OnceInitializedOnceDisposedAsync, ICrossTargetSubscriptionsHost
     {
+#pragma warning disable CA2213 // OnceInitializedOnceDisposedAsync are not tracked corretly by the IDisposeable analyzer
         private readonly SemaphoreSlim _gate = new SemaphoreSlim(initialCount: 1);
+#pragma warning restore CA2213
         private readonly IUnconfiguredProjectCommonServices _commonServices;
         private readonly Lazy<IAggregateCrossTargetProjectContextProvider> _contextProvider;
         private readonly IProjectAsynchronousTasksService _tasksService;
@@ -307,6 +309,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
                         await _contextProvider.Value.ReleaseProjectContextAsync(_currentAggregateProjectContext).ConfigureAwait(false);
                     }
                 }).ConfigureAwait(false);
+
+                _gate?.Dispose();
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/SearchGraphActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/SearchGraphActionHandler.cs
@@ -164,7 +164,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
         /// <summary>
         /// Does flat search among dependency world lists to find any dependencies that match search criteria.
         /// </summary>
-        private HashSet<IDependency> SearchFlat(
+        private static HashSet<IDependency> SearchFlat(
             string projectPath,
             string searchTerm,
             IGraphContext graphContext,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
@@ -350,7 +350,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
             }
         }
 
-        private GraphNodeId GetGraphNodeId(string projectPath, GraphNode parentNode, string modelId)
+        private static GraphNodeId GetGraphNodeId(string projectPath, GraphNode parentNode, string modelId)
         {
             var partialValues = new List<GraphNodeId>
             {
@@ -382,7 +382,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
             return GraphNodeId.GetNested(partialValues.ToArray());
         }
 
-        private GraphNodeId GetTopLevelGraphNodeId(string projectPath, string modelId)
+        private static GraphNodeId GetTopLevelGraphNodeId(string projectPath, string modelId)
         {
             var partialValues = new List<GraphNodeId>
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GroupedByTargetTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GroupedByTargetTreeViewProvider.cs
@@ -151,7 +151,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             return FindByPathInternal(dependenciesNode, path);
         }
 
-        private IProjectTree FindByPathInternal(IProjectTree root, string path)
+        private static IProjectTree FindByPathInternal(IProjectTree root, string path)
         {
             foreach (IProjectTree node in root.GetSelfAndDescendentsBreadthFirst())
             {
@@ -297,7 +297,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// <summary>
         /// Removes nodes that don't exist anymore
         /// </summary>
-        private IProjectTree CleanupOldNodes(IProjectTree rootNode, IEnumerable<IProjectTree> currentNodes)
+        private static IProjectTree CleanupOldNodes(IProjectTree rootNode, IEnumerable<IProjectTree> currentNodes)
         {
             foreach (var nodeToRemove in rootNode.Children.Except(currentNodes))
             {
@@ -454,7 +454,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     expandedIcon: viewModel.ExpandedIcon.ToProjectSystemType());
         }
 
-        private ProjectTreeFlags FilterFlags(
+        private static ProjectTreeFlags FilterFlags(
             ProjectTreeFlags flags,
             ProjectTreeFlags? additionalFlags,
             ProjectTreeFlags? excludedFlags)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependenciesRuleHandlerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependenciesRuleHandlerBase.cs
@@ -125,7 +125,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             }
         }
 
-        protected bool DoesUnresolvedProjectItemExist(string itemSpec, IProjectChangeDescription unresolvedChanges)
+        protected static bool DoesUnresolvedProjectItemExist(string itemSpec, IProjectChangeDescription unresolvedChanges)
         {
             return unresolvedChanges != null && unresolvedChanges.After.Items.ContainsKey(itemSpec);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
@@ -148,7 +148,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 
             // We need to process the update within a lock to ensure that we do not release this context during processing.
             // TODO: Enable concurrent execution of updates themeselves, i.e. two separate invocations of HandleAsync
-            //       should be able to run concurrently. 
+            //       should be able to run concurrently.
             using (await _gate.DisposableWaitAsync().ConfigureAwait(true))
             {
                 // Get the inner workspace project context to update for this change.
@@ -245,7 +245,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             if (initialized)
             {
                 await ReleaseSubscriptionsAsync().ConfigureAwait(false);
-                _gate?.Dispose();
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
@@ -214,7 +214,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             }
         }
 
-        private IDependencyModel CreateDependencyModel(
+        private static IDependencyModel CreateDependencyModel(
                     string itemSpec,
                     ITargetFramework targetFramework,
                     bool resolved)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
@@ -21,7 +21,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
     [AppliesTo(ProjectCapability.DependenciesTree)]
     internal class DependencySharedProjectsSubscriber : OnceInitializedOnceDisposedAsync, IDependencyCrossTargetSubscriber
     {
+#pragma warning disable CA2213 // OnceInitializedOnceDisposedAsync are not tracked corretly by the IDisposeable analyzer
         private readonly SemaphoreSlim _gate = new SemaphoreSlim(initialCount: 1);
+#pragma warning restore CA2213
         private readonly List<IDisposable> _subscriptionLinks;
         private readonly IProjectAsynchronousTasksService _tasksService;
         private readonly IDependenciesSnapshotProvider _dependenciesSnapshotProvider;
@@ -243,6 +245,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             if (initialized)
             {
                 await ReleaseSubscriptionsAsync().ConfigureAwait(false);
+                _gate?.Dispose();
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySubscriptionsHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySubscriptionsHost.cs
@@ -301,7 +301,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             }
         }
 
-        private HashSet<string> GetProjectItemSpecsFromSnapshot(IProjectCatalogSnapshot catalogs)
+        private static HashSet<string> GetProjectItemSpecsFromSnapshot(IProjectCatalogSnapshot catalogs)
         {
             // We don't have catalog snapshot, we're likely updating because one of our project 
             // dependencies changed. Just return 'no data'

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/DontShowAgainMessageBox.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/DontShowAgainMessageBox.xaml.cs
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UI
         public string MessageText { get; }
         public string DialogCaption { get; }
         public string CheckboxText { get; }
-        public string OkButtonText => VSResources.OKButtonText;
+        public static string OkButtonText => VSResources.OKButtonText;
         public string LearnMoreText { get; private set; }
 
         public ICommand LearnMoreCommand { get; set; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/Web/DefaultHttpClient.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/Web/DefaultHttpClient.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
             }
         }
 
-        private HttpClient CreateClient()
+        private static HttpClient CreateClient()
         {
             var client = new HttpClient();
             client.DefaultRequestHeaders.Remove("Connection");

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/VsTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/VsTelemetryService.cs
@@ -104,8 +104,10 @@ namespace Microsoft.VisualStudio.Telemetry
             }
 
             var inputBytes = Encoding.UTF8.GetBytes(value);
-            var hashedBytes = new SHA256CryptoServiceProvider().ComputeHash(inputBytes);
-            return BitConverter.ToString(hashedBytes);
+            using (var cryptoServiceProvider = new SHA256CryptoServiceProvider())
+            {
+                return BitConverter.ToString(cryptoServiceProvider.ComputeHash(inputBytes));
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractProjectDynamicLoadComponent.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractProjectDynamicLoadComponent.cs
@@ -14,7 +14,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
     internal abstract partial class AbstractProjectDynamicLoadComponent : OnceInitializedOnceDisposedAsync, IProjectDynamicLoadComponent
     {
         private readonly object _lock = new object();
+#pragma warning disable CA2213 // OnceInitializedOnceDisposedAsync are not tracked corretly by the IDisposeable analyzer
         private AbstractProjectDynamicLoadInstance _instance;
+#pragma warning restore CA2213
 
         protected AbstractProjectDynamicLoadComponent(JoinableTaskContextNode joinableTaskContextNode)
             : base(joinableTaskContextNode)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractSpecialFolderProjectTreePropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractSpecialFolderProjectTreePropertiesProvider.cs
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             }
         }
 
-        private void ApplySpecialFolderItemProperties(IProjectTreeCustomizablePropertyValues propertyValues)
+        private static void ApplySpecialFolderItemProperties(IProjectTreeCustomizablePropertyValues propertyValues)
         {
             propertyValues.Flags = propertyValues.Flags.Add(ProjectTreeFlags.Common.VisibleOnlyInShowAllFiles);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -21,7 +21,7 @@ using Newtonsoft.Json.Linq;
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
     /// <summary>
-    /// Manages the set of Debug profiles and web server settings and provides these as a dataflow source. Note 
+    /// Manages the set of Debug profiles and web server settings and provides these as a dataflow source. Note
     /// that many of the methods are protected so that unit tests can derive from this class and poke them as
     /// needed w/o making them public
     /// </summary>
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         //  Command that means run an executable
         public const string RunExecutableCommandName = "Executable";
 
-        // These are used internally to loop in debuggers to handle F5 when there are errors in 
+        // These are used internally to loop in debuggers to handle F5 when there are errors in
         // the launch settings file or when there are no profiles specified (like class libraries)
         public const string ErrorProfileCommandName = "ErrorProfile";
 
@@ -177,13 +177,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             _changedSourceBlock = _broadcastBlock.SafePublicize();
 
 
-            // Subscribe to changes to the broadcast block using the idle scheduler. This should filter out a lot of the intermediates 
+            // Subscribe to changes to the broadcast block using the idle scheduler. This should filter out a lot of the intermediates
             // states that files can be in.
             if (ProjectSubscriptionService != null)
             {
-                // The use of AsyncLazy with dataflow can allow state stored in the execution context to leak through. The downstream affect is 
+                // The use of AsyncLazy with dataflow can allow state stored in the execution context to leak through. The downstream affect is
                 // calls to say, get properties, may fail. To avoid this, we capture the execution context here, and it will be reapplied when
-                // we get new subscription data from the dataflow. 
+                // we get new subscription data from the dataflow.
                 var projectChangesBlock = new ActionBlock<IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectCapabilitiesSnapshot>>>(
                             DataflowUtilities.CaptureAndApplyExecutionContext<IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectCapabilitiesSnapshot>>>(ProjectRuleBlock_ChangedAsync));
                 var evaluationLinkOptions = new StandardRuleDataflowLinkOptions();
@@ -242,8 +242,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         /// <summary>
-        /// Does the processing to update the profiles when changes have been made to either the file or the active profile. 
-        /// When merging with the disk, it needs to honor in-memory only profiles that may have been programmatically added. If 
+        /// Does the processing to update the profiles when changes have been made to either the file or the active profile.
+        /// When merging with the disk, it needs to honor in-memory only profiles that may have been programmatically added. If
         /// a profile on disk has the same name as an in-memory profile, the one on disk wins. It tries to add the in-memory profiles
         /// in the same order they appeared prior to the disk change.
         /// </summary>
@@ -302,7 +302,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// Re-applies in-memory profiles to the newly created snapshot. Note that we don't want to merge in the error
         /// profile
         /// </summary>
-        protected void MergeExistingInMemoryProfiles(LaunchSettingsData newSnapshot, ILaunchSettings prevSnapshot)
+        protected static void MergeExistingInMemoryProfiles(LaunchSettingsData newSnapshot, ILaunchSettings prevSnapshot)
         {
             for (int i = 0; i < prevSnapshot.Profiles.Count; i++)
             {
@@ -330,7 +330,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// <summary>
         /// Re-applies in-memory global options to the newly created snapshot
         /// </summary>
-        protected void MergeExistingInMemoryGlobalSettings(LaunchSettingsData newSnapshot, ILaunchSettings prevSnapshot)
+        protected static void MergeExistingInMemoryGlobalSettings(LaunchSettingsData newSnapshot, ILaunchSettings prevSnapshot)
         {
             if (prevSnapshot.GlobalSettings != null)
             {
@@ -402,7 +402,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         /// <summary>
-        /// Creates the intiial set of settings based on the file on disk 
+        /// Creates the intiial set of settings based on the file on disk
         /// </summary>
         protected async Task<LaunchSettingsData> GetLaunchSettingsAsync()
         {
@@ -421,7 +421,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 settings = new LaunchSettingsData();
             }
 
-            // Make sure there is at least an empty profile list 
+            // Make sure there is at least an empty profile list
             if (settings.Profiles == null)
             {
                 settings.Profiles = new List<LaunchProfileData>();
@@ -506,7 +506,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// Does a quick validation to make sure at least a name is present in each profile. Removes bad ones and
         /// logs errors. Returns the resultant profiles as a list
         /// </summary>
-        private List<LaunchProfileData> FixupProfilesAndLogErrors(Dictionary<string, LaunchProfileData> profilesData)
+        private static List<LaunchProfileData> FixupProfilesAndLogErrors(Dictionary<string, LaunchProfileData> profilesData)
         {
             if (profilesData == null)
             {
@@ -532,17 +532,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             return validProfiles;
         }
 
-        private void LogError(string errorText, bool isWarning)
+        private static void LogError(string errorText, bool isWarning)
         {
             // ProjectErrorManager.AddError(ErrorOwnerString, errorText, isWarning);
         }
 
-        private void LogError(string errorText, string filename, int line, int col, bool isWarning)
+        private static void LogError(string errorText, string filename, int line, int col, bool isWarning)
         {
             // ProjectErrorManager.AddError(ErrorOwnerString, errorText, filename, line, col, isWarning);
         }
 
-        private void ClearErrors()
+        private static void ClearErrors()
         {
             //ProjectErrorManager.ClearErrorsForOwner(ErrorOwnerString);
         }
@@ -585,11 +585,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         /// <summary>
-        /// Gets the serialization object for the set of profiles and custom settings. It filters out built in profiles that get added to 
+        /// Gets the serialization object for the set of profiles and custom settings. It filters out built in profiles that get added to
         /// wire up the debugger infrastructure (NoAction profiles). Returns a dictionary of the elements to serialize.
         /// Removes in-memory profiles and global objects
         /// </summary>
-        protected Dictionary<string, object> GetSettingsToSerialize(ILaunchSettings curSettings)
+        protected static Dictionary<string, object> GetSettingsToSerialize(ILaunchSettings curSettings)
         {
             var profileData = new Dictionary<string, Dictionary<string, object>>(StringComparer.Ordinal);
             foreach (var profile in curSettings.Profiles)
@@ -621,7 +621,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// <summary>
         /// Helper returns true if this is a profile which should be persisted. Filters out noaction profiles
         /// </summary>
-        private bool ProfileShouldBePersisted(ILaunchProfile profile)
+        private static bool ProfileShouldBePersisted(ILaunchProfile profile)
         {
             return !profile.IsInMemoryObject();
         }
@@ -653,8 +653,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 string fileName = LaunchSettingsFile;
 #pragma warning restore CS0618
 
-                // Only do something if the file is truly different than what we synced. Here, we want to 
-                // throttle. 
+                // Only do something if the file is truly different than what we synced. Here, we want to
+                // throttle.
                 if (!FileManager.FileExists(fileName) || FileManager.LastFileWriteTime(fileName) != LastSettingsFileSyncTime)
                 {
                     FileChangeScheduler.ScheduleAsyncTask(async token =>
@@ -701,7 +701,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         /// <summary>
-        /// Sets up a file system watcher to look for changes to the launchsettings.json file. It watches at the root of the 
+        /// Sets up a file system watcher to look for changes to the launchsettings.json file. It watches at the root of the
         /// project oltherwise we force the project to have a properties folder.
         /// </summary>
         private void WatchLaunchSettingsFile()
@@ -808,7 +808,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         /// <summary>
-        /// Adds the given profile to the list and saves to disk. If a profile with the same 
+        /// Adds the given profile to the list and saves to disk. If a profile with the same
         /// name exists (case sensitive), it will be replaced with the new profile. If addToFront is
         /// true the profile will be the first one in the list. This is useful since quite often callers want
         /// their just added profile to be listed first in the start menu. If addToFront is false but there is
@@ -885,7 +885,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         /// <summary>
-        /// Adds or updates the global settings represented by settingName. Saves the 
+        /// Adds or updates the global settings represented by settingName. Saves the
         /// updated settings to disk. Note that the settings object must be serializable.
         /// </summary>
         public async Task AddOrUpdateGlobalSettingAsync(string settingName, object settingContent)
@@ -959,8 +959,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
         internal async Task<string> GetLaunchSettingsFilePathNoCacheAsync()
         {
-            // NOTE: To reduce behavior changes, we currently cache the folder that we get from the AppDesignerSpecialFileProvider, 
-            // even though it can change over the lifetime of the project. We should fix this and convert to using dataflow  
+            // NOTE: To reduce behavior changes, we currently cache the folder that we get from the AppDesignerSpecialFileProvider,
+            // even though it can change over the lifetime of the project. We should fix this and convert to using dataflow
             // see: https://github.com/dotnet/project-system/issues/2316.
 
             string folder = await _appDesignerSpecialFileProvider.Value.GetFileAsync(SpecialFiles.AppDesigner, SpecialFileFlags.FullPath)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
@@ -216,7 +216,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             return designTimeDifference;
         }
 
-        private IProjectChangeDiff ResolveConflicts(IProjectChangeDiff evaluationDifferences, IProjectChangeDiff designTimeDifferences)
+        private static IProjectChangeDiff ResolveConflicts(IProjectChangeDiff evaluationDifferences, IProjectChangeDiff designTimeDifferences)
         {
             // Remove added items that were removed by later evaluations, and vice versa
             IImmutableSet<string> added = designTimeDifferences.AddedItems.Except(evaluationDifferences.RemovedItems);
@@ -250,7 +250,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             _evaluations.Enqueue(new VersionedProjectChangeDiff(version, evaluationDifference));
         }
 
-        private IProjectChangeDiff NormalizeDifferences(IProjectChangeDiff difference)
+        private static IProjectChangeDiff NormalizeDifferences(IProjectChangeDiff difference)
         {
             // Optimize for common case
             if (difference.RenamedItems.Count == 0)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             return null;
         }
 
-        private string GetLinkedParentFolder(IImmutableDictionary<string, string> metadata)
+        private static string GetLinkedParentFolder(IImmutableDictionary<string, string> metadata)
         {
             string linkFilePath = FileItemServices.GetLinkFilePath(metadata);
             if (linkFilePath != null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHandlerManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHandlerManager.cs
@@ -140,7 +140,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             return new string[] { CompilerCommandLineArgs.SchemaName };
         }
 
-        private void ProcessDesignTimeBuildFailure(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, IProjectLogger logger)
+        private static void ProcessDesignTimeBuildFailure(IProjectChangeDescription projectChange, IWorkspaceProjectContext context, IProjectLogger logger)
         {
             // If 'CompileDesignTime' didn't run due to a preceeding failed target, or a failure in itself, CPS will send us an empty IProjectChangeDescription
             // that represents as if 'CompileDesignTime' ran but returned zero results.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -19,7 +19,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     [Export(typeof(ILanguageServiceHost))]
     internal partial class LanguageServiceHost : OnceInitializedOnceDisposedAsync, ILanguageServiceHost
     {
+#pragma warning disable CA2213 // OnceInitializedOnceDisposedAsync are not tracked corretly by the IDisposeable analyzer
         private readonly SemaphoreSlim _gate = new SemaphoreSlim(initialCount: 1);
+#pragma warning restore CA2213
         private readonly IUnconfiguredProjectCommonServices _commonServices;
         private readonly Lazy<IProjectContextProvider> _contextProvider;
         private readonly IProjectAsynchronousTasksService _tasksService;
@@ -285,6 +287,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                         await _contextProvider.Value.ReleaseProjectContextAsync(_currentAggregateProjectContext).ConfigureAwait(false);
                     }
                 }).ConfigureAwait(false);
+                _gate?.Dispose();
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -266,7 +266,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             }).ConfigureAwait(false);
         }
 
-        private bool HasTargetFrameworksChanged(IProjectVersionedValue<IProjectSubscriptionUpdate> e)
+        private static bool HasTargetFrameworksChanged(IProjectVersionedValue<IProjectSubscriptionUpdate> e)
         {
             return e.Value.ProjectChanges.TryGetValue(ConfigurationGeneral.SchemaName, out IProjectChangeDescription projectChange) &&
                  projectChange.Difference.ChangedProperties.Contains(ConfigurationGeneral.TargetFrameworksProperty);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -287,7 +287,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                         await _contextProvider.Value.ReleaseProjectContextAsync(_currentAggregateProjectContext).ConfigureAwait(false);
                     }
                 }).ConfigureAwait(false);
-                _gate?.Dispose();
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractSpecialFileProvider.cs
@@ -148,7 +148,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         /// <summary>
         /// Find a file with the given filename within the given node.
         /// </summary>
-        private IProjectTree FindFileWithinNode(IProjectTree parentNode, string fileName)
+        private static IProjectTree FindFileWithinNode(IProjectTree parentNode, string fileName)
         {
             parentNode.TryFindImmediateChild(fileName, out IProjectTree fileNode);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheckLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheckLogger.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 _logger?.WriteLine($"FastUpToDate: {string.Format(message, values)} ({_fileName})");
             }
         }
-        private void ConvertToLocalTimes(object[] values)
+        private static void ConvertToLocalTimes(object[] values)
         {
             for (int i = 0; i < values.Length; i++)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/SequencialTaskExecutor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/SequencialTaskExecutor.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace Microsoft.VisualStudio.Threading.Tasks
 {
     /// <summary>
-    /// Runs tasks in the sequence they are added. This is done by starting with a completed task, and leveraging ContinueWith\Unwrap to 
+    /// Runs tasks in the sequence they are added. This is done by starting with a completed task, and leveraging ContinueWith\Unwrap to
     /// "schedule" subsequent tasks to start after the previous one is completed. The Task containing the callers function is returned so that
     /// the caller can await for their specific task to complete. When disposed unprocessed tasks are cancelled.
     /// </summary>
@@ -16,17 +16,19 @@ namespace Microsoft.VisualStudio.Threading.Tasks
         private bool _disposed;
         private Task _taskAdded = Task.CompletedTask;
         private readonly object _syncObject = new object();
+#pragma warning disable CA2213 // Tests fail is this is disposed
         private CancellationTokenSource _disposedCancelTokenSource = new CancellationTokenSource();
+#pragma warning restore CA2213 
 
         /// <summary>
         /// Deadlocks will occur if a task returned from ExecuteTask , awaits a task which also calls ExcecuteTask. The 2nd one will never get started since
-        /// it will be backed up behind the first one completing. The AysncLocal is used to detect when a task is being executed, and if a downstream one gets 
+        /// it will be backed up behind the first one completing. The AysncLocal is used to detect when a task is being executed, and if a downstream one gets
         /// added, it will be executed directly, rather than get queued
         /// </summary>
         private System.Threading.AsyncLocal<bool> _executingTask = new System.Threading.AsyncLocal<bool>();
 
         /// <summary>
-        /// Adds a new task to the continuation chain and returns it so that it can be awaited. 
+        /// Adds a new task to the continuation chain and returns it so that it can be awaited.
         /// </summary>
         public Task ExecuteTask(Func<Task> asyncFunction)
         {


### PR DESCRIPTION
Updating analyzers to latest versions

- **Disabled:** VSTHRD108 (Assert thread affinity unconditionally) for **all projects**
- **Disabled:** CS1822 (Mark members as static) in **test projects**
- **Disabled:** CA2000 (Dispose Objects Before Losing Scope) in **test projects**
- **Disabled:** CA2009 (Do not call ToImmutableCollection on an ImmutableCollection value) in **test projects**
- **Enabled and Fixed:** CA1507 (Use nameof to express symbol names) for **all projects**
- **Enabled and Fixed:** CS1822 (Mark members as static) in **shipping projects**
- **Enabled and Fixed:** CA2000 (Dispose Objects Before Losing Scope) in **shipping projects**