### PR TITLE
Import IProjectGuidService2 as ImportMany

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectGuidService2Factory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectGuidService2Factory.cs
@@ -13,6 +13,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             mock.Setup(s => s.GetProjectGuidAsync())
                 .ReturnsAsync(result);
 
+            mock.As<IProjectGuidService>()
+                .Setup(s => s.ProjectGuid)
+                .Returns(result);
 
             return mock.Object;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/UnconfiguredProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/UnconfiguredProjectContextProvider.cs
@@ -28,7 +28,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         private readonly List<AggregateWorkspaceProjectContext> _contexts = new List<AggregateWorkspaceProjectContext>();
         private readonly IProjectHostProvider _projectHostProvider;
         private readonly IActiveConfiguredProjectsProvider _activeConfiguredProjectsProvider;
-        private readonly IProjectGuidService2 _projectGuidService;
         private readonly IUnconfiguredProjectHostObject _unconfiguredProjectHostObject;
         private readonly Dictionary<ConfiguredProject, IWorkspaceProjectContext> _configuredProjectContextsMap = new Dictionary<ConfiguredProject, IWorkspaceProjectContext>();
         private readonly Dictionary<ConfiguredProject, IConfiguredProjectHostObject> _configuredProjectHostObjectsMap = new Dictionary<ConfiguredProject, IConfiguredProjectHostObject>();
@@ -39,8 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
                                                  IProjectAsyncLoadDashboard asyncLoadDashboard,
                                                  ITaskScheduler taskScheduler,
                                                  IProjectHostProvider projectHostProvider,
-                                                 IActiveConfiguredProjectsProvider activeConfiguredProjectsProvider,
-                                                 [Import(typeof(IProjectGuidService))]IProjectGuidService2 projectGuidService)
+                                                 IActiveConfiguredProjectsProvider activeConfiguredProjectsProvider)
         {
             Requires.NotNull(commonServices, nameof(commonServices));
             Requires.NotNull(contextFactory, nameof(contextFactory));
@@ -55,8 +53,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             _taskScheduler = taskScheduler;
             _projectHostProvider = projectHostProvider;
             _activeConfiguredProjectsProvider = activeConfiguredProjectsProvider;
-            _projectGuidService = projectGuidService;
             _unconfiguredProjectHostObject = _projectHostProvider.UnconfiguredProjectHostObject;
+
+            ProjectGuidServices = new OrderPrecedenceImportCollection<IProjectGuidService>(projectCapabilityCheckProvider: commonServices.Project);
+        }
+
+        [ImportMany]
+        public OrderPrecedenceImportCollection<IProjectGuidService> ProjectGuidServices
+        {
+            get;
         }
 
         public async Task<AggregateWorkspaceProjectContext> CreateProjectContextAsync()
@@ -159,6 +164,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             return Task.CompletedTask;
         }
 
+        private Task<Guid> GetProjectGuidAsync()
+        {
+            if (ProjectGuidServices.FirstOrDefault()?.Value is IProjectGuidService2 projectGuidService)
+                return projectGuidService.GetProjectGuidAsync();
+
+            return Task.FromResult(Guid.Empty);
+        }
+
         // Returns the name that is the handshake between Roslyn and the csproj/vbproj
         private async Task<string> GetLanguageServiceName()
         {
@@ -221,8 +234,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             if (string.IsNullOrEmpty(languageName))
                 return null;
 
-            Guid projectGuid = await _projectGuidService.GetProjectGuidAsync()
-                                                        .ConfigureAwait(false);
+            Guid projectGuid = await GetProjectGuidAsync().ConfigureAwait(false);
 
             string targetPath = await GetTargetPathAsync().ConfigureAwait(false);
             if (string.IsNullOrEmpty(targetPath))


### PR DESCRIPTION
When C++ is installed, StartupProjectRegistrar and UnconfiguedProjectContextProvider fail to be instantiated breaking startup project registration and language service.

Fixes: #3341 

This was a regression.