### PR TITLE
Fix up to date check in presence of deleted files

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -314,7 +314,7 @@
   <!-- This target collects all the extra inputs for the up to date check. -->
   <Target Name="CollectUpToDateCheckInputDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(UpToDateCheckInput)">
     <ItemGroup>
-      <!-- MSBuild input cache file, so we can detect deleted glob files -->
+      <!-- MSBuild additional compile file, such as the file input cache file -->
       <UpToDateCheckInput Include="@(CustomAdditionalCompileInputs)"/>
     </ItemGroup>
   </Target>
@@ -340,9 +340,6 @@
       
       <!-- app.config -->
       <UpToDateCheckBuilt Condition=" '@(AppConfigWithTargetPath)' != '' " Include="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')" Original="@(AppConfigWithTargetPath)"/>
-
-      <!-- MSBuild input cache file, so we can detect deleted glob files -->
-      <UpToDateCheckInput Include="@(CustomAdditionalCompileInputs)"/>
     </ItemGroup>
   </Target>
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -311,9 +311,20 @@
   <!-- This target collects all the resolved references that are used to actually compile. -->
   <Target Name="CollectResolvedCompilationReferencesDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(ReferencePathWithRefAssemblies)" />
   
+  <!-- This target collects all the extra inputs for the up to date check. -->
+  <Target Name="CollectUpToDateCheckInputDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(UpToDateCheckInput)">
+    <ItemGroup>
+      <!-- MSBuild input cache file, so we can detect deleted glob files -->
+      <UpToDateCheckInput Include="@(CustomAdditionalCompileInputs)"/>
+    </ItemGroup>
+  </Target>
+
+  <!-- This target collects all the extra inputs for the up to date check. -->
+  <Target Name="CollectUpToDateCheckOutputDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(UpToDateCheckOutput)" />
+
   <!-- This target collects all the things built by the project for the up to date check. -->
   <!-- See CopyFileToOutputDirectory target -->
-  <Target Name="CollectBuiltDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(UpToDateCheckBuilt)">
+  <Target Name="CollectUpToDateCheckBuiltDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(UpToDateCheckBuilt)">
     <ItemGroup>
       <!-- Assembly output, bin and obj -->
       <UpToDateCheckBuilt Condition="'$(CopyBuildOutputToOutputDirectory)' != 'false' and '$(SkipCopyBuildProduct)' != 'true'" Include="$(TargetPath)"/>
@@ -329,6 +340,9 @@
       
       <!-- app.config -->
       <UpToDateCheckBuilt Condition=" '@(AppConfigWithTargetPath)' != '' " Include="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')" Original="@(AppConfigWithTargetPath)"/>
+
+      <!-- MSBuild input cache file, so we can detect deleted glob files -->
+      <UpToDateCheckInput Include="@(CustomAdditionalCompileInputs)"/>
     </ItemGroup>
   </Target>
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckBuilt.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckBuilt.xaml
@@ -1,18 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule
-    Name="UpToDateCheckBuilt"
-    DisplayName="Up-to-date check built artifact"
-    PageTemplate="generic"
-    Description="File Properties"
-    xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="UpToDateCheckBuilt" xmlns="http://schemas.microsoft.com/build/2009/properties">
     <Rule.DataSource>
-        <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="UpToDateCheckBuilt" SourceOfDefaultValue="AfterContext" 
-                    SourceType="TargetResults" MSBuildTarget="CollectBuiltDesignTime"/>
+        <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" 
+                    SourceType="TargetResults" MSBuildTarget="CollectUpToDateCheckBuiltDesignTime"/>
     </Rule.DataSource>
     <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
-    <StringProperty
-        Name="Original"
-        Category="Misc"
-        Description="If set, specifies that this built output comes from this source file." />
+    <StringProperty Name="Original" Category="Misc" Description="If set, specifies that this built output comes from this source file." />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckInput.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckInput.xaml
@@ -1,16 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule
-    Name="UpToDateCheckInput"
-    DisplayName="Up-to-date check input"
-    PageTemplate="generic"
-    Description="File Properties"
-    xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="UpToDateCheckInput" xmlns="http://schemas.microsoft.com/build/2009/properties">
     <Rule.DataSource>
-        <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="UpToDateCheckInput" SourceOfDefaultValue="AfterContext" />
+        <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" 
+                    SourceType="TargetResults" MSBuildTarget="CollectUpToDateCheckInputDesignTime"/>
     </Rule.DataSource>
-    <Rule.Categories>
-        <Category Name="Advanced" DisplayName="Advanced" />
-        <Category Name="Misc" DisplayName="Misc" />
-    </Rule.Categories>
+    <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckOutput.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckOutput.xaml
@@ -1,16 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule
-    Name="UpToDateCheckOutput"
-    DisplayName="Up-to-date check output"
-    PageTemplate="generic"
-    Description="File Properties"
-    xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="UpToDateCheckOutput" xmlns="http://schemas.microsoft.com/build/2009/properties">
     <Rule.DataSource>
-        <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="UpToDateCheckOutput" SourceOfDefaultValue="AfterContext" />
+        <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" 
+                    SourceType="TargetResults" MSBuildTarget="CollectUpToDateCheckOutputDesignTime"/>
     </Rule.DataSource>
-    <Rule.Categories>
-        <Category Name="Advanced" DisplayName="Advanced" />
-        <Category Name="Misc" DisplayName="Misc" />
-    </Rule.Categories>
+    <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.cs.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../UpToDateCheckBuilt.xaml">
     <body>
-      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
-        <source>Up-to-date check built artifact</source>
-        <target state="translated">Artefakt sestavený s kontrolou aktuálnosti</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
-        <source>File Properties</source>
-        <target state="translated">Vlastnosti souboru</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Original|Description">
         <source>If set, specifies that this built output comes from this source file.</source>
         <target state="translated">Pokud je možnost nastavená, určuje, že tento sestavený výstup pochází z tohoto zdrojového souboru.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.de.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../UpToDateCheckBuilt.xaml">
     <body>
-      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
-        <source>Up-to-date check built artifact</source>
-        <target state="translated">UpToDateCheckBuilt-Artefakt</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
-        <source>File Properties</source>
-        <target state="translated">Dateieigenschaften</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Original|Description">
         <source>If set, specifies that this built output comes from this source file.</source>
         <target state="translated">Gibt bei Festlegung an, dass die Ausgabe aus dieser Quelldatei stammt.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.es.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../UpToDateCheckBuilt.xaml">
     <body>
-      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
-        <source>Up-to-date check built artifact</source>
-        <target state="translated">Actualización de artefacto compilado por comprobaciones</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
-        <source>File Properties</source>
-        <target state="translated">Propiedades del archivo</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Original|Description">
         <source>If set, specifies that this built output comes from this source file.</source>
         <target state="translated">Si está configurado, especifica que esta salida de compilación procede de este archivo de origen.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.fr.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../UpToDateCheckBuilt.xaml">
     <body>
-      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
-        <source>Up-to-date check built artifact</source>
-        <target state="translated">Artefact de build du contrôle de mise à jour</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
-        <source>File Properties</source>
-        <target state="translated">Propriétés du fichier</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Original|Description">
         <source>If set, specifies that this built output comes from this source file.</source>
         <target state="translated">Si cette option est définie, elle spécifie que la sortie de build provient de ce fichier source.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.it.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../UpToDateCheckBuilt.xaml">
     <body>
-      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
-        <source>Up-to-date check built artifact</source>
-        <target state="translated">Artefatto compilato da controllo aggiornamenti</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
-        <source>File Properties</source>
-        <target state="translated">Proprietà file</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Original|Description">
         <source>If set, specifies that this built output comes from this source file.</source>
         <target state="translated">Se impostata, specifica che questo output compilato deriva da questo file di origine.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ja.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../UpToDateCheckBuilt.xaml">
     <body>
-      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
-        <source>Up-to-date check built artifact</source>
-        <target state="translated">最新チェック ビルド成果物</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
-        <source>File Properties</source>
-        <target state="translated">ファイルのプロパティ</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Original|Description">
         <source>If set, specifies that this built output comes from this source file.</source>
         <target state="translated">設定される場合、このビルド出力はこのソース ファイルから派生することを指定します。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ko.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../UpToDateCheckBuilt.xaml">
     <body>
-      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
-        <source>Up-to-date check built artifact</source>
-        <target state="translated">최신 검사로 빌드된 아티팩트</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
-        <source>File Properties</source>
-        <target state="translated">파일 속성</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Original|Description">
         <source>If set, specifies that this built output comes from this source file.</source>
         <target state="translated">설정하면 이 빌드된 출력이 이 소스 파일에서 나오도록 지정합니다.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.pl.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../UpToDateCheckBuilt.xaml">
     <body>
-      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
-        <source>Up-to-date check built artifact</source>
-        <target state="translated">Artefakt kompilacji testu aktualności</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
-        <source>File Properties</source>
-        <target state="translated">Właściwości pliku</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Original|Description">
         <source>If set, specifies that this built output comes from this source file.</source>
         <target state="translated">Jeśli ta opcja jest ustawiona, określa, że dane wyjściowe kompilacji pochodzą z tego pliku źródłowego.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.pt-BR.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../UpToDateCheckBuilt.xaml">
     <body>
-      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
-        <source>Up-to-date check built artifact</source>
-        <target state="translated">Artefato de criação de verificação atualizado</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
-        <source>File Properties</source>
-        <target state="translated">Propriedades do Arquivo</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Original|Description">
         <source>If set, specifies that this built output comes from this source file.</source>
         <target state="translated">Se definido, especifica que essa saída criada é proveniente desse arquivo de origem.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.ru.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../UpToDateCheckBuilt.xaml">
     <body>
-      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
-        <source>Up-to-date check built artifact</source>
-        <target state="translated">Артефакт сборки проверки наличия обновлений</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
-        <source>File Properties</source>
-        <target state="translated">Свойства файла</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Original|Description">
         <source>If set, specifies that this built output comes from this source file.</source>
         <target state="translated">Если он задан, указывает, что сборка получена из этого файла исходного кода.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.tr.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../UpToDateCheckBuilt.xaml">
     <body>
-      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
-        <source>Up-to-date check built artifact</source>
-        <target state="translated">Derlenen yapıt üzerinde güncellik denetimi</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
-        <source>File Properties</source>
-        <target state="translated">Dosya Özellikleri</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Original|Description">
         <source>If set, specifies that this built output comes from this source file.</source>
         <target state="translated">Ayarlanırsa, bu derleme çıkışının bu kaynak dosyadan geldiğini belirtir.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.zh-Hans.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../UpToDateCheckBuilt.xaml">
     <body>
-      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
-        <source>Up-to-date check built artifact</source>
-        <target state="translated">最新检查生成的项目</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
-        <source>File Properties</source>
-        <target state="translated">文件属性</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Original|Description">
         <source>If set, specifies that this built output comes from this source file.</source>
         <target state="translated">如果设置，则指定此生成的输出来自此源文件。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckBuilt.xaml.zh-Hant.xlf
@@ -2,16 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../UpToDateCheckBuilt.xaml">
     <body>
-      <trans-unit id="Rule|UpToDateCheckBuilt|DisplayName">
-        <source>Up-to-date check built artifact</source>
-        <target state="translated">最新狀態檢查已建置的成品</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckBuilt|Description">
-        <source>File Properties</source>
-        <target state="translated">檔案屬性</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Original|Description">
         <source>If set, specifies that this built output comes from this source file.</source>
         <target state="translated">如有設定，會指定這個建置輸出來自這個來源檔案。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.cs.xlf
@@ -1,27 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../UpToDateCheckInput.xaml">
-    <body>
-      <trans-unit id="Rule|UpToDateCheckInput|DisplayName">
-        <source>Up-to-date check input</source>
-        <target state="translated">Vstup kontroly aktuálnosti</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckInput|Description">
-        <source>File Properties</source>
-        <target state="translated">Vlastnosti souboru</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Advanced|DisplayName">
-        <source>Advanced</source>
-        <target state="translated">Upřesnit</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Misc|DisplayName">
-        <source>Misc</source>
-        <target state="translated">Různé</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.de.xlf
@@ -1,27 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../UpToDateCheckInput.xaml">
-    <body>
-      <trans-unit id="Rule|UpToDateCheckInput|DisplayName">
-        <source>Up-to-date check input</source>
-        <target state="translated">Aktualitätsprüfungseingabe</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckInput|Description">
-        <source>File Properties</source>
-        <target state="translated">Dateieigenschaften</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Advanced|DisplayName">
-        <source>Advanced</source>
-        <target state="translated">Erweitert</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Misc|DisplayName">
-        <source>Misc</source>
-        <target state="translated">Sonst.</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.es.xlf
@@ -1,27 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../UpToDateCheckInput.xaml">
-    <body>
-      <trans-unit id="Rule|UpToDateCheckInput|DisplayName">
-        <source>Up-to-date check input</source>
-        <target state="translated">Entrada de comprobación de actualizaciones</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckInput|Description">
-        <source>File Properties</source>
-        <target state="translated">Propiedades del archivo</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Advanced|DisplayName">
-        <source>Advanced</source>
-        <target state="translated">Avanzadas</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Misc|DisplayName">
-        <source>Misc</source>
-        <target state="translated">Varios</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.fr.xlf
@@ -1,27 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../UpToDateCheckInput.xaml">
-    <body>
-      <trans-unit id="Rule|UpToDateCheckInput|DisplayName">
-        <source>Up-to-date check input</source>
-        <target state="translated">Entrée du contrôle de mise à jour</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckInput|Description">
-        <source>File Properties</source>
-        <target state="translated">Propriétés du fichier</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Advanced|DisplayName">
-        <source>Advanced</source>
-        <target state="translated">Avancé</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Misc|DisplayName">
-        <source>Misc</source>
-        <target state="translated">Divers</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.it.xlf
@@ -1,27 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../UpToDateCheckInput.xaml">
-    <body>
-      <trans-unit id="Rule|UpToDateCheckInput|DisplayName">
-        <source>Up-to-date check input</source>
-        <target state="translated">Input controllo aggiornamenti</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckInput|Description">
-        <source>File Properties</source>
-        <target state="translated">Proprietà file</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Advanced|DisplayName">
-        <source>Advanced</source>
-        <target state="translated">Avanzate</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Misc|DisplayName">
-        <source>Misc</source>
-        <target state="translated">Varie</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.ja.xlf
@@ -1,27 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../UpToDateCheckInput.xaml">
-    <body>
-      <trans-unit id="Rule|UpToDateCheckInput|DisplayName">
-        <source>Up-to-date check input</source>
-        <target state="translated">最新状態チェック入力</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckInput|Description">
-        <source>File Properties</source>
-        <target state="translated">ファイルのプロパティ</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Advanced|DisplayName">
-        <source>Advanced</source>
-        <target state="translated">詳細設定</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Misc|DisplayName">
-        <source>Misc</source>
-        <target state="translated">その他</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.ko.xlf
@@ -1,27 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../UpToDateCheckInput.xaml">
-    <body>
-      <trans-unit id="Rule|UpToDateCheckInput|DisplayName">
-        <source>Up-to-date check input</source>
-        <target state="translated">최신 검사 입력</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckInput|Description">
-        <source>File Properties</source>
-        <target state="translated">파일 속성</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Advanced|DisplayName">
-        <source>Advanced</source>
-        <target state="translated">고급</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Misc|DisplayName">
-        <source>Misc</source>
-        <target state="translated">기타</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.pl.xlf
@@ -1,27 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../UpToDateCheckInput.xaml">
-    <body>
-      <trans-unit id="Rule|UpToDateCheckInput|DisplayName">
-        <source>Up-to-date check input</source>
-        <target state="translated">Dane wejściowe testu aktualności</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckInput|Description">
-        <source>File Properties</source>
-        <target state="translated">Właściwości pliku</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Advanced|DisplayName">
-        <source>Advanced</source>
-        <target state="translated">Zaawansowane</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Misc|DisplayName">
-        <source>Misc</source>
-        <target state="translated">Różne</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.pt-BR.xlf
@@ -1,27 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../UpToDateCheckInput.xaml">
-    <body>
-      <trans-unit id="Rule|UpToDateCheckInput|DisplayName">
-        <source>Up-to-date check input</source>
-        <target state="translated">Entrada da verificação atualizada</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckInput|Description">
-        <source>File Properties</source>
-        <target state="translated">Propriedades do Arquivo</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Advanced|DisplayName">
-        <source>Advanced</source>
-        <target state="translated">Avançado</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Misc|DisplayName">
-        <source>Misc</source>
-        <target state="translated">Diversos</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.ru.xlf
@@ -1,27 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../UpToDateCheckInput.xaml">
-    <body>
-      <trans-unit id="Rule|UpToDateCheckInput|DisplayName">
-        <source>Up-to-date check input</source>
-        <target state="translated">Входные данные проверки наличия обновлений</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckInput|Description">
-        <source>File Properties</source>
-        <target state="translated">Свойства файла</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Advanced|DisplayName">
-        <source>Advanced</source>
-        <target state="translated">Дополнительно</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Misc|DisplayName">
-        <source>Misc</source>
-        <target state="translated">Прочее</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.tr.xlf
@@ -1,27 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../UpToDateCheckInput.xaml">
-    <body>
-      <trans-unit id="Rule|UpToDateCheckInput|DisplayName">
-        <source>Up-to-date check input</source>
-        <target state="translated">Güncellik denetimi girişi</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckInput|Description">
-        <source>File Properties</source>
-        <target state="translated">Dosya Özellikleri</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Advanced|DisplayName">
-        <source>Advanced</source>
-        <target state="translated">Gelişmiş</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Misc|DisplayName">
-        <source>Misc</source>
-        <target state="translated">Çeşitli</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.zh-Hans.xlf
@@ -1,27 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../UpToDateCheckInput.xaml">
-    <body>
-      <trans-unit id="Rule|UpToDateCheckInput|DisplayName">
-        <source>Up-to-date check input</source>
-        <target state="translated">最新检查输入</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckInput|Description">
-        <source>File Properties</source>
-        <target state="translated">文件属性</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Advanced|DisplayName">
-        <source>Advanced</source>
-        <target state="translated">高级</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Misc|DisplayName">
-        <source>Misc</source>
-        <target state="translated">杂项</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckInput.xaml.zh-Hant.xlf
@@ -1,27 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../UpToDateCheckInput.xaml">
-    <body>
-      <trans-unit id="Rule|UpToDateCheckInput|DisplayName">
-        <source>Up-to-date check input</source>
-        <target state="translated">最新版檢查輸入</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckInput|Description">
-        <source>File Properties</source>
-        <target state="translated">檔案屬性</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Advanced|DisplayName">
-        <source>Advanced</source>
-        <target state="translated">進階</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Misc|DisplayName">
-        <source>Misc</source>
-        <target state="translated">其他</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.cs.xlf
@@ -1,27 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../UpToDateCheckOutput.xaml">
-    <body>
-      <trans-unit id="Rule|UpToDateCheckOutput|DisplayName">
-        <source>Up-to-date check output</source>
-        <target state="translated">Výstup kontroly aktuálnosti</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckOutput|Description">
-        <source>File Properties</source>
-        <target state="translated">Vlastnosti souboru</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Advanced|DisplayName">
-        <source>Advanced</source>
-        <target state="translated">Upřesnit</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Misc|DisplayName">
-        <source>Misc</source>
-        <target state="translated">Různé</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.de.xlf
@@ -1,27 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../UpToDateCheckOutput.xaml">
-    <body>
-      <trans-unit id="Rule|UpToDateCheckOutput|DisplayName">
-        <source>Up-to-date check output</source>
-        <target state="translated">Aktualitätsprüfungsausgabe</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckOutput|Description">
-        <source>File Properties</source>
-        <target state="translated">Dateieigenschaften</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Advanced|DisplayName">
-        <source>Advanced</source>
-        <target state="translated">Erweitert</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Misc|DisplayName">
-        <source>Misc</source>
-        <target state="translated">Sonst.</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.es.xlf
@@ -1,27 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../UpToDateCheckOutput.xaml">
-    <body>
-      <trans-unit id="Rule|UpToDateCheckOutput|DisplayName">
-        <source>Up-to-date check output</source>
-        <target state="translated">Salida de comprobación de actualizaciones</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckOutput|Description">
-        <source>File Properties</source>
-        <target state="translated">Propiedades del archivo</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Advanced|DisplayName">
-        <source>Advanced</source>
-        <target state="translated">Avanzadas</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Misc|DisplayName">
-        <source>Misc</source>
-        <target state="translated">Varios</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.fr.xlf
@@ -1,27 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../UpToDateCheckOutput.xaml">
-    <body>
-      <trans-unit id="Rule|UpToDateCheckOutput|DisplayName">
-        <source>Up-to-date check output</source>
-        <target state="translated">Sortie du contrôle de mise à jour</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckOutput|Description">
-        <source>File Properties</source>
-        <target state="translated">Propriétés du fichier</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Advanced|DisplayName">
-        <source>Advanced</source>
-        <target state="translated">Avancé</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Misc|DisplayName">
-        <source>Misc</source>
-        <target state="translated">Divers</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.it.xlf
@@ -1,27 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../UpToDateCheckOutput.xaml">
-    <body>
-      <trans-unit id="Rule|UpToDateCheckOutput|DisplayName">
-        <source>Up-to-date check output</source>
-        <target state="translated">Output controllo aggiornamenti</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckOutput|Description">
-        <source>File Properties</source>
-        <target state="translated">Proprietà file</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Advanced|DisplayName">
-        <source>Advanced</source>
-        <target state="translated">Avanzate</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Misc|DisplayName">
-        <source>Misc</source>
-        <target state="translated">Varie</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.ja.xlf
@@ -1,27 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../UpToDateCheckOutput.xaml">
-    <body>
-      <trans-unit id="Rule|UpToDateCheckOutput|DisplayName">
-        <source>Up-to-date check output</source>
-        <target state="translated">最新状態チェック出力</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckOutput|Description">
-        <source>File Properties</source>
-        <target state="translated">ファイルのプロパティ</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Advanced|DisplayName">
-        <source>Advanced</source>
-        <target state="translated">詳細設定</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Misc|DisplayName">
-        <source>Misc</source>
-        <target state="translated">その他</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.ko.xlf
@@ -1,27 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../UpToDateCheckOutput.xaml">
-    <body>
-      <trans-unit id="Rule|UpToDateCheckOutput|DisplayName">
-        <source>Up-to-date check output</source>
-        <target state="translated">최신 검사 출력</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckOutput|Description">
-        <source>File Properties</source>
-        <target state="translated">파일 속성</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Advanced|DisplayName">
-        <source>Advanced</source>
-        <target state="translated">고급</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Misc|DisplayName">
-        <source>Misc</source>
-        <target state="translated">기타</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.pl.xlf
@@ -1,27 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../UpToDateCheckOutput.xaml">
-    <body>
-      <trans-unit id="Rule|UpToDateCheckOutput|DisplayName">
-        <source>Up-to-date check output</source>
-        <target state="translated">Dane wyjściowe testu aktualności</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckOutput|Description">
-        <source>File Properties</source>
-        <target state="translated">Właściwości pliku</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Advanced|DisplayName">
-        <source>Advanced</source>
-        <target state="translated">Zaawansowane</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Misc|DisplayName">
-        <source>Misc</source>
-        <target state="translated">Różne</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.pt-BR.xlf
@@ -1,27 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../UpToDateCheckOutput.xaml">
-    <body>
-      <trans-unit id="Rule|UpToDateCheckOutput|DisplayName">
-        <source>Up-to-date check output</source>
-        <target state="translated">Saída da verificação atualizada</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckOutput|Description">
-        <source>File Properties</source>
-        <target state="translated">Propriedades do Arquivo</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Advanced|DisplayName">
-        <source>Advanced</source>
-        <target state="translated">Avançado</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Misc|DisplayName">
-        <source>Misc</source>
-        <target state="translated">Diversos</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.ru.xlf
@@ -1,27 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../UpToDateCheckOutput.xaml">
-    <body>
-      <trans-unit id="Rule|UpToDateCheckOutput|DisplayName">
-        <source>Up-to-date check output</source>
-        <target state="translated">Выходные данные проверки наличия обновлений</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckOutput|Description">
-        <source>File Properties</source>
-        <target state="translated">Свойства файла</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Advanced|DisplayName">
-        <source>Advanced</source>
-        <target state="translated">Дополнительно</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Misc|DisplayName">
-        <source>Misc</source>
-        <target state="translated">Прочее</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.tr.xlf
@@ -1,27 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../UpToDateCheckOutput.xaml">
-    <body>
-      <trans-unit id="Rule|UpToDateCheckOutput|DisplayName">
-        <source>Up-to-date check output</source>
-        <target state="translated">Güncellik denetimi çıkışı</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckOutput|Description">
-        <source>File Properties</source>
-        <target state="translated">Dosya Özellikleri</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Advanced|DisplayName">
-        <source>Advanced</source>
-        <target state="translated">Gelişmiş</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Misc|DisplayName">
-        <source>Misc</source>
-        <target state="translated">Çeşitli</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.zh-Hans.xlf
@@ -1,27 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../UpToDateCheckOutput.xaml">
-    <body>
-      <trans-unit id="Rule|UpToDateCheckOutput|DisplayName">
-        <source>Up-to-date check output</source>
-        <target state="translated">最新检查输出</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckOutput|Description">
-        <source>File Properties</source>
-        <target state="translated">文件属性</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Advanced|DisplayName">
-        <source>Advanced</source>
-        <target state="translated">高级</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Misc|DisplayName">
-        <source>Misc</source>
-        <target state="translated">杂项</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/UpToDateCheckOutput.xaml.zh-Hant.xlf
@@ -1,27 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../UpToDateCheckOutput.xaml">
-    <body>
-      <trans-unit id="Rule|UpToDateCheckOutput|DisplayName">
-        <source>Up-to-date check output</source>
-        <target state="translated">最新版檢查輸出</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Rule|UpToDateCheckOutput|Description">
-        <source>File Properties</source>
-        <target state="translated">檔案屬性</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Advanced|DisplayName">
-        <source>Advanced</source>
-        <target state="translated">進階</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|Misc|DisplayName">
-        <source>Misc</source>
-        <target state="translated">其他</target>
-        <note />
-      </trans-unit>
-    </body>
+    <body />
   </file>
 </xliff>


### PR DESCRIPTION
**Customer scenario**

The customer has a built project. They delete a file and hit F5. The project thinks it is up to date and just runs without building.

This fix adds the additional compiler inputs as inputs to the up to date check, making it more closely match MSBuild. (This change also has the side-effect of allowing targets to contribute UpToDateCheckInput and UpToDateCheckOutput items, something that used to previously not work.)

**Bugs this fixes:** 

#3245

**Workarounds, if any**

User has to manually rebuild (assuming they notice the project didn't build).

**Risk**

Low. This just updates the process for collecting up to date things to check.

**Performance impact**

Low impact, only checks one extra file.

**Is this a regression from a previous update?**

No

**How was the bug found?**

Customer report
