### PR TITLE
[WIP] Added Paste Ordering

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelperTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelperTests.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using Microsoft.Build.Evaluation;
 using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
-
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
@@ -374,7 +372,9 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 
             var project = new Project(projectRootElement);
 
-            Assert.True(OrderingHelper.TryMoveAbove(project, tree.Children[0], tree.Children[2]));
+            var elements = OrderingHelper.GetElements(project, tree.Children[0]);
+
+            Assert.True(OrderingHelper.TryMoveElementsAbove(project, elements, tree.Children[2]));
             Assert.True(project.IsDirty);
 
             var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
@@ -420,7 +420,9 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 
             var project = new Project(projectRootElement);
 
-            Assert.True(OrderingHelper.TryMoveBelow(project, tree.Children[0], tree.Children[2]));
+            var elements = OrderingHelper.GetElements(project, tree.Children[0]);
+
+            Assert.True(OrderingHelper.TryMoveElementsBelow(project, elements, tree.Children[2]));
             Assert.True(project.IsDirty);
 
             var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
@@ -456,9 +458,6 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
     File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 4, ItemName: ""test3.fs""
 ");
 
-            var addedNodes = new List<IProjectTree>();
-            addedNodes.Add(updatedTree.Children[2]);
-
             var projectRootElement = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
 
@@ -478,7 +477,9 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 
             var project = new Project(projectRootElement);
 
-            Assert.True(OrderingHelper.TryMoveNodesToTop(project, addedNodes, tree), "TryMoveNodesToTop returned false.");
+            var elements = OrderingHelper.GetElements(project, updatedTree.Children[2]);
+
+            Assert.True(OrderingHelper.TryMoveElementsToTop(project, elements, tree), "TryMoveElementsToTop returned false.");
             Assert.True(project.IsDirty);
 
             var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
@@ -516,10 +517,6 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
     File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 5, ItemName: ""test3.fs""
 ");
 
-            var addedNodes = new List<IProjectTree>();
-            addedNodes.Add(updatedTree.Children[2]);
-            addedNodes.Add(updatedTree.Children[3]);
-
             var projectRootElement = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
 
@@ -540,7 +537,11 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 
             var project = new Project(projectRootElement);
 
-            Assert.True(OrderingHelper.TryMoveNodesToTop(project, addedNodes, tree), "TryMoveNodesToTop returned false.");
+            var elements = 
+                OrderingHelper.GetElements(project, updatedTree.Children[2])
+                .AddRange(OrderingHelper.GetElements(project, updatedTree.Children[3]));
+
+            Assert.True(OrderingHelper.TryMoveElementsToTop(project, elements, tree), "TryMoveElementsToTop returned false.");
             Assert.True(project.IsDirty);
 
             var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
@@ -583,10 +584,6 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
     File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 7, ItemName: ""test3.fs""
 ");
 
-            var addedNodes = new List<IProjectTree>();
-            addedNodes.Add(updatedTree.Children[2].Children[0].Children[0]);
-            addedNodes.Add(updatedTree.Children[2].Children[0].Children[1]);
-
             var projectRootElement = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
 
@@ -607,7 +604,11 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 
             var project = new Project(projectRootElement);
 
-            Assert.True(OrderingHelper.TryMoveNodesToTop(project, addedNodes, tree.Children[0].Children[0]), "TryMoveNodesToTop returned false.");
+            var elements =
+                OrderingHelper.GetElements(project, updatedTree.Children[2].Children[0].Children[0])
+                .AddRange(OrderingHelper.GetElements(project, updatedTree.Children[2].Children[0].Children[1]));
+
+            Assert.True(OrderingHelper.TryMoveElementsToTop(project, elements, tree), "TryMoveElementsToTop returned false.");
             Assert.True(project.IsDirty);
 
             var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AbstractMoveCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AbstractMoveCommand.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.Threading.Tasks;
-
+using Microsoft.Build.Evaluation;
 using Microsoft.VisualStudio.Packaging;
 using Microsoft.VisualStudio.ProjectSystem.Input;
 using Microsoft.VisualStudio.Shell;
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 
         protected abstract bool CanMove(IProjectTree node);
 
-        protected abstract Task<bool> TryMoveAsync(ConfiguredProject configuredProject, IProjectTree node);
+        protected abstract bool TryMove(Project project, IProjectTree node);
 
         protected override async Task<CommandStatusResult> GetCommandStatusAsync(IProjectTree node, bool focused, string commandText, CommandStatus progressiveStatus)
         {
@@ -41,76 +41,40 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             return await GetCommandStatusResult.Handled(commandText, CommandStatus.Enabled).ConfigureAwait(true);
         }
 
