### PR TITLE
Add "Full Path" to project properties

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -85,7 +85,7 @@
         <EnumValue Name="OnOutputUpdated" DisplayName="When the build updates the project output" />
     </EnumProperty>
     <StringProperty Name="ReferencePath" DisplayName="Reference Path" Visible="False"/>
-    <StringProperty Name="FileName" DisplayName="Project File" ReadOnly="True" Category="Misc">
+    <StringProperty Name="FileName" DisplayName="File Name" ReadOnly="True" Category="Misc">
         <StringProperty.DataSource>
             <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectFile" SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -85,12 +85,12 @@
         <EnumValue Name="OnOutputUpdated" DisplayName="When the build updates the project output" />
     </EnumProperty>
     <StringProperty Name="ReferencePath" DisplayName="Reference Path" Visible="False"/>
-    <StringProperty Name="FileName" DisplayName="Project File" ReadOnly="True">
+    <StringProperty Name="FileName" DisplayName="Project File" ReadOnly="True" Category="Misc">
         <StringProperty.DataSource>
             <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectFile" SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
     </StringProperty>
-    <StringProperty Name="FullPath" DisplayName="Project Folder" ReadOnly="True">
+    <StringProperty Name="FullPath" DisplayName="Project Folder" ReadOnly="True" Category="Misc">
         <StringProperty.DataSource>
             <DataSource Persistence="ProjectFile" PersistedName="ProjectDir" SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -95,6 +95,13 @@
             <DataSource Persistence="ProjectFile" PersistedName="ProjectDir" SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
     </StringProperty>
+    <!-- NOTE: csproj.dll does not provide this property on the browse object, but calls it behind the scenes. -->
+    <StringProperty Name="FullProjectFileName" DisplayName="Full Path" ReadOnly="True" Category="Misc" Description="Full name of the project file.">
+        <StringProperty.DataSource>
+            <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectFullPath" SourceOfDefaultValue="AfterContext" />
+        </StringProperty.DataSource>
+    </StringProperty>
+  
     <StringProperty Name="LocalPath" ReadOnly="True" Visible="False">
         <StringProperty.DataSource>
             <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectDirectory" SourceOfDefaultValue="AfterContext" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -85,12 +85,12 @@
         <EnumValue Name="OnOutputUpdated" DisplayName="When the build updates the project output" />
     </EnumProperty>
     <StringProperty Name="ReferencePath" DisplayName="Reference Path" Visible="False"/>
-    <StringProperty Name="FileName" DisplayName="File Name" ReadOnly="True" Category="Misc">
+    <StringProperty Name="FileName" DisplayName="File Name" ReadOnly="True" Category="Misc" Description="Name of the project file.">
         <StringProperty.DataSource>
             <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectFile" SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
     </StringProperty>
-    <StringProperty Name="FullPath" DisplayName="Project Folder" ReadOnly="True" Category="Misc">
+    <StringProperty Name="FullPath" DisplayName="Project Folder" ReadOnly="True" Category="Misc" Description="Location of the project file.">
         <StringProperty.DataSource>
             <DataSource Persistence="ProjectFile" PersistedName="ProjectDir" SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -95,7 +95,7 @@
             <DataSource Persistence="ProjectFile" PersistedName="ProjectDir" SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
     </StringProperty>
-    <!-- NOTE: csproj.dll does not provide this property on the browse object, but calls it behind the scenes. -->
+    <!-- NOTE: csproj.dll does not provide this property on the browse object, but calls it "FullProjectFileName" behind the scenes. -->
     <StringProperty Name="FullProjectFileName" DisplayName="Full Path" ReadOnly="True" Category="Misc" Description="Full name of the project file.">
         <StringProperty.DataSource>
             <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectFullPath" SourceOfDefaultValue="AfterContext" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -4,7 +4,7 @@
   Name="ConfigurationGeneralBrowseObject"
   DisplayName="General"
   PageTemplate="generic"
-  Description="General"
+  Description="Project Properties"
   OverrideMode= "Replace"
   xmlns="http://schemas.microsoft.com/build/2009/properties">
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.cs.xlf
@@ -4,12 +4,12 @@
     <body>
       <trans-unit id="Rule|ConfigurationGeneralBrowseObject|DisplayName">
         <source>General</source>
