### PR TITLE
docs: make solitications for help more discoverable on GitHub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-We welcome contributions. Great ways to contribute include trying things out, filing bugs, joining in design conversations and fixing issues. If you're looking at places to contribute code, take a look at our [up-for-grabs issues](https://github.com/dotnet/roslyn-project-system/issues?q=is%3Aopen+is%3Aissue+label%3A%22Up+for+Grabs%22).
+We welcome contributions. Great ways to contribute include trying things out, filing bugs, joining in design conversations and fixing issues. If you're looking at places to contribute code, take a look at our [help wanted issues](https://github.com/dotnet/roslyn-project-system/issues?q=is%3Aopen+is%3Aissue+label%3A%22Help+Wanted%22).
 
 If you want to submit a feature or a substantial code contribution, please discuss it first with the the team by [filing an issue](https://github.com/dotnet/roslyn-project-system/issues/new), making sure it follows our [Roadmap](docs/repo/roadmap.md).
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ There are many technologies that come together to make up the .NET project syste
 ![image](https://cloud.githubusercontent.com/assets/1103906/24277819/d1e48eba-1093-11e7-811f-ae5debcc1e6c.png)
 
 ## How do I engage and contribute?
-We welcome you to try things out, [file issues](https://github.com/dotnet/roslyn-project-system/issues), make feature requests and join us in design conversations. If you are looking for something to work on, take a look at our [up-for-grabs issues](https://github.com/dotnet/roslyn-project-system/issues?q=is%3Aopen+is%3Aissue+label%3A%22Up+for+Grabs%22) for a great place to start. Also be sure to check out our [contributing guide](CONTRIBUTING.md).
+We welcome you to try things out, [file issues](https://github.com/dotnet/roslyn-project-system/issues), make feature requests and join us in design conversations. If you are looking for something to work on, take a look at our [help wanted issues](https://github.com/dotnet/roslyn-project-system/issues?q=is%3Aopen+is%3Aissue+label%3A%22Help+Wanted%22) for a great place to start. Also be sure to check out our [contributing guide](CONTRIBUTING.md).
 
 This project has adopted a code of conduct adapted from the [Contributor Covenant](http://contributor-covenant.org/) to clarify expected behavior in our community. This code of conduct has been [adopted by many other projects](http://contributor-covenant.org/adopters/). For more information see [Contributors Code of conduct](https://github.com/dotnet/home/blob/master/guidance/be-nice.md). 


### PR DESCRIPTION
Howdy Folks.

You need to rename the GitHub issue label on this repo.

`up-for-grabs` is the old convention popularized by shifty's 3rd party website but GitHub recently launched official discovery mechanisms and if you follow their conventions then solicitations for help are more discoverable.

See https://help.github.com/articles/finding-open-source-projects-on-github/#searching-using-labels

* [x] Use more acceptable language; use GitHub convention
* [ ] Rename GitHub issue labels on `project-system` from up-for-grabs to `Help Wanted`