### PR TITLE
 Changing <TargetFrameworks> property causes us to grow our configured-project data flow subscriptions without unregistering

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -228,20 +228,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
                 foreach (var configuredProject in newProjectContext.InnerConfiguredProjects)
                 {
-                    if (_projectConfigurationsWithSubscriptions.Contains(configuredProject.ProjectConfiguration))
+                    if (_projectConfigurationsWithSubscriptions.Add(configuredProject.ProjectConfiguration))
                     {
-                        continue;
+                        _subscriptions.AddDisposable(configuredProject.Services.ProjectSubscription.JointRuleSource.SourceBlock.LinkTo(
+                            new ActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(e => OnProjectChangedCoreAsync(e, RuleHandlerType.DesignTimeBuild)),
+                            ruleNames: watchedDesignTimeBuildRules, suppressVersionOnlyUpdates: true));
+
+                        _subscriptions.AddDisposable(configuredProject.Services.ProjectSubscription.ProjectRuleSource.SourceBlock.LinkTo(
+                            new ActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(e => OnProjectChangedCoreAsync(e, RuleHandlerType.Evaluation)),
+                            ruleNames: watchedEvaluationRules, suppressVersionOnlyUpdates: true));
                     }
-
-                    _subscriptions.AddDisposable(configuredProject.Services.ProjectSubscription.JointRuleSource.SourceBlock.LinkTo(
-                        new ActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(e => OnProjectChangedCoreAsync(e, RuleHandlerType.DesignTimeBuild)),
-                        ruleNames: watchedDesignTimeBuildRules, suppressVersionOnlyUpdates: true));
-
-                    _subscriptions.AddDisposable(configuredProject.Services.ProjectSubscription.ProjectRuleSource.SourceBlock.LinkTo(
-                        new ActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(e => OnProjectChangedCoreAsync(e, RuleHandlerType.Evaluation)),
-                        ruleNames: watchedEvaluationRules, suppressVersionOnlyUpdates: true));
-
-                    _projectConfigurationsWithSubscriptions.Add(configuredProject.ProjectConfiguration);
                 }
 
                 return Task.CompletedTask;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -279,20 +279,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                  projectChange.Difference.ChangedProperties.Contains(ConfigurationGeneral.TargetFrameworksProperty);
         }
 
-        protected override async Task DisposeCoreAsync(bool initialized)
+        protected override Task DisposeCoreAsync(bool initialized)
         {
             if (initialized)
             {
                 DisposeAndClearSubscriptions();
 
-                await ExecuteWithinLockAsync(async () =>
+                return ExecuteWithinLockAsync(() =>
                 {
                     if (_currentAggregateProjectContext != null)
                     {
-                        await _contextProvider.Value.ReleaseProjectContextAsync(_currentAggregateProjectContext).ConfigureAwait(false);
+                        return _contextProvider.Value.ReleaseProjectContextAsync(_currentAggregateProjectContext);
                     }
-                }).ConfigureAwait(false);
+
+                    return Task.CompletedTask;
+                });
             }
+
+            return Task.CompletedTask;
         }
 
         private void DisposeAndClearSubscriptions()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         private readonly IActiveProjectConfigurationRefreshService _activeProjectConfigurationRefreshService;
         private readonly LanguageServiceHandlerManager _languageServiceHandlerManager;
         private readonly DisposableBag _subscriptions = new DisposableBag(CancellationToken.None);
-        private readonly HashSet<ProjectConfiguration> _projectConfigurationsWithSubscriptions;
+        private readonly HashSet<ProjectConfiguration> _projectConfigurationsWithSubscriptions = new HashSet<ProjectConfiguration>();
 
         /// <summary>
         /// Current AggregateWorkspaceProjectContext - accesses to this field must be done with a lock on <see cref="_gate"/>.
@@ -65,7 +65,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             _activeConfiguredProjectSubscriptionService = activeConfiguredProjectSubscriptionService;
             _activeProjectConfigurationRefreshService = activeProjectConfigurationRefreshService;
             _languageServiceHandlerManager = languageServiceHandlerManager;
-            _projectConfigurationsWithSubscriptions = new HashSet<ProjectConfiguration>();
         }
 
         public object HostSpecificErrorReporter => _currentAggregateProjectContext?.HostSpecificErrorReporter;


### PR DESCRIPTION
This includes https://github.com/dotnet/project-system/pull/3417 so only review https://github.com/dotnet/project-system/commit/fd6bd653123a111f8c44f6e655a84b371d381834.

Fixes: #1583