### PR TITLE
Add ProjectLoadedInHost and PrioritizedProjectLoadedInHost

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ILoadedInHostListenerFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ILoadedInHostListenerFactory.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class ILoadedInHostListenerFactory
+    {
+        public static ILoadedInHostListener Create()
+        {
+            return Mock.Of<ILoadedInHostListener>();
+        }
+
+        public static ILoadedInHostListener ImplementStartListeningAsync(Action action)
+        {
+            var mock = new Mock<ILoadedInHostListener>();
+            mock.Setup(t => t.StartListeningAsync())
+                .ReturnsAsync(action);
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ConfiguredProjectImplicitActivationTrackingTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ConfiguredProjectImplicitActivationTrackingTests.cs
@@ -233,7 +233,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var configurationGroups = IConfigurationGroupFactory.CreateFromConfigurationNames(configurations);
             await source.SendAndCompleteAsync(configurationGroups, service.TargetBlock);
 
-            Assert.True(result.IsCompleted);
+            Assert.True(result.Status == TaskStatus.RanToCompletion);
         }
 
         [Theory]                           // Active configs                                                         Current

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UnconfiguredProjectTasksServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UnconfiguredProjectTasksServiceTests.cs
@@ -1,0 +1,120 @@
+﻿// Copyright(c) Microsoft.All Rights Reserved.Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    public class UnconfiguredProjectTasksServiceTests
+    {
+        [Fact]
+        public void ProjectLoadedInHost_WhenNotProjectLoadedInHost_ReturnsUncompletedTask()
+        {
+            var service = CreateInstance();
+
+            var result = service.ProjectLoadedInHost;
+
+            Assert.False(result.IsCompleted);
+        }
+
+        [Fact]
+        public void PrioritizedProjectLoadedInHost_WhenNotPrioritizedProjectLoadedInHost_ReturnsUncompletedTask()
+        {
+            var service = CreateInstance();
+
+            var result = service.PrioritizedProjectLoadedInHost;
+
+            Assert.False(result.IsCompleted);
+        }
+
+        [Fact]
+        public void ProjectLoadedInHost_WhenProjectUnloaded_ReturnsCancelledTask()
+        {
+            var tasksService = IProjectAsynchronousTasksServiceFactory.ImplementUnloadCancellationToken(new CancellationToken(true));
+            var service = CreateInstance(tasksService);
+
+            var result = service.ProjectLoadedInHost;
+
+            Assert.True(result.IsCanceled);
+        }
+
+        [Fact]
+        public void PrioritizedProjectLoadedInHost_WhenProjectUnloaded_ReturnsCancelledTask()
+        {
+            var tasksService = IProjectAsynchronousTasksServiceFactory.ImplementUnloadCancellationToken(new CancellationToken(true));
+            var service = CreateInstance(tasksService);
+
+            var result = service.PrioritizedProjectLoadedInHost;
+
+            Assert.True(result.IsCanceled);
+        }
+
+        [Fact]
+        public void ProjectLoadedInHost_WhenPrioritizedProjectLoadedInHost_ReturnsUncompletedTask()
+        {
+            var service = CreateInstance();
+
+            var result = service.ProjectLoadedInHost;
+
+            service.OnPrioritizedProjectLoadedInHost();
+
+            Assert.False(result.IsCompleted);
+        }
+
+        [Fact]
+        public void PrioritizedProjectLoadedInHost_WhenProjectLoadedInHost_ReturnsUncompletedTask()
+        {
+            var service = CreateInstance();
+
+            var result = service.PrioritizedProjectLoadedInHost;
+
+            service.OnProjectLoadedInHost();
+            
+            Assert.False(result.IsCompleted);
+        }
+
+        [Fact]
+        public void ProjectLoadedInHost_WhenProjectLoadedInHost_ReturnsCompletedTask()
+        {
+            var service = CreateInstance();
+
+            var result = service.ProjectLoadedInHost;
+            service.OnProjectLoadedInHost();
+
+            Assert.True(result.Status == TaskStatus.RanToCompletion);
+        }
+
+        [Fact]
+        public void PrioritizedProjectLoadedInHost_WhenPrioritizedProjectLoadedInHost_ReturnsCompletedTask()
+        {
+            var service = CreateInstance();
+
+            var result = service.PrioritizedProjectLoadedInHost;
+            service.OnPrioritizedProjectLoadedInHost();
+
+            Assert.True(result.Status == TaskStatus.RanToCompletion);
+        }
+
+        [Fact]
+        public void OnProjectFactoryCompleted_StartsLoadedInHostListening()
+        {
+            int callCount = 0;
+            var loadedInHostListener = ILoadedInHostListenerFactory.ImplementStartListeningAsync(() => { callCount++; });
+
+            var service = CreateInstance(loadedInHostListener: loadedInHostListener);
+
+            service.OnProjectFactoryCompleted();
+
+            Assert.Equal(1, callCount);
+        }
+
+        private static UnconfiguredProjectTasksService CreateInstance(IProjectAsynchronousTasksService tasksService = null, ILoadedInHostListener loadedInHostListener = null)
+        {
+            tasksService = tasksService ?? IProjectAsynchronousTasksServiceFactory.Create();
+            loadedInHostListener  = loadedInHostListener ?? ILoadedInHostListenerFactory.Create();
+
+            return new UnconfiguredProjectTasksService(tasksService, loadedInHostListener);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Build/LanguageServiceErrorListProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Build/LanguageServiceErrorListProviderTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
 
             var result = provider.ClearAllAsync();
 
-            Assert.True(result.IsCompleted);
+            Assert.True(result.Status == TaskStatus.RanToCompletion);
         }
 
         [Fact]
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
 
             var result = provider.ClearMessageFromTargetAsync("targetName");
 
-            Assert.True(result.IsCompleted);
+            Assert.True(result.Status == TaskStatus.RanToCompletion);
         }
 
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSolutionEventListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSolutionEventListener.cs
@@ -51,8 +51,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 {
                     await _threadingService.SwitchToUIThread();
 
-                    // Due to synchronous disposable, we should be on UI thread,
-                    // accessing IVsService<T>.Value will enforce that.
                     HResult result = _solution.Value.UnadviseSolutionEvents(_cookie);
                     if (result.Failed)
                         throw result.Exception;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSolutionEventListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSolutionEventListener.cs
@@ -62,10 +62,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         public int OnAfterOpenProject(IVsHierarchy pHierarchy, int fAdded)
         {
             UnconfiguredProjectTasksService tasksService = GetUnconfiguredProjectTasksServiceIfApplicable(pHierarchy);
-            if (tasksService != null)
-            {
-                tasksService.OnProjectLoadedInHost();
-            }
+            tasksService?.OnProjectLoadedInHost();
 
             return HResult.OK;
         }
@@ -73,10 +70,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         public int PrioritizedOnAfterOpenProject(IVsHierarchy pHierarchy, int fAdded)
         {
             UnconfiguredProjectTasksService tasksService = GetUnconfiguredProjectTasksServiceIfApplicable(pHierarchy);
-            if (tasksService != null)
-            {
-                tasksService.OnPrioritizedProjectLoadedInHost();
-            }
+            tasksService?.OnPrioritizedProjectLoadedInHost();
 
             return HResult.OK;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSolutionEventListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSolutionEventListener.cs
@@ -45,17 +45,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         protected override async Task DisposeCoreAsync(bool initialized)
         {
-            await _threadingService.SwitchToUIThread();
-
-            if (_cookie != VSConstants.VSCOOKIE_NIL)
+            if (initialized)
             {
-                // Due to synchronous disposable, we should be on UI thread,
-                // accessing IVsService<T>.Value will enforce that.
-                HResult result = _solution.Value.UnadviseSolutionEvents(_cookie);
-                if (result.Failed)
-                    throw result.Exception;
+                if (_cookie != VSConstants.VSCOOKIE_NIL)
+                {
+                    await _threadingService.SwitchToUIThread();
 
-                _cookie = VSConstants.VSCOOKIE_NIL;
+                    // Due to synchronous disposable, we should be on UI thread,
+                    // accessing IVsService<T>.Value will enforce that.
+                    HResult result = _solution.Value.UnadviseSolutionEvents(_cookie);
+                    if (result.Failed)
+                        throw result.Exception;
+
+                    _cookie = VSConstants.VSCOOKIE_NIL;
+                }
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSolutionEventListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSolutionEventListener.cs
@@ -1,0 +1,214 @@
+﻿// Copyright(c) Microsoft.All Rights Reserved.Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    /// <summary>
+    ///     Responsible for listening to project loaded events and firing <see cref="IUnconfiguredProjectTasksService.PrioritizedProjectLoadedInHost"/> and 
+    ///     <see cref="IUnconfiguredProjectTasksService.ProjectLoadedInHost"/>.
+    /// </summary>
+    [Export(typeof(ILoadedInHostListener))]
+    internal class VsSolutionEventListener : OnceInitializedOnceDisposedAsync, IVsSolutionEvents, IVsPrioritizedSolutionEvents, ILoadedInHostListener
+    {
+        private readonly IVsService<IVsSolution> _solution;
+        private readonly IProjectThreadingService _threadingService;
+        private uint _cookie = VSConstants.VSCOOKIE_NIL;
+
+        [ImportingConstructor]
+        public VsSolutionEventListener(IVsService<SVsSolution, IVsSolution> solution, IProjectThreadingService threadingService)
+            : base(threadingService.JoinableTaskContext)
+        {
+            _solution = solution;
+            _threadingService = threadingService;
+        }
+
+        public Task StartListeningAsync()
+        {
+            return InitializeAsync(CancellationToken.None);
+        }
+
+        protected override async Task InitializeCoreAsync(CancellationToken cancellationToken)
+        {
+            await _threadingService.SwitchToUIThread();
+
+            HResult result = _solution.Value.AdviseSolutionEvents(this, out _cookie);
+            if (result.Failed)
+                throw result.Exception;
+        }
+
+        protected override async Task DisposeCoreAsync(bool initialized)
+        {
+            await _threadingService.SwitchToUIThread();
+
+            if (_cookie != VSConstants.VSCOOKIE_NIL)
+            {
+                // Due to synchronous disposable, we should be on UI thread,
+                // accessing IVsService<T>.Value will enforce that.
+                HResult result = _solution.Value.UnadviseSolutionEvents(_cookie);
+                if (result.Failed)
+                    throw result.Exception;
+
+                _cookie = VSConstants.VSCOOKIE_NIL;
+            }
+        }
+
+        public int OnAfterOpenProject(IVsHierarchy pHierarchy, int fAdded)
+        {
+            UnconfiguredProjectTasksService tasksService = GetUnconfiguredProjectTasksServiceIfApplicable(pHierarchy);
+            if (tasksService != null)
+            {
+                tasksService.OnProjectLoadedInHost();
+            }
+
+            return HResult.OK;
+        }
+
+        public int PrioritizedOnAfterOpenProject(IVsHierarchy pHierarchy, int fAdded)
+        {
+            UnconfiguredProjectTasksService tasksService = GetUnconfiguredProjectTasksServiceIfApplicable(pHierarchy);
+            if (tasksService != null)
+            {
+                tasksService.OnPrioritizedProjectLoadedInHost();
+            }
+
+            return HResult.OK;
+        }
+
+        private static UnconfiguredProjectTasksService GetUnconfiguredProjectTasksServiceIfApplicable(IVsHierarchy hierarchy)
+        {
+            if (hierarchy is IVsBrowseObjectContext context)
+            {
+                // Only want to run in projects where this is applicable
+                Lazy<UnconfiguredProjectTasksService, IAppliesToMetadataView> export = context.UnconfiguredProject.Services.ExportProvider.GetExport<UnconfiguredProjectTasksService, IAppliesToMetadataView>();
+                if (export.AppliesTo(context.UnconfiguredProject.Capabilities))
+                {
+                    return export.Value;
+                }
+            }
+
+            return null;
+        }
+
+        public int OnQueryCloseProject(IVsHierarchy pHierarchy, int fRemoving, ref int pfCancel)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int OnBeforeCloseProject(IVsHierarchy pHierarchy, int fRemoved)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int OnAfterLoadProject(IVsHierarchy pStubHierarchy, IVsHierarchy pRealHierarchy)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int OnQueryUnloadProject(IVsHierarchy pRealHierarchy, ref int pfCancel)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int OnBeforeUnloadProject(IVsHierarchy pRealHierarchy, IVsHierarchy pStubHierarchy)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int OnAfterOpenSolution(object pUnkReserved, int fNewSolution)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int OnQueryCloseSolution(object pUnkReserved, ref int pfCancel)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int OnBeforeCloseSolution(object pUnkReserved)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int OnAfterCloseSolution(object pUnkReserved)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int PrioritizedOnBeforeCloseProject(IVsHierarchy pHierarchy, int fRemoved)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int PrioritizedOnAfterLoadProject(IVsHierarchy pStubHierarchy, IVsHierarchy pRealHierarchy)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int PrioritizedOnBeforeUnloadProject(IVsHierarchy pRealHierarchy, IVsHierarchy pStubHierarchy)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int PrioritizedOnAfterOpenSolution(object pUnkReserved, int fNewSolution)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int PrioritizedOnBeforeCloseSolution(object pUnkReserved)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int PrioritizedOnAfterCloseSolution(object pUnkReserved)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int PrioritizedOnAfterMergeSolution(object pUnkReserved)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int PrioritizedOnBeforeOpeningChildren(IVsHierarchy pHierarchy)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int PrioritizedOnAfterOpeningChildren(IVsHierarchy pHierarchy)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int PrioritizedOnBeforeClosingChildren(IVsHierarchy pHierarchy)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int PrioritizedOnAfterClosingChildren(IVsHierarchy pHierarchy)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int PrioritizedOnAfterRenameProject(IVsHierarchy pHierarchy)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int PrioritizedOnAfterChangeProjectParent(IVsHierarchy pHierarchy)
+        {
+            return HResult.NotImplemented;
+        }
+
+        public int PrioritizedOnAfterAsynchOpenProject(IVsHierarchy pHierarchy, int fAdded)
+        {
+            return HResult.NotImplemented;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ILoadedInHostListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ILoadedInHostListener.cs
@@ -1,0 +1,21 @@
+﻿// Copyright(c) Microsoft.All Rights Reserved.Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    /// <summary>
+    ///     Represents a service that listen for project loaded events in a host.
+    /// </summary>
+    [ProjectSystemContract(ProjectSystemContractScope.ProjectService, ProjectSystemContractProvider.Private)]
+    internal interface ILoadedInHostListener
+    {
+        /// <summary>
+        ///     Starts listening for project events in a host.
+        /// </summary>
+        /// <returns>
+        ///     Once this method has been called once, all future calls are no-ops.
+        /// </returns>
+        Task StartListeningAsync();
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IUnconfiguredProjectTasksService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IUnconfiguredProjectTasksService.cs
@@ -6,11 +6,45 @@ using System.Threading.Tasks;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     /// <summary>
-    ///     Provides methods for that assist in managing project-related background tasks. 
+    ///     Provides methods for that assist in managing project-related background tasks. This interface replaces 
+    ///     <see cref="IProjectAsyncLoadDashboard"/> usage.
     /// </summary>
     [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Private)]
     internal interface IUnconfiguredProjectTasksService
-    {   // Provides unit testable versions of CommonProjectSystemTools.LoadedProjectAsync
+    {
+        /// <summary>
+        ///     Gets a task that completes when the host recognizes that the project is loaded, 
+        ///     or is cancelled if the project is unloaded before that occurs.
+        /// </summary>
+        /// <remarks>
+        ///     This task completes after <see cref="PrioritizedProjectLoadedInHost"/> and is intended for
+        ///     non-critical services that need to complete after the project has been loaded, but
+        ///     after critical services.
+        /// </remarks>
+        /// <exception cref="OperationCanceledException">
+        ///     Thrown if the project was unloaded.
+        /// </exception>
+        Task ProjectLoadedInHost
+        {
+            get;
+        }
+
+        /// <summary>
+        ///     Gets a task that completes when the host recognizes that the project is loaded,
+        ///     or is cancelled if the project is unloaded before that occurs.
+        /// </summary>
+        /// <remarks>
+        ///     This task completes before <see cref="ProjectLoadedInHost"/> and is intended for
+        ///     critical 
+        ///     services that need to do work before non-critical services.
+        /// </remarks>
+        /// <exception cref="OperationCanceledException">
+        ///     Thrown if the project was unloaded.
+        /// </exception>
+        Task PrioritizedProjectLoadedInHost
+        {
+            get;
+        }
 
         /// <summary>
         ///     Provides protection for an operation that the project will not close before the completion of some task.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectTasksService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectTasksService.cs
@@ -3,20 +3,42 @@
 using System;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
-
 using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
+    [Export]
     [Export(typeof(IUnconfiguredProjectTasksService))]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
     internal class UnconfiguredProjectTasksService : IUnconfiguredProjectTasksService
     {
         private readonly IProjectAsynchronousTasksService _tasksService;
+        private readonly ILoadedInHostListener _loadedInHostListener;
+        private readonly TaskCompletionSource<object> _projectLoadedInHost = new TaskCompletionSource<object>();
+        private readonly TaskCompletionSource<object> _prioritizedProjectLoadedInHost = new TaskCompletionSource<object>();
 
         [ImportingConstructor]
-        public UnconfiguredProjectTasksService([Import(ExportContractNames.Scopes.UnconfiguredProject)]IProjectAsynchronousTasksService tasksService)
+        public UnconfiguredProjectTasksService([Import(ExportContractNames.Scopes.UnconfiguredProject)]IProjectAsynchronousTasksService tasksService, ILoadedInHostListener loadedInHostListener)
         {
             _tasksService = tasksService;
+            _loadedInHostListener = loadedInHostListener;
+        }
+
+        [ProjectAutoLoad(completeBy:ProjectLoadCheckpoint.ProjectFactoryCompleted)]
+        [AppliesTo(ProjectCapability.CSharpOrVisualBasicOrFSharp)]
+        public Task OnProjectFactoryCompleted()
+        {
+            return _loadedInHostListener.StartListeningAsync();
+        }
+
+        public Task ProjectLoadedInHost
+        {
+            get { return _projectLoadedInHost.Task.WithCancellation(_tasksService.UnloadCancellationToken); }
+        }
+
+        public Task PrioritizedProjectLoadedInHost
+        {
+            get { return _prioritizedProjectLoadedInHost.Task.WithCancellation(_tasksService.UnloadCancellationToken); }
         }
 
         public Task LoadedProjectAsync(Func<Task> action)
@@ -31,6 +53,16 @@ namespace Microsoft.VisualStudio.ProjectSystem
             JoinableTask<T> joinable = _tasksService.LoadedProjectAsync(action);
 
             return joinable.Task;
+        }
+
+        public void OnProjectLoadedInHost()
+        {
+            _projectLoadedInHost.SetResult(null);
+        }
+
+        public void OnPrioritizedProjectLoadedInHost()
+        {
+            _prioritizedProjectLoadedInHost.SetResult(null);
         }
     }
 }


### PR DESCRIPTION
This is the first part of fixing https://github.com/dotnet/project-system/issues/3414 by moving language service initialization to PrioritizedOnAfterOpenProject instead of OnAfterOpenProject.

Add two properties intended as a replacement for IProjectAsyncLoadDashboard usage. This has an added advantage of:

- Being able to hook onto both OnAfterOpenProject *and* PrioritizedOnAfterOpenProject solution events, instead of just OnAfterOpenProject.

- Avoid needing to combine IProjectAsyncLoadDashboard.ProjectLoadedInHost with IProjectAsynchronousTasksService.UnloadCancellationToken to avoid hanging when the project fails to open.