### PR TITLE
Trigger design-time buld when project.assets.json file changes

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -268,6 +268,11 @@
     </PropertyPageSchema>
   </ItemGroup>
 
+  <!-- List of external files that trigger design-time builds when they are modified -->
+  <ItemGroup>
+    <AdditionalDesignTimeBuildInput Include="$(ProjectAssetsFile)" />   <!-- NuGet assets file -->
+  </ItemGroup>
+
   <!--
     EmbeddedFiles are source files to be embedded to the PDB. 
     We need to set Visible to false in order to not display duplicate entries in project UI.


### PR DESCRIPTION
**Customer scenario**

Installing a NuGet package no longer causes the compiler to pick up the new dlls.

**Bugs this fixes:** 

**Workarounds, if any**

No viable workaround.

**Risk**

Low

**Performance impact**

None

**Is this a regression from a previous update?** 

Yes, the new design-time build caching only triggers a design-time build if items in the project have changed. It's unaware of the logic that we have that causes a reevaluation if project.assets.json changes - this change makes it aware of that file.

**Root cause analysis:**

We didn't miss it - it was a fallout of the design.

**How was the bug found?**

Ad hoc testing and customers have started running into it.
