### PR TITLE
Avoid using the registry for OpenCover in 32-bit tests

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -69,7 +69,9 @@
     <PropertyGroup Condition="'$(_UseOpenCover)' == 'true'">
       <_OpenCoverConsoleExe>OpenCover.Console.exe</_OpenCoverConsoleExe>
       <_OpenCoverCommand>$(NuGetPackageRoot)opencover\$(OpenCoverVersion)\tools\$(_OpenCoverConsoleExe)</_OpenCoverCommand>
-      <_OpenCoverCommandArgs>-register:user -returntargetcode -hideskipped:All -filter:"+[*]*" -excludebyattribute:*.ExcludeFromCodeCoverage* -excludebyfile:*\*Designer.cs -output:"$(_TestResultsOpenCoverPath)"</_OpenCoverCommandArgs>
+      <_OpenCoverRegister>user</_OpenCoverRegister>
+      <_OpenCoverRegister Condition="'$(_TestArchitecture)' == 'x86'">path32</_OpenCoverRegister>
+      <_OpenCoverCommandArgs>-register:$(_OpenCoverRegister) -returntargetcode -hideskipped:All -filter:"+[*]*" -excludebyattribute:*.ExcludeFromCodeCoverage* -excludebyfile:*\*Designer.cs -output:"$(_TestResultsOpenCoverPath)"</_OpenCoverCommandArgs>
       <_TestRunnerCommand>"$(_OpenCoverCommand)" $(_OpenCoverCommandArgs) -target:"$(_XUnitRunnerCommand)" -targetargs:"$(_XUnitRunnerCommandArgs.Replace(`"`, `\"`))"</_TestRunnerCommand>
     </PropertyGroup>
 


### PR DESCRIPTION
regsvr32 has a race condition which can cause parallel test execution to fail when OpenCover is used with -register:user. For 32-bit test scenarios, use -register:path32 instead to force the exclusive use of 32-bit profiling.

See https://github.com/OpenCover/opencover/issues/557#issuecomment-193205134