### PR TITLE
Fix the remove implementation of DelegatedProjectPropertiesProviderBase

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/DelegatedProjectPropertiesProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/DelegatedProjectPropertiesProviderBase.cs
@@ -47,19 +47,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         public event AsyncEventHandler<ProjectPropertyChangedEventArgs> ProjectPropertyChanged
         {
             add { DelegatedProvider.ProjectPropertyChanged += value; }
-            remove { DelegatedProvider.ProjectPropertyChanged += value; }
+            remove { DelegatedProvider.ProjectPropertyChanged -= value; }
         }
 
         public event AsyncEventHandler<ProjectPropertyChangedEventArgs> ProjectPropertyChangedOnWriter
         {
             add { DelegatedProvider.ProjectPropertyChangedOnWriter += value; }
-            remove { DelegatedProvider.ProjectPropertyChangedOnWriter += value; }
+            remove { DelegatedProvider.ProjectPropertyChangedOnWriter -= value; }
         }
 
         public event AsyncEventHandler<ProjectPropertyChangedEventArgs> ProjectPropertyChanging
         {
             add { DelegatedProvider.ProjectPropertyChanging += value; }
-            remove { DelegatedProvider.ProjectPropertyChanging += value; }
+            remove { DelegatedProvider.ProjectPropertyChanging -= value; }
         }
 
         public virtual IProjectProperties GetCommonProperties()


### PR DESCRIPTION
Fix #3455: Update the remove implementation of DelegatedProjectPropertiesProviderBase to properly remove the handler instead of accidentally adding it

**Customer scenario**

Not sure in which scenario's CPS calls this code, so not sure how user can hit it. I observed this during reviewing of the code

**Bugs this fixes:** 

#3455

**Risk**

Low: CPS's backing class implements remove properly.

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

**Root cause analysis:**

Was introduced like this since initial commit. I don't know when CPS will call remove on the event, CPS itself only seems to be calling the event, not even adding.

**How was the bug found?**

Reviewing of the codebase.