### PR TITLE
Remove unused export

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPropertyPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPropertyPage.cs
@@ -1,21 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 using System;
-using System.ComponentModel.Composition;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 {
-
-    [Export(typeof(IPageMetadata))]
-    internal partial class DebugPropertyPageMetaData : IPageMetadata
-    {
-        bool IPageMetadata.HasConfigurationCondition { get { return false; } }
-        string IPageMetadata.Name { get { return DebugPropertyPage.PageName; } }
-        Guid IPageMetadata.PageGuid { get { return typeof(DebugPropertyPage).GUID; } }
-        int IPageMetadata.PageOrder { get { return 30; } }
-    }
-
     [Guid("0273C280-1882-4ED0-9308-52914672E3AA")]
     [ExcludeFromCodeCoverage]
     internal partial class DebugPropertyPage : WpfBasedPropertyPage

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/IPageMetadata.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/IPageMetadata.cs
@@ -3,6 +3,7 @@ using System;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 {
+    [Obsolete("This interface will be removed in a future release.", true)]
     public interface IPageMetadata
     {
         bool HasConfigurationCondition { get; }


### PR DESCRIPTION
- Remove unused export
This was ported over when the debug property page was ported, but is not used anywhere in our tree or outside. Property pages are populated by IVsProjectDesignerPageProvider instances and not are imported.

- Obsolete unused public interface
This interface was ported when Debug property page was ported, and is a mirror of Microsoft.VisualStudio.ProjectSystem.VS.Properties.IPageMetadata. I believe it was added to make the ported code compile (the namespace changed between 14.0 -> 15.0), but is not used anywhere. Will remove in 15.8.