### PR TITLE
Update RepoToolset to 1.0.0-beta-62705-01

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -9,7 +9,7 @@
     <UsingToolIbcOptimization>true</UsingToolIbcOptimization>
 
     <!-- Toolset -->
-    <RoslynToolsRepoToolsetVersion>1.0.0-beta-62615-02</RoslynToolsRepoToolsetVersion>
+    <RoslynToolsRepoToolsetVersion>1.0.0-beta-62705-01</RoslynToolsRepoToolsetVersion>
     <RoslynToolsVsixExpInstallerVersion>1.0.0-beta-62503-02</RoslynToolsVsixExpInstallerVersion>
     <RoslynDependenciesProjectSystemOptimizationDataVersion>2.6.0-beta1-62205-02</RoslynDependenciesProjectSystemOptimizationDataVersion>
     <VSWhereVersion>2.1.4</VSWhereVersion>


### PR DESCRIPTION
Infrastructure only.

Changes included in the toolset:
https://github.com/dotnet/roslyn-tools/commits/pre-SDK/sdks/RepoToolset
 Previous update was 1bc665575121187618aabc26cdc35afde255d1f5