### PR TITLE
Avoid loading additional configurations for multi-targeting projects

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -94,7 +94,7 @@
   <PropertyGroup>
     <RestoreSources>
       $(RestoreSources);
-      http://www.myget.org/F/vs-devcore/api/v3/index.json;
+      https://vside.myget.org/F/devcore/api/v3/index.json;
       https://dotnet.myget.org/F/msbuild/api/v3/index.json;
       https://dotnet.myget.org/F/nuget-build/api/v3/index.json;
       https://dotnet.myget.org/F/roslyn/api/v3/index.json;

--- a/build/Versions.props
+++ b/build/Versions.props
@@ -53,9 +53,8 @@
     <MicrosoftVisualStudioShellInterop150DesignTimeVersion>15.0.26201</MicrosoftVisualStudioShellInterop150DesignTimeVersion>
     <MicrosoftVisualStudioShellInterop153DesignTimeVersion>15.0.26606</MicrosoftVisualStudioShellInterop153DesignTimeVersion>
     <MicrosoftVisualStudioTemplateWizardInterfaceVersion>8.0.0-alpha</MicrosoftVisualStudioTemplateWizardInterfaceVersion>
-    <MicrosoftVisualStudioThreadingVersion>15.5.13-beta</MicrosoftVisualStudioThreadingVersion>
+    <MicrosoftVisualStudioThreadingVersion>15.5.24</MicrosoftVisualStudioThreadingVersion>
     <MicrosoftVisualStudioThreadingAnalyzersVersion>15.5.13-beta</MicrosoftVisualStudioThreadingAnalyzersVersion>
-    <MicrosoftVisualStudioProjectSystemAnalyzersVersion>15.3.224</MicrosoftVisualStudioProjectSystemAnalyzersVersion>
     <MicrosoftVisualStudioUtilitiesVersion>15.0.26607</MicrosoftVisualStudioUtilitiesVersion>
     <MicrosoftVisualStudioValidationVersion>15.3.32</MicrosoftVisualStudioValidationVersion>
     <MicrosoftVisualStudioVsHelpVersion>15.0.26606-alpha</MicrosoftVisualStudioVsHelpVersion>
@@ -65,7 +64,8 @@
     <VsWebSiteInteropVersion>8.0.0-alpha</VsWebSiteInteropVersion>
 
     <!-- CPS -->
-    <MicrosoftVisualStudioProjectSystemSDKVersion>15.6.128-pre</MicrosoftVisualStudioProjectSystemSDKVersion>
+    <MicrosoftVisualStudioProjectSystemSDKVersion>15.7.117-pre</MicrosoftVisualStudioProjectSystemSDKVersion>
+    <MicrosoftVisualStudioProjectSystemAnalyzersVersion>$(MicrosoftVisualStudioProjectSystemSDKVersion)</MicrosoftVisualStudioProjectSystemAnalyzersVersion>
     
     <!-- Roslyn -->
     <MicrosoftVisualStudioLanguageServicesVersion>2.6.0-beta1-62113-02</MicrosoftVisualStudioLanguageServicesVersion>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ConfigurationProjectConfigurationDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ConfigurationProjectConfigurationDimensionProviderTests.cs
@@ -234,12 +234,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         }
 
         [Theory]
-        [InlineData("Dbg",               "Dbg")]
-        [InlineData(" Dbg ",             "Dbg")]
-        [InlineData("Retail",            "Retail")]
-        [InlineData("Dbg;Retail",        "Dbg")]
-        [InlineData(";Dbg;Retail",       "Dbg")]
-        public async Task GetBestGuessDefaultValuesForDimensionsAsync_ReturnsFirstValue(string configurations, string expected)
+        [InlineData("Dbg",                      "Dbg")]
+        [InlineData(" Dbg ",                    "Dbg")]
+        [InlineData("Retail",                   "Retail")]
+        [InlineData("Dbg;",                     "Dbg")]
+        [InlineData("Dbg;Retail",               "Dbg")]
+        [InlineData(";Dbg;Retail",              "Dbg")]
+        [InlineData("$(Foo);Dbg;Retail",        "Dbg")]
+        [InlineData("$(Foo); Dbg ;Retail",      "Dbg")]
+        [InlineData("Dbg_$(Foo); Dbg ;Retail",  "Dbg")]
+        public async Task GetBestGuessDefaultValuesForDimensionsAsync_ReturnsFirstParsableValue(string configurations, string expected)
         {
             string projectXml =
 $@"<Project>
@@ -266,6 +270,8 @@ $@"<Project>
         [InlineData(";;;")]
         [InlineData("$(Property)")]
         [InlineData("Foo_$(Property)")]
+        [InlineData("Foo_$(Property);")]
+        [InlineData(";Foo_$(Property);")]
         public async Task GetBestGuessDefaultValuesForDimensionsAsync_WhenConfigurationsIsEmpty_ReturnsDefault(string configurations)
         {
             string projectXml =

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ConfigurationProjectConfigurationDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ConfigurationProjectConfigurationDimensionProviderTests.cs
@@ -234,11 +234,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         }
 
         [Theory]
-        [InlineData("Debug",               "Debug")]
-        [InlineData(" Debug ",             "Debug")]
-        [InlineData("Release",             "Release")]
-        [InlineData("Debug;Release",       "Debug")]
-        [InlineData(";Debug;Release",      "Debug")]
+        [InlineData("Dbg",               "Dbg")]
+        [InlineData(" Dbg ",             "Dbg")]
+        [InlineData("Retail",            "Retail")]
+        [InlineData("Dbg;Retail",        "Dbg")]
+        [InlineData(";Dbg;Retail",       "Dbg")]
         public async Task GetBestGuessDefaultValuesForDimensionsAsync_ReturnsFirstValue(string configurations, string expected)
         {
             string projectXml =
@@ -266,7 +266,7 @@ $@"<Project>
         [InlineData(";;;")]
         [InlineData("$(Property)")]
         [InlineData("Foo_$(Property)")]
-        public async Task GetBestGuessDefaultValuesForDimensionsAsync_WhenConfigurationsIsEmpty_ReturnsEmpty(string configurations)
+        public async Task GetBestGuessDefaultValuesForDimensionsAsync_WhenConfigurationsIsEmpty_ReturnsDefault(string configurations)
         {
             string projectXml =
 $@"<Project>
@@ -279,7 +279,9 @@ $@"<Project>
 
             var result = await provider.GetBestGuessDefaultValuesForDimensionsAsync(UnconfiguredProjectFactory.Create());
 
-            Assert.Empty(result);
+            Assert.Single(result);
+            Assert.Equal("Configuration", result.First().Key);
+            Assert.Equal("Debug", result.First().Value);
         }
 
         [Fact]
@@ -288,8 +290,8 @@ $@"<Project>
             string projectXml =
 $@"<Project>
   <PropertyGroup>
-    <Configurations>Debug</Configurations>
-    <Configurations>Release;Debug</Configurations>
+    <Configurations>Dbg</Configurations>
+    <Configurations>Retail;Dbg</Configurations>
   </PropertyGroup>
 </Project>";
 
@@ -299,11 +301,11 @@ $@"<Project>
 
             Assert.Single(result);
             Assert.Equal("Configuration", result.First().Key);
-            Assert.Equal("Release", result.First().Value);
+            Assert.Equal("Retail", result.First().Value);
         }
 
         [Fact]
-        public async Task GetBestGuessDefaultValuesForDimensionsAsync_WhenConfigurationsIsMissing_ReturnsEmpty()
+        public async Task GetBestGuessDefaultValuesForDimensionsAsync_WhenConfigurationsIsMissing_ReturnsDefault()
         {
             string projectXml =
 $@"<Project>
@@ -315,48 +317,52 @@ $@"<Project>
 
             var result = await provider.GetBestGuessDefaultValuesForDimensionsAsync(UnconfiguredProjectFactory.Create());
 
-            Assert.Empty(result);
+            Assert.Single(result);
+            Assert.Equal("Configuration", result.First().Key);
+            Assert.Equal("Debug", result.First().Value);
         }
 
         [Theory]
         [InlineData(
 @"<Project>
   <PropertyGroup>
-    <Configurations Condition=""'$(BuildingInsideVisualStudio)' != 'true'"">Debug</Configurations>
+    <Configurations Condition=""'$(BuildingInsideVisualStudio)' != 'true'"">Dbg</Configurations>
   </PropertyGroup>
 </Project>")]
         [InlineData(
 @"<Project>
   <PropertyGroup>
-    <Configurations Condition=""'$(OS)' != 'Windows_NT'"">Debug</Configurations>
+    <Configurations Condition=""'$(OS)' != 'Windows_NT'"">Dbg</Configurations>
   </PropertyGroup>
 </Project>")]
         [InlineData(
 @"<Project>
   <PropertyGroup>
-    <Configurations Condition=""'$(OS)' == 'Unix'"">Debug</Configurations>
+    <Configurations Condition=""'$(OS)' == 'Unix'"">Dbg</Configurations>
   </PropertyGroup>
 </Project>")]
         [InlineData(
 @"<Project>
   <PropertyGroup>
-    <Configurations Condition=""'$(Foo)' == 'true'"">Debug</Configurations>
+    <Configurations Condition=""'$(Foo)' == 'true'"">Dbg</Configurations>
   </PropertyGroup>
 </Project>")]
         [InlineData(
 @"<Project>
   <PropertyGroup>
-    <Configuration>Debug</Configuration>
-    <Configurations Condition=""'$(OS)' != 'Windows_NT'"">Debug</Configurations>
+    <Configuration>Dbg</Configuration>
+    <Configurations Condition=""'$(OS)' != 'Windows_NT'"">Dbg</Configurations>
   </PropertyGroup>
 </Project>")]
-        public async Task GetBestGuessDefaultValuesForDimensionsAsync_WhenConfigurationsHasUnrecognizedCondition_ReturnsEmpty(string projectXml)
+        public async Task GetBestGuessDefaultValuesForDimensionsAsync_WhenConfigurationsHasUnrecognizedCondition_ReturnsDefault(string projectXml)
         {
             var provider = CreateInstance(projectXml);
 
             var result = await provider.GetBestGuessDefaultValuesForDimensionsAsync(UnconfiguredProjectFactory.Create());
 
-            Assert.Empty(result);
+            Assert.Single(result);
+            Assert.Equal("Configuration", result.First().Key);
+            Assert.Equal("Debug", result.First().Value);
         }
 
 
@@ -364,34 +370,34 @@ $@"<Project>
         [InlineData(
 @"<Project>
   <PropertyGroup>
-    <Configurations Condition=""'$(BuildingInsideVisualStudio)' == 'true'"">Debug</Configurations>
-    <Configurations Condition=""'$(BuildingInsideVisualStudio)' != 'true'"">Release</Configurations>
+    <Configurations Condition=""'$(BuildingInsideVisualStudio)' == 'true'"">Dbg</Configurations>
+    <Configurations Condition=""'$(BuildingInsideVisualStudio)' != 'true'"">Retail</Configurations>
   </PropertyGroup>
 </Project>")]
         [InlineData(
 @"<Project>
   <PropertyGroup>
-    <Configurations Condition=""'$(OS)' == 'Windows_NT'"">Debug</Configurations>
-    <Configurations Condition=""'$(OS)' != 'Windows_NT'"">Release</Configurations>
+    <Configurations Condition=""'$(OS)' == 'Windows_NT'"">Dbg</Configurations>
+    <Configurations Condition=""'$(OS)' != 'Windows_NT'"">Retail</Configurations>
   </PropertyGroup>
 </Project>")]
         [InlineData(
 @"<Project>
   <PropertyGroup>
-    <Configurations Condition=""'$(OS)' == 'Windows_NT'"">Debug</Configurations>
-    <Configurations Condition=""'$(OS)' == 'Unix'"">Release</Configurations>
+    <Configurations Condition=""'$(OS)' == 'Windows_NT'"">Dbg</Configurations>
+    <Configurations Condition=""'$(OS)' == 'Unix'"">Retail</Configurations>
   </PropertyGroup>
 </Project>")]
         [InlineData(
 @"<Project>
   <PropertyGroup>
-    <Configurations Condition=""true"">Debug</Configurations>
+    <Configurations Condition=""true"">Dbg</Configurations>
   </PropertyGroup>
 </Project>")]
         [InlineData(
 @"<Project>
   <PropertyGroup>
-    <Configurations Condition="""">Debug</Configurations>
+    <Configurations Condition="""">Dbg</Configurations>
   </PropertyGroup>
 </Project>")]
         public async Task GetBestGuessDefaultValuesForDimensionsAsync_WhenConfigurationsHasRecognizedCondition_ReturnsValue(string projectXml)
@@ -402,7 +408,7 @@ $@"<Project>
 
             Assert.Single(result);
             Assert.Equal("Configuration", result.First().Key);
-            Assert.Equal("Debug", result.First().Value);
+            Assert.Equal("Dbg", result.First().Value);
         }
 
         private static ConfigurationProjectConfigurationDimensionProvider CreateInstance(string projectXml)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ConfigurationProjectConfigurationDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ConfigurationProjectConfigurationDimensionProviderTests.cs
@@ -283,6 +283,26 @@ $@"<Project>
         }
 
         [Fact]
+        public async Task GetBestGuessDefaultValuesForDimensionsAsync_ReturnsFirstValueFromLastConfigurationsElement()
+        {
+            string projectXml =
+$@"<Project>
+  <PropertyGroup>
+    <Configurations>Debug</Configurations>
+    <Configurations>Release;Debug</Configurations>
+  </PropertyGroup>
+</Project>";
+
+            var provider = CreateInstance(projectXml);
+
+            var result = await provider.GetBestGuessDefaultValuesForDimensionsAsync(UnconfiguredProjectFactory.Create());
+
+            Assert.Single(result);
+            Assert.Equal("Configuration", result.First().Key);
+            Assert.Equal("Release", result.First().Value);
+        }
+
+        [Fact]
         public async Task GetBestGuessDefaultValuesForDimensionsAsync_WhenConfigurationsIsMissing_ReturnsEmpty()
         {
             string projectXml =

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/PlatformProjectConfigurationDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/PlatformProjectConfigurationDimensionProviderTests.cs
@@ -161,12 +161,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         }
 
         [Theory]
-        [InlineData("ARM",               "ARM")]
-        [InlineData(" ARM ",             "ARM")]
-        [InlineData("x64",               "x64")]
-        [InlineData("ARM;x64",           "ARM")]
-        [InlineData(";ARM;x64",          "ARM")]
-        public async Task GetBestGuessDefaultValuesForDimensionsAsync_ReturnsFirstValue(string platforms, string expected)
+        [InlineData("ARM",                  "ARM")]
+        [InlineData(" ARM ",                "ARM")]
+        [InlineData("x64",                  "x64")]
+        [InlineData("ARM;",                 "ARM")]
+        [InlineData("ARM;x64",              "ARM")]
+        [InlineData(";ARM;x64",             "ARM")]
+        [InlineData("$(Foo);ARM;x64",       "ARM")]
+        [InlineData("$(Foo); ARM ;x64",     "ARM")]
+        [InlineData("x64_$(Foo); ARM ;x64", "ARM")]
+        public async Task GetBestGuessDefaultValuesForDimensionsAsync_ReturnsFirstParsableValue(string platforms, string expected)
         {
             string projectXml =
 $@"<Project>
@@ -193,6 +197,8 @@ $@"<Project>
         [InlineData(";;;")]
         [InlineData("$(Property)")]
         [InlineData("Foo_$(Property)")]
+        [InlineData("Foo_$(Property);")]
+        [InlineData(";Foo_$(Property);")]
         public async Task GetBestGuessDefaultValuesForDimensionsAsync_WhenPlatformsIsEmpty_ReturnsDefault(string platforms)
         {
             string projectXml =

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/PlatformProjectConfigurationDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/PlatformProjectConfigurationDimensionProviderTests.cs
@@ -161,11 +161,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         }
 
         [Theory]
-        [InlineData("AnyCPU",               "AnyCPU")]
-        [InlineData(" AnyCPU ",             "AnyCPU")]
-        [InlineData("x64",                  "x64")]
-        [InlineData("AnyCPU;x64",           "AnyCPU")]
-        [InlineData(";AnyCPU;x64",          "AnyCPU")]
+        [InlineData("ARM",               "ARM")]
+        [InlineData(" ARM ",             "ARM")]
+        [InlineData("x64",               "x64")]
+        [InlineData("ARM;x64",           "ARM")]
+        [InlineData(";ARM;x64",          "ARM")]
         public async Task GetBestGuessDefaultValuesForDimensionsAsync_ReturnsFirstValue(string platforms, string expected)
         {
             string projectXml =
@@ -193,7 +193,7 @@ $@"<Project>
         [InlineData(";;;")]
         [InlineData("$(Property)")]
         [InlineData("Foo_$(Property)")]
-        public async Task GetBestGuessDefaultValuesForDimensionsAsync_WhenPlatformsIsEmpty_ReturnsEmpty(string platforms)
+        public async Task GetBestGuessDefaultValuesForDimensionsAsync_WhenPlatformsIsEmpty_ReturnsDefault(string platforms)
         {
             string projectXml =
 $@"<Project>
@@ -206,7 +206,9 @@ $@"<Project>
 
             var result = await provider.GetBestGuessDefaultValuesForDimensionsAsync(UnconfiguredProjectFactory.Create());
 
-            Assert.Empty(result);
+            Assert.Single(result);
+            Assert.Equal("Platform", result.First().Key);
+            Assert.Equal("AnyCPU", result.First().Value);
         }
 
         [Fact]
@@ -216,7 +218,25 @@ $@"<Project>
 $@"<Project>
   <PropertyGroup>
     <Platforms>x64</Platforms>
-    <Platforms>AnyCPU;x86</Platforms>
+    <Platforms>ARM;x86</Platforms>
+  </PropertyGroup>
+</Project>";
+
+            var provider = CreateInstance(projectXml);
+
+            var result = await provider.GetBestGuessDefaultValuesForDimensionsAsync(UnconfiguredProjectFactory.Create());
+
+            Assert.Single(result);
+            Assert.Equal("Platform", result.First().Key);
+            Assert.Equal("ARM", result.First().Value);
+        }
+
+        [Fact]
+        public async Task GetBestGuessDefaultValuesForDimensionsAsync_WhenPlatformsIsMissing_ReturnsDefault()
+        {
+            string projectXml =
+$@"<Project>
+  <PropertyGroup>
   </PropertyGroup>
 </Project>";
 
@@ -229,61 +249,47 @@ $@"<Project>
             Assert.Equal("AnyCPU", result.First().Value);
         }
 
-        [Fact]
-        public async Task GetBestGuessDefaultValuesForDimensionsAsync_WhenPlatformsIsMissing_ReturnsEmpty()
-        {
-            string projectXml =
-$@"<Project>
-  <PropertyGroup>
-  </PropertyGroup>
-</Project>";
-
-            var provider = CreateInstance(projectXml);
-
-            var result = await provider.GetBestGuessDefaultValuesForDimensionsAsync(UnconfiguredProjectFactory.Create());
-
-            Assert.Empty(result);
-        }
-
         [Theory]
         [InlineData(
 @"<Project>
   <PropertyGroup>
-    <Platforms Condition=""'$(BuildingInsideVisualStudio)' != 'true'"">AnyCPU</Platforms>
+    <Platforms Condition=""'$(BuildingInsideVisualStudio)' != 'true'"">ARM</Platforms>
   </PropertyGroup>
 </Project>")]
         [InlineData(
 @"<Project>
   <PropertyGroup>
-    <Platforms Condition=""'$(OS)' != 'Windows_NT'"">AnyCPU</Platforms>
+    <Platforms Condition=""'$(OS)' != 'Windows_NT'"">ARM</Platforms>
   </PropertyGroup>
 </Project>")]
         [InlineData(
 @"<Project>
   <PropertyGroup>
-    <Platforms Condition=""'$(OS)' == 'Unix'"">AnyCPU</Platforms>
+    <Platforms Condition=""'$(OS)' == 'Unix'"">ARM</Platforms>
   </PropertyGroup>
 </Project>")]
         [InlineData(
 @"<Project>
   <PropertyGroup>
-    <Platforms Condition=""'$(Foo)' == 'true'"">AnyCPU</Platforms>
+    <Platforms Condition=""'$(Foo)' == 'true'"">ARM</Platforms>
   </PropertyGroup>
 </Project>")]
         [InlineData(
 @"<Project>
   <PropertyGroup>
-    <Platform>AnyCPU</Platform>
-    <Platforms Condition=""'$(OS)' != 'Windows_NT'"">AnyCPU</Platforms>
+    <Platform>ARM</Platform>
+    <Platforms Condition=""'$(OS)' != 'Windows_NT'"">ARM</Platforms>
   </PropertyGroup>
 </Project>")]
-        public async Task GetBestGuessDefaultValuesForDimensionsAsync_WhenPlatformsHasUnrecognizedCondition_ReturnsEmpty(string projectXml)
+        public async Task GetBestGuessDefaultValuesForDimensionsAsync_WhenPlatformsHasUnrecognizedCondition_ReturnsDefault(string projectXml)
         {
             var provider = CreateInstance(projectXml);
 
             var result = await provider.GetBestGuessDefaultValuesForDimensionsAsync(UnconfiguredProjectFactory.Create());
 
-            Assert.Empty(result);
+            Assert.Single(result);
+            Assert.Equal("Platform", result.First().Key);
+            Assert.Equal("AnyCPU", result.First().Value);
         }
 
 
@@ -291,34 +297,34 @@ $@"<Project>
         [InlineData(
 @"<Project>
   <PropertyGroup>
-    <Platforms Condition=""'$(BuildingInsideVisualStudio)' == 'true'"">AnyCPU</Platforms>
+    <Platforms Condition=""'$(BuildingInsideVisualStudio)' == 'true'"">ARM</Platforms>
     <Platforms Condition=""'$(BuildingInsideVisualStudio)' != 'true'"">x86</Platforms>
   </PropertyGroup>
 </Project>")]
         [InlineData(
 @"<Project>
   <PropertyGroup>
-    <Platforms Condition=""'$(OS)' == 'Windows_NT'"">AnyCPU</Platforms>
+    <Platforms Condition=""'$(OS)' == 'Windows_NT'"">ARM</Platforms>
     <Platforms Condition=""'$(OS)' != 'Windows_NT'"">x86</Platforms>
   </PropertyGroup>
 </Project>")]
         [InlineData(
 @"<Project>
   <PropertyGroup>
-    <Platforms Condition=""'$(OS)' == 'Windows_NT'"">AnyCPU</Platforms>
+    <Platforms Condition=""'$(OS)' == 'Windows_NT'"">ARM</Platforms>
     <Platforms Condition=""'$(OS)' == 'Unix'"">x86</Platforms>
   </PropertyGroup>
 </Project>")]
         [InlineData(
 @"<Project>
   <PropertyGroup>
-    <Platforms Condition=""true"">AnyCPU</Platforms>
+    <Platforms Condition=""true"">ARM</Platforms>
   </PropertyGroup>
 </Project>")]
         [InlineData(
 @"<Project>
   <PropertyGroup>
-    <Platforms Condition="""">AnyCPU</Platforms>
+    <Platforms Condition="""">ARM</Platforms>
   </PropertyGroup>
 </Project>")]
         public async Task GetBestGuessDefaultValuesForDimensionsAsync_WhenPlatformsHasRecognizedCondition_ReturnsValue(string projectXml)
@@ -329,7 +335,7 @@ $@"<Project>
 
             Assert.Single(result);
             Assert.Equal("Platform", result.First().Key);
-            Assert.Equal("AnyCPU", result.First().Value);
+            Assert.Equal("ARM", result.First().Value);
         }
 
         private static PlatformProjectConfigurationDimensionProvider CreateInstance(string projectXml)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/PlatformProjectConfigurationDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/PlatformProjectConfigurationDimensionProviderTests.cs
@@ -210,6 +210,26 @@ $@"<Project>
         }
 
         [Fact]
+        public async Task GetBestGuessDefaultValuesForDimensionsAsync_ReturnsFirstValueFromLastPlatformsElement()
+        {
+            string projectXml =
+$@"<Project>
+  <PropertyGroup>
+    <Platforms>x64</Platforms>
+    <Platforms>AnyCPU;x86</Platforms>
+  </PropertyGroup>
+</Project>";
+
+            var provider = CreateInstance(projectXml);
+
+            var result = await provider.GetBestGuessDefaultValuesForDimensionsAsync(UnconfiguredProjectFactory.Create());
+
+            Assert.Single(result);
+            Assert.Equal("Platform", result.First().Key);
+            Assert.Equal("AnyCPU", result.First().Value);
+        }
+
+        [Fact]
         public async Task GetBestGuessDefaultValuesForDimensionsAsync_WhenPlatformsIsMissing_ReturnsEmpty()
         {
             string projectXml =
@@ -224,6 +244,8 @@ $@"<Project>
 
             Assert.Empty(result);
         }
+
+
 
         private static PlatformProjectConfigurationDimensionProvider CreateInstance(string projectXml)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/TargetFrameworkProjectConfigurationDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/TargetFrameworkProjectConfigurationDimensionProviderTests.cs
@@ -127,12 +127,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         }
 
         [Theory]
-        [InlineData("net45",                "net45")]
-        [InlineData(" net45 ",              "net45")]
-        [InlineData("net46",                "net46")]
-        [InlineData("net45;net46",          "net45")]
-        [InlineData(";net45;net46",         "net45")]
-        public async Task GetBestGuessDefaultValuesForDimensionsAsync_ReturnsFirstValue(string frameworks, string expected)
+        [InlineData("net45",                      "net45")]
+        [InlineData(" net45 ",                    "net45")]
+        [InlineData("net46",                      "net46")]
+        [InlineData("net45;",                     "net45")]
+        [InlineData("net45;net46",                "net45")]
+        [InlineData(";net45;net46",               "net45")]
+        [InlineData("$(Foo);net45;net46",         "net45")]
+        [InlineData("$(Foo); net45 ;net46",       "net45")]
+        [InlineData("net45_$(Foo); net45 ;net46", "net45")]
+        public async Task GetBestGuessDefaultValuesForDimensionsAsync_ReturnsFirstParsableValue(string frameworks, string expected)
         {
             string projectXml =
 $@"<Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/TargetFrameworkProjectConfigurationDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/TargetFrameworkProjectConfigurationDimensionProviderTests.cs
@@ -211,6 +211,136 @@ $@"<Project>
             Assert.Empty(result);
         }
 
+
+        [Theory]
+        [InlineData(
+@"<Project>
+  <PropertyGroup>
+    <TargetFrameworks Condition=""'$(BuildingInsideVisualStudio)' != 'true'"">net45</TargetFrameworks>
+  </PropertyGroup>
+</Project>")]
+        [InlineData(
+@"<Project>
+  <PropertyGroup>
+    <TargetFrameworks Condition=""'$(BuildingInsideVisualStudio)' != 'true'"">net45</TargetFrameworks>
+    <TargetFramework>net45</TargetFramework>
+  </PropertyGroup>
+</Project>")]
+        [InlineData(
+@"<Project>
+  <PropertyGroup>
+    <TargetFramework>net45</TargetFramework>
+    <TargetFrameworks Condition=""'$(BuildingInsideVisualStudio)' != 'true'"">net45</TargetFrameworks>
+  </PropertyGroup>
+</Project>")]
+        [InlineData(
+@"<Project>
+  <PropertyGroup>
+    <TargetFrameworks Condition=""'$(OS)' != 'Windows_NT'"">net45</TargetFrameworks>
+  </PropertyGroup>
+</Project>")]
+        [InlineData(
+@"<Project>
+  <PropertyGroup>
+    <TargetFrameworks Condition=""'$(OS)' == 'Unix'"">net45</TargetFrameworks>
+  </PropertyGroup>
+</Project>")]
+        [InlineData(
+@"<Project>
+  <PropertyGroup>
+    <TargetFrameworks Condition=""'$(Foo)' == 'true'"">net45</TargetFrameworks>
+  </PropertyGroup>
+</Project>")]
+        [InlineData(
+@"<Project>
+  <PropertyGroup>
+    <TargetFramework>net45</TargetFramework>
+    <TargetFrameworks Condition=""'$(OS)' != 'Windows_NT'"">net45</TargetFrameworks>
+  </PropertyGroup>
+</Project>")]
+        public async Task GetBestGuessDefaultValuesForDimensionsAsync_WhenTargetFrameworksHasUnrecognizedCondition_ReturnsEmpty(string projectXml)
+        {
+            var provider = CreateInstance(projectXml);
+
+            var result = await provider.GetBestGuessDefaultValuesForDimensionsAsync(UnconfiguredProjectFactory.Create());
+
+            Assert.Empty(result);
+        }
+
+
+        [Theory]
+        [InlineData(
+@"<Project>
+  <PropertyGroup>
+    <TargetFrameworks Condition=""'$(BuildingInsideVisualStudio)' == 'true'"">net45</TargetFrameworks>
+    <TargetFrameworks Condition=""'$(BuildingInsideVisualStudio)' != 'true'"">netstandard20</TargetFrameworks>
+  </PropertyGroup>
+</Project>")]
+        [InlineData(
+@"<Project>
+  <PropertyGroup>
+    <TargetFrameworks Condition=""'$(BuildingInsideVisualStudio)' == 'true'"">netstandard20</TargetFrameworks>
+    <TargetFrameworks>net45</TargetFrameworks>
+  </PropertyGroup>
+</Project>")]
+        [InlineData(
+@"<Project>
+  <PropertyGroup>
+    <TargetFrameworks>netstandard20</TargetFrameworks>
+    <TargetFrameworks Condition=""'$(BuildingInsideVisualStudio)' == 'true'"">net45</TargetFrameworks>
+  </PropertyGroup>
+</Project>")]
+        [InlineData(
+@"<Project>
+  <PropertyGroup>
+    <TargetFrameworks Condition=""'$(BuildingInsideVisualStudio)' != 'true'"">netstandard20</TargetFrameworks>
+    <TargetFrameworks>net45</TargetFrameworks>
+  </PropertyGroup>
+</Project>")]
+        [InlineData(
+@"<Project>
+  <PropertyGroup>
+    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks Condition=""'$(BuildingInsideVisualStudio)' != 'true'"">netstandard20</TargetFrameworks>
+  </PropertyGroup>
+</Project>")]
+        [InlineData(
+@"<Project>
+  <PropertyGroup>
+    <TargetFrameworks Condition=""'$(OS)' == 'Windows_NT'"">net45</TargetFrameworks>
+    <TargetFrameworks Condition=""'$(OS)' != 'Windows_NT'"">netstandard20</TargetFrameworks>
+  </PropertyGroup>
+</Project>")]
+        [InlineData(
+@"<Project>
+  <PropertyGroup>
+    <TargetFrameworks Condition=""'$(OS)' == 'Windows_NT'"">net45</TargetFrameworks>
+    <TargetFrameworks Condition=""'$(OS)' == 'Unix'"">netstandard20</TargetFrameworks>
+  </PropertyGroup>
+</Project>")]
+        [InlineData(
+@"<Project>
+  <PropertyGroup>
+    <TargetFrameworks Condition=""true"">net45</TargetFrameworks>
+  </PropertyGroup>
+</Project>")]
+        [InlineData(
+@"<Project>
+  <PropertyGroup>
+    <TargetFrameworks Condition="""">net45</TargetFrameworks>
+  </PropertyGroup>
+</Project>")]
+        public async Task GetBestGuessDefaultValuesForDimensionsAsync_WhenTargetFrameworksHasRecognizedCondition_ReturnsValue(string projectXml)
+        {
+            var provider = CreateInstance(projectXml);
+
+            var result = await provider.GetBestGuessDefaultValuesForDimensionsAsync(UnconfiguredProjectFactory.Create());
+
+            Assert.Single(result);
+            Assert.Equal("TargetFramework", result.First().Key);
+            Assert.Equal("net45", result.First().Value);
+        }
+
         private static TargetFrameworkProjectConfigurationDimensionProvider CreateInstance(string projectXml)
         {
             var projectAccessor = IProjectAccessorFactory.Create(projectXml);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/TargetFrameworkProjectConfigurationDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/TargetFrameworkProjectConfigurationDimensionProviderTests.cs
@@ -176,6 +176,26 @@ $@"<Project>
         }
 
         [Fact]
+        public async Task GetBestGuessDefaultValuesForDimensionsAsync_ReturnsFirstValueFromLastTargetFrameworksElement()
+        {
+            string projectXml =
+$@"<Project>
+  <PropertyGroup>
+    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks>net46;net47</TargetFrameworks>
+  </PropertyGroup>
+</Project>";
+
+            var provider = CreateInstance(projectXml);
+
+            var result = await provider.GetBestGuessDefaultValuesForDimensionsAsync(UnconfiguredProjectFactory.Create());
+
+            Assert.Single(result);
+            Assert.Equal("TargetFramework", result.First().Key);
+            Assert.Equal("net46", result.First().Value);
+        }
+
+        [Fact]
         public async Task GetBestGuessDefaultValuesForDimensionsAsync_WhenTargetFrameworksIsMissing_ReturnsEmpty()
         {
             string projectXml =

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AvoidPersistingProjectGuidStorageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AvoidPersistingProjectGuidStorageProvider.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
+using Microsoft.VisualStudio.Build;
 using Microsoft.VisualStudio.ProjectSystem.Build;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
@@ -97,7 +98,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
         private static bool TryParseGuid(ProjectPropertyElement property, out Guid result)
         {
-            string unescapedValue = ProjectCollection.Unescape(property.Value);
+            string unescapedValue = property.GetUnescapedValue();
 
             return Guid.TryParse(unescapedValue, out result);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildExtensions.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
+
+namespace Microsoft.VisualStudio.Build
+{
+    internal static class BuildExtensions
+    {
+        /// <summary>
+        ///     Gets the unescaped, unevaluated value.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="element"/> is <see langword="null" />.
+        /// </exception>
+        public static string GetUnescapedValue(this ProjectPropertyElement element)
+        {
+            Requires.NotNull(element, nameof(element));
+
+            return ProjectCollection.Unescape(element.Value);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildUtilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildUtilities.cs
@@ -16,6 +16,35 @@ namespace Microsoft.VisualStudio.Build
     internal static class BuildUtilities
     {
         /// <summary>
+        ///     Returns a value indicating whether the specified property has a condition that 
+        ///     always evaluates to <see langword="true"/>.
+        /// </summary>
+        public static bool HasWellKnownConditionsThatAlwaysEvaluateToTrue(ProjectPropertyElement element)
+        {
+            Requires.NotNull(element, nameof(element));
+
+            // We look for known conditions that evaluate to true so that 
+            // projects can have patterns where they opt in/out of target 
+            // frameworks based on whether they are inside Visual Studio or not.
+
+            // For example:
+            // 
+            // <TargetFrameworks>net461;net452</TargetFrameworks>
+            // <TargetFrameworks Condition = "'$(BuildingInsideVisualStudio)' == 'true'">net461</TargetFrameworks>
+
+            switch (element.Condition)
+            {
+                case "":
+                case "true":
+                case "'$(OS)' == 'Windows_NT'":
+                case "'$(BuildingInsideVisualStudio)' == 'true'":
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Gets a project property.
         /// </summary>
         /// <param name="project">Xml representation of the MsBuild project.</param>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
@@ -173,14 +173,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
             if (string.IsNullOrEmpty(values))
                 return null;
 
-            string defaultValue = BuildUtilities.GetPropertyValues(values).FirstOrDefault();
+            foreach (string defaultValue in BuildUtilities.GetPropertyValues(values))
+            {
+                // If this property is derived from another property, skip it and just
+                // pull default from next known values. This is better than picking a 
+                // default that is not actually one of the known configs.
+                if (defaultValue.IndexOf("$(") == -1)
+                    return defaultValue;
+            }
 
-            // If this property is derived from another property, just bail, we'll get it when we go
-            // to calculate the real value in GetDefaultValuesForDimensionsAsync.
-            if (defaultValue == null || defaultValue.IndexOf("$(") != -1)
-                return null;
-
-            return defaultValue;
+            return null;
         }
 
         private Task<string> FindDimensionPropertyAsync(UnconfiguredProject project)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
@@ -182,31 +182,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
             return projectXml.PropertyGroups.SelectMany(group => group.Properties)
                                             .Reverse()
                                             .Where(p => StringComparers.PropertyNames.Equals(PropertyName, p.Name))
-                                            .Where(p => HasRecognizedConditionThatEvaluatesToTrue(p))
+                                            .Where(p => BuildUtilities.HasWellKnownConditionsThatAlwaysEvaluateToTrue(p))
                                             .FirstOrDefault();
-        }
-
-        private bool HasRecognizedConditionThatEvaluatesToTrue(ProjectPropertyElement element)
-        {
-            // We look for known conditions that evaluate to true so that 
-            // projects can have patterns where they opt in/out of target 
-            // frameworks based on whether they are inside Visual Studio or not.
-
-            // For example:
-            // 
-            // <TargetFrameworks>net461;net452</TargetFrameworks>
-            // <TargetFrameworks Condition = "'$(BuildingInsideVisualStudio)' == 'true'">net461</TargetFrameworks>
-
-            switch (element.Condition)
-            {
-                case "":
-                case "true":
-                case "'$(OS)' == 'Windows_NT'":
-                case "'$(BuildingInsideVisualStudio)' == 'true'":
-                    return true;
-            }
-
-            return false;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/ConfigurationProjectConfigurationDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/ConfigurationProjectConfigurationDimensionProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
     {
         [ImportingConstructor]
         public ConfigurationProjectConfigurationDimensionProvider(IProjectAccessor projectAccessor)
-            : base(projectAccessor, ConfigurationGeneral.ConfigurationProperty, "Configurations")
+            : base(projectAccessor, ConfigurationGeneral.ConfigurationProperty, "Configurations", "Debug")
         {
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/ConfigurationProjectConfigurationDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/ConfigurationProjectConfigurationDimensionProvider.cs
@@ -19,6 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
     [Export(typeof(IProjectConfigurationDimensionsProvider))]
     [AppliesTo(ProjectCapabilities.ProjectConfigurationsDeclaredDimensions)]
     [Order(DimensionProviderOrder.Configuration)]
+    [ConfigurationDimensionDescription(ConfigurationGeneral.ConfigurationProperty)]
     internal class ConfigurationProjectConfigurationDimensionProvider : BaseProjectConfigurationDimensionProvider
     {
         [ImportingConstructor]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/PlatformProjectConfigurationDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/PlatformProjectConfigurationDimensionProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
     {
         [ImportingConstructor]
         public PlatformProjectConfigurationDimensionProvider(IProjectAccessor projectAccessor)
-            : base(projectAccessor, ConfigurationGeneral.PlatformProperty, "Platforms")
+            : base(projectAccessor, ConfigurationGeneral.PlatformProperty, "Platforms", "AnyCPU")
         {
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/PlatformProjectConfigurationDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/PlatformProjectConfigurationDimensionProvider.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
     [Export(typeof(IProjectConfigurationDimensionsProvider))]
     [AppliesTo(ProjectCapabilities.ProjectConfigurationsDeclaredDimensions)]
     [Order(DimensionProviderOrder.Platform)]
-    [ConfigurationDimensionDescription(ConfigurationGeneral.ConfigurationProperty)]
+    [ConfigurationDimensionDescription(ConfigurationGeneral.PlatformProperty)]
     internal class PlatformProjectConfigurationDimensionProvider : BaseProjectConfigurationDimensionProvider
     {
         [ImportingConstructor]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/PlatformProjectConfigurationDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/PlatformProjectConfigurationDimensionProvider.cs
@@ -19,6 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
     [Export(typeof(IProjectConfigurationDimensionsProvider))]
     [AppliesTo(ProjectCapabilities.ProjectConfigurationsDeclaredDimensions)]
     [Order(DimensionProviderOrder.Platform)]
+    [ConfigurationDimensionDescription(ConfigurationGeneral.ConfigurationProperty)]
     internal class PlatformProjectConfigurationDimensionProvider : BaseProjectConfigurationDimensionProvider
     {
         [ImportingConstructor]


### PR DESCRIPTION
To determine the configurations when loading a project, we need to read the project for the dimensions (the `<Configurations>`, `<Platforms>` and `<TargetFrameworks>` properties). This leads to a chicken and egg problem; to figure out all configurations for a given project you need to load at least one configuration to evaluate. CPS made a change to read the same config as the one active in the solution, however, this pattern doesn't work for multi-targeting projects as TargetFramework dimension is never "active", this results us loading an unneeded config that matches the solution just to grab the actual real configurations, see: #2711.

To avoid unnecessarily loading this unneeded config, we "guess" what the defaults will be based on reading the the first value in Configurations, Platforms, TargetFrameworks elements via the MSBuild construction model without evaluating. Configuration and Platform are only read if the solution didn't provide a default. TargetFramework is always read. This avoids unneeded load of a configuration if we guess correctly.

- [x] Need to figure if we should default Platform/Configuration if they aren't present (which is default) to what the SDK provides (Debug/AnyCPU)
- [x] Order matters, we should walk backwards to mimic evaluation
- [x] Add tests for what happens when multiple elements are present
- [x] Need to consider this pattern: https://github.com/MetacoSA/NBitcoin/commit/ca3b52c1b5fc5e25dabaa9e04c57679bbabfcbce?w=1#diff-2b336f1d9878772008f8ab40ba3d1fc7R19.