### PR TITLE
added check for circular dependencies

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
@@ -55,6 +55,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         private Dictionary<string, bool> _unresolvedDescendantsMap
             = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
 
+        private HashSet<string> _seenDependencies = new HashSet<string>();
+
         private bool? _hasUresolvedDependency;
         public bool HasUnresolvedDependency
         {
@@ -113,7 +115,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
         private bool FindUnresolvedDependenciesRecursive(IDependency dependency)
         {
+
             var result = false;
+
+            if (!_seenDependencies.Contains(dependency.Id))
+            {
+                _seenDependencies.Add(dependency.Id);
+            }
+            else
+            {
+                return result;
+            }
+
             if (dependency.DependencyIDs.Count > 0)
             {
                 foreach (var child in GetDependencyChildren(dependency))


### PR DESCRIPTION
**Customer scenario**

In certain circumstances, there can be a circular dependency that creates a stack overflow when recursively checking for unresolved child dependencies, causing a complete VS crash. 

**Bugs this fixes:** 

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/487858
https://github.com/dotnet/project-system/issues/3374

**Workarounds, if any**

None

**Risk**

Low, there are some threading concerns that I am looking into to make sure that the Hashset is not shared - but I do not think that will be an issue because I am editing a private method and the class is instantiated when creating a snapshot.

**Performance impact**

Low. Just adding a HashSet. 

**Is this a regression from a previous update?**

No

**Root cause analysis:**

There was no check that a dependency was not already resolved. 

**How was the bug found?**

Customer feedback.