### PR TITLE
[WIP] Language Service hookup rewrite

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ActiveIntellisenseProjectProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ActiveIntellisenseProjectProvider.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.TextManager.Interop;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
+{
+    [Export(typeof(IActiveIntellisenseProjectProvider))]
+    [ExportProjectNodeComService(typeof(IVsContainedLanguageProjectNameProvider))]
+    internal class ActiveIntellisenseProjectProvider : IActiveIntellisenseProjectProvider, IVsContainedLanguageProjectNameProvider
+    {
+        [ImportingConstructor]
+        public ActiveIntellisenseProjectProvider(UnconfiguredProject project)
+        {
+        }
+
+        public string ActiveIntellisenseProjectContext
+        {
+            get;
+            set;
+        }
+
+        public int GetProjectName(uint itemid, out string pbstrProjectName)
+        {
+            pbstrProjectName = ActiveIntellisenseProjectContext;
+            return HResult.OK;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/GlobalSuppressions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/GlobalSuppressions.cs
@@ -1,0 +1,9 @@
+﻿
+// This file is used by Code Analysis to maintain SuppressMessage 
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given 
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "<Pending>", Scope = "member", Target = "~F:Microsoft.VisualStudio.ProjectSystem.LanguageServices.WorkspaceContextHost.WorkspaceContextHostInstance._subscriptions")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2213:Disposable fields should be disposed", Justification = "<Pending>", Scope = "member", Target = "~F:Microsoft.VisualStudio.ProjectSystem.LanguageServices.WorkspaceContextHost.WorkspaceContextHostInstance._applyChangesToWorkspaceContext")]
+

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractImplicitlyActiveComponent.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractImplicitlyActiveComponent.cs
@@ -9,14 +9,14 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     /// <summary>
     ///     An <see langword="abstract"/> base class that loads, or unloads its inner instance when a 
-    ///     <see cref="ConfiguredProject"/> becomes implicitly activated, or deactivated, respectively.
+    ///     <see cref="ConfiguredProject"/> becomes implicitly activated, or deactivated.
     /// </summary>
     internal abstract class AbstractImplicitlyActiveComponent : AbstractProjectDynamicLoadComponent
     {
         private readonly IConfiguredProjectImplicitActivationTracking _activationTracking;
 
         protected AbstractImplicitlyActiveComponent(IConfiguredProjectImplicitActivationTracking activationTracking, 
-                                                 JoinableTaskContextNode joinableTaskContextNode)
+                                                    JoinableTaskContextNode joinableTaskContextNode)
             : base(joinableTaskContextNode)
         {
             Requires.NotNull(activationTracking, nameof(activationTracking));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractImplicitlyActiveComponent.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractImplicitlyActiveComponent.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    /// <summary>
+    ///     An <see langword="abstract"/> base class that loads, or unloads its inner instance when a 
+    ///     <see cref="ConfiguredProject"/> becomes implicitly activated, or deactivated, respectively.
+    /// </summary>
+    internal abstract class AbstractImplicitlyActiveComponent : AbstractProjectDynamicLoadComponent
+    {
+        private readonly IConfiguredProjectImplicitActivationTracking _activationTracking;
+
+        protected AbstractImplicitlyActiveComponent(IConfiguredProjectImplicitActivationTracking activationTracking, 
+                                                 JoinableTaskContextNode joinableTaskContextNode)
+            : base(joinableTaskContextNode)
+        {
+            Requires.NotNull(activationTracking, nameof(activationTracking));
+
+            _activationTracking = activationTracking;
+        }
+
+        protected override Task InitializeCoreAsync(CancellationToken cancellationToken)
+        {
+            _activationTracking.ImplicitlyActivated += OnImplicitlyActivated;
+            _activationTracking.ImplicitlyDeactivated += OnImplicitlyDeactivated;
+
+            if (_activationTracking.IsImplicitlyActive)
+                return LoadAsync();
+
+            return Task.CompletedTask;
+        }
+
+        private Task OnImplicitlyActivated(object sender, EventArgs args)
+        {
+            return LoadAsync();
+        }
+
+        private Task OnImplicitlyDeactivated(object sender, EventArgs args)
+        {
+            return UnloadAsync();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractImplicitlyActiveComponent.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractImplicitlyActiveComponent.cs
@@ -44,5 +44,13 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             return UnloadAsync();
         }
+
+        protected override Task DisposeCoreAsync(bool initialized)
+        {
+            _activationTracking.ImplicitlyActivated -= OnImplicitlyActivated;
+            _activationTracking.ImplicitlyDeactivated -= OnImplicitlyDeactivated;
+
+            return base.DisposeCoreAsync(initialized);
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.Collections.Generic;
-
+using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.Logging;
@@ -12,6 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     /// <summary>
     ///     Handles changes to the  &lt;AdditionalFiles/&gt; item during design-time builds.
     /// </summary>
+    [Export(typeof(IWorkspaceContextHandler))]
     internal class AdditionalFilesItemHandler : ICommandLineHandler
     {
         // WORKAROUND: To avoid Roslyn throwing when we add duplicate additonal files, we remember what 
@@ -19,15 +20,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         // See: https://github.com/dotnet/project-system/issues/2230
 
         private readonly UnconfiguredProject _project;
-        private readonly IWorkspaceProjectContext _context;
+        private IWorkspaceProjectContext _context;
         private readonly HashSet<string> _paths = new HashSet<string>(StringComparers.Paths);
+
+        [ImportingConstructor]
+        public AdditionalFilesItemHandler(UnconfiguredProject project)
+            : this(project, null)
+        {
+        }
 
         public AdditionalFilesItemHandler(UnconfiguredProject project, IWorkspaceProjectContext context)
         {
             Requires.NotNull(project, nameof(project));
-            Requires.NotNull(context, nameof(context));
-
+            
             _project = project;
+            _context = context;
+        }
+
+        public void Initialize(IWorkspaceProjectContext context)
+        {
             _context = context;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
@@ -12,6 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     /// <summary>
     ///     Handles changes to the  &lt;Analyzer/&gt; item during design-time builds.
     /// </summary>
+    [Export(typeof(IWorkspaceContextHandler))]
     internal class AnalyzerItemHandler : ICommandLineHandler
     {
         // WORKAROUND: To avoid Roslyn throwing when we add duplicate analyzers, we remember what 
@@ -19,15 +20,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
         // See: https://github.com/dotnet/project-system/issues/2230
         private readonly UnconfiguredProject _project;
-        private readonly IWorkspaceProjectContext _context;
+        private IWorkspaceProjectContext _context;
         private readonly HashSet<string> _paths = new HashSet<string>(StringComparers.Paths);
+
+        [ImportingConstructor]
+        public AnalyzerItemHandler(UnconfiguredProject project)
+            : this(project, null)
+        {
+        }
 
         public AnalyzerItemHandler(UnconfiguredProject project, IWorkspaceProjectContext context)
         {
             Requires.NotNull(project, nameof(project));
-            Requires.NotNull(context, nameof(context));
 
             _project = project;
+            _context = context;
+        }
+
+        public void Initialize(IWorkspaceProjectContext context)
+        {
             _context = context;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.Collections.Generic;
-
+using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.Logging;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-
+using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.Logging;
@@ -13,6 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     /// <summary>
     ///     Handles changes to references that are passed to the compiler during design-time builds.
     /// </summary>
+    [Export(typeof(IWorkspaceContextHandler))]
     internal class MetadataReferenceItemHandler : ICommandLineHandler
     {
         // WORKAROUND: The language services through IWorkspaceProjectContext doesn't expect to see AddMetadataReference called more than
@@ -20,15 +21,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         // See: https://github.com/dotnet/project-system/issues/2230
 
         private readonly UnconfiguredProject _project;
-        private readonly IWorkspaceProjectContext _context;
+        private IWorkspaceProjectContext _context;
         private readonly Dictionary<string, MetadataReferenceProperties> _addedPathsWithMetadata = new Dictionary<string, MetadataReferenceProperties>(StringComparers.Paths);
+
+        [ImportingConstructor]
+        public MetadataReferenceItemHandler(UnconfiguredProject project)
+            : this(project, null)
+        {
+        }
 
         public MetadataReferenceItemHandler(UnconfiguredProject project, IWorkspaceProjectContext context)
         {
             Requires.NotNull(project, nameof(project));
-            Requires.NotNull(context, nameof(context));
 
             _project = project;
+            _context = context;
+        }
+
+        public void Initialize(IWorkspaceProjectContext context)
+        {
             _context = context;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
@@ -12,12 +12,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     /// </summary>
     internal class ProjectPropertiesItemHandler : IEvaluationHandler
     {
-        private readonly IWorkspaceProjectContext _context;
+        private IWorkspaceProjectContext _context;
 
         public ProjectPropertiesItemHandler(IWorkspaceProjectContext context)
         {
             Requires.NotNull(context, nameof(context));
 
+            _context = context;
+        }
+
+        public string EvaluationRule
+        {
+            get { return ConfigurationGeneral.SchemaName; }
+        }
+
+        public void Initialize(IWorkspaceProjectContext context)
+        {
             _context = context;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.ComponentModel.Composition;
 using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
@@ -14,18 +15,34 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     ///     Handles changes to sources files during project evaluations and sources files that are passed
     ///     to the compiler during design-time builds.
     /// </summary>
+    [Export(typeof(IWorkspaceContextHandler))]
     internal partial class SourceItemHandler : AbstractEvaluationCommandLineHandler, IEvaluationHandler, ICommandLineHandler
     {
         private readonly UnconfiguredProject _project;
-        private readonly IWorkspaceProjectContext _context;
+        private IWorkspaceProjectContext _context;
+
+        [ImportingConstructor]
+        public SourceItemHandler(UnconfiguredProject project)
+            : this(project, null)
+        {
+        }
 
         public SourceItemHandler(UnconfiguredProject project, IWorkspaceProjectContext context)
             : base(project)
         {
             Requires.NotNull(project, nameof(project));
-            Requires.NotNull(context, nameof(context));
 
             _project = project;
+            _context = context;
+        }
+
+        public string EvaluationRule
+        {
+            get { return Compile.SchemaName; }
+        }
+
+        public void Initialize(IWorkspaceProjectContext context)
+        {
             _context = context;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IWorkspaceContextHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IWorkspaceContextHandler.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
+{
+    /// <summary>
+    ///     Represents a marker interface for types that apply changes to <see cref="IWorkspaceProjectContext"/> instances.
+    /// </summary>
+    internal interface IWorkspaceContextHandler
+    {
+        /// <summary>
+        ///     Initializes the handler with the specified <see cref="IWorkspaceProjectContext"/>.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="context"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///     <see cref="Initialize(IWorkspaceProjectContext)"/> has already been called.
+        /// </exception>
+        void Initialize(IWorkspaceProjectContext context);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Rewrite/ApplyChangesToWorkspaceContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Rewrite/ApplyChangesToWorkspaceContext.cs
@@ -1,0 +1,169 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
+{
+    [Export(typeof(IApplyChangesToWorkspaceContext))]
+    internal class ApplyChangesToWorkspaceContext : OnceInitializedOnceDisposed, IApplyChangesToWorkspaceContext
+    {
+        private readonly ConfiguredProject _project;
+        private readonly ICommandLineParserService _commandLineParser;
+
+        private IWorkspaceProjectContext _context;
+        private ExportLifetimeContext<IWorkspaceContextHandler>[] _handlers;
+
+        [ImportingConstructor]
+        public ApplyChangesToWorkspaceContext(ConfiguredProject project, ICommandLineParserService commandLineParser)
+        {
+            _project = project;
+            _commandLineParser = commandLineParser;
+
+            HandlerFactories = new OrderPrecedenceExportFactoryCollection<IWorkspaceContextHandler>();
+        }
+
+        [ImportMany]
+        public OrderPrecedenceExportFactoryCollection<IWorkspaceContextHandler> HandlerFactories
+        {
+            get;
+        }
+
+        public void Initialize(IWorkspaceProjectContext context)
+        {
+            Requires.NotNull(context, nameof(context));
+
+            if (_context != null)
+                throw new InvalidOperationException();
+
+            _context = context;
+
+            EnsureInitialized();
+        }
+
+        public void ApplyDesignTime(IProjectVersionedValue<IProjectSubscriptionUpdate> update, bool isActiveContext)
+        {
+            Requires.NotNull(update, nameof(update));
+
+            if (!IsInitialized)
+                throw new InvalidOperationException();
+
+            Assumes.False(update.Value.ProjectChanges.Count == 0, "CPS should never send us an empty design-time build data.");
+
+            IComparable version = update.DataSourceVersions[ProjectDataSources.ConfiguredProjectVersion];
+
+            IProjectChangeDescription projectChange = update.Value.ProjectChanges[CompilerCommandLineArgs.SchemaName];
+
+            // If nothing changed (even another failed design-time build), don't do anything
+            if (projectChange.Difference.AnyChanges)
+            {
+                ProcessOptions(projectChange);
+                ProcessItems(version, projectChange, isActiveContext);
+                ProcessDesignTimeBuildFailure(projectChange);
+            }
+        }
+
+        public void ApplyEvaluation(IProjectVersionedValue<IProjectSubscriptionUpdate> update, bool isActiveContext)
+        {
+            Requires.NotNull(update, nameof(update));
+
+            if (!IsInitialized)
+                throw new InvalidOperationException();
+
+            Assumes.False(update.Value.ProjectChanges.Count == 0, "CPS should never send us an empty evaluation data.");
+
+            IComparable version = update.DataSourceVersions[ProjectDataSources.ConfiguredProjectVersion];
+
+            foreach (ExportLifetimeContext<IWorkspaceContextHandler> handler in _handlers)
+            {
+                if (handler.Value is IEvaluationHandler evaluationHandler)
+                {
+                    IProjectChangeDescription projectChange = update.Value.ProjectChanges[evaluationHandler.EvaluationRule];
+                    if (projectChange.Difference.AnyChanges)
+                    {
+                        evaluationHandler.Handle(version, projectChange, isActiveContext, null);
+                    }
+                }
+            }
+        }
+
+        public IEnumerable<string> GetEvaluationRules()
+        {
+            return _handlers.Select(e => e.Value)
+                            .OfType<IEvaluationHandler>()
+                            .Select(e => e.EvaluationRule)
+                            .Distinct(StringComparers.RuleNames);
+        }
+
+        public IEnumerable<string> GetDesignTimeRules()
+        {
+            return new string[] { CompilerCommandLineArgs.SchemaName };
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            foreach (ExportLifetimeContext<IWorkspaceContextHandler> handler in _handlers)
+            {
+                handler.Dispose();
+            }
+
+            _context = null;
+            _handlers = null;
+        }
+
+        protected override void Initialize()
+        {
+            _handlers = HandlerFactories.Select(h => h.CreateExport())
+                                        .ToArray();
+
+            foreach (ExportLifetimeContext<IWorkspaceContextHandler> handler in _handlers)
+            {
+                handler.Value.Initialize(_context);
+            }
+
+            // By default, set "LastDesignTimeBuildSucceeded = false" to turn off diagnostics until first design time build succeeds for this project.
+            _context.LastDesignTimeBuildSucceeded = false;
+        }
+
+        private void ProcessDesignTimeBuildFailure(IProjectChangeDescription projectChange)
+        {
+            // If 'CompileDesignTime' didn't run due to a preceeding failed target, or a failure in itself, CPS will send us an empty IProjectChangeDescription
+            // that represents as if 'CompileDesignTime' ran but returned zero results.
+            //
+            // We still forward those 'removes' of references, sources, etc onto Roslyn to avoid duplicate/incorrect results when the next
+            // successful build occurs, because it will be diff between it and this failed build.
+            bool succeeded = projectChange.After.Items.Count > 0;
+
+            if (_context.LastDesignTimeBuildSucceeded != succeeded)
+            {
+                _context.LastDesignTimeBuildSucceeded = succeeded;
+            }
+        }
+
+        private void ProcessOptions(IProjectChangeDescription projectChange)
+        {
+            // We don't pass differences to Roslyn for options, we just pass them all
+            string commandlineArguments = string.Join(" ", projectChange.After.Items.Keys);
+
+            _context.SetOptions(commandlineArguments);
+        }
+
+        private void ProcessItems(IComparable version, IProjectChangeDescription projectChange, bool isActiveContext)
+        {
+            BuildOptions addedItems = _commandLineParser.Parse(projectChange.Difference.AddedItems);
+            BuildOptions removedItems = _commandLineParser.Parse(projectChange.Difference.RemovedItems);
+
+            foreach (ExportLifetimeContext<IWorkspaceContextHandler> handler in _handlers)
+            {
+                if (handler.Value is ICommandLineHandler commandLineHandler)
+                {
+                    commandLineHandler.Handle(version, addedItems, removedItems, isActiveContext, null);
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Rewrite/ApplyChangesToWorkspaceContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Rewrite/ApplyChangesToWorkspaceContext.cs
@@ -47,6 +47,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         public void ApplyDesignTime(IProjectVersionedValue<IProjectSubscriptionUpdate> update, bool isActiveContext)
         {
+            // TODO: Prevent overlap
+
             Requires.NotNull(update, nameof(update));
 
             if (!IsInitialized)
@@ -69,6 +71,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         public void ApplyEvaluation(IProjectVersionedValue<IProjectSubscriptionUpdate> update, bool isActiveContext)
         {
+            // TODO: Prevent overlap
+
             Requires.NotNull(update, nameof(update));
 
             if (!IsInitialized)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Rewrite/IApplyChangesToWorkspaceContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Rewrite/IApplyChangesToWorkspaceContext.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
+{
+    internal interface IApplyChangesToWorkspaceContext
+    {
+        IEnumerable<string> GetEvaluationRules();
+
+        IEnumerable<string> GetDesignTimeRules();
+
+        /// <summary>
+        ///     Initializes the service with the specified <see cref="IWorkspaceProjectContext"/>.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="context"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///     <see cref="Initialize(IWorkspaceProjectContext)"/> has already been called.
+        /// </exception>
+        void Initialize(IWorkspaceProjectContext context);
+
+        /// <summary>
+        ///     Applys evaluation changes to the underlying <see cref="IWorkspaceProjectContext"/>.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="update"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///     <see cref="Initialize(IWorkspaceProjectContext)"/> has not been called.
+        /// </exception>
+        void ApplyEvaluation(IProjectVersionedValue<IProjectSubscriptionUpdate> update, bool isActiveContext);
+
+        /// <summary>
+        ///     Applys evaluation changes to the underlying <see cref="IWorkspaceProjectContext"/>.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="update"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///     <see cref="Initialize(IWorkspaceProjectContext)"/> has not been called.
+        /// </exception>
+        void ApplyDesignTime(IProjectVersionedValue<IProjectSubscriptionUpdate> update, bool isActiveContext);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Rewrite/IEvaluationHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Rewrite/IEvaluationHandler.cs
@@ -10,8 +10,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     ///     Handles changes to a language service rule, and applies them to a
     ///     <see cref="IWorkspaceProjectContext"/> instance.
     /// </summary>
-    internal interface IEvaluationHandler
+    internal interface IEvaluationHandler : IWorkspaceContextHandler
     {
+        /// <summary>
+        ///     Gets the evaluation rule that the <see cref="IEvaluationHandler"/> handles.
+        /// </summary>
+        string EvaluationRule
+        {
+            get;
+        }
+
         /// <summary>
         ///     Handles the specified set of changes to a rule, and applies them
         ///     to the underlying <see cref="IWorkspaceProjectContext"/>.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Rewrite/WorkspaceContextHost.WorkspaceContextHostInstance.ProjectData.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Rewrite/WorkspaceContextHost.WorkspaceContextHostInstance.ProjectData.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.IO;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
+{
+    internal partial class WorkspaceContextHost
+    {
+        private partial class WorkspaceContextHostInstance
+        {
+            private struct ProjectData
+            {
+                public string LanguageName;
+                public string BinOutputPath;
+                public string ProjectFilePath;
+                public string DisplayName;
+
+                public static ProjectData FromSnapshot(ConfiguredProject project, IProjectRuleSnapshot snapshot)
+                {
+                    var data = new ProjectData();
+
+                    snapshot.Properties.TryGetValue(ConfigurationGeneral.LanguageServiceNameProperty, out data.LanguageName);
+                    snapshot.Properties.TryGetValue(ConfigurationGeneral.TargetPathProperty, out data.BinOutputPath);
+                    snapshot.Properties.TryGetValue(ConfigurationGeneral.MSBuildProjectFullPathProperty, out data.ProjectFilePath);
+
+                    data.DisplayName = GetDisplayName(data.ProjectFilePath, project.ProjectConfiguration);
+
+                    return data;
+                }
+
+                private static string GetDisplayName(string filePath, ProjectConfiguration projectConfiguration)
+                {
+                    string displayName = Path.GetFileNameWithoutExtension(filePath);
+
+                    // TODO: Multi-targeting
+                    return $"{displayName} ({projectConfiguration.Name})";
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Rewrite/WorkspaceContextHost.WorkspaceContextHostInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Rewrite/WorkspaceContextHost.WorkspaceContextHostInstance.cs
@@ -1,0 +1,162 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.Utilities;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
+{
+    partial class WorkspaceContextHost
+    {
+        private class WorkspaceContextHostInstance : AbstractProjectDynamicLoadInstance
+        {
+            private readonly ConfiguredProject _project;
+            private readonly IUnconfiguredProjectCommonServices _projectServices;
+            private readonly IProjectSubscriptionService _projectSubscriptionService;
+            private readonly ISafeProjectGuidService _projectGuidService;
+            private readonly Lazy<IWorkspaceProjectContextFactory> _workspaceProjectContextFactory;
+            private readonly ExportFactory<IApplyChangesToWorkspaceContext> _applyChangesToWorkspaceContextFactory;
+
+            private ExportLifetimeContext<IApplyChangesToWorkspaceContext> _applyChangesToWorkspaceContext;
+            private IWorkspaceProjectContext _context;
+            private DisposableBag _subscriptions = new DisposableBag(CancellationToken.None);
+
+            public WorkspaceContextHostInstance(ConfiguredProject project,
+                                                IUnconfiguredProjectCommonServices projectServices, 
+                                                IProjectSubscriptionService projectSubscriptionService, 
+                                                ISafeProjectGuidService projectGuidService,
+                                                Lazy<IWorkspaceProjectContextFactory> workspaceProjectContextFactory,
+                                                ExportFactory<IApplyChangesToWorkspaceContext> applyChangesToWorkspaceContextFactory)
+                : base(projectServices.ThreadingService.JoinableTaskContext)
+            {
+                _projectGuidService = projectGuidService;
+                _project = project;
+                _projectServices = projectServices;
+                _projectSubscriptionService = projectSubscriptionService;
+                _workspaceProjectContextFactory = workspaceProjectContextFactory;
+                _applyChangesToWorkspaceContextFactory = applyChangesToWorkspaceContextFactory;
+            }
+
+            protected override Task DisposeCoreAsync(bool initialized)
+            {
+                _subscriptions.Dispose();
+                _applyChangesToWorkspaceContext?.Dispose();
+                _context?.Dispose();
+
+                return Task.CompletedTask;
+            }
+
+            protected override Task InitializeCoreAsync(CancellationToken cancellationToken)
+            {
+                _subscriptions.AddDisposable(_projectSubscriptionService.ProjectRuleSource.SourceBlock.LinkTo(
+                    target: new ActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(OnProjectChangedAsync),
+                    ruleNames: ConfigurationGeneral.SchemaName,
+                    suppressVersionOnlyUpdates: true,
+                    linkOptions: new DataflowLinkOptions() { PropagateCompletion = true }));
+
+                return Task.CompletedTask;
+            }
+
+            internal async Task OnProjectChangedAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> e)
+            {
+                if (IsDisposing || IsDisposed)
+                    return;
+
+                var details = ProjectData.FromSnapshot(e.Value.CurrentState[ConfigurationGeneral.SchemaName]);
+
+                await InitializeProjectContext(details).ConfigureAwait(false);
+
+                // Was the project setup correctly?
+                if (_context == null)
+                    return;
+
+                _context.BinOutputPath = details.BinOutputPath;
+                _context.DisplayName = details.DisplayName;
+                _context.ProjectFilePath = details.ProjectFilePath;
+            }
+
+            private async Task InitializeProjectContext(ProjectData details)
+            {
+                if (_context == null)
+                {
+                    _context = await CreateProjectContextAsync(details).ConfigureAwait(false);
+
+                    if (_context == null)
+                        return;
+                    
+                    _applyChangesToWorkspaceContext = _applyChangesToWorkspaceContextFactory.CreateExport();
+                    _applyChangesToWorkspaceContext.Value.Initialize(_context);
+
+                    _subscriptions.AddDisposable(_project.Services.ProjectSubscription.JointRuleSource.SourceBlock.LinkTo(
+                        new ActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(e => OnDesignTimeChanges(e)),
+                         ruleNames: _applyChangesToWorkspaceContext.Value.GetDesignTimeRules(), suppressVersionOnlyUpdates: true));
+
+                    _subscriptions.AddDisposable(_project.Services.ProjectSubscription.ProjectRuleSource.SourceBlock.LinkTo(
+                        new ActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(e => OnEvaluationChanges(e)),
+                        ruleNames: _applyChangesToWorkspaceContext.Value.GetEvaluationRules(), suppressVersionOnlyUpdates: true));
+                }
+            }
+
+            private void OnDesignTimeChanges(IProjectVersionedValue<IProjectSubscriptionUpdate> e)
+            {
+                _applyChangesToWorkspaceContext.Value.ApplyDesignTime(e, true /* TODO: IsActiveContext */);
+            }
+
+            private void OnEvaluationChanges(IProjectVersionedValue<IProjectSubscriptionUpdate> e)
+            {
+                _applyChangesToWorkspaceContext.Value.ApplyEvaluation(e, true /* TODO: IsActiveContext */);
+            }
+
+            private async Task<IWorkspaceProjectContext> CreateProjectContextAsync(ProjectData details)
+            {
+                // Bail if our project doesn't have the right properties set
+                if (string.IsNullOrEmpty(details.LanguageName) || string.IsNullOrEmpty(details.BinOutputPath))
+                    return null;
+
+                Guid projectGuid = await _projectGuidService.GetProjectGuidAsync()
+                                                            .ConfigureAwait(false);
+
+                Assumes.False(projectGuid == Guid.Empty);
+                
+                // Fire up the Roslyn "project"
+                return _workspaceProjectContextFactory.Value.CreateProjectContext(details.LanguageName, details.DisplayName, details.ProjectFilePath, projectGuid, _projectServices.Project.Services.HostObject, details.BinOutputPath);
+            }
+
+            private struct ProjectData
+            {
+                public string LanguageName;
+                public string BinOutputPath;
+                public string DisplayName;
+                public string ProjectFilePath;
+
+                public static ProjectData FromSnapshot(IProjectRuleSnapshot snapshot)
+                {
+                    var data = new ProjectData();
+
+                    snapshot.Properties.TryGetValue(ConfigurationGeneral.LanguageServiceNameProperty, out data.LanguageName);
+                    snapshot.Properties.TryGetValue(ConfigurationGeneral.TargetPathProperty, out data.BinOutputPath);
+                    snapshot.Properties.TryGetValue(ConfigurationGeneral.MSBuildProjectFullPathProperty, out data.ProjectFilePath);
+
+                    data.DisplayName = GetDisplayName(data.ProjectFilePath);
+
+                    return data;
+                }
+
+                public static string GetDisplayName(string filePath)
+                {
+                    string displayName = Path.GetFileNameWithoutExtension(filePath);
+
+                    // TODO: Multi-targeting
+                    return displayName;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Rewrite/WorkspaceContextHost.WorkspaceContextHostInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Rewrite/WorkspaceContextHost.WorkspaceContextHostInstance.cs
@@ -2,46 +2,74 @@
 
 using System;
 using System.ComponentModel.Composition;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
-using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
-    partial class WorkspaceContextHost
+    internal partial class WorkspaceContextHost
     {
-        private class WorkspaceContextHostInstance : AbstractProjectDynamicLoadInstance
+        private partial class WorkspaceContextHostInstance : AbstractProjectDynamicLoadInstance
         {
             private readonly ConfiguredProject _project;
-            private readonly IUnconfiguredProjectCommonServices _projectServices;
             private readonly IProjectSubscriptionService _projectSubscriptionService;
-            private readonly ISafeProjectGuidService _projectGuidService;
-            private readonly Lazy<IWorkspaceProjectContextFactory> _workspaceProjectContextFactory;
+            private readonly Lazy<WorkspaceProjectContextCreator> _workspaceProjectContextCreator;
             private readonly ExportFactory<IApplyChangesToWorkspaceContext> _applyChangesToWorkspaceContextFactory;
+            private readonly DisposableBag _subscriptions = new DisposableBag(CancellationToken.None);
 
             private ExportLifetimeContext<IApplyChangesToWorkspaceContext> _applyChangesToWorkspaceContext;
             private IWorkspaceProjectContext _context;
-            private DisposableBag _subscriptions = new DisposableBag(CancellationToken.None);
+            
 
             public WorkspaceContextHostInstance(ConfiguredProject project,
-                                                IUnconfiguredProjectCommonServices projectServices, 
                                                 IProjectSubscriptionService projectSubscriptionService, 
-                                                ISafeProjectGuidService projectGuidService,
-                                                Lazy<IWorkspaceProjectContextFactory> workspaceProjectContextFactory,
+                                                IProjectThreadingService threadingService,
+                                                Lazy<WorkspaceProjectContextCreator> workspaceProjectContextCreator,
                                                 ExportFactory<IApplyChangesToWorkspaceContext> applyChangesToWorkspaceContextFactory)
-                : base(projectServices.ThreadingService.JoinableTaskContext)
+                : base(threadingService.JoinableTaskContext)
             {
-                _projectGuidService = projectGuidService;
                 _project = project;
-                _projectServices = projectServices;
                 _projectSubscriptionService = projectSubscriptionService;
-                _workspaceProjectContextFactory = workspaceProjectContextFactory;
+                _workspaceProjectContextCreator = workspaceProjectContextCreator;
                 _applyChangesToWorkspaceContextFactory = applyChangesToWorkspaceContextFactory;
+            }
+
+            internal async Task OnProjectChangedAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> e)
+            {
+                if (IsDisposing || IsDisposed)
+                    return;
+
+                var details = ProjectData.FromSnapshot(_project, e.Value.CurrentState[ConfigurationGeneral.SchemaName]);
+
+                await InitializeProjectContext(details).ConfigureAwait(true);
+
+                _context.BinOutputPath = details.BinOutputPath;
+                _context.DisplayName = details.DisplayName;
+                _context.ProjectFilePath = details.ProjectFilePath;
+            }
+
+            private async Task InitializeProjectContext(ProjectData details)
+            {
+                if (_context != null)
+                    return;
+
+                _context = await _workspaceProjectContextCreator.Value.CreateProjectContext(details.LanguageName, details.BinOutputPath, details.ProjectFilePath)
+                                                                      .ConfigureAwait(true);
+
+                _applyChangesToWorkspaceContext = _applyChangesToWorkspaceContextFactory.CreateExport();
+                _applyChangesToWorkspaceContext.Value.Initialize(_context);
+
+                _subscriptions.AddDisposable(_project.Services.ProjectSubscription.JointRuleSource.SourceBlock.LinkTo(
+                    new ActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(e => OnDesignTimeChanges(e)),
+                        ruleNames: _applyChangesToWorkspaceContext.Value.GetDesignTimeRules(), suppressVersionOnlyUpdates: true));
+
+                _subscriptions.AddDisposable(_project.Services.ProjectSubscription.ProjectRuleSource.SourceBlock.LinkTo(
+                    new ActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(e => OnEvaluationChanges(e)),
+                    ruleNames: _applyChangesToWorkspaceContext.Value.GetEvaluationRules(), suppressVersionOnlyUpdates: true));
             }
 
             protected override Task DisposeCoreAsync(bool initialized)
@@ -64,98 +92,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 return Task.CompletedTask;
             }
 
-            internal async Task OnProjectChangedAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> e)
+            private void OnDesignTimeChanges(IProjectVersionedValue<IProjectSubscriptionUpdate> e)
             {
+                // TODO: Race condition can be disposed after this
                 if (IsDisposing || IsDisposed)
                     return;
 
-                var details = ProjectData.FromSnapshot(e.Value.CurrentState[ConfigurationGeneral.SchemaName]);
-
-                await InitializeProjectContext(details).ConfigureAwait(false);
-
-                // Was the project setup correctly?
-                if (_context == null)
-                    return;
-
-                _context.BinOutputPath = details.BinOutputPath;
-                _context.DisplayName = details.DisplayName;
-                _context.ProjectFilePath = details.ProjectFilePath;
-            }
-
-            private async Task InitializeProjectContext(ProjectData details)
-            {
-                if (_context == null)
-                {
-                    _context = await CreateProjectContextAsync(details).ConfigureAwait(false);
-
-                    if (_context == null)
-                        return;
-                    
-                    _applyChangesToWorkspaceContext = _applyChangesToWorkspaceContextFactory.CreateExport();
-                    _applyChangesToWorkspaceContext.Value.Initialize(_context);
-
-                    _subscriptions.AddDisposable(_project.Services.ProjectSubscription.JointRuleSource.SourceBlock.LinkTo(
-                        new ActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(e => OnDesignTimeChanges(e)),
-                         ruleNames: _applyChangesToWorkspaceContext.Value.GetDesignTimeRules(), suppressVersionOnlyUpdates: true));
-
-                    _subscriptions.AddDisposable(_project.Services.ProjectSubscription.ProjectRuleSource.SourceBlock.LinkTo(
-                        new ActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(e => OnEvaluationChanges(e)),
-                        ruleNames: _applyChangesToWorkspaceContext.Value.GetEvaluationRules(), suppressVersionOnlyUpdates: true));
-                }
-            }
-
-            private void OnDesignTimeChanges(IProjectVersionedValue<IProjectSubscriptionUpdate> e)
-            {
                 _applyChangesToWorkspaceContext.Value.ApplyDesignTime(e, true /* TODO: IsActiveContext */);
             }
 
             private void OnEvaluationChanges(IProjectVersionedValue<IProjectSubscriptionUpdate> e)
             {
+                // TODO: Race condition can be disposed after this
+                if (IsDisposing || IsDisposed)
+                    return;
+
                 _applyChangesToWorkspaceContext.Value.ApplyEvaluation(e, true /* TODO: IsActiveContext */);
-            }
-
-            private async Task<IWorkspaceProjectContext> CreateProjectContextAsync(ProjectData details)
-            {
-                // Bail if our project doesn't have the right properties set
-                if (string.IsNullOrEmpty(details.LanguageName) || string.IsNullOrEmpty(details.BinOutputPath))
-                    return null;
-
-                Guid projectGuid = await _projectGuidService.GetProjectGuidAsync()
-                                                            .ConfigureAwait(false);
-
-                Assumes.False(projectGuid == Guid.Empty);
-                
-                // Fire up the Roslyn "project"
-                return _workspaceProjectContextFactory.Value.CreateProjectContext(details.LanguageName, details.DisplayName, details.ProjectFilePath, projectGuid, _projectServices.Project.Services.HostObject, details.BinOutputPath);
-            }
-
-            private struct ProjectData
-            {
-                public string LanguageName;
-                public string BinOutputPath;
-                public string DisplayName;
-                public string ProjectFilePath;
-
-                public static ProjectData FromSnapshot(IProjectRuleSnapshot snapshot)
-                {
-                    var data = new ProjectData();
-
-                    snapshot.Properties.TryGetValue(ConfigurationGeneral.LanguageServiceNameProperty, out data.LanguageName);
-                    snapshot.Properties.TryGetValue(ConfigurationGeneral.TargetPathProperty, out data.BinOutputPath);
-                    snapshot.Properties.TryGetValue(ConfigurationGeneral.MSBuildProjectFullPathProperty, out data.ProjectFilePath);
-
-                    data.DisplayName = GetDisplayName(data.ProjectFilePath);
-
-                    return data;
-                }
-
-                public static string GetDisplayName(string filePath)
-                {
-                    string displayName = Path.GetFileNameWithoutExtension(filePath);
-
-                    // TODO: Multi-targeting
-                    return displayName;
-                }
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Rewrite/WorkspaceContextHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Rewrite/WorkspaceContextHost.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
+{
+    /// <summary>
+    ///     Responsible for creating and pushing changes to an <see cref="IWorkspaceProjectContext"/> with 
+    ///     evaluation and design-time build results.
+    /// </summary>
+    internal partial class WorkspaceContextHost : AbstractImplicitlyActiveComponent
+    {
+        private readonly ConfiguredProject _project;
+        private readonly IUnconfiguredProjectCommonServices _projectServices;
+        private readonly IProjectSubscriptionService _projectSubscriptionService;
+        private readonly ISafeProjectGuidService _projectGuidService;
+        private readonly Lazy<IWorkspaceProjectContextFactory> _workspaceProjectContextFactory;
+        private readonly ExportFactory<IApplyChangesToWorkspaceContext> _applyChangesToWorkspaceContextFactory;
+
+        [ImportingConstructor]
+        public WorkspaceContextHost(ConfiguredProject project,
+                                    IUnconfiguredProjectCommonServices projectServices,
+                                    IProjectSubscriptionService projectSubscriptionService,
+                                    IConfiguredProjectImplicitActivationTracking activationTracking,
+                                    ISafeProjectGuidService projectGuidService,
+                                    Lazy<IWorkspaceProjectContextFactory> workspaceProjectContextFactory,
+                                    ExportFactory<IApplyChangesToWorkspaceContext> applyChangesToWorkspaceContextFactory)
+            : base(activationTracking, projectServices.ThreadingService.JoinableTaskContext)
+        {
+            _project = project;
+            _projectServices = projectServices;
+            _projectSubscriptionService = projectSubscriptionService;
+            _projectGuidService = projectGuidService;
+            _workspaceProjectContextFactory = workspaceProjectContextFactory;
+            _applyChangesToWorkspaceContextFactory = applyChangesToWorkspaceContextFactory;
+        }
+
+        [ConfiguredProjectAutoLoad]
+        [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharpLanguageService)]
+        public Task InitializeAsync()
+        {
+            return InitializeAsync(CancellationToken.None);
+        }
+
+        protected override AbstractProjectDynamicLoadInstance CreateInstance()
+        {
+            return new WorkspaceContextHostInstance(_project, _projectServices, _projectSubscriptionService, _projectGuidService, _workspaceProjectContextFactory, _applyChangesToWorkspaceContextFactory);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Rewrite/WorkspaceContextHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Rewrite/WorkspaceContextHost.cs
@@ -16,32 +16,30 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     internal partial class WorkspaceContextHost : AbstractImplicitlyActiveComponent
     {
         private readonly ConfiguredProject _project;
-        private readonly IUnconfiguredProjectCommonServices _projectServices;
+        private readonly IProjectThreadingService _threadingService;
         private readonly IProjectSubscriptionService _projectSubscriptionService;
-        private readonly ISafeProjectGuidService _projectGuidService;
-        private readonly Lazy<IWorkspaceProjectContextFactory> _workspaceProjectContextFactory;
+        private readonly Lazy<WorkspaceProjectContextCreator> _workspaceProjectContextCreator;
         private readonly ExportFactory<IApplyChangesToWorkspaceContext> _applyChangesToWorkspaceContextFactory;
 
         [ImportingConstructor]
         public WorkspaceContextHost(ConfiguredProject project,
                                     IUnconfiguredProjectCommonServices projectServices,
+                                    IProjectThreadingService threadingService,
                                     IProjectSubscriptionService projectSubscriptionService,
                                     IConfiguredProjectImplicitActivationTracking activationTracking,
-                                    ISafeProjectGuidService projectGuidService,
-                                    Lazy<IWorkspaceProjectContextFactory> workspaceProjectContextFactory,
+                                    Lazy<WorkspaceProjectContextCreator> workspaceProjectContextCreator,
                                     ExportFactory<IApplyChangesToWorkspaceContext> applyChangesToWorkspaceContextFactory)
             : base(activationTracking, projectServices.ThreadingService.JoinableTaskContext)
         {
             _project = project;
-            _projectServices = projectServices;
+            _threadingService = threadingService;
             _projectSubscriptionService = projectSubscriptionService;
-            _projectGuidService = projectGuidService;
-            _workspaceProjectContextFactory = workspaceProjectContextFactory;
+            _workspaceProjectContextCreator = workspaceProjectContextCreator;
             _applyChangesToWorkspaceContextFactory = applyChangesToWorkspaceContextFactory;
         }
 
         [ConfiguredProjectAutoLoad]
-        [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharpLanguageService)]
+        [AppliesTo(ProjectCapability.DotNetLanguageService)]
         public Task InitializeAsync()
         {
             return InitializeAsync(CancellationToken.None);
@@ -49,7 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         protected override AbstractProjectDynamicLoadInstance CreateInstance()
         {
-            return new WorkspaceContextHostInstance(_project, _projectServices, _projectSubscriptionService, _projectGuidService, _workspaceProjectContextFactory, _applyChangesToWorkspaceContextFactory);
+            return new WorkspaceContextHostInstance(_project, _projectSubscriptionService, _threadingService, _workspaceProjectContextCreator, _applyChangesToWorkspaceContextFactory);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Rewrite/WorkspaceProjectContextCreator.NullWorkspaceProjectContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Rewrite/WorkspaceProjectContextCreator.NullWorkspaceProjectContext.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
+{
+    internal partial class WorkspaceProjectContextCreator
+    {
+        private class NullWorkspaceProjectContext : IWorkspaceProjectContext
+        {
+            public static readonly IWorkspaceProjectContext Instance = new NullWorkspaceProjectContext();
+
+            public string DisplayName { get; set; }
+            public string ProjectFilePath { get; set; }
+            public Guid Guid { get; set; }
+            public bool LastDesignTimeBuildSucceeded { get; set; }
+            public string BinOutputPath { get; set; }
+
+            public void AddAdditionalFile(string filePath, bool isInCurrentContext = true)
+            {
+            }
+
+            public void AddAnalyzerReference(string referencePath)
+            {
+            }
+
+            public void AddMetadataReference(string referencePath, MetadataReferenceProperties properties)
+            {
+            }
+
+            public void AddProjectReference(IWorkspaceProjectContext project, MetadataReferenceProperties properties)
+            {
+            }
+
+            public void AddSourceFile(string filePath, bool isInCurrentContext = true, IEnumerable<string> folderNames = null, SourceCodeKind sourceCodeKind = SourceCodeKind.Regular)
+            {
+            }
+
+            public void Dispose()
+            {
+            }
+
+            public void RemoveAdditionalFile(string filePath)
+            {
+            }
+
+            public void RemoveAnalyzerReference(string referencePath)
+            {
+            }
+
+            public void RemoveMetadataReference(string referencePath)
+            {
+            }
+
+            public void RemoveProjectReference(IWorkspaceProjectContext project)
+            {
+            }
+
+            public void RemoveSourceFile(string filePath)
+            {
+            }
+
+            public void SetOptions(string commandLineForOptions)
+            {
+            }
+
+            public void SetRuleSetFile(string filePath)
+            {
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Rewrite/WorkspaceProjectContextCreator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Rewrite/WorkspaceProjectContextCreator.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
+{
+    /// <summary>
+    ///     Responsible for creating <see cref="IWorkspaceProjectContext"/> instances based on specified inputs.
+    /// </summary>
+    internal partial class WorkspaceProjectContextCreator
+    {
+        private readonly ConfiguredProject _project;
+        private readonly Lazy<IWorkspaceProjectContextFactory> _workspaceProjectContextFactory;
+        private readonly Lazy<ISafeProjectGuidService> _projectGuidService;
+        private readonly IUnconfiguredProjectCommonServices _projectServices;
+
+        [ImportingConstructor]
+        public WorkspaceProjectContextCreator(ConfiguredProject project,
+                                             Lazy<IWorkspaceProjectContextFactory> workspaceProjectContextFactory,
+                                             Lazy<ISafeProjectGuidService> projectGuidService,
+                                             IUnconfiguredProjectCommonServices projectServices)
+        {
+            _project = project;
+            _workspaceProjectContextFactory = workspaceProjectContextFactory;
+            _projectGuidService = projectGuidService;
+            _projectServices = projectServices;
+        }
+
+        public async Task<IWorkspaceProjectContext> CreateProjectContext(string languageName, string binOutputPath, string projectFilePath)
+        {
+            Requires.NotNullOrEmpty(projectFilePath, nameof(projectFilePath));
+
+            Guid projectGuid = await _projectGuidService.Value.GetProjectGuidAsync()
+                                                              .ConfigureAwait(true);
+
+            Assumes.False(projectGuid == Guid.Empty);
+
+            // If these properties (coming from MSBuild) are empty, return a "null" project context
+            if (string.IsNullOrEmpty(languageName) || string.IsNullOrEmpty(binOutputPath))
+                return NullWorkspaceProjectContext.Instance;
+
+            string workspaceProjectContextId = GetWorkspaceProjectContextId(projectFilePath, _project.ProjectConfiguration);
+            object hostObject = _projectServices.Project.Services.HostObject;
+
+            try
+            {
+                return _workspaceProjectContextFactory.Value.CreateProjectContext(languageName, workspaceProjectContextId, projectFilePath, projectGuid, hostObject, binOutputPath);
+            }
+            catch (Exception)
+            {   // TODO: Watson
+            }
+
+            return NullWorkspaceProjectContext.Instance;
+        }
+
+        private static string GetWorkspaceProjectContextId(string filePath, ProjectConfiguration projectConfiguration)
+        {
+            // WorkspaceContextId must be unique across the entire solution, therefore as we fire up a workspace context 
+            // per implicitly active config, we factor in both the full path of the project + the name of the config.
+            //
+            // NOTE: Roslyn also uses this name as the default "AssemblyName" until we explicitly set it, so we need to make 
+            // sure it doesn't contain any invalid path characters.
+            //
+            // For example:
+            //      C:\Project\Project.csproj (Debug_AnyCPU)
+            //      C:\Project\MultiTarget.csproj (Debug_AnyCPU_net45)
+
+            // TODO: filePath isn't stable
+            return $"{filePath} ({projectConfiguration.Name.Replace("|", "_")})";
+        }
+    }
+}


### PR DESCRIPTION
This is a rewrite of the language service hookup that moves from an all knowing single object `LanguageServiceHost` that is aware of all configurations and related IWorkspaceProjectContext, to instead individual configured-project-based services `WorkspaceContextHostInstance` that get fired up and torn down when a configuration becomes "implicitly" active. This naturally supports active config switches from debug -> release, and multi-targeting projects.

This also fixes: https://github.com/dotnet/project-system/issues/2733.

Currently this lives alongside the existing language service hookup, but is intended to replace it. 

Lots of TODOs:

- [ ] Feature flag to turn it on but turn off the other one
- [ ] Multi-targeting display names
- [ ] All IVsHierarchy interaction with Roslyn is through the "real" hierarchy and we handle any of the context properties
- [ ] "Active Context"
- [ ] All external iteration; Container Language, Error List, Edit & Continue, Code Model
- [ ] Need to push to UI thread
- [ ] Need to avoid overlapping evalution/design-time builds
- [ ] Prevent unloading project while updating context - but also bail early

