### PR TITLE
Added Paste Ordering

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelperTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelperTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Immutable;
 using Microsoft.Build.Evaluation;
 using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
 using Xunit;
@@ -372,7 +373,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 
             var project = new Project(projectRootElement);
 
-            var elements = OrderingHelper.GetElements(project, tree.Children[0]);
+            var elements = OrderingHelper.GetItemElements(project, tree.Children[0], ImmutableArray<string>.Empty);
 
             Assert.True(OrderingHelper.TryMoveElementsAbove(project, elements, tree.Children[2]));
             Assert.True(project.IsDirty);
@@ -420,7 +421,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 
             var project = new Project(projectRootElement);
 
-            var elements = OrderingHelper.GetElements(project, tree.Children[0]);
+            var elements = OrderingHelper.GetItemElements(project, tree.Children[0], ImmutableArray<string>.Empty);
 
             Assert.True(OrderingHelper.TryMoveElementsBelow(project, elements, tree.Children[2]));
             Assert.True(project.IsDirty);
@@ -477,7 +478,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 
             var project = new Project(projectRootElement);
 
-            var elements = OrderingHelper.GetElements(project, updatedTree.Children[2]);
+            var elements = OrderingHelper.GetItemElements(project, updatedTree.Children[2], ImmutableArray<string>.Empty);
 
             Assert.True(OrderingHelper.TryMoveElementsToTop(project, elements, tree), "TryMoveElementsToTop returned false.");
             Assert.True(project.IsDirty);
@@ -538,8 +539,8 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
             var project = new Project(projectRootElement);
 
             var elements = 
-                OrderingHelper.GetElements(project, updatedTree.Children[2])
-                .AddRange(OrderingHelper.GetElements(project, updatedTree.Children[3]));
+                OrderingHelper.GetItemElements(project, updatedTree.Children[2], ImmutableArray<string>.Empty)
+                .AddRange(OrderingHelper.GetItemElements(project, updatedTree.Children[3], ImmutableArray<string>.Empty));
 
             Assert.True(OrderingHelper.TryMoveElementsToTop(project, elements, tree), "TryMoveElementsToTop returned false.");
             Assert.True(project.IsDirty);
@@ -605,8 +606,8 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
             var project = new Project(projectRootElement);
 
             var elements =
-                OrderingHelper.GetElements(project, updatedTree.Children[2].Children[0].Children[0])
-                .AddRange(OrderingHelper.GetElements(project, updatedTree.Children[2].Children[0].Children[1]));
+                OrderingHelper.GetItemElements(project, updatedTree.Children[2].Children[0].Children[0], ImmutableArray<string>.Empty)
+                .AddRange(OrderingHelper.GetItemElements(project, updatedTree.Children[2].Children[0].Children[1], ImmutableArray<string>.Empty));
 
             Assert.True(OrderingHelper.TryMoveElementsToTop(project, elements, tree), "TryMoveElementsToTop returned false.");
             Assert.True(project.IsDirty);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AbstractAddItemCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AbstractAddItemCommand.cs
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             }
         }
 
-        protected virtual OrderAddItemHintReceiverAction Action => OrderAddItemHintReceiverAction.MoveToTop;
+        protected virtual OrderingMoveAction Action => OrderingMoveAction.MoveToTop;
 
         protected override async Task<bool> TryHandleCommandAsync(IProjectTree node, bool focused, long commandExecuteOptions, IntPtr variantArgIn, IntPtr variantArgOut)
         {
@@ -77,8 +77,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             IProjectTree target;
             switch (Action)
             {
-                case OrderAddItemHintReceiverAction.MoveAbove:
-                case OrderAddItemHintReceiverAction.MoveBelow:
+                case OrderingMoveAction.MoveAbove:
+                case OrderingMoveAction.MoveBelow:
                     target = node.Parent;
                     break;
                 default:

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemAboveCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemAboveCommand.cs
@@ -32,6 +32,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             return OrderingHelper.HasValidDisplayOrder(target);
         }
 
-        protected override OrderAddItemHintReceiverAction Action => OrderAddItemHintReceiverAction.MoveAbove;
+        protected override OrderingMoveAction Action => OrderingMoveAction.MoveAbove;
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemBelowCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemBelowCommand.cs
@@ -32,6 +32,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             return OrderingHelper.HasValidDisplayOrder(target);
         }
 
-        protected override OrderAddItemHintReceiverAction Action => OrderAddItemHintReceiverAction.MoveBelow;
+        protected override OrderingMoveAction Action => OrderingMoveAction.MoveBelow;
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemAboveCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemAboveCommand.cs
@@ -32,6 +32,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             return OrderingHelper.HasValidDisplayOrder(target);
         }
 
