### PR TITLE
 Fix hang in language service integration when latter evaluation occurs before design-time build 

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectChangeDiffFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectChangeDiffFactory.cs
@@ -1,14 +1,45 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Moq;
+using System.Collections.Immutable;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal static class IProjectChangeDiffFactory
     {
-        public static IProjectChangeDiff Create()
+        public static IProjectChangeDiff WithAddedItems(string semiColonSeparatedItems)
         {
-            return Mock.Of<IProjectChangeDiff>();
+            if (semiColonSeparatedItems.Length == 0)
+                return WithNoChanges();
+
+            return WithAddedItems(semiColonSeparatedItems.Split(';'));
+        }
+
+        public static IProjectChangeDiff WithAddedItems(params string[] addedItems)
+        {
+            return Create(addedItems: ImmutableHashSet.Create(StringComparers.Paths, addedItems));
+        }
+
+        public static IProjectChangeDiff WithRemovedItems(string semiColonSeparatedItems)
+        {
+            if (semiColonSeparatedItems.Length == 0)
+                return WithNoChanges();
+
+            return WithRemovedItems(semiColonSeparatedItems.Split(';'));
+        }
+
+        public static IProjectChangeDiff WithRemovedItems(params string[] removedItems)
+        {
+            return Create(removedItems: ImmutableHashSet.Create(StringComparers.Paths, removedItems));
+        }
+
+        public static IProjectChangeDiff WithNoChanges()
+        {
+            return new ProjectChangeDiff();
+        }
+
+        public static IProjectChangeDiff Create(IImmutableSet<string> addedItems = null, IImmutableSet<string> removedItems = null, IImmutableSet<string> changedItems = null)
+        {
+            return new ProjectChangeDiff(addedItems, removedItems, changedItems);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectChangeDiffFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectChangeDiffFactory.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class IProjectChangeDiffFactory
+    {
+        public static IProjectChangeDiff Create()
+        {
+            return Mock.Of<IProjectChangeDiff>();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectLogger.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Logging
+{
+    internal static class IProjectLoggerFactory
+    {
+        public static IProjectLogger Create()
+        {
+            return Mock.Of<IProjectLogger>();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/UnconfiguredProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/UnconfiguredProjectFactory.cs
@@ -12,6 +12,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal static class UnconfiguredProjectFactory
     {
+        public static UnconfiguredProject ImplementFullPath(string fullPath)
+        {
+            return Create(filePath: fullPath);
+        }
+
         public static UnconfiguredProject Create(object hostObject = null, IEnumerable<string> capabilities = null, string filePath = null,
             IProjectConfigurationsService projectConfigurationsService = null, ConfiguredProject configuredProject = null, Encoding projectEncoding = null,
             IProjectCapabilitiesScope scope = null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.ConcreteAbstractEvaluationCommandLineHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.ConcreteAbstractEvaluationCommandLineHandler.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+using Microsoft.VisualStudio.ProjectSystem.Logging;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
+{
+    partial class AbstractEvaluationCommandLineHandlerTests
+    {
+        private class ConcreteAbstractEvaluationCommandLineHandler : AbstractEvaluationCommandLineHandler
+        {
+            public ConcreteAbstractEvaluationCommandLineHandler(UnconfiguredProject project) 
+                : base(project)
+            {
+                Files = new Dictionary<string, IImmutableDictionary<string, string>>();
+            }
+
+            public Dictionary<string, IImmutableDictionary<string, string>> Files
+            {
+                get;
+            }
+
+            protected override void AddToContext(string fullPath, IImmutableDictionary<string, string> metadata, bool isActiveContext, IProjectLogger logger)
+            {
+                Files.Add(fullPath, metadata);
+            }
+
+            protected override void RemoveFromContext(string fullPath, IProjectLogger logger)
+            {
+                Files.Remove(fullPath);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.EvaluationCommandLineHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.EvaluationCommandLineHandler.cs
@@ -1,30 +1,29 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
-
+using System.Collections.ObjectModel;
 using Microsoft.VisualStudio.ProjectSystem.Logging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
     partial class AbstractEvaluationCommandLineHandlerTests
     {
-        private class ConcreteAbstractEvaluationCommandLineHandler : AbstractEvaluationCommandLineHandler
+        private class EvaluationCommandLineHandler : AbstractEvaluationCommandLineHandler
         {
-            public ConcreteAbstractEvaluationCommandLineHandler(UnconfiguredProject project) 
+            public EvaluationCommandLineHandler(UnconfiguredProject project) 
                 : base(project)
             {
-                Files = new Dictionary<string, IImmutableDictionary<string, string>>();
+                Files = new Collection<string>();
             }
 
-            public Dictionary<string, IImmutableDictionary<string, string>> Files
+            public Collection<string> Files
             {
                 get;
             }
 
             protected override void AddToContext(string fullPath, IImmutableDictionary<string, string> metadata, bool isActiveContext, IProjectLogger logger)
             {
-                Files.Add(fullPath, metadata);
+                Files.Add(fullPath);
             }
 
             protected override void RemoveFromContext(string fullPath, IProjectLogger logger)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
@@ -326,6 +326,40 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Assert.Equal(handler.Files.OrderBy(f => f), expectedFiles.OrderBy(f => f));
         }
 
+        [Fact]
+        public void ApplyDesignTimeChanges_WhenNewerEvaluationChangesWithAddedConflict_EvaluationWinsOut()
+        {
+            var handler = CreateInstance(@"C:\Project\Project.cs");
+
+            int evaluationVersion = 1;
+
+            // Setup the "current state"
+            ApplyEvaluationChanges(handler, evaluationVersion, IProjectChangeDiffFactory.WithAddedItems("Source.cs"));
+
+            int designTimeVersion = 0;
+
+            ApplyDesignTimeChanges(handler, designTimeVersion, IProjectChangeDiffFactory.WithRemovedItems("Source.cs"));
+
+            Assert.Single(handler.Files, @"C:\Project\Source.cs");
+        }
+
+        [Fact]
+        public void ApplyDesignTimeChanges_WhenNewerEvaluationChangesWithRemovedConflict_EvaluationWinsOut()
+        {
+            var handler = CreateInstance(@"C:\Project\Project.cs");
+
+            int evaluationVersion = 1;
+
+            // Setup the "current state"
+            ApplyEvaluationChanges(handler, evaluationVersion, IProjectChangeDiffFactory.WithRemovedItems("Source.cs"));
+
+            int designTimeVersion = 0;
+
+            ApplyDesignTimeChanges(handler, designTimeVersion, IProjectChangeDiffFactory.WithAddedItems("Source.cs"));
+
+            Assert.Empty(handler.Files);
+        }
+
         private static void ApplyEvaluationChanges(AbstractEvaluationCommandLineHandler handler, IComparable version, IProjectChangeDiff difference)
         {
             var metadata = ImmutableDictionary<string, IImmutableDictionary<string, string>>.Empty;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+
+using Microsoft.VisualStudio.ProjectSystem.Logging;
+
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
+{
+    public partial class AbstractEvaluationCommandLineHandlerTests
+    {
+        [Fact]
+        public void ApplyEvaluationChanges_NullAsVersion_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+
+            var difference = IProjectChangeDiffFactory.Create();
+            var metadata = ImmutableDictionary<string, IImmutableDictionary<string, string>>.Empty;
+            var logger = IProjectLoggerFactory.Create();
+            
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                handler.ApplyEvaluationChanges((IComparable)null, difference, metadata, true, logger);
+            });
+        }
+
+        [Fact]
+        public void ApplyEvaluationChanges_NullAsDifference_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+
+            var version = 1;
+            var metadata = ImmutableDictionary<string, IImmutableDictionary<string, string>>.Empty;
+            var logger = IProjectLoggerFactory.Create();
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                handler.ApplyEvaluationChanges(version, (IProjectChangeDiff)null, metadata, true, logger);
+            });
+        }
+
+        [Fact]
+        public void ApplyEvaluationChanges_NullAsMetadata_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+
+            var version = 1;
+            var difference = IProjectChangeDiffFactory.Create();
+            var logger = IProjectLoggerFactory.Create();
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                handler.ApplyEvaluationChanges(version, difference, (ImmutableDictionary<string, IImmutableDictionary<string, string>>)null, true, logger);
+            });
+        }
+
+        [Fact]
+        public void ApplyEvaluationChanges_NullAsLogger_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+
+            var version = 1;
+            var difference = IProjectChangeDiffFactory.Create();
+            var metadata = ImmutableDictionary<string, IImmutableDictionary<string, string>>.Empty;
+            
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                handler.ApplyEvaluationChanges(version, difference, metadata, true, (IProjectLogger)null);
+            });
+        }
+
+        [Fact]
+        public void ApplyDesignTimeChanges_NullAsVersion_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+
+            var difference = IProjectChangeDiffFactory.Create();
+            var logger = IProjectLoggerFactory.Create();
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                handler.ApplyDesignTimeChanges((IComparable)null, difference, true, logger);
+            });
+        }
+
+        [Fact]
+        public void ApplyDesignTimeChanges_NullAsDifference_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+
+            var version = 1;
+            var logger = IProjectLoggerFactory.Create();
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                handler.ApplyDesignTimeChanges(version, (IProjectChangeDiff)null, true, logger);
+            });
+        }
+
+        [Fact]
+        public void ApplyDesignTimeChanges_NullAsLogger_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+
+            var version = 1;
+            var difference = IProjectChangeDiffFactory.Create();
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                handler.ApplyDesignTimeChanges(version, difference, true, (IProjectLogger)null);
+            });
+        }
+
+        private static ConcreteAbstractEvaluationCommandLineHandler CreateInstance(string fullPath = null)
+        {
+            var project = UnconfiguredProjectFactory.ImplementFullPath(fullPath);
+
+            return new ConcreteAbstractEvaluationCommandLineHandler(project);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+
 using Microsoft.VisualStudio.ProjectSystem.Logging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
@@ -103,7 +104,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         public void ApplyEvaluationChanges(IComparable version, IProjectChangeDiff difference, IImmutableDictionary<string, IImmutableDictionary<string, string>> metadata, bool isActiveContext, IProjectLogger logger)
         {
             Requires.NotNull(version, nameof(version));
-            Requires.NotNull(version, nameof(version));
+            Requires.NotNull(difference, nameof(difference));
             Requires.NotNull(metadata, nameof(metadata));
             Requires.NotNull(logger, nameof(logger));
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
@@ -237,10 +237,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             while (_evaluations.Count > 0)
             {
                 VersionedProjectChangeDiff evaluation = _evaluations.Peek();
-                if (evaluation.Version.IsEarlierThanOrEqualTo(version))
-                {
-                    _evaluations.Dequeue();
-                }
+                if (!evaluation.Version.IsEarlierThanOrEqualTo(version))
+                    break;
+                
+                _evaluations.Dequeue();
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     /// </summary>
     internal abstract partial class AbstractEvaluationCommandLineHandler
     {
-        // This class is not thread-safe, and the assumption is that the caller will mkaes sure that evaluations and design-time builds do 
+        // This class is not thread-safe, and the assumption is that the caller will make sure that evaluations and design-time builds do 
         // overlap inside the class at the same time.
         //
         // In the ideal world, we would simply wait for a design-time build to get the command-line arguments that would have been passed


### PR DESCRIPTION
This includes https://github.com/dotnet/project-system/pull/3346, so just review https://github.com/dotnet/project-system/commit/a1ce728734f6458fa2092d7444f5e79de7423cfc.

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/537755.

When evaluating in quick succession, Visual Studio can hang when attempting to throw away old evaluation results.

This can occur when AbstractEvaluationCommandLineHandler receives results in the following order:

1. Evaluation (Version 1)
2. Evaluation (Version 2)
3. Design Time Build (Version 1) <-- Hang attempting to throw away results from in step 1

It will continually loop the previous evaluations neither discarding them or breaking from the loop.