### PR TITLE
Apply var rules across the tree

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/LanguageServices/CSharpLanguageFeaturesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/LanguageServices/CSharpLanguageFeaturesProvider.cs
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         {
             Requires.NotNullOrEmpty(name, nameof(name));
 
-            var identifier = string.Concat(name.Select(c => IsValidIdentifierChar(c) ? c : '_'));
+            string identifier = string.Concat(name.Select(c => IsValidIdentifierChar(c) ? c : '_'));
             if (!IsValidFirstIdentifierChar(identifier[0]))
             {
                 identifier = '_' + identifier;
@@ -122,13 +122,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
 
         private static bool IsValidIdentifierChar(char c)
         {
-            var category = CharUnicodeInfo.GetUnicodeCategory(c);
+            UnicodeCategory category = CharUnicodeInfo.GetUnicodeCategory(c);
             return s_identifierCharCategories.Contains(category);
         }
 
         private static bool IsValidFirstIdentifierChar(char c)
         {
-            var category = CharUnicodeInfo.GetUnicodeCategory(c);
+            UnicodeCategory category = CharUnicodeInfo.GetUnicodeCategory(c);
             return s_firstIdentifierCharCategories.Contains(category);
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Properties/CSharpProjectDesignerPageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Properties/CSharpProjectDesignerPageProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
         public Task<IReadOnlyCollection<IPageMetadata>> GetPagesAsync()
         {
-            var builder = ImmutableArray.CreateBuilder<IPageMetadata>();
+            ImmutableArray<IPageMetadata>.Builder builder = ImmutableArray.CreateBuilder<IPageMetadata>();
 
             builder.Add(CSharpProjectDesignerPage.Application);
             builder.Add(CSharpProjectDesignerPage.Build);

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/GlobalJsonRemover.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/GlobalJsonRemover.cs
@@ -74,12 +74,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         public int OnAfterOpenSolution(object pUnkReserved, int fNewSolution)
         {
             UIThreadHelper.VerifyOnUIThread();
-            var dte = _serviceProvider.GetService<DTE2, DTE>();
-            var solution = _serviceProvider.GetService<IVsSolution, SVsSolution>();
+            DTE2 dte = _serviceProvider.GetService<DTE2, DTE>();
+            IVsSolution solution = _serviceProvider.GetService<IVsSolution, SVsSolution>();
             try
             {
                 Verify.HResult(solution.GetSolutionInfo(out string directory, out string solutionFile, out string optsFile));
-                var globalJsonPath = Path.Combine(directory, "global.json");
+                string globalJsonPath = Path.Combine(directory, "global.json");
                 ProjectItem globalJson = dte.Solution.FindProjectItem(globalJsonPath);
                 globalJson?.Delete();
                 try

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/Packaging/FSharpProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/Packaging/FSharpProjectSystemPackage.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.Packaging
         protected override System.Threading.Tasks.Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
             _projectSelectorService = this.GetService<IVsRegisterProjectSelector, SVsRegisterProjectTypes>();
-            var selectorGuid = typeof(FSharpProjectSelector).GUID;
+            Guid selectorGuid = typeof(FSharpProjectSelector).GUID;
             _projectSelectorService.RegisterProjectSelector(ref selectorGuid, new FSharpProjectSelector(), out _projectSelectorCookie);
 
             return base.InitializeAsync(cancellationToken, progress);

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/ProjectSystem/VS/FSharpProjectSelector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/ProjectSystem/VS/FSharpProjectSelector.cs
@@ -32,8 +32,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             // If the project has either a Project-level SDK attribute or an Import-level SDK attribute, we'll open it with the new project system.
             // Check both namespace-qualified and unqualified forms to include projects with and without the xmlns attribute.
-            var hasProjectElementWithSdkAttribute = doc.XPathSelectElement("/msb:Project[@Sdk]", nsm) != null || doc.XPathSelectElement("/Project[@Sdk]") != null;
-            var hasImportElementWithSdkAttribute = doc.XPathSelectElement("/*/msb:Import[@Sdk]", nsm) != null || doc.XPathSelectElement("/*/Import[@Sdk]") != null;
+            bool hasProjectElementWithSdkAttribute = doc.XPathSelectElement("/msb:Project[@Sdk]", nsm) != null || doc.XPathSelectElement("/Project[@Sdk]") != null;
+            bool hasImportElementWithSdkAttribute = doc.XPathSelectElement("/*/msb:Import[@Sdk]", nsm) != null || doc.XPathSelectElement("/*/Import[@Sdk]") != null;
 
             if (hasProjectElementWithSdkAttribute || hasImportElementWithSdkAttribute)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/ProjectSystem/VS/Properties/FSharpProjectDesignerPageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/ProjectSystem/VS/Properties/FSharpProjectDesignerPageProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
         public Task<IReadOnlyCollection<IPageMetadata>> GetPagesAsync()
         {
-            var builder = ImmutableArray.CreateBuilder<IPageMetadata>();
+            ImmutableArray<IPageMetadata>.Builder builder = ImmutableArray.CreateBuilder<IPageMetadata>();
             builder.Add(FSharpProjectDesignerPage.Application);
             builder.Add(FSharpProjectDesignerPage.Build);
             builder.Add(FSharpProjectDesignerPage.BuildEvents);

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp/ProjectSystem/LanguageServices/FSharpParseBuildOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp/ProjectSystem/LanguageServices/FSharpParseBuildOptions.cs
@@ -30,10 +30,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var metadataReferences = new List<CommandLineReference>();
             var commandLineOptions = new List<string>();
 
-            foreach (var commandLineArgument in commandLineArgs)
+            foreach (string commandLineArgument in commandLineArgs)
             {
-                var args = commandLineArgument.Split(';');
-                foreach (var arg in args)
+                string[] args = commandLineArgument.Split(';');
+                foreach (string arg in args)
                 {
                     if (arg.StartsWith(HyphenReferencePrefix))
                     {
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                     else if (!(arg.StartsWith("-") || arg.StartsWith("/")))
                     {
                         // not an option, should be a regular file
-                        var extension = Path.GetExtension(arg).ToLowerInvariant();
+                        string extension = Path.GetExtension(arg).ToLowerInvariant();
                         switch (extension)
                         {
                             case ".fs":
@@ -90,7 +90,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         {
             if (added is FSharpBuildOptions fscAdded)
             {
-                foreach (var handler in _handlers)
+                foreach (Action<string, ImmutableArray<CommandLineSourceFile>, ImmutableArray<CommandLineReference>, ImmutableArray<string>> handler in _handlers)
                 {
                     handler?.Invoke(binPath, fscAdded.SourceFiles, fscAdded.MetadataReferences, fscAdded.CompileOptions);
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectTree.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectTree.cs
@@ -103,7 +103,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             {
                 get
                 {
-                    var root = this;
+                    MutableProjectTree root = this;
                     while (root.Parent != null)
                     {
                         root = root.Parent;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.cs
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 throw FormatException(ProjectTreeFormatError.MultipleRoots, "Encountered another project root, when tree can only have one.");
 #pragma warning restore IDE0016 // Use 'throw' expression
 
-            var tree = ReadProjectItem();
+            MutableProjectTree tree = ReadProjectItem();
             tree.Parent = parent;
             parent.Children.Add(tree);
             return tree;
@@ -298,7 +298,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             Tokenizer tokenizer = Tokenizer(Delimiters.PropertyValue);
 
-            var identifier = tokenizer.ReadIdentifier(IdentifierParseOptions.None);
+            string identifier = tokenizer.ReadIdentifier(IdentifierParseOptions.None);
 
             tree.DisplayOrder = int.Parse(identifier);
         }
@@ -339,7 +339,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             if (tokenizer.SkipIf(TokenType.RightBrace))
                 return;
 
-            var moniker = ReadProjectImageMoniker();
+            ProjectImageMoniker moniker = ReadProjectImageMoniker();
 
             if (expandedIcon)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/Workspaces/WorkspaceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/Workspaces/WorkspaceFactory.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.Workspaces
             var projectInfo = ProjectInfo.Create(ProjectId.CreateNewId(), VersionStamp.Create(), "TestProject", "TestProject", language,
                                                  filePath: "D:\\Test.proj",
                                                  metadataReferences: new[] { s_corlibReference, s_systemCoreReference, s_systemReference });
-            var project = workspace.AddProject(projectInfo);
+            Project project = workspace.AddProject(projectInfo);
 
             var documentInfo = DocumentInfo.Create(DocumentId.CreateNewId(projectInfo.Id), "TestDocument");
             workspace.AddDocument(project.Id, "TestDocument", SourceText.From(text));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
@@ -70,12 +70,12 @@ namespace Microsoft.VisualStudio.Packaging
 
             var componentModel = (IComponentModel)(await GetServiceAsync(typeof(SComponentModel)).ConfigureAwait(true));
             ICompositionService compositionService = componentModel.DefaultCompositionService;
-            var debugFrameworksCmd = componentModel.DefaultExportProvider.GetExport<DebugFrameworksDynamicMenuCommand>();
+            Lazy<DebugFrameworksDynamicMenuCommand> debugFrameworksCmd = componentModel.DefaultExportProvider.GetExport<DebugFrameworksDynamicMenuCommand>();
 
             var mcs = (await GetServiceAsync(typeof(IMenuCommandService)).ConfigureAwait(true)) as OleMenuCommandService;
             mcs.AddCommand(debugFrameworksCmd.Value);
 
-            var debugFrameworksMenuTextUpdater = componentModel.DefaultExportProvider.GetExport<DebugFrameworkPropertyMenuTextUpdater>();
+            Lazy<DebugFrameworkPropertyMenuTextUpdater> debugFrameworksMenuTextUpdater = componentModel.DefaultExportProvider.GetExport<DebugFrameworkPropertyMenuTextUpdater>();
             mcs.AddCommand(debugFrameworksMenuTextUpdater.Value);
 
             // Need to use the CPS export provider to get the dotnet compatibility detector

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsProject.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsProject.cs
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
         {
             get
             {
-                var imports = ImportsImpl.FirstOrDefault();
+                Lazy<Imports, IOrderPrecedenceMetadataView> imports = ImportsImpl.FirstOrDefault();
                 if (imports != null)
                 {
                     return imports.Value;
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
         {
             get
             {
-                var vsprojectevent = VSProjectEventsImpl.FirstOrDefault();
+                Lazy<VSProjectEvents, IOrderPrecedenceMetadataView> vsprojectevent = VSProjectEventsImpl.FirstOrDefault();
                 if (vsprojectevent != null)
                 {
                     return vsprojectevent.Value;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsProject_VsLangProjectProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsProject_VsLangProjectProperties.cs
@@ -21,8 +21,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             {
                 return _threadingService.ExecuteSynchronously(async () =>
                 {
-                    var configurationGeneralProperties = await ProjectProperties.GetConfigurationGeneralBrowseObjectPropertiesAsync().ConfigureAwait(true);
-                    var value = await configurationGeneralProperties.OutputType.GetValueAsync().ConfigureAwait(true);
+                    ConfigurationGeneralBrowseObject configurationGeneralProperties = await ProjectProperties.GetConfigurationGeneralBrowseObjectPropertiesAsync().ConfigureAwait(true);
+                    object value = await configurationGeneralProperties.OutputType.GetValueAsync().ConfigureAwait(true);
                     return (prjOutputTypeEx)value;
                 });
             }
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             {
                 _threadingService.ExecuteSynchronously(async () =>
                 {
-                    var configurationGeneralProperties = await ProjectProperties.GetConfigurationGeneralBrowseObjectPropertiesAsync().ConfigureAwait(true);
+                    ConfigurationGeneralBrowseObject configurationGeneralProperties = await ProjectProperties.GetConfigurationGeneralBrowseObjectPropertiesAsync().ConfigureAwait(true);
                     await configurationGeneralProperties.OutputType.SetValueAsync(value).ConfigureAwait(true);
                 });
             }
@@ -45,8 +45,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             {
                 return _threadingService.ExecuteSynchronously(async () =>
                 {
-                    var configurationGeneralProperties = await ProjectProperties.GetConfigurationGeneralBrowseObjectPropertiesAsync().ConfigureAwait(true);
-                    var value = await configurationGeneralProperties.OutputType.GetValueAsync().ConfigureAwait(true);
+                    ConfigurationGeneralBrowseObject configurationGeneralProperties = await ProjectProperties.GetConfigurationGeneralBrowseObjectPropertiesAsync().ConfigureAwait(true);
+                    object value = await configurationGeneralProperties.OutputType.GetValueAsync().ConfigureAwait(true);
                     return (prjOutputType)value;
                 });
             }
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             {
                 _threadingService.ExecuteSynchronously(async () =>
                 {
-                    var configurationGeneralProperties = await ProjectProperties.GetConfigurationGeneralBrowseObjectPropertiesAsync().ConfigureAwait(true);
+                    ConfigurationGeneralBrowseObject configurationGeneralProperties = await ProjectProperties.GetConfigurationGeneralBrowseObjectPropertiesAsync().ConfigureAwait(true);
                     await configurationGeneralProperties.OutputType.SetValueAsync(value).ConfigureAwait(true);
                 });
             }
@@ -67,7 +67,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             {
                 return _threadingService.ExecuteSynchronously(async () =>
                 {
-                    var configurationGeneralProperties = await ProjectProperties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(true);
+                    ConfigurationGeneral configurationGeneralProperties = await ProjectProperties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(true);
                     return await configurationGeneralProperties.AssemblyName.GetEvaluatedValueAtEndAsync().ConfigureAwait(true);
                 });
             }
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             {
                 _threadingService.ExecuteSynchronously(async () =>
                 {
-                    var browseObjectProperties = await ProjectProperties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(true);
+                    ConfigurationGeneral browseObjectProperties = await ProjectProperties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(true);
                     await browseObjectProperties.AssemblyName.SetValueAsync(value).ConfigureAwait(true);
                 });
             }
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             {
                 return _threadingService.ExecuteSynchronously(async () =>
                 {
-                    var configurationGeneralProperties = await ProjectProperties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(true);
+                    ConfigurationGeneral configurationGeneralProperties = await ProjectProperties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(true);
                     return await configurationGeneralProperties.ProjectDir.GetEvaluatedValueAtEndAsync().ConfigureAwait(true);
                 });
             }
@@ -102,7 +102,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             {
                 return _threadingService.ExecuteSynchronously(async () =>
                 {
-                    var browseObjectProperties = await ProjectProperties.GetConfigurationGeneralBrowseObjectPropertiesAsync().ConfigureAwait(true);
+                    ConfigurationGeneralBrowseObject browseObjectProperties = await ProjectProperties.GetConfigurationGeneralBrowseObjectPropertiesAsync().ConfigureAwait(true);
                     return await browseObjectProperties.FullPath.GetEvaluatedValueAtEndAsync().ConfigureAwait(true);
                 });
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/LanguageServiceErrorListProvider.ErrorListDetails.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/LanguageServiceErrorListProvider.ErrorListDetails.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
 
             public string GetFileFullPath(ILanguageServiceHost languageServiceHost)
             {
-                var projectFile = ProjectFile;
+                string projectFile = ProjectFile;
                 if (string.IsNullOrEmpty(projectFile))
                 {
                     projectFile = languageServiceHost.ActiveProjectContext?.ProjectFilePath;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/CreateFileFromTemplateService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/CreateFileFromTemplateService.cs
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             {
                 HierarchyId parentId = _projectVsServices.VsProject.GetHierarchyId(parentDocumentMoniker);
                 var result = new VSADDRESULT[1];
-                var files = new string[] { templateFilePath };
+                string[] files = new string[] { templateFilePath };
                 _projectVsServices.VsProject.AddItemWithSpecific(parentId, VSADDITEMOPERATION.VSADDITEMOP_RUNWIZARD, fileName, (uint)files.Length, files, IntPtr.Zero, 0, Guid.Empty, null, Guid.Empty, result);
 
                 if (result[0] == VSADDRESULT.ADDRESULT_Success)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileDebugTargetGenerator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileDebugTargetGenerator.cs
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                     // Compute the new enum values from the profile provider
                     var generatedResult = DebugProfileEnumValuesGenerator.GetEnumeratorEnumValues(update).ToImmutableList();
                     _dataSourceVersion++;
-                    var dataSources = ImmutableDictionary<NamedIdentity, IComparable>.Empty.Add(DataSourceKey, DataSourceVersion);
+                    ImmutableDictionary<NamedIdentity, IComparable> dataSources = ImmutableDictionary<NamedIdentity, IComparable>.Empty.Add(DataSourceKey, DataSourceVersion);
                     return new ProjectVersionedValue<IReadOnlyList<IEnumValue>>(generatedResult, dataSources);
                 });
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileEnumValuesGenerator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileEnumValuesGenerator.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
             _listedValues = new AsyncLazy<ICollection<IEnumValue>>(delegate
             {
-                var curSnapshot = profileProvider.CurrentSnapshot;
+                ILaunchSettings curSnapshot = profileProvider.CurrentSnapshot;
                 if (curSnapshot != null)
                 {
                     return Task.FromResult(GetEnumeratorEnumValues(curSnapshot));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectDebuggerProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectDebuggerProvider.cs
@@ -115,7 +115,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         {
             // Get the active debug profile (timeout of 5s, though in reality is should never take this long as even in error conditions
             // a snapshot is produced).
-            var currentProfiles = await LaunchSettingsProvider.WaitForFirstSnapshot(5000).ConfigureAwait(false);
+            ILaunchSettings currentProfiles = await LaunchSettingsProvider.WaitForFirstSnapshot(5000).ConfigureAwait(false);
             ILaunchProfile activeProfile = currentProfiles?.ActiveProfile;
 
             // Should have a profile
@@ -125,7 +125,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             }
 
             // Now find the DebugTargets provider for this profile
-            var launchProvider = GetLaunchTargetsProvider(activeProfile) ??
+            IDebugProfileLaunchTargetsProvider launchProvider = GetLaunchTargetsProvider(activeProfile) ??
                 throw new Exception(string.Format(VSResources.DontKnowHowToRunProfile, activeProfile.Name));
 
             IReadOnlyList<IDebugLaunchSettings> launchSettings;
@@ -148,7 +148,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         public IDebugProfileLaunchTargetsProvider GetLaunchTargetsProvider(ILaunchProfile profile)
         {
             // We search through the imports in order to find the one which supports the profile
-            foreach (var provider in ProfileLaunchTargetsProviders)
+            foreach (Lazy<IDebugProfileLaunchTargetsProvider, IOrderPrecedenceMetadataView> provider in ProfileLaunchTargetsProviders)
             {
                 if (provider.Value.SupportsProfile(profile))
                 {
@@ -164,11 +164,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// </summary>
         public override async Task LaunchAsync(DebugLaunchOptions launchOptions)
         {
-            var targets = await QueryDebugTargetsInternalAsync(launchOptions, fromDebugLaunch: true).ConfigureAwait(false);
+            IReadOnlyList<IDebugLaunchSettings> targets = await QueryDebugTargetsInternalAsync(launchOptions, fromDebugLaunch: true).ConfigureAwait(false);
 
             ILaunchProfile activeProfile = LaunchSettingsProvider.ActiveProfile;
 
-            var targetProfile = GetLaunchTargetsProvider(activeProfile);
+            IDebugProfileLaunchTargetsProvider targetProfile = GetLaunchTargetsProvider(activeProfile);
             if (targetProfile != null)
             {
                 await targetProfile.OnBeforeLaunchAsync(launchOptions, activeProfile).ConfigureAwait(false);
@@ -206,7 +206,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             finally
             {
                 // Free up the memory allocated to the (mostly) managed debugger structure.
-                foreach (var nativeStruct in launchSettingsNative)
+                foreach (VsDebugTargetInfo4 nativeStruct in launchSettingsNative)
                 {
                     FreeVsDebugTargetInfoStruct(nativeStruct);
                 }
@@ -305,7 +305,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
             // Collect all the variables as a null delimited list of key=value pairs.
             var result = new StringBuilder();
-            foreach (var pair in environment)
+            foreach (KeyValuePair<string, string> pair in environment)
             {
                 result.Append(pair.Key);
                 result.Append('=');

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DotNetCoreProjectCompatibilityDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DotNetCoreProjectCompatibilityDetector.cs
@@ -109,7 +109,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             if (_solutionCookie != VSConstants.VSCOOKIE_NIL)
             {
-                var solution = _serviceProvider.GetService<IVsSolution, SVsSolution>();
+                IVsSolution solution = _serviceProvider.GetService<IVsSolution, SVsSolution>();
                 if (solution != null)
                 {
                     Verify.HResult(solution.UnadviseSolutionEvents(_solutionCookie));
@@ -136,7 +136,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
                         // We need to check if this project has been newly created. Our projects will implement IProjectCreationState -we can 
                         // skip any that don't
-                        var projectCreationState = project.Services.ExportProvider.GetExportedValueOrDefault<IProjectCreationState>();
+                        IProjectCreationState projectCreationState = project.Services.ExportProvider.GetExportedValueOrDefault<IProjectCreationState>();
                         if (projectCreationState != null && !projectCreationState.WasNewlyCreated)
                         {
                             CompatibilityLevel compatLevel = await GetProjectCompatibilityAsync(project, compatData).ConfigureAwait(false);
@@ -177,7 +177,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 CompatibilityLevel finalCompatLevel = CompatibilityLevel.Recommended;
                 IProjectService projectService = _projectServiceAccessor.Value.GetProjectService();
                 IEnumerable<UnconfiguredProject> projects = projectService.LoadedUnconfiguredProjects;
-                foreach (var project in projects)
+                foreach (UnconfiguredProject project in projects)
                 {
                     // Track the most severe compatibility level
                     CompatibilityLevel compatLevel = await GetProjectCompatibilityAsync(project, compatDataToUse).ConfigureAwait(false);
@@ -228,7 +228,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
                     if (!suppressPrompt)
                     {
-                        var msg = string.Format(compatData.OpenSupportedMessage, compatData.SupportedVersion.Major, compatData.SupportedVersion.Minor);
+                        string msg = string.Format(compatData.OpenSupportedMessage, compatData.SupportedVersion.Major, compatData.SupportedVersion.Minor);
                         suppressPrompt = _dialogServices.Value.DontShowAgainMessageBox(caption, msg, VSResources.DontShowAgain, false, VSResources.LearnMore, SupportedLearnMoreFwlink);
                         if (suppressPrompt && settingsManager != null)
                         {
@@ -272,7 +272,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                         IImmutableSet<IUnresolvedPackageReference> pkgReferences = await project.Services.ActiveConfiguredProjectProvider.ActiveConfiguredProject.Services.PackageReferences.GetUnresolvedReferencesAsync().ConfigureAwait(false);
 
                         // Look through the package references
-                        foreach (var pkgRef in pkgReferences)
+                        foreach (IUnresolvedPackageReference pkgRef in pkgReferences)
                         {
                             if (string.Equals(pkgRef.EvaluatedInclude, "Microsoft.AspNetCore.All", StringComparison.OrdinalIgnoreCase) ||
                                 string.Equals(pkgRef.EvaluatedInclude, "Microsoft.AspNetCore", StringComparison.OrdinalIgnoreCase))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DteEnvironmentOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DteEnvironmentOptions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         public T GetOption<T>(string category, string page, string option, T defaultValue)
         {
-            var properties = _dteServices.Dte.Properties[category, page];
+            EnvDTE.Properties properties = _dteServices.Dte.Properties[category, page];
             if (properties != null)
             {
                 return ((T)properties.Item(option).Value);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Extensibility/ProjectExportProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Extensibility/ProjectExportProvider.cs
@@ -35,13 +35,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Extensibility
                 throw new ArgumentNullException(nameof(projectFilePath));
             }
 
-            var projectService = _projectServiceAccessor.GetProjectService();
+            IProjectService projectService = _projectServiceAccessor.GetProjectService();
             if (projectService == null)
             {
                 return null;
             }
 
-            var project = projectService.LoadedUnconfiguredProjects
+            UnconfiguredProject project = projectService.LoadedUnconfiguredProjects
                                                     .FirstOrDefault(x => x.FullPath.Equals(projectFilePath,
                                                                             StringComparison.OrdinalIgnoreCase));
             return project?.Services.ExportProvider.GetExportedValueOrDefault<T>();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Generators/SingleFileGeneratorFactoryAggregator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Generators/SingleFileGeneratorFactoryAggregator.cs
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Generators
 
             // Get the guid of the project
             UIThreadHelper.VerifyOnUIThread();
-            var projectGuid = _projectIntegrationService.ProjectTypeGuid;
+            Guid projectGuid = _projectIntegrationService.ProjectTypeGuid;
 
             if (projectGuid.Equals(Guid.Empty))
             {
@@ -74,7 +74,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Generators
                 return hr;
             }
 
-            var key = $"Generators\\{projectGuid.ToString("B")}\\{wszProgId}";
+            string key = $"Generators\\{projectGuid.ToString("B")}\\{wszProgId}";
             hr = store.CollectionExists(key, out int exists);
             if (!hr.Succeeded)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IProjectTreeExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IProjectTreeExtensions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 if (itemFilter(item))
                 {
                     // Double check we don't already have this one -  we shouldn't
-                    var existingNode = tree.FindImmediateChildByPath(item);
+                    IProjectTree existingNode = tree.FindImmediateChildByPath(item);
                     System.Diagnostics.Debug.Assert(existingNode == null);
                     if (existingNode == null)
                     {
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 if (itemFilter(file))
                 {
                     // See if we already have this one -  we shouldn't
-                    var existingNode = tree.FindImmediateChildByPath(file);
+                    IProjectTree existingNode = tree.FindImmediateChildByPath(file);
                     System.Diagnostics.Debug.Assert(existingNode != null);
                     if (existingNode != null)
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommand.cs
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
             if (ShouldHandle(node))
             {
                 // Enable the command if the build manager is ready to build.
-                var commandStatus = await IsReadyToBuildAsync().ConfigureAwait(false) ? CommandStatus.Enabled : CommandStatus.Supported;
+                CommandStatus commandStatus = await IsReadyToBuildAsync().ConfigureAwait(false) ? CommandStatus.Enabled : CommandStatus.Supported;
                 return await GetCommandStatusResult.Handled(GetCommandText(), commandStatus).ConfigureAwait(false);
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/DebugFrameworksDynamicMenuCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/DebugFrameworksDynamicMenuCommand.cs
@@ -38,12 +38,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         public override bool ExecCommand(int cmdIndex, EventArgs e)
         {
             bool handled = false;
-            var activeDebugFramework = StartupProjectHelper.GetExportFromSingleDotNetStartupProject<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles);
+            IActiveDebugFrameworkServices activeDebugFramework = StartupProjectHelper.GetExportFromSingleDotNetStartupProject<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles);
             if (activeDebugFramework != null)
             {
                 ExecuteSynchronously(async () =>
                 {
-                    var frameworks = await activeDebugFramework.GetProjectFrameworksAsync().ConfigureAwait(false);
+                    List<string> frameworks = await activeDebugFramework.GetProjectFrameworksAsync().ConfigureAwait(false);
                     if (frameworks != null && cmdIndex >= 0 && cmdIndex < frameworks.Count)
                     {
                         await activeDebugFramework.SetActiveDebuggingFrameworkPropertyAsync(frameworks[cmdIndex]).ConfigureAwait(false);
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         /// </summary>       
         public override bool QueryStatusCommand(int cmdIndex, EventArgs e)
         {
-            var activeDebugFramework = StartupProjectHelper.GetExportFromSingleDotNetStartupProject<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles);
+            IActiveDebugFrameworkServices activeDebugFramework = StartupProjectHelper.GetExportFromSingleDotNetStartupProject<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles);
             if (activeDebugFramework != null)
             {
                 // See if this project supports at least two runtimes

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/DebugFrameworksMenuTextUpdater.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/DebugFrameworksMenuTextUpdater.cs
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 
         public void QueryStatus()
         {
-            var activeDebugFramework = StartupProjectHelper.GetExportFromSingleDotNetStartupProject<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles);
+            IActiveDebugFrameworkServices activeDebugFramework = StartupProjectHelper.GetExportFromSingleDotNetStartupProject<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles);
             if (activeDebugFramework != null)
             {
                 string activeFramework = null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AbstractAddItemCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AbstractAddItemCommand.cs
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 
         protected override async Task<bool> TryHandleCommandAsync(IProjectTree node, bool focused, long commandExecuteOptions, IntPtr variantArgIn, IntPtr variantArgOut)
         {
-            var nodeToAddTo = GetNodeToAddTo(node);
+            IProjectTree nodeToAddTo = GetNodeToAddTo(node);
 
             // We use a hint receiver that listens for when a file gets added.
             // The reason is so we can modify the MSBuild project inside the same write lock of when a file gets added internally in CPS.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AbstractMoveCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AbstractMoveCommand.cs
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 
         protected override async Task<bool> TryHandleCommandAsync(IProjectTree node, bool focused, long commandExecuteOptions, IntPtr variantArgIn, IntPtr variantArgOut)
         {
-            var didMove = false;
+            bool didMove = false;
                 
             await _accessor.OpenProjectForWriteAsync(_configuredProject, project => didMove = TryMove(project, node)).ConfigureAwait(false);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/HACK_AddItemHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/HACK_AddItemHelper.cs
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             Requires.NotNull(serviceProvider, nameof(serviceProvider));
             Requires.NotNull(target, nameof(target));
 
-            var strBrowseLocations = projectTree.TreeProvider.GetAddNewItemDirectory(target);
+            string strBrowseLocations = projectTree.TreeProvider.GetAddNewItemDirectory(target);
 
             await projectVsServices.ThreadingService.SwitchToUIThread();
             ShowAddItemDialog(serviceProvider, target, projectVsServices.VsProject, strBrowseLocations, addItemAction);
@@ -67,16 +67,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// </summary>
         private static int ShowAddItemDialog(SVsServiceProvider serviceProvider, IProjectTree target, IVsProject vsProject, string strBrowseLocations, AddItemAction addItemAction)
         {
-            var addItemDialog = serviceProvider.GetService<IVsAddProjectItemDlg, SVsAddProjectItemDlg>();
+            IVsAddProjectItemDlg addItemDialog = serviceProvider.GetService<IVsAddProjectItemDlg, SVsAddProjectItemDlg>();
             Assumes.Present(addItemDialog);
 
-            var uiFlags = __VSADDITEMFLAGS.VSADDITEM_AddNewItems | __VSADDITEMFLAGS.VSADDITEM_SuggestTemplateName | __VSADDITEMFLAGS.VSADDITEM_AllowHiddenTreeView;
+            __VSADDITEMFLAGS uiFlags = __VSADDITEMFLAGS.VSADDITEM_AddNewItems | __VSADDITEMFLAGS.VSADDITEM_SuggestTemplateName | __VSADDITEMFLAGS.VSADDITEM_AllowHiddenTreeView;
             if (addItemAction == AddItemAction.ExistingItem)
             {
                 uiFlags = __VSADDITEMFLAGS.VSADDITEM_AddExistingItems | __VSADDITEMFLAGS.VSADDITEM_AllowMultiSelect | __VSADDITEMFLAGS.VSADDITEM_AllowStickyFilter | __VSADDITEMFLAGS.VSADDITEM_ProjectHandlesLinks;
             }
 
-            var strFilter = string.Empty;
+            string strFilter = string.Empty;
             Guid addItemTemplateGuid = Guid.Empty;  // Let the dialog ask the hierarchy itself
 
             return addItemDialog.AddProjectItemDlg(target.GetHierarchyId(), ref addItemTemplateGuid, vsProject, (uint)uiFlags,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/NodeHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/NodeHelper.cs
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 
             try
             {
-                if (ErrorHandler.Succeeded(shell.FindToolWindow(0, ref persistenceSlot, out var frame)) && frame != null)
+                if (ErrorHandler.Succeeded(shell.FindToolWindow(0, ref persistenceSlot, out IVsWindowFrame frame)) && frame != null)
                 {
                     ErrorHandler.ThrowOnFailure(frame.GetProperty((int)__VSFPROPID.VSFPROPID_DocView, out pvar));
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderAddItemHintReceiver.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderAddItemHintReceiver.cs
@@ -33,8 +33,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         {
             if (CanMove() && !_previousIncludes.IsEmpty && hints.ContainsKey(ProjectChangeFileSystemEntityHint.AddedFile))
             {
-                var hint = hints[ProjectChangeFileSystemEntityHint.AddedFile].First();
-                var configuredProject = hint.UnconfiguredProject.Services.ActiveConfiguredProjectProvider.ActiveConfiguredProject;
+                IProjectChangeHint hint = hints[ProjectChangeFileSystemEntityHint.AddedFile].First();
+                ConfiguredProject configuredProject = hint.UnconfiguredProject.Services.ActiveConfiguredProjectProvider.ActiveConfiguredProject;
                 await OrderingHelper.Move(configuredProject, _accessor, _previousIncludes, _target, _action).ConfigureAwait(false);
             }
 
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             // However we check to see if we captured the previous includes for sanity to ensure it only gets set once.
             if (CanMove() && _previousIncludes.IsEmpty)
             {
-                var configuredProject = hint.UnconfiguredProject.Services.ActiveConfiguredProjectProvider.ActiveConfiguredProject;
+                ConfiguredProject configuredProject = hint.UnconfiguredProject.Services.ActiveConfiguredProjectProvider.ActiveConfiguredProject;
 
                 _previousIncludes = await OrderingHelper.GetAllEvaluatedIncludes(configuredProject, _accessor).ConfigureAwait(false);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/PasteOrdering.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/PasteOrdering.cs
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             get
             {
                 // Grab the paste handler that has the highest order precedence that is below PasteOrdering's order precedence. 
-                var pasteHandler =
+                IPasteHandler pasteHandler =
                     PasteHandlers.Where(x => x.Metadata.OrderPrecedence < OrderPrecedence)
                     .OrderByDescending(x => x.Metadata.OrderPrecedence).First().Value;
 
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             get
             {
                 // Grab the paste processor that has the highest order precedence that is below PasteOrdering's order precedence. 
-                var pasteProcessor =
+                IPasteDataObjectProcessor pasteProcessor =
                     PasteProcessors.Where(x => x.Metadata.OrderPrecedence < OrderPrecedence)
                     .OrderByDescending(x => x.Metadata.OrderPrecedence).First().Value;
 
@@ -100,8 +100,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             Assumes.NotNull(_dropTarget);
 
             // ConfigureAwait is true because we need to come back for PasteItemsAsync to work. If not, PasteItemsAsync will throw.
-            var previousIncludes = await OrderingHelper.GetAllEvaluatedIncludes(_configuredProject, _accessor).ConfigureAwait(true);
-            var result = await PasteHandler.PasteItemsAsync(items, effect).ConfigureAwait(false);
+            System.Collections.Immutable.ImmutableHashSet<string> previousIncludes = await OrderingHelper.GetAllEvaluatedIncludes(_configuredProject, _accessor).ConfigureAwait(true);
+            PasteItemsResult result = await PasteHandler.PasteItemsAsync(items, effect).ConfigureAwait(false);
 
             await OrderingHelper.Move(_configuredProject, _accessor, previousIncludes, _dropTarget, OrderingMoveAction.MoveToTop).ConfigureAwait(false);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/UnconfiguredProjectHostObject.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/UnconfiguredProjectHostObject.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         {
             Requires.Range(!DisposingConfiguredProjectHostObjects, nameof(DisposingConfiguredProjectHostObjects));
 
-            foreach (var itemId in _pendingItemIds)
+            foreach (uint itemId in _pendingItemIds)
             {
                 OnPropertyChanged(itemId, (int)__VSHPROPID7.VSHPROPID_SharedItemContextHierarchy);
             }
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
 
         public override int AdviseHierarchyEvents(IVsHierarchyEvents pEventSink, out uint pdwCookie)
         {
-            var hr = base.AdviseHierarchyEvents(pEventSink, out pdwCookie);
+            int hr = base.AdviseHierarchyEvents(pEventSink, out pdwCookie);
             if (hr == VSConstants.S_OK)
             {
                 _hierEventSinks.Add(pdwCookie, pEventSink);
@@ -96,7 +96,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
                 return;
             }
 
-            foreach (var eventSinkKvp in _hierEventSinks)
+            foreach (KeyValuePair<uint, IVsHierarchyEvents> eventSinkKvp in _hierEventSinks)
             {
                 eventSinkKvp.Value.OnPropertyChanged(itemid, propid, flags);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
@@ -110,10 +110,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
 
         public async Task<Guid?> GetLanguageServiceId()
         {
-            var properties = await _projectVsServices.ActiveConfiguredProjectProperties.GetConfigurationGeneralPropertiesAsync()
+            ConfigurationGeneral properties = await _projectVsServices.ActiveConfiguredProjectProperties.GetConfigurationGeneralPropertiesAsync()
                                                                                        .ConfigureAwait(false);
 
-            var languageServiceIdString = (string)await properties.LanguageServiceId.GetValueAsync()
+            string languageServiceIdString = (string)await properties.LanguageServiceId.GetValueAsync()
                                                                                     .ConfigureAwait(false);
             if (string.IsNullOrEmpty(languageServiceIdString))
                 return null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectRestoreInfoBuilder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectRestoreInfoBuilder.cs
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
 
             foreach (IProjectVersionedValue<IProjectSubscriptionUpdate> update in updates)
             {
-                var nugetRestoreChanges = update.Value.ProjectChanges[NuGetRestore.SchemaName];
+                IProjectChangeDescription nugetRestoreChanges = update.Value.ProjectChanges[NuGetRestore.SchemaName];
                 msbuildProjectExtensionsPath = msbuildProjectExtensionsPath ??
                     nugetRestoreChanges.After.Properties[NuGetRestore.MSBuildProjectExtensionsPathProperty];
                 originalTargetFrameworks = originalTargetFrameworks ??
@@ -61,8 +61,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
 
                 if (!targetFrameworks.Contains(targetFramework))
                 {
-                    var projectReferencesChanges = update.Value.ProjectChanges[ProjectReference.SchemaName];
-                    var packageReferencesChanges = update.Value.ProjectChanges[PackageReference.SchemaName];
+                    IProjectChangeDescription projectReferencesChanges = update.Value.ProjectChanges[ProjectReference.SchemaName];
+                    IProjectChangeDescription packageReferencesChanges = update.Value.ProjectChanges[PackageReference.SchemaName];
 
                     targetFrameworks.Add(new TargetFrameworkInfo
                     {
@@ -73,8 +73,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
                     });
                 }
 
-                var toolReferencesChanges = update.Value.ProjectChanges[DotNetCliToolReference.SchemaName];
-                foreach (var item in toolReferencesChanges.After.Items)
+                IProjectChangeDescription toolReferencesChanges = update.Value.ProjectChanges[DotNetCliToolReference.SchemaName];
+                foreach (KeyValuePair<string, IImmutableDictionary<string, string>> item in toolReferencesChanges.After.Items)
                 {
                     if (!toolReferences.Contains(item.Key))
                     {
@@ -134,13 +134,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             IImmutableDictionary<string, IImmutableDictionary<string, string>> projectReferenceItems,
             UnconfiguredProject project)
         {
-            var referenceItems = GetReferences(projectReferenceItems);
+            IVsReferenceItems referenceItems = GetReferences(projectReferenceItems);
 
             // compute project file full path property for each reference
             foreach (ReferenceItem item in referenceItems)
             {
-                var definingProjectDirectory = item.Properties.Item(DefiningProjectDirectoryProperty);
-                var projectFileFullPath = definingProjectDirectory != null
+                IVsReferenceProperty definingProjectDirectory = item.Properties.Item(DefiningProjectDirectoryProperty);
+                string projectFileFullPath = definingProjectDirectory != null
                     ? MakeRooted(definingProjectDirectory.Value, item.Name)
                     : project.MakeRooted(item.Name);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/VsItemList.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/VsItemList.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         {
             Requires.NotNull(collection, nameof(collection));
 
-            foreach (var item in collection)
+            foreach (T item in collection)
             {
                 Add(item);
             }
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         {
             if (index is string)
             {
-                TryGetValue((string)index, out var value);
+                TryGetValue((string)index, out T value);
                 return value;
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AbstractProjectConfigurationProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AbstractProjectConfigurationProperties.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             {
                 return _threadingService.ExecuteSynchronously(async () =>
                 {
-                    var browseObjectProperties = await _projectProperties.GetConfiguredBrowseObjectPropertiesAsync().ConfigureAwait(true);
+                    ConfiguredBrowseObject browseObjectProperties = await _projectProperties.GetConfiguredBrowseObjectPropertiesAsync().ConfigureAwait(true);
                     return await browseObjectProperties.LangVersion.GetEvaluatedValueAtEndAsync().ConfigureAwait(true);
                 });
             }
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             {
                 _threadingService.ExecuteSynchronously(async () =>
                 {
-                    var browseObjectProperties = await _projectProperties.GetConfiguredBrowseObjectPropertiesAsync().ConfigureAwait(true);
+                    ConfiguredBrowseObject browseObjectProperties = await _projectProperties.GetConfiguredBrowseObjectPropertiesAsync().ConfigureAwait(true);
                     await browseObjectProperties.LangVersion.SetValueAsync(value).ConfigureAwait(true);
                 });
             }
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             {
                 return _threadingService.ExecuteSynchronously(async () =>
                 {
-                    var browseObjectProperties = await _projectProperties.GetConfiguredBrowseObjectPropertiesAsync().ConfigureAwait(true);
+                    ConfiguredBrowseObject browseObjectProperties = await _projectProperties.GetConfiguredBrowseObjectPropertiesAsync().ConfigureAwait(true);
                     return await browseObjectProperties.CodeAnalysisRuleSet.GetEvaluatedValueAtEndAsync().ConfigureAwait(true);
                 });
             }
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             {
                 _threadingService.ExecuteSynchronously(async () =>
                 {
-                    var browseObjectProperties = await _projectProperties.GetConfiguredBrowseObjectPropertiesAsync().ConfigureAwait(true);
+                    ConfiguredBrowseObject browseObjectProperties = await _projectProperties.GetConfiguredBrowseObjectPropertiesAsync().ConfigureAwait(true);
                     await browseObjectProperties.CodeAnalysisRuleSet.SetValueAsync(value).ConfigureAwait(true);
                 });
             }
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             {
                 return _threadingService.ExecuteSynchronously(async () =>
                 {
-                    var browseObjectProperties = await _projectProperties.GetConfiguredBrowseObjectPropertiesAsync().ConfigureAwait(true);
+                    ConfiguredBrowseObject browseObjectProperties = await _projectProperties.GetConfiguredBrowseObjectPropertiesAsync().ConfigureAwait(true);
                     return await browseObjectProperties.OutputPath.GetEvaluatedValueAtEndAsync().ConfigureAwait(true);
                 });
             }
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             {
                 _threadingService.ExecuteSynchronously(async () =>
                 {
-                    var browseObjectProperties = await _projectProperties.GetConfiguredBrowseObjectPropertiesAsync().ConfigureAwait(true);
+                    ConfiguredBrowseObject browseObjectProperties = await _projectProperties.GetConfiguredBrowseObjectPropertiesAsync().ConfigureAwait(true);
                     await browseObjectProperties.OutputPath.SetValueAsync(value).ConfigureAwait(true);
                 });
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.AbstractBuildEventHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.AbstractBuildEventHelper.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
             public async Task<string> GetPropertyAsync(ProjectRootElement projectXml, IProjectProperties defaultProperties)
             {
                 // check if value already exists
-                var unevaluatedPropertyValue = await defaultProperties.GetUnevaluatedPropertyValueAsync(BuildEvent).ConfigureAwait(true);
+                string unevaluatedPropertyValue = await defaultProperties.GetUnevaluatedPropertyValueAsync(BuildEvent).ConfigureAwait(true);
                 if (unevaluatedPropertyValue != null)
                 {
                     return unevaluatedPropertyValue;
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
                     return null;
                 }
 
-                if (execTask.Parameters.TryGetValue(Command, out var commandText))
+                if (execTask.Parameters.TryGetValue(Command, out string commandText))
                 {
                     return commandText;
                 }
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
 
             private async Task<bool> TrySetPropertyAsync(string unevaluatedPropertyValue, IProjectProperties defaultProperties, ProjectRootElement projectXml)
             {
-                var currentValue = await defaultProperties.GetUnevaluatedPropertyValueAsync(BuildEvent).ConfigureAwait(true);
+                string currentValue = await defaultProperties.GetUnevaluatedPropertyValueAsync(BuildEvent).ConfigureAwait(true);
                 if (currentValue == null)
                 {
                     return false;
@@ -108,7 +108,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
 
             private (bool success, ProjectTaskElement execTask) FindExecTaskInTargets(ProjectRootElement projectXml)
             {
-                var execTask = projectXml.Targets
+                ProjectTaskElement execTask = projectXml.Targets
                                     .Where(target =>
                                         StringComparer.OrdinalIgnoreCase.Compare(GetTarget(target), BuildEvent) == 0 &&
                                         StringComparer.OrdinalIgnoreCase.Compare(target.Name, TargetName) == 0)
@@ -120,7 +120,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
 
             private (bool success, ProjectTargetElement target) FindTargetToRemove(ProjectRootElement projectXml)
             {
-                var foundTarget = projectXml.Targets
+                ProjectTargetElement foundTarget = projectXml.Targets
                                         .Where(target =>
                                             StringComparer.OrdinalIgnoreCase.Compare(GetTarget(target), BuildEvent) == 0 &&
                                             StringComparer.OrdinalIgnoreCase.Compare(target.Name, TargetName) == 0 &&
@@ -133,7 +133,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
 
             private void SetParameter(ProjectRootElement projectXml, string unevaluatedPropertyValue)
             {
-                var result = FindExecTaskInTargets(projectXml);
+                (bool success, ProjectTaskElement execTask) result = FindExecTaskInTargets(projectXml);
 
                 if (result.success == true)
                 {
@@ -141,9 +141,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
                 }
                 else
                 {
-                    var target = projectXml.AddTarget(TargetName);
+                    ProjectTargetElement target = projectXml.AddTarget(TargetName);
                     SetTargetDependencies(target);
-                    var execTask = target.AddTask(ExecTask);
+                    ProjectTaskElement execTask = target.AddTask(ExecTask);
                     SetExecParameter(execTask, unevaluatedPropertyValue);
                 }
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.cs
@@ -27,9 +27,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
             string evaluatedPropertyValue,
             IProjectProperties defaultProperties)
         {
-            using (var access = await _projectLockService.ReadLockAsync())
+            using (ProjectLockReleaser access = await _projectLockService.ReadLockAsync())
             {
-                var projectXml = await access.GetProjectXmlAsync(_unconfiguredProject.FullPath).ConfigureAwait(true);
+                Microsoft.Build.Construction.ProjectRootElement projectXml = await access.GetProjectXmlAsync(_unconfiguredProject.FullPath).ConfigureAwait(true);
                 return await _helper.GetPropertyAsync(projectXml, defaultProperties).ConfigureAwait(true);
             }
         }
@@ -39,9 +39,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
             IProjectProperties defaultProperties,
             IReadOnlyDictionary<string, string> dimensionalConditions = null)
         {
-            using (var access = await _projectLockService.WriteLockAsync())
+            using (ProjectWriteLockReleaser access = await _projectLockService.WriteLockAsync())
             {
-                var projectXml = await access.GetProjectXmlAsync(_unconfiguredProject.FullPath).ConfigureAwait(true);
+                Microsoft.Build.Construction.ProjectRootElement projectXml = await access.GetProjectXmlAsync(_unconfiguredProject.FullPath).ConfigureAwait(true);
                 await _helper.SetPropertyAsync(unevaluatedPropertyValue, defaultProperties, projectXml).ConfigureAwait(true);
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/OutputTypeValueProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/OutputTypeValueProviderBase.cs
@@ -23,8 +23,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
         public override async Task<string> OnGetEvaluatedPropertyValueAsync(string evaluatedPropertyValue, IProjectProperties defaultProperties)
         {
-            var configuration = await _properties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(false);
-            var value = await configuration.OutputType.GetEvaluatedValueAtEndAsync().ConfigureAwait(false);
+            ConfigurationGeneral configuration = await _properties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(false);
+            string value = await configuration.OutputType.GetEvaluatedValueAtEndAsync().ConfigureAwait(false);
             if (GetMap.TryGetValue(value, out string returnValue))
             {
                 return returnValue;
@@ -36,8 +36,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
         public override async Task<string> OnSetPropertyValueAsync(string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string> dimensionalConditions = null)
         {
-            var value = SetMap[unevaluatedPropertyValue];
-            var configuration = await _properties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(false);
+            string value = SetMap[unevaluatedPropertyValue];
+            ConfigurationGeneral configuration = await _properties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(false);
             await configuration.OutputType.SetValueAsync(value).ConfigureAwait(false);
 
             // Since we have persisted the value of OutputType, we dont have to persist the incoming value

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikerValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikerValueProvider.cs
@@ -31,9 +31,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
         public override async Task<string> OnSetPropertyValueAsync(string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string> dimensionalConditions = null)
         {
-            var configuration = await _properties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(true);
-            var currentTargetFramework = (string)await configuration.TargetFramework.GetValueAsync().ConfigureAwait(true);
-            var currentTargetFrameworks = (string)await configuration.TargetFrameworks.GetValueAsync().ConfigureAwait(true);
+            ConfigurationGeneral configuration = await _properties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(true);
+            string currentTargetFramework = (string)await configuration.TargetFramework.GetValueAsync().ConfigureAwait(true);
+            string currentTargetFrameworks = (string)await configuration.TargetFrameworks.GetValueAsync().ConfigureAwait(true);
             if (!string.IsNullOrEmpty(currentTargetFrameworks))
             {
                 throw new InvalidOperationException(VSResources.MultiTFEditNotSupported);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikersValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikersValueProvider.cs
@@ -21,13 +21,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
 
         public override async Task<string> OnGetEvaluatedPropertyValueAsync(string evaluatedPropertyValue, IProjectProperties defaultProperties)
         {
-            var configuredProjects = await _projectProvider.GetActiveConfiguredProjectsAsync().ConfigureAwait(true);
-            var builder = ImmutableArray.CreateBuilder<string>();
-            foreach (var configuredProject in configuredProjects.Objects)
+            ActiveConfiguredObjects<ConfiguredProject> configuredProjects = await _projectProvider.GetActiveConfiguredProjectsAsync().ConfigureAwait(true);
+            ImmutableArray<string>.Builder builder = ImmutableArray.CreateBuilder<string>();
+            foreach (ConfiguredProject configuredProject in configuredProjects.Objects)
             {
-                var projectProperties = configuredProject.Services.ExportProvider.GetExportedValue<ProjectProperties>();
-                var configuration = await projectProperties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(true);
-                var currentTargetFrameworkMoniker = (string)await configuration.TargetFrameworkMoniker.GetValueAsync().ConfigureAwait(true);
+                ProjectProperties projectProperties = configuredProject.Services.ExportProvider.GetExportedValue<ProjectProperties>();
+                ConfigurationGeneral configuration = await projectProperties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(true);
+                string currentTargetFrameworkMoniker = (string)await configuration.TargetFrameworkMoniker.GetValueAsync().ConfigureAwait(true);
                 builder.Add(currentTargetFrameworkMoniker);
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
@@ -53,12 +53,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public async Task<ICollection<IEnumValue>> GetListedValuesAsync()
         {
-            var project = _workspace.CurrentSolution.Projects.Where(p => PathHelper.IsSamePath(p.FilePath, _unconfiguredProject.FullPath)).First();
-            var compilation = await project.GetCompilationAsync().ConfigureAwait(false);
+            Project project = _workspace.CurrentSolution.Projects.Where(p => PathHelper.IsSamePath(p.FilePath, _unconfiguredProject.FullPath)).First();
+            Compilation compilation = await project.GetCompilationAsync().ConfigureAwait(false);
 
-            var entryPointFinderService = project.LanguageServices.GetService<IEntryPointFinderService>();
-            var entryPoints = entryPointFinderService.FindEntryPoints(compilation.GlobalNamespace, SearchForEntryPointsInFormsOnly);
-            var entryPointNames = entryPoints.Select(e => e.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted)));
+            IEntryPointFinderService entryPointFinderService = project.LanguageServices.GetService<IEntryPointFinderService>();
+            IEnumerable<INamedTypeSymbol> entryPoints = entryPointFinderService.FindEntryPoints(compilation.GlobalNamespace, SearchForEntryPointsInFormsOnly);
+            IEnumerable<string> entryPointNames = entryPoints.Select(e => e.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted)));
 
             return entryPointNames.Select(name => (IEnumValue)new PageEnumValue(new EnumValue { Name = name, DisplayName = name })).ToArray();
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/BuildMacroInfo.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/BuildMacroInfo.cs
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         public int GetBuildMacroValue(string bstrBuildMacroName, out string pbstrBuildMacroValue)
         {
             pbstrBuildMacroValue = null;
-            var commonProperties = _configuredProject.Value.Services.ProjectPropertiesProvider.GetCommonProperties();
+            ProjectSystem.Properties.IProjectProperties commonProperties = _configuredProject.Value.Services.ProjectPropertiesProvider.GetCommonProperties();
             pbstrBuildMacroValue = _threadingService.ExecuteSynchronously(() => commonProperties.GetEvaluatedPropertyValueAsync(bstrBuildMacroName));
 
             if (pbstrBuildMacroValue == null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml.cs
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                     if ((DataContext as DebugPageViewModel).EnvironmentVariables.Count > 0)
                     {
                         // get the new cell, set focus, then open for edit
-                        var cell = WpfHelper.GetCell(dataGridEnvironmentVariables, (DataContext as DebugPageViewModel).EnvironmentVariables.Count - 1, 0);
+                        DataGridCell cell = WpfHelper.GetCell(dataGridEnvironmentVariables, (DataContext as DebugPageViewModel).EnvironmentVariables.Count - 1, 0);
                         cell.Focus();
                         dataGridEnvironmentVariables.BeginEdit();
                     }
@@ -104,7 +104,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 _customControlLayoutUpdateRequired = false;
 
                 // Get the control that was added to the grid
-                var customControl = ((DebugPageViewModel)DataContext).ActiveProviderUserControl;
+                UserControl customControl = ((DebugPageViewModel)DataContext).ActiveProviderUserControl;
                 if (customControl != null)
                 {
                     if (customControl.Content is Grid childGrid && childGrid.ColumnDefinitions.Count == _mainGrid.ColumnDefinitions.Count)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
@@ -105,7 +105,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             }
             set
             {
-                var oldActiveProvider = ActiveProvider;
+                ILaunchSettingsUIProvider oldActiveProvider = ActiveProvider;
                 if (OnPropertyChanged(ref _selectedLaunchType, value))
                 {
                     // Existing commands are shown in the UI as project
@@ -161,7 +161,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             // Now hook into the current providers notifications. We do that after having set the profile on the provider
             // so that we don't get notifications while the control is initializing. Note that this is likely the first time the 
             // custom control is asked for and we want to call it and have it created prior to setting the active profile
-            var customControl = ActiveProvider?.CustomUI;
+            UserControl customControl = ActiveProvider?.CustomUI;
             if (customControl != null)
             {
                 ActiveProvider.ProfileSelected(CurrentLaunchSettings);
@@ -338,7 +338,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         /// </summary>
         private bool ActiveProviderSupportsProperty(string propertyName)
         {
-            var activeProvider = ActiveProvider;
+            ILaunchSettingsUIProvider activeProvider = ActiveProvider;
             return activeProvider?.ShouldEnableProperty(propertyName) ?? false;
         }
 
@@ -389,7 +389,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             {
                 if (CurrentLaunchSettings != null && CurrentLaunchSettings.ActiveProfile != value)
                 {
-                    var oldProfile = CurrentLaunchSettings.ActiveProfile;
+                    IWritableLaunchProfile oldProfile = CurrentLaunchSettings.ActiveProfile;
                     CurrentLaunchSettings.ActiveProfile = value;
                     NotifySelectedChanged(oldProfile);
                 }
@@ -477,7 +477,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         {
             get
             {
-                var provider = ActiveProvider;
+                ILaunchSettingsUIProvider provider = ActiveProvider;
                 return ActiveProvider?.CustomUI;
             }
         }
@@ -541,7 +541,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             if (EnvironmentVariables != null && EnvironmentVariables.Count > 0 && SelectedDebugProfile != null)
             {
                 SelectedDebugProfile.EnvironmentVariables.Clear();
-                foreach (var kvp in EnvironmentVariables)
+                foreach (NameValuePair kvp in EnvironmentVariables)
                 {
                     SelectedDebugProfile.EnvironmentVariables.Add(kvp.Name, kvp.Value);
                 }
@@ -561,7 +561,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 if (_environmentVariables.Count > 0)
                 {
                     oldProfile.EnvironmentVariables.Clear();
-                    foreach (var kvp in EnvironmentVariables)
+                    foreach (NameValuePair kvp in EnvironmentVariables)
                     {
                         oldProfile.EnvironmentVariables.Add(kvp.Name, kvp.Value);
                     }
@@ -601,7 +601,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         /// </summary>
         internal virtual void InitializeDebugTargetsCore(ILaunchSettings profiles)
         {
-            var newSettings = profiles.ToWritableLaunchSettings();
+            IWritableLaunchSettings newSettings = profiles.ToWritableLaunchSettings();
 
             // Since this get's reentered if the user saves or the user switches active profiles.
             if (CurrentLaunchSettings != null && !CurrentLaunchSettings.SetttingsDiffer(newSettings))
@@ -624,7 +624,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 
                 // Reload the launch profiles collection
                 LaunchProfiles.Clear();
-                foreach (var profile in CurrentLaunchSettings.Profiles)
+                foreach (IWritableLaunchProfile profile in CurrentLaunchSettings.Profiles)
                 {
                     LaunchProfiles.Add(profile);
                 }
@@ -686,7 +686,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                     InitializeDebugTargetsCore(profiles);
                 });
 
-                var profileProvider = GetDebugProfileProvider();
+                ILaunchSettingsProvider profileProvider = GetDebugProfileProvider();
                 _debugProfileProviderLink = profileProvider.SourceBlock.LinkTo(
                     debugProfilesBlock,
                     linkOptions: new DataflowLinkOptions { PropagateCompletion = true });
@@ -703,8 +703,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         {
             // We need to get the set of UI providers, if any.
             _uiProviders = new OrderPrecedenceImportCollection<ILaunchSettingsUIProvider>(ImportOrderPrecedenceComparer.PreferenceOrder.PreferredComesFirst, Project);
-            var uiProviders = GetUIProviders();
-            foreach (var uiProvider in uiProviders)
+            IEnumerable<Lazy<ILaunchSettingsUIProvider, IOrderPrecedenceMetadataView>> uiProviders = GetUIProviders();
+            foreach (Lazy<ILaunchSettingsUIProvider, IOrderPrecedenceMetadataView> uiProvider in uiProviders)
             {
                 _uiProviders.Add(uiProvider);
             }
@@ -731,7 +731,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                     return null;
                 }
 
-                var activeProvider = _uiProviders.FirstOrDefault((p) => string.Equals(p.Value.CommandName, SelectedLaunchType.CommandName, StringComparison.OrdinalIgnoreCase));
+                Lazy<ILaunchSettingsUIProvider, IOrderPrecedenceMetadataView> activeProvider = _uiProviders.FirstOrDefault((p) => string.Equals(p.Value.CommandName, SelectedLaunchType.CommandName, StringComparison.OrdinalIgnoreCase));
                 return activeProvider?.Value;
             }
         }
@@ -805,12 +805,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                     {
                         using (var dialog = new System.Windows.Forms.FolderBrowserDialog())
                         {
-                            var folder = WorkingDirectory;
+                            string folder = WorkingDirectory;
                             if (!string.IsNullOrEmpty(folder) && Directory.Exists(folder))
                             {
                                 dialog.SelectedPath = folder;
                             }
-                            var result = dialog.ShowDialog();
+                            System.Windows.Forms.DialogResult result = dialog.ShowDialog();
                             if (result == System.Windows.Forms.DialogResult.OK)
                             {
                                 WorkingDirectory = dialog.SelectedPath.ToString();
@@ -830,7 +830,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                     {
                         using (var dialog = new System.Windows.Forms.OpenFileDialog())
                         {
-                            var file = ExecutablePath;
+                            string file = ExecutablePath;
                             if (!string.IsNullOrEmpty(file) && (file.IndexOfAny(Path.GetInvalidPathChars()) == -1) && Path.IsPathRooted(file))
                             {
                                 dialog.InitialDirectory = Path.GetDirectoryName(file);
@@ -838,7 +838,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                             }
                             dialog.Multiselect = false;
                             dialog.Filter = _executableFilter;
-                            var result = dialog.ShowDialog();
+                            System.Windows.Forms.DialogResult result = dialog.ShowDialog();
                             if (result == System.Windows.Forms.DialogResult.OK)
                             {
                                 ExecutablePath = dialog.FileName.ToString();
@@ -897,7 +897,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 return LazyInitializer.EnsureInitialized(ref _deleteProfileCommand, () =>
                     new DelegateCommand(state =>
                     {
-                        var profileToRemove = SelectedDebugProfile;
+                        IWritableLaunchProfile profileToRemove = SelectedDebugProfile;
                         SelectedDebugProfile = null;
 
                         CurrentLaunchSettings.Profiles.Remove(profileToRemove);
@@ -957,7 +957,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             if (_providerLaunchTypes == null)
             {
                 _providerLaunchTypes = new List<LaunchType>();
-                foreach (var provider in _uiProviders)
+                foreach (Lazy<ILaunchSettingsUIProvider, IOrderPrecedenceMetadataView> provider in _uiProviders)
                 {
                     if (_providerLaunchTypes.FirstOrDefault((lt) => lt.CommandName.Equals(provider.Value.CommandName)) == null)
                     {
@@ -966,7 +966,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 }
             }
 
-            var selectedProfile = SelectedDebugProfile;
+            IWritableLaunchProfile selectedProfile = SelectedDebugProfile;
             LaunchType selectedLaunchType = null;
 
             _launchTypes = new List<LaunchType>();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/EnvironmentGridTemplateColumn.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/EnvironmentGridTemplateColumn.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             if (frameworkElement != null && frameworkElement is ContentPresenter)
             {
                 var contentPresenter = frameworkElement as ContentPresenter;
-                var textBox = WpfHelper.GetVisualChild<TextBox>(contentPresenter);
+                TextBox textBox = WpfHelper.GetVisualChild<TextBox>(contentPresenter);
                 if (textBox != null)
                 {
                     textBox.SelectAll();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPage.cs
@@ -315,7 +315,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         /// </summary>
         internal virtual UnconfiguredProject GetUnconfiguredProject(IVsHierarchy hier)
         {
-            var provider = GetExport<IProjectExportProvider>(hier);
+            IProjectExportProvider provider = GetExport<IProjectExportProvider>(hier);
             return provider.GetExport<UnconfiguredProject>(hier.GetDTEProject().FileName);
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/BaseReferenceContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/BaseReferenceContextProvider.cs
@@ -30,8 +30,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             _nextHandler = new Lazy<Lazy<IVsReferenceManagerUserAsync, IVsReferenceManagerUserComponentMetadataView>>(() =>
             {
                 Type provider = GetType();
-                var order = provider.GetCustomAttribute<OrderAttribute>();
-                var user = provider.GetCustomAttribute<ExportIVsReferenceManagerUserAsyncAttribute>();
+                OrderAttribute order = provider.GetCustomAttribute<OrderAttribute>();
+                ExportIVsReferenceManagerUserAsyncAttribute user = provider.GetCustomAttribute<ExportIVsReferenceManagerUserAsyncAttribute>();
                 return VsReferenceManagerUsers.FirstOrDefault(
                         export =>
                             export.Metadata.OrderPrecedence < order.OrderPrecedence &&

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/AbstractRenameStrategy.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/AbstractRenameStrategy.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
             }
 
             await _threadingService.SwitchToUIThread();
-            var userNeedPrompt = _environmentOptions.GetOption("Environment", "ProjectsAndSolution", "PromptForRenameSymbol", false);
+            bool userNeedPrompt = _environmentOptions.GetOption("Environment", "ProjectsAndSolution", "PromptForRenameSymbol", false);
             if (userNeedPrompt)
             {
                 string renamePromptMessage = string.Format(CultureInfo.CurrentCulture, VSResources.RenameSymbolPrompt, oldFileName);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileRenameTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileRenameTracker.cs
@@ -43,13 +43,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
 
         public Task HintedAsync(IImmutableDictionary<Guid, IImmutableSet<IProjectChangeHint>> hints)
         {
-            var files = hints[ProjectChangeFileSystemEntityRenameHint.RenamedFile];
+            IImmutableSet<IProjectChangeHint> files = hints[ProjectChangeFileSystemEntityRenameHint.RenamedFile];
             if (files.Count == 1)
             {
                 var hint = (IProjectChangeFileRenameHint)files.First();
                 if (!hint.ChangeAlreadyOccurred)
                 {
-                    var kvp = hint.RenamedFiles.First();
+                    System.Collections.Generic.KeyValuePair<string, string> kvp = hint.RenamedFiles.First();
                     ScheduleRename(kvp.Key, kvp.Value);
                 }
             }
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
                 return;
             }
 
-            var myProject = _visualStudioWorkspace
+            CodeAnalysis.Project myProject = _visualStudioWorkspace
                  .CurrentSolution
                  .Projects.Where(p => StringComparers.Paths.Equals(p.FilePath, _projectVsServices.Project.FullPath))
                  .FirstOrDefault();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/Renamer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/Renamer.cs
@@ -70,15 +70,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
             if (_docAdded && _docRemoved && _docChanged)
             {
                 _workspace.WorkspaceChanged -= OnWorkspaceChangedAsync;
-                var myNewProject = _workspace.CurrentSolution.Projects.Where(p => StringComparers.Paths.Equals(p.FilePath, _project.FilePath)).FirstOrDefault();
+                Project myNewProject = _workspace.CurrentSolution.Projects.Where(p => StringComparers.Paths.Equals(p.FilePath, _project.FilePath)).FirstOrDefault();
                 await RenameAsync(myNewProject).ConfigureAwait(false);
             }
         }
 
         public async Task RenameAsync(Project project)
         {
-            var isCaseSensitive = await IsCompilationCaseSensitiveAsync(project).ConfigureAwait(false);
-            var renameStrategy = GetStrategy(project, isCaseSensitive);
+            bool isCaseSensitive = await IsCompilationCaseSensitiveAsync(project).ConfigureAwait(false);
+            IRenameStrategy renameStrategy = GetStrategy(project, isCaseSensitive);
             if (renameStrategy != null)
                 await renameStrategy.RenameAsync(project, _oldFilePath, _newFilePath, isCaseSensitive).ConfigureAwait(false);
         }
@@ -94,8 +94,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
 
         private static async Task<bool> IsCompilationCaseSensitiveAsync(Project project)
         {
-            var isCaseSensitive = false;
-            var compilation = await project.GetCompilationAsync().ConfigureAwait(false);
+            bool isCaseSensitive = false;
+            Compilation compilation = await project.GetCompilationAsync().ConfigureAwait(false);
             if (compilation != null)
             {
                 isCaseSensitive = compilation.IsCaseSensitive;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContext.cs
@@ -53,10 +53,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         public void SetProjectFilePathAndDisplayName(string projectFilePath, string displayName)
         {
             // Update the project file path and display name for all the inner project contexts.
-            foreach (var innerProjectContextKvp in _configuredProjectContextsByTargetFramework)
+            foreach (KeyValuePair<ITargetFramework, ITargetedProjectContext> innerProjectContextKvp in _configuredProjectContextsByTargetFramework)
             {
-                var targetFramework = innerProjectContextKvp.Key;
-                var innerProjectContext = innerProjectContextKvp.Value;
+                ITargetFramework targetFramework = innerProjectContextKvp.Key;
+                ITargetedProjectContext innerProjectContext = innerProjectContextKvp.Value;
 
                 // For cross targeting projects, we ensure that the display name is unique per every target framework.
                 innerProjectContext.DisplayName = IsCrossTargeting ? $"{displayName}({targetFramework})" : displayName;
@@ -68,9 +68,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         {
             if (projectConfiguration.IsCrossTargeting())
             {
-                var targetFrameworkMoniker =
+                string targetFrameworkMoniker =
                     projectConfiguration.Dimensions[ConfigurationGeneral.TargetFrameworkProperty];
-                var targetFramework = TargetFrameworkProvider.GetTargetFramework(targetFrameworkMoniker);
+                ITargetFramework targetFramework = TargetFrameworkProvider.GetTargetFramework(targetFrameworkMoniker);
 
                 isActiveConfiguration = _activeTargetFramework.Equals(targetFramework);
 
@@ -105,7 +105,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             Assumes.True(activeProjectConfiguration.IsCrossTargeting());
             Assumes.True(knownProjectConfigurations.All(c => c.IsCrossTargeting()));
 
-            var activeTargetFramework = TargetFrameworkProvider.GetTargetFramework(activeProjectConfiguration.Dimensions[ConfigurationGeneral.TargetFrameworkProperty]);
+            ITargetFramework activeTargetFramework = TargetFrameworkProvider.GetTargetFramework(activeProjectConfiguration.Dimensions[ConfigurationGeneral.TargetFrameworkProperty]);
             if (!_activeTargetFramework.Equals(activeTargetFramework))
             {
                 // Active target framework is different.
@@ -120,9 +120,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
                 return false;
             }
 
-            foreach (var targetFrameworkMoniker in targetFrameworks)
+            foreach (string targetFrameworkMoniker in targetFrameworks)
             {
-                var targetFramework = TargetFrameworkProvider.GetTargetFramework(targetFrameworkMoniker);
+                ITargetFramework targetFramework = TargetFrameworkProvider.GetTargetFramework(targetFrameworkMoniker);
                 if (!_configuredProjectContextsByTargetFramework.ContainsKey(targetFramework))
                 {
                     // Differing TargetFramework
@@ -137,7 +137,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         {
             // Dispose the inner project contexts.
             var disposedContexts = new List<ITargetedProjectContext>();
-            foreach (var innerProjectContext in InnerProjectContexts)
+            foreach (ITargetedProjectContext innerProjectContext in InnerProjectContexts)
             {
                 if (shouldDisposeInnerContext(innerProjectContext))
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         {
             EnsureInitialized();
 
-            var context = await CreateProjectContextAsyncCore().ConfigureAwait(false);
+            AggregateCrossTargetProjectContext context = await CreateProjectContextAsyncCore().ConfigureAwait(false);
             if (context == null)
             {
                 return null;
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             {
                 // There's a race here, by the time we've created the project context,
                 // the project could have been renamed, handle this.
-                var projectData = GetProjectData();
+                ProjectData projectData = GetProjectData();
 
                 context.SetProjectFilePathAndDisplayName(projectData.FullPath, projectData.DisplayName);
                 _contexts.Add(context);
@@ -104,15 +104,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             }
 
             var unusedConfiguredProjects = new HashSet<ConfiguredProject>(_configuredProjectContextsMap.Keys);
-            foreach (var context in _contexts)
+            foreach (AggregateCrossTargetProjectContext context in _contexts)
             {
-                foreach (var configuredProject in context.InnerConfiguredProjects)
+                foreach (ConfiguredProject configuredProject in context.InnerConfiguredProjects)
                 {
                     unusedConfiguredProjects.Remove(configuredProject);
                 }
             }
 
-            foreach (var configuredProject in unusedConfiguredProjects)
+            foreach (ConfiguredProject configuredProject in unusedConfiguredProjects)
             {
                 _configuredProjectContextsMap.Remove(configuredProject);
             }
@@ -140,9 +140,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         {
             lock (_gate)
             {
-                var projectData = GetProjectData();
+                ProjectData projectData = GetProjectData();
 
-                foreach (var context in _contexts)
+                foreach (AggregateCrossTargetProjectContext context in _contexts)
                 {
                     context.SetProjectFilePathAndDisplayName(projectData.FullPath, projectData.DisplayName);
                 }
@@ -202,28 +202,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 
             return await _taskScheduler.RunAsync(TaskSchedulerPriority.UIThreadBackgroundPriority, async () =>
             {
-                var projectData = GetProjectData();
+                ProjectData projectData = GetProjectData();
 
                 // Get the set of active configured projects ignoring target framework.
 #pragma warning disable CS0618 // Type or member is obsolete
-                var configuredProjectsMap = await _activeConfiguredProjectsProvider.GetActiveConfiguredProjectsMapAsync().ConfigureAwait(true);
+                ImmutableDictionary<string, ConfiguredProject> configuredProjectsMap = await _activeConfiguredProjectsProvider.GetActiveConfiguredProjectsMapAsync().ConfigureAwait(true);
 #pragma warning restore CS0618 // Type or member is obsolete
-                var activeProjectConfiguration = _commonServices.ActiveConfiguredProject.ProjectConfiguration;
-                var innerProjectContextsBuilder = ImmutableDictionary.CreateBuilder<ITargetFramework, ITargetedProjectContext>();
-                var activeTargetFramework = TargetFramework.Empty;
+                ProjectConfiguration activeProjectConfiguration = _commonServices.ActiveConfiguredProject.ProjectConfiguration;
+                ImmutableDictionary<ITargetFramework, ITargetedProjectContext>.Builder innerProjectContextsBuilder = ImmutableDictionary.CreateBuilder<ITargetFramework, ITargetedProjectContext>();
+                ITargetFramework activeTargetFramework = TargetFramework.Empty;
 
-                foreach (var kvp in configuredProjectsMap)
+                foreach (KeyValuePair<string, ConfiguredProject> kvp in configuredProjectsMap)
                 {
-                    var configuredProject = kvp.Value;
-                    var projectProperties = configuredProject.Services.ExportProvider.GetExportedValue<ProjectProperties>();
-                    var configurationGeneralProperties = await projectProperties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(true);
-                    var targetFramework = await GetTargetFrameworkAsync(kvp.Key, configurationGeneralProperties).ConfigureAwait(false);
+                    ConfiguredProject configuredProject = kvp.Value;
+                    ProjectProperties projectProperties = configuredProject.Services.ExportProvider.GetExportedValue<ProjectProperties>();
+                    ConfigurationGeneral configurationGeneralProperties = await projectProperties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(true);
+                    ITargetFramework targetFramework = await GetTargetFrameworkAsync(kvp.Key, configurationGeneralProperties).ConfigureAwait(false);
 
                     if (!TryGetConfiguredProjectState(configuredProject, out ITargetedProjectContext targetedProjectContext))
                     {
                         // Get the target path for the configured project.
-                        var targetPath = (string)await configurationGeneralProperties.TargetPath.GetValueAsync().ConfigureAwait(true);
-                        var displayName = GetDisplayName(configuredProject, projectData, targetFramework.FullName);
+                        string targetPath = (string)await configurationGeneralProperties.TargetPath.GetValueAsync().ConfigureAwait(true);
+                        string displayName = GetDisplayName(configuredProject, projectData, targetFramework.FullName);
 
                         targetedProjectContext = new TargetedProjectContext(targetFramework, projectData.FullPath, displayName, targetPath)
                         {
@@ -243,7 +243,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
                     }
                 }
 
-                var isCrossTargeting = !(configuredProjectsMap.Count == 1 && string.IsNullOrEmpty(configuredProjectsMap.First().Key));
+                bool isCrossTargeting = !(configuredProjectsMap.Count == 1 && string.IsNullOrEmpty(configuredProjectsMap.First().Key));
                 return new AggregateCrossTargetProjectContext(isCrossTargeting,
                                                               innerProjectContextsBuilder.ToImmutable(),
                                                               configuredProjectsMap,
@@ -258,7 +258,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         {
             if (string.IsNullOrEmpty(shortOrFullName))
             {
-                var targetObject = await configurationGeneralProperties.TargetFramework.GetValueAsync().ConfigureAwait(false);
+                object targetObject = await configurationGeneralProperties.TargetFramework.GetValueAsync().ConfigureAwait(false);
                 if (targetObject == null)
                 {
                     return TargetFramework.Empty;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetFrameworkProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetFrameworkProvider.cs
@@ -40,11 +40,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
                 {
                     if (!TryGetCachedTargetFramework(shortOrFullName, out targetFramework))
                     {
-                        var frameworkName = _nuGetFrameworkParser.ParseFrameworkName(shortOrFullName);
+                        System.Runtime.Versioning.FrameworkName frameworkName = _nuGetFrameworkParser.ParseFrameworkName(shortOrFullName);
                         if (frameworkName != null &&
                             !TryGetCachedTargetFramework(frameworkName.FullName, out targetFramework))
                         {
-                            var shortName = _nuGetFrameworkParser.GetShortFrameworkName(frameworkName);
+                            string shortName = _nuGetFrameworkParser.GetShortFrameworkName(frameworkName);
                             targetFramework = new TargetFramework(frameworkName, shortName);
                             // remember target framework - there can not be too many of them across the solution.
                             _cachedTargetFrameworks.Add(targetFramework);
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
                 return null;
             }
 
-            var nearestFrameworkName = _nuGetComparer.GetNearest(
+            System.Runtime.Versioning.FrameworkName nearestFrameworkName = _nuGetComparer.GetNearest(
                 targetFramework.FrameworkName, otherFrameworks.Select(x => x.FrameworkName));
             if (nearestFrameworkName == null)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -141,14 +141,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 return false;
             }
 
-            var snapshot = DependenciesSnapshotProvider.CurrentSnapshot;
+            IDependenciesSnapshot snapshot = DependenciesSnapshotProvider.CurrentSnapshot;
             if (snapshot == null)
             {
                 return false;
             }
 
             bool canRemove = true;
-            foreach (var node in nodes)
+            foreach (IProjectTree node in nodes)
             {
                 if (!node.Flags.Contains(DependencyTreeFlags.SupportsRemove))
                 {
@@ -156,13 +156,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     break;
                 }
 
-                var filePath = UnconfiguredProject.GetRelativePath(node.FilePath);
+                string filePath = UnconfiguredProject.GetRelativePath(node.FilePath);
                 if (string.IsNullOrEmpty(filePath))
                 {
                     continue;
                 }
 
-                var dependency = snapshot.FindDependency(filePath, topLevel: true);
+                IDependency dependency = snapshot.FindDependency(filePath, topLevel: true);
                 if (dependency == null || dependency.Implicit)
                 {
                     canRemove = false;
@@ -203,12 +203,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             // Get the list of normal reference Item Nodes (this excludes any shared import nodes).
             IEnumerable<IProjectTree> referenceItemNodes = nodes.Except(sharedImportNodes);
 
-            using (var access = await ProjectLockService.WriteLockAsync())
+            using (ProjectWriteLockReleaser access = await ProjectLockService.WriteLockAsync())
             {
-                var project = await access.GetProjectAsync(ActiveConfiguredProject).ConfigureAwait(true);
+                Microsoft.Build.Evaluation.Project project = await access.GetProjectAsync(ActiveConfiguredProject).ConfigureAwait(true);
 
                 // Handle the removal of normal reference Item Nodes (this excludes any shared import nodes).
-                foreach (var node in referenceItemNodes)
+                foreach (IProjectTree node in referenceItemNodes)
                 {
                     if (node.BrowseObjectProperties == null || node.BrowseObjectProperties.Context == null)
                     {
@@ -221,8 +221,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                         continue;
                     }
 
-                    var nodeItemContext = node.BrowseObjectProperties.Context;
-                    var unresolvedReferenceItem = project.GetItemsByEvaluatedInclude(nodeItemContext.ItemName)
+                    IProjectPropertiesContext nodeItemContext = node.BrowseObjectProperties.Context;
+                    Microsoft.Build.Evaluation.ProjectItem unresolvedReferenceItem = project.GetItemsByEvaluatedInclude(nodeItemContext.ItemName)
                         .FirstOrDefault(item => string.Equals(item.ItemType,
                                                               nodeItemContext.ItemType,
                                                               StringComparison.OrdinalIgnoreCase));
@@ -236,7 +236,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     }
                 }
 
-                var snapshot = DependenciesSnapshotProvider.CurrentSnapshot;
+                IDependenciesSnapshot snapshot = DependenciesSnapshotProvider.CurrentSnapshot;
                 Requires.NotNull(snapshot, nameof(snapshot));
                 if (snapshot == null)
                 {
@@ -244,17 +244,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 }
 
                 // Handle the removal of shared import nodes.
-                var projectXml = await access.GetProjectXmlAsync(UnconfiguredProject.FullPath)
+                Microsoft.Build.Construction.ProjectRootElement projectXml = await access.GetProjectXmlAsync(UnconfiguredProject.FullPath)
                                              .ConfigureAwait(true);
-                foreach (var sharedImportNode in sharedImportNodes)
+                foreach (IProjectTree sharedImportNode in sharedImportNodes)
                 {
-                    var sharedFilePath = UnconfiguredProject.GetRelativePath(sharedImportNode.FilePath);
+                    string sharedFilePath = UnconfiguredProject.GetRelativePath(sharedImportNode.FilePath);
                     if (string.IsNullOrEmpty(sharedFilePath))
                     {
                         continue;
                     }
 
-                    var sharedProjectDependency = snapshot.FindDependency(sharedFilePath, topLevel: true);
+                    IDependency sharedProjectDependency = snapshot.FindDependency(sharedFilePath, topLevel: true);
                     if (sharedProjectDependency != null)
                     {
                         sharedFilePath = sharedProjectDependency.Path;
@@ -262,13 +262,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
                     // Find the import that is included in the evaluation of the specified ConfiguredProject that
                     // imports the project file whose full path matches the specified one.
-                    var matchingImports = from import in project.Imports
+                    IEnumerable<Microsoft.Build.Evaluation.ResolvedImport> matchingImports = from import in project.Imports
                                           where import.ImportingElement.ContainingProject == projectXml
                                           where PathHelper.IsSamePath(import.ImportedProject.FullPath, sharedFilePath)
                                           select import;
-                    foreach (var importToRemove in matchingImports)
+                    foreach (Microsoft.Build.Evaluation.ResolvedImport importToRemove in matchingImports)
                     {
-                        var importingElementToRemove = importToRemove.ImportingElement;
+                        Microsoft.Build.Construction.ProjectImportElement importingElementToRemove = importToRemove.ImportingElement;
                         Report.IfNot(importingElementToRemove != null,
                                      "Cannot find shared project reference to remove.");
                         if (importingElementToRemove != null)
@@ -330,10 +330,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                             DependenciesSnapshotProvider.SnapshotChanged += OnDependenciesSnapshotChanged;
 
                             Verify.NotDisposed(this);
-                            var nowait = SubmitTreeUpdateAsync(
+                            Task<IProjectVersionedValue<IProjectTreeSnapshot>> nowait = SubmitTreeUpdateAsync(
                                 (treeSnapshot, configuredProjectExports, cancellationToken) =>
                                 {
-                                    var dependenciesNode = CreateDependenciesFolder(null);
+                                    IProjectTree dependenciesNode = CreateDependenciesFolder(null);
 
                                     // TODO create providers nodes that can be visible when empty
                                     //dependenciesNode = CreateOrUpdateSubTreeProviderNodes(dependenciesNode, 
@@ -358,7 +358,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
         private void OnDependenciesSnapshotChanged(object sender, SnapshotChangedEventArgs e)
         {
-            var snapshot = e.Snapshot;
+            IDependenciesSnapshot snapshot = e.Snapshot;
             if (snapshot == null)
             {
                 return;
@@ -388,16 +388,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
         private Task BuildTreeForSnapshotAsync(IDependenciesSnapshot snapshot)
         {
-            var viewProvider = ViewProviders.FirstOrDefault();
+            Lazy<IDependenciesTreeViewProvider, IOrderPrecedenceMetadataView> viewProvider = ViewProviders.FirstOrDefault();
             if (viewProvider == null)
             {
                 return Task.CompletedTask;
             }
 
-            var nowait = SubmitTreeUpdateAsync(
+            Task<IProjectVersionedValue<IProjectTreeSnapshot>> nowait = SubmitTreeUpdateAsync(
                 async (treeSnapshot, configuredProjectExports, cancellationToken) =>
                 {
-                    var dependenciesNode = treeSnapshot.Value.Tree;
+                    IProjectTree dependenciesNode = treeSnapshot.Value.Tree;
                     if (!cancellationToken.IsCancellationRequested)
                     {
                         dependenciesNode = await viewProvider.Value.BuildTreeAsync(dependenciesNode, snapshot, cancellationToken)
@@ -500,8 +500,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             // (old code used to check if rule datasource has SourceType=TargetResults, which was true for Resolved,
             // dependencies. However now we have custom logic for collecting unresolved dependencies too and use 
             // DesignTime build results there too. Thats why we swicthed to check for persistence).
-            var browseObjectCatalog = namedCatalogs[PropertyPageContexts.BrowseObject];
-            var schemas = browseObjectCatalog.GetPropertyPagesSchemas(itemType);
+            IPropertyPagesCatalog browseObjectCatalog = namedCatalogs[PropertyPageContexts.BrowseObject];
+            IReadOnlyCollection<string> schemas = browseObjectCatalog.GetPropertyPagesSchemas(itemType);
 
             return from schemaName in browseObjectCatalog.GetPropertyPagesSchemas(itemType)
                    let schema = browseObjectCatalog.GetSchema(schemaName)
@@ -517,7 +517,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                         IProjectTreeCustomizablePropertyContext context,
                         ReferencesProjectTreeCustomizablePropertyValues values)
         {
-            foreach (var provider in ProjectTreePropertiesProviders.ExtensionValues())
+            foreach (IProjectTreePropertiesProvider provider in ProjectTreePropertiesProviders.ExtensionValues())
             {
                 provider.CalculatePropertyValues(context, values);
             }
@@ -596,13 +596,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                                 .ConfigureAwait(false) ?? ActiveConfiguredProject;
             }
 
-            var configuredProjectExports = GetActiveConfiguredProjectExports(project);
-            var namedCatalogs = await GetNamedCatalogsAsync(catalogs).ConfigureAwait(false);
+            ConfiguredProjectExports configuredProjectExports = GetActiveConfiguredProjectExports(project);
+            IImmutableDictionary<string, IPropertyPagesCatalog> namedCatalogs = await GetNamedCatalogsAsync(catalogs).ConfigureAwait(false);
             Requires.NotNull(namedCatalogs, nameof(namedCatalogs));
 
-            var browseObjectsCatalog = namedCatalogs[PropertyPageContexts.BrowseObject];
-            var schema = browseObjectsCatalog.GetSchema(dependency.SchemaName);
-            var itemSpec = string.IsNullOrEmpty(dependency.OriginalItemSpec) ? dependency.Path : dependency.OriginalItemSpec;
+            IPropertyPagesCatalog browseObjectsCatalog = namedCatalogs[PropertyPageContexts.BrowseObject];
+            Rule schema = browseObjectsCatalog.GetSchema(dependency.SchemaName);
+            string itemSpec = string.IsNullOrEmpty(dependency.OriginalItemSpec) ? dependency.Path : dependency.OriginalItemSpec;
             var context = ProjectPropertiesContext.GetContext(UnconfiguredProject,
                 itemType: dependency.SchemaItemType,
                 itemName: itemSpec);
@@ -627,7 +627,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             {
                 // Since we have no browse object, we still need to create *something* so
                 // that standard property pages can pop up.
-                var emptyRule = RuleExtensions.SynthesizeEmptyRule(context.ItemType);
+                Rule emptyRule = RuleExtensions.SynthesizeEmptyRule(context.ItemType);
                 return configuredProjectExports.PropertyPagesDataModelProvider.GetRule(
                             emptyRule,
                             context.File,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -62,9 +62,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 if (_stopTelemetry)
                     return;
 
-                var telemetryState = _telemetryStates.GetOrAdd(targetFramework, (key) => new TelemetryState());
+                TelemetryState telemetryState = _telemetryStates.GetOrAdd(targetFramework, (key) => new TelemetryState());
 
-                foreach (var rule in rules)
+                foreach (string rule in rules)
                 {
                     telemetryState.InitializeRule(rule);
                 }
@@ -83,9 +83,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 if (_stopTelemetry)
                     return;
 
-                if (_telemetryStates.TryGetValue(targetFramework, out var telemetryState))
+                if (_telemetryStates.TryGetValue(targetFramework, out TelemetryState telemetryState))
                 {
-                    foreach (var rule in rules)
+                    foreach (string rule in rules)
                     {
                         telemetryState.ObserveRule(rule);
                     }
@@ -124,7 +124,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
         private void InitializeProjectId()
         {
-            var projectGuidService = _project.Services.ExportProvider.GetExportedValueOrDefault<IProjectGuidService>();
+            IProjectGuidService projectGuidService = _project.Services.ExportProvider.GetExportedValueOrDefault<IProjectGuidService>();
             if (projectGuidService != null)
             {
                 SetProjectId(projectGuidService.ProjectGuid.ToString());

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/CheckChildrenGraphActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/CheckChildrenGraphActionHandler.cs
@@ -31,26 +31,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
 
         public override bool HandleRequest(IGraphContext graphContext)
         {
-            foreach (var inputGraphNode in graphContext.InputNodes)
+            foreach (GraphNode inputGraphNode in graphContext.InputNodes)
             {
                 if (graphContext.CancelToken.IsCancellationRequested)
                 {
                     return false;
                 }
 
-                var projectPath = inputGraphNode.Id.GetValue(CodeGraphNodeIdName.Assembly);
+                string projectPath = inputGraphNode.Id.GetValue(CodeGraphNodeIdName.Assembly);
                 if (string.IsNullOrEmpty(projectPath))
                 {
                     continue;
                 }
 
-                var dependency = GetDependency(graphContext, inputGraphNode, out IDependenciesSnapshot snapshot);
+                IDependency dependency = GetDependency(graphContext, inputGraphNode, out IDependenciesSnapshot snapshot);
                 if (dependency == null || snapshot == null)
                 {
                     continue;
                 }
 
-                var viewProvider = ViewProviders.FirstOrDefault(x => x.Value.SupportsDependency(dependency));
+                System.Lazy<ViewProviders.IDependenciesGraphViewProvider, IOrderPrecedenceMetadataView> viewProvider = ViewProviders.FirstOrDefault(x => x.Value.SupportsDependency(dependency));
                 if (viewProvider == null)
                 {
                     continue;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/GetChildrenGraphActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/GetChildrenGraphActionHandler.cs
@@ -30,27 +30,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
 
         public override bool HandleRequest(IGraphContext graphContext)
         {
-            var trackChanges = false;
-            foreach (var inputGraphNode in graphContext.InputNodes)
+            bool trackChanges = false;
+            foreach (GraphNode inputGraphNode in graphContext.InputNodes)
             {
                 if (graphContext.CancelToken.IsCancellationRequested)
                 {
                     return trackChanges;
                 }
 
-                var projectPath = inputGraphNode.Id.GetValue(CodeGraphNodeIdName.Assembly);
+                string projectPath = inputGraphNode.Id.GetValue(CodeGraphNodeIdName.Assembly);
                 if (string.IsNullOrEmpty(projectPath))
                 {
                     continue;
                 }
 
-                var dependency = GetDependency(graphContext, inputGraphNode, out IDependenciesSnapshot snapshot);
+                IDependency dependency = GetDependency(graphContext, inputGraphNode, out IDependenciesSnapshot snapshot);
                 if (dependency == null || snapshot == null)
                 {
                     continue;
                 }
 
-                var viewProvider = ViewProviders.FirstOrDefault(x => x.Value.SupportsDependency(dependency));
+                System.Lazy<ViewProviders.IDependenciesGraphViewProvider, IOrderPrecedenceMetadataView> viewProvider = ViewProviders.FirstOrDefault(x => x.Value.SupportsDependency(dependency));
                 if (viewProvider == null)
                 {
                     continue;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/GraphActionHandlerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/GraphActionHandlerBase.cs
@@ -55,14 +55,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
         {
             snapshot = null;
 
-            var projectPath = inputGraphNode.Id.GetValue(CodeGraphNodeIdName.Assembly);
+            string projectPath = inputGraphNode.Id.GetValue(CodeGraphNodeIdName.Assembly);
             if (string.IsNullOrEmpty(projectPath))
             {
                 return null;
             }
 
-            var projectFolder = Path.GetDirectoryName(projectPath);
-            var id = inputGraphNode.GetValue<string>(DependenciesGraphSchema.DependencyIdProperty);
+            string projectFolder = Path.GetDirectoryName(projectPath);
+            string id = inputGraphNode.GetValue<string>(DependenciesGraphSchema.DependencyIdProperty);
             if (id == null)
             {
                 // this is top level node and it contains full path 
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
 
         protected IDependenciesSnapshot GetSnapshot(string projectPath)
         {
-            var snapshotProvider = AggregateSnapshotProvider.GetSnapshotProvider(projectPath);
+            IDependenciesSnapshotProvider snapshotProvider = AggregateSnapshotProvider.GetSnapshotProvider(projectPath);
             return snapshotProvider?.CurrentSnapshot;
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/SearchGraphActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/SearchGraphActionHandler.cs
@@ -44,14 +44,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
         /// </summary>
         private void Search(IGraphContext graphContext)
         {
-            var searchParametersTypeName = typeof(ISolutionSearchParameters).GUID.ToString();
-            var searchParameters = graphContext.GetValue<ISolutionSearchParameters>(searchParametersTypeName);
+            string searchParametersTypeName = typeof(ISolutionSearchParameters).GUID.ToString();
+            ISolutionSearchParameters searchParameters = graphContext.GetValue<ISolutionSearchParameters>(searchParametersTypeName);
             if (searchParameters == null)
             {
                 return;
             }
 
-            var searchTerm = searchParameters.SearchQuery.SearchString?.ToLowerInvariant();
+            string searchTerm = searchParameters.SearchQuery.SearchString?.ToLowerInvariant();
             if (searchTerm == null)
             {
                 return;
@@ -60,10 +60,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
             var cachedDependencyToMatchingResultsMap = new Dictionary<string, HashSet<IDependency>>(StringComparer.OrdinalIgnoreCase);
             var searchResultsPerContext = new Dictionary<string, HashSet<IDependency>>(StringComparer.OrdinalIgnoreCase);
 
-            var snapshotProviders = AggregateSnapshotProvider.GetSnapshotProviders();
-            foreach (var snapshotProvider in snapshotProviders)
+            IEnumerable<IDependenciesSnapshotProvider> snapshotProviders = AggregateSnapshotProvider.GetSnapshotProviders();
+            foreach (IDependenciesSnapshotProvider snapshotProvider in snapshotProviders)
             {
-                var snapshot = snapshotProvider.CurrentSnapshot;
+                IDependenciesSnapshot snapshot = snapshotProvider.CurrentSnapshot;
                 if (snapshot == null)
                 {
                     continue;
@@ -75,33 +75,33 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
                                                                                      snapshot);
             }
 
-            foreach (var snapshotProvider in snapshotProviders)
+            foreach (IDependenciesSnapshotProvider snapshotProvider in snapshotProviders)
             {
-                var snapshot = snapshotProvider.CurrentSnapshot;
+                IDependenciesSnapshot snapshot = snapshotProvider.CurrentSnapshot;
                 if (snapshot == null)
                 {
                     continue;
                 }
 
-                var allTopLevelDependencies = snapshot.GetFlatTopLevelDependencies();
-                var matchedDependencies = searchResultsPerContext[snapshotProvider.ProjectFilePath];
+                IEnumerable<IDependency> allTopLevelDependencies = snapshot.GetFlatTopLevelDependencies();
+                HashSet<IDependency> matchedDependencies = searchResultsPerContext[snapshotProvider.ProjectFilePath];
 
                 using (var scope = new GraphTransactionScope())
                 {
-                    foreach (var topLevelDependency in allTopLevelDependencies)
+                    foreach (IDependency topLevelDependency in allTopLevelDependencies)
                     {
-                        var targetedSnapshot = snapshot.Targets[topLevelDependency.TargetFramework];
+                        ITargetedDependenciesSnapshot targetedSnapshot = snapshot.Targets[topLevelDependency.TargetFramework];
 
                         if (!cachedDependencyToMatchingResultsMap
                                 .TryGetValue(topLevelDependency.Id, out HashSet<IDependency> topLevelDependencyMatches))
                         {
-                            var viewProvider = ViewProviders.FirstOrDefault(x => x.Value.SupportsDependency(topLevelDependency));
+                            Lazy<ViewProviders.IDependenciesGraphViewProvider, IOrderPrecedenceMetadataView> viewProvider = ViewProviders.FirstOrDefault(x => x.Value.SupportsDependency(topLevelDependency));
                             if (viewProvider == null)
                             {
                                 continue;
                             }
 
-                            var processed = viewProvider.Value.MatchSearchResults(
+                            bool processed = viewProvider.Value.MatchSearchResults(
                                 snapshotProvider.ProjectFilePath,
                                 topLevelDependency,
                                 searchResultsPerContext,
@@ -129,12 +129,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
                             continue;
                         }
 
-                        var topLevelNode = Builder.AddTopLevelGraphNode(graphContext,
+                        GraphNode topLevelNode = Builder.AddTopLevelGraphNode(graphContext,
                                                                 snapshotProvider.ProjectFilePath,
                                                                 topLevelDependency.ToViewModel(targetedSnapshot));
-                        foreach (var matchedDependency in topLevelDependencyMatches)
+                        foreach (IDependency matchedDependency in topLevelDependencyMatches)
                         {
-                            var matchedDependencyNode = Builder.AddGraphNode(graphContext,
+                            GraphNode matchedDependencyNode = Builder.AddGraphNode(graphContext,
                                                                     snapshotProvider.ProjectFilePath,
                                                                     topLevelNode,
                                                                     matchedDependency.ToViewModel(targetedSnapshot));
@@ -171,9 +171,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
             IDependenciesSnapshot dependenciesSnapshot)
         {
             var matchedDependencies = new HashSet<IDependency>();
-            foreach (var targetedSnapshot in dependenciesSnapshot.Targets)
+            foreach (KeyValuePair<CrossTarget.ITargetFramework, ITargetedDependenciesSnapshot> targetedSnapshot in dependenciesSnapshot.Targets)
             {
-                foreach (var dependency in targetedSnapshot.Value.DependenciesWorld)
+                foreach (KeyValuePair<string, IDependency> dependency in targetedSnapshot.Value.DependenciesWorld)
                 {
                     if (dependency.Value.Visible && dependency.Value.Caption.ToLowerInvariant().Contains(searchTerm))
                     {
@@ -192,7 +192,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
             Dictionary<string, HashSet<IDependency>> cachedPositiveResults)
         {
             var matchingNodes = new HashSet<IDependency>();
-            foreach (var childDependency in rootDependency.DependencyIDs)
+            foreach (string childDependency in rootDependency.DependencyIDs)
             {
                 if (!snapshot.DependenciesWorld
                         .TryGetValue(childDependency, out IDependency childDependencyMetadata))
@@ -211,7 +211,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
                     continue;
                 }
 
-                var children = GetMatchingResultsForDependency(
+                HashSet<IDependency> children = GetMatchingResultsForDependency(
                     childDependencyMetadata,
                     snapshot,
                     flatMatchingDependencies,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/TrackChangesGraphActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/TrackChangesGraphActionHandler.cs
@@ -30,33 +30,33 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
 
         public override bool HandleChanges(IGraphContext graphContext, SnapshotChangedEventArgs changes)
         {
-            var snapshot = changes.Snapshot;
+            IDependenciesSnapshot snapshot = changes.Snapshot;
             if (snapshot == null)
             {
                 return false;
             }
 
-            foreach (var inputGraphNode in graphContext.InputNodes.ToList())
+            foreach (GraphNode inputGraphNode in graphContext.InputNodes.ToList())
             {
-                var existingDependencyId = inputGraphNode.GetValue<string>(DependenciesGraphSchema.DependencyIdProperty);
+                string existingDependencyId = inputGraphNode.GetValue<string>(DependenciesGraphSchema.DependencyIdProperty);
                 if (string.IsNullOrEmpty(existingDependencyId))
                 {
                     continue;
                 }
 
-                var projectPath = inputGraphNode.Id.GetValue(CodeGraphNodeIdName.Assembly);
+                string projectPath = inputGraphNode.Id.GetValue(CodeGraphNodeIdName.Assembly);
                 if (string.IsNullOrEmpty(projectPath))
                 {
                     continue;
                 }
 
-                var updatedDependency = GetDependency(projectPath, existingDependencyId, out IDependenciesSnapshot updatedSnapshot);
+                IDependency updatedDependency = GetDependency(projectPath, existingDependencyId, out IDependenciesSnapshot updatedSnapshot);
                 if (updatedDependency == null)
                 {
                     continue;
                 }
 
-                var viewProvider = ViewProviders.FirstOrDefault(x => x.Value.SupportsDependency(updatedDependency));
+                System.Lazy<ViewProviders.IDependenciesGraphViewProvider, IOrderPrecedenceMetadataView> viewProvider = ViewProviders.FirstOrDefault(x => x.Value.SupportsDependency(updatedDependency));
                 if (viewProvider == null)
                 {
                     continue;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
@@ -148,8 +148,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
             {
                 await InitializeAsync().ConfigureAwait(false);
 
-                var actionHandlers = GraphActionHandlers.Where(x => x.Value.CanHandleRequest(context));
-                var shouldTrackChanges = actionHandlers.Aggregate(
+                IEnumerable<Lazy<IDependenciesGraphActionHandler, IOrderPrecedenceMetadataView>> actionHandlers = GraphActionHandlers.Where(x => x.Value.CanHandleRequest(context));
+                bool shouldTrackChanges = actionHandlers.Aggregate(
                     false, (previousTrackFlag, handler) => previousTrackFlag || handler.Value.HandleRequest(context));
 
                 lock (_expandedGraphContextsLock)
@@ -176,7 +176,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
         /// </summary>
         private void OnSnapshotChanged(object sender, SnapshotChangedEventArgs e)
         {
-            var snapshot = e.Snapshot;
+            IDependenciesSnapshot snapshot = e.Snapshot;
             if (snapshot == null)
             {
                 return;
@@ -215,7 +215,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
                     _changedContextsQueue.Clear();
                 }
 
-                foreach (var context in queue)
+                foreach (SnapshotChangedEventArgs context in queue)
                 {
                     await TrackChangesAsync(context).ConfigureAwait(false);
                 }
@@ -241,13 +241,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
                 return Task.CompletedTask;
             }
 
-            var actionHandlers = GraphActionHandlers.Where(x => x.Value.CanHandleChanges());
+            IEnumerable<Lazy<IDependenciesGraphActionHandler, IOrderPrecedenceMetadataView>> actionHandlers = GraphActionHandlers.Where(x => x.Value.CanHandleChanges());
             if (!actionHandlers.Any())
             {
                 return Task.CompletedTask;
             }
 
-            foreach (var graphContext in expandedContexts.ToList())
+            foreach (IGraphContext graphContext in expandedContexts.ToList())
             {
                 try
                 {
@@ -284,8 +284,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
         {
             Assumes.True(IsInitialized);
 
-            var modelId = viewModel.OriginalModel == null ? viewModel.Caption : viewModel.OriginalModel.Id;
-            var newNodeId = GetGraphNodeId(projectPath, parentNode, modelId);
+            string modelId = viewModel.OriginalModel == null ? viewModel.Caption : viewModel.OriginalModel.Id;
+            GraphNodeId newNodeId = GetGraphNodeId(projectPath, parentNode, modelId);
             return DoAddGraphNode(newNodeId, graphContext, projectPath, parentNode, viewModel);
         }
 
@@ -297,7 +297,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
 
             Assumes.True(IsInitialized);
 
-            var newNodeId = GetTopLevelGraphNodeId(projectPath, viewModel.OriginalModel.GetTopLevelId());
+            GraphNodeId newNodeId = GetTopLevelGraphNodeId(projectPath, viewModel.OriginalModel.GetTopLevelId());
             return DoAddGraphNode(newNodeId, graphContext, projectPath, parentNode: null, viewModel: viewModel);
         }
 
@@ -310,7 +310,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
         {
             RegisterIcons(viewModel.GetIcons());
 
-            var newNode = graphContext.Graph.Nodes.GetOrCreate(graphNodeId, viewModel.Caption, null);
+            GraphNode newNode = graphContext.Graph.Nodes.GetOrCreate(graphNodeId, viewModel.Caption, null);
             newNode.SetValue(DgmlNodeProperties.Icon, GetIconStringName(viewModel.Icon));
             // priority sets correct order among peers
             newNode.SetValue(CodeNodeProperties.SourceLocation,
@@ -340,8 +340,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
         {
             Assumes.True(IsInitialized);
 
-            var id = GetGraphNodeId(projectPath, parentNode, modelId);
-            var nodeToRemove = graphContext.Graph.Nodes.Get(id);
+            GraphNodeId id = GetGraphNodeId(projectPath, parentNode, modelId);
+            GraphNode nodeToRemove = graphContext.Graph.Nodes.Get(id);
 
             if (nodeToRemove != null)
             {
@@ -360,14 +360,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
                                        new Uri(modelId.ToLowerInvariant(), UriKind.RelativeOrAbsolute))
             };
 
-            var parents = string.Empty;
+            string parents = string.Empty;
             if (parentNode != null)
             {
                 // to ensure Graph id for node is unique we add a hashcodes for node's parents separated by ';'
                 parents = parentNode.Id.GetNestedValueByName<string>(CodeGraphNodeIdName.Namespace);
                 if (string.IsNullOrEmpty(parents))
                 {
-                    var currentProject = parentNode.Id.GetValue(CodeGraphNodeIdName.Assembly) ?? projectPath;
+                    string currentProject = parentNode.Id.GetValue(CodeGraphNodeIdName.Assembly) ?? projectPath;
                     parents = currentProject.GetHashCode().ToString();
                 }
             }
@@ -389,7 +389,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
                 GraphNodeId.GetPartial(CodeGraphNodeIdName.Assembly, new Uri(projectPath, UriKind.RelativeOrAbsolute))
             };
 
-            var projectFolder = Path.GetDirectoryName(projectPath)?.ToLowerInvariant() ?? string.Empty;
+            string projectFolder = Path.GetDirectoryName(projectPath)?.ToLowerInvariant() ?? string.Empty;
             var filePath = new Uri(Path.Combine(projectFolder, modelId.ToLowerInvariant()), UriKind.RelativeOrAbsolute);
 
             partialValues.Add(GraphNodeId.GetPartial(CodeGraphNodeIdName.File, filePath));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/GraphNodeIdExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/GraphNodeIdExtensions.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             {
                 try
                 {
-                    var value = id.GetNestedValueByName<Uri>(idPartName);
+                    Uri value = id.GetNestedValueByName<Uri>(idPartName);
 
                     // for idPartName == CodeGraphNodeIdName.File it can be null, avoid unnecessary exception
                     if (value == null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/GenericGraphViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/GenericGraphViewProvider.cs
@@ -31,13 +31,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
             dependencyGraphNode.SetValue(DependenciesGraphSchema.DependencyIdProperty, dependency.Id);
             dependencyGraphNode.SetValue(DependenciesGraphSchema.ResolvedProperty, dependency.Resolved);
 
-            var children = targetedSnapshot.GetDependencyChildren(dependency);
+            System.Collections.Generic.IEnumerable<IDependency> children = targetedSnapshot.GetDependencyChildren(dependency);
             if (children == null)
             {
                 return;
             }
 
-            foreach (var childDependency in children)
+            foreach (IDependency childDependency in children)
             {
                 if (!childDependency.Visible)
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/GraphViewProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/GraphViewProviderBase.cs
@@ -40,13 +40,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
             dependencyGraphNode.SetValue(DependenciesGraphSchema.DependencyIdProperty, dependency.Id);
             dependencyGraphNode.SetValue(DependenciesGraphSchema.ResolvedProperty, dependency.Resolved);
 
-            var children = targetedSnapshot.GetDependencyChildren(dependency);
+            IEnumerable<IDependency> children = targetedSnapshot.GetDependencyChildren(dependency);
             if (children == null)
             {
                 return;
             }
 
-            foreach (var childDependency in children)
+            foreach (IDependency childDependency in children)
             {
                 if (!childDependency.Visible)
                 {
@@ -84,12 +84,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
                 return false;
             }
 
-            foreach (var nodeToRemove in nodesToRemove)
+            foreach (DependencyNodeInfo nodeToRemove in nodesToRemove)
             {
                 Builder.RemoveGraphNode(graphContext, projectPath, nodeToRemove.Id, dependencyGraphNode);
             }
 
-            foreach (var nodeToAdd in nodesToAdd)
+            foreach (DependencyNodeInfo nodeToAdd in nodesToAdd)
             {
                 if (!targetedSnapshot.DependenciesWorld.TryGetValue(nodeToAdd.Id, out IDependency dependency)
                     || dependency == null
@@ -133,10 +133,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
         {
             dependencyProjectPath = projectPath;
 
-            var existingChildrenInfo = GetExistingChildren(dependencyGraphNode);
-            var updatedChildren = targetedSnapshot.GetDependencyChildren(updatedDependency)
+            IEnumerable<DependencyNodeInfo> existingChildrenInfo = GetExistingChildren(dependencyGraphNode);
+            IEnumerable<IDependency> updatedChildren = targetedSnapshot.GetDependencyChildren(updatedDependency)
                 ?? Enumerable.Empty<IDependency>();
-            var updatedChildrenInfo = updatedChildren.Select(x => DependencyNodeInfo.FromDependency(x));
+            IEnumerable<DependencyNodeInfo> updatedChildrenInfo = updatedChildren.Select(x => DependencyNodeInfo.FromDependency(x));
 
             return AnyChanges(existingChildrenInfo, updatedChildrenInfo, out nodesToAdd, out nodesToRemove);
         }
@@ -156,9 +156,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
         protected static IEnumerable<DependencyNodeInfo> GetExistingChildren(GraphNode inputGraphNode)
         {
             var children = new List<DependencyNodeInfo>();
-            foreach (var childNode in inputGraphNode.FindDescendants())
+            foreach (GraphNode childNode in inputGraphNode.FindDescendants())
             {
-                var id = childNode.GetValue<string>(DependenciesGraphSchema.DependencyIdProperty);
+                string id = childNode.GetValue<string>(DependenciesGraphSchema.DependencyIdProperty);
                 if (string.IsNullOrEmpty(id))
                 {
                     continue;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/PackageGraphViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/PackageGraphViewProvider.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
             dependencyGraphNode.SetValue(DependenciesGraphSchema.DependencyIdProperty, dependency.Id);
             dependencyGraphNode.SetValue(DependenciesGraphSchema.ResolvedProperty, dependency.Resolved);
 
-            var children = targetedSnapshot.GetDependencyChildren(dependency);
+            IEnumerable<IDependency> children = targetedSnapshot.GetDependencyChildren(dependency);
             if (children == null)
             {
                 return;
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
 
             var regularChildren = new List<IDependency>();
             var fxAssembliesChildren = new List<IDependency>();
-            foreach (var childDependency in children)
+            foreach (IDependency childDependency in children)
             {
                 if (!childDependency.Visible)
                 {
@@ -63,10 +63,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
                 }
             }
 
-            var isFxAssembliesFolder = dependencyGraphNode.GetValue<bool>(DependenciesGraphSchema.IsFrameworkAssemblyFolderProperty);
+            bool isFxAssembliesFolder = dependencyGraphNode.GetValue<bool>(DependenciesGraphSchema.IsFrameworkAssemblyFolderProperty);
             if (isFxAssembliesFolder)
             {
-                foreach (var fxAssembly in fxAssembliesChildren)
+                foreach (IDependency fxAssembly in fxAssembliesChildren)
                 {
                     Builder.AddGraphNode(
                         graphContext,
@@ -77,7 +77,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
             }
             else
             {
-                foreach (var childDependency in regularChildren)
+                foreach (IDependency childDependency in regularChildren)
                 {
                     Builder.AddGraphNode(
                         graphContext,
@@ -89,7 +89,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
                 if (fxAssembliesChildren.Count > 0)
                 {
                     var fxAssembliesViewModel = new PackageFrameworkAssembliesViewModel();
-                    var fxAssembliesNode = Builder.AddGraphNode(graphContext, projectPath, dependencyGraphNode, fxAssembliesViewModel);
+                    GraphNode fxAssembliesNode = Builder.AddGraphNode(graphContext, projectPath, dependencyGraphNode, fxAssembliesViewModel);
                     fxAssembliesNode.SetValue(DgmlNodeProperties.ContainsChildren, true);
                     fxAssembliesNode.SetValue(DependenciesGraphSchema.IsFrameworkAssemblyFolderProperty, true);
                     fxAssembliesNode.SetValue(DependenciesGraphSchema.DependencyIdProperty, dependency.Id);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GroupedByTargetTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GroupedByTargetTreeViewProvider.cs
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             IDependenciesSnapshot snapshot,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            var originalTree = dependenciesTree;
+            IProjectTree originalTree = dependenciesTree;
             var currentTopLevelNodes = new List<IProjectTree>();
             Func<IProjectTree, IEnumerable<IProjectTree>, IProjectTree> rememberNewNodes = (rootNode, currentNodes) =>
             {
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             if (snapshot.Targets.Where(x => !x.Key.Equals(TargetFramework.Any)).Count() == 1)
             {
-                foreach (var target in snapshot.Targets)
+                foreach (KeyValuePair<ITargetFramework, ITargetedDependenciesSnapshot> target in snapshot.Targets)
                 {
                     if (cancellationToken.IsCancellationRequested)
                     {
@@ -77,7 +77,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             }
             else
             {
-                foreach (var target in snapshot.Targets)
+                foreach (KeyValuePair<ITargetFramework, ITargetedDependenciesSnapshot> target in snapshot.Targets)
                 {
                     if (cancellationToken.IsCancellationRequested)
                     {
@@ -94,9 +94,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     }
                     else
                     {
-                        var node = dependenciesTree.FindNodeByCaption(target.Key.FriendlyName);
-                        var shouldAddTargetNode = node == null;
-                        var targetViewModel = ViewModelFactory.CreateTargetViewModel(target.Value);
+                        IProjectTree node = dependenciesTree.FindNodeByCaption(target.Key.FriendlyName);
+                        bool shouldAddTargetNode = node == null;
+                        IDependencyViewModel targetViewModel = ViewModelFactory.CreateTargetViewModel(target.Value);
 
                         node = CreateOrUpdateNode(node,
                                                   targetViewModel,
@@ -122,7 +122,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             dependenciesTree = CleanupOldNodes(dependenciesTree, currentTopLevelNodes);
 
             // now update root Dependencies node status
-            var rootIcon = ViewModelFactory.GetDependenciesRootIcon(snapshot.HasUnresolvedDependency).ToProjectSystemType();
+            ProjectImageMoniker rootIcon = ViewModelFactory.GetDependenciesRootIcon(snapshot.HasUnresolvedDependency).ToProjectSystemType();
             return dependenciesTree.SetProperties(icon: rootIcon, expandedIcon: rootIcon);
         }
 
@@ -175,7 +175,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         {
             var currentNodes = new List<IProjectTree>();
             var grouppedByProviderType = new Dictionary<string, List<IDependency>>(StringComparer.OrdinalIgnoreCase);
-            foreach (var dependency in targetedSnapshot.TopLevelDependencies)
+            foreach (IDependency dependency in targetedSnapshot.TopLevelDependencies)
             {
                 if (!dependency.Visible)
                 {
@@ -198,15 +198,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 dependencies.Add(dependency);
             }
 
-            var isActiveTarget = targetedSnapshot.TargetFramework.Equals(activeTarget);
-            foreach (var dependencyGroup in grouppedByProviderType)
+            bool isActiveTarget = targetedSnapshot.TargetFramework.Equals(activeTarget);
+            foreach (KeyValuePair<string, List<IDependency>> dependencyGroup in grouppedByProviderType)
             {
-                var subTreeViewModel = ViewModelFactory.CreateRootViewModel(
+                IDependencyViewModel subTreeViewModel = ViewModelFactory.CreateRootViewModel(
                     dependencyGroup.Key, targetedSnapshot.CheckForUnresolvedDependencies(dependencyGroup.Key));
-                var subTreeNode = rootNode.FindNodeByCaption(subTreeViewModel.Caption);
-                var isNewSubTreeNode = subTreeNode == null;
+                IProjectTree subTreeNode = rootNode.FindNodeByCaption(subTreeViewModel.Caption);
+                bool isNewSubTreeNode = subTreeNode == null;
 
-                var excludedFlags = ProjectTreeFlags.Empty;
+                ProjectTreeFlags excludedFlags = ProjectTreeFlags.Empty;
                 if (targetedSnapshot.TargetFramework.Equals(TargetFramework.Any))
                 {
                     excludedFlags = ProjectTreeFlags.Create(ProjectTreeFlags.Common.BubbleUp);
@@ -254,10 +254,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             bool shouldCleanup)
         {
             var currentNodes = new List<IProjectTree>();
-            foreach (var dependency in dependencies)
+            foreach (IDependency dependency in dependencies)
             {
-                var dependencyNode = rootNode.FindNodeByCaption(dependency.Caption);
-                var isNewDependencyNode = dependencyNode == null;
+                IProjectTree dependencyNode = rootNode.FindNodeByCaption(dependency.Caption);
+                bool isNewDependencyNode = dependencyNode == null;
 
                 if (!isNewDependencyNode
                     && dependency.Flags.Contains(DependencyTreeFlags.SupportsHierarchy))
@@ -299,7 +299,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// </summary>
         private static IProjectTree CleanupOldNodes(IProjectTree rootNode, IEnumerable<IProjectTree> currentNodes)
         {
-            foreach (var nodeToRemove in rootNode.Children.Except(currentNodes))
+            foreach (IProjectTree nodeToRemove in rootNode.Children.Except(currentNodes))
             {
                 rootNode = rootNode.Remove(nodeToRemove);
             }
@@ -366,10 +366,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 // For IProjectTree remove ProjectTreeFlags.Common.Reference flag, otherwise CPS would fail to 
                 // map this node to graph node and GraphProvider would be never called. 
                 // Only IProjectItemTree can have this flag
-                var flags = FilterFlags(viewModel.Flags.Except(DependencyTreeFlags.BaseReferenceFlags),
+                ProjectTreeFlags flags = FilterFlags(viewModel.Flags.Except(DependencyTreeFlags.BaseReferenceFlags),
                                         additionalFlags,
                                         excludedFlags);
-                var filePath = (viewModel.OriginalModel != null && viewModel.OriginalModel.TopLevel && viewModel.OriginalModel.Resolved)
+                string filePath = (viewModel.OriginalModel != null && viewModel.OriginalModel.TopLevel && viewModel.OriginalModel.Resolved)
                                 ? viewModel.OriginalModel.GetTopLevelId()
                                 : viewModel.FilePath;
 
@@ -402,8 +402,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         {
             if (node == null)
             {
-                var flags = FilterFlags(viewModel.Flags, additionalFlags, excludedFlags);
-                var filePath = (viewModel.OriginalModel != null && viewModel.OriginalModel.TopLevel && viewModel.OriginalModel.Resolved)
+                ProjectTreeFlags flags = FilterFlags(viewModel.Flags, additionalFlags, excludedFlags);
+                string filePath = (viewModel.OriginalModel != null && viewModel.OriginalModel.TopLevel && viewModel.OriginalModel.Resolved)
                                     ? viewModel.OriginalModel.GetTopLevelId()
                                     : viewModel.FilePath;
 
@@ -436,7 +436,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             IDependencyViewModel viewModel,
             IRule rule)
         {
-            var updatedNodeParentContext = GetCustomPropertyContext(node.Parent);
+            ProjectTreeCustomizablePropertyContext updatedNodeParentContext = GetCustomPropertyContext(node.Parent);
             var updatedValues = new ReferencesProjectTreeCustomizablePropertyValues
             {
                 Caption = viewModel.Caption,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/SdkDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/SdkDependencyModel.cs
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             UnresolvedExpandedIcon = UnresolvedIcon;
             Version = properties != null && properties.ContainsKey(ProjectItemMetadata.Version)
                         ? properties[ProjectItemMetadata.Version] : string.Empty;
-            var baseCaption = Path.Split(CommonConstants.CommaDelimiter, StringSplitOptions.RemoveEmptyEntries)
+            string baseCaption = Path.Split(CommonConstants.CommaDelimiter, StringSplitOptions.RemoveEmptyEntries)
                                 .FirstOrDefault();
             Caption = string.IsNullOrEmpty(Version) ? baseCaption : $"{baseCaption} ({Version})";
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/AggregateDependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/AggregateDependenciesSnapshotProvider.cs
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         /// </summary>
         internal void OnSnapshotProviderUnloading(object sender, SnapshotProviderUnloadingEventArgs e)
         {
-            var snapshotProvider = e.SnapshotProvider;
+            IDependenciesSnapshotProvider snapshotProvider = e.SnapshotProvider;
             if (snapshotProvider == null)
             {
                 return;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -75,9 +75,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             {
                 // if top level first try to find by top level id with full path,
                 // if found - return, if not - try regular Id in the DependenciesWorld
-                foreach (var target in Targets)
+                foreach (KeyValuePair<ITargetFramework, ITargetedDependenciesSnapshot> target in Targets)
                 {
-                    var dependency = target.Value.TopLevelDependencies.FirstOrDefault(
+                    IDependency dependency = target.Value.TopLevelDependencies.FirstOrDefault(
                         x => x.GetTopLevelId().Equals(id, StringComparison.OrdinalIgnoreCase));
                     if (dependency != null)
                     {
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 }
             }
 
-            foreach (var target in Targets)
+            foreach (KeyValuePair<ITargetFramework, ITargetedDependenciesSnapshot> target in Targets)
             {
                 if (target.Value.DependenciesWorld.TryGetValue(id, out IDependency dependency))
                 {
@@ -104,9 +104,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             IEnumerable<IProjectDependenciesSubTreeProvider> subTreeProviders,
             HashSet<string> projectItemSpecs)
         {
-            var anyChanges = false;
+            bool anyChanges = false;
             var builder = _targets.ToBuilder();
-            foreach (var change in changes)
+            foreach (KeyValuePair<ITargetFramework, IDependenciesChanges> change in changes)
             {
                 builder.TryGetValue(change.Key, out ITargetedDependenciesSnapshot previousSnapshot);
                 var newTargetedSnapshot = TargetedDependenciesSnapshot.FromChanges(
@@ -128,7 +128,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             }
 
             // now get rid of empty target frameworks (if there no any dependencies for them)
-            foreach (var targetKvp in builder.ToList())
+            foreach (KeyValuePair<ITargetFramework, ITargetedDependenciesSnapshot> targetKvp in builder.ToList())
             {
                 if (targetKvp.Value.DependenciesWorld.Count <= 0)
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
@@ -89,8 +89,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             }
             else
             {
-                var normalizedDependencyIDs = ImmutableList.CreateBuilder<string>();
-                foreach (var id in dependencyModel.DependencyIDs)
+                ImmutableList<string>.Builder normalizedDependencyIDs = ImmutableList.CreateBuilder<string>();
+                foreach (string id in dependencyModel.DependencyIDs)
                 {
                     normalizedDependencyIDs.Add(GetID(TargetFramework, ProviderType, id));
                 }
@@ -168,7 +168,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 // Thus always set predefined itemType for all custom nodes.
                 // TODO: generate specific xaml rule for generic Dependency nodes
                 // tracking issue: https://github.com/dotnet/roslyn-project-system/issues/1102
-                var isGenericNodeType = Flags.Contains(DependencyTreeFlags.GenericDependencyFlags);
+                bool isGenericNodeType = Flags.Contains(DependencyTreeFlags.GenericDependencyFlags);
                 return isGenericNodeType ? _schemaItemType : Folder.PrimaryDataSourceItemType;
             }
             protected set
@@ -315,7 +315,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
         private static string GetAlias(IDependency dependency)
         {
-            var path = dependency.OriginalItemSpec ?? dependency.Path;
+            string path = dependency.OriginalItemSpec ?? dependency.Path;
             if (string.IsNullOrEmpty(path) || path.Equals(dependency.Caption, StringComparison.OrdinalIgnoreCase))
             {
                 return dependency.Caption;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DuplicatedDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DuplicatedDependenciesSnapshotFilter.cs
@@ -32,10 +32,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             out bool filterAnyChanges)
         {
             filterAnyChanges = false;
-            var resultDependency = dependency;
+            IDependency resultDependency = dependency;
 
             IDependency matchingDependency = null;
-            foreach (var x in topLevelBuilder)
+            foreach (IDependency x in topLevelBuilder)
             {
                 if (!x.Id.Equals(dependency.Id, StringComparison.OrdinalIgnoreCase)
                      && x.ProviderType.Equals(dependency.ProviderType, StringComparison.OrdinalIgnoreCase)
@@ -48,11 +48,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
 
             // If found node with same caption, or if there were nodes with same caption but with Alias already applied
             // NOTE: Performance sensitive, so avoid formatting the Caption with parenthesis if it's possible to avoid it.
-            var shouldApplyAlias = matchingDependency != null;
+            bool shouldApplyAlias = matchingDependency != null;
             if (!shouldApplyAlias)
             {
-                var adjustedLength = dependency.Caption.Length + " (".Length;
-                foreach (var x in topLevelBuilder)
+                int adjustedLength = dependency.Caption.Length + " (".Length;
+                foreach (IDependency x in topLevelBuilder)
                 {
                     if (!x.Id.Equals(dependency.Id)
                          && x.ProviderType.Equals(dependency.ProviderType, StringComparison.OrdinalIgnoreCase)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/SdkAndPackagesDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/SdkAndPackagesDependenciesSnapshotFilter.cs
@@ -44,8 +44,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             if (dependency.Flags.Contains(DependencyTreeFlags.SdkSubTreeNodeFlags))
             {
                 // find package with the same name
-                var packageModelId = dependency.Name;
-                var packageId = Dependency.GetID(targetFramework, PackageRuleHandler.ProviderTypeString, packageModelId);
+                string packageModelId = dependency.Name;
+                string packageId = Dependency.GetID(targetFramework, PackageRuleHandler.ProviderTypeString, packageModelId);
 
                 if (worldBuilder.TryGetValue(packageId, out IDependency package) && package.Resolved)
                 {
@@ -58,8 +58,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             else if (dependency.Flags.Contains(DependencyTreeFlags.PackageNodeFlags) && dependency.Resolved)
             {
                 // find sdk with the same name
-                var sdkModelId = dependency.Name;
-                var sdkId = Dependency.GetID(targetFramework, SdkRuleHandler.ProviderTypeString, sdkModelId);
+                string sdkModelId = dependency.Name;
+                string sdkId = Dependency.GetID(targetFramework, SdkRuleHandler.ProviderTypeString, sdkModelId);
 
                 if (worldBuilder.TryGetValue(sdkId, out IDependency sdk))
                 {
@@ -95,8 +95,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             if (dependency.Flags.Contains(DependencyTreeFlags.PackageNodeFlags))
             {
                 // find sdk with the same name and clean dependencyIDs
-                var sdkModelId = dependency.Name;
-                var sdkId = Dependency.GetID(targetFramework, SdkRuleHandler.ProviderTypeString, sdkModelId);
+                string sdkModelId = dependency.Name;
+                string sdkId = Dependency.GetID(targetFramework, SdkRuleHandler.ProviderTypeString, sdkModelId);
 
                 if (worldBuilder.TryGetValue(sdkId, out IDependency sdk))
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/UnsupportedProjectsSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/UnsupportedProjectsSnapshotFilter.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
                 && resultDependency.Flags.Contains(DependencyTreeFlags.ProjectNodeFlags)
                 && !resultDependency.Flags.Contains(DependencyTreeFlags.SharedProjectFlags))
             {
-                var snapshot = GetSnapshot(projectPath, resultDependency);
+                ITargetedDependenciesSnapshot snapshot = GetSnapshot(projectPath, resultDependency);
                 if (snapshot != null && snapshot.HasUnresolvedDependency)
                 {
                     filterAnyChanges = true;
@@ -63,19 +63,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
 
         private ITargetedDependenciesSnapshot GetSnapshot(string projectPath, IDependency dependency)
         {
-            var snapshotProvider = AggregateSnapshotProvider.GetSnapshotProvider(dependency.FullPath);
+            IDependenciesSnapshotProvider snapshotProvider = AggregateSnapshotProvider.GetSnapshotProvider(dependency.FullPath);
             if (snapshotProvider == null)
             {
                 return null;
             }
 
-            var snapshot = snapshotProvider.CurrentSnapshot;
+            IDependenciesSnapshot snapshot = snapshotProvider.CurrentSnapshot;
             if (snapshot == null)
             {
                 return null;
             }
 
-            var targetFramework = TargetFrameworkProvider.GetNearestFramework(
+            ITargetFramework targetFramework = TargetFrameworkProvider.GetNearestFramework(
                                     dependency.TargetFramework, snapshot.Targets.Keys);
             if (targetFramework == null)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependenciesSnapshotExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependenciesSnapshotExtensions.cs
@@ -8,9 +8,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
     {
         public static IEnumerable<IDependency> GetFlatTopLevelDependencies(this IDependenciesSnapshot self)
         {
-            foreach (var targetedSnapshot in self.Targets.Values)
+            foreach (ITargetedDependenciesSnapshot targetedSnapshot in self.Targets.Values)
             {
-                foreach (var dependency in targetedSnapshot.TopLevelDependencies)
+                foreach (IDependency dependency in targetedSnapshot.TopLevelDependencies)
                 {
                     yield return dependency;
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IEnumerableExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IEnumerableExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
     {
         public static void ForEach<T>(this IEnumerable<T> self, Action<T> action)
         {
-            foreach (var item in self)
+            foreach (T item in self)
             {
                 action.Invoke(item);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
@@ -38,8 +38,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         internal TargetedDependenciesSnapshot(IDictionary<string, IDependency> dependenciesWorld, IEnumerable<IDependency> topLevelDependencies)
         {
             DependenciesWorld = ImmutableStringDictionary<IDependency>.EmptyOrdinalIgnoreCase.AddRange(dependenciesWorld);
-            var dependencies = ImmutableHashSet<IDependency>.Empty;
-            foreach (var d in topLevelDependencies)
+            ImmutableHashSet<IDependency> dependencies = ImmutableHashSet<IDependency>.Empty;
+            foreach (IDependency d in topLevelDependencies)
             {
                 dependencies = dependencies.Add(d);
             }
@@ -110,7 +110,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 if (!_dependenciesChildrenMap.TryGetValue(dependency.Id, out IList<IDependency> children))
                 {
                     children = new List<IDependency>();
-                    foreach (var id in dependency.DependencyIDs)
+                    foreach (string id in dependency.DependencyIDs)
                     {
                         if (TryToFindDependency(id, out IDependency child))
                         {
@@ -127,11 +127,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
         private bool FindUnresolvedDependenciesRecursive(IDependency dependency)
         {
-            var unresolved = false;
+            bool unresolved = false;
 
             if (dependency.DependencyIDs.Count > 0)
             {
-                foreach (var child in GetDependencyChildren(dependency))
+                foreach (IDependency child in GetDependencyChildren(dependency))
                 {
                     if (!child.Resolved)
                     {
@@ -183,11 +183,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             var worldBuilder = DependenciesWorld.ToBuilder();
             var topLevelBuilder = TopLevelDependencies.ToBuilder();
 
-            var anyChanges = false;
+            bool anyChanges = false;
 
-            foreach (var removed in changes.RemovedNodes)
+            foreach (IDependencyModel removed in changes.RemovedNodes)
             {
-                var targetedId = Dependency.GetID(TargetFramework, removed.ProviderType, removed.Id);
+                string targetedId = Dependency.GetID(TargetFramework, removed.ProviderType, removed.Id);
                 if (!worldBuilder.TryGetValue(targetedId, out IDependency dependency))
                 {
                     continue;
@@ -195,7 +195,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
                 if (snapshotFilters != null)
                 {
-                    foreach (var filter in snapshotFilters)
+                    foreach (IDependenciesSnapshotFilter filter in snapshotFilters)
                     {
                         dependency = filter.BeforeRemove(
                             ProjectPath, TargetFramework, dependency, worldBuilder, topLevelBuilder, out bool filterAnyChanges);
@@ -220,15 +220,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 topLevelBuilder.Remove(dependency);
             }
 
-            var subTreeProvidersMap = GetSubTreeProviderMap(subTreeProviders);
+            Dictionary<string, IProjectDependenciesSubTreeProvider> subTreeProvidersMap = GetSubTreeProviderMap(subTreeProviders);
 
-            foreach (var added in changes.AddedNodes)
+            foreach (IDependencyModel added in changes.AddedNodes)
             {
                 IDependency newDependency = new Dependency(added, TargetFramework, ProjectPath);
 
                 if (snapshotFilters != null)
                 {
-                    foreach (var filter in snapshotFilters)
+                    foreach (IDependenciesSnapshotFilter filter in snapshotFilters)
                     {
                         newDependency = filter.BeforeAdd(
                             ProjectPath,
@@ -275,7 +275,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
         private void ConstructTopLevelDependenciesByPathMap()
         {
-            foreach (var topLevelDependency in TopLevelDependencies)
+            foreach (IDependency topLevelDependency in TopLevelDependencies)
             {
                 if (!string.IsNullOrEmpty(topLevelDependency.Path))
                 {
@@ -309,7 +309,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 StringComparer.OrdinalIgnoreCase);
             if (subTreeProviders != null)
             {
-                foreach (var provider in subTreeProviders)
+                foreach (IProjectDependenciesSubTreeProvider provider in subTreeProviders)
                 {
                     subTreeProvidersMap[provider.ProviderType] = provider;
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependenciesRuleHandlerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependenciesRuleHandlerBase.cs
@@ -94,18 +94,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             DependenciesRuleChangeContext ruleChangeContext,
             Func<IDependencyModel, bool> shouldProcess)
         {
-            foreach (var removedItem in projectChange.Difference.RemovedItems)
+            foreach (string removedItem in projectChange.Difference.RemovedItems)
             {
-                var model = CreateDependencyModelForRule(removedItem, resolved, projectChange.Before, context.TargetFramework);
+                IDependencyModel model = CreateDependencyModelForRule(removedItem, resolved, projectChange.Before, context.TargetFramework);
                 if (shouldProcess(model))
                 {
                     ruleChangeContext.IncludeRemovedChange(context.TargetFramework, model);
                 }
             }
 
-            foreach (var changedItem in projectChange.Difference.ChangedItems)
+            foreach (string changedItem in projectChange.Difference.ChangedItems)
             {
-                var model = CreateDependencyModelForRule(changedItem, resolved, projectChange.After, context.TargetFramework);
+                IDependencyModel model = CreateDependencyModelForRule(changedItem, resolved, projectChange.After, context.TargetFramework);
                 if (shouldProcess(model))
                 {
                     // For changes we try to add new dependency. If it is a resolved dependency, it would just override
@@ -115,9 +115,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 }
             }
 
-            foreach (var addedItem in projectChange.Difference.AddedItems)
+            foreach (string addedItem in projectChange.Difference.AddedItems)
             {
-                var model = CreateDependencyModelForRule(addedItem, resolved, projectChange.After, context.TargetFramework);
+                IDependencyModel model = CreateDependencyModelForRule(addedItem, resolved, projectChange.After, context.TargetFramework);
                 if (shouldProcess(model))
                 {
                     ruleChangeContext.IncludeAddedChange(context.TargetFramework, model);
@@ -136,14 +136,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             IProjectRuleSnapshot projectRuleSnapshot,
             ITargetFramework targetFramework)
         {
-            var properties = GetProjectItemProperties(projectRuleSnapshot, itemSpec);
-            var originalItemSpec = itemSpec;
+            IImmutableDictionary<string, string> properties = GetProjectItemProperties(projectRuleSnapshot, itemSpec);
+            string originalItemSpec = itemSpec;
             if (resolved)
             {
                 originalItemSpec = GetOriginalItemSpec(properties);
             }
 
-            var isImplicit = false;
+            bool isImplicit = false;
             if (properties != null
                 && properties.TryGetValue(ProjectItemMetadata.IsImplicitlyDefined, out string isImplicitlyDefinedString)
                 && bool.TryParse(isImplicitlyDefinedString, out bool isImplicitlyDefined))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySubscriptionsHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySubscriptionsHost.cs
@@ -116,7 +116,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 {
                     if (_subscribers == null)
                     {
-                        foreach (var subscriber in DependencySubscribers)
+                        foreach (Lazy<IDependencyCrossTargetSubscriber, IOrderPrecedenceMetadataView> subscriber in DependencySubscribers)
                         {
                             subscriber.Value.DependenciesChanged += OnSubscriberDependenciesChanged;
                         }
@@ -144,7 +144,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
             AggregateSnapshotProvider.RegisterSnapshotProvider(this);
 
-            foreach (var provider in SubTreeProviders)
+            foreach (Lazy<IProjectDependenciesSubTreeProvider, IOrderPrecedenceMetadataView> provider in SubTreeProviders)
             {
                 provider.Value.DependenciesChanged += OnSubtreeProviderDependenciesChanged;
             }
@@ -165,12 +165,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
             SnapshotProviderUnloading?.Invoke(this, new SnapshotProviderUnloadingEventArgs(this));
 
-            foreach (var subscriber in DependencySubscribers)
+            foreach (Lazy<IDependencyCrossTargetSubscriber, IOrderPrecedenceMetadataView> subscriber in DependencySubscribers)
             {
                 subscriber.Value.DependenciesChanged -= OnSubscriberDependenciesChanged;
             }
 
-            foreach (var provider in SubTreeProviders)
+            foreach (Lazy<IProjectDependenciesSubTreeProvider, IOrderPrecedenceMetadataView> provider in SubTreeProviders)
             {
                 provider.Value.DependenciesChanged -= OnSubtreeProviderDependenciesChanged;
             }
@@ -257,7 +257,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 targetFramework = TargetFramework.Any;
             }
 
-            var changes = ImmutableDictionary<ITargetFramework, IDependenciesChanges>.Empty.Add(targetFramework, e.Changes);
+            ImmutableDictionary<ITargetFramework, IDependenciesChanges> changes = ImmutableDictionary<ITargetFramework, IDependenciesChanges>.Empty.Add(targetFramework, e.Changes);
 
             UpdateDependenciesSnapshotAsync(changes, e.Catalogs, activeTargetFramework: null);
         }
@@ -333,7 +333,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                     return Task.FromCanceled(token);
                 }
 
-                var snapshot = CurrentSnapshot;
+                IDependenciesSnapshot snapshot = CurrentSnapshot;
                 if (snapshot == null)
                 {
                     return Task.CompletedTask;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/PackageRuleHandler.cs
@@ -87,10 +87,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 return;
             }
 
-            foreach (var removedItem in projectChange.Difference.RemovedItems)
+            foreach (string removedItem in projectChange.Difference.RemovedItems)
             {
-                var properties = GetProjectItemProperties(projectChange.Before, removedItem);
-                var model = GetDependencyModel(removedItem, resolved,
+                IImmutableDictionary<string, string> properties = GetProjectItemProperties(projectChange.Before, removedItem);
+                IDependencyModel model = GetDependencyModel(removedItem, resolved,
                                             properties, projectChange, unresolvedChanges, targetFramework);
                 if (model == null)
                 {
@@ -100,10 +100,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 ruleChangeContext.IncludeRemovedChange(targetFramework, model);
             }
 
-            foreach (var changedItem in projectChange.Difference.ChangedItems)
+            foreach (string changedItem in projectChange.Difference.ChangedItems)
             {
-                var properties = GetProjectItemProperties(projectChange.After, changedItem);
-                var model = GetDependencyModel(changedItem, resolved,
+                IImmutableDictionary<string, string> properties = GetProjectItemProperties(projectChange.After, changedItem);
+                IDependencyModel model = GetDependencyModel(changedItem, resolved,
                                             properties, projectChange, unresolvedChanges, targetFramework);
                 if (model == null)
                 {
@@ -114,10 +114,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 ruleChangeContext.IncludeAddedChange(targetFramework, model);
             }
 
-            foreach (var addedItem in projectChange.Difference.AddedItems)
+            foreach (string addedItem in projectChange.Difference.AddedItems)
             {
-                var properties = GetProjectItemProperties(projectChange.After, addedItem);
-                var model = GetDependencyModel(addedItem, resolved,
+                IImmutableDictionary<string, string> properties = GetProjectItemProperties(projectChange.After, addedItem);
+                IDependencyModel model = GetDependencyModel(addedItem, resolved,
                                             properties, projectChange, unresolvedChanges, targetFramework);
                 if (model == null)
                 {
@@ -137,8 +137,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             ITargetFramework targetFramework)
         {
             PackageDependencyMetadata metadata;
-            var isTopLevel = true;
-            var isTarget = false;
+            bool isTopLevel = true;
+            bool isTarget = false;
             if (resolved)
             {
                 metadata = new PackageDependencyMetadata(itemSpec, properties);
@@ -147,7 +147,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                                  && unresolvedChanges != null
                                  && unresolvedChanges.Contains(metadata.Name));
                 isTarget = metadata.IsTarget;
-                var packageTargetFramework = TargetFrameworkProvider.GetTargetFramework(metadata.Target);
+                ITargetFramework packageTargetFramework = TargetFrameworkProvider.GetTargetFramework(metadata.Target);
                 if (!(packageTargetFramework?.Equals(targetFramework) == true))
                 {
                     return null;
@@ -163,7 +163,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 return null;
             }
 
-            var originalItemSpec = itemSpec;
+            string originalItemSpec = itemSpec;
             if (resolved && isTopLevel)
             {
                 originalItemSpec = metadata.Name;
@@ -314,10 +314,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 if (properties.ContainsKey(ProjectItemMetadata.Dependencies)
                     && properties[ProjectItemMetadata.Dependencies] != null)
                 {
-                    var dependencyIds = properties[ProjectItemMetadata.Dependencies]
+                    string[] dependencyIds = properties[ProjectItemMetadata.Dependencies]
                         .Split(CommonConstants.SemicolonDelimiter, StringSplitOptions.RemoveEmptyEntries);
                     // store only unique dependency IDs
-                    foreach (var dependencyId in dependencyIds)
+                    foreach (string dependencyId in dependencyIds)
                     {
                         dependenciesHashSet.Add($"{Target}/{dependencyId}");
                     }
@@ -344,7 +344,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
             private T GetEnumMetadata<T>(string metadataName, T defaultValue) where T : struct
             {
-                var enumString = GetStringMetadata(metadataName);
+                string enumString = GetStringMetadata(metadataName);
                 T enumValue = defaultValue;
                 Enum.TryParse(enumString ?? string.Empty, /*ignoreCase */ true, out enumValue);
 
@@ -353,7 +353,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
             private bool GetBoolMetadata(string metadataName, bool defaultValue)
             {
-                var boolString = GetStringMetadata(metadataName);
+                string boolString = GetStringMetadata(metadataName);
                 bool boolValue = defaultValue;
                 bool.TryParse(boolString ?? "false", out boolValue);
 
@@ -362,7 +362,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
             public static string GetTargetFromDependencyId(string dependencyId)
             {
-                var idParts = dependencyId.Split(CommonConstants.FowardSlashDelimiter, StringSplitOptions.RemoveEmptyEntries);
+                string[] idParts = dependencyId.Split(CommonConstants.FowardSlashDelimiter, StringSplitOptions.RemoveEmptyEntries);
                 Requires.NotNull(idParts, nameof(idParts));
                 if (idParts.Count() <= 0)
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ProjectRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ProjectRuleHandler.cs
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
         /// </param>
         private void OnOtherProjectDependenciesChanged(IDependenciesSnapshot otherProjectSnapshot, bool shouldBeResolved)
         {
-            var projectSnapshot = SnapshotProvider.CurrentSnapshot;
+            IDependenciesSnapshot projectSnapshot = SnapshotProvider.CurrentSnapshot;
 
             if (otherProjectSnapshot == null || projectSnapshot == null || projectSnapshot.Equals(otherProjectSnapshot))
             {
@@ -109,12 +109,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 return;
             }
 
-            var otherProjectPath = otherProjectSnapshot.ProjectPath;
+            string otherProjectPath = otherProjectSnapshot.ProjectPath;
 
             var dependencyThatNeedChange = new List<IDependency>();
-            foreach (var target in projectSnapshot.Targets)
+            foreach (KeyValuePair<ITargetFramework, ITargetedDependenciesSnapshot> target in projectSnapshot.Targets)
             {
-                foreach (var dependency in target.Value.TopLevelDependencies)
+                foreach (IDependency dependency in target.Value.TopLevelDependencies)
                 {
                     // We're only interested in project dependencies
                     if (!StringComparers.DependencyProviderTypes.Equals(dependency.ProviderType, ProviderTypeString))
@@ -134,9 +134,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 return;
             }
 
-            foreach (var dependency in dependencyThatNeedChange)
+            foreach (IDependency dependency in dependencyThatNeedChange)
             {
-                var model = CreateDependencyModel(
+                IDependencyModel model = CreateDependencyModel(
                                 ProviderType,
                                 dependency.Path,
                                 dependency.OriginalItemSpec,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/TreeViewProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/TreeViewProviderBase.cs
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                         IProjectTreeCustomizablePropertyContext context,
                         ReferencesProjectTreeCustomizablePropertyValues values)
         {
-            foreach (var provider in ProjectTreePropertiesProviders.ExtensionValues())
+            foreach (IProjectTreePropertiesProvider provider in ProjectTreePropertiesProviders.ExtensionValues())
             {
                 provider.CalculatePropertyValues(context, values);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/UnconfiguredProjectExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/UnconfiguredProjectExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
     {
         public static string GetRelativePath(this UnconfiguredProject self, string path)
         {
-            var projectFolder = Path.GetDirectoryName(self.FullPath);
+            string projectFolder = Path.GetDirectoryName(self.FullPath);
             if (path.StartsWith(projectFolder, StringComparison.OrdinalIgnoreCase))
             {
                 path = path.Substring(projectFolder.Length).TrimStart('\\');

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProvider.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
         /// </summary>
         private static string GetDisplayPath(UnconfiguredProject project, ProjectItemIdentity item)
         {
-            var linkPath = item.LinkPath;
+            string linkPath = item.LinkPath;
 
             if (!string.IsNullOrWhiteSpace(linkPath))
             {
@@ -55,17 +55,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
         /// </summary>
         private static Dictionary<string, int> CreateOrderedMap(UnconfiguredProject project, IReadOnlyCollection<ProjectItemIdentity> orderedItems)
         {
-            var displayOrder = 1;
+            int displayOrder = 1;
             var orderedMap = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
-            foreach (var item in orderedItems)
+            foreach (ProjectItemIdentity item in orderedItems)
             {
-                var displayPath = GetDisplayPath(project, item);
-                var folders = GetPathFolders(displayPath);
+                string displayPath = GetDisplayPath(project, item);
+                string[] folders = GetPathFolders(displayPath);
 
                 // We need assign the display order to folders first before the file.
                 // These folders could be physical or virtual. Virtual coming from link paths.
-                foreach (var folder in folders)
+                foreach (string folder in folders)
                 {
                     // Folders are special. 
                     // FIXME: Due to the lack of metadata/info from property context 
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
                     }
                 }
 
-                var fullPath = project.MakeRooted(item.EvaluatedInclude);
+                string fullPath = project.MakeRooted(item.EvaluatedInclude);
 
                 // We uniquely identify a file by its fullpath.
                 if (!orderedMap.ContainsKey(fullPath))
@@ -108,7 +108,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
                 return _orderedMap.TryGetValue(propertyContext.ItemName, out displayOrder);
             }
 
-            return propertyContext.Metadata.TryGetValue(FullPathProperty, out var fullPath) &&
+            return propertyContext.Metadata.TryGetValue(FullPathProperty, out string fullPath) &&
                 _orderedMap.TryGetValue(fullPath, out displayOrder);
         }
 
@@ -125,7 +125,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
             if (propertyValues is IProjectTreeCustomizablePropertyValues2 propertyValues2)
             {
                 // assign display order to folders and items that appear in order map
-                if (TryGetDisplayOrder(propertyContext, out var displayOrder))
+                if (TryGetDisplayOrder(propertyContext, out int displayOrder))
                 {
                     // sometimes these items temporarily have null item type. Ignore these cases
                     if (propertyContext.ItemType != null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/DialogServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/DialogServices.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UI
         public MultiChoiceMsgBoxResult ShowMultiChoiceMsgBox(string dialogTitle, string errorText, string[] buttons)
         {
             var dlg = new MultiChoiceMsgBox(dialogTitle, errorText, buttons);
-            var result = dlg.ShowModal();
+            bool? result = dlg.ShowModal();
             if (result == true)
             {
                 return dlg.SelectedAction;
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UI
         public bool DontShowAgainMessageBox(string caption, string message, string checkboxText, bool initialStateOfCheckbox, string learnMoreText, string learnMoreUrl)
         {
             var dlg = new DontShowAgainMessageBox(caption, message, checkboxText, initialStateOfCheckbox, learnMoreText, learnMoreUrl, _userNotificationServices);
-            var result = dlg.ShowModal();
+            bool? result = dlg.ShowModal();
             if (result == true)
             {
                 return dlg.CheckboxState;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/VsShellUtilitiesHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/VsShellUtilitiesHelper.cs
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UI
         {
             await _threadingService.SwitchToUIThread();
 
-            var shell = serviceProvider.GetService<IVsShell, SVsShell>();
+            IVsShell shell = serviceProvider.GetService<IVsShell, SVsShell>();
             if (ErrorHandler.Succeeded(shell.GetProperty((int)__VSSPROPID4.VSSPROPID_LocalAppDataDir, out object objDataFolder)) && objDataFolder is string appDataFolder)
             {
                 return appDataFolder;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UserNotificationServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UserNotificationServices.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             _threadingService.VerifyOnUIThread();
             if (!VsShellUtilities.IsInAutomationFunction(_serviceProvider))
             {
-                var result = VsShellUtilities.ShowMessageBox(_serviceProvider, message, null, OLEMSGICON.OLEMSGICON_QUERY,
+                int result = VsShellUtilities.ShowMessageBox(_serviceProvider, message, null, OLEMSGICON.OLEMSGICON_QUERY,
                              OLEMSGBUTTON.OLEMSGBUTTON_YESNO, OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST);
                 if (result == (int)VSConstants.MessageBoxResult.IDNO)
                 {
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             _threadingService.VerifyOnUIThread();
             if (!VsShellUtilities.IsInAutomationFunction(_serviceProvider))
             {
-                var result = VsShellUtilities.ShowMessageBox(_serviceProvider, failureMessage, null, OLEMSGICON.OLEMSGICON_WARNING,
+                int result = VsShellUtilities.ShowMessageBox(_serviceProvider, failureMessage, null, OLEMSGICON.OLEMSGICON_WARNING,
                                OLEMSGBUTTON.OLEMSGBUTTON_OK, OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST);
             }
         }
@@ -55,9 +55,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             _threadingService.VerifyOnUIThread();
 
-            var vsUIShell = _serviceProvider.GetService<IVsUIShell, SVsUIShell>();
+            IVsUIShell vsUIShell = _serviceProvider.GetService<IVsUIShell, SVsUIShell>();
 
-            var result = vsUIShell.ReportErrorInfo(hr);
+            int result = vsUIShell.ReportErrorInfo(hr);
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/Converters.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/Converters.cs
@@ -280,12 +280,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
             if (values.Length >= 3)
             {
                 var textBlock = values[0] as TextBlock;
-                var format = values[1] as string;
-                var tokens = Tokenizer.ParseTokens(format);
+                string format = values[1] as string;
+                List<Token> tokens = Tokenizer.ParseTokens(format);
                 int hyperLinkIndex = 0;
                 for (int i = 2; i < values.Length; i++)
                 {
-                    var token = tokens.FirstOrDefault((p) => string.Equals(p.Value as string, "{" + hyperLinkIndex + "}"));
+                    Token token = tokens.FirstOrDefault((p) => string.Equals(p.Value as string, "{" + hyperLinkIndex + "}"));
                     if (token != null)
                     {
                         token.Value = values[i];
@@ -295,7 +295,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
                 }
 
                 textBlock.Inlines.Clear();
-                foreach (var token in tokens)
+                foreach (Token token in tokens)
                 {
                     if (token.Value is Hyperlink)
                     {
@@ -328,8 +328,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
             public static List<Token> ParseTokens(string format)
             {
                 var tokens = new List<Token>();
-                var strings = Regex.Split(format, @"({\d+})");
-                foreach (var str in strings)
+                string[] strings = Regex.Split(format, @"({\d+})");
+                foreach (string str in strings)
                 {
                     tokens.Add(new Token() { Value = str });
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/ManagedPathHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/ManagedPathHelper.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
             // We don't use System.IO.Path.IsPathRooted because it doesn't support
             // URIs, and because it returns true for paths like "\dir\file", which is
             // relative to whatever drive we're talking about.
-            return Uri.TryCreate(path, UriKind.Absolute, out var result);
+            return Uri.TryCreate(path, UriKind.Absolute, out Uri result);
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/ObservableListExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/ObservableListExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
         public static ObservableList<NameValuePair> CreateList(this IDictionary<string, string> dictionary)
         {
             var list = new ObservableList<NameValuePair>();
-            foreach (var kvp in dictionary)
+            foreach (KeyValuePair<string, string> kvp in dictionary)
             {
                 list.Add(new NameValuePair(kvp.Key, kvp.Value, list));
             }
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
         public static IDictionary<string, string> CreateDictionary(this ObservableList<NameValuePair> list)
         {
             var dictionary = new Dictionary<string, string>();
-            foreach (var ev in list)
+            foreach (NameValuePair ev in list)
             {
                 dictionary.Add(ev.Name, ev.Value);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/DesignTimeTelemetryLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/DesignTimeTelemetryLogger.cs
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.Telemetry
         {
             var builder = new StringBuilder();
 
-            foreach (var target in _targets.Values
+            foreach (TargetRecord target in _targets.Values
                 .Where(v => v.Elapsed != TimeSpan.Zero)
                 .OrderByDescending(v => v.Elapsed)
                 .Take(10))
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.Telemetry
                 builder.Append(';');
             }
 
-            var targetResults = builder.ToString();
+            string targetResults = builder.ToString();
 
             _telemetryService.PostProperties("DesignTimeBuildComplete", new[]
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/DesignTimeTelemetryLoggerProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/DesignTimeTelemetryLoggerProvider.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.Telemetry
         {
             IImmutableSet<ILogger> loggers = ImmutableHashSet<ILogger>.Empty;
 
-            if (properties.TryGetValue("DesignTimeBuild", out var designTimeBuildValue) &&
+            if (properties.TryGetValue("DesignTimeBuild", out string designTimeBuildValue) &&
                 string.Equals(designTimeBuildValue, "true", StringComparison.OrdinalIgnoreCase))
             {
                 loggers = loggers.Add(new DesignTimeTelemetryLogger(TelemetryService));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/VsTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/VsTelemetryService.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.Telemetry
 
         private (string eventPath, ConcurrentDictionary<string, string> properties) GetEventInfo(string eventName)
         {
-            if (!_eventCache.TryGetValue(eventName, out var eventInfo))
+            if (!_eventCache.TryGetValue(eventName, out (string Event, ConcurrentDictionary<string, string> Properties) eventInfo))
             {
                 eventInfo = (EventPrefix + eventName.ToLower(), new ConcurrentDictionary<string, string>());
                 _eventCache[eventName] = eventInfo;
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.Telemetry
         private string GetPropertyName(string eventName, string propertyName)
         {
             (_, ConcurrentDictionary<string, string> properties) = GetEventInfo(eventName);
-            if (!properties.TryGetValue(propertyName, out var fullPropertyName))
+            if (!properties.TryGetValue(propertyName, out string fullPropertyName))
             {
                 fullPropertyName = BuildPropertyName(eventName, propertyName);
                 properties[propertyName] = fullPropertyName;
@@ -103,7 +103,7 @@ namespace Microsoft.VisualStudio.Telemetry
                 return value;
             }
 
-            var inputBytes = Encoding.UTF8.GetBytes(value);
+            byte[] inputBytes = Encoding.UTF8.GetBytes(value);
             using (var cryptoServiceProvider = new SHA256CryptoServiceProvider())
             {
                 return BitConverter.ToString(cryptoServiceProvider.ComputeHash(inputBytes));
@@ -123,7 +123,7 @@ namespace Microsoft.VisualStudio.Telemetry
         /// </remarks>
         private static string BuildPropertyName(string eventName, string propertyName)
         {
-            var name = PropertyPrefix + eventName.Replace('/', '.');
+            string name = PropertyPrefix + eventName.Replace('/', '.');
 
             if (!name.EndsWith("."))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildUtilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildUtilities.cs
@@ -67,11 +67,11 @@ namespace Microsoft.VisualStudio.Build
         /// <returns>Collection of individual values in the property.</returns>
         public static ImmutableArray<string> GetPropertyValues(string propertyValue, char delimiter = ';')
         {
-            var values = propertyValue.Split(delimiter).Select(f => f.Trim());
+            System.Collections.Generic.IEnumerable<string> values = propertyValue.Split(delimiter).Select(f => f.Trim());
 
             // We need to ensure that we return values in the specified order.
-            var valuesBuilder = ImmutableArray.CreateBuilder<string>();
-            foreach (var value in values)
+            ImmutableArray<string>.Builder valuesBuilder = ImmutableArray.CreateBuilder<string>();
+            foreach (string value in values)
             {
                 if (!string.IsNullOrEmpty(value))
                 {
@@ -98,7 +98,7 @@ namespace Microsoft.VisualStudio.Build
 
             ProjectPropertyElement property = GetOrAddProperty(project, propertyName);
             var newValue = new StringBuilder();
-            foreach (var value in GetPropertyValues(evaluatedPropertyValue, delimiter))
+            foreach (string value in GetPropertyValues(evaluatedPropertyValue, delimiter))
             {
                 newValue.Append(value);
                 newValue.Append(delimiter);
@@ -126,7 +126,7 @@ namespace Microsoft.VisualStudio.Build
             Requires.NotNull(evaluatedPropertyValue, nameof(evaluatedPropertyValue));
             Requires.NotNullOrEmpty(propertyName, nameof(propertyName));
 
-            var property = GetOrAddProperty(project, propertyName);
+            ProjectPropertyElement property = GetOrAddProperty(project, propertyName);
             var newValue = new StringBuilder();
             bool valueFound = false;
             foreach (string value in GetPropertyValues(evaluatedPropertyValue, delimiter))
@@ -169,7 +169,7 @@ namespace Microsoft.VisualStudio.Build
             Requires.NotNull(evaluatedPropertyValue, nameof(evaluatedPropertyValue));
             Requires.NotNullOrEmpty(propertyName, nameof(propertyName));
 
-            var property = GetOrAddProperty(project, propertyName);
+            ProjectPropertyElement property = GetOrAddProperty(project, propertyName);
             var value = new StringBuilder();
             bool valueFound = false;
             foreach (string propertyValue in GetPropertyValues(evaluatedPropertyValue, delimiter))
@@ -203,7 +203,7 @@ namespace Microsoft.VisualStudio.Build
         public static ProjectPropertyElement GetOrAddProperty(ProjectRootElement project, string propertyName)
         {
             Requires.NotNull(project, "project");
-            var property = GetProperty(project, propertyName);
+            ProjectPropertyElement property = GetProperty(project, propertyName);
 
             if (property != null)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Collections/DictionaryEqualityComparer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Collections/DictionaryEqualityComparer.cs
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.Collections
             IEqualityComparer<TValue> valueComparer = concreteDictionary1 != null ? concreteDictionary1.ValueComparer : EqualityComparer<TValue>.Default;
             if (obj != null)
             {
-                foreach (var pair in obj)
+                foreach (KeyValuePair<TKey, TValue> pair in obj)
                 {
                     hashCode += keyComparer.GetHashCode(pair.Key) + valueComparer.GetHashCode(pair.Value);
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Composition/EnumerableExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Composition/EnumerableExtensions.cs
@@ -24,9 +24,9 @@ namespace Microsoft.VisualStudio.Composition
         internal static IEnumerable<T> ExtensionValues<T>(this IEnumerable<Lazy<T>> extensions, bool onlyCreatedValues = false)
         {
             Requires.NotNull(extensions, nameof(extensions));
-            var traceErrorMessage = "Roslyn project system extension rejected due to exception: {0}";
+            string traceErrorMessage = "Roslyn project system extension rejected due to exception: {0}";
 
-            foreach (var extension in extensions)
+            foreach (Lazy<T> extension in extensions)
             {
                 T value;
                 try

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
@@ -129,7 +129,7 @@ namespace Microsoft.VisualStudio.IO
 
         public string GetTempDirectoryOrFileName()
         {
-            var fileNameWithoutPath = Path.GetRandomFileName();
+            string fileNameWithoutPath = Path.GetRandomFileName();
 
             return Path.Combine(Path.GetTempPath(), fileNameWithoutPath);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
@@ -74,16 +74,16 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public async Task<ImmutableDictionary<string, ConfiguredProject>> GetActiveConfiguredProjectsMapAsync()
         {
-            var builder = ImmutableDictionary.CreateBuilder<string, ConfiguredProject>();
+            ImmutableDictionary<string, ConfiguredProject>.Builder builder = ImmutableDictionary.CreateBuilder<string, ConfiguredProject>();
 
             ActiveConfiguredObjects<ConfiguredProject> projects = await GetActiveConfiguredProjectsAsync().ConfigureAwait(false);
 
-            var isCrossTargeting = projects.Objects.All(project => project.ProjectConfiguration.IsCrossTargeting());
+            bool isCrossTargeting = projects.Objects.All(project => project.ProjectConfiguration.IsCrossTargeting());
             if (isCrossTargeting)
             {
                 foreach (ConfiguredProject project in projects.Objects)
                 {
-                    var targetFramework = project.ProjectConfiguration.Dimensions[ConfigurationGeneral.TargetFrameworkProperty];
+                    string targetFramework = project.ProjectConfiguration.Dimensions[ConfigurationGeneral.TargetFrameworkProperty];
                     builder.Add(targetFramework, project);
                 }
             }
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             if (configurations == null)
                 return null;
 
-            var builder = ImmutableArray.CreateBuilder<ConfiguredProject>(configurations.Objects.Count);
+            ImmutableArray<ConfiguredProject>.Builder builder = ImmutableArray.CreateBuilder<ConfiguredProject>(configurations.Objects.Count);
 
             foreach (ProjectConfiguration configuration in configurations.Objects)
             {
@@ -123,7 +123,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             IImmutableSet<ProjectConfiguration> configurations = await _services.ProjectConfigurationsService.GetKnownProjectConfigurationsAsync()
                                                                                                              .ConfigureAwait(false);
 
-            var builder = ImmutableArray.CreateBuilder<ProjectConfiguration>(configurations.Count);
+            ImmutableArray<ProjectConfiguration>.Builder builder = ImmutableArray.CreateBuilder<ProjectConfiguration>(configurations.Count);
             IImmutableSet<string> dimensionNames = GetDimensionNames();
 
             foreach (ProjectConfiguration configuration in configurations)
@@ -140,7 +140,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         private IImmutableSet<string> GetDimensionNames()
         {
-            var builder = ImmutableHashSet.CreateBuilder(StringComparers.ConfigurationDimensionNames);
+            ImmutableHashSet<string>.Builder builder = ImmutableHashSet.CreateBuilder(StringComparers.ConfigurationDimensionNames);
 
             foreach (Lazy<IActiveConfiguredProjectsDimensionProvider> dimensionProvider in DimensionProviders)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/ImplicitlyActiveConfiguredProjectReadyToBuild.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/ImplicitlyActiveConfiguredProjectReadyToBuild.cs
@@ -37,8 +37,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Build
         {
             lock (_configuredProject)
             {
-                var previouslyActive = _activationTask.Task.IsCompleted;
-                var nowActive = IsActive();
+                bool previouslyActive = _activationTask.Task.IsCompleted;
+                bool nowActive = IsActive();
                 if (previouslyActive)
                 {
                     if (!nowActive)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
@@ -89,7 +89,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         {
             Requires.NotNull(project, nameof(project));
 
-            var values = await GetOrderedPropertyValuesAsync(project).ConfigureAwait(false);
+            ImmutableArray<string> values = await GetOrderedPropertyValuesAsync(project).ConfigureAwait(false);
             if (values.IsEmpty)
             {
                 return ImmutableArray<KeyValuePair<string, string>>.Empty;
@@ -97,7 +97,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
             else
             {
                 // First value is the default one.
-                var defaultValues = ImmutableArray.CreateBuilder<KeyValuePair<string, string>>();
+                ImmutableArray<KeyValuePair<string, string>>.Builder defaultValues = ImmutableArray.CreateBuilder<KeyValuePair<string, string>>();
                 defaultValues.Add(new KeyValuePair<string, string>(DimensionName, values.First()));
                 return defaultValues.ToImmutable();
             }
@@ -117,14 +117,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         {
             Requires.NotNull(project, nameof(project));
 
-            var values = await GetOrderedPropertyValuesAsync(project).ConfigureAwait(false);
+            ImmutableArray<string> values = await GetOrderedPropertyValuesAsync(project).ConfigureAwait(false);
             if (values.IsEmpty)
             {
                 return ImmutableArray<KeyValuePair<string, IEnumerable<string>>>.Empty;
             }
             else
             {
-                var dimensionValues = ImmutableArray.CreateBuilder<KeyValuePair<string, IEnumerable<string>>>();
+                ImmutableArray<KeyValuePair<string, IEnumerable<string>>>.Builder dimensionValues = ImmutableArray.CreateBuilder<KeyValuePair<string, IEnumerable<string>>>();
                 dimensionValues.Add(new KeyValuePair<string, IEnumerable<string>>(DimensionName, values));
                 return dimensionValues.ToImmutable();
             }
@@ -158,7 +158,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         /// </remarks>
         protected async Task<string> GetPropertyValue(UnconfiguredProject project, string propertyName = null)
         {
-            var configuredProject = await project.GetSuggestedConfiguredProjectAsync()
+            ConfiguredProject configuredProject = await project.GetSuggestedConfiguredProjectAsync()
                                                  .ConfigureAwait(false);
 
             return await ProjectAccessor.OpenProjectForReadAsync(configuredProject, evaluatedProject =>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DataFlowUtilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DataFlowUtilities.cs
@@ -30,8 +30,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var context = ExecutionContext.Capture();
             return input =>
             {
-                var currentSynchronizationContext = SynchronizationContext.Current;
-                using (var copy = context.CreateCopy())
+                SynchronizationContext currentSynchronizationContext = SynchronizationContext.Current;
+                using (ExecutionContext copy = context.CreateCopy())
                 {
                     Task result = null;
                     ExecutionContext.Run(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ActiveDebugFrameworkServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ActiveDebugFrameworkServices.cs
@@ -33,9 +33,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             // It is important that we return the frameworks in the order they are specified in the project to ensure the default is set
             // correctly. 
-            var props = await _commonProjectServices.ActiveConfiguredProjectProperties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(false);
+            ConfigurationGeneral props = await _commonProjectServices.ActiveConfiguredProjectProperties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(false);
 
-            var targetFrameworks = (string)await props.TargetFrameworks.GetValueAsync().ConfigureAwait(false);
+            string targetFrameworks = (string)await props.TargetFrameworks.GetValueAsync().ConfigureAwait(false);
 
             if (!string.IsNullOrWhiteSpace(targetFrameworks))
             {
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </summary>
         public async Task SetActiveDebuggingFrameworkPropertyAsync(string activeFramework)
         {
-            var props = await _commonProjectServices.ActiveConfiguredProjectProperties.GetProjectDebuggerPropertiesAsync().ConfigureAwait(false);
+            ProjectDebugger props = await _commonProjectServices.ActiveConfiguredProjectProperties.GetProjectDebuggerPropertiesAsync().ConfigureAwait(false);
             await props.ActiveDebugFramework.SetValueAsync(activeFramework).ConfigureAwait(true);
         }
 
@@ -58,8 +58,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </summary>
         public async Task<string> GetActiveDebuggingFrameworkPropertyAsync()
         {
-            var props = await _commonProjectServices.ActiveConfiguredProjectProperties.GetProjectDebuggerPropertiesAsync().ConfigureAwait(false);
-            var activeValue = await props.ActiveDebugFramework.GetValueAsync().ConfigureAwait(true) as string;
+            ProjectDebugger props = await _commonProjectServices.ActiveConfiguredProjectProperties.GetProjectDebuggerPropertiesAsync().ConfigureAwait(false);
+            string activeValue = await props.ActiveDebugFramework.GetValueAsync().ConfigureAwait(true) as string;
             return activeValue;
         }
 
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         public async Task<ConfiguredProject> GetConfiguredProjectForActiveFrameworkAsync()
         {
 #pragma warning disable CS0618 // Type or member is obsolete
-            var configProjects = await _activeConfiguredProjectsProvider.GetActiveConfiguredProjectsMapAsync().ConfigureAwait(false);
+            System.Collections.Immutable.ImmutableDictionary<string, ConfiguredProject> configProjects = await _activeConfiguredProjectsProvider.GetActiveConfiguredProjectsMapAsync().ConfigureAwait(false);
 #pragma warning restore CS0618 // Type or member is obsolete
 
             // If there is only one we are done
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 return configProjects.First().Value;
             }
 
-            var activeFramework = await GetActiveDebuggingFrameworkPropertyAsync().ConfigureAwait(false);
+            string activeFramework = await GetActiveDebuggingFrameworkPropertyAsync().ConfigureAwait(false);
             if (!string.IsNullOrWhiteSpace(activeFramework))
             {
                 if (configProjects.TryGetValue(activeFramework, out ConfiguredProject configuredProject))
@@ -89,7 +89,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             // We can't just select the first one. If activeFramework is not set we must pick the first one as defined by the 
             // targetFrameworks property. So we need the order as returned by GetProjectFrameworks()
-            var frameworks = await GetProjectFrameworksAsync().ConfigureAwait(false);
+            List<string> frameworks = await GetProjectFrameworksAsync().ConfigureAwait(false);
             if (frameworks != null && frameworks.Count > 0)
             {
                 if (configProjects.TryGetValue(frameworks[0], out ConfiguredProject configuredProject))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugTokenReplacer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugTokenReplacer.cs
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             // Since Env variables are an immutable dictionary they are a little messy to update.
             if (resolvedProfile.EnvironmentVariables != null)
             {
-                foreach (var kvp in resolvedProfile.EnvironmentVariables)
+                foreach (System.Collections.Generic.KeyValuePair<string, string> kvp in resolvedProfile.EnvironmentVariables)
                 {
                     resolvedProfile.EnvironmentVariables = resolvedProfile.EnvironmentVariables.SetItem(kvp.Key, await ReplaceTokensInStringAsync(kvp.Value, true).ConfigureAwait(false));
                 }
@@ -74,7 +74,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             if (resolvedProfile.OtherSettings != null)
             {
-                foreach (var kvp in resolvedProfile.OtherSettings)
+                foreach (System.Collections.Generic.KeyValuePair<string, object> kvp in resolvedProfile.OtherSettings)
                 {
                     if (kvp.Value is string)
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileData.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileData.cs
@@ -83,7 +83,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             }
 
             // We walk the profilesObject and serialize each subobject component as either a string, or a dictionary<string,string>
-            foreach (var profile in profilesObject)
+            foreach (KeyValuePair<string, JToken> profile in profilesObject)
             {
                 // Name of profile is the key, value is it's contents. We have specific serializing of the data based on the 
                 // JToken type
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
                 // Now pick up any custom properties. Handle string, int, boolean
                 var customSettings = new Dictionary<string, object>(StringComparer.Ordinal);
-                foreach (var data in profile.Value.Children())
+                foreach (JToken data in profile.Value.Children())
                 {
                     if (!(data is JProperty dataProperty))
                     {
@@ -117,7 +117,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                                     }
                                 case JTokenType.Object:
                                     {
-                                        var value = JsonConvert.DeserializeObject<Dictionary<string, string>>(dataProperty.Value.ToString());
+                                        Dictionary<string, string> value = JsonConvert.DeserializeObject<Dictionary<string, string>>(dataProperty.Value.ToString());
                                         customSettings.Add(dataProperty.Name, value);
                                         break;
                                     }
@@ -198,7 +198,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             if (profile.OtherSettings != null)
             {
-                foreach (var kvp in profile.OtherSettings)
+                foreach (KeyValuePair<string, object> kvp in profile.OtherSettings)
                 {
                     data.Add(kvp.Key, kvp.Value);
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettings.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettings.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         public LaunchSettings(IEnumerable<ILaunchProfile> profiles, IDictionary<string, object> globalSettings, string activeProfile = null)
         {
             Profiles = ImmutableList<ILaunchProfile>.Empty;
-            foreach (var profile in profiles)
+            foreach (ILaunchProfile profile in profiles)
             {
                 Profiles = Profiles.Add(new LaunchProfile(profile));
             }
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         public LaunchSettings(LaunchSettingsData settingsData, string activeProfile = null)
         {
             Profiles = ImmutableList<ILaunchProfile>.Empty;
-            foreach (var profile in settingsData.Profiles)
+            foreach (LaunchProfileData profile in settingsData.Profiles)
             {
                 Profiles = Profiles.Add(new LaunchProfile(profile));
             }
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         public LaunchSettings(IWritableLaunchSettings settings)
         {
             Profiles = ImmutableList<ILaunchProfile>.Empty;
-            foreach (var profile in settings.Profiles)
+            foreach (IWritableLaunchProfile profile in settings.Profiles)
             {
                 Profiles = Profiles.Add(new LaunchProfile(profile));
             }
@@ -51,7 +51,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             // For global settings we want to make new copies of each entry so that the snapshot remains immutable. If the object implements 
             // ICloneable that is used, otherwise, it is serialized back to json, and a new object rehydrated from that
             GlobalSettings = ImmutableStringDictionary<object>.EmptyOrdinal;
-            foreach (var kvp in settings.GlobalSettings)
+            foreach (KeyValuePair<string, object> kvp in settings.GlobalSettings)
             {
                 if (kvp.Value is ICloneable clonableObject)
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/WritableLaunchSettings.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/WritableLaunchSettings.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             if (settings.Profiles != null)
             {
-                foreach (var profile in settings.Profiles)
+                foreach (ILaunchProfile profile in settings.Profiles)
                 {
                     Profiles.Add(new WritableLaunchProfile(profile));
                 }
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             // ICloneable that is used, otherwise, it is serialized back to json, and a new object rehydrated from that
             if (settings.GlobalSettings != null)
             {
-                foreach (var kvp in settings.GlobalSettings)
+                foreach (KeyValuePair<string, object> kvp in settings.GlobalSettings)
                 {
                     if (kvp.Value is ICloneable clonableObject)
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/AggregateWorkspaceProjectContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/AggregateWorkspaceProjectContext.cs
@@ -57,10 +57,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         public void SetProjectFilePathAndDisplayName(string projectFilePath, string displayName)
         {
             // Update the project file path and display name for all the inner project contexts.
-            foreach (var innerProjectContextKvp in _configuredProjectContextsByTargetFramework)
+            foreach (KeyValuePair<string, IWorkspaceProjectContext> innerProjectContextKvp in _configuredProjectContextsByTargetFramework)
             {
-                var targetFramework = innerProjectContextKvp.Key;
-                var innerProjectContext = innerProjectContextKvp.Value;
+                string targetFramework = innerProjectContextKvp.Key;
+                IWorkspaceProjectContext innerProjectContext = innerProjectContextKvp.Value;
 
                 // For cross targeting projects, we ensure that the display name is unique per every target framework.
                 innerProjectContext.DisplayName = IsCrossTargeting ? $"{displayName}({targetFramework})" : displayName;
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         {
             if (projectConfiguration.IsCrossTargeting())
             {
-                var targetFramework = projectConfiguration.Dimensions[ConfigurationGeneral.TargetFrameworkProperty];
+                string targetFramework = projectConfiguration.Dimensions[ConfigurationGeneral.TargetFrameworkProperty];
                 isActiveConfiguration = string.Equals(targetFramework, _activeTargetFramework);
                 return _configuredProjectContextsByTargetFramework.TryGetValue(targetFramework, out IWorkspaceProjectContext projectContext) ?
                     projectContext :
@@ -99,7 +99,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             Assumes.True(activeProjectConfiguration.IsCrossTargeting());
             Assumes.True(knownProjectConfigurations.All(c => c.IsCrossTargeting()));
 
-            var activeTargetFramework = activeProjectConfiguration.Dimensions[ConfigurationGeneral.TargetFrameworkProperty];
+            string activeTargetFramework = activeProjectConfiguration.Dimensions[ConfigurationGeneral.TargetFrameworkProperty];
             if (!string.Equals(activeTargetFramework, _activeTargetFramework))
             {
                 // Active target framework is different.
@@ -113,7 +113,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 return false;
             }
 
-            foreach (var targetFramework in targetFrameworks)
+            foreach (string targetFramework in targetFrameworks)
             {
                 if (!_configuredProjectContextsByTargetFramework.ContainsKey(targetFramework))
                 {
@@ -132,7 +132,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             // Dispose the inner project contexts.
             var disposedContexts = new List<IWorkspaceProjectContext>();
-            foreach (var innerProjectContext in InnerProjectContexts)
+            foreach (IWorkspaceProjectContext innerProjectContext in InnerProjectContexts)
             {
                 if (shouldDisposeInnerContext(innerProjectContext))
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/CommandLineParserService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/CommandLineParserService.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             if (parser == null)
                 throw new InvalidOperationException();
 
-            var buildOptions = parser.Value.Parse(arguments, _project.FullPath);
+            BuildOptions buildOptions = parser.Value.Parse(arguments, _project.FullPath);
 
             return buildOptions;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ContextHandlerProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ContextHandlerProvider.cs
@@ -56,10 +56,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         private Handlers CreateHandlers(IWorkspaceProjectContext context)
         {
-            var evaluationHandlers = ImmutableArray.CreateBuilder<(IEvaluationHandler handler, string evaluationRuleName)>(s_handlerFactories.Length);
-            var commandLineHandlers = ImmutableArray.CreateBuilder<ICommandLineHandler>(s_handlerFactories.Length);
+            ImmutableArray<(IEvaluationHandler handler, string evaluationRuleName)>.Builder evaluationHandlers = ImmutableArray.CreateBuilder<(IEvaluationHandler handler, string evaluationRuleName)>(s_handlerFactories.Length);
+            ImmutableArray<ICommandLineHandler>.Builder commandLineHandlers = ImmutableArray.CreateBuilder<ICommandLineHandler>(s_handlerFactories.Length);
 
-            foreach (var factory in s_handlerFactories)
+            foreach ((HandlerFactory factory, string evaluationRuleName) factory in s_handlerFactories)
             {
                 object handler = factory.factory(_project, context);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
@@ -195,7 +195,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             // other reason, that our state of the world remains consistent
             if (!_paths.Contains(fullPath))
             {
-                var itemMetadata = metadata.GetValueOrDefault(includePath, ImmutableStringDictionary<string>.EmptyOrdinal);
+                IImmutableDictionary<string, string> itemMetadata = metadata.GetValueOrDefault(includePath, ImmutableStringDictionary<string>.EmptyOrdinal);
                 AddToContext(fullPath, itemMetadata, isActiveContext, logger);
                 bool added = _paths.Add(fullPath);
                 Assumes.True(added);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
@@ -40,14 +40,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             foreach (CommandLineSourceFile additionalFile in removed.AdditionalFiles)
             {
-                var fullPath = _project.MakeRooted(additionalFile.Path);
+                string fullPath = _project.MakeRooted(additionalFile.Path);
 
                 RemoveFromContextIfPresent(fullPath, logger);
             }
 
             foreach (CommandLineSourceFile additionalFile in added.AdditionalFiles)
             {
-                var fullPath = _project.MakeRooted(additionalFile.Path);
+                string fullPath = _project.MakeRooted(additionalFile.Path);
 
                 AddToContextIfNotPresent(fullPath, isActiveContext, logger);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
@@ -41,14 +41,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             foreach (CommandLineAnalyzerReference analyzer in removed.AnalyzerReferences)
             {
-                var fullPath = _project.MakeRooted(analyzer.FilePath);
+                string fullPath = _project.MakeRooted(analyzer.FilePath);
 
                 RemoveFromContextIfPresent(fullPath, logger);
             }
 
             foreach (CommandLineAnalyzerReference analyzer in added.AnalyzerReferences)
             {
-                var fullPath = _project.MakeRooted(analyzer.FilePath);
+                string fullPath = _project.MakeRooted(analyzer.FilePath);
 
                 AddToContextIfNotPresent(fullPath, logger);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
@@ -41,14 +41,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             foreach (CommandLineReference reference in removed.MetadataReferences)
             {
-                var fullPath = _project.MakeRooted(reference.Reference);
+                string fullPath = _project.MakeRooted(reference.Reference);
 
                 RemoveFromContextIfPresent(fullPath, reference.Properties, logger);
             }
 
             foreach (CommandLineReference reference in added.MetadataReferences)
             {
-                var fullPath = _project.MakeRooted(reference.Reference);
+                string fullPath = _project.MakeRooted(reference.Reference);
 
                 AddToContextIfNotPresent(fullPath, reference.Properties, logger);
             }
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
         private void AddToContextIfNotPresent(string fullPath, MetadataReferenceProperties properties, IProjectLogger logger)
         {
-            if (_addedPathsWithMetadata.TryGetValue(fullPath, out var existingProperties))
+            if (_addedPathsWithMetadata.TryGetValue(fullPath, out MetadataReferenceProperties existingProperties))
             {
                 logger.WriteLine("Removing existing {0} '{1}' so we can update the aliases.", properties.EmbedInteropTypes ? "link" : "reference", fullPath);
 
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
                 // existing one, compute merged properties, and add the new one.
                 _context.RemoveMetadataReference(fullPath);
 
-                var combinedAliases = GetEmptyIfGlobalAlias(GetGlobalAliasIfEmpty(existingProperties.Aliases).AddRange(GetGlobalAliasIfEmpty(properties.Aliases)));
+                ImmutableArray<string> combinedAliases = GetEmptyIfGlobalAlias(GetGlobalAliasIfEmpty(existingProperties.Aliases).AddRange(GetGlobalAliasIfEmpty(properties.Aliases)));
                 properties = properties.WithAliases(combinedAliases);
             }
 
@@ -77,14 +77,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
         private void RemoveFromContextIfPresent(string fullPath, MetadataReferenceProperties properties, IProjectLogger logger)
         {
-            if (_addedPathsWithMetadata.TryGetValue(fullPath, out var existingProperties))
+            if (_addedPathsWithMetadata.TryGetValue(fullPath, out MetadataReferenceProperties existingProperties))
             {
                 logger.WriteLine("Removing {0} '{1}'", properties.EmbedInteropTypes ? "link" : "reference", fullPath);
 
                 _context.RemoveMetadataReference(fullPath);
 
                 // Subtract any existing aliases out. This will be an empty list if we should remove the reference entirely
-                var resultantAliases = GetGlobalAliasIfEmpty(existingProperties.Aliases).RemoveRange(GetGlobalAliasIfEmpty(properties.Aliases));
+                ImmutableArray<string> resultantAliases = GetGlobalAliasIfEmpty(existingProperties.Aliases).RemoveRange(GetGlobalAliasIfEmpty(properties.Aliases));
 
                 if (resultantAliases.IsEmpty)
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             if (projectChange.Difference.ChangedProperties.Contains(ConfigurationGeneral.TargetPathProperty))
             {
-                var newBinOutputPath = projectChange.After.Properties[ConfigurationGeneral.TargetPathProperty];
+                string newBinOutputPath = projectChange.After.Properties[ConfigurationGeneral.TargetPathProperty];
                 if (!string.IsNullOrEmpty(newBinOutputPath))
                 {
                     logger.WriteLine("BinOutputPath: {0}", newBinOutputPath);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHandlerManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHandlerManager.cs
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             {
                 WriteHeader(logger, update, version, RuleHandlerType.Evaluation, isActiveContext);
 
-                foreach (var handler in handlers)
+                foreach ((IEvaluationHandler handler, string evaluationRuleName) handler in handlers)
                 {
                     string ruleName = handler.evaluationRuleName;
 
@@ -173,7 +173,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             BuildOptions addedItems = _commandLineParser.Parse(projectChange.Difference.AddedItems);
             BuildOptions removedItems = _commandLineParser.Parse(projectChange.Difference.RemovedItems);
 
-            foreach (var handler in handlers)
+            foreach (ICommandLineHandler handler in handlers)
             {
                 handler.Handle(version, addedItems, removedItems, isActiveContext, logger);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -116,8 +116,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         private async Task UpdateProjectContextAndSubscriptionsAsync()
         {
-            var previousProjectContext = _currentAggregateProjectContext;
-            var newProjectContext = await UpdateProjectContextAsync().ConfigureAwait(false);
+            AggregateWorkspaceProjectContext previousProjectContext = _currentAggregateProjectContext;
+            AggregateWorkspaceProjectContext newProjectContext = await UpdateProjectContextAsync().ConfigureAwait(false);
 
             if (previousProjectContext != newProjectContext)
             {
@@ -149,7 +149,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 await _commonServices.ThreadingService.SwitchToUIThread();
 
                 string newTargetFramework = null;
-                var projectProperties = await _commonServices.ActiveConfiguredProjectProperties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(false);
+                ConfigurationGeneral projectProperties = await _commonServices.ActiveConfiguredProjectProperties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(false);
 
                 // Check if we have already computed the project context.
                 if (_currentAggregateProjectContext != null)
@@ -172,8 +172,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                     else
                     {
                         // Check if the current project context is up-to-date for the current active and known project configurations.
-                        var activeProjectConfiguration = _commonServices.ActiveConfiguredProject.ProjectConfiguration;
-                        var knownProjectConfigurations = await _commonServices.Project.Services.ProjectConfigurationsService.GetKnownProjectConfigurationsAsync().ConfigureAwait(false);
+                        ProjectConfiguration activeProjectConfiguration = _commonServices.ActiveConfiguredProject.ProjectConfiguration;
+                        System.Collections.Immutable.IImmutableSet<ProjectConfiguration> knownProjectConfigurations = await _commonServices.Project.Services.ProjectConfigurationsService.GetKnownProjectConfigurationsAsync().ConfigureAwait(false);
                         if (knownProjectConfigurations.All(c => c.IsCrossTargeting()) &&
                             _currentAggregateProjectContext.HasMatchingTargetFrameworks(activeProjectConfiguration, knownProjectConfigurations))
                         {
@@ -210,7 +210,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         {
             await _contextProvider.Value.ReleaseProjectContextAsync(projectContext).ConfigureAwait(false);
 
-            foreach (var innerContext in projectContext.DisposedInnerProjectContexts)
+            foreach (IWorkspaceProjectContext innerContext in projectContext.DisposedInnerProjectContexts)
             {
                 _languageServiceHandlerManager.OnContextReleased(innerContext);
             }
@@ -223,10 +223,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             await _commonServices.ThreadingService.SwitchToUIThread();
             await _tasksService.LoadedProjectAsync(() =>
             {
-                var watchedEvaluationRules = _languageServiceHandlerManager.GetWatchedRules(RuleHandlerType.Evaluation);
-                var watchedDesignTimeBuildRules = _languageServiceHandlerManager.GetWatchedRules(RuleHandlerType.DesignTimeBuild);
+                IEnumerable<string> watchedEvaluationRules = _languageServiceHandlerManager.GetWatchedRules(RuleHandlerType.Evaluation);
+                IEnumerable<string> watchedDesignTimeBuildRules = _languageServiceHandlerManager.GetWatchedRules(RuleHandlerType.DesignTimeBuild);
 
-                foreach (var configuredProject in newProjectContext.InnerConfiguredProjects)
+                foreach (ConfiguredProject configuredProject in newProjectContext.InnerConfiguredProjects)
                 {
                     if (_projectConfigurationsWithSubscriptions.Contains(configuredProject.ProjectConfiguration))
                     {
@@ -259,7 +259,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 await _commonServices.ThreadingService.SwitchToUIThread();
 
                 // Get the inner workspace project context to update for this change.
-                var projectContextToUpdate = _currentAggregateProjectContext.GetInnerProjectContext(update.Value.ProjectConfiguration, out bool isActiveContext);
+                IWorkspaceProjectContext projectContextToUpdate = _currentAggregateProjectContext.GetInnerProjectContext(update.Value.ProjectConfiguration, out bool isActiveContext);
                 if (projectContextToUpdate == null)
                 {
                     return;
@@ -293,7 +293,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         private void DisposeAndClearSubscriptions()
         {
-            foreach (var link in _evaluationSubscriptionLinks.Concat(_designTimeBuildSubscriptionLinks))
+            foreach (IDisposable link in _evaluationSubscriptionLinks.Concat(_designTimeBuildSubscriptionLinks))
             {
                 link.Dispose();
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectConfigurationExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectConfigurationExtensions.cs
@@ -35,10 +35,10 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 return projectConfiguration1.Equals(projectConfiguration2);
             }
 
-            foreach (var dimensionKvp in projectConfiguration1.Dimensions)
+            foreach (System.Collections.Generic.KeyValuePair<string, string> dimensionKvp in projectConfiguration1.Dimensions)
             {
-                var dimensionName = dimensionKvp.Key;
-                var dimensionValue = dimensionKvp.Value;
+                string dimensionName = dimensionKvp.Key;
+                string dimensionValue = dimensionKvp.Value;
 
                 // Ignore the TargetFramework.
                 if (StringComparers.ConfigurationDimensionNames.Equals(dimensionName, ConfigurationGeneral.TargetFrameworkProperty))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectTreeFlagsExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectTreeFlagsExtensions.cs
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// </summary>
         public static bool Contains(this ProjectTreeFlags source, ProjectTreeFlags flags)
         {
-            var newFlags = source.Except(flags);
+            ProjectTreeFlags newFlags = source.Except(flags);
 
             return ((source.Count - newFlags.Count)) == flags.Count;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/AbstractProjectFileOrAssemblyInfoPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/AbstractProjectFileOrAssemblyInfoPropertiesProvider.cs
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// </summary>
         public override IProjectProperties GetProperties(string file, string itemType, string item)
         {
-            var delegatedProperties = base.GetProperties(file, itemType, item);
+            IProjectProperties delegatedProperties = base.GetProperties(file, itemType, item);
             IProjectProperties assemblyInfoProperties = new AssemblyInfoProperties(delegatedProperties, _getActiveProjectId, _workspace, _threadingService);
             return _interceptingValueProviders.IsDefaultOrEmpty ?
                 assemblyInfoProperties :

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/AssemblyInfoProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/AssemblyInfoProperties.cs
@@ -44,8 +44,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             Workspace workspace,
             IProjectThreadingService threadingService)
         {
-            var builder = ImmutableDictionary.CreateBuilder<string, SourceAssemblyAttributePropertyValueProvider>();
-            foreach (var kvp in AssemblyPropertyInfoMap)
+            ImmutableDictionary<string, SourceAssemblyAttributePropertyValueProvider>.Builder builder = ImmutableDictionary.CreateBuilder<string, SourceAssemblyAttributePropertyValueProvider>();
+            foreach (KeyValuePair<string, (string attributeName, string generatePropertyInProjectFileName)> kvp in AssemblyPropertyInfoMap)
             {
                 var provider = new SourceAssemblyAttributePropertyValueProvider(kvp.Value.attributeName, getActiveProjectId, workspace, threadingService);
                 builder.Add(kvp.Key, provider);
@@ -119,7 +119,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             // Generate property in project file only if:
             // 1. "GenerateAssemblyInfo" is true AND
             // 2. "GenerateXXX" for this specific property is true.
-            var propertyValue = await base.GetEvaluatedPropertyValueAsync("GenerateAssemblyInfo").ConfigureAwait(true);
+            string propertyValue = await base.GetEvaluatedPropertyValueAsync("GenerateAssemblyInfo").ConfigureAwait(true);
             if (!bool.TryParse(propertyValue, out bool value) || !value)
             {
                 return false;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectProperties.cs
@@ -28,10 +28,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         {
             Requires.NotNullOrEmpty(valueProviders, nameof(valueProviders));
 
-            var builder = ImmutableDictionary.CreateBuilder<string, Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>>(StringComparer.OrdinalIgnoreCase);
-            foreach (var valueProvider in valueProviders)
+            ImmutableDictionary<string, Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>>.Builder builder = ImmutableDictionary.CreateBuilder<string, Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>>(StringComparer.OrdinalIgnoreCase);
+            foreach (Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata> valueProvider in valueProviders)
             {
-                var propertyName = valueProvider.Metadata.PropertyName;
+                string propertyName = valueProvider.Metadata.PropertyName;
 
                 // CONSIDER: Allow duplicate intercepting property value providers for same property name.
                 Requires.Argument(!builder.ContainsKey(propertyName), nameof(valueProviders), "Duplicate property value providers for same property name");
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public override async Task<string> GetEvaluatedPropertyValueAsync(string propertyName)
         {
-            var evaluatedProperty = await base.GetEvaluatedPropertyValueAsync(propertyName);
+            string evaluatedProperty = await base.GetEvaluatedPropertyValueAsync(propertyName);
             if (_valueProviders.TryGetValue(propertyName, out Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata> valueProvider))
             {
                 evaluatedProperty = await valueProvider.Value.OnGetEvaluatedPropertyValueAsync(evaluatedProperty, DelegatedProperties);
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public override async Task<string> GetUnevaluatedPropertyValueAsync(string propertyName)
         {
-            var unevaluatedProperty = await base.GetUnevaluatedPropertyValueAsync(propertyName);
+            string unevaluatedProperty = await base.GetUnevaluatedPropertyValueAsync(propertyName);
             if (_valueProviders.TryGetValue(propertyName, out Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata> valueProvider))
             {
                 unevaluatedProperty = await valueProvider.Value.OnGetUnevaluatedPropertyValueAsync(unevaluatedProperty, DelegatedProperties);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectPropertiesProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectPropertiesProviderBase.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public override IProjectProperties GetProperties(string file, string itemType, string item)
         {
-            var defaultProperties = base.GetProperties(file, itemType, item);
+            IProjectProperties defaultProperties = base.GetProperties(file, itemType, item);
             return _interceptingValueProviders.IsDefaultOrEmpty ? defaultProperties : new InterceptedProjectProperties(_interceptingValueProviders, defaultProperties);
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/AssemblyVersionValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/AssemblyVersionValueProvider.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
         protected async override Task<Version> GetDefaultVersionAsync(IProjectProperties defaultProperties)
         {
             // Default semantic/package version just has 3 fields, we need to append an additional Revision field with value "0".
-            var defaultVersion = await base.GetDefaultVersionAsync(defaultProperties).ConfigureAwait(true);
+            Version defaultVersion = await base.GetDefaultVersionAsync(defaultProperties).ConfigureAwait(true);
             if (ReferenceEquals(defaultVersion, DefaultVersion))
             {
                 return s_defaultAssemblyVersion;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/BaseVersionValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/BaseVersionValueProvider.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
 
         protected virtual async Task<Version> GetDefaultVersionAsync(IProjectProperties defaultProperties)
         {
-            var versionStr = await defaultProperties.GetEvaluatedPropertyValueAsync(PackageVersionMSBuildProperty).ConfigureAwait(true);
+            string versionStr = await defaultProperties.GetEvaluatedPropertyValueAsync(PackageVersionMSBuildProperty).ConfigureAwait(true);
             if (string.IsNullOrEmpty(versionStr))
             {
                 return DefaultVersion;
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
             }
 
             // Default value is Version (major.minor.build components only)
-            var version = await GetDefaultVersionAsync(defaultProperties).ConfigureAwait(true);
+            Version version = await GetDefaultVersionAsync(defaultProperties).ConfigureAwait(true);
             return version.ToString();
         }
 
@@ -45,12 +45,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
             //  1. There is no existing property entry AND
             //  2. The new value is identical to the default value.
 
-            var propertyNames = await defaultProperties.GetPropertyNamesAsync().ConfigureAwait(true);
+            IEnumerable<string> propertyNames = await defaultProperties.GetPropertyNamesAsync().ConfigureAwait(true);
             if (!propertyNames.Contains(PropertyName))
             {
                 if (Version.TryParse(unevaluatedPropertyValue, out Version version))
                 {
-                    var defaultVersion = await GetDefaultVersionAsync(defaultProperties).ConfigureAwait(true);
+                    Version defaultVersion = await GetDefaultVersionAsync(defaultProperties).ConfigureAwait(true);
                     if (version.Equals(defaultVersion))
                     {
                         return null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/FileVersionValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/FileVersionValueProvider.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
         protected async override Task<Version> GetDefaultVersionAsync(IProjectProperties defaultProperties)
         {
             // Default semantic/package version just has 3 fields, we need to append an additional Revision field with value "0".
-            var defaultVersion = await base.GetDefaultVersionAsync(defaultProperties).ConfigureAwait(true);
+            Version defaultVersion = await base.GetDefaultVersionAsync(defaultProperties).ConfigureAwait(true);
             if (ReferenceEquals(defaultVersion, DefaultVersion))
             {
                 return s_defaultFileVersion;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/TargetFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/TargetFrameworkValueProvider.cs
@@ -19,17 +19,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public override async Task<string> OnGetEvaluatedPropertyValueAsync(string evaluatedPropertyValue, IProjectProperties defaultProperties)
         {
-            var configuration = await _properties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(false);
-            var targetFrameworkMoniker = (string)await configuration.TargetFrameworkMoniker.GetValueAsync().ConfigureAwait(false);
+            ConfigurationGeneral configuration = await _properties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(false);
+            string targetFrameworkMoniker = (string)await configuration.TargetFrameworkMoniker.GetValueAsync().ConfigureAwait(false);
             if (targetFrameworkMoniker != null)
             {
                 var targetFramework = new FrameworkName(targetFrameworkMoniker);
 
                 // define MAKETARGETFRAMEWORKVERSION(maj, min, rev) (TARGETFRAMEWORKVERSION)((maj) << 16 | (rev) << 8 | (min))
-                var maj = targetFramework.Version.Major;
-                var min = targetFramework.Version.Minor;
-                var rev = targetFramework.Version.Revision >= 0 ? targetFramework.Version.Revision : 0;
-                var propertyValue = unchecked((uint)((maj << 16) | (rev << 8) | min));
+                int maj = targetFramework.Version.Major;
+                int min = targetFramework.Version.Minor;
+                int rev = targetFramework.Version.Revision >= 0 ? targetFramework.Version.Revision : 0;
+                uint propertyValue = unchecked((uint)((maj << 16) | (rev << 8) | min));
                 return propertyValue.ToString();
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Reload/ProjectReloadInterceptor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Reload/ProjectReloadInterceptor.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             // If user added or removed TargetFramework/TargetFrameworks property, then force a full project reload.
             (bool hasTargetFramework, bool hasTargetFrameworks) = ComputeProjectTargets(oldProperties);
-            var newTargets = ComputeProjectTargets(newProperties);
+            (bool hasTargetFramework, bool hasTargetFrameworks) newTargets = ComputeProjectTargets(newProperties);
 
             return hasTargetFramework != newTargets.hasTargetFramework || hasTargetFrameworks != newTargets.hasTargetFrameworks;
         }
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             (bool hasTargetFramework, bool hasTargetFrameworks) targets = (false, false);
 
-            foreach (var property in properties)
+            foreach (ProjectPropertyElement property in properties)
             {
                 if (property.Name.Equals(ConfigurationGeneral.TargetFrameworkProperty, StringComparison.OrdinalIgnoreCase))
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractSpecialFileProvider.cs
@@ -206,8 +206,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         {
             IProjectTree rootNode = await GetParentFolderAsync(createIfNotExists: true).ConfigureAwait(false);
 
-            var parentPath = _projectTree.TreeProvider.GetRootedAddNewItemDirectory(rootNode);
-            var specialFilePath = Path.Combine(parentPath, specialFileName);
+            string parentPath = _projectTree.TreeProvider.GetRootedAddNewItemDirectory(rootNode);
+            string specialFilePath = Path.Combine(parentPath, specialFileName);
 
             // If we can create the file from the template do it, otherwise just create an empty file.
             if (_templateFileCreationService != null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppManifestSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppManifestSpecialFileProvider.cs
@@ -35,8 +35,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         protected override async Task<IProjectTree> FindFileAsync(string specialFileName)
         {
             // If the ApplicationManifest property is defined then we should just use that - otherwise fall back to the default logic to find app.manifest.
-            var configurationGeneral = await _projectProperties.GetConfigurationGeneralBrowseObjectPropertiesAsync().ConfigureAwait(false);
-            var appManifestProperty = await configurationGeneral.ApplicationManifest.GetEvaluatedValueAtEndAsync().ConfigureAwait(false) as string;
+            ConfigurationGeneralBrowseObject configurationGeneral = await _projectProperties.GetConfigurationGeneralBrowseObjectPropertiesAsync().ConfigureAwait(false);
+            string appManifestProperty = await configurationGeneral.ApplicationManifest.GetEvaluatedValueAtEndAsync().ConfigureAwait(false) as string;
 
             if (!string.IsNullOrEmpty(appManifestProperty) &&
                 !appManifestProperty.Equals(DefaultManifestValue, StringComparison.InvariantCultureIgnoreCase) &&

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Text/StringBuilderExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Text/StringBuilderExtensions.cs
@@ -51,8 +51,8 @@ namespace Microsoft.VisualStudio.Text
         {
             while (builder.Length > 0)
             {
-                var match = false;
-                foreach (var c in trimChars)
+                bool match = false;
+                foreach (char c in trimChars)
                 {
                     if (builder[builder.Length - 1] == c)
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/TaskDelayScheduler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/TaskDelayScheduler.cs
@@ -63,7 +63,7 @@ namespace Microsoft.VisualStudio.Threading.Tasks
                 ClearPendingUpdates(cancel: true);
 
                 PendingUpdateTokenSource = CancellationTokenSource.CreateLinkedTokenSource(OriginalSourceToken);
-                var token = PendingUpdateTokenSource.Token;
+                CancellationToken token = PendingUpdateTokenSource.Token;
 
                 // We want to return a joinable task so wrap the function
                 LatestScheduledTask = _threadingService.JoinableTaskFactory.RunAsync(async () =>
@@ -124,7 +124,7 @@ namespace Microsoft.VisualStudio.Threading.Tasks
                     {
                         PendingUpdateTokenSource.Cancel();
                     }
-                    var cts = PendingUpdateTokenSource;
+                    CancellationTokenSource cts = PendingUpdateTokenSource;
                     PendingUpdateTokenSource = null;
                     cts.Dispose();
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Automation/VisualBasicNamespaceImportsList.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Automation/VisualBasicNamespaceImportsList.cs
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             {
                 lock (_lock)
                 {
-                    var sortedItems = projectChange.After.Items.Keys.OrderBy(s => s, StringComparer.OrdinalIgnoreCase);
+                    IOrderedEnumerable<string> sortedItems = projectChange.After.Items.Keys.OrderBy(s => s, StringComparer.OrdinalIgnoreCase);
                     int newListCount = sortedItems.Count();
                     int oldListCount = _list.Count;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Properties/VisualBasicProjectDesignerPageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Properties/VisualBasicProjectDesignerPageProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
         public Task<IReadOnlyCollection<IPageMetadata>> GetPagesAsync()
         {
-            var builder = ImmutableArray.CreateBuilder<IPageMetadata>();
+            ImmutableArray<IPageMetadata>.Builder builder = ImmutableArray.CreateBuilder<IPageMetadata>();
             builder.Add(VisualBasicProjectDesignerPage.Application);
             builder.Add(VisualBasicProjectDesignerPage.Compile);
 


### PR DESCRIPTION
Per coding conventions & [editorconfig enforcement](https://github.com/dotnet/project-system/blob/master/.editorconfig#L122)

"We only use var when it's obvious what the variable type is (e.g. var stream = new FileStream(...) not var stream = OpenStandardInput())."