### PR TITLE
Bump the version in dev15.7.x branch

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VersionBase Condition="'$(UseVisualStudioVersion)' == 'true'">15.6.0</VersionBase>
-    <VersionBase Condition="'$(UseVisualStudioVersion)' != 'true'">2.6.0</VersionBase>
+    <VersionBase Condition="'$(UseVisualStudioVersion)' == 'true'">15.7.0</VersionBase>
+    <VersionBase Condition="'$(UseVisualStudioVersion)' != 'true'">2.7.0</VersionBase>
     <PreReleaseVersionLabel>beta4</PreReleaseVersionLabel>
 
     <!-- Opt-in repo features -->


### PR DESCRIPTION
This change should have been about revving the
`$(PreReleaseVersionLabel)` from `beta3` to `beta4`, but it turns out
that we haven't updated version numbers in a while. So instead
`$(PreReleaseVersionLabel)` is already at `beta4` and staying there,
while `$(VersionBase)` is being revved to 15.7.0/2.7.0.
