### PR TITLE
Enable NuGet package signing

### DIFF
--- a/build/SignToolData.json
+++ b/build/SignToolData.json
@@ -62,7 +62,7 @@
       ]
     },
     {
-      "certificate": null,
+      "certificate": "NuGet",
       "strongName": null,
       "values": [
         "packages/*.nupkg"


### PR DESCRIPTION
**Customer scenario**

Infrastructure only change. NuGet packages are required to be signed.

**Bugs this fixes:** 


**Workarounds, if any**


**Risk**


**Performance impact**


**Is this a regression from a previous update?**

**Root cause analysis:**


**How was the bug found?**

(E.g. customer reported it vs. ad hoc testing)