-        <target state="translated">Obecné</target>
+        <target state="needs-review-translation">Obecné</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ConfigurationGeneralBrowseObject|Description">
-        <source>General</source>
-        <target state="translated">Obecné</target>
+        <source>Project Properties</source>
+        <target state="needs-review-translation">Obecné</target>
         <note />
       </trans-unit>
       <trans-unit id="Category|General|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.cs.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileName|DisplayName">
-        <source>Project File</source>
-        <target state="translated">Soubor projektu</target>
+        <source>File Name</source>
+        <target state="needs-review-translation">Soubor projektu</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|DisplayName">
@@ -240,6 +240,26 @@
       <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Type that contains the entry point</source>
         <target state="translated">Typ obsahující vstupní bod</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FileName|Description">
+        <source>Name of the project file.</source>
+        <target state="new">Name of the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullPath|Description">
+        <source>Location of the project file.</source>
+        <target state="new">Location of the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullProjectFileName|DisplayName">
+        <source>Full Path</source>
+        <target state="new">Full Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullProjectFileName|Description">
+        <source>Full name of the project file.</source>
+        <target state="new">Full name of the project file.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.de.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileName|DisplayName">
-        <source>Project File</source>
-        <target state="translated">Projektdatei</target>
+        <source>File Name</source>
+        <target state="needs-review-translation">Projektdatei</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|DisplayName">
@@ -240,6 +240,26 @@
       <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Type that contains the entry point</source>
         <target state="translated">Typ, der den Einstiegspunkt enthält</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FileName|Description">
+        <source>Name of the project file.</source>
+        <target state="new">Name of the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullPath|Description">
+        <source>Location of the project file.</source>
+        <target state="new">Location of the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullProjectFileName|DisplayName">
+        <source>Full Path</source>
+        <target state="new">Full Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullProjectFileName|Description">
+        <source>Full name of the project file.</source>
+        <target state="new">Full name of the project file.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.de.xlf
@@ -4,12 +4,12 @@
     <body>
       <trans-unit id="Rule|ConfigurationGeneralBrowseObject|DisplayName">
         <source>General</source>
-        <target state="translated">Allgemein</target>
+        <target state="needs-review-translation">Allgemein</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ConfigurationGeneralBrowseObject|Description">
-        <source>General</source>
-        <target state="translated">Allgemein</target>
+        <source>Project Properties</source>
+        <target state="needs-review-translation">Allgemein</target>
         <note />
       </trans-unit>
       <trans-unit id="Category|General|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.es.xlf
@@ -4,12 +4,12 @@
     <body>
       <trans-unit id="Rule|ConfigurationGeneralBrowseObject|DisplayName">
         <source>General</source>
-        <target state="translated">General</target>
+        <target state="needs-review-translation">General</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ConfigurationGeneralBrowseObject|Description">
-        <source>General</source>
-        <target state="translated">General</target>
+        <source>Project Properties</source>
+        <target state="needs-review-translation">General</target>
         <note />
       </trans-unit>
       <trans-unit id="Category|General|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.es.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileName|DisplayName">
-        <source>Project File</source>
-        <target state="translated">Archivo de proyecto</target>
+        <source>File Name</source>
+        <target state="needs-review-translation">Archivo de proyecto</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|DisplayName">
@@ -240,6 +240,26 @@
       <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Type that contains the entry point</source>
         <target state="translated">Tipo que contiene el punto de entrada</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FileName|Description">
+        <source>Name of the project file.</source>
+        <target state="new">Name of the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullPath|Description">
+        <source>Location of the project file.</source>
+        <target state="new">Location of the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullProjectFileName|DisplayName">
+        <source>Full Path</source>
+        <target state="new">Full Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullProjectFileName|Description">
+        <source>Full name of the project file.</source>
+        <target state="new">Full name of the project file.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.fr.xlf
@@ -4,12 +4,12 @@
     <body>
       <trans-unit id="Rule|ConfigurationGeneralBrowseObject|DisplayName">
         <source>General</source>
-        <target state="translated">Général</target>
+        <target state="needs-review-translation">Général</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ConfigurationGeneralBrowseObject|Description">
-        <source>General</source>
-        <target state="translated">Général</target>
+        <source>Project Properties</source>
+        <target state="needs-review-translation">Général</target>
         <note />
       </trans-unit>
       <trans-unit id="Category|General|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.fr.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileName|DisplayName">