+        private async Task<TResult> OpenProjectForWriteAsync<TResult>(ConfiguredProject project, Func<Project, TResult> action)
+        {
+            Requires.NotNull(project, nameof(project));
+            Requires.NotNull(project, nameof(action));
+
+            var projectLockService = _configuredProject.Services.ProjectService.Services.ProjectLockService;
+
+            using (ProjectWriteLockReleaser access = await projectLockService.WriteLockAsync())
+            {
+                await access.CheckoutAsync(project.UnconfiguredProject.FullPath)
+                            .ConfigureAwait(true);
+
+                Project evaluatedProject = await access.GetProjectAsync(project)
+                                                       .ConfigureAwait(true);
+
+                // Deliberately not async to reduce the type of
+                // code you can run while holding the lock.
+                return action(evaluatedProject);
+            }
+        }
+
         protected override async Task<bool> TryHandleCommandAsync(IProjectTree node, bool focused, long commandExecuteOptions, IntPtr variantArgIn, IntPtr variantArgOut)
         {
-            var didMove = await TryMoveAsync(_configuredProject, node).ConfigureAwait(true);
+            var didMove = await OpenProjectForWriteAsync(_configuredProject, project => TryMove(project, node)).ConfigureAwait(true);
 
             if (didMove)
             {
                 // Wait for updating to finish before re-selecting the node that moved.
                 // We need to re-select the node after it is moved in order to continuously move the node using hotkeys.
                 await _projectTree.TreeService.PublishLatestTreeAsync(waitForFileSystemUpdates: true).ConfigureAwait(true);
-
-                if (_configuredProject.UnconfiguredProject.Services.HostObject is IVsUIHierarchy hierarchy)
-                {
-                    // The node moved will retain its identity.
-                    var itemId = (uint)node.Identity.ToInt32();
-                    var window = GetUIHierarchyWindow(_serviceProvider, Guid.Parse(ManagedProjectSystemPackage.SolutionExplorerGuid));
-
-                    window.ExpandItem(hierarchy, itemId, EXPANDFLAGS.EXPF_SelectItem);
-
-                    // If we moved a folder, collapse it.
-                    if (node.IsFolder)
-                    {
-                        window.ExpandItem(hierarchy, itemId, EXPANDFLAGS.EXPF_CollapseFolder);
-                    }
-                }
+                HACK_NodeHelper.Select(_configuredProject, _serviceProvider, node);
             }
 
             return didMove;
-        }
-
-        /// <summary>
-        /// Get reference to IVsUIHierarchyWindow interface from guid persistence slot.
-        /// </summary>
-        /// <param name="serviceProvider">The service provider.</param>
-        /// <param name="persistenceSlot">Unique identifier for a tool window created using IVsUIShell::CreateToolWindow.
-        /// The caller of this method can use predefined identifiers that map to tool windows if those tool windows
-        /// are known to the caller. </param>
-        /// <returns>A reference to an IVsUIHierarchyWindow interface, or <c>null</c> if the window isn't available, such as command line mode.</returns>
-        private static IVsUIHierarchyWindow GetUIHierarchyWindow(IServiceProvider serviceProvider, Guid persistenceSlot)
-        {
-            if (serviceProvider == null)
-            {
-                throw new ArgumentNullException(nameof(serviceProvider));
-            }
-
-            IVsUIShell shell = serviceProvider.GetService(typeof(SVsUIShell)) as IVsUIShell;
-
-            if (shell == null)
-            {
-                throw new InvalidOperationException();
-            }
-
-            object pvar = null;
-            IVsUIHierarchyWindow uiHierarchyWindow = null;
-
-            try
-            {
-                if (ErrorHandler.Succeeded(shell.FindToolWindow(0, ref persistenceSlot, out var frame)) && frame != null)
-                {
-                    ErrorHandler.ThrowOnFailure(frame.GetProperty((int)__VSFPROPID.VSFPROPID_DocView, out pvar));
-                }
-            }
-            finally
-            {
-                if (pvar != null)
-                {
-                    uiHierarchyWindow = (IVsUIHierarchyWindow)pvar;
-                }
-            }
-
-            return uiHierarchyWindow;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemAboveCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemAboveCommand.cs
@@ -1,8 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel.Composition;
-
+using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
 using Microsoft.VisualStudio.Packaging;
 using Microsoft.VisualStudio.ProjectSystem.Input;
 using Microsoft.VisualStudio.Shell;
@@ -30,12 +31,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             return ShowAddExistingFilesDialogAsync(nodeToAddTo);
         }
 
-        protected override async Task OnAddedNodesAsync(ConfiguredProject configuredProject, IProjectTree target, IEnumerable<IProjectTree> addedNodes, IProjectTree updatedTarget)
+        protected override void OnAddedElements(Project project, ImmutableArray<ProjectItemElement> elements, IProjectTree target, IProjectTree nodeToAddTo)
         {
-            foreach (var addedNode in addedNodes)
-            {
-                await OrderingHelper.TryMoveAboveAsync(configuredProject, addedNode, target).ConfigureAwait(true);
-            }
+            OrderingHelper.TryMoveElementsAbove(project, elements, target);
         }
 
         protected override bool CanAdd(IProjectTree target)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemBelowCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemBelowCommand.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Linq;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel.Composition;
-
+using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
 using Microsoft.VisualStudio.Packaging;
 using Microsoft.VisualStudio.ProjectSystem.Input;
 using Microsoft.VisualStudio.Shell;
@@ -31,12 +31,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             return ShowAddExistingFilesDialogAsync(nodeToAddTo);
         }
 
-        protected override async Task OnAddedNodesAsync(ConfiguredProject configuredProject, IProjectTree target, IEnumerable<IProjectTree> addedNodes, IProjectTree updatedTarget)
+        protected override void OnAddedElements(Project project, ImmutableArray<ProjectItemElement> elements, IProjectTree target, IProjectTree nodeToAddTo)
         {
-            foreach (var addedNode in addedNodes.Reverse())
-            {
-                await OrderingHelper.TryMoveBelowAsync(configuredProject, addedNode, target).ConfigureAwait(true);
-            }
+            OrderingHelper.TryMoveElementsBelow(project, elements, target);
         }
 
         protected override bool CanAdd(IProjectTree target)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemAboveCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemAboveCommand.cs