-        protected override OrderAddItemHintReceiverAction Action => OrderAddItemHintReceiverAction.MoveAbove;
+        protected override OrderingMoveAction Action => OrderingMoveAction.MoveAbove;
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemBelowCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemBelowCommand.cs
@@ -32,6 +32,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             return OrderingHelper.HasValidDisplayOrder(target);
         }
 
-        protected override OrderAddItemHintReceiverAction Action => OrderAddItemHintReceiverAction.MoveBelow;
+        protected override OrderingMoveAction Action => OrderingMoveAction.MoveBelow;
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             {
                 // We do a sanity re-evaluation to absolutely ensure changes were met.
                 project.ReevaluateIfNecessary();
-                var addedElements = GetAddedElements(previousIncludes, project);
+                var addedElements = GetAddedItemElements(previousIncludes, project);
 
                 switch (action)
                 {
@@ -131,7 +131,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             Requires.NotNull(project, nameof(project));
             Requires.NotNull(target, nameof(target));
 
-            var referenceElement = GetReferenceElement(project, target, MoveAction.Above);
+            var referenceElement = TryGetReferenceElement(project, target, ImmutableArray<string>.Empty, MoveAction.Above);
             return TryMoveElements(elements, referenceElement, MoveAction.Above);
         }
 
@@ -143,7 +143,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             Requires.NotNull(project, nameof(project));
             Requires.NotNull(target, nameof(target));
 
-            var referenceElement = GetReferenceElement(project, target, MoveAction.Below);
+            var referenceElement = TryGetReferenceElement(project, target, ImmutableArray<string>.Empty, MoveAction.Below);
             return TryMoveElements(elements, referenceElement, MoveAction.Below);
         }
 
@@ -176,7 +176,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
                 return false;
             }
 
-            var referenceElement = GetReferenceElement(project, targetChild, MoveAction.Above);
+            // Make sure we exclude the moving elements when trying to find a reference element; this prevents us from choosing a reference element that is part of the moving elements.
+            var referenceElement = TryGetReferenceElement(project, targetChild, elements.Select(x => x.Include).ToImmutableArray(), MoveAction.Above);
+
+            // If we couldn't find a reference element, we can't move the elements and we don't need to.
+            if (referenceElement == null)
+            {
+                return false;
+            }
+
             return TryMoveElements(elements, referenceElement, MoveAction.Above);
         }
 
@@ -184,13 +192,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// Get project item elements based on the project tree.
         /// Project tree can be a folder or item.
         /// </summary>
-        public static ImmutableArray<ProjectItemElement> GetElements(Project project, IProjectTree projectTree)
+        public static ImmutableArray<ProjectItemElement> GetItemElements(Project project, IProjectTree projectTree, ImmutableArray<string> excludeIncludes)
         {
             Requires.NotNull(project, nameof(project));
             Requires.NotNull(projectTree, nameof(projectTree));
 
-            var includes = GetEvaluatedIncludes(projectTree);
+            var includes = GetEvaluatedIncludes(projectTree).Except(excludeIncludes, StringComparer.OrdinalIgnoreCase).ToImmutableArray();
+            return GetItemElements(project, includes);
+        }
 
+        /// <summary>
+        /// Determines if we are moving up or down files or folders.
+        /// </summary>
+        private enum MoveAction { Above = 0, Below = 1 }
+
+        private static ImmutableArray<ProjectItemElement> GetItemElements(Project project, ImmutableArray<string> includes)
+        {
             var elements = ImmutableArray.CreateBuilder<ProjectItemElement>();
 
             foreach (var include in includes)
@@ -210,15 +227,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         }
 
         /// <summary>
-        /// Determines if we are moving up or down files or folders.
-        /// </summary>
-        private enum MoveAction { Above = 0, Below = 1 }
-
-        /// <summary>
         /// Gets a read-only collection with the evaluated includes associated with a project tree.
         /// Evaluated includes will be in order by their display order.
         /// </summary>
-        private static ImmutableArray<string> GetEvaluatedIncludes(IProjectTree projectTree)
+        private static IEnumerable<string> GetEvaluatedIncludes(IProjectTree projectTree)
         {
             var treeQueue = new Queue<IProjectTree>();
 
@@ -252,7 +264,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
                 }
             }
 
-            return includes.Select(x => x.Value).ToImmutableArray();
+            return includes.Select(x => x.Value);
         }
 
         /// <summary>
@@ -354,15 +366,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// Gets a reference element based on the given project tree and move action. Can return null.
         /// The reference element is the element for which moved items will be above or below it.
         /// </summary>
-        private static ProjectItemElement GetReferenceElement(Project project, IProjectTree projectTree, MoveAction moveAction)
+        private static ProjectItemElement TryGetReferenceElement(Project project, IProjectTree projectTree, ImmutableArray<string> excludeIncludes, MoveAction moveAction)
         {
             switch (moveAction)
             {
                 case MoveAction.Above:
-                    return GetElements(project, projectTree).FirstOrDefault();
+                    return GetItemElements(project, projectTree, excludeIncludes).FirstOrDefault();
 
                 case MoveAction.Below:
-                    return GetElements(project, projectTree).LastOrDefault();
+                    return GetItemElements(project, projectTree, excludeIncludes).LastOrDefault();
             }
 
             return null;
@@ -375,6 +387,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// <returns>true or false; 'true' if all elements were successfully moved. 'false' if just one element was not moved successfully.</returns>
         private static bool TryMoveElements(ImmutableArray<ProjectItemElement> elements, ProjectItemElement referenceElement, MoveAction moveAction)
         {
+            Requires.NotNull(referenceElement, nameof(referenceElement));
+
             var parent = referenceElement.Parent;
             if (parent == null || !elements.Any())
             {
@@ -445,11 +459,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             if (referenceProjectTree != null)
             {
                 // The reference element is the element for which moved items will be above or below it.
-                var referenceElement = GetReferenceElement(project, referenceProjectTree, moveAction);
+                var referenceElement = TryGetReferenceElement(project, referenceProjectTree, ImmutableArray<string>.Empty, moveAction);
 
                 if (referenceElement != null)
                 {
-                    var elements = GetElements(project, projectTree);
+                    var elements = GetItemElements(project, projectTree, ImmutableArray<string>.Empty);
                     return TryMoveElements(elements, referenceElement, moveAction);
                 }
             }
@@ -468,7 +482,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             return TryMove(project, projectTree, sibling, moveAction);
         }
 
-        private static ImmutableArray<ProjectItemElement> GetAddedElements(ImmutableHashSet<string> previousIncludes, Project project)
+        private static ImmutableArray<ProjectItemElement> GetAddedItemElements(ImmutableHashSet<string> previousIncludes, Project project)
         {
             return project.AllEvaluatedItems
                 .Where(x => !previousIncludes.Contains(x.EvaluatedInclude, StringComparer.OrdinalIgnoreCase))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
@@ -485,7 +485,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         private static ImmutableArray<ProjectItemElement> GetAddedItemElements(ImmutableHashSet<string> previousIncludes, Project project)
         {
             return project.AllEvaluatedItems
-                .Where(x => !previousIncludes.Contains(x.EvaluatedInclude, StringComparer.OrdinalIgnoreCase))
+                // We are excluding folder elements until CPS allows empty folders to be part of the order; when they do, we can omit checking the item type for "Folder".
+                // Related changes will also need to happen in TryMoveElementsToTop when CPS allows empty folders in ordering.
+                .Where(x => !previousIncludes.Contains(x.EvaluatedInclude, StringComparer.OrdinalIgnoreCase) && !x.ItemType.Equals("Folder", StringComparison.OrdinalIgnoreCase))
                 .Select(x => x.Xml)
                 .ToImmutableArray();
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingMoveAction.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingMoveAction.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
-    internal enum OrderAddItemHintReceiverAction
+    internal enum OrderingMoveAction
     {
         NoOp = 0,
         MoveToTop = 1,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/PasteOrdering.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/PasteOrdering.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
+{
+    /// <summary>
+    /// This does proper file ordering for pasting or dropping items into a folder or project.
+    /// </summary>
+    [Export(typeof(IPasteDataObjectProcessor))]
+    [Export(typeof(IPasteHandler))]
+    [AppliesTo(ProjectCapabilities.SortByDisplayOrder)]
+    [Order(OrderPrecedence)]
+    internal class PasteOrdering : IPasteHandler, IPasteDataObjectProcessor
+    {
+        public const int OrderPrecedence = 10000;
+
+        private readonly ConfiguredProject _configuredProject;
+        private readonly IProjectAccessor _accessor;
+
+        private IProjectTree _dropTarget;
+
+        private IPasteHandler _pasteHandler;
+        private IPasteDataObjectProcessor _pasteProcessor;
+
+        [ImportingConstructor]
+        public PasteOrdering(UnconfiguredProject unconfiguredProject, IProjectAccessor accessor)
+        {
+            Requires.NotNull(unconfiguredProject, nameof(unconfiguredProject));
+            Requires.NotNull(accessor, nameof(accessor));
+
+            _configuredProject = unconfiguredProject.Services.ActiveConfiguredProjectProvider.ActiveConfiguredProject;
+            _accessor = accessor;
+
+            PasteHandlers = new OrderPrecedenceImportCollection<IPasteHandler>(projectCapabilityCheckProvider: unconfiguredProject);
+            PasteProcessors = new OrderPrecedenceImportCollection<IPasteDataObjectProcessor>(projectCapabilityCheckProvider: unconfiguredProject);
+        }
+
+        [ImportMany]
+        private OrderPrecedenceImportCollection<IPasteHandler> PasteHandlers { get; set; }
+
+        [ImportMany]
+        private OrderPrecedenceImportCollection<IPasteDataObjectProcessor> PasteProcessors { get; set; }
+
+        private IPasteHandler PasteHandler
+        {
+            get
+            {
+                if (_pasteHandler == null)
+                {
+                    // Grab the paste handler that has the highest order precedence that is below PasteOrdering's order precedence. 
+                    _pasteHandler =
+                        PasteHandlers.Where(x => x.Metadata.OrderPrecedence < OrderPrecedence)
+                        .OrderByDescending(x => x.Metadata.OrderPrecedence).First().Value;
+                }
+
+                Assumes.NotNull(_pasteHandler);
+
+                return _pasteHandler;
+            }
+        }
+
+        private IPasteDataObjectProcessor PasteProcessor
+        {
+            get
+            {
+                if (_pasteProcessor == null)
+                {
+                    // Grab the paste processor that has the highest order precedence that is below PasteOrdering's order precedence. 
+                    _pasteProcessor =
+                        PasteProcessors.Where(x => x.Metadata.OrderPrecedence < OrderPrecedence)
+                        .OrderByDescending(x => x.Metadata.OrderPrecedence).First().Value;
+                }
+
+                Assumes.NotNull(_pasteProcessor);
+
+                return _pasteProcessor;
+            }
+        }
+
+        public bool CanHandleDataObject(object dataObject, IProjectTree dropTarget, IProjectTreeProvider currentProvider)
+        {
+            return PasteProcessor.CanHandleDataObject(dataObject, dropTarget, currentProvider);
+        }
+
+        public Task<IEnumerable<ICopyPasteItem>> ProcessDataObjectAsync(object dataObject, IProjectTree dropTarget, IProjectTreeProvider currentProvider, DropEffects effect)
+        {
+            _dropTarget = dropTarget;
+            return PasteProcessor.ProcessDataObjectAsync(dataObject, dropTarget, currentProvider, effect);
+        }
+
+        public DropEffects? QueryDropEffect(object dataObject, int grfKeyState, bool draggedFromThisProject)
+        {
+            return PasteProcessor.QueryDropEffect(dataObject, grfKeyState, draggedFromThisProject);
+        }
+
+        public Task ProcessPostFilterAsync(IEnumerable<ICopyPasteItem> items)
+        {
+            return PasteProcessor.ProcessPostFilterAsync(items);
+        }
+
+        public bool CanHandleItem(Type itemType)
+        {
+            return PasteHandler.CanHandleItem(itemType);
+        }
+
+        public void FilterItemList(IEnumerable<ICopyPasteItem> items, DropEffects effect)
+        {
+            PasteHandler.FilterItemList(items, effect);
+        }
+
+        public async Task<PasteItemsResult> PasteItemsAsync(IEnumerable<ICopyPasteItem> items, DropEffects effect)
+        {
+            Assumes.NotNull(_dropTarget);
+
+            // ConfigureAwait is true because we need to come back for PasteItemsAsync to work.
+            var previousIncludes = await OrderingHelper.GetAllEvaluatedIncludes(_configuredProject, _accessor).ConfigureAwait(true);
+            var result = await PasteHandler.PasteItemsAsync(items, effect).ConfigureAwait(false);
+
+            await OrderingHelper.Move(_configuredProject, _accessor, previousIncludes, _dropTarget, OrderingMoveAction.MoveToTop).ConfigureAwait(false);
+
+            return result;
+        }
+
+        public bool PromptForAnyOverwrites(IEnumerable<ICopyPasteItem> items, ref DropEffects effect)
+        {
+            return PasteHandler.PromptForAnyOverwrites(items, ref effect);
+        }
+
+        public Task<IEnumerable<string>> ValidateItemListAsync(IEnumerable<ICopyPasteItem> items, DropEffects effect)
+        {
+            return PasteHandler.ValidateItemListAsync(items, effect);
+        }
+    }
+}


### PR DESCRIPTION
**Customer scenario**

When pasting copied, cut, or dropped F# files into a project or folder, those files need to be moved to the top of it's parent; parent being a project or folder.

**Bugs this fixes:** 

(n/a)

**Workarounds, if any**

Modify fsproj

**Risk**

Low

**Performance impact**

None

**Is this a regression from a previous update?**

No

**Root cause analysis:**

(n/a)

**How was the bug found?**

(n/a)
