### PR TITLE
Removed SDK references from OrderingHelperTests

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelperTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelperTests.cs
@@ -31,7 +31,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 ");
 
             var projectRootElement = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
+<Project>
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -51,7 +51,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
             Assert.True(project.IsDirty);
 
             var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+<Project>
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
@@ -74,7 +74,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 ");
 
             var projectRootElement = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
+<Project>
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -94,7 +94,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
             Assert.False(project.IsDirty);
 
             var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+<Project>
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
@@ -119,7 +119,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         File (flags: {}), FilePath: ""C:\Foo\test\test4.fs"", DisplayOrder: 5, ItemName: ""test/test4.fs""
 ");
             var projectRootElement = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
+<Project>
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -141,7 +141,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
             Assert.True(project.IsDirty);
 
             var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+<Project>
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
@@ -166,7 +166,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 ");
 
             var projectRootElement = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
+<Project>
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -186,7 +186,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
             Assert.True(project.IsDirty);
 
             var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+<Project>
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
@@ -209,7 +209,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 ");
 
             var projectRootElement = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
+<Project>
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -229,7 +229,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
             Assert.False(project.IsDirty);
 
             var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+<Project>
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
@@ -254,7 +254,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
     File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 5, ItemName: ""test2.fs""
 ");
             var projectRootElement = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
+<Project>
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -276,7 +276,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
             Assert.True(project.IsDirty);
 
             var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+<Project>
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
@@ -305,7 +305,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
     File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 7, ItemName: ""test2.fs""
 ");
             var projectRootElement = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
+<Project>
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -328,7 +328,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
             Assert.True(project.IsDirty);
 
             var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+<Project>
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
@@ -355,7 +355,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 ");
 
             var projectRootElement = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
+<Project>
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -376,7 +376,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
             Assert.True(project.IsDirty);
 
             var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+<Project>
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
@@ -401,7 +401,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 ");
 
             var projectRootElement = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
+<Project>
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -422,7 +422,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
             Assert.True(project.IsDirty);
 
             var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project Sdk=""Microsoft.NET.Sdk"">
+<Project>
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>


### PR DESCRIPTION
Removes SDK references in OrderingHelperTests. We need this for builds to pass now.