@@ -1,8 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel.Composition;
-
+using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
 using Microsoft.VisualStudio.Packaging;
 using Microsoft.VisualStudio.ProjectSystem.Input;
 using Microsoft.VisualStudio.Shell;
@@ -30,12 +31,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             return ShowAddNewFileDialogAsync(nodeToAddTo);
         }
 
-        protected override async Task OnAddedNodesAsync(ConfiguredProject configuredProject, IProjectTree target, IEnumerable<IProjectTree> addedNodes, IProjectTree updatedTarget)
+        protected override void OnAddedElements(Project project, ImmutableArray<ProjectItemElement> elements, IProjectTree target, IProjectTree nodeToAddTo)
         {
-            foreach (var addedNode in addedNodes)
-            {
-                await OrderingHelper.TryMoveAboveAsync(configuredProject, addedNode, target).ConfigureAwait(true);
-            }
+            OrderingHelper.TryMoveElementsAbove(project, elements, target);
         }
 
         protected override bool CanAdd(IProjectTree target)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemBelowCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemBelowCommand.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Linq;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel.Composition;
-
+using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
 using Microsoft.VisualStudio.Packaging;
 using Microsoft.VisualStudio.ProjectSystem.Input;
 using Microsoft.VisualStudio.Shell;
@@ -31,12 +31,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             return ShowAddNewFileDialogAsync(nodeToAddTo);
         }
 
-        protected override async Task OnAddedNodesAsync(ConfiguredProject configuredProject, IProjectTree target, IEnumerable<IProjectTree> addedNodes, IProjectTree updatedTarget)
+        protected override void OnAddedElements(Project project, ImmutableArray<ProjectItemElement> elements, IProjectTree target, IProjectTree nodeToAddTo)
         {
-            foreach (var addedNode in addedNodes.Reverse())
-            {
-                await OrderingHelper.TryMoveBelowAsync(configuredProject, addedNode, target).ConfigureAwait(true);
-            }
+            OrderingHelper.TryMoveElementsBelow(project, elements, target);
         }
 
         protected override bool CanAdd(IProjectTree target)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/HACK_AddItemHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/HACK_AddItemHelper.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/HACK_NodeHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/HACK_NodeHelper.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
