### PR TITLE
Fix up to date check of imports

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -84,6 +84,7 @@
     <StringProperty Name="ProjectDir" Visible="false"/>
     <StringProperty Name="MSBuildProjectDirectory" Visible="false"/>
     <StringProperty Name="MSBuildProjectFullPath" Visible="false" />
+    <StringProperty Name="MSBuildAllProjects" Visible="false" />
     <StringProperty Name="DefaultPlatform" Visible="false" />
     <StringProperty Name="PackageAction" Visible="false" Description="The MSBuild target to use when packaging a project." />
     <StringProperty Name="DefaultContentType" Visible="false" Description="The default content type name to use when adding files." />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -117,8 +117,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             _outputRelativeOrFullPath = e.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.OutputPathProperty, _outputRelativeOrFullPath);
 
             var allProjects = e.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildAllProjectsProperty, string.Empty)
-                .Split(';')
-                .Where(path => !string.IsNullOrWhiteSpace(path));
+                .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
             _imports.Clear();
             _imports.AddRange(allProjects);
 


### PR DESCRIPTION
**Customer scenario**

The up to date check for .NET Core projects is currently too aggressive -- we currently check the project against all imported target files. MSBuild, however, only checks the projects listed in $(MSBuildAllProjects). So you can get into a situation where a targets file has been touched and the project will never be considered up to date because the build won't regenerate the output (since MSBuild thinks it's up to date).

**Bugs this fixes:** 

#3273

**Workarounds, if any**

User would have to do a manual rebuild.

**Risk**

Low to moderate. This should be more precise, but it's possible there is some quirk about $(MSBuildAllProjects) that might cause the up to date behavior to be wrong.

**Performance impact**

Low, we'll be checking fewer targets files than before.

**Is this a regression from a previous update?**

No

**How was the bug found?**

Customer reported
