### PR TITLE
fixing tests

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ConfigurationProjectConfigurationDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ConfigurationProjectConfigurationDimensionProviderTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         private const string Configurations = nameof(Configurations);
 
         private string projectXml =
-@"<Project Sdk=""Microsoft.NET.Sdk"">
+@"<Project>
   <PropertyGroup>
     <Configurations>Debug;Release;CustomConfiguration</Configurations>
   </PropertyGroup>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/PlatformProjectConfigurationDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/PlatformProjectConfigurationDimensionProviderTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         private const string Platforms = nameof(Platforms);
 
         private string projectXml =
-@"<Project Sdk=""Microsoft.NET.Sdk"">
+@"<Project>
   <PropertyGroup>
     <Platforms>AnyCPU;x64;x86</Platforms>
   </PropertyGroup>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/TargetFrameworkProjectConfigurationDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/TargetFrameworkProjectConfigurationDimensionProviderTests.cs
@@ -14,21 +14,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
     public class TargetFrameworkProjectConfigurationDimensionProviderTests
     {
         private const string ProjectXmlTFM =
-@"<Project Sdk=""Microsoft.NET.Sdk"">
+@"<Project>
   <PropertyGroup>
     <TargetFramework>netcoreapp1.0</TargetFramework>
   </PropertyGroup>
 </Project>";
 
         private const string ProjectXmlTFMs =
-@"<Project Sdk=""Microsoft.NET.Sdk"">
+@"<Project>
   <PropertyGroup>
     <TargetFrameworks>netcoreapp1.0;net45</TargetFrameworks>
   </PropertyGroup>
 </Project>";
 
         private const string ProjectXmlTFMAndTFMs =
-@"<Project Sdk=""Microsoft.NET.Sdk"">
+@"<Project>
   <PropertyGroup>
     <TargetFrameworks>netcoreapp1.0;net45</TargetFrameworks>
     <TargetFramework>netcoreapp1.0</TargetFramework>


### PR DESCRIPTION
removing `Sdk=""Microsoft.NET.Sdk""` from project xml in tests so they don't sporatically fail looking for the SDK resolver