-        <source>Project File</source>
-        <target state="translated">Fichier projet</target>
+        <source>File Name</source>
+        <target state="needs-review-translation">Fichier projet</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|DisplayName">
@@ -240,6 +240,26 @@
       <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Type that contains the entry point</source>
         <target state="translated">Type contenant le point d'entrée</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FileName|Description">
+        <source>Name of the project file.</source>
+        <target state="new">Name of the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullPath|Description">
+        <source>Location of the project file.</source>
+        <target state="new">Location of the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullProjectFileName|DisplayName">
+        <source>Full Path</source>
+        <target state="new">Full Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullProjectFileName|Description">
+        <source>Full name of the project file.</source>
+        <target state="new">Full name of the project file.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.it.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileName|DisplayName">
-        <source>Project File</source>
-        <target state="translated">File di progetto</target>
+        <source>File Name</source>
+        <target state="needs-review-translation">File di progetto</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|DisplayName">
@@ -240,6 +240,26 @@
       <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Type that contains the entry point</source>
         <target state="translated">Tipo che contiene il punto di ingresso</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FileName|Description">
+        <source>Name of the project file.</source>
+        <target state="new">Name of the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullPath|Description">
+        <source>Location of the project file.</source>
+        <target state="new">Location of the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullProjectFileName|DisplayName">
+        <source>Full Path</source>
+        <target state="new">Full Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullProjectFileName|Description">
+        <source>Full name of the project file.</source>
+        <target state="new">Full name of the project file.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.it.xlf
@@ -4,12 +4,12 @@
     <body>
       <trans-unit id="Rule|ConfigurationGeneralBrowseObject|DisplayName">
         <source>General</source>
-        <target state="translated">Generale</target>
+        <target state="needs-review-translation">Generale</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ConfigurationGeneralBrowseObject|Description">
-        <source>General</source>
-        <target state="translated">Generale</target>
+        <source>Project Properties</source>
+        <target state="needs-review-translation">Generale</target>
         <note />
       </trans-unit>
       <trans-unit id="Category|General|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.ja.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileName|DisplayName">
-        <source>Project File</source>
-        <target state="translated">プロジェクト ファイル</target>
+        <source>File Name</source>
+        <target state="needs-review-translation">プロジェクト ファイル</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|DisplayName">
@@ -240,6 +240,26 @@
       <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Type that contains the entry point</source>
         <target state="translated">エントリ ポイントを含む型</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FileName|Description">
+        <source>Name of the project file.</source>
+        <target state="new">Name of the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullPath|Description">
+        <source>Location of the project file.</source>
+        <target state="new">Location of the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullProjectFileName|DisplayName">
+        <source>Full Path</source>
+        <target state="new">Full Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullProjectFileName|Description">
+        <source>Full name of the project file.</source>
+        <target state="new">Full name of the project file.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.ja.xlf
@@ -4,12 +4,12 @@
     <body>
       <trans-unit id="Rule|ConfigurationGeneralBrowseObject|DisplayName">
         <source>General</source>
-        <target state="translated">全般</target>
+        <target state="needs-review-translation">全般</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ConfigurationGeneralBrowseObject|Description">
-        <source>General</source>
-        <target state="translated">全般</target>
+        <source>Project Properties</source>
+        <target state="needs-review-translation">全般</target>
         <note />
       </trans-unit>
       <trans-unit id="Category|General|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.ko.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileName|DisplayName">
-        <source>Project File</source>
-        <target state="translated">프로젝트 파일</target>
+        <source>File Name</source>
+        <target state="needs-review-translation">프로젝트 파일</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|DisplayName">
@@ -240,6 +240,26 @@
       <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Type that contains the entry point</source>
         <target state="translated">진입점을 포함하는 형식입니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FileName|Description">
+        <source>Name of the project file.</source>
+        <target state="new">Name of the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullPath|Description">
+        <source>Location of the project file.</source>
+        <target state="new">Location of the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullProjectFileName|DisplayName">
+        <source>Full Path</source>
+        <target state="new">Full Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullProjectFileName|Description">
+        <source>Full name of the project file.</source>
+        <target state="new">Full name of the project file.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.ko.xlf
@@ -4,12 +4,12 @@
     <body>
       <trans-unit id="Rule|ConfigurationGeneralBrowseObject|DisplayName">
         <source>General</source>
-        <target state="translated">일반</target>
+        <target state="needs-review-translation">일반</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ConfigurationGeneralBrowseObject|Description">
-        <source>General</source>
-        <target state="translated">일반</target>
+        <source>Project Properties</source>
+        <target state="needs-review-translation">일반</target>
         <note />
       </trans-unit>
       <trans-unit id="Category|General|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.pl.xlf
@@ -4,12 +4,12 @@
     <body>
       <trans-unit id="Rule|ConfigurationGeneralBrowseObject|DisplayName">
         <source>General</source>
-        <target state="translated">Ogólne</target>
+        <target state="needs-review-translation">Ogólne</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ConfigurationGeneralBrowseObject|Description">
-        <source>General</source>
-        <target state="translated">Ogólne</target>
+        <source>Project Properties</source>
+        <target state="needs-review-translation">Ogólne</target>
         <note />
       </trans-unit>
       <trans-unit id="Category|General|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.pl.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileName|DisplayName">
-        <source>Project File</source>
-        <target state="translated">Plik projektu</target>
+        <source>File Name</source>
+        <target state="needs-review-translation">Plik projektu</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|DisplayName">
@@ -240,6 +240,26 @@
       <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Type that contains the entry point</source>
         <target state="translated">Typ, który zawiera punkt wejścia</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FileName|Description">
+        <source>Name of the project file.</source>
+        <target state="new">Name of the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullPath|Description">
+        <source>Location of the project file.</source>
+        <target state="new">Location of the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullProjectFileName|DisplayName">
+        <source>Full Path</source>
+        <target state="new">Full Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullProjectFileName|Description">
+        <source>Full name of the project file.</source>
+        <target state="new">Full name of the project file.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.pt-BR.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileName|DisplayName">
-        <source>Project File</source>
-        <target state="translated">Arquivo de Projeto</target>
+        <source>File Name</source>
+        <target state="needs-review-translation">Arquivo de Projeto</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|DisplayName">
@@ -240,6 +240,26 @@
       <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Type that contains the entry point</source>
         <target state="translated">Tipo que contém o ponto de entrada</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FileName|Description">
+        <source>Name of the project file.</source>
+        <target state="new">Name of the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullPath|Description">
+        <source>Location of the project file.</source>
+        <target state="new">Location of the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullProjectFileName|DisplayName">
+        <source>Full Path</source>
+        <target state="new">Full Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullProjectFileName|Description">
+        <source>Full name of the project file.</source>
+        <target state="new">Full name of the project file.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.pt-BR.xlf
@@ -4,12 +4,12 @@
     <body>
       <trans-unit id="Rule|ConfigurationGeneralBrowseObject|DisplayName">
         <source>General</source>
-        <target state="translated">Geral</target>
+        <target state="needs-review-translation">Geral</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ConfigurationGeneralBrowseObject|Description">
-        <source>General</source>
-        <target state="translated">Geral</target>
+        <source>Project Properties</source>
+        <target state="needs-review-translation">Geral</target>
         <note />
       </trans-unit>
       <trans-unit id="Category|General|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.ru.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileName|DisplayName">
-        <source>Project File</source>
-        <target state="translated">Файл проекта</target>
+        <source>File Name</source>
+        <target state="needs-review-translation">Файл проекта</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|DisplayName">
@@ -240,6 +240,26 @@
       <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Type that contains the entry point</source>
         <target state="translated">Тип, содержащий точку входа</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FileName|Description">
+        <source>Name of the project file.</source>
+        <target state="new">Name of the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullPath|Description">
+        <source>Location of the project file.</source>
+        <target state="new">Location of the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullProjectFileName|DisplayName">
+        <source>Full Path</source>
+        <target state="new">Full Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullProjectFileName|Description">
+        <source>Full name of the project file.</source>
+        <target state="new">Full name of the project file.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.ru.xlf
@@ -4,12 +4,12 @@
     <body>
       <trans-unit id="Rule|ConfigurationGeneralBrowseObject|DisplayName">
         <source>General</source>
-        <target state="translated">Общие</target>
+        <target state="needs-review-translation">Общие</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ConfigurationGeneralBrowseObject|Description">
-        <source>General</source>
-        <target state="translated">Общие</target>
+        <source>Project Properties</source>
+        <target state="needs-review-translation">Общие</target>
         <note />
       </trans-unit>
       <trans-unit id="Category|General|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.tr.xlf
@@ -4,12 +4,12 @@
     <body>
       <trans-unit id="Rule|ConfigurationGeneralBrowseObject|DisplayName">
         <source>General</source>
-        <target state="translated">Genel</target>
+        <target state="needs-review-translation">Genel</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ConfigurationGeneralBrowseObject|Description">
-        <source>General</source>
-        <target state="translated">Genel</target>
+        <source>Project Properties</source>
+        <target state="needs-review-translation">Genel</target>
         <note />
       </trans-unit>
       <trans-unit id="Category|General|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.tr.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileName|DisplayName">
-        <source>Project File</source>
-        <target state="translated">Proje Dosyası</target>
+        <source>File Name</source>
+        <target state="needs-review-translation">Proje Dosyası</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|DisplayName">
@@ -240,6 +240,26 @@
       <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Type that contains the entry point</source>
         <target state="translated">Giriş noktasını içeren tür</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FileName|Description">
+        <source>Name of the project file.</source>
+        <target state="new">Name of the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullPath|Description">
+        <source>Location of the project file.</source>
+        <target state="new">Location of the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullProjectFileName|DisplayName">
+        <source>Full Path</source>
+        <target state="new">Full Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullProjectFileName|Description">
+        <source>Full name of the project file.</source>
+        <target state="new">Full name of the project file.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.zh-Hans.xlf
@@ -4,12 +4,12 @@
     <body>
       <trans-unit id="Rule|ConfigurationGeneralBrowseObject|DisplayName">
         <source>General</source>
-        <target state="translated">常规</target>
+        <target state="needs-review-translation">常规</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ConfigurationGeneralBrowseObject|Description">
-        <source>General</source>
-        <target state="translated">常规</target>
+        <source>Project Properties</source>
+        <target state="needs-review-translation">常规</target>
         <note />
       </trans-unit>
       <trans-unit id="Category|General|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.zh-Hans.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileName|DisplayName">
-        <source>Project File</source>
-        <target state="translated">项目文件</target>
+        <source>File Name</source>
+        <target state="needs-review-translation">项目文件</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|DisplayName">
@@ -240,6 +240,26 @@
       <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Type that contains the entry point</source>
         <target state="translated">包含入口点的类型</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FileName|Description">
+        <source>Name of the project file.</source>
+        <target state="new">Name of the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullPath|Description">
+        <source>Location of the project file.</source>
+        <target state="new">Location of the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullProjectFileName|DisplayName">
+        <source>Full Path</source>
+        <target state="new">Full Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullProjectFileName|Description">
+        <source>Full name of the project file.</source>
+        <target state="new">Full name of the project file.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.zh-Hant.xlf
@@ -4,12 +4,12 @@
     <body>
       <trans-unit id="Rule|ConfigurationGeneralBrowseObject|DisplayName">
         <source>General</source>
-        <target state="translated">一般</target>
+        <target state="needs-review-translation">一般</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ConfigurationGeneralBrowseObject|Description">
-        <source>General</source>
-        <target state="translated">一般</target>
+        <source>Project Properties</source>
+        <target state="needs-review-translation">一般</target>
         <note />
       </trans-unit>
       <trans-unit id="Category|General|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralBrowseObject.xaml.zh-Hant.xlf
@@ -98,8 +98,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|FileName|DisplayName">
-        <source>Project File</source>
-        <target state="translated">專案檔</target>
+        <source>File Name</source>
+        <target state="needs-review-translation">專案檔</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|FullPath|DisplayName">
@@ -240,6 +240,26 @@
       <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Type that contains the entry point</source>
         <target state="translated">包含進入點的類型</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FileName|Description">
+        <source>Name of the project file.</source>
+        <target state="new">Name of the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullPath|Description">
+        <source>Location of the project file.</source>
+        <target state="new">Location of the project file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullProjectFileName|DisplayName">
+        <source>Full Path</source>
+        <target state="new">Full Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|FullProjectFileName|Description">
+        <source>Full name of the project file.</source>
+        <target state="new">Full name of the project file.</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
- Made project's properties in Properties tool window consistent with project items & legacy project system, favoring the former where they disagreed (such as "Project File").
- Add new "Full Path" property that shows the entire file name of the project

Before:
![image](https://user-images.githubusercontent.com/1103906/39416113-9f94c498-4c8d-11e8-90b3-bbc80b75cca6.png)


After:

![image](https://user-images.githubusercontent.com/1103906/39416098-8abb84f8-4c8d-11e8-97bd-42e4dddae34c.png)