+{
+    internal static class HACK_NodeHelper
+    {
+        public static void Select(ConfiguredProject configuredProject, IServiceProvider serviceProvider, IProjectTree node)
+        {
+            Select(configuredProject, serviceProvider, (uint)node.Identity.ToInt32());
+        }
+
+        public static void ExpandFolder(ConfiguredProject configuredProject, IServiceProvider serviceProvider, IProjectTree node)
+        {
+            ExpandFolder(configuredProject, serviceProvider, (uint)node.Identity.ToInt32());
+        }
+
+        public static void CollapseFolder(ConfiguredProject configuredProject, IServiceProvider serviceProvider, IProjectTree node)
+        {
+            CollapseFolder(configuredProject, serviceProvider, (uint)node.Identity.ToInt32());
+        }
+
+        private static void Select(ConfiguredProject configuredProject, IServiceProvider serviceProvider, uint itemId)
+        {
+            UseWindow(configuredProject, serviceProvider, (hierarchy, window) =>
+            {
+                // We need to unselect the item if it is already selected to re-select it correctly.
+                window.ExpandItem(hierarchy, itemId, EXPANDFLAGS.EXPF_UnSelectItem);
+                window.ExpandItem(hierarchy, itemId, EXPANDFLAGS.EXPF_SelectItem);
+            });
+        }
+
+        private static void ExpandFolder(ConfiguredProject configuredProject, IServiceProvider serviceProvider, uint itemId)
+        {
+            UseWindow(configuredProject, serviceProvider, (hierarchy, window) =>
+            {
+                window.ExpandItem(hierarchy, itemId, EXPANDFLAGS.EXPF_ExpandFolder);
+            });
+        }
+
+        private static void CollapseFolder(ConfiguredProject configuredProject, IServiceProvider serviceProvider, uint itemId)
+        {
+            UseWindow(configuredProject, serviceProvider, (hierarchy, window) =>
+            {
+                window.ExpandItem(hierarchy, itemId, EXPANDFLAGS.EXPF_CollapseFolder);
+            });
+        }
+
+        private static void UseWindow(ConfiguredProject configuredProject, IServiceProvider serviceProvider, Action<IVsUIHierarchy, IVsUIHierarchyWindow> callback)
+        {
+            if (configuredProject.UnconfiguredProject.Services.HostObject is IVsUIHierarchy hierarchy)
+            {
+                callback(hierarchy, GetUIHierarchyWindow(serviceProvider, Guid.Parse(ManagedProjectSystemPackage.SolutionExplorerGuid)));
+            }
+        }
+
+        /// <summary>
+        /// Get reference to IVsUIHierarchyWindow interface from guid persistence slot.
+        /// </summary>
+        /// <param name="serviceProvider">The service provider.</param>
+        /// <param name="persistenceSlot">Unique identifier for a tool window created using IVsUIShell::CreateToolWindow.
+        /// The caller of this method can use predefined identifiers that map to tool windows if those tool windows
+        /// are known to the caller. </param>
+        /// <returns>A reference to an IVsUIHierarchyWindow interface, or <c>null</c> if the window isn't available, such as command line mode.</returns>
+        private static IVsUIHierarchyWindow GetUIHierarchyWindow(IServiceProvider serviceProvider, Guid persistenceSlot)
+        {
+            if (serviceProvider == null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider));
+            }
+
+
+            if (!(serviceProvider.GetService(typeof(SVsUIShell)) is IVsUIShell shell))
+            {
+                throw new InvalidOperationException();
+            }
+
+            object pvar = null;
+            IVsUIHierarchyWindow uiHierarchyWindow = null;
+
+            try
+            {
+                if (ErrorHandler.Succeeded(shell.FindToolWindow(0, ref persistenceSlot, out var frame)) && frame != null)
+                {
+                    ErrorHandler.ThrowOnFailure(frame.GetProperty((int)__VSFPROPID.VSFPROPID_DocView, out pvar));
+                }
+            }
+            finally
+            {
+                if (pvar != null)
+                {
+                    uiHierarchyWindow = (IVsUIHierarchyWindow)pvar;
+                }
+            }
+
+            return uiHierarchyWindow;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/HACK_PasteOrdering.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/HACK_PasteOrdering.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
+{
+    /// <summary>
+    /// This is a hack due to CPS not exposing easier ways to handle pasting items.
+    /// This does proper file ordering for pasting or dropping items into a folder or project.
+    /// </summary>
+    [Export(typeof(IPasteDataObjectProcessor))]
+    [Export(typeof(IPasteHandler))]
+    [AppliesTo(ProjectCapabilities.SortByDisplayOrder)]
+    [Order(OrderPrecedence)]
+    internal class HACK_PasteOrdering : IPasteHandler, IPasteDataObjectProcessor
+    {
+        public const int OrderPrecedence = 10000;
+
+        private readonly IPhysicalProjectTree _projectTree;
+        private readonly IUnconfiguredProjectVsServices _projectVsServices;
+
+        private IProjectTree _dropTarget;
+
+        private IPasteHandler _pasteHandler;
+        private IPasteDataObjectProcessor _pasteProcessor;
+
+        [ImportingConstructor]
+        public HACK_PasteOrdering(IPhysicalProjectTree projectTree, IUnconfiguredProjectVsServices projectVsServices, UnconfiguredProject unconfiguredProject)
+        {
+            Requires.NotNull(projectTree, nameof(IPhysicalProjectTree));
+            Requires.NotNull(unconfiguredProject, nameof(UnconfiguredProject));
+
+            _projectTree = projectTree;
+            _projectVsServices = projectVsServices;
+
+            PasteHandlers = new OrderPrecedenceImportCollection<IPasteHandler>(projectCapabilityCheckProvider: unconfiguredProject);
+            PasteProcessors = new OrderPrecedenceImportCollection<IPasteDataObjectProcessor>(projectCapabilityCheckProvider: unconfiguredProject);
+        }
+
+        [ImportMany]
+        private OrderPrecedenceImportCollection<IPasteHandler> PasteHandlers { get; set; }
+
+        [ImportMany]
+        private OrderPrecedenceImportCollection<IPasteDataObjectProcessor> PasteProcessors { get; set; }
+
+        private IPasteHandler PasteHandler
+        {
+            get
+            {
+                if (_pasteHandler == null)
+                {
+                    // Grab the paste handler that has the highest order precedence that is below HACK_PasteOrdering's order precedence. 
+                    _pasteHandler = 
+                        PasteHandlers.Where(x => x.Metadata.OrderPrecedence < OrderPrecedence)
+                        .OrderByDescending(x => x.Metadata.OrderPrecedence).First().Value;
+                }
+
+                Assumes.NotNull(_pasteHandler);
+
+                return _pasteHandler;
+            }
+        }
+
+        private IPasteDataObjectProcessor PasteProcessor
+        {
+            get
+            {
+                if (_pasteProcessor == null)
+                {
+                    // Grab the paste processor that has the highest order precedence that is below HACK_PasteOrdering's order precedence. 
+                    _pasteProcessor = 
+                        PasteProcessors.Where(x => x.Metadata.OrderPrecedence < OrderPrecedence)
+                        .OrderByDescending(x => x.Metadata.OrderPrecedence).First().Value;
+                }
+
+                Assumes.NotNull(_pasteProcessor);
+
+                return _pasteProcessor;
+            }
+        }
+
+        #region IPasteDataObjectProcessor
+        public bool CanHandleDataObject(object dataObject, IProjectTree dropTarget, IProjectTreeProvider currentProvider)
+        {
+            return PasteProcessor.CanHandleDataObject(dataObject, dropTarget, currentProvider);
+        }
+
+        public Task<IEnumerable<ICopyPasteItem>> ProcessDataObjectAsync(object dataObject, IProjectTree dropTarget, IProjectTreeProvider currentProvider, DropEffects effect)
+        {
+            _dropTarget = dropTarget;
+            return PasteProcessor.ProcessDataObjectAsync(dataObject, dropTarget, currentProvider, effect);
+        }
+
+        public DropEffects? QueryDropEffect(object dataObject, int grfKeyState, bool draggedFromThisProject)
+        {
+            return PasteProcessor.QueryDropEffect(dataObject, grfKeyState, draggedFromThisProject);
+        }
+
+        public Task ProcessPostFilterAsync(IEnumerable<ICopyPasteItem> items)
+        {
+            return PasteProcessor.ProcessPostFilterAsync(items);
+        }
+        #endregion
+
+        #region IPasteHandler
+        public bool CanHandleItem(Type itemType)
+        {
+            return PasteHandler.CanHandleItem(itemType);
+        }
+
+        public void FilterItemList(IEnumerable<ICopyPasteItem> items, DropEffects effect)
+        {
+            PasteHandler.FilterItemList(items, effect);
+        }
+
+        public async Task<PasteItemsResult> PasteItemsAsync(IEnumerable<ICopyPasteItem> items, DropEffects effect)
+        {
+            Assumes.NotNull(_dropTarget);
+
+            var result = new PasteItemsResult();
+
+            var addedElements = await OrderingHelper.AddItems(_projectVsServices.ActiveConfiguredProject, _projectVsServices.ProjectLockService, async () =>
+            {
+                result = await PasteHandler.PasteItemsAsync(items, effect).ConfigureAwait(false);
+            }).ConfigureAwait(false);
+
+            await new ProjectAccessor(_projectVsServices.ProjectLockService).OpenProjectForWriteAsync(_projectVsServices.ActiveConfiguredProject, project =>
+            {
+                OrderingHelper.TryMoveElementsToTop(project, addedElements, _dropTarget);
+            }).ConfigureAwait(false);
+
+            return result;
+        }
+
+        public bool PromptForAnyOverwrites(IEnumerable<ICopyPasteItem> items, ref DropEffects effect)
+        {
+            return PasteHandler.PromptForAnyOverwrites(items, ref effect);
+        }
+
+        public Task<IEnumerable<string>> ValidateItemListAsync(IEnumerable<ICopyPasteItem> items, DropEffects effect)
+        {
+            return PasteHandler.ValidateItemListAsync(items, effect);
+        }
+        #endregion
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/MoveDownCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/MoveDownCommand.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.ComponentModel.Composition;
-using System.Threading.Tasks;
-
+using Microsoft.Build.Evaluation;
 using Microsoft.VisualStudio.Packaging;
 using Microsoft.VisualStudio.ProjectSystem.Input;
 using Microsoft.VisualStudio.Shell;
@@ -23,9 +22,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             return OrderingHelper.CanMoveDown(node);
         }
 
-        protected override Task<bool> TryMoveAsync(ConfiguredProject configuredProject, IProjectTree node)
+        protected override bool TryMove(Project project, IProjectTree node)
         {
-            return OrderingHelper.TryMoveDownAsync(configuredProject, node);
+            return OrderingHelper.TryMoveDown(project, node);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/MoveUpCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/MoveUpCommand.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.ComponentModel.Composition;
-using System.Threading.Tasks;
-
+using Microsoft.Build.Evaluation;
 using Microsoft.VisualStudio.Packaging;
 using Microsoft.VisualStudio.ProjectSystem.Input;
 using Microsoft.VisualStudio.Shell;
@@ -23,9 +22,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             return OrderingHelper.CanMoveUp(node);
         }
 
-        protected override Task<bool> TryMoveAsync(ConfiguredProject configuredProject, IProjectTree node)
+        protected override bool TryMove(Project project, IProjectTree node)
         {
-            return OrderingHelper.TryMoveUpAsync(configuredProject, node);
+            return OrderingHelper.TryMoveUp(project, node);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
@@ -3,10 +3,8 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
-
 using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
 
@@ -45,7 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         {
             Requires.NotNull(projectTree, nameof(projectTree));
 
-            return GetSiblingByMoveAction(projectTree, MoveAction.Up) != null;
+            return GetSiblingByMoveAction(projectTree, MoveAction.Above) != null;
         }
 
         /// <summary>
@@ -56,42 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             Requires.NotNull(project, nameof(project));
             Requires.NotNull(projectTree, nameof(projectTree));
 
-            return TryMove(project, projectTree, MoveAction.Up);
-        }
-
-        /// <summary>
-        /// Move the project tree up over one of its siblings.
-        /// </summary>
-        public static Task<bool> TryMoveUpAsync(ConfiguredProject configuredProject, IProjectTree projectTree)
-        {
-            Requires.NotNull(configuredProject, nameof(configuredProject));
-            Requires.NotNull(projectTree, nameof(projectTree));
-
-            return TryMoveAsync(configuredProject, projectTree, MoveAction.Up);
-        }
-
-        /// <summary>
-        /// Move a project tree above the target project tree.
-        /// </summary>
-        public static bool TryMoveAbove(Project project, IProjectTree projectTree, IProjectTree target)
-        {
-            Requires.NotNull(project, nameof(project));
-            Requires.NotNull(projectTree, nameof(projectTree));
-            Requires.NotNull(target, nameof(target));
-
-            return TryMove(project, projectTree, target, MoveAction.Up);
-        }
-
-        /// <summary>
-        /// Move a project tree above the target project tree.
-        /// </summary>
-        public static Task<bool> TryMoveAboveAsync(ConfiguredProject configuredProject, IProjectTree projectTree, IProjectTree target)
-        {
-            Requires.NotNull(configuredProject, nameof(configuredProject));
-            Requires.NotNull(projectTree, nameof(projectTree));
-            Requires.NotNull(target, nameof(target));
-
-            return TryMoveAsync(configuredProject, projectTree, target, MoveAction.Up);
+            return TryMove(project, projectTree, MoveAction.Above);
         }
 
         /// <summary>
@@ -101,7 +64,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         {
             Requires.NotNull(projectTree, nameof(projectTree));
 
-            return GetSiblingByMoveAction(projectTree, MoveAction.Down) != null;
+            return GetSiblingByMoveAction(projectTree, MoveAction.Below) != null;
         }
 
         /// <summary>
@@ -112,142 +75,94 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             Requires.NotNull(project, nameof(project));
             Requires.NotNull(projectTree, nameof(projectTree));
 
-            return TryMove(project, projectTree, MoveAction.Down);
+            return TryMove(project, projectTree, MoveAction.Below);
         }
 
         /// <summary>
-        /// Move the project tree down over one of its siblings.
+        /// Move the respective item elements above the target.
         /// </summary>
-        public static Task<bool> TryMoveDownAsync(ConfiguredProject configuredProject, IProjectTree projectTree)
+        public static bool TryMoveElementsAbove(Project project, ImmutableArray<ProjectItemElement> elements, IProjectTree target)
         {
-            Requires.NotNull(configuredProject, nameof(configuredProject));
-            Requires.NotNull(projectTree, nameof(projectTree));
-
-            return TryMoveAsync(configuredProject, projectTree, MoveAction.Down);
+            var referenceElement = GetReferenceElement(project, target, MoveAction.Above);
+            return TryMoveElements(elements, referenceElement, MoveAction.Above);
         }
 
         /// <summary>
-        /// Move a project tree below the target project tree.
+        /// Move the respective item elements below the target.
         /// </summary>
-        public static bool TryMoveBelow(Project project, IProjectTree projectTree, IProjectTree target)
+        public static bool TryMoveElementsBelow(Project project, ImmutableArray<ProjectItemElement> elements, IProjectTree target)
         {
-            Requires.NotNull(project, nameof(project));
-            Requires.NotNull(projectTree, nameof(projectTree));
-            Requires.NotNull(target, nameof(target));
-
-            return TryMove(project, projectTree, target, MoveAction.Down);
+            var referenceElement = GetReferenceElement(project, target, MoveAction.Below);
+            return TryMoveElements(elements, referenceElement, MoveAction.Below);
         }
 
         /// <summary>
-        /// Move a project tree below the project tree.
+        /// Move the respective item elements to the top of the target's children.
         /// </summary>
-        public static Task<bool> TryMoveBelowAsync(ConfiguredProject configuredProject, IProjectTree projectTree, IProjectTree target)
+        public static bool TryMoveElementsToTop(Project project, ImmutableArray<ProjectItemElement> elements, IProjectTree target)
         {
-            Requires.NotNull(configuredProject, nameof(configuredProject));
-            Requires.NotNull(projectTree, nameof(projectTree));
-            Requires.NotNull(target, nameof(target));
-
-            return TryMoveAsync(configuredProject, projectTree, target, MoveAction.Down);
-        }
-
-        /// <summary>
-        /// Gets the last child of a project tree.
-        /// The child will have a valid display order.
-        /// Returns null if there are no children, or no children with a valid display order.
-        /// </summary>
-        public static IProjectTree GetLastChild(IProjectTree projectTree)
-        {
-            Requires.NotNull(projectTree, nameof(projectTree));
-
-            return GetChildren(projectTree).LastOrDefault();
-        }
-
-        /// <summary>
-        /// Gets the first child of a project tree.
-        /// The child will have a valid display order.
-        /// Returns null if there are no children, or no children with a valid display order.
-        /// </summary>
-        public static IProjectTree GetFirstChild(IProjectTree projectTree)
-        {
-            Requires.NotNull(projectTree, nameof(projectTree));
-
-            return GetChildren(projectTree).FirstOrDefault();
-        }
-
-        /// <summary>
-        /// Get the difference to see what was added.
-        /// We do a sanity check to make sure they have a valid display order.
-        /// We also order the added nodes by their display order.
-        /// </summary>
-        public static ImmutableArray<IProjectTree> GetAddedNodes(IProjectTree previousTarget, IProjectTree currentTarget)
-        {
-            Requires.NotNull(previousTarget, nameof(previousTarget));
-            Requires.NotNull(currentTarget, nameof(currentTarget));
-
-            return currentTarget.Children
-                .Where(updatedChild => IsAddedNode(previousTarget, updatedChild))
-                .OrderBy(GetDisplayOrder)
-                .ToImmutableArray();
-        }
-
-        /// <summary>
-        /// This moves the nodes above the target's first child. 
-        /// If there are no children with a valid display order of the target or the target is an empty folder, it will try the parent target's first child.
-        /// </summary>
-        public static bool TryMoveNodesToTop(Project project, IEnumerable<IProjectTree> nodes, IProjectTree target)
-        {
-            Requires.NotNull(project, nameof(project));
-            Requires.NotNull(nodes, nameof(nodes));
-            Requires.NotNull(target, nameof(target));
-
-            // Move added nodes to the top. 
-            var nodeToAddAbove = GetFirstChild(target);
-
-            // This could have been an empty folder and nodeToAddAbove is null, therefore
-            //     get the first child of the target's parent.
-            // Empty folders do not have a valid display order.
-            // In the future, if we want to order empty folders, meaning they have a valid display order, 
-            //     this will need to be extended to handle that behavior.
-
-            // This recursively tries to find a node to work with. If there is none at all, this will break on project root.
-            var currentTarget = target;
-            while(nodeToAddAbove == null && currentTarget.IsFolder && !GetChildren(currentTarget).Any())
+            var targetChild = GetChildren(target).FirstOrDefault();
+            if (targetChild == null)
             {
-                currentTarget = currentTarget.Parent;
-                nodeToAddAbove = GetFirstChild(currentTarget);
-            }
-
-            if (nodeToAddAbove != null && nodes.Any())
-            {
-                var didAllMoveSuccessfully = true;
-
-                foreach (var node in nodes)
+                targetChild = GetChildren(target.Parent).FirstOrDefault();
+                if (targetChild == null)
                 {
-                    if (!TryMoveAbove(project, node, nodeToAddAbove))
-                    {
-                        didAllMoveSuccessfully = false;
-                    }
+                    return false;
                 }
-
-                return didAllMoveSuccessfully;
             }
 
-            return false;
+            var referenceElement = GetReferenceElement(project, targetChild, MoveAction.Above);
+            return TryMoveElements(elements, referenceElement, MoveAction.Above);
         }
 
         /// <summary>
-        /// This moves the nodes above the target's first child. 
-        /// If there are no children with a valid display order of the target or the target is an empty folder, it will try the parent target's first child.
+        /// Get project item elements based on the project tree.
+        /// Project tree can be a folder or item.
         /// </summary>
-        public static Task<bool> TryMoveNodesToTopAsync(ConfiguredProject configuredProject, IEnumerable<IProjectTree> nodes, IProjectTree target)
+        public static ImmutableArray<ProjectItemElement> GetElements(Project project, IProjectTree projectTree)
         {
-            return ModifyProjectAsync(configuredProject, project => TryMoveNodesToTop(project, nodes, target));
+            var includes = GetEvaluatedIncludes(projectTree);
+
+            var elements = new List<ProjectItemElement>();
+
+            foreach (var include in includes)
+            {
+                // GetItemsByEvaluatedInclude is efficient and uses a MultiDictionary underneath.
+                //     It uses this: new MultiDictionary<string, ProjectItem>(StringComparer.OrdinalIgnoreCase);
+                var item = project.GetItemsByEvaluatedInclude(include).FirstOrDefault();
+
+                // We only care about adding one item associated with the evaluated include.
+                if (item?.Xml is ProjectItemElement element)
+                {
+                    elements.Add(element);
+                }
+            }
+
+            return elements.ToImmutableArray();
+        }
+
+        /// <summary>
+        /// If the project gets any additional items from the callback, this will return those added items.
+        /// </summary>
+        public static async Task<ImmutableArray<ProjectItemElement>> AddItems(ConfiguredProject configuredProject, IProjectLockService projectLockService, Func<Task> addItems)
+        {
+            var accessor = new ProjectAccessor(projectLockService);
+
+            var previousIncludes = await accessor.OpenProjectForReadAsync(configuredProject, project =>
+            {
+                return project.AllEvaluatedItems.Select(x => x.EvaluatedInclude).ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
+            }).ConfigureAwait(true);
+
+            await addItems().ConfigureAwait(true);
+
+            return 
+                await accessor.OpenProjectForReadAsync(configuredProject, project => GetAddedElements(previousIncludes, project)).ConfigureAwait(true);
         }
 
         /// <summary>
         /// Determines if we are moving up or down files or folders.
         /// </summary>
-        private enum MoveAction { Up = 0, Down = 1 }
+        private enum MoveAction { Above = 0, Below = 1 }
 
         /// <summary>
         /// Gets a read-only collection with the evaluated includes associated with a project tree.
@@ -291,48 +206,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         }
 
         /// <summary>
-        /// Get project item elements based on the project tree.
-        /// Project tree can be a folder or item.
-        /// </summary>
-        private static ReadOnlyCollection<ProjectItemElement> GetElements(Project project, IProjectTree projectTree)
-        {
-            var includes = GetEvaluatedIncludes(projectTree);
-
-            var elements = new List<ProjectItemElement>();
-
-            foreach (var include in includes)
-            {
-                // GetItemsByEvaluatedInclude is efficient and uses a MultiDictionary underneath.
-                //     It uses this: new MultiDictionary<string, ProjectItem>(StringComparer.OrdinalIgnoreCase);
-                var item = project.GetItemsByEvaluatedInclude(include).FirstOrDefault();
-
-                // We only care about adding one item associated with the evaluated include.
-                if (item?.Xml is ProjectItemElement element)
-                {
-                    elements.Add(element);
-                }
-            }
-
-            return elements.AsReadOnly();
-        }
-
-        /// <summary>
         /// Checks to see if the display order is valid.
         /// </summary>
         private static bool IsValidDisplayOrder(int displayOrder)
         {
             return displayOrder > 0 && displayOrder != int.MaxValue;
-        }
-
-        /// <summary>
-        /// Checks to see if the target child is a node that was added based on the target tree.
-        /// </summary>
-        private static bool IsAddedNode(IProjectTree target, IProjectTree targetChild)
-        {
-            var hasChild = target.TryFind(targetChild.Identity, out var child);
-            var hasValidTargetChild = HasValidDisplayOrder(targetChild);
-
-            return (!hasChild || (hasChild && !HasValidDisplayOrder(child))) && hasValidTargetChild;
         }
 
         /// <summary>
