### PR TITLE
Disable code coverage for pull requests submitted by @dotnet-bot

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -111,7 +111,7 @@ function Build {
   }
 
   $nodeReuse = !$ci
-  $useCodecov = $ci -and $env:CODECOV_TOKEN -and ($configuration -eq 'Debug')
+  $useCodecov = $ci -and $env:CODECOV_TOKEN -and ($configuration -eq 'Debug') -and ($env:ghprbPullAuthorLogin -ne 'dotnet-bot')
   $useOpenCover = $useCodecov
 
   & $MsbuildExe $ToolsetBuildProj /m /nologo /clp:Summary /nodeReuse:$nodeReuse /warnaserror /v:$verbosity $logCmd /p:Configuration=$configuration /p:SolutionPath=$solution /p:Restore=$restore /p:QuietRestore=true /p:DeployDeps=$deployDeps /p:Build=$build /p:Rebuild=$rebuild /p:Deploy=$deploy /p:Test=$test /p:IntegrationTest=$integrationTest /p:Sign=$sign /p:Pack=$pack /p:UseCodecov=$useCodecov /p:UseOpenCover=$useOpenCover /p:CIBuild=$ci /p:NuGetPackageRoot=$NuGetPackageRoot $properties


### PR DESCRIPTION
These pull requests are typically branch merges in the repository, where coverage information is already available for the source branch. Building a pull request results in an incorrect merge of coverage information from the source branch as well as the merge commit from the pull request.
