### PR TITLE
Also support GetCommonProperties from InterceptedProjectPropertiesProvider

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectInstancePropertiesProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectInstancePropertiesProviderFactory.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Build.Execution;
+using Microsoft.Build.Framework;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 
 using Moq;
@@ -7,10 +8,27 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal static class IProjectInstancePropertiesProviderFactory
     {
-        public static IProjectInstancePropertiesProvider Create()
-            => Mock.Of<IProjectInstancePropertiesProvider>();
+        public static IProjectInstancePropertiesProvider Create(IProjectProperties itemProps = null, IProjectProperties commonProps = null)
+        {
+            var mock = new Mock<IProjectInstancePropertiesProvider>();
 
-        public static IProjectInstancePropertiesProvider ImplementsGetItemTypeProperties(IProjectProperties projectProperties = null)
+            if (itemProps != null)
+            {
+                mock.Setup(t => t.GetItemProperties(It.IsAny<ProjectInstance>(), It.IsAny<string>(), It.IsAny<string>()))
+                                .Returns(itemProps);
+                mock.Setup(t => t.GetItemProperties(It.IsAny<ITaskItem>()))
+                                .Returns(itemProps);
+            }
+
+            if (commonProps != null)
+            {
+                mock.Setup(t => t.GetCommonProperties(It.IsAny<ProjectInstance>())).Returns(commonProps);
+            }
+
+            return mock.Object;
+        }
+
+            public static IProjectInstancePropertiesProvider ImplementsGetItemTypeProperties(IProjectProperties projectProperties = null)
         {
             var mock = new Mock<IProjectInstancePropertiesProvider>();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectPropertiesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectPropertiesProviderTests.cs
@@ -47,5 +47,82 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             await properties.SetPropertyValueAsync(MockPropertyName, "NewValue", null);
             Assert.True(setValueInvoked);
         }
+
+        [Fact]
+        public async Task VerifyInterceptedCommonPropertiesProviderAsync()
+        {
+            var delegatePropertiesMock = IProjectPropertiesFactory
+                .MockWithPropertiesAndValues(new Dictionary<string, string>() {
+                    { MockPropertyName, "DummyValue" }
+                });
+
+            var delegateProperties = delegatePropertiesMock.Object;
+            var delegateProvider = IProjectPropertiesProviderFactory.Create(commonProps: delegateProperties);
+
+            bool getEvaluatedInvoked = false;
+            bool getUnevaluatedInvoked = false;
+            bool setValueInvoked = false;
+
+            var mockPropertyProvider = IInterceptingPropertyValueProviderFactory.Create(MockPropertyName,
+                onGetEvaluatedPropertyValue: (v, p) => { getEvaluatedInvoked = true; return v; },
+                onGetUnevaluatedPropertyValue: (v, p) => { getUnevaluatedInvoked = true; return v; },
+                onSetPropertyValue: (v, p, d) => { setValueInvoked = true; return v; });
+            var unconfiguredProject = UnconfiguredProjectFactory.Create();
+            var instanceProvider = IProjectInstancePropertiesProviderFactory.Create();
+
+            var interceptedProvider = new ProjectFileInterceptedProjectPropertiesProvider(delegateProvider, instanceProvider, unconfiguredProject, new[] { mockPropertyProvider });
+            var properties = interceptedProvider.GetCommonProperties();
+
+            // Verify interception for GetEvaluatedPropertyValueAsync.
+            var propertyValue = await properties.GetEvaluatedPropertyValueAsync(MockPropertyName);
+            Assert.True(getEvaluatedInvoked);
+
+            // Verify interception for GetUnevaluatedPropertyValueAsync.
+            propertyValue = await properties.GetUnevaluatedPropertyValueAsync(MockPropertyName);
+            Assert.True(getUnevaluatedInvoked);
+
+            // Verify interception for SetPropertyValueAsync.
+            await properties.SetPropertyValueAsync(MockPropertyName, "NewValue", null);
+            Assert.True(setValueInvoked);
+        }
+
+        [Fact]
+        public async Task VerifyInterceptedInstanceCommonPropertiesProviderAsync()
+        {
+            var delegatePropertiesMock = IProjectPropertiesFactory
+                .MockWithPropertiesAndValues(new Dictionary<string, string>() {
+                    { MockPropertyName, "DummyValue" }
+                });
+
+            var delegateProperties = delegatePropertiesMock.Object;
+            var delegateInstanceProvider = IProjectInstancePropertiesProviderFactory.Create(commonProps: delegateProperties);
+
+            bool getEvaluatedInvoked = false;
+            bool getUnevaluatedInvoked = false;
+            bool setValueInvoked = false;
+
+            var mockPropertyProvider = IInterceptingPropertyValueProviderFactory.Create(MockPropertyName,
+                onGetEvaluatedPropertyValue: (v, p) => { getEvaluatedInvoked = true; return v; },
+                onGetUnevaluatedPropertyValue: (v, p) => { getUnevaluatedInvoked = true; return v; },
+                onSetPropertyValue: (v, p, d) => { setValueInvoked = true; return v; });
+
+            var unconfiguredProject = UnconfiguredProjectFactory.Create();
+            var provider = IProjectPropertiesProviderFactory.Create();
+
+            var interceptedProvider = new ProjectFileInterceptedProjectPropertiesProvider(provider, delegateInstanceProvider, unconfiguredProject, new[] { mockPropertyProvider });
+            var properties = interceptedProvider.GetCommonProperties(projectInstance: null);
+
+            // Verify interception for GetEvaluatedPropertyValueAsync.
+            var propertyValue = await properties.GetEvaluatedPropertyValueAsync(MockPropertyName);
+            Assert.True(getEvaluatedInvoked);
+
+            // Verify interception for GetUnevaluatedPropertyValueAsync.
+            propertyValue = await properties.GetUnevaluatedPropertyValueAsync(MockPropertyName);
+            Assert.True(getUnevaluatedInvoked);
+
+            // Verify interception for SetPropertyValueAsync.
+            await properties.SetPropertyValueAsync(MockPropertyName, "NewValue", null);
+            Assert.True(setValueInvoked);
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectPropertiesProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectPropertiesProviderBase.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using Microsoft.Build.Execution;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Properties
 {
@@ -28,6 +29,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         public override IProjectProperties GetProperties(string file, string itemType, string item)
         {
             var defaultProperties = base.GetProperties(file, itemType, item);
+            return _interceptingValueProviders.IsDefaultOrEmpty ? defaultProperties : new InterceptedProjectProperties(_interceptingValueProviders, defaultProperties);
+        }
+
+        public override IProjectProperties GetCommonProperties()
+        {
+            var defaultProperties = base.GetCommonProperties();
+            return _interceptingValueProviders.IsDefaultOrEmpty ? defaultProperties : new InterceptedProjectProperties(_interceptingValueProviders, defaultProperties);
+        }
+
+        public override IProjectProperties GetCommonProperties(ProjectInstance projectInstance)
+        {
+            var defaultProperties = base.GetCommonProperties(projectInstance);
             return _interceptingValueProviders.IsDefaultOrEmpty ? defaultProperties : new InterceptedProjectProperties(_interceptingValueProviders, defaultProperties);
         }
     }


### PR DESCRIPTION
CPS has a new optimization that goes through CommonProperties, and without this we
don't get a chance to intercept these values.

<details>
**Customer scenario**

What does the customer do to get into this situation, and why do we think this
is common enough to address in Escrow.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

**Bugs this fixes:** 

(either VSO or GitHub links)

**Workarounds, if any**

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

**Risk**

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

**Is this a regression from a previous update?**

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

(E.g. customer reported it vs. ad hoc testing)
</details>