### PR TITLE
Add a safe way to grab the project GUID

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ISafeProjectGuidServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ISafeProjectGuidServiceFactory.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class ISafeProjectGuidServiceFactory
+    {
+        public static ISafeProjectGuidService ImplementGetProjectGuidAsync(Guid guid)
+        {
+            var mock = new Mock<ISafeProjectGuidService>();
+            mock.Setup(s => s.GetProjectGuidAsync())
+                .ReturnsAsync(guid);
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
+    [Trait("UnitTest", "ProjectSystem")]
     public partial class AbstractEvaluationCommandLineHandlerTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectAsyncLoadDashboardFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectAsyncLoadDashboardFactory.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    internal static class IProjectAsyncLoadDashboardFactory
+    {
+        public static IProjectAsyncLoadDashboard ImplementProjectLoadedInHost(Func<Task> action)
+        {
+            var mock = new Mock<IProjectAsyncLoadDashboard>();
+
+            mock.SetupGet(s => s.ProjectLoadedInHost)
+                .Returns(action);
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectGuidService2Factory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectGuidService2Factory.cs
@@ -7,17 +7,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
     internal static class IProjectGuidService2Factory
     {
-        public static IProjectGuidService2 ImplementGetProjectGuidAsync(Guid result)
+        public static IProjectGuidService ImplementGetProjectGuidAsync(Guid result)
+        {
+            return ImplementGetProjectGuidAsync(() => result);
+        }
+
+        public static IProjectGuidService ImplementGetProjectGuidAsync(Func<Guid> action)
         {
             var mock = new Mock<IProjectGuidService2>();
             mock.Setup(s => s.GetProjectGuidAsync())
-                .ReturnsAsync(result);
+                .ReturnsAsync(action);
 
-            mock.As<IProjectGuidService>()
-                .Setup(s => s.ProjectGuid)
-                .Returns(result);
-
-            return mock.Object;
+            // All IProjectGuidService2 have to be IProjectGuidService instances
+            return mock.As<IProjectGuidService>().Object;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectGuidServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectGuidServiceFactory.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    internal static class IProjectGuidServiceFactory
+    {
+        public static IProjectGuidService ImplementProjectGuid(Guid result)
+        {
+            var mock = new Mock<IProjectGuidService>();
+            mock.Setup(s => s.ProjectGuid)
+                .Returns(result);
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/DebugTests/StartupProjectRegistrarTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/DebugTests/StartupProjectRegistrarTests.cs
@@ -151,7 +151,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
         private Task<StartupProjectRegistrar> CreateInitializedInstanceAsync(Guid projectGuid, IVsStartupProjectsListService vsStartupProjectsListService, params IDebugLaunchProvider[] launchProviders)
         {
-            var projectGuidService = IProjectGuidService2Factory.ImplementGetProjectGuidAsync(projectGuid);
+            var projectGuidService = ISafeProjectGuidServiceFactory.ImplementGetProjectGuidAsync(projectGuid);
             var debuggerLaunchProviders = new DebuggerLaunchProviders(ConfiguredProjectFactory.Create());
 
             int orderPrecedence = 0;
@@ -166,11 +166,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         }
 
         private async Task<StartupProjectRegistrar> CreateInitializedInstanceAsync(
-            UnconfiguredProject project = null,
+           UnconfiguredProject project = null,
            IAsyncServiceProvider serviceProvider = null,
            IVsStartupProjectsListService vsStartupProjectsListService = null,
            IProjectThreadingService threadingService = null,
-           IProjectGuidService projectGuidService = null,
+           ISafeProjectGuidService projectGuidService = null,
            IActiveConfiguredProjectSubscriptionService projectSubscriptionService = null,
            ActiveConfiguredProject<DebuggerLaunchProviders> launchProviders = null)
         {
@@ -185,7 +185,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             IAsyncServiceProvider serviceProvider = null,
             IVsStartupProjectsListService vsStartupProjectsListService = null,
             IProjectThreadingService threadingService = null,
-            IProjectGuidService projectGuidService = null,
+            ISafeProjectGuidService projectGuidService = null,
             IActiveConfiguredProjectSubscriptionService projectSubscriptionService = null,
             ActiveConfiguredProject<DebuggerLaunchProviders> launchProviders = null)
         {
@@ -201,13 +201,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 project ?? UnconfiguredProjectFactory.Create(),
                 serviceProvider,
                 threadingService ?? new IProjectThreadingServiceMock(),
+                projectGuidService ?? ISafeProjectGuidServiceFactory.ImplementGetProjectGuidAsync(Guid.NewGuid()),
                 projectSubscriptionService ?? IActiveConfiguredProjectSubscriptionServiceFactory.Create(),
                 launchProviders);
-
-            if (projectGuidService != null)
-            {
-                instance.ProjectGuidServices.Add(projectGuidService);
-            }
 
             return instance;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/DebugTests/StartupProjectRegistrarTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/DebugTests/StartupProjectRegistrarTests.cs
@@ -170,7 +170,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
            IAsyncServiceProvider serviceProvider = null,
            IVsStartupProjectsListService vsStartupProjectsListService = null,
            IProjectThreadingService threadingService = null,
-           IProjectGuidService2 projectGuidService = null,
+           IProjectGuidService projectGuidService = null,
            IActiveConfiguredProjectSubscriptionService projectSubscriptionService = null,
            ActiveConfiguredProject<DebuggerLaunchProviders> launchProviders = null)
         {
@@ -185,7 +185,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             IAsyncServiceProvider serviceProvider = null,
             IVsStartupProjectsListService vsStartupProjectsListService = null,
             IProjectThreadingService threadingService = null,
-            IProjectGuidService2 projectGuidService = null,
+            IProjectGuidService projectGuidService = null,
             IActiveConfiguredProjectSubscriptionService projectSubscriptionService = null,
             ActiveConfiguredProject<DebuggerLaunchProviders> launchProviders = null)
         {
@@ -206,7 +206,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
             if (projectGuidService != null)
             {
-                instance.ProjectGuidServices.Add((IProjectGuidService)projectGuidService);
+                instance.ProjectGuidServices.Add(projectGuidService);
             }
 
             return instance;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/AvoidPersistingProjectGuidStorageProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/AvoidPersistingProjectGuidStorageProviderTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 {
+    [Trait("UnitTest", "ProjectSystem")]
     public class AvoidPersistingProjectGuidStorageProviderTests
     {
         [Theory]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/VsSafeProjectGuidServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/VsSafeProjectGuidServiceTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
+    [Trait("UnitTest", "ProjectSystem")]
     public class VsSafeProjectGuidServiceTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/VsSafeProjectGuidServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/VsSafeProjectGuidServiceTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         public void GetProjectGuidAsync_WhenProjectAlreadyUnloaded_ReturnsCancelledTask()
         {
             var tasksService = IProjectAsynchronousTasksServiceFactory.ImplementUnloadCancellationToken(new CancellationToken(canceled: true));
-            var loadDashboard = IProjectAsyncLoadDashboardFactory.ImplementProjectLoadedInHost(() => Task.Delay(-1));
+            var loadDashboard = IProjectAsyncLoadDashboardFactory.ImplementProjectLoadedInHost(() => Task.Delay(Timeout.Infinite));
 
             var accessor = CreateInstance(tasksService, loadDashboard);
 
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             var projectUnloaded = new CancellationTokenSource();
             var tasksService = IProjectAsynchronousTasksServiceFactory.ImplementUnloadCancellationToken(projectUnloaded.Token);
-            var loadDashboard = IProjectAsyncLoadDashboardFactory.ImplementProjectLoadedInHost(() => Task.Delay(-1));
+            var loadDashboard = IProjectAsyncLoadDashboardFactory.ImplementProjectLoadedInHost(() => Task.Delay(Timeout.Infinite));
 
             var accessor = CreateInstance(tasksService, loadDashboard);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/VsSafeProjectGuidServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/VsSafeProjectGuidServiceTests.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    public class VsSafeProjectGuidServiceTests
+    {
+        [Fact]
+        public void GetProjectGuidAsync_WhenProjectAlreadyUnloaded_ReturnsCancelledTask()
+        {
+            var tasksService = IProjectAsynchronousTasksServiceFactory.ImplementUnloadCancellationToken(new CancellationToken(canceled: true));
+            var loadDashboard = IProjectAsyncLoadDashboardFactory.ImplementProjectLoadedInHost(() => Task.Delay(-1));
+
+            var accessor = CreateInstance(tasksService, loadDashboard);
+
+            var result = accessor.GetProjectGuidAsync();
+
+            Assert.True(result.IsCanceled);
+        }
+
+        [Fact]
+        public async Task GetProjectGuidAsync_WhenProjectUnloads_CancelsTask()
+        {
+            var projectUnloaded = new CancellationTokenSource();
+            var tasksService = IProjectAsynchronousTasksServiceFactory.ImplementUnloadCancellationToken(projectUnloaded.Token);
+            var loadDashboard = IProjectAsyncLoadDashboardFactory.ImplementProjectLoadedInHost(() => Task.Delay(-1));
+
+            var accessor = CreateInstance(tasksService, loadDashboard);
+
+            var result = accessor.GetProjectGuidAsync();
+
+            Assert.False(result.IsCanceled);
+
+            // Now "unload" the project
+            projectUnloaded.Cancel();
+
+            await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            {
+                return result;
+            });
+        }
+
+        [Fact]
+        public async Task GetProjectGuidAsync_WhenNoProjectGuidService_ReturnsEmpty()
+        {
+            var accessor = CreateInstance();
+
+            var result = await accessor.GetProjectGuidAsync();
+
+            Assert.Equal(result, Guid.Empty);
+        }
+
+        [Fact]
+        public async Task GetProjectGuidAsync_WhenOnlyNonAsyncProjectGuidService_ReturnsProjectGuidProperty()
+        {
+            var accessor = CreateInstance();
+            var guid = Guid.NewGuid();
+            var projectGuidService = IProjectGuidServiceFactory.ImplementProjectGuid(guid);
+            accessor.ProjectGuidServices.Add(projectGuidService);
+
+            var result = await accessor.GetProjectGuidAsync();
+
+            Assert.Equal(result, guid);
+        }
+
+        [Fact]
+        public async Task GetProjectGuidAsync_WhenProjectGuidService2_ReturnsGetProjectGuidAsync()
+        {
+            var accessor = CreateInstance();
+            var guid = Guid.NewGuid();
+            var projectGuidService = IProjectGuidService2Factory.ImplementGetProjectGuidAsync(guid);
+            accessor.ProjectGuidServices.Add(projectGuidService);
+
+            var result = await accessor.GetProjectGuidAsync();
+
+            Assert.Equal(result, guid);
+        }
+
+        [Fact]
+        public async Task GetProjectGuidAsync_WhenProjectGuidService2Cancels_CancelsTask()
+        {
+            var accessor = CreateInstance();
+            var projectGuidService = IProjectGuidService2Factory.ImplementGetProjectGuidAsync(() => throw new OperationCanceledException());
+            accessor.ProjectGuidServices.Add(projectGuidService);
+
+            var result = accessor.GetProjectGuidAsync();
+
+            await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            {
+                return result;
+            });
+        }
+
+        private static VsSafeProjectGuidService CreateInstance(IProjectAsynchronousTasksService tasksService = null, IProjectAsyncLoadDashboard loadDashboard = null)
+        {
+            var project = UnconfiguredProjectFactory.Create();
+            tasksService = tasksService ?? IProjectAsynchronousTasksServiceFactory.Create();
+            loadDashboard = loadDashboard ?? IProjectAsyncLoadDashboardFactory.ImplementProjectLoadedInHost(() => Task.CompletedTask);
+            
+            return new VsSafeProjectGuidService(project, tasksService, loadDashboard);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
@@ -54,14 +54,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             _projectGuidService = projectGuidService;
             _projectSubscriptionService = projectSubscriptionService;
             _launchProviders = launchProviders;
-
-            ProjectGuidServices = new OrderPrecedenceImportCollection<IProjectGuidService>(projectCapabilityCheckProvider: project);
-        }
-
-        [ImportMany]
-        public OrderPrecedenceImportCollection<IProjectGuidService> ProjectGuidServices
-        {
-            get;
         }
 
         [ProjectAutoLoad(startAfter: ProjectLoadCheckpoint.ProjectFactoryCompleted)]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
@@ -22,6 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
     {
         private readonly IAsyncServiceProvider _serviceProvider;
         private readonly IProjectThreadingService _threadingService;
+        private readonly ISafeProjectGuidService _projectGuidService;
         private readonly IActiveConfiguredProjectSubscriptionService _projectSubscriptionService;
         private readonly ActiveConfiguredProject<DebuggerLaunchProviders> _launchProviders;
         private IVsStartupProjectsListService _startupProjectsListService;
@@ -32,9 +33,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         public StartupProjectRegistrar(
             UnconfiguredProject project,
             IProjectThreadingService threadingService,
+            ISafeProjectGuidService projectGuidService,
             IActiveConfiguredProjectSubscriptionService projectSubscriptionService,
             ActiveConfiguredProject<DebuggerLaunchProviders> launchProviders)
-            : this(project, AsyncServiceProvider.GlobalProvider, threadingService, projectSubscriptionService, launchProviders)
+            : this(project, AsyncServiceProvider.GlobalProvider, threadingService, projectGuidService, projectSubscriptionService, launchProviders)
         {
         }
 
@@ -42,12 +44,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             UnconfiguredProject project,
             IAsyncServiceProvider serviceProvider,
             IProjectThreadingService threadingService,
+            ISafeProjectGuidService projectGuidService,
             IActiveConfiguredProjectSubscriptionService projectSubscriptionService,
             ActiveConfiguredProject<DebuggerLaunchProviders> launchProviders)
         : base(threadingService.JoinableTaskContext)
         {
             _serviceProvider = serviceProvider;
             _threadingService = threadingService;
+            _projectGuidService = projectGuidService;
             _projectSubscriptionService = projectSubscriptionService;
             _launchProviders = launchProviders;
 
@@ -69,12 +73,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
         protected override async Task InitializeCoreAsync(CancellationToken cancellationToken)
         {
-            IProjectGuidService2 projectGuidService = ProjectGuidServices.FirstOrDefault()?.Value as IProjectGuidService2;
-            if (projectGuidService == null)
-                return;
-
-            _projectGuid = await projectGuidService.GetProjectGuidAsync()
-                                                   .ConfigureAwait(false);
+            _projectGuid = await _projectGuidService.GetProjectGuidAsync()
+                                                    .ConfigureAwait(false);
 
             Assumes.False(_projectGuid == Guid.Empty);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSafeProjectGuidService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSafeProjectGuidService.cs
@@ -16,6 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         private readonly IProjectAsynchronousTasksService _tasksService;
         private readonly IProjectAsyncLoadDashboard _loadDashboard;
 
+        [ImportingConstructor]
         public VsSafeProjectGuidService(UnconfiguredProject project, [Import(ExportContractNames.Scopes.UnconfiguredProject)]IProjectAsynchronousTasksService tasksService, IProjectAsyncLoadDashboard loadDashboard)
         {
             _tasksService = tasksService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSafeProjectGuidService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSafeProjectGuidService.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    /// <summary>
+    ///     An implementation of <see cref="IProjectGuidSafeAccessor"/> that waits until the project
+    ///     has been loaded into the host environment before returning the project GUID.
+    /// </summary>
+    [Export(typeof(ISafeProjectGuidService))]
+    internal class VsSafeProjectGuidService : ISafeProjectGuidService
+    {
+        private readonly IProjectAsynchronousTasksService _tasksService;
+        private readonly IProjectAsyncLoadDashboard _loadDashboard;
+
+        public VsSafeProjectGuidService(UnconfiguredProject project, [Import(ExportContractNames.Scopes.UnconfiguredProject)]IProjectAsynchronousTasksService tasksService, IProjectAsyncLoadDashboard loadDashboard)
+        {
+            _tasksService = tasksService;
+            _loadDashboard = loadDashboard;
+
+            ProjectGuidServices = new OrderPrecedenceImportCollection<IProjectGuidService>(projectCapabilityCheckProvider: project);
+        }
+
+        [ImportMany]
+        public OrderPrecedenceImportCollection<IProjectGuidService> ProjectGuidServices
+        {
+            get;
+        }
+
+        public async Task<Guid> GetProjectGuidAsync()
+        {
+            await _loadDashboard.ProjectLoadedInHostWithCancellation(_tasksService)
+                                .ConfigureAwait(false);
+
+            IProjectGuidService projectGuidService = ProjectGuidServices.FirstOrDefault()?.Value;
+            if (projectGuidService == null)
+                return Guid.Empty;
+
+            if (projectGuidService is IProjectGuidService2 projectGuidService2)
+            {
+                return await projectGuidService2.GetProjectGuidAsync()
+                                                .ConfigureAwait(false);
+            }
+
+            return projectGuidService.ProjectGuid;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSafeProjectGuidService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSafeProjectGuidService.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
     /// <summary>
-    ///     An implementation of <see cref="IProjectGuidSafeAccessor"/> that waits until the project
+    ///     An implementation of <see cref="ISafeProjectGuidService"/> that waits until the project
     ///     has been loaded into the host environment before returning the project GUID.
     /// </summary>
     [Export(typeof(ISafeProjectGuidService))]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ISafeProjectGuidService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ISafeProjectGuidService.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    /// <summary>
+    ///     Provides a mechanism to safely access the project GUID. Replaces usage of <see cref="IProjectGuidService"/> 
+    ///     and <see cref="IProjectGuidService2"/>.
+    /// </summary>
+    /// <remarks>
+    ///     <see cref="IProjectGuidService"/> and <see cref="IProjectGuidService2"/> will retrieve the project GUID of 
+    ///     the project *at the time* that it is called. During project initialization, the GUID may be changed by the 
+    ///     solution in reaction to a clash with another project. <see cref="ISafeProjectGuidService"/> will wait until
+    ///     it is safe to retrieve the project GUID before returning it.
+    /// </remarks>
+    internal interface ISafeProjectGuidService
+    {
+        /// <summary>
+        ///     Returns the project GUID, waiting until project load has safely progressed 
+        ///     to a point where the GUID is guaranteed not to change.
+        /// </summary>
+        /// <returns>
+        ///     The GUID of the current project.
+        /// </returns>
+        /// <exception cref="OperationCanceledException">
+        ///     The project was unloaded before project load had finished.
+        /// </exception>
+        Task<Guid> GetProjectGuidAsync();
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectAsyncLoadDashboardExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectAsyncLoadDashboardExtensions.cs
@@ -13,13 +13,47 @@ namespace Microsoft.VisualStudio.ProjectSystem
     internal static class ProjectAsyncLoadDashboardExtensions
     {
         /// <summary>
-        /// Gets a task that completes when the host recognizes that this project is loaded.
-        /// The returned task is cancelled if the project is unloaded before it completes.
-        /// This extension should be used instead of waiting on ProjectLoadedInHost directly.
+        ///     Returns a task that completes when the host recognizes that the project has loaded, 
+        ///     cancelling if the project is unloaded before it completes.
         /// </summary>
-        public static Task ProjectLoadedInHostWithCancellation(
-            this IProjectAsyncLoadDashboard dashboard, UnconfiguredProject project)
-            => dashboard.ProjectLoadedInHost.WithCancellation(
-                project.Services.ProjectAsynchronousTasks.UnloadCancellationToken);
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="dashboard"/> is <see langword="null"/>.
+        ///     <para>
+        ///         -or-
+        ///     </para>
+        ///     <paramref name="project"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">
+        ///     The project was unloaded before project load had finished.
+        /// </exception>
+        public static Task ProjectLoadedInHostWithCancellation(this IProjectAsyncLoadDashboard dashboard, UnconfiguredProject project)
+        {
+            Requires.NotNull(project, nameof(project));
+
+            return ProjectLoadedInHostWithCancellation(dashboard, project.Services.ProjectAsynchronousTasks);
+
+        }
+
+        /// <summary>
+        ///     Returns a task that completes when the host recognizes that the project has loaded, 
+        ///     cancelling if the project is unloaded before it completes.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="dashboard"/> is <see langword="null"/>.
+        ///     <para>
+        ///         -or-
+        ///     </para>
+        ///     <paramref name="tasksService"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="OperationCanceledException">
+        ///     The project was unloaded before project load had finished.
+        /// </exception>
+        public static Task ProjectLoadedInHostWithCancellation(this IProjectAsyncLoadDashboard dashboard, IProjectAsynchronousTasksService tasksService)
+        {
+            Requires.NotNull(dashboard, nameof(dashboard));
+            Requires.NotNull(tasksService, nameof(tasksService));
+
+            return dashboard.ProjectLoadedInHost.WithCancellation(tasksService.UnloadCancellationToken);
+        }
     }
 }


### PR DESCRIPTION
The project GUID can be set by the solution right up to the point it fires IVsSolutionEvents.OnAfterOpenProject (IProjectAsyncLoadDashboard.ProjectLoadedInHost completes) in reaction to a clash with another project. Add a singleton API that is intended as a wrapper around IProjectGuidService/IProjectGuidService2 that waits for the project to be loaded before retrieving the GUID..

Fixes: #3338

Updated services to consume that.

Still testing this, but code is complete.