### PR TITLE
Add URL property to GeneralBrowseObject

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -100,6 +100,11 @@
             <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectDirectory" SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
     </StringProperty>
+    <StringProperty Name="URL" ReadOnly="True" Visible="False">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectFullPath" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
 
     <!-- Package properties -->
     <BoolProperty Name="GeneratePackageOnBuild" DisplayName="Generate Package On Build" Default="False" Visible="False"/>


### PR DESCRIPTION
**Customer scenario**

Add the URL property to GeneralBrowseObject. This is to support in-memory editor. XML language service queries this property to find the canonical name of the project.

**Bugs this fixes:** 

Not a bug fix.

**Workarounds, if any**

None

**Risk**

Low

**Performance impact**

None. Adds support for another property via already used method.

**Is this a regression from a previous update?**

No
