### PR TITLE
Fix load of ManagedProjectSystemPackage in F#

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.Packaging
     [ProvideUIContextRule(ActivationContextGuid, "Load Managed Project Package",
         "dotnetcore",
         new string[] { "dotnetcore" },
-        new string[] { "SolutionHasProjectCapability:(CSharp | VB) & CPS" }
+        new string[] { "SolutionHasProjectCapability:.NET & CPS" }
         )]
 
     [ProvideMenuResource("Menus.ctmenu", 3)]


### PR DESCRIPTION
Convert ManagedProjectSystemPackage to use '.NET' for it's load context
capability.