@@ -412,10 +290,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         {
             switch (moveAction)
             {
-                case MoveAction.Up:
+                case MoveAction.Above:
                     return GetPreviousSibling(projectTree);
 
-                case MoveAction.Down:
+                case MoveAction.Below:
                     return GetNextSibling(projectTree);
             }
 
@@ -430,10 +308,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         {
             switch (moveAction)
             {
-                case MoveAction.Up:
+                case MoveAction.Above:
                     return GetElements(project, projectTree).FirstOrDefault();
 
-                case MoveAction.Down:
+                case MoveAction.Below:
                     return GetElements(project, projectTree).LastOrDefault();
             }
 
@@ -444,7 +322,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// Moves child elements based on the reference element and move action.
         /// </summary>
         /// <param name="referenceElement">element for which moved items will be above or below it</param>
-        private static bool TryMoveElements(ReadOnlyCollection<ProjectItemElement> elements, ProjectItemElement referenceElement, MoveAction moveAction)
+        private static bool TryMoveElements(ImmutableArray<ProjectItemElement> elements, ProjectItemElement referenceElement, MoveAction moveAction)
         {
             var parent = referenceElement.Parent;
             if (parent == null || !elements.Any())
@@ -453,11 +331,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             }
 
             // Sanity check
-            var atLeastOneElementMoved = false;
+            var didAllElementsMove = true;
 
             switch (moveAction)
             {
-                case MoveAction.Up:
+                case MoveAction.Above:
                     foreach (var element in elements)
                     {
                         var elementParent = element.Parent;
@@ -465,15 +343,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
                         {
                             elementParent.RemoveChild(element);
                             parent.InsertBeforeChild(element, referenceElement);
-                            atLeastOneElementMoved = true;
+                        }
+                        else
+                        {
+                            didAllElementsMove = false;
                         }
                     }
                     break;
 
-                case MoveAction.Down:
+                case MoveAction.Below:
                     // Iterate in reverse order when we are wanting to move elements down.
                     // If we didn't do this, the end result would be the moved elements are reversed.
-                    for (var i = elements.Count - 1; i >= 0; --i)
+                    for (var i = elements.Length - 1; i >= 0; --i)
                     {
                         var element = elements[i];
 
@@ -482,13 +363,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
                         {
                             elementParent.RemoveChild(element);
                             parent.InsertAfterChild(element, referenceElement);
-                            atLeastOneElementMoved = true;
+                        }
+                        else
+                        {
+                            didAllElementsMove = false;
                         }
                     }
                     break;
             }
 
-            return atLeastOneElementMoved;
+            return didAllElementsMove;
         }
 
         /// <summary>
@@ -534,40 +418,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         }
 
         /// <summary>
