### PR TITLE
Remove tests/types to correct namespace

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/ActiveDebugFrameworkServicesTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/ActiveDebugFrameworkServicesTests.cs
@@ -9,7 +9,7 @@ using Moq;
 
 using Xunit;
 
-namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
+namespace Microsoft.VisualStudio.ProjectSystem.Input.Commands
 {
     [Trait("UnitTest", "ProjectSystem")]
     public class ActiveDebugFrameworkServicesTests

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Reload/ProjectReloadInterceptorTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Reload/ProjectReloadInterceptorTests.cs
@@ -9,7 +9,7 @@ using Microsoft.Build.Construction;
 
 using Xunit;
 
-namespace Microsoft.VisualStudio.ProjectSystem.VS
+namespace Microsoft.VisualStudio.ProjectSystem
 {
     [Trait("UnitTest", "ProjectSystem")]
     public class ProjectReloadInterceptorTests

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
@@ -11,13 +11,12 @@ using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
-using Microsoft.VisualStudio.ProjectSystem.VS.Debug;
 
 using Moq;
 
 using Xunit;
 
-namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 {
     [Trait("UnitTest", "ProjectSystem")]
     public class ConsoleDebugLaunchProviderTest

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/DebugProfileEnumValuesGeneratorTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/DebugProfileEnumValuesGeneratorTests.cs
@@ -4,14 +4,14 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
-
+using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 
 using Moq;
 
 using Xunit;
 
-namespace Microsoft.VisualStudio.ProjectSystem.Debug
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 {
     [Trait("UnitTest", "ProjectSystem")]
     public class DebugProfileEnumValuesGenerator_Tests

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/PropertyPageTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/PropertyPageTests.cs
@@ -3,14 +3,13 @@
 using System;
 
 using Microsoft.VisualStudio.OLE.Interop;
-using Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages;
 
 using Moq;
 using Moq.Protected;
 
 using Xunit;
 
-namespace Microsoft.VisualStudio.ProjectSystem.DotNet.Test.PropertyPages
+namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 {
     [Trait("UnitTest", "ProjectSystem")]
     public class PropertyPageTests

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileEnumValuesGenerator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileEnumValuesGenerator.cs
@@ -6,12 +6,13 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.Threading;
 
 using Task = System.Threading.Tasks.Task;
 
-namespace Microsoft.VisualStudio.ProjectSystem.Debug
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 {
     /// <summary>
     /// Provides the IEnumValue's for the ActiveDebugProfile property. This is what is used to drive


### PR DESCRIPTION
These tests live in VS assembly and hence namespace.