### PR TITLE
Fixed duplicate items for FSharp

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProviderTests.cs
@@ -42,6 +42,39 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
             Assert.Equal(expectedOrder, values.DisplayOrder);
         }
 
+        private List<(string type, string include)> _simpleOrderFileDuplicate = new List<(string type, string include)>
+        {
+            ("Compile", "Order.fs"),
+            ("Compile", "Customer.fs"),
+            ("Compile", "Program.fs"),
+            ("Compile", "Program.fs")
+        };
+
+        [Theory]
+        [InlineData("Customer.fs", "Compile", false, "X:\\Project\\Customer.fs", 2)]
+        [InlineData("order.fs", "Compile", false, "X:\\Project\\order.fs", 1)] // case insensitive
+        [InlineData("Program.fs", "Compile", false, "X:\\Project\\Program.fs", 3)]
+        [InlineData("Misc.txt", "Content", false, "X:\\Project\\Misc.txt", int.MaxValue)] // unknown type
+        [InlineData("ordered.fsproj", null, false, "X:\\Project\\ordered.fsproj", int.MaxValue)] // hidden file
+        [InlineData("Debug", null, true, null, 0)] // unknown folder
+        public void VerifySimpleOrderedUnderProjectRootDuplicate(string itemName, string itemType, bool isFolder, string rootedPath, int expectedOrder)
+        {
+            var orderedItems = _simpleOrderFileDuplicate
+                .Select(p => new ProjectItemIdentity(p.type, p.include))
+                .ToList();
+
+            var provider = new TreeItemOrderPropertyProvider(orderedItems, UnconfiguredProjectFactory.Create(filePath: "X:\\Project\\"));
+
+            var metadata = rootedPath == null ? null : new Dictionary<string, string> { { "FullPath", rootedPath } }.ToImmutableDictionary();
+
+            var context = GetContext(itemName, itemType, isFolder, ProjectTreeFlags.ProjectRoot, metadata);
+            var values = GetInitialValues();
+
+            provider.CalculatePropertyValues(context, values);
+
+            Assert.Equal(expectedOrder, values.DisplayOrder);
+        }
+
         [Theory]
         [MemberData(nameof(TestTreeItems))]
         public void VerifyOrderIncreasesMonotonically(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProvider.cs
@@ -85,7 +85,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
                 var fullPath = project.MakeRooted(item.EvaluatedInclude);
 
                 // We uniquely identify a file by its fullpath.
-                orderedMap.Add(fullPath, displayOrder++);
+                if (!orderedMap.ContainsKey(fullPath))
+                {
+                    orderedMap.Add(fullPath, displayOrder++);
+                }
             }
 
             return orderedMap;


### PR DESCRIPTION
**Customer scenario**

Customers sometimes reference the same file in projects.

**Bugs this fixes:** 

https://github.com/dotnet/project-system/issues/3218

**Workarounds, if any**

Don't include duplicate files in the same project.

**Risk**

Very Low

**Performance impact**

None

**Is this a regression from a previous update?**

Yes.

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

We missed it due to no testing duplicate files. In the future, we should try to get more F# users on the preview builds.

**How was the bug found?**
Customer report