-        /// Call to get a callback that allows modifying the project.
+        /// Gets the difference between the previous evaluated includes and the project's evaluated includes to find what items were added.
         /// </summary>
-        private static async Task<bool> ModifyProjectAsync(ConfiguredProject configuredProject, Func<Project, bool> modify)
+        private static ImmutableArray<ProjectItemElement> GetAddedElements(ImmutableHashSet<string> previousIncludes, Project project)
         {
-            var projectLockService = configuredProject.UnconfiguredProject.ProjectService.Services.ProjectLockService;
-
-            // Do a write lock.
-            using (var writeLock = await projectLockService.WriteLockAsync())
-            {
-                // Grab the project.
-                var project = await writeLock.GetProjectAsync(configuredProject).ConfigureAwait(true);
-
-                // We must perform a checkout of the project file before we can modify it.
-                await writeLock.CheckoutAsync(project.FullPath).ConfigureAwait(true);
-
-                return modify(project);
-            }
-        }
-
-        /// <summary>
-        /// Move project elements based on the given project tree and move action. 
-        /// </summary>
-        private static Task<bool> TryMoveAsync(ConfiguredProject configuredProject, IProjectTree projectTree, MoveAction moveAction)
-        {
-            return ModifyProjectAsync(configuredProject, project => TryMove(project, projectTree, moveAction));
-        }
-
-
-        /// <summary>
-        /// Move project elements based on the given project tree and move action. 
-        /// </summary>
-        private static Task<bool> TryMoveAsync(ConfiguredProject configuredProject, IProjectTree projectTree, IProjectTree referenceProjectTree, MoveAction moveAction)
-        {
-            return ModifyProjectAsync(configuredProject, project => TryMove(project, projectTree, referenceProjectTree, moveAction));
+            return project.AllEvaluatedItems
+                .Where(x => !previousIncludes.Contains(x.EvaluatedInclude))
+                .Select(x => x.Xml)
+                .ToImmutableArray();
         }
     }
 }


### PR DESCRIPTION
**Customer scenario**

When a user pastes or drop items into a project or folder, those items need to move to the top.

**Bugs this fixes:** 

(na)

**Workarounds, if any**

Manually edit proj files.

**Risk**

Low to Mild. Changes how ordering is done for most commands.

**Performance impact**

Low

**Is this a regression from a previous update?** No


--

This is highly work in progress right now. There is much work to be done here.
