### PR TITLE
Adding telemetry to track when the language service is finished initializing

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/DesignTimeBuildTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/DesignTimeBuildTelemetryService.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Threading;
+
+namespace Microsoft.VisualStudio.Telemetry
+{
+    [Export(typeof(IDesignTimeBuildTelemetryService))]
+    internal class DesignTimeBuildTelemetryService : IDesignTimeBuildTelemetryService
+    {
+        private static volatile int s_numberOfProjectsInDesignTimeBuildQueue = 0;
+        private static volatile int s_numberOfProjectsInLanguageServiceQueue = 0;
+        private static readonly object s_seenProjectLock = new object();
+        private static List<string> s_seenProjects = new List<string>();
+
+        private readonly ITelemetryService _telemetryService;
+
+        [ImportingConstructor]
+        public DesignTimeBuildTelemetryService(ITelemetryService telemetryService)
+        {
+            _telemetryService = telemetryService;
+        }
+
+        /// <summary>
+        /// When a new project is created by the project system this method is called.
+        /// This indicates that a design-time build has been queued.
+        /// </summary>
+        public void OnDesignTimeBuildQueued()
+        {
+            if (Interlocked.Increment(ref s_numberOfProjectsInDesignTimeBuildQueue) == 1)
+            {
+                _telemetryService.PostEvent("Load/DesignTimeBuild/Start");
+            }
+        }
+
+        /// <summary>
+        /// A design-time build has completed.
+        /// </summary>
+        public void OnDesignTimeBuildCompleted(string fullPathToProject)
+        {
+            lock (s_seenProjectLock)
+            {
+                if (!s_seenProjects.Contains(fullPathToProject))
+                {
+                    s_numberOfProjectsInLanguageServiceQueue++;
+                    s_seenProjects.Add(fullPathToProject);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Project system has finished notifying the language service of the project items.
+        /// </summary>
+        public void OnLanguageServicePopulated()
+        {
+            var numberOfProjectsInLanguageServiceQueue = Interlocked.Decrement(ref s_numberOfProjectsInLanguageServiceQueue);
+
+            // Every design time build that has been queued has been handed off to the
+            // Language service.
+            if (s_seenProjects.Count == s_numberOfProjectsInDesignTimeBuildQueue &&
+                numberOfProjectsInLanguageServiceQueue == 0)
+            {
+                _telemetryService.PostEvent("Load/DesignTimeBuild/End");
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -102,9 +102,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             LogLanguageServiceHostInitializeStop();
         }
 
-        private static volatile bool s_isFirstStartEvent = true;
         private static volatile int s_numberOfTimesInitialized = 0;
-        private static object s_telemetryLock = new object();
 
         /// <summary>
         /// Only posts an event the first time this method is called in the VS process
@@ -112,19 +110,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         /// </summary>
         private void LogLanguageServiceHostInitializeStart()
         {
-            if (s_isFirstStartEvent)
+            if(Interlocked.Increment(ref s_numberOfTimesInitialized) == 1)
             {
-                lock (s_telemetryLock)
-                {
-                    if (s_isFirstStartEvent)
-                    {
-                        s_isFirstStartEvent = false;
-                        _telemetryService.PostEvent("LanguageServiceHost/Start");
-                    }
-                }
+                _telemetryService.PostEvent("AbstractProjectCreation/Start");
             }
-
-            Interlocked.Increment(ref s_numberOfTimesInitialized);
         }
 
         /// <summary>
@@ -133,10 +122,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         /// </summary>
         private void LogLanguageServiceHostInitializeStop()
         {
-            Interlocked.Decrement(ref s_numberOfTimesInitialized);
-            if (s_numberOfTimesInitialized == 0)
+            if (Interlocked.Decrement(ref s_numberOfTimesInitialized) == 0)
             {
-                _telemetryService.PostEvent("LanguageServiceHost/Stop");
+                _telemetryService.PostEvent("AbstractProjectCreation/Stop");
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/IDesignTimeBuildTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/IDesignTimeBuildTelemetryService.cs
@@ -1,0 +1,9 @@
+﻿namespace Microsoft.VisualStudio.Telemetry
+{
+    internal interface IDesignTimeBuildTelemetryService
+    {
+        void OnDesignTimeBuildQueued();
+        void OnDesignTimeBuildCompleted(string fullPathToProject);
+        void OnLanguageServicePopulated();
+    }
+}


### PR DESCRIPTION
simple change in order to track language service initialization
