### PR TITLE
When nominating NuGet restore, pass MSBuildProjectExtensionsPath inst…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/NuGet/ProjectRestoreInfoBuilderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/NuGet/ProjectRestoreInfoBuilderTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             var definingProjectFullPath = "C:\\Test\\Projects\\TestProj\\TestProj.csproj";
 
             // properties
-            Assert.Equal("obj\\", tfm.Properties.Item("BaseIntermediateOutputPath").Value);
+            Assert.Equal("obj\\", tfm.Properties.Item("MSBuildProjectExtensionsPath").Value);
             Assert.Equal(".NETCoreApp,Version=v1.0", tfm.Properties.Item("TargetFrameworkMoniker").Value);
             Assert.Equal("netcoreapp1.0", tfm.Properties.Item("TargetFrameworks").Value);
             Assert.Equal("netcoreapp1.0;netstandard16", tfm.Properties.Item("PackageTargetFallback").Value);
@@ -137,7 +137,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             },
             ""After"": {
                 ""Properties"": {
-                   ""BaseIntermediateOutputPath"": ""obj\\"",
+                   ""MSBuildProjectExtensionsPath"": ""obj\\"",
                    ""TargetFrameworkMoniker"": "".NETCoreApp,Version=v1.0"",
                    ""TargetFrameworks"": ""netcoreapp1.0"",
                    ""TargetFramework"": ""netcoreapp1.0""
@@ -195,7 +195,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             },
             ""After"": {
                 ""Properties"": {
-                   ""BaseIntermediateOutputPath"": ""obj\\"",
+                   ""MSBuildProjectExtensionsPath"": ""obj\\"",
                    ""TargetFrameworkMoniker"": "".NETCoreApp,Version=v1.0"",
                    ""TargetFrameworks"": ""netcoreapp1.0"",
                    ""TargetFramework"": """"
@@ -265,7 +265,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             },
             ""After"": {
                 ""Properties"": {
-                   ""BaseIntermediateOutputPath"": ""obj\\"",
+                   ""MSBuildProjectExtensionsPath"": ""obj\\"",
                    ""TargetFrameworks"": """",
                    ""TargetFrameworkMoniker"": "".NETCoreApp,Version=v1.0""
                 }
@@ -312,7 +312,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             },
             ""After"": {
                 ""Properties"": {
-                   ""BaseIntermediateOutputPath"": ""obj\\"",
+                   ""MSBuildProjectExtensionsPath"": ""obj\\"",
                    ""TargetFrameworks"": """",
                    ""TargetFrameworkMoniker"": "".NETStandard,Version=v1.4""
                 }
@@ -371,7 +371,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             },
             ""After"": {
                 ""Properties"": {
-                   ""BaseIntermediateOutputPath"": ""obj\\"",
+                   ""MSBuildProjectExtensionsPath"": ""obj\\"",
                    ""TargetFrameworks"": """",
                    ""TargetFrameworkMoniker"": "".NETCoreApp,Version=v1.0""
                 }
@@ -425,7 +425,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             },
             ""After"": {
                 ""Properties"": {
-                   ""BaseIntermediateOutputPath"": ""obj\\"",
+                   ""MSBuildProjectExtensionsPath"": ""obj\\"",
                    ""TargetFrameworkMoniker"": "".NETStandard,Version=v1.4""
                 }
             }
@@ -492,7 +492,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             },
             ""After"": {
                 ""Properties"": {
-                   ""BaseIntermediateOutputPath"": ""obj\\"",
+                   ""MSBuildProjectExtensionsPath"": ""obj\\"",
                    ""TargetFrameworks"": """",
                    ""TargetFrameworkMoniker"": "".NETCoreApp,Version=v1.0""
                 }
@@ -561,7 +561,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             },
             ""After"": {
                 ""Properties"": {
-                   ""BaseIntermediateOutputPath"": ""obj\\"",
+                   ""MSBuildProjectExtensionsPath"": ""obj\\"",
                    ""TargetFrameworkMoniker"": "".NETCoreApp,Version=v1.0"",
                    ""TargetFrameworkIdentifier"": "".NETCoreApp"",
                    ""TargetFrameworkVersion"": ""v1.0"",

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectRestoreInfoBuilder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectRestoreInfoBuilder.cs
@@ -87,9 +87,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             return targetFrameworks.Any()
                 ? new ProjectRestoreInfo
                 {
-                    // NOTE: We pass MSBuildProjectExtensionsPath as BaseIntermediatePath, because people often set
-                    // BaseIntermediatePath too late.  See https://github.com/dotnet/project-system/issues/3466 for
-                    // details.
+                    // NOTE: We pass MSBuildProjectExtensionsPath as BaseIntermediatePath instead of using
+                    // BaseIntermediateOutputPath. This is because NuGet switched from using BaseIntermediateOutputPath
+                    // to MSBuildProjectExtensionsPath, since the value of BaseIntermediateOutputPath is often set too
+                    // late (after *.g.props files would need to have been imported from it). Instead of modifying the
+                    // IVsProjectRestoreInfo interface or introducing something like IVsProjectRestoreInfo with an
+                    // MSBuildProjectExtensionsPath property, we opted to leave the interface the same but change the
+                    // meaning of its BaseIntermediatePath proprtey. See
+                    // https://github.com/dotnet/project-system/issues/3466for for details.
                     BaseIntermediatePath = msbuildProjectExtensionsPath,
                     OriginalTargetFrameworks = originalTargetFrameworks,
                     TargetFrameworks = targetFrameworks,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectRestoreInfoBuilder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectRestoreInfoBuilder.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
                 return null;
             }
 
-            string baseIntermediatePath = null;
+            string msbuildProjectExtensionsPath = null;
             string originalTargetFrameworks = null;
             var targetFrameworks = new TargetFrameworks();
             var toolReferences = new ReferenceItems();
@@ -45,8 +45,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             foreach (IProjectVersionedValue<IProjectSubscriptionUpdate> update in updates)
             {
                 var nugetRestoreChanges = update.Value.ProjectChanges[NuGetRestore.SchemaName];
-                baseIntermediatePath = baseIntermediatePath ??
-                    nugetRestoreChanges.After.Properties[NuGetRestore.BaseIntermediateOutputPathProperty];
+                msbuildProjectExtensionsPath = msbuildProjectExtensionsPath ??
+                    nugetRestoreChanges.After.Properties[NuGetRestore.MSBuildProjectExtensionsPathProperty];
                 originalTargetFrameworks = originalTargetFrameworks ??
                     nugetRestoreChanges.After.Properties[NuGetRestore.TargetFrameworksProperty];
                 bool noTargetFramework =
@@ -87,7 +87,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             return targetFrameworks.Any()
                 ? new ProjectRestoreInfo
                 {
-                    BaseIntermediatePath = baseIntermediatePath,
+                    // NOTE: We pass MSBuildProjectExtensionsPath as BaseIntermediatePath, because people often set
+                    // BaseIntermediatePath too late.  See https://github.com/dotnet/project-system/issues/3466 for
+                    // details.
+                    BaseIntermediatePath = msbuildProjectExtensionsPath,
                     OriginalTargetFrameworks = originalTargetFrameworks,
                     TargetFrameworks = targetFrameworks,
                     ToolReferences = toolReferences

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -42,11 +42,11 @@
         </StringProperty.DataSource>
     </StringProperty>
 
-    <StringProperty Name="BaseIntermediateOutputPath" 
+    <StringProperty Name="MSBuildProjectDirectory" 
                     Visible="False" 
                     ReadOnly="True" />
 
-    <StringProperty Name="MSBuildProjectDirectory" 
+    <StringProperty Name="MSBuildProjectExtensionsPath" 
                     Visible="False" 
                     ReadOnly="True" />
 


### PR DESCRIPTION
…ead of BaseIntermediateOutputPath

Fixes #3466.

<details>
**Customer scenario**

What does the customer do to get into this situation, and why do we think this
is common enough to address in Escrow.  (Granted, sometimes this will be
obvious "Open project, VS crashes" but in general, I need to understand how
common a scenario is)

**Bugs this fixes:** 

(either VSO or GitHub links)

**Workarounds, if any**

Also, why we think they are insufficient for RC vs. RC2, RC3, or RTW

**Risk**

This is generally a measure our how central the affected code is to adjacent
scenarios and thus how likely your fix is to destabilize a broader area of code

**Performance impact**

(with a brief justification for that assessment (e.g. "Low perf impact because no extra allocations/no complexity changes" vs. "Low")

**Is this a regression from a previous update?**

**Root cause analysis:**

How did we miss it?  What tests are we adding to guard against it in the future?

**How was the bug found?**

(E.g. customer reported it vs. ad hoc testing)
</details>