### PR TITLE
Constants do not begin with s_

### DIFF
--- a/src/Common/ManagedCodeMarkers.vb
+++ b/src/Common/ManagedCodeMarkers.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.Win32
 Imports System.Runtime.InteropServices
@@ -28,7 +28,7 @@ Namespace Microsoft.Internal.Performance
             End Sub
 #End If 'Codemarkers_IncludeAppEnum           
 
-            <DllImport(s_testDllName, EntryPoint:="PerfCodeMarker")>
+            <DllImport(TestDllName, EntryPoint:="PerfCodeMarker")>
             Public Shared Sub TestDllPerfCodeMarker(nTimerID As Integer, uiLow As UInteger, uiHigh As UInteger)
             End Sub
 
@@ -43,7 +43,7 @@ Namespace Microsoft.Internal.Performance
             End Sub
 #End If 'Codemarkers_IncludeAppEnum           
 
-            <DllImport(s_productDllName, EntryPoint:="PerfCodeMarker")>
+            <DllImport(ProductDllName, EntryPoint:="PerfCodeMarker")>
             Public Shared Sub ProductDllPerfCodeMarker(nTimerID As Integer, uiLow As UInteger, uiHigh As UInteger)
             End Sub
 
@@ -72,13 +72,13 @@ Namespace Microsoft.Internal.Performance
 
         ' Atom name. This ATOM will be set by the host application when code markers are enabled
         ' in the registry.
-        Private Const s_atomName As String = "VSCodeMarkersEnabled"
+        Private Const AtomName As String = "VSCodeMarkersEnabled"
 
         ' Test CodeMarkers DLL name
-        Private Const s_testDllName As String = "Microsoft.Internal.Performance.CodeMarkers.dll"
+        Private Const TestDllName As String = "Microsoft.Internal.Performance.CodeMarkers.dll"
 
         ' Product CodeMarkers DLL name
-        Private Const s_productDllName As String = "Microsoft.VisualStudio.CodeMarkers.dll"
+        Private Const ProductDllName As String = "Microsoft.VisualStudio.CodeMarkers.dll"
 
         ' Do we want to use code markers?
         Private _fUseCodeMarkers As Boolean
@@ -95,7 +95,7 @@ Namespace Microsoft.Internal.Performance
                         ' in the InitPerf context we have a regroot and should check for the test DLL registration
                         ' in the AttachPerf context we should see which module is already loaded 
                         If _regroot = Nothing Then
-                            _fShouldUseTestDll = NativeMethods.GetModuleHandle(s_productDllName) = IntPtr.Zero
+                            _fShouldUseTestDll = NativeMethods.GetModuleHandle(ProductDllName) = IntPtr.Zero
                         Else
                             ' if CodeMarkers are explictly enabled in the registry then try to
                             ' use the test DLL, otherwise fall back to trying to use the product DLL
@@ -114,7 +114,7 @@ Namespace Microsoft.Internal.Performance
         ' Checks to see if code markers are enabled by looking for a named ATOM
         Private Sub New()
             ' This ATOM will be set by the native Code Markers host
-            _fUseCodeMarkers = (NativeMethods.FindAtom(s_atomName) <> 0)
+            _fUseCodeMarkers = (NativeMethods.FindAtom(AtomName) <> 0)
         End Sub 'New
 
         ' Implements sending the code marker value nTimerID.

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerView.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerView.vb
@@ -69,9 +69,9 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ' explicitly hard-coding these strings since that's what QA's
         '   automation will look for in order to find our various tabs
         '
-        Private Const s_PROP_PAGE_TAB_PREFIX As String = "PropPage_"
-        Private Const s_RESOURCES_AUTOMATION_TAB_NAME As String = "Resources"
-        Private Const s_SETTINGS_AUTOMATION_TAB_NAME As String = "Settings"
+        Private Const PROP_PAGE_TAB_PREFIX As String = "PropPage_"
+        Private Const RESOURCES_AUTOMATION_TAB_NAME As String = "Resources"
+        Private Const SETTINGS_AUTOMATION_TAB_NAME As String = "Settings"
 
         'The designer panels hold the property pages and other designers
         Private _designerPanels As ApplicationDesignerPanel()
@@ -760,7 +760,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                         .EditorCaption = PropertyPages(Index).Title
 
                         .TabTitle = .EditorCaption
-                        .TabAutomationName = s_PROP_PAGE_TAB_PREFIX & PropertyPages(Index).Guid.ToString("N")
+                        .TabAutomationName = PROP_PAGE_TAB_PREFIX & PropertyPages(Index).Guid.ToString("N")
 
                     Else
                         Dim FileName As String = DirectCast(AppDesignerItems(Index - PropertyPages.Length), String)
@@ -770,7 +770,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                             'Add .resx file with a known editor so user config cannot change
                             .EditorGuid = New Guid(My.Resources.Designer.ResourceEditorFactory_GUID)
                             .EditorCaption = My.Resources.Designer.APPDES_ResourceTabTitle
-                            .TabAutomationName = s_RESOURCES_AUTOMATION_TAB_NAME
+                            .TabAutomationName = RESOURCES_AUTOMATION_TAB_NAME
 
                             'If the resx file doesn't actually exist yet, we have to display the "Click here
                             '  to create it" message instead of the actual editor.
@@ -787,7 +787,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                             'Add .settings file with a known editor so user config cannot change
                             .EditorGuid = New Guid(My.Resources.Designer.SettingsDesignerEditorFactory_GUID)
                             .EditorCaption = My.Resources.Designer.APPDES_SettingsTabTitle
-                            .TabAutomationName = s_SETTINGS_AUTOMATION_TAB_NAME
+                            .TabAutomationName = SETTINGS_AUTOMATION_TAB_NAME
 
                             'If the settings file doesn't actually exist yet, we have to display the "Click here
                             '  to create it" message instead of the actual editor.

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/CmdTargetHelper.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/CmdTargetHelper.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.VisualStudio.Shell.Interop
 Imports Common = Microsoft.VisualStudio.Editors.AppDesCommon
@@ -26,21 +26,21 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         End Sub
 
         ' Window navigation items
-        Private Const s_cmdidPaneNextSubPane As Integer = 1062
-        Private Const s_cmdidPanePrevSubPane As Integer = 1063
-        Private Const s_cmdidPaneNextPane As Integer = 316
-        Private Const s_cmdidPanePrevPane As Integer = 317
-        Private Const s_cmdidPaneNextTab As Integer = 286
-        Private Const s_cmdidPanePrevTab As Integer = 287
-        Private Const s_cmdidCloseDocument As Integer = 658
+        Private Const CmdIdPaneNextSubPane As Integer = 1062
+        Private Const CmdIdPanePrevSubPane As Integer = 1063
+        Private Const CmdIdPaneNextPane As Integer = 316
+        Private Const CmdIdPanePrevPane As Integer = 317
+        Private Const CmdIdPaneNextTab As Integer = 286
+        Private Const CmdIdPanePrevTab As Integer = 287
+        Private Const CmdIdCloseDocument As Integer = 658
         'case cmdidPaneCloseToolWindow
         'case cmdidPaneActivateDocWindow
-        Private Const s_cmdidCloseAllDocuments As Integer = 627
-        Private Const s_cmdidNextDocumentNav As Integer = 1124
-        Private Const s_cmdidPrevDocumentNav As Integer = 1125
-        Private Const s_cmdidNextDocument As Integer = 628
-        Private Const s_cmdidPrevDocument As Integer = 629
-        Private Const s_cmdidSaveSolution As Integer = 224
+        Private Const CmdIdCloseAllDocuments As Integer = 627
+        Private Const CmdIdNextDocumentNav As Integer = 1124
+        Private Const CmdIdPrevDocumentNav As Integer = 1125
+        Private Const CmdIdNextDocument As Integer = 628
+        Private Const CmdIdPrevDocument As Integer = 629
+        Private Const CmdIdSaveSolution As Integer = 224
 
         ''' <summary>
         ''' Executes a specified command or displays help for a command.
@@ -83,7 +83,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                         'Execute a Save for the App Designer (saves all DocData pages)
                         Return HrSaveProjectDesigner()
 
-                    Case s_cmdidSaveSolution
+                    Case CmdIdSaveSolution
                         Common.Switches.TracePDCmdTarget(TraceLevel.Warning, "  Peeking: cmdidSaveSolution")
 
                         'There are scenarios with some property pages where a page doesn't get saved properly
@@ -104,7 +104,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                         Return NativeMethods.S_OK
 
 
-                    Case Constants.MenuConstants.cmdidFileClose, s_cmdidCloseDocument
+                    Case Constants.MenuConstants.cmdidFileClose, CmdIdCloseDocument
                         'cmdidFileClose = File.CLose
                         'cmdidCloseDocument = CTRL+F4 or right-click Close on the MDI tab
 
@@ -118,7 +118,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                         _windowPane.ClosePromptSave()
                         Return NativeMethods.S_OK
 
-                    Case s_cmdidCloseAllDocuments
+                    Case CmdIdCloseAllDocuments
                         'There are scenarios with some property pages where a page doesn't get saved properly
                         '  with pending changes if all documents are closed.  This makes sure things get saved
                         '  properly.
@@ -130,12 +130,12 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                         'Now let the shell do its normal processing of this command
                         Return NativeMethods.OLECMDERR_E_NOTSUPPORTED
 
-                    Case s_cmdidPaneNextTab 'Window.NextTab (CTRL+PGDN by default) - move to the next tab in the project designer
+                    Case CmdIdPaneNextTab 'Window.NextTab (CTRL+PGDN by default) - move to the next tab in the project designer
                         Common.Switches.TracePDCmdTarget(TraceLevel.Warning, "  Handling: cmdidPaneNextTab")
                         _windowPane.NextTab()
                         Return NativeMethods.S_OK
 
-                    Case s_cmdidPanePrevTab 'Window.PrevTab (CTRL+PGUP by default) - move to the previous tab in the project designer
+                    Case CmdIdPanePrevTab 'Window.PrevTab (CTRL+PGUP by default) - move to the previous tab in the project designer
                         Common.Switches.TracePDCmdTarget(TraceLevel.Warning, "  Handling: cmdidPanePrevTab")
                         _windowPane.PrevTab()
                         Return NativeMethods.S_OK
@@ -215,12 +215,12 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                         prgCmds(0).cmdf = Supported Or Invisible 'CONSIDER: Invisible doesn't seem to work, but it does at least get disabled
                         Return NativeMethods.S_OK
 
-                    Case Constants.MenuConstants.cmdidFileClose, s_cmdidCloseDocument
+                    Case Constants.MenuConstants.cmdidFileClose, CmdIdCloseDocument
                         Common.Switches.TracePDCmdTarget(TraceLevel.Info, "  Query: cmdidFileClose, cmdidCloseDocument")
                         prgCmds(0).cmdf = Supported Or Enabled
                         Return NativeMethods.S_OK
 
-                    Case s_cmdidPaneNextTab, s_cmdidPanePrevTab
+                    Case CmdIdPaneNextTab, CmdIdPanePrevTab
                         Common.Switches.TracePDCmdTarget(TraceLevel.Info, "  Query: cmdidPaneNextTab or cmdidPanePrevTab")
                         prgCmds(0).cmdf = Supported Or Enabled
                         Return NativeMethods.S_OK

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabControlRenderer.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabControlRenderer.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Common = Microsoft.VisualStudio.Editors.AppDesCommon
 Imports Microsoft.VisualStudio.Shell.Interop
@@ -77,24 +77,24 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         'The top Y position for the topmost button
         Private _buttonsLocationY As Integer 'Start y location
         'Smallest text width to allow for in the buttons, even if all of the buttons have text wider than this value
-        Private Const s_minimumButtonTextWidthSpace As Integer = 25
+        Private Const MinimumButtonTextWidthSpace As Integer = 25
 
         'The width and height to use for all of the buttons.
-        Private Const s_defaultButtonHeight = 24
+        Private Const DefaultButtonHeight = 24
         Private _buttonHeight As Integer
         Private _buttonWidth As Integer
 
-        Private Const s_buttonTextLeftOffset As Integer = 8 'Padding from left side of the button to where the tab text is drawn
-        Private Const s_buttonTextRightSpace As Integer = 8 'Extra space to leave after tab text
+        Private Const ButtonTextLeftOffset As Integer = 8 'Padding from left side of the button to where the tab text is drawn
+        Private Const ButtonTextRightSpace As Integer = 8 'Extra space to leave after tab text
         Private _visibleButtonSlots As Integer '# of button positions we are currently displaying (min = 1), the rest go into overflow when not enough room
         Private _buttonPagePadding As Padding
 
         'The width/height of the downward-slanting line underneath the buttons (not including the two curved ends' (arcs') width/height)
 
-        Private Const s_buttonBorderWidth As Integer = 1   'Thickness of each half of the separators between buttons
+        Private Const ButtonBorderWidth As Integer = 1   'Thickness of each half of the separators between buttons
 
-        Private Const s_overflowButtonTopOffset As Integer = 2 'Offset of overflow button (the button's edge, not the glyph inside it) from the bottom of the bottommost button
-        Private Const s_overflowButtonRightOffset As Integer = 2 'Offset of right edge of overflow button from vertical line 3
+        Private Const OverflowButtonTopOffset As Integer = 2 'Offset of overflow button (the button's edge, not the glyph inside it) from the bottom of the bottommost button
+        Private Const OverflowButtonRightOffset As Integer = 2 'Offset of right edge of overflow button from vertical line 3
 
         Private _tabControlRect As Rectangle 'The entire area of the tab control, including the tabs and panel area
 
@@ -379,7 +379,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                 maxTextHeight = Math.Max(size.Height, maxTextHeight)
             Next button
 
-            Return New Size(Math.Max(maxTextWidth + s_buttonTextRightSpace, s_minimumButtonTextWidthSpace), maxTextHeight) 'Add buffer for right hand side
+            Return New Size(Math.Max(maxTextWidth + ButtonTextRightSpace, MinimumButtonTextWidthSpace), maxTextHeight) 'Add buffer for right hand side
         End Function
 
         ''' <summary>
@@ -395,7 +395,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             Dim largestButtonTextSize As Size = GetLargestButtonTextSize()
 
             ' Calculate the height of the tab button, we either take the max of either the default size or the text size + padding. 
-            _buttonHeight = Math.Max(largestButtonTextSize.Height + _buttonPagePadding.Vertical, s_defaultButtonHeight)
+            _buttonHeight = Math.Max(largestButtonTextSize.Height + _buttonPagePadding.Vertical, DefaultButtonHeight)
 
             'Now calculate the minimum width 
             minimumWidth = _owner.HostingPanel.MinimumSize.Width + 1 + _buttonPagePadding.Right + 1
@@ -507,9 +507,9 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
 #End If
 
             'Now calculate the position of the overflow button, and whether it should be visible
-            _owner.OverflowButton.Location = New Point( _
-                _buttonsLocationX + _buttonWidth - s_overflowButtonTopOffset - _owner.OverflowButton.Width, _
-                _buttonsLocationY + _visibleButtonSlots * _buttonHeight + s_overflowButtonTopOffset)
+            _owner.OverflowButton.Location = New Point(
+                _buttonsLocationX + _buttonWidth - OverflowButtonTopOffset - _owner.OverflowButton.Width,
+                _buttonsLocationY + _visibleButtonSlots * _buttonHeight + OverflowButtonTopOffset)
             _owner.OverflowButton.Visible = OverflowNeeded
         End Sub
 
@@ -612,7 +612,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                 g.DrawRectangle(borderPen, New Rectangle(0, 0, triangleHorizontalStart, button.Height - 1))
             End If
 
-            Dim textRect As New Rectangle(s_buttonTextLeftOffset, 0, button.Width - s_buttonTextLeftOffset, button.Height)
+            Dim textRect As New Rectangle(ButtonTextLeftOffset, 0, button.Width - ButtonTextLeftOffset, button.Height)
             TextRenderer.DrawText(g, button.TextWithDirtyIndicator, button.Font, textRect, foregroundColor, TextFormatFlags.Left Or TextFormatFlags.SingleLine Or TextFormatFlags.VerticalCenter)
         End Sub 'RenderButton 
 

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/PropertyPageInfo.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/PropertyPageInfo.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Common = Microsoft.VisualStudio.Editors.AppDesCommon
 Imports Microsoft.VisualStudio.Editors.AppDesInterop
@@ -25,10 +25,8 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         Private _parentView As ApplicationDesignerView 'The owning application designer view
         Private _loadAlreadyAttempted As Boolean 'Whether or not we've attempted to load this property page
 
-        Private Const s_REGKEY_CachedPageTitles As String = "\ProjectDesigner\CachedPageTitles"
-        Private Const s_REGVALUE_CachedLocaleId As String = "LocaleID"
-
-
+        Private Const REGKEY_CachedPageTitles As String = "\ProjectDesigner\CachedPageTitles"
+        Private Const REGVALUE_CachedLocaleId As String = "LocaleID"
 
         ''' <summary>
         ''' Constructor
@@ -209,7 +207,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                 'Cache the title for future use
                 CachedTitle = _info.pszTitle
 
-            Catch Ex As Exception When Common.ReportWithoutCrash(ex, NameOf(TryLoadPropertyPage), NameOf(PropertyPageInfo))
+            Catch Ex As Exception When Common.ReportWithoutCrash(Ex, NameOf(TryLoadPropertyPage), NameOf(PropertyPageInfo))
                 If _comPropPageInstance IsNot Nothing Then
                     'IPropertyPage.GetPageInfo probably failed - if that didn't 
                     ' succeed, then nothing much else will likely work on the page either
@@ -298,7 +296,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <remarks></remarks>
         Private Property CachedTitle() As String
             Get
-                Dim KeyPath As String = _parentView.DTEProject.DTE.RegistryRoot & s_REGKEY_CachedPageTitles
+                Dim KeyPath As String = _parentView.DTEProject.DTE.RegistryRoot & REGKEY_CachedPageTitles
                 Dim Key As Win32.RegistryKey = Nothing
                 Try
                     Key = Win32.Registry.CurrentUser.OpenSubKey(KeyPath)
@@ -325,7 +323,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                 End If
                 Dim Key As Win32.RegistryKey = Nothing
                 Try
-                    Key = Win32.Registry.CurrentUser.CreateSubKey(_parentView.DTEProject.DTE.RegistryRoot & s_REGKEY_CachedPageTitles)
+                    Key = Win32.Registry.CurrentUser.CreateSubKey(_parentView.DTEProject.DTE.RegistryRoot & REGKEY_CachedPageTitles)
                     If Key IsNot Nothing Then
                         Key.SetValue(CachedTitleValueName, value, Win32.RegistryValueKind.String)
                     End If

--- a/src/Microsoft.VisualStudio.AppDesigner/Common/DTEUtils.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/Common/DTEUtils.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports EnvDTE
 Imports Microsoft.VisualStudio.Shell.Interop
@@ -15,8 +15,8 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
 
         'The relevant project property names
 
-        Private Const s_PROJECTPROPERTY_MSBUILD_ITEMTYPE As String = "ItemType"
-        Private Const s_PROJECTPROPERTY_BUILDACTION As String = "BuildAction"
+        Private Const PROJECTPROPERTY_MSBUILD_ITEMTYPE As String = "ItemType"
+        Private Const PROJECTPROPERTY_BUILDACTION As String = "BuildAction"
 
         ''' <summary>
         ''' This is a shared class - disallow instantation.
@@ -154,7 +154,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <param name="Item">The ProjectItem on which to set the property</param>
         ''' <remarks></remarks>
         Public Shared Sub SetBuildAction(Item As ProjectItem, BuildAction As VSLangProj.prjBuildAction)
-            Dim BuildActionProperty As [Property] = GetProjectItemProperty(Item, s_PROJECTPROPERTY_BUILDACTION)
+            Dim BuildActionProperty As [Property] = GetProjectItemProperty(Item, PROJECTPROPERTY_BUILDACTION)
             If BuildActionProperty IsNot Nothing Then
                 BuildActionProperty.Value = BuildAction
             End If
@@ -167,7 +167,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <param name="Item">The ProjectItem on which to set the property</param>
         ''' <remarks></remarks>
         Public Shared Function GetBuildAction(Item As ProjectItem) As VSLangProj.prjBuildAction
-            Dim BuildActionProperty As [Property] = GetProjectItemProperty(Item, s_PROJECTPROPERTY_BUILDACTION)
+            Dim BuildActionProperty As [Property] = GetProjectItemProperty(Item, PROJECTPROPERTY_BUILDACTION)
             If BuildActionProperty IsNot Nothing Then
                 Return CType(BuildActionProperty.Value, VSLangProj.prjBuildAction)
             End If
@@ -186,7 +186,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' </remarks>
         Public Shared Sub SetBuildActionAsString(item As ProjectItem, buildAction As String)
 
-            Dim BuildActionProperty As [Property] = GetProjectItemProperty(item, s_PROJECTPROPERTY_MSBUILD_ITEMTYPE)
+            Dim BuildActionProperty As [Property] = GetProjectItemProperty(item, PROJECTPROPERTY_MSBUILD_ITEMTYPE)
             If BuildActionProperty IsNot Nothing Then
                 BuildActionProperty.Value = buildAction
             End If
@@ -199,7 +199,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <param name="Item">The ProjectItem on which to set the property</param>
         ''' <remarks></remarks>
         Public Shared Function GetBuildActionAsString(Item As ProjectItem) As String
-            Dim BuildActionProperty As [Property] = GetProjectItemProperty(Item, s_PROJECTPROPERTY_MSBUILD_ITEMTYPE)
+            Dim BuildActionProperty As [Property] = GetProjectItemProperty(Item, PROJECTPROPERTY_MSBUILD_ITEMTYPE)
             If BuildActionProperty IsNot Nothing Then
                 Return CType(BuildActionProperty.Value, String)
             End If

--- a/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel.Design
 Imports System.Drawing
@@ -22,7 +22,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         Public VBPackageInstance As IVBPackage = Nothing
 
         ' The maximal amount of files that can be added at one shot. (copied from other VS features)
-        Private Const s_VSDPLMAXFILES As Integer = 200
+        Private Const VSDPLMAXFILES As Integer = 200
 
         'Property page GUIDs.  These are used only for sorting the tabs in the project designer, and for providing a
         '  unique ID for SQM.  Both cases are optional (we handle getting property pages with GUIDs we don't recognize).
@@ -248,7 +248,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <remarks></remarks>
         Public Function IsCheckoutCanceledException(ex As Exception) As Boolean
             If (TypeOf ex Is CheckoutException AndAlso ex.Equals(CheckoutException.Canceled)) _
-                OrElse _
+                OrElse
                 (TypeOf ex Is COMException AndAlso DirectCast(ex, COMException).ErrorCode = AppDesInterop.win.OLE_E_PROMPTSAVECANCELLED) _
             Then
                 Return True
@@ -458,13 +458,13 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <param name="NeedThrowError">Throw error when the dialog fails unexpectedly</param>
         ''' <returns>a collection of files</returns>
         ''' <remarks></remarks>
-        Public Function GetFilesViaBrowse(ServiceProvider As IServiceProvider, ParentWindow As IntPtr, _
-                InitialDirectory As String, DialogTitle As String, _
-                Filter As String, FilterIndex As UInteger, MutiSelect As Boolean, _
-                Optional DefaultFileName As String = Nothing, _
+        Public Function GetFilesViaBrowse(ServiceProvider As IServiceProvider, ParentWindow As IntPtr,
+                InitialDirectory As String, DialogTitle As String,
+                Filter As String, FilterIndex As UInteger, MutiSelect As Boolean,
+                Optional DefaultFileName As String = Nothing,
                 Optional NeedThrowError As Boolean = False) As ArrayList
 
-            Dim uishell As Interop.IVsUIShell = _
+            Dim uishell As Interop.IVsUIShell =
                 CType(ServiceProvider.GetService(GetType(Interop.IVsUIShell)), Interop.IVsUIShell)
 
             Dim fileNames As New ArrayList()
@@ -478,7 +478,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
 
             Dim MaxPathName As Integer = AppDesInterop.win.MAX_PATH + 1
             If MutiSelect Then
-                MaxPathName = (AppDesInterop.win.MAX_PATH + 1) * s_VSDPLMAXFILES
+                MaxPathName = (AppDesInterop.win.MAX_PATH + 1) * VSDPLMAXFILES
             End If
 
             Dim vsOpenFileName As Interop.VSOPENFILENAMEW()

--- a/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/DesignerMessageBox.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/DesignerMessageBox.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.VisualStudio.Shell.Interop
 Imports System.Windows.Forms
@@ -16,7 +16,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
     ' This class is converted from <DD>\wizard\vsdesigner\designer\microsoft\vsdesigner\VSDMessageBox.cs.
     Public Class DesignerMessageBox
 
-        Private Const s_maxErrorMessageLength As Integer = 600
+        Private Const MaxErrorMessageLength As Integer = 600
 
         '= Public =============================================================
 
@@ -28,10 +28,10 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         ''' <param name="Caption">The text to display in the title bar of the message box.</param>
         ''' <param name="HelpLink">Link to the help topic for this message box.</param>
         ''' <remarks></remarks>
-        Public Shared Function Show(RootDesigner As BaseRootDesigner, Message As String, _
-                Caption As String, Buttons As MessageBoxButtons, Icon As MessageBoxIcon, _
-                Optional DefaultButton As MessageBoxDefaultButton = MessageBoxDefaultButton.Button1, _
-                Optional HelpLink As String = Nothing _
+        Public Shared Function Show(RootDesigner As BaseRootDesigner, Message As String,
+                Caption As String, Buttons As MessageBoxButtons, Icon As MessageBoxIcon,
+                Optional DefaultButton As MessageBoxDefaultButton = MessageBoxDefaultButton.Button1,
+                Optional HelpLink As String = Nothing
         ) As DialogResult
             Return Show(DirectCast(RootDesigner, IServiceProvider), Message, Caption, Buttons, Icon, DefaultButton, HelpLink)
         End Function 'Show
@@ -45,7 +45,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         ''' <param name="Caption">The text to display in the title bar of the message box.</param>
         ''' <param name="HelpLink">Link to the help topic for this message box.</param>
         ''' <remarks></remarks>
-        Public Shared Sub Show(ServiceProvider As IServiceProvider, ex As Exception, _
+        Public Shared Sub Show(ServiceProvider As IServiceProvider, ex As Exception,
                 Caption As String, Optional HelpLink As String = Nothing)
             Show(ServiceProvider, Nothing, ex, Caption, HelpLink)
         End Sub
@@ -62,7 +62,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         ''' <remarks>
         ''' The exception's message will be on a second line after errorMessage.
         ''' </remarks>
-        Public Shared Sub Show(ServiceProvider As IServiceProvider, Message As String, ex As Exception, _
+        Public Shared Sub Show(ServiceProvider As IServiceProvider, Message As String, ex As Exception,
                 Caption As String, Optional HelpLink As String = Nothing)
 
             If ex Is Nothing Then
@@ -94,8 +94,8 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
                 End If
 
                 ' limit the length of message to prevent a bad layout.
-                If Message.Length > s_maxErrorMessageLength Then
-                    Message = Message.Substring(0, s_maxErrorMessageLength)
+                If Message.Length > MaxErrorMessageLength Then
+                    Message = Message.Substring(0, MaxErrorMessageLength)
                 End If
             Else
                 Debug.Assert(Message <> "")

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropertyPageSerializationService_Store.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropertyPageSerializationService_Store.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel
 Imports System.ComponentModel.Design
@@ -103,8 +103,8 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
 #Region "ISerialization implementation"
 
             'Serialization keys for ISerializable
-            Private Const s_KEY_STATE As String = "State"
-            Private Const s_KEY_OBJECTNAMES As String = "ObjectNames"
+            Private Const KEY_STATE As String = "State"
+            Private Const KEY_OBJECTNAMES As String = "ObjectNames"
 
             ''' <summary>
             '''     Implements the save part of ISerializable.
@@ -114,7 +114,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             ''' <param name="context">Serialization context</param>
             ''' <remarks></remarks>
             Private Sub GetObjectData(info As SerializationInfo, context As StreamingContext) Implements ISerializable.GetObjectData
-                info.AddValue(s_KEY_STATE, _serializedState)
+                info.AddValue(KEY_STATE, _serializedState)
             End Sub
 
 
@@ -126,7 +126,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             ''' <param name="Context">Serialization context</param>
             ''' <remarks></remarks>
             Private Sub New(Info As SerializationInfo, Context As StreamingContext)
-                _serializedState = DirectCast(Info.GetValue(s_KEY_STATE, GetType(ArrayList)), ArrayList)
+                _serializedState = DirectCast(Info.GetValue(KEY_STATE, GetType(ArrayList)), ArrayList)
             End Sub
 
 #End Region
@@ -350,7 +350,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
 
             End Function
 
-            Private Const s_const_Configuration As String = "{Configuration}"
+            Private Const Const_Configuration As String = "{Configuration}"
 
             Private Sub SetProperty(component As Component, PropertyName As String, Value As Object)
                 Dim View As PropPageDesignerView

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPage.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPage.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel.Design
 Imports Common = Microsoft.VisualStudio.Editors.AppDesCommon
@@ -102,7 +102,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Private _propPage As Control
         Private _pageSite As IPropertyPageSite
         Private ReadOnly _isDirty As Boolean
-        Private Const s_SW_HIDE As Integer = 0
+        Private Const SW_HIDE As Integer = 0
         Private _size As Drawing.Size
         Private _defaultSize As Drawing.Size
         Private _docString As String
@@ -503,7 +503,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
             ' if we're in native, show/hide our secret scrolling panel too
             ' See Create(hWnd) for more info on where that comes from
-            If nCmdShow <> s_SW_HIDE Then
+            If nCmdShow <> SW_HIDE Then
                 If _hostedInNative Then
                     _propPage.Parent.Show()
                 End If

--- a/src/Microsoft.VisualStudio.AppDesigner/VSProductSKU.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/VSProductSKU.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Common = Microsoft.VisualStudio.Editors.AppDesCommon
 Imports Interop = Microsoft.VisualStudio.Editors.AppDesInterop
@@ -45,8 +45,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Web = &H40 'from vsappid80.idl
         End Enum
 
-        Private Const s_VSAPROPID_SKUEdition As Integer = -8534
-        Private Const s_VSAPROPID_SubSKUEdition As Integer = -8546
+        Private Const VSAPROPID_SKUEdition As Integer = -8534
+        Private Const VSAPROPID_SubSKUEdition As Integer = -8546
 
 
         ''' <summary>
@@ -211,11 +211,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             VsAppIdService = TryCast(ServiceProvider.GetService(GetType(Interop.IVsAppId)), Interop.IVsAppId)
             If VsAppIdService IsNot Nothing Then
                 Try
-                    hr = VsAppIdService.GetProperty(s_VSAPROPID_SKUEdition, objSKU)
+                    hr = VsAppIdService.GetProperty(VSAPROPID_SKUEdition, objSKU)
                     If hr >= 0 AndAlso (TypeOf objSKU Is Integer) Then
                         s_productSKU = DirectCast(CInt(objSKU), VSASKUEdition)
                     End If
-                    hr = VsAppIdService.GetProperty(s_VSAPROPID_SubSKUEdition, objSubSKU)
+                    hr = VsAppIdService.GetProperty(VSAPROPID_SubSKUEdition, objSubSKU)
                     If hr >= 0 AndAlso (TypeOf objSubSKU Is Integer) Then
                         s_productSubSKU = DirectCast(CInt(objSubSKU), VSASubSKUEdition)
                     End If

--- a/src/Microsoft.VisualStudio.AppDesigner/VisualStudioEditorsID.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/VisualStudioEditorsID.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel.Design
 
@@ -27,15 +27,15 @@ Namespace Microsoft.VisualStudio.Editors
 
             Friend Shared ReadOnly guidVSStd97 As Guid = s_CMDSETID_StandardCommandSet97
             Friend Shared ReadOnly guidVSStd2K As Guid = s_CMDSETID_StandardCommandSet2K
-            Private Const s_cmdidCopy As Integer = 15
-            Private Const s_cmdidCut As Integer = 16
+            Private Const CmdIdCopy As Integer = 15
+            Private Const CmdIdCut As Integer = 16
             Friend Const cmdidFileClose As Integer = 223
             Friend Const cmdidSave As Integer = 110
             Friend Const cmdidSaveAs As Integer = 111
             Friend Const cmdidSaveProjectItemAs As Integer = 226
             Friend Const cmdidSaveProjectItem As Integer = 331
 
-            Friend Shared ReadOnly CommandIDVSStd97cmdidCut As New CommandID(guidVSStd97, s_cmdidCut)
+            Friend Shared ReadOnly CommandIDVSStd97cmdidCut As New CommandID(guidVSStd97, CmdIdCut)
 
             ' GUID constants.
 

--- a/src/Microsoft.VisualStudio.AppDesigner/interop/NativeMethods.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/interop/NativeMethods.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Runtime.InteropServices
 Imports Microsoft.VisualStudio.OLE.Interop
@@ -9,8 +9,8 @@ Namespace Microsoft.VisualStudio.Editors.AppDesInterop
     <ComVisible(False)> _
     Friend NotInheritable Class NativeMethods
 
-        Private Const s_VB_COMPILER_GUID As String = "019971d6-4685-11d2-b48a-0000f87572eb"
-        Public Shared ReadOnly VBCompilerGuid As Guid = New Guid(s_VB_COMPILER_GUID)
+        Private Const VB_COMPILER_GUID As String = "019971d6-4685-11d2-b48a-0000f87572eb"
+        Public Shared ReadOnly VBCompilerGuid As Guid = New Guid(VB_COMPILER_GUID)
 
         '/ <summary>
         '/     Handle type for HDC's that count against the Win98 limit of five DC's.  HDC's

--- a/src/Microsoft.VisualStudio.Editors/Common/DTEUtils.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/DTEUtils.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports EnvDTE
 Imports Microsoft.VisualStudio.Shell.Interop
@@ -18,8 +18,8 @@ Namespace Microsoft.VisualStudio.Editors.Common
         Public Const PROJECTPROPERTY_CUSTOMTOOL As String = "CustomTool"
         Public Const PROJECTPROPERTY_CUSTOMTOOLNAMESPACE As String = "CustomToolNamespace"
 
-        Private Const s_PROJECTPROPERTY_MSBUILD_ITEMTYPE As String = "ItemType"
-        Private Const s_PROJECTPROPERTY_BUILDACTION As String = "BuildAction"
+        Private Const PROJECTPROPERTY_MSBUILD_ITEMTYPE As String = "ItemType"
+        Private Const PROJECTPROPERTY_BUILDACTION As String = "BuildAction"
 
         ''' <summary>
         ''' This is a shared class - disallow instantation.
@@ -239,7 +239,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <param name="Item">The ProjectItem on which to set the property</param>
         ''' <remarks></remarks>
         Public Shared Sub SetBuildAction(Item As ProjectItem, BuildAction As VSLangProj.prjBuildAction)
-            Dim BuildActionProperty As [Property] = GetProjectItemProperty(Item, s_PROJECTPROPERTY_BUILDACTION)
+            Dim BuildActionProperty As [Property] = GetProjectItemProperty(Item, PROJECTPROPERTY_BUILDACTION)
             If BuildActionProperty IsNot Nothing Then
                 BuildActionProperty.Value = BuildAction
             End If
@@ -252,7 +252,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <param name="Item">The ProjectItem on which to set the property</param>
         ''' <remarks></remarks>
         Public Shared Function GetBuildAction(Item As ProjectItem) As VSLangProj.prjBuildAction
-            Dim BuildActionProperty As [Property] = GetProjectItemProperty(Item, s_PROJECTPROPERTY_BUILDACTION)
+            Dim BuildActionProperty As [Property] = GetProjectItemProperty(Item, PROJECTPROPERTY_BUILDACTION)
             If BuildActionProperty IsNot Nothing Then
                 Return CType(BuildActionProperty.Value, VSLangProj.prjBuildAction)
             End If
@@ -271,7 +271,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' </remarks>
         Public Shared Sub SetBuildActionAsString(item As ProjectItem, buildAction As String)
 
-            Dim BuildActionProperty As [Property] = GetProjectItemProperty(item, s_PROJECTPROPERTY_MSBUILD_ITEMTYPE)
+            Dim BuildActionProperty As [Property] = GetProjectItemProperty(item, PROJECTPROPERTY_MSBUILD_ITEMTYPE)
             If BuildActionProperty IsNot Nothing Then
                 BuildActionProperty.Value = buildAction
             End If
@@ -284,7 +284,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <param name="Item">The ProjectItem on which to set the property</param>
         ''' <remarks></remarks>
         Public Shared Function GetBuildActionAsString(Item As ProjectItem) As String
-            Dim BuildActionProperty As [Property] = GetProjectItemProperty(Item, s_PROJECTPROPERTY_MSBUILD_ITEMTYPE)
+            Dim BuildActionProperty As [Property] = GetProjectItemProperty(Item, PROJECTPROPERTY_MSBUILD_ITEMTYPE)
             If BuildActionProperty IsNot Nothing Then
                 Return CType(BuildActionProperty.Value, String)
             End If

--- a/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
 
 
         ' The maximal amount of files that can be added at one shot. (copied from other VS features)
-        Private Const s_VSDPLMAXFILES As Integer = 200
+        Private Const VSDPLMAXFILES As Integer = 200
 
         Private s_imageService As IVsImageService2
 
@@ -700,7 +700,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
 
             Dim MaxPathName As Integer = win.MAX_PATH + 1
             If MutiSelect Then
-                MaxPathName = (win.MAX_PATH + 1) * s_VSDPLMAXFILES
+                MaxPathName = (win.MAX_PATH + 1) * VSDPLMAXFILES
             End If
 
             Dim vsOpenFileName As VSOPENFILENAMEW()

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerMessageBox.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerMessageBox.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.VisualStudio.Shell.Interop
 Imports System.Windows.Forms
@@ -16,7 +16,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
     ' This class is converted from <DD>\wizard\vsdesigner\designer\microsoft\vsdesigner\VSDMessageBox.cs.
     Friend Class DesignerMessageBox
 
-        Private Const s_maxErrorMessageLength As Integer = 600
+        Private Const MaxErrorMessageLength As Integer = 600
 
         '= FRIEND =============================================================
 
@@ -28,10 +28,10 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="Caption">The text to display in the title bar of the message box.</param>
         ''' <param name="HelpLink">Link to the help topic for this message box.</param>
         ''' <remarks></remarks>
-        Friend Shared Function Show(RootDesigner As BaseRootDesigner, Message As String, _
-                Caption As String, Buttons As MessageBoxButtons, Icon As MessageBoxIcon, _
-                Optional DefaultButton As MessageBoxDefaultButton = MessageBoxDefaultButton.Button1, _
-                Optional HelpLink As String = Nothing _
+        Friend Shared Function Show(RootDesigner As BaseRootDesigner, Message As String,
+                Caption As String, Buttons As MessageBoxButtons, Icon As MessageBoxIcon,
+                Optional DefaultButton As MessageBoxDefaultButton = MessageBoxDefaultButton.Button1,
+                Optional HelpLink As String = Nothing
         ) As DialogResult
             Return Show(DirectCast(RootDesigner, IServiceProvider), Message, Caption, Buttons, Icon, DefaultButton, HelpLink)
         End Function 'Show
@@ -45,7 +45,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="Caption">The text to display in the title bar of the message box.</param>
         ''' <param name="HelpLink">Link to the help topic for this message box.</param>
         ''' <remarks></remarks>
-        Friend Shared Sub Show(ServiceProvider As IServiceProvider, ex As Exception, _
+        Friend Shared Sub Show(ServiceProvider As IServiceProvider, ex As Exception,
                 Caption As String, Optional HelpLink As String = Nothing)
             Show(ServiceProvider, Nothing, ex, Caption, HelpLink)
         End Sub
@@ -62,7 +62,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <remarks>
         ''' The exception's message will be on a second line after errorMessage.
         ''' </remarks>
-        Friend Shared Sub Show(ServiceProvider As IServiceProvider, Message As String, ex As Exception, _
+        Friend Shared Sub Show(ServiceProvider As IServiceProvider, Message As String, ex As Exception,
                 Caption As String, Optional HelpLink As String = Nothing)
 
             If ex Is Nothing Then
@@ -94,8 +94,8 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                 End If
 
                 ' limit the length of message to prevent a bad layout.
-                If Message.Length > s_maxErrorMessageLength Then
-                    Message = Message.Substring(0, s_maxErrorMessageLength)
+                If Message.Length > MaxErrorMessageLength Then
+                    Message = Message.Substring(0, MaxErrorMessageLength)
                 End If
             Else
                 Debug.Assert(Message <> "")

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/GenericComponentSerializationStore.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/GenericComponentSerializationStore.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel
 Imports System.ComponentModel.Design.Serialization
@@ -84,7 +84,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
 #Region "ISerialization implementation"
 
         'Serialization keys for ISerializable
-        Private Const s_KEY_STATE As String = "State"
+        Private Const KEY_STATE As String = "State"
 
         ''' <summary>
         '''     Implements the save part of ISerializable.
@@ -93,9 +93,9 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="info">Serialization info</param>
         ''' <param name="context">Serialization context</param>
         ''' <remarks></remarks>
-        <Security.Permissions.SecurityPermission(Security.Permissions.SecurityAction.Demand, SerializationFormatter:=True)> _
+        <Security.Permissions.SecurityPermission(Security.Permissions.SecurityAction.Demand, SerializationFormatter:=True)>
         Public Sub GetObjectData(info As SerializationInfo, context As StreamingContext) Implements ISerializable.GetObjectData
-            info.AddValue(s_KEY_STATE, _serializedState)
+            info.AddValue(KEY_STATE, _serializedState)
         End Sub
 
 
@@ -107,7 +107,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="Context">Serialization context</param>
         ''' <remarks></remarks>
         Private Sub New(Info As SerializationInfo, Context As StreamingContext)
-            _serializedState = DirectCast(Info.GetValue(s_KEY_STATE, GetType(ArrayList)), ArrayList)
+            _serializedState = DirectCast(Info.GetValue(KEY_STATE, GetType(ArrayList)), ArrayList)
         End Sub
 
 #End Region

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/ThemedBorderUserControl.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/ThemedBorderUserControl.vb
@@ -7,8 +7,8 @@ Imports System.Windows.Forms.VisualStyles
 Namespace Microsoft.VisualStudio.Editors.DesignerFramework
     Friend Class ThemedBorderUserControl
         Private _borderPen As Pen
-        Private Const s_WS_EX_CLIENTEDGE As Integer = &H200
-        Private Const s_WS_BORDER As Integer = &H800000
+        Private Const WS_EX_CLIENTEDGE As Integer = &H200
+        Private Const WS_BORDER As Integer = &H800000
 
         Public Sub New()
             _borderPen = New Pen(VisualStyleInformation.TextControlBorder)
@@ -17,15 +17,15 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         Protected Overrides ReadOnly Property CreateParams() As CreateParams
             Get
                 Dim cp As CreateParams = MyBase.CreateParams
-                cp.ExStyle = cp.ExStyle And Not s_WS_EX_CLIENTEDGE
-                cp.Style = cp.Style And Not s_WS_BORDER
+                cp.ExStyle = cp.ExStyle And Not WS_EX_CLIENTEDGE
+                cp.Style = cp.Style And Not WS_BORDER
                 If Not UseVisualStyles Then
 
                     Select Case BorderStyle
                         Case BorderStyle.Fixed3D
-                            cp.ExStyle = cp.ExStyle Or s_WS_EX_CLIENTEDGE
+                            cp.ExStyle = cp.ExStyle Or WS_EX_CLIENTEDGE
                         Case BorderStyle.FixedSingle
-                            cp.Style = cp.Style Or s_WS_BORDER
+                            cp.Style = cp.Style Or WS_BORDER
                     End Select
                 End If
                 Return cp

--- a/src/Microsoft.VisualStudio.Editors/DesignerUI/VisualStudioEditorsID.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerUI/VisualStudioEditorsID.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel.Design
 
@@ -23,10 +23,10 @@ Namespace Microsoft.VisualStudio.Editors
             ' Menu IDs (0x01??)
             ' *********************************************************************
 
-            Private Const s_IDM_CTX_RESX_ContextMenu As Integer = &H100
-            Private Const s_IDM_VS_MENU_Resources As Integer = &H105
-            Private Const s_IDM_CTX_SETTINGSDESIGNER_ContextMenu As Integer = &H110
-            Private Const s_IDM_VS_MNUCTRL_NAVIGATE As Integer = &H106
+            Private Const IDM_CTX_RESX_ContextMenu As Integer = &H100
+            Private Const IDM_VS_MENU_Resources As Integer = &H105
+            Private Const IDM_CTX_SETTINGSDESIGNER_ContextMenu As Integer = &H110
+            Private Const IDM_VS_MNUCTRL_NAVIGATE As Integer = &H106
             Public Const IDM_VS_TOOLBAR_Settings As Integer = &H210
             Public Const IDM_VS_TOOLBAR_Resources As Integer = &H211
             Public Const IDM_VS_TOOLBAR_Resources_ResW As Integer = &H212
@@ -41,51 +41,51 @@ Namespace Microsoft.VisualStudio.Editors
             ' Command IDs (0x2???)
             ' *********************************************************************
 
-            Private Const s_cmdidRESXImport As Integer = &H2003
-            Private Const s_cmdidRESXExport As Integer = &H2004
-            Private Const s_cmdidRESXPlay As Integer = &H2005
+            Private Const CmdIdRESXImport As Integer = &H2003
+            Private Const CmdIdRESXExport As Integer = &H2004
+            Private Const CmdIdRESXPlay As Integer = &H2005
 
-            Private Const s_cmdidRESXAddFixedMenuCommand As Integer = &H2019
-            Private Const s_cmdidRESXAddExistingFile As Integer = &H2020
-            Private Const s_cmdidRESXAddNewString As Integer = &H2021
-            Private Const s_cmdidRESXAddNewImagePNG As Integer = &H2022
-            Private Const s_cmdidRESXAddNewImageBMP As Integer = &H2023
-            Private Const s_cmdidRESXAddNewImageGIF As Integer = &H2024
-            Private Const s_cmdidRESXAddNewImageJPEG As Integer = &H2025
-            Private Const s_cmdidRESXAddNewImageTIFF As Integer = &H2026
-            Private Const s_cmdidRESXAddNewIcon As Integer = &H2027
-            Private Const s_cmdidRESXAddNewTextFile As Integer = &H2028
-            Private Const s_cmdidRESXAddDefaultResource As Integer = &H2030
+            Private Const CmdIdRESXAddFixedMenuCommand As Integer = &H2019
+            Private Const CmdIdRESXAddExistingFile As Integer = &H2020
+            Private Const CmdIdRESXAddNewString As Integer = &H2021
+            Private Const CmdIdRESXAddNewImagePNG As Integer = &H2022
+            Private Const CmdIdRESXAddNewImageBMP As Integer = &H2023
+            Private Const CmdIdRESXAddNewImageGIF As Integer = &H2024
+            Private Const CmdIdRESXAddNewImageJPEG As Integer = &H2025
+            Private Const CmdIdRESXAddNewImageTIFF As Integer = &H2026
+            Private Const CmdIdRESXAddNewIcon As Integer = &H2027
+            Private Const CmdIdRESXAddNewTextFile As Integer = &H2028
+            Private Const CmdIdRESXAddDefaultResource As Integer = &H2030
 
-            Private Const s_cmdidRESXResTypeStrings As Integer = &H2040
-            Private Const s_cmdidRESXResTypeImages As Integer = &H2041
-            Private Const s_cmdidRESXResTypeIcons As Integer = &H2042
-            Private Const s_cmdidRESXResTypeAudio As Integer = &H2043
-            Private Const s_cmdidRESXResTypeFiles As Integer = &H2044
-            Private Const s_cmdidRESXResTypeOther As Integer = &H2045
+            Private Const CmdIdRESXResTypeStrings As Integer = &H2040
+            Private Const CmdIdRESXResTypeImages As Integer = &H2041
+            Private Const CmdIdRESXResTypeIcons As Integer = &H2042
+            Private Const CmdIdRESXResTypeAudio As Integer = &H2043
+            Private Const CmdIdRESXResTypeFiles As Integer = &H2044
+            Private Const CmdIdRESXResTypeOther As Integer = &H2045
 
-            Private Const s_cmdidIDRESXViewsFixedMenuCommand As Integer = &H2018
-            Private Const s_cmdidRESXViewsList As Integer = &H2050
-            Private Const s_cmdidRESXViewsDetails As Integer = &H2051
-            Private Const s_cmdidRESXViewsThumbnails As Integer = &H2052
+            Private Const CmdIdIDRESXViewsFixedMenuCommand As Integer = &H2018
+            Private Const CmdIdRESXViewsList As Integer = &H2050
+            Private Const CmdIdRESXViewsDetails As Integer = &H2051
+            Private Const CmdIdRESXViewsThumbnails As Integer = &H2052
 
-            Private Const s_cmdidRESXGenericRemove As Integer = &H2060
+            Private Const CmdIdRESXGenericRemove As Integer = &H2060
 
-            Private Const s_cmdidRESXAccessModifierCombobox As Integer = &H2061
-            Private Const s_cmdidRESXGetAccessModifierOptions As Integer = &H2062
+            Private Const CmdIdRESXAccessModifierCombobox As Integer = &H2061
+            Private Const CmdIdRESXGetAccessModifierOptions As Integer = &H2062
 
-            Private Const s_cmdidSETTINGSDESIGNERViewCode As Integer = &H2104
-            Private Const s_cmdidSETTINGSDESIGNERSynchronize As Integer = &H2105
-            Private Const s_cmdidSETTINGSDESIGNERAccessModifierCombobox As Integer = &H2106
-            Private Const s_cmdidSETTINGSDESIGNERGetAccessModifierOptions As Integer = &H2107
-            Private Const s_cmdidSETTINGSDESIGNERLoadWebSettings As Integer = &H2108
+            Private Const CmdIdSETTINGSDESIGNERViewCode As Integer = &H2104
+            Private Const CmdIdSETTINGSDESIGNERSynchronize As Integer = &H2105
+            Private Const CmdIdSETTINGSDESIGNERAccessModifierCombobox As Integer = &H2106
+            Private Const CmdIdSETTINGSDESIGNERGetAccessModifierOptions As Integer = &H2107
+            Private Const CmdIdSETTINGSDESIGNERLoadWebSettings As Integer = &H2108
 
-            Private Const s_cmdidCurrentProfile As Integer = &H2201
-            Private Const s_cmdidCurrentProfileListGet As Integer = &H2202
+            Private Const CmdIdCurrentProfile As Integer = &H2201
+            Private Const CmdIdCurrentProfileListGet As Integer = &H2202
 
-            Private Const s_cmdidCOMMONEditCell As Integer = &H2F00
-            Private Const s_cmdidCOMMONAddRow As Integer = &H2F01
-            Private Const s_cmdidCOMMONRemoveRow As Integer = &H2F02
+            Private Const CmdIdCOMMONEditCell As Integer = &H2F00
+            Private Const CmdIdCOMMONAddRow As Integer = &H2F01
+            Private Const CmdIdCOMMONRemoveRow As Integer = &H2F02
 
             ' *********************************************************************
 
@@ -96,21 +96,21 @@ Namespace Microsoft.VisualStudio.Editors
             Private Shared ReadOnly s_CMDSETID_StandardCommandSet2K As New Guid("1496A755-94DE-11D0-8C3F-00C04FC2AAE2")
             Public Shared ReadOnly guidVSStd97 As Guid = s_CMDSETID_StandardCommandSet97
             Public Shared ReadOnly guidVSStd2K As Guid = s_CMDSETID_StandardCommandSet2K
-            Private Const s_cmdidCopy As Integer = 15
+            Private Const CmdIdCopy As Integer = 15
             Public Const cmdidCut As Integer = 16
-            Private Const s_cmdidDelete As Integer = 17
+            Private Const CmdIdDelete As Integer = 17
             Public Const cmdidRedo As Integer = 29
             Public Const cmdidMultiLevelRedo As Integer = 30
             Public Const cmdidMultiLevelRedoList As Integer = 299
             Public Const cmdidUndo As Integer = 43
             Public Const cmdidMultiLevelUndo As Integer = 44
             Public Const cmdidMultiLevelUndoList As Integer = 299
-            Private Const s_cmdidRemove As Integer = 168
-            Private Const s_cmdidPaste As Integer = 26
-            Private Const s_cmdidOpen As Integer = 261
-            Private Const s_cmdidOpenWith As Integer = 199
-            Private Const s_cmdidRename As Integer = 150
-            Private Const s_cmdidSelectAll As Integer = 31
+            Private Const CmdIdRemove As Integer = 168
+            Private Const CmdIdPaste As Integer = 26
+            Private Const CmdIdOpen As Integer = 261
+            Private Const CmdIdOpenWith As Integer = 199
+            Private Const CmdIdRename As Integer = 150
+            Private Const CmdIdSelectAll As Integer = 31
             Public Const cmdidFileClose As Integer = 223
             Public Const cmdidSave As Integer = 110
             Public Const cmdidSaveAs As Integer = 111
@@ -122,12 +122,12 @@ Namespace Microsoft.VisualStudio.Editors
 
 
             Public Shared ReadOnly CommandIDVSStd97cmdidCut As New CommandID(guidVSStd97, cmdidCut)
-            Public Shared ReadOnly CommandIDVSStd97cmdidCopy As New CommandID(guidVSStd97, s_cmdidCopy)
-            Public Shared ReadOnly CommandIDVSStd97cmdidPaste As New CommandID(guidVSStd97, s_cmdidPaste)
-            Public Shared ReadOnly CommandIDVSStd97cmdidDelete As New CommandID(guidVSStd97, s_cmdidDelete)
-            Public Shared ReadOnly CommandIDVSStd97cmdidRemove As New CommandID(guidVSStd97, s_cmdidRemove)
-            Public Shared ReadOnly CommandIDVSStd97cmdidRename As New CommandID(guidVSStd97, s_cmdidRename)
-            Public Shared ReadOnly CommandIDVSStd97cmdidSelectAll As New CommandID(guidVSStd97, s_cmdidSelectAll)
+            Public Shared ReadOnly CommandIDVSStd97cmdidCopy As New CommandID(guidVSStd97, CmdIdCopy)
+            Public Shared ReadOnly CommandIDVSStd97cmdidPaste As New CommandID(guidVSStd97, CmdIdPaste)
+            Public Shared ReadOnly CommandIDVSStd97cmdidDelete As New CommandID(guidVSStd97, CmdIdDelete)
+            Public Shared ReadOnly CommandIDVSStd97cmdidRemove As New CommandID(guidVSStd97, CmdIdRemove)
+            Public Shared ReadOnly CommandIDVSStd97cmdidRename As New CommandID(guidVSStd97, CmdIdRename)
+            Public Shared ReadOnly CommandIDVSStd97cmdidSelectAll As New CommandID(guidVSStd97, CmdIdSelectAll)
             Public Shared ReadOnly CommandIDVSStd97cmdidEditLabel As New CommandID(guidVSStd97, cmdidEditLabel)
             Public Shared ReadOnly CommandIDVSStd97cmdidViewCode As New CommandID(guidVSStd97, cmdidViewCode)
             Public Shared ReadOnly CommandIDVSStd2kECMD_CANCEL As New CommandID(guidVSStd2K, ECMD_CANCEL)
@@ -149,68 +149,68 @@ Namespace Microsoft.VisualStudio.Editors
             Private Shared ReadOnly s_GUID_MS_VS_Editors_CommandId As New Guid("E4B9BB05-1963-4774-8CFC-518359E3FCE3")
 
             ' Command ID = GUID + cmdid.
-            Public Shared ReadOnly CommandIDVSStd97Open As New CommandID(guidVSStd97, s_cmdidOpen)
-            Public Shared ReadOnly CommandIDVSStd97OpenWith As New CommandID(guidVSStd97, s_cmdidOpenWith)
-            Public Shared ReadOnly CommandIDResXImport As New CommandID(s_GUID_RESX_CommandID, s_cmdidRESXImport)
-            Public Shared ReadOnly CommandIDResXExport As New CommandID(s_GUID_RESX_CommandID, s_cmdidRESXExport)
-            Public Shared ReadOnly CommandIDResXPlay As New CommandID(s_GUID_RESX_CommandID, s_cmdidRESXPlay)
+            Public Shared ReadOnly CommandIDVSStd97Open As New CommandID(guidVSStd97, CmdIdOpen)
+            Public Shared ReadOnly CommandIDVSStd97OpenWith As New CommandID(guidVSStd97, CmdIdOpenWith)
+            Public Shared ReadOnly CommandIDResXImport As New CommandID(s_GUID_RESX_CommandID, CmdIdRESXImport)
+            Public Shared ReadOnly CommandIDResXExport As New CommandID(s_GUID_RESX_CommandID, CmdIdRESXExport)
+            Public Shared ReadOnly CommandIDResXPlay As New CommandID(s_GUID_RESX_CommandID, CmdIdRESXPlay)
 
-            Public Shared ReadOnly CommandIDRESXAddFixedMenuCommand As New CommandID(s_GUID_RESX_CommandID, s_cmdidRESXAddFixedMenuCommand)
-            Public Shared ReadOnly CommandIDRESXAddExistingFile As New CommandID(s_GUID_RESX_CommandID, s_cmdidRESXAddExistingFile)
-            Public Shared ReadOnly CommandIDRESXAddNewString As New CommandID(s_GUID_RESX_CommandID, s_cmdidRESXAddNewString)
-            Public Shared ReadOnly CommandIDRESXAddNewImagePNG As New CommandID(s_GUID_RESX_CommandID, s_cmdidRESXAddNewImagePNG)
-            Public Shared ReadOnly CommandIDRESXAddNewImageBMP As New CommandID(s_GUID_RESX_CommandID, s_cmdidRESXAddNewImageBMP)
-            Public Shared ReadOnly CommandIDRESXAddNewImageGIF As New CommandID(s_GUID_RESX_CommandID, s_cmdidRESXAddNewImageGIF)
-            Public Shared ReadOnly CommandIDRESXAddNewImageJPEG As New CommandID(s_GUID_RESX_CommandID, s_cmdidRESXAddNewImageJPEG)
-            Public Shared ReadOnly CommandIDRESXAddNewImageTIFF As New CommandID(s_GUID_RESX_CommandID, s_cmdidRESXAddNewImageTIFF)
-            Public Shared ReadOnly CommandIDRESXAddNewIcon As New CommandID(s_GUID_RESX_CommandID, s_cmdidRESXAddNewIcon)
-            Public Shared ReadOnly CommandIDRESXAddNewTextFile As New CommandID(s_GUID_RESX_CommandID, s_cmdidRESXAddNewTextFile)
-            Public Shared ReadOnly CommandIDRESXAddDefaultResource As New CommandID(s_GUID_RESX_CommandID, s_cmdidRESXAddDefaultResource)
+            Public Shared ReadOnly CommandIDRESXAddFixedMenuCommand As New CommandID(s_GUID_RESX_CommandID, CmdIdRESXAddFixedMenuCommand)
+            Public Shared ReadOnly CommandIDRESXAddExistingFile As New CommandID(s_GUID_RESX_CommandID, CmdIdRESXAddExistingFile)
+            Public Shared ReadOnly CommandIDRESXAddNewString As New CommandID(s_GUID_RESX_CommandID, CmdIdRESXAddNewString)
+            Public Shared ReadOnly CommandIDRESXAddNewImagePNG As New CommandID(s_GUID_RESX_CommandID, CmdIdRESXAddNewImagePNG)
+            Public Shared ReadOnly CommandIDRESXAddNewImageBMP As New CommandID(s_GUID_RESX_CommandID, CmdIdRESXAddNewImageBMP)
+            Public Shared ReadOnly CommandIDRESXAddNewImageGIF As New CommandID(s_GUID_RESX_CommandID, CmdIdRESXAddNewImageGIF)
+            Public Shared ReadOnly CommandIDRESXAddNewImageJPEG As New CommandID(s_GUID_RESX_CommandID, CmdIdRESXAddNewImageJPEG)
+            Public Shared ReadOnly CommandIDRESXAddNewImageTIFF As New CommandID(s_GUID_RESX_CommandID, CmdIdRESXAddNewImageTIFF)
+            Public Shared ReadOnly CommandIDRESXAddNewIcon As New CommandID(s_GUID_RESX_CommandID, CmdIdRESXAddNewIcon)
+            Public Shared ReadOnly CommandIDRESXAddNewTextFile As New CommandID(s_GUID_RESX_CommandID, CmdIdRESXAddNewTextFile)
+            Public Shared ReadOnly CommandIDRESXAddDefaultResource As New CommandID(s_GUID_RESX_CommandID, CmdIdRESXAddDefaultResource)
 
-            Public Shared ReadOnly CommandIDRESXResTypeStrings As New CommandID(s_GUID_RESX_CommandID, s_cmdidRESXResTypeStrings)
-            Public Shared ReadOnly CommandIDRESXResTypeImages As New CommandID(s_GUID_RESX_CommandID, s_cmdidRESXResTypeImages)
-            Public Shared ReadOnly CommandIDRESXResTypeIcons As New CommandID(s_GUID_RESX_CommandID, s_cmdidRESXResTypeIcons)
-            Public Shared ReadOnly CommandIDRESXResTypeAudio As New CommandID(s_GUID_RESX_CommandID, s_cmdidRESXResTypeAudio)
-            Public Shared ReadOnly CommandIDRESXResTypeFiles As New CommandID(s_GUID_RESX_CommandID, s_cmdidRESXResTypeFiles)
-            Public Shared ReadOnly CommandIDRESXResTypeOther As New CommandID(s_GUID_RESX_CommandID, s_cmdidRESXResTypeOther)
-            Public Shared ReadOnly CommandIDRESXViewsFixedMenuCommand As New CommandID(s_GUID_RESX_CommandID, s_cmdidIDRESXViewsFixedMenuCommand)
-            Public Shared ReadOnly CommandIDRESXViewsList As New CommandID(s_GUID_RESX_CommandID, s_cmdidRESXViewsList)
-            Public Shared ReadOnly CommandIDRESXViewsDetails As New CommandID(s_GUID_RESX_CommandID, s_cmdidRESXViewsDetails)
-            Public Shared ReadOnly CommandIDRESXViewsThumbnails As New CommandID(s_GUID_RESX_CommandID, s_cmdidRESXViewsThumbnails)
+            Public Shared ReadOnly CommandIDRESXResTypeStrings As New CommandID(s_GUID_RESX_CommandID, CmdIdRESXResTypeStrings)
+            Public Shared ReadOnly CommandIDRESXResTypeImages As New CommandID(s_GUID_RESX_CommandID, CmdIdRESXResTypeImages)
+            Public Shared ReadOnly CommandIDRESXResTypeIcons As New CommandID(s_GUID_RESX_CommandID, CmdIdRESXResTypeIcons)
+            Public Shared ReadOnly CommandIDRESXResTypeAudio As New CommandID(s_GUID_RESX_CommandID, CmdIdRESXResTypeAudio)
+            Public Shared ReadOnly CommandIDRESXResTypeFiles As New CommandID(s_GUID_RESX_CommandID, CmdIdRESXResTypeFiles)
+            Public Shared ReadOnly CommandIDRESXResTypeOther As New CommandID(s_GUID_RESX_CommandID, CmdIdRESXResTypeOther)
+            Public Shared ReadOnly CommandIDRESXViewsFixedMenuCommand As New CommandID(s_GUID_RESX_CommandID, CmdIdIDRESXViewsFixedMenuCommand)
+            Public Shared ReadOnly CommandIDRESXViewsList As New CommandID(s_GUID_RESX_CommandID, CmdIdRESXViewsList)
+            Public Shared ReadOnly CommandIDRESXViewsDetails As New CommandID(s_GUID_RESX_CommandID, CmdIdRESXViewsDetails)
+            Public Shared ReadOnly CommandIDRESXViewsThumbnails As New CommandID(s_GUID_RESX_CommandID, CmdIdRESXViewsThumbnails)
 
-            Public Shared ReadOnly CommandIDRESXGenericRemove As New CommandID(s_GUID_RESX_CommandID, s_cmdidRESXGenericRemove)
-            Public Shared ReadOnly CommandIDRESXAccessModifierCombobox As New CommandID(s_GUID_RESX_CommandID, s_cmdidRESXAccessModifierCombobox)
-            Public Shared ReadOnly CommandIDRESXGetAccessModifierOptions As New CommandID(s_GUID_RESX_CommandID, s_cmdidRESXGetAccessModifierOptions)
+            Public Shared ReadOnly CommandIDRESXGenericRemove As New CommandID(s_GUID_RESX_CommandID, CmdIdRESXGenericRemove)
+            Public Shared ReadOnly CommandIDRESXAccessModifierCombobox As New CommandID(s_GUID_RESX_CommandID, CmdIdRESXAccessModifierCombobox)
+            Public Shared ReadOnly CommandIDRESXGetAccessModifierOptions As New CommandID(s_GUID_RESX_CommandID, CmdIdRESXGetAccessModifierOptions)
 
-            Public Shared ReadOnly ResXContextMenuID As New CommandID(GUID_RESX_MenuGroup, s_IDM_CTX_RESX_ContextMenu)
-            Public Shared ReadOnly SettingsDesignerContextMenuID As New CommandID(GUID_SETTINGSDESIGNER_MenuGroup, s_IDM_CTX_SETTINGSDESIGNER_ContextMenu)
+            Public Shared ReadOnly ResXContextMenuID As New CommandID(GUID_RESX_MenuGroup, IDM_CTX_RESX_ContextMenu)
+            Public Shared ReadOnly SettingsDesignerContextMenuID As New CommandID(GUID_SETTINGSDESIGNER_MenuGroup, IDM_CTX_SETTINGSDESIGNER_ContextMenu)
             Public Shared ReadOnly SettingsDesignerToolbar As New CommandID(GUID_SETTINGSDESIGNER_MenuGroup, IDM_VS_TOOLBAR_Settings)
 
-            Public Shared ReadOnly CommandIDSettingsDesignerViewCode As New CommandID(s_GUID_SETTINGSDESIGNER_CommandID, s_cmdidSETTINGSDESIGNERViewCode)
-            Public Shared ReadOnly CommandIDSettingsDesignerSynchronize As New CommandID(s_GUID_SETTINGSDESIGNER_CommandID, s_cmdidSETTINGSDESIGNERSynchronize)
-            Public Shared ReadOnly CommandIDSettingsDesignerAccessModifierCombobox As New CommandID(s_GUID_SETTINGSDESIGNER_CommandID, s_cmdidSETTINGSDESIGNERAccessModifierCombobox)
-            Public Shared ReadOnly CommandIDSettingsDesignerGetAccessModifierOptions As New CommandID(s_GUID_SETTINGSDESIGNER_CommandID, s_cmdidSETTINGSDESIGNERGetAccessModifierOptions)
-            Public Shared ReadOnly CommandIDSettingsDesignerLoadWebSettings As New CommandID(s_GUID_SETTINGSDESIGNER_CommandID, s_cmdidSETTINGSDESIGNERLoadWebSettings)
+            Public Shared ReadOnly CommandIDSettingsDesignerViewCode As New CommandID(s_GUID_SETTINGSDESIGNER_CommandID, CmdIdSETTINGSDESIGNERViewCode)
+            Public Shared ReadOnly CommandIDSettingsDesignerSynchronize As New CommandID(s_GUID_SETTINGSDESIGNER_CommandID, CmdIdSETTINGSDESIGNERSynchronize)
+            Public Shared ReadOnly CommandIDSettingsDesignerAccessModifierCombobox As New CommandID(s_GUID_SETTINGSDESIGNER_CommandID, CmdIdSETTINGSDESIGNERAccessModifierCombobox)
+            Public Shared ReadOnly CommandIDSettingsDesignerGetAccessModifierOptions As New CommandID(s_GUID_SETTINGSDESIGNER_CommandID, CmdIdSETTINGSDESIGNERGetAccessModifierOptions)
+            Public Shared ReadOnly CommandIDSettingsDesignerLoadWebSettings As New CommandID(s_GUID_SETTINGSDESIGNER_CommandID, CmdIdSETTINGSDESIGNERLoadWebSettings)
 
             ' Shared commands
-            Public Shared ReadOnly CommandIDCOMMONEditCell As New CommandID(s_GUID_MS_VS_Editors_CommandId, s_cmdidCOMMONEditCell)
-            Public Shared ReadOnly CommandIDCOMMONAddRow As New CommandID(s_GUID_MS_VS_Editors_CommandId, s_cmdidCOMMONAddRow)
-            Public Shared ReadOnly CommandIDCOMMONRemoveRow As New CommandID(s_GUID_MS_VS_Editors_CommandId, s_cmdidCOMMONRemoveRow)
+            Public Shared ReadOnly CommandIDCOMMONEditCell As New CommandID(s_GUID_MS_VS_Editors_CommandId, CmdIdCOMMONEditCell)
+            Public Shared ReadOnly CommandIDCOMMONAddRow As New CommandID(s_GUID_MS_VS_Editors_CommandId, CmdIdCOMMONAddRow)
+            Public Shared ReadOnly CommandIDCOMMONRemoveRow As New CommandID(s_GUID_MS_VS_Editors_CommandId, CmdIdCOMMONRemoveRow)
 
 #Region "My Extension feature menus"
             ' GUID for My Extension feature menus.
             Private Shared ReadOnly s_GUID_MYEXTENSION_Menu As New Guid("6C37AED7-D987-4fdf-ADF5-B71EB3F7236C")
             ' ID for My Extension context menu.
-            Private Const s_IDM_CTX_MYEXTENSION_ContextMenu As Integer = &H110
+            Private Const IDM_CTX_MYEXTENSION_ContextMenu As Integer = &H110
             ' ID for My Extension context menu's only group.
-            Private Const s_IDG_MYEXTENSION_CTX_AddRemove As Integer = &H1101
+            Private Const IDG_MYEXTENSION_CTX_AddRemove As Integer = &H1101
             ' ID for My Extension menu buttons.
-            Private Const s_cmdidMYEXTENSIONAddExtension As Integer = &H2001
-            Private Const s_cmdidMYEXTENSIONRemoveExtension As Integer = &H2002
+            Private Const CmdIdMYEXTENSIONAddExtension As Integer = &H2001
+            Private Const CmdIdMYEXTENSIONRemoveExtension As Integer = &H2002
             ' Command IDs to use in My Extension Property Page
-            Public Shared ReadOnly CommandIDMYEXTENSIONContextMenu As New CommandID(s_GUID_MYEXTENSION_Menu, s_IDM_CTX_MYEXTENSION_ContextMenu)
-            Public Shared ReadOnly CommandIDMyEXTENSIONAddExtension As New CommandID(s_GUID_MYEXTENSION_Menu, s_cmdidMYEXTENSIONAddExtension)
-            Public Shared ReadOnly CommandIDMyEXTENSIONRemoveExtension As New CommandID(s_GUID_MYEXTENSION_Menu, s_cmdidMYEXTENSIONRemoveExtension)
+            Public Shared ReadOnly CommandIDMYEXTENSIONContextMenu As New CommandID(s_GUID_MYEXTENSION_Menu, IDM_CTX_MYEXTENSION_ContextMenu)
+            Public Shared ReadOnly CommandIDMyEXTENSIONAddExtension As New CommandID(s_GUID_MYEXTENSION_Menu, CmdIdMYEXTENSIONAddExtension)
+            Public Shared ReadOnly CommandIDMyEXTENSIONRemoveExtension As New CommandID(s_GUID_MYEXTENSION_Menu, CmdIdMYEXTENSIONRemoveExtension)
 #End Region
 
         End Class

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationCodeGenerator.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationCodeGenerator.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel
 Imports System.Runtime.InteropServices
@@ -29,7 +29,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         Private _codeDomProvider As CodeDomProvider
         Private _serviceProvider As ServiceProvider
 
-        Private Const s_myNamespaceName As String = "My"
+        Private Const MyNamespaceName As String = "My"
         Friend Const SingleFileGeneratorName As String = "MyApplicationCodeGenerator"
 
         ''' <summary>
@@ -143,7 +143,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
 
             ' Create a new namespace to put our class in
             '
-            Dim MyNamespace As New CodeDom.CodeNamespace(s_myNamespaceName)
+            Dim MyNamespace As New CodeDom.CodeNamespace(MyNamespaceName)
 
             'MySubMain will be set to indicate a WindowsApplication sans MY, or non-WindowsApplication type
             If MyApplication.MySubMain AndAlso MyApplicationProperties.IsMySubMainSupported(DirectCast(GetService(GetType(IVsHierarchy)), IVsHierarchy)) Then

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationProperties.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationProperties.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+ï»¿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.VisualStudio.Editors.Common
 Imports Microsoft.VisualStudio.Editors.Common.Utils
@@ -260,14 +260,14 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         Friend Const Const_MyType_Custom As String = "Custom"
 
         'Constants for property change notifications
-        Private Const s_PROPNAME_CustomSubMain As String = "CustomSubMain"
-        Private Const s_PROPNAME_MainForm As String = "MainForm"
-        Private Const s_PROPNAME_SingleInstance As String = "SingleInstance"
-        Private Const s_PROPNAME_ShutdownMode As String = "ShutdownMode"
-        Private Const s_PROPNAME_EnableVisualStyles As String = "EnableVisualStyles"
-        Private Const s_PROPNAME_SaveMySettingsOnExit As String = "SaveMySettingsOnExit"
-        Private Const s_PROPNAME_AuthenticationMode As String = "AuthenticationMode"
-        Private Const s_PROPNAME_SplashScreen As String = "SplashScreen"
+        Private Const PROPNAME_CustomSubMain As String = "CustomSubMain"
+        Private Const PROPNAME_MainForm As String = "MainForm"
+        Private Const PROPNAME_SingleInstance As String = "SingleInstance"
+        Private Const PROPNAME_ShutdownMode As String = "ShutdownMode"
+        Private Const PROPNAME_EnableVisualStyles As String = "EnableVisualStyles"
+        Private Const PROPNAME_SaveMySettingsOnExit As String = "SaveMySettingsOnExit"
+        Private Const PROPNAME_AuthenticationMode As String = "AuthenticationMode"
+        Private Const PROPNAME_SplashScreen As String = "SplashScreen"
 
         Private _projectHierarchy As IVsHierarchy
         Private WithEvents _myAppDocData As DocData 'The DocData which backs the MyApplication.myapp file
@@ -277,24 +277,24 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         Private _myAppData As MyApplicationData
 
         'The filename for the XML file where we store the MyApplication properties
-        Private Const s_const_MyApplicationFileName As String = "Application.myapp"
-        Private Const s_const_MyApplicationFileName_B1Compat As String = "MyApplication.myapp" 'Old (Beta 1) name for this file to remain backwards compatible
+        Private Const Const_MyApplicationFileName As String = "Application.myapp"
+        Private Const Const_MyApplicationFileName_B1Compat As String = "MyApplication.myapp" 'Old (Beta 1) name for this file to remain backwards compatible
 
         Private _myAppFileName As String 'The actual file for the XML file that we found and are using (*not* including the path)
 
-        Private Const s_const_MyApplicationEntryPoint As String = "My.MyApplication"
+        Private Const Const_MyApplicationEntryPoint As String = "My.MyApplication"
 
         'The name of the file where users hook up My events
-        Private Const s_const_MyEventsFileName As String = "ApplicationEvents.vb"
-        Private Const s_const_MyEventsFileName_B2Compat As String = "Application.vb"
-        Private Const s_const_MyEventsFileName_B1Compat As String = "MyEvents.vb" 'Old (Beta 1) name for this file to remain backwards compatible
+        Private Const Const_MyEventsFileName As String = "ApplicationEvents.vb"
+        Private Const Const_MyEventsFileName_B2Compat As String = "Application.vb"
+        Private Const Const_MyEventsFileName_B1Compat As String = "MyEvents.vb" 'Old (Beta 1) name for this file to remain backwards compatible
 
         'The relevant project property names
-        Private Const s_PROJECTPROPERTY_CUSTOMTOOL As String = "CustomTool"
-        Private Const s_PROJECTPROPERTY_CUSTOMTOOLNAMESPACE As String = "CustomToolNamespace"
+        Private Const PROJECTPROPERTY_CUSTOMTOOL As String = "CustomTool"
+        Private Const PROJECTPROPERTY_CUSTOMTOOLNAMESPACE As String = "CustomToolNamespace"
 
         'The custom tool name to use for the default resx file in VB projects
-        Private Const s_MYAPPCUSTOMTOOL As String = "MyApplicationCodeGenerator"
+        Private Const MYAPPCUSTOMTOOL As String = "MyApplicationCodeGenerator"
 
         ''' <summary>
         ''' Constructor.
@@ -332,14 +332,14 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
             _projectDesignerProjectItem = GetProjectItemForProjectDesigner(ProjectHierarchy)
 
             'Determine the filename for the .myapp file
-            _myAppFileName = s_const_MyApplicationFileName
+            _myAppFileName = Const_MyApplicationFileName
 
             'BEGIN Beta 1 Backwards compatibility
             If Not File.Exists(MyAppFileNameWithPath) Then
-                Dim FileNameCompat As String = Path.Combine(ProjectDesignerProjectItem.FileNames(1), s_const_MyApplicationFileName_B1Compat)
+                Dim FileNameCompat As String = Path.Combine(ProjectDesignerProjectItem.FileNames(1), Const_MyApplicationFileName_B1Compat)
                 If File.Exists(FileNameCompat) Then
                     'The new version of the filename does not exist, but the old one does - use it instead
-                    _myAppFileName = s_const_MyApplicationFileName_B1Compat
+                    _myAppFileName = Const_MyApplicationFileName_B1Compat
                     Debug.Assert(File.Exists(MyAppFileNameWithPath), "Huh?")
                 End If
             End If
@@ -481,7 +481,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                     RunCustomTool()
 
                     'Notify users of property change
-                    OnPropertyChanged(s_PROPNAME_CustomSubMain)
+                    OnPropertyChanged(PROPNAME_CustomSubMain)
                 End If
             End Set
         End Property
@@ -530,7 +530,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                     RunCustomTool()
 
                     'Notify users of property change
-                    OnPropertyChanged(s_PROPNAME_MainForm)
+                    OnPropertyChanged(PROPNAME_MainForm)
                 End If
             End Set
         End Property
@@ -546,7 +546,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                     FlushToDocData()
 
                     'Notify users of property change
-                    OnPropertyChanged(s_PROPNAME_SingleInstance)
+                    OnPropertyChanged(PROPNAME_SingleInstance)
                 End If
             End Set
         End Property
@@ -558,7 +558,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
             Set(value As Integer)
                 Select Case value
                     Case _
-                    ApplicationServices.ShutdownMode.AfterMainFormCloses, _
+                    ApplicationServices.ShutdownMode.AfterMainFormCloses,
                     ApplicationServices.ShutdownMode.AfterAllFormsClose
                         'Valid - continue
                     Case Else
@@ -571,7 +571,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                     FlushToDocData()
 
                     'Notify users of property change
-                    OnPropertyChanged(s_PROPNAME_ShutdownMode)
+                    OnPropertyChanged(PROPNAME_ShutdownMode)
                 End If
             End Set
         End Property
@@ -587,7 +587,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                     FlushToDocData()
 
                     'Notify users of property change
-                    OnPropertyChanged(s_PROPNAME_EnableVisualStyles)
+                    OnPropertyChanged(PROPNAME_EnableVisualStyles)
                 End If
             End Set
         End Property
@@ -603,7 +603,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                     FlushToDocData()
 
                     'Notify users of property change
-                    OnPropertyChanged(s_PROPNAME_SaveMySettingsOnExit)
+                    OnPropertyChanged(PROPNAME_SaveMySettingsOnExit)
                 End If
             End Set
         End Property
@@ -615,7 +615,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
             Set(value As Integer)
                 Select Case value
                     Case _
-                    ApplicationServices.AuthenticationMode.Windows, _
+                    ApplicationServices.AuthenticationMode.Windows,
                     ApplicationServices.AuthenticationMode.ApplicationDefined
                         'Valid - continue
                     Case Else
@@ -628,7 +628,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                     FlushToDocData()
 
                     'Notify users of property change
-                    OnPropertyChanged(s_PROPNAME_AuthenticationMode)
+                    OnPropertyChanged(PROPNAME_AuthenticationMode)
                 End If
             End Set
         End Property
@@ -675,7 +675,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                     RunCustomTool()
 
                     'Notify users of property change
-                    OnPropertyChanged(s_PROPNAME_SplashScreen)
+                    OnPropertyChanged(PROPNAME_SplashScreen)
                 End If
             End Set
         End Property
@@ -729,7 +729,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                 Item = AddFileToProject(ProjectDesignerProjectItem.ProjectItems, MyAppFileNameWithPath, False)
 
                 'Make sure the custom tool for the MyApplication data file is set correctly
-                SetCustomTool(Item, s_MYAPPCUSTOMTOOL)
+                SetCustomTool(Item, MYAPPCUSTOMTOOL)
 
                 'BuildAction should be None so the file doesn't get published
                 SetBuildAction(Item, VSLangProj.prjBuildAction.prjBuildActionNone)
@@ -870,8 +870,8 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ''' </summary>
         ''' <remarks>Caller is responsible for catching exceptions</remarks>
         Private Sub SetCustomTool(ProjectItem As ProjectItem, Value As String)
-            Dim ToolProperty As [Property] = GetProjectItemProperty(ProjectItem, s_PROJECTPROPERTY_CUSTOMTOOL)
-            Dim NamespaceProperty As [Property] = GetProjectItemProperty(ProjectItem, s_PROJECTPROPERTY_CUSTOMTOOLNAMESPACE)
+            Dim ToolProperty As [Property] = GetProjectItemProperty(ProjectItem, PROJECTPROPERTY_CUSTOMTOOL)
+            Dim NamespaceProperty As [Property] = GetProjectItemProperty(ProjectItem, PROJECTPROPERTY_CUSTOMTOOLNAMESPACE)
 
             Try
                 If ToolProperty Is Nothing Then
@@ -1000,18 +1000,18 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
 
             'Search for the Application.vb (used to be MyEvents.vb) file
             Dim FileIsNew As Boolean
-            Dim MyEventsProjectItem As ProjectItem = QueryProjectItems(ProjectDesignerProjectItem.ProjectItems, s_const_MyEventsFileName)
+            Dim MyEventsProjectItem As ProjectItem = QueryProjectItems(ProjectDesignerProjectItem.ProjectItems, Const_MyEventsFileName)
             If MyEventsProjectItem Is Nothing Then
                 'The file doesn't exist in the My Application folder.  Let's also look in the root folder, in case the user
                 '  moved it there.
-                MyEventsProjectItem = QueryProjectItems(ProjectDesignerProjectItem.ContainingProject.ProjectItems, s_const_MyEventsFileName)
+                MyEventsProjectItem = QueryProjectItems(ProjectDesignerProjectItem.ContainingProject.ProjectItems, Const_MyEventsFileName)
 
                 'BEGIN Beta 2 Backwards compatibility
                 If MyEventsProjectItem Is Nothing Then
                     'Could not find the file with the new, expected name.  Also search for the old name in both places
-                    MyEventsProjectItem = QueryProjectItems(ProjectDesignerProjectItem.ProjectItems, s_const_MyEventsFileName_B2Compat)
+                    MyEventsProjectItem = QueryProjectItems(ProjectDesignerProjectItem.ProjectItems, Const_MyEventsFileName_B2Compat)
                     If MyEventsProjectItem Is Nothing Then
-                        MyEventsProjectItem = QueryProjectItems(ProjectDesignerProjectItem.ContainingProject.ProjectItems, s_const_MyEventsFileName_B2Compat)
+                        MyEventsProjectItem = QueryProjectItems(ProjectDesignerProjectItem.ContainingProject.ProjectItems, Const_MyEventsFileName_B2Compat)
                     End If
                 End If
                 'END Beta 2 Backwards compatibility
@@ -1019,9 +1019,9 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                 'BEGIN Beta 1 Backwards compatibility
                 If MyEventsProjectItem Is Nothing Then
                     'Could not find the file with the new, expected name.  Also search for the old name in both places
-                    MyEventsProjectItem = QueryProjectItems(ProjectDesignerProjectItem.ProjectItems, s_const_MyEventsFileName_B1Compat)
+                    MyEventsProjectItem = QueryProjectItems(ProjectDesignerProjectItem.ProjectItems, Const_MyEventsFileName_B1Compat)
                     If MyEventsProjectItem Is Nothing Then
-                        MyEventsProjectItem = QueryProjectItems(ProjectDesignerProjectItem.ContainingProject.ProjectItems, s_const_MyEventsFileName_B1Compat)
+                        MyEventsProjectItem = QueryProjectItems(ProjectDesignerProjectItem.ContainingProject.ProjectItems, Const_MyEventsFileName_B1Compat)
                     End If
                 End If
                 'END Beta 1 Backwards compatibility
@@ -1042,7 +1042,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                         Return
                     End If
 
-                    MyEventsProjectItem = CreateNewMyEventsFile(ProjectDesignerProjectItem.ContainingProject.ProjectItems, s_const_MyEventsFileName, Const_MyEventsNamespace, Const_MyEventsClassName)
+                    MyEventsProjectItem = CreateNewMyEventsFile(ProjectDesignerProjectItem.ContainingProject.ProjectItems, Const_MyEventsFileName, Const_MyEventsNamespace, Const_MyEventsClassName)
                     FileIsNew = True
                 End If
             End If
@@ -1252,42 +1252,42 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         Private Sub FireChangeNotificationsForNewValues(OldValues As MyApplicationData, NewValues As MyApplicationData)
             'AuthenticationMode
             If OldValues.AuthenticationMode <> NewValues.AuthenticationMode Then
-                OnPropertyChanged(s_PROPNAME_AuthenticationMode)
+                OnPropertyChanged(PROPNAME_AuthenticationMode)
             End If
 
             'CustomSubMain
             If OldValues.MySubMain <> NewValues.MySubMain Then
-                OnPropertyChanged(s_PROPNAME_CustomSubMain)
+                OnPropertyChanged(PROPNAME_CustomSubMain)
             End If
 
             'EnableVisualStyles
             If OldValues.EnableVisualStyles <> NewValues.EnableVisualStyles Then
-                OnPropertyChanged(s_PROPNAME_EnableVisualStyles)
+                OnPropertyChanged(PROPNAME_EnableVisualStyles)
             End If
 
             'MainForm
             If Not StringPropertyValuesEqual(OldValues.MainFormNoRootNS, NewValues.MainFormNoRootNS) Then
-                OnPropertyChanged(s_PROPNAME_MainForm)
+                OnPropertyChanged(PROPNAME_MainForm)
             End If
 
             'SaveMySettingsOnExit
             If OldValues.SaveMySettingsOnExit <> NewValues.SaveMySettingsOnExit Then
-                OnPropertyChanged(s_PROPNAME_SaveMySettingsOnExit)
+                OnPropertyChanged(PROPNAME_SaveMySettingsOnExit)
             End If
 
             'ShutdownMode
             If OldValues.ShutdownMode <> NewValues.ShutdownMode Then
-                OnPropertyChanged(s_PROPNAME_ShutdownMode)
+                OnPropertyChanged(PROPNAME_ShutdownMode)
             End If
 
             'SingleInstance
             If OldValues.SingleInstance <> NewValues.SingleInstance Then
-                OnPropertyChanged(s_PROPNAME_SingleInstance)
+                OnPropertyChanged(PROPNAME_SingleInstance)
             End If
 
             'SplashScreen
             If Not StringPropertyValuesEqual(OldValues.SplashScreenNoRootNS, NewValues.SplashScreenNoRootNS) Then
-                OnPropertyChanged(s_PROPNAME_SplashScreen)
+                OnPropertyChanged(PROPNAME_SplashScreen)
             End If
 
         End Sub
@@ -1359,10 +1359,10 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         '
         '  Application Type      ->  MyType
         '  -------------------       ------
-        '  Windows Application   ->  “WindowsForms” or "WindowsFormsWithCustomSubMain"
-        '  Windows Class Library ->  “Windows”
-        '  Console Application   ->  “Console”
-        '  Windows Service       ->  “Console”
+        '  Windows Application   ->  â€œWindowsFormsâ€ or "WindowsFormsWithCustomSubMain"
+        '  Windows Class Library ->  â€œWindowsâ€
+        '  Console Application   ->  â€œConsoleâ€
+        '  Windows Service       ->  â€œConsoleâ€
         '  Web Control Library   ->  "WebControl"
         '
 

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityProjectSettings.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityProjectSettings.vb
@@ -89,9 +89,9 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
                     Try
                         Dim extensionProjectItemID As UInteger = DTEUtils.ItemIdOfProjectItem(
                             _projectHierarchy, projectItemAdded)
-                        _vsBuildPropertyStorage.SetItemAttribute(extensionProjectItemID, s_MSBUILD_ATTR_ASSEMBLY, extensionTemplate.AssemblyFullName)
-                        _vsBuildPropertyStorage.SetItemAttribute(extensionProjectItemID, s_MSBUILD_ATTR_ID, extensionTemplate.ID)
-                        _vsBuildPropertyStorage.SetItemAttribute(extensionProjectItemID, s_MSBUILD_ATTR_VERSION, extensionTemplate.Version.ToString())
+                        _vsBuildPropertyStorage.SetItemAttribute(extensionProjectItemID, MSBUILD_ATTR_ASSEMBLY, extensionTemplate.AssemblyFullName)
+                        _vsBuildPropertyStorage.SetItemAttribute(extensionProjectItemID, MSBUILD_ATTR_ID, extensionTemplate.ID)
+                        _vsBuildPropertyStorage.SetItemAttribute(extensionProjectItemID, MSBUILD_ATTR_VERSION, extensionTemplate.Version.ToString())
 
                         AddExtensionProjectFile(extensionTemplate.AssemblyFullName, projectItemAdded,
                             extensionTemplate.ID, extensionTemplate.Version, extensionTemplate.DisplayName, extensionTemplate.Description)
@@ -222,7 +222,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
 
             Dim result As ProjectItem = Nothing
             For Each projectItem As ProjectItem In parentProjectItems
-                If StringEquals(projectItem.Name, s_EXTENSION_FOLDER_NAME) Then
+                If StringEquals(projectItem.Name, EXTENSION_FOLDER_NAME) Then
                     _extensionFolderProjectItem = projectItem
                     Exit For
                 End If
@@ -242,7 +242,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
                     Dim parentProjectItems As ProjectItems = GetParentProjectItems()
                     Debug.Assert(parentProjectItems IsNot Nothing, "Could not find parent ProjectItems!")
 
-                    _extensionFolderProjectItem = parentProjectItems.AddFolder(s_EXTENSION_FOLDER_NAME)
+                    _extensionFolderProjectItem = parentProjectItems.AddFolder(EXTENSION_FOLDER_NAME)
                 End If
             End If
 
@@ -361,12 +361,12 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
             For Each extensionProjectItem As ProjectItem In _extensionFolderProjectItem.ProjectItems
                 Dim extensionProjectItemID As UInteger = DTEUtils.ItemIdOfProjectItem(_projectHierarchy, extensionProjectItem)
 
-                Dim assemblyName As String = GetBuildAttribute(extensionProjectItemID, s_MSBUILD_ATTR_ASSEMBLY)
+                Dim assemblyName As String = GetBuildAttribute(extensionProjectItemID, MSBUILD_ATTR_ASSEMBLY)
                 If assemblyName Is Nothing Then
                     assemblyName = String.Empty
                 End If
-                Dim templateID As String = GetBuildAttribute(extensionProjectItemID, s_MSBUILD_ATTR_ID)
-                Dim templateVersion As Version = GetVersion(GetBuildAttribute(extensionProjectItemID, s_MSBUILD_ATTR_VERSION))
+                Dim templateID As String = GetBuildAttribute(extensionProjectItemID, MSBUILD_ATTR_ID)
+                Dim templateVersion As Version = GetVersion(GetBuildAttribute(extensionProjectItemID, MSBUILD_ATTR_VERSION))
 
                 If String.IsNullOrEmpty(templateID) Then
                     Continue For
@@ -537,7 +537,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
             If _extensionFolderProjectItem IsNot Nothing Then
                 For Each dirPath As String In rgpszMkDocuments
                     Dim dirName As String = GetDirectoryName(dirPath)
-                    If StringEquals(dirName, s_EXTENSION_FOLDER_NAME) Then
+                    If StringEquals(dirName, EXTENSION_FOLDER_NAME) Then
                         FindMyExtensionsFolderProjectItem()
                         If _extensionFolderProjectItem Is Nothing Then
                             RaiseChangeEvent()
@@ -562,7 +562,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
             Dim namesToCheck As String() = IIf(myExtensionsFolderExistsBefore, rgszMkOldNames, rgszMkNewNames)
             For Each dirPath As String In namesToCheck
                 Dim dirName As String = GetDirectoryName(dirPath)
-                If StringEquals(dirName, s_EXTENSION_FOLDER_NAME) Then
+                If StringEquals(dirName, EXTENSION_FOLDER_NAME) Then
                     FindMyExtensionsFolderProjectItem()
                     Dim myExtensionsFolderExistsAfter As Boolean = _extensionFolderProjectItem IsNot Nothing
                     If myExtensionsFolderExistsAfter <> myExtensionsFolderExistsBefore Then
@@ -637,7 +637,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         ''' </summary>
         Private Function GetProjectItemName(templateBaseName As String) As String
             If StringIsNullEmptyOrBlank(templateBaseName) Then ' Verify and fix up input.
-                templateBaseName = s_DEFAULT_CODE_FILE_NAME
+                templateBaseName = DEFAULT_CODE_FILE_NAME
             End If
 
             If _extensionFolderProjectItem Is Nothing Then ' If MyExtensions does not exist, no point to search for it.
@@ -656,8 +656,8 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
             Return candidateProjectItemName
         End Function
 
-        Private Sub New(projectService As MyExtensibilityProjectService, _
-                serviceProvider As IServiceProvider, project As Project, _
+        Private Sub New(projectService As MyExtensibilityProjectService,
+                serviceProvider As IServiceProvider, project As Project,
                 projectHierarchy As IVsHierarchy, vsBuildPropertyStorage As IVsBuildPropertyStorage)
 
             Debug.Assert(projectService IsNot Nothing, "projectService")
@@ -690,13 +690,13 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         Private _extProjItemGroups As AssemblyDictionary(Of MyExtensionProjectItemGroup)
 
         ' MyExtensions folder and Extensions.xml file name.
-        Private Const s_EXTENSION_FOLDER_NAME As String = "MyExtensions"
+        Private Const EXTENSION_FOLDER_NAME As String = "MyExtensions"
         ' Extension code file's attributes in project file.
-        Private Const s_MSBUILD_ATTR_ASSEMBLY As String = "VBMyExtensionAssembly"
-        Private Const s_MSBUILD_ATTR_ID As String = "VBMyExtensionTemplateID"
-        Private Const s_MSBUILD_ATTR_VERSION As String = "VBMyExtensionTemplateVersion"
+        Private Const MSBUILD_ATTR_ASSEMBLY As String = "VBMyExtensionAssembly"
+        Private Const MSBUILD_ATTR_ID As String = "VBMyExtensionTemplateID"
+        Private Const MSBUILD_ATTR_VERSION As String = "VBMyExtensionTemplateVersion"
         ' Default code file name.
-        Private Const s_DEFAULT_CODE_FILE_NAME As String = "Code.vb"
+        Private Const DEFAULT_CODE_FILE_NAME As String = "Code.vb"
 
     End Class
 End Namespace

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilitySettings.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilitySettings.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Strict On
 Option Explicit On
@@ -29,7 +29,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         ''' </summary>
         Public Sub New(folderPath As String)
             Try ' Attempt to construct the setting file path. Ignore ArgumentException.
-                _settingsFilePath = Path.Combine(folderPath, s_ASM_SETTINGS_FILE_NAME)
+                _settingsFilePath = Path.Combine(folderPath, ASM_SETTINGS_FILE_NAME)
             Catch ex As ArgumentException
             End Try
 
@@ -238,7 +238,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
 
             Dim templatesWithCustomData As Templates = Nothing
             Try
-                templatesWithCustomData = solution3.GetProjectItemTemplates(projectTypeID, s_CUSTOM_DATA_SIGNATURE)
+                templatesWithCustomData = solution3.GetProjectItemTemplates(projectTypeID, CUSTOM_DATA_SIGNATURE)
             Catch ex As Exception When ReportWithoutCrash(ex, NameOf(InitializeProjectKindSettings), NameOf(MyExtensibilitySettings))
                 ' Ignore exceptions.
             End Try
@@ -302,18 +302,18 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
             For Each childNode As XmlNode In xmlElement.ChildNodes
                 Dim assemblyElement As XmlElement = TryCast(childNode, XmlElement)
                 If assemblyElement Is Nothing OrElse
-                        Not StringEquals(assemblyElement.LocalName, s_ASSEMBLY_ELEMENT) Then
+                        Not StringEquals(assemblyElement.LocalName, ASSEMBLY_ELEMENT) Then
                     Continue For
                 End If
 
                 Dim assemblyFullName As String = NormalizeAssemblyFullName(
-                    GetAttributeValue(assemblyElement, s_ASSEMBLY_FULLNAME_ATTRIBUTE))
+                    GetAttributeValue(assemblyElement, ASSEMBLY_FULLNAME_ATTRIBUTE))
                 If StringIsNullEmptyOrBlank(assemblyFullName) OrElse _autoOptions.ContainsKey(assemblyFullName) Then
                     Continue For
                 End If
 
-                Dim autoAdd As AssemblyOption = ReadAssemblyOptionAttribute(assemblyElement, s_ASSEMBLY_AUTOADD_ATTRIBUTE)
-                Dim autoRemove As AssemblyOption = ReadAssemblyOptionAttribute(assemblyElement, s_ASSEMBLY_AUTOREMOVE_ATTRIBUTE)
+                Dim autoAdd As AssemblyOption = ReadAssemblyOptionAttribute(assemblyElement, ASSEMBLY_AUTOADD_ATTRIBUTE)
+                Dim autoRemove As AssemblyOption = ReadAssemblyOptionAttribute(assemblyElement, ASSEMBLY_AUTOREMOVE_ATTRIBUTE)
 
                 _autoOptions.Add(assemblyFullName, New AssemblyAutoOption(autoAdd, autoRemove))
             Next
@@ -335,13 +335,13 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
                 xmlWriter.Indentation = 2
 
                 xmlWriter.WriteStartDocument()
-                xmlWriter.WriteStartElement(s_MY_EXTENSIONS_ELEMENT, s_MY_EXTENSIONS_ELEMENT_NAMESPACE)
+                xmlWriter.WriteStartElement(MY_EXTENSIONS_ELEMENT, MY_EXTENSIONS_ELEMENT_NAMESPACE)
 
                 For Each entry As KeyValuePair(Of String, AssemblyAutoOption) In _autoOptions
-                    xmlWriter.WriteStartElement(s_ASSEMBLY_ELEMENT)
-                    xmlWriter.WriteAttributeString(s_ASSEMBLY_FULLNAME_ATTRIBUTE, entry.Key)
-                    WriteAssemblyOptionAttribute(xmlWriter, s_ASSEMBLY_AUTOADD_ATTRIBUTE, entry.Value.AutoAdd)
-                    WriteAssemblyOptionAttribute(xmlWriter, s_ASSEMBLY_AUTOREMOVE_ATTRIBUTE, entry.Value.AutoRemove)
+                    xmlWriter.WriteStartElement(ASSEMBLY_ELEMENT)
+                    xmlWriter.WriteAttributeString(ASSEMBLY_FULLNAME_ATTRIBUTE, entry.Key)
+                    WriteAssemblyOptionAttribute(xmlWriter, ASSEMBLY_AUTOADD_ATTRIBUTE, entry.Value.AutoAdd)
+                    WriteAssemblyOptionAttribute(xmlWriter, ASSEMBLY_AUTOREMOVE_ATTRIBUTE, entry.Value.AutoRemove)
                     xmlWriter.WriteEndElement()
                 Next
 
@@ -477,16 +477,16 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         Private Shared s_assemblyOptionConverter As TypeConverter
 
         ' Custom data signature in .vstemplate file
-        Private Const s_CUSTOM_DATA_SIGNATURE As String = "Microsoft.VisualBasic.MyExtension"
+        Private Const CUSTOM_DATA_SIGNATURE As String = "Microsoft.VisualBasic.MyExtension"
         ' File name, element / attribute names for triggering assemblies settings.
-        Private Const s_ASM_SETTINGS_FILE_NAME As String = "VBMyExtensionSettings.xml"
-        Private Const s_MY_EXTENSIONS_ELEMENT As String = "VBMyExtensions"
-        Private Const s_MY_EXTENSIONS_ELEMENT_NAMESPACE As String = _
+        Private Const ASM_SETTINGS_FILE_NAME As String = "VBMyExtensionSettings.xml"
+        Private Const MY_EXTENSIONS_ELEMENT As String = "VBMyExtensions"
+        Private Const MY_EXTENSIONS_ELEMENT_NAMESPACE As String =
             "urn:schemas-microsoft-com:xml-msvbmyextensions"
-        Private Const s_ASSEMBLY_ELEMENT As String = "Assembly"
-        Private Const s_ASSEMBLY_FULLNAME_ATTRIBUTE As String = "FullName"
-        Private Const s_ASSEMBLY_AUTOADD_ATTRIBUTE As String = "AutoAdd"
-        Private Const s_ASSEMBLY_AUTOREMOVE_ATTRIBUTE As String = "AutoRemove"
+        Private Const ASSEMBLY_ELEMENT As String = "Assembly"
+        Private Const ASSEMBLY_FULLNAME_ATTRIBUTE As String = "FullName"
+        Private Const ASSEMBLY_AUTOADD_ATTRIBUTE As String = "AutoAdd"
+        Private Const ASSEMBLY_AUTOREMOVE_ATTRIBUTE As String = "AutoRemove"
 
     End Class
 End Namespace

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensionTemplate.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensionTemplate.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Strict On
 Option Explicit On
@@ -42,7 +42,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
                     xmlDocument.Load(reader)
                 End Using
 
-                Dim extensionNodes As XmlNodeList = xmlDocument.GetElementsByTagName(s_MY_EXTENSION_TEMPLATE_ELEMENT_NAME)
+                Dim extensionNodes As XmlNodeList = xmlDocument.GetElementsByTagName(MY_EXTENSION_TEMPLATE_ELEMENT_NAME)
                 If extensionNodes.Count <= 0 Then
                     Return Nothing
                 End If
@@ -59,14 +59,14 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
                     Return Nothing
                 End If
 
-                templateID = GetAttributeValue(extensionElement, s_ID_ATTRIBUTE_NAME)
-                Dim templateVersionString As String = GetAttributeValue(extensionElement, s_VERSION_ATTRIBUTE_NAME)
+                templateID = GetAttributeValue(extensionElement, ID_ATTRIBUTE_NAME)
+                Dim templateVersionString As String = GetAttributeValue(extensionElement, VERSION_ATTRIBUTE_NAME)
                 If StringIsNullEmptyOrBlank(templateVersionString) Then
                     Return Nothing
                 End If
                 templateVersion = GetVersion(templateVersionString)
-                assemblyFullName = NormalizeAssemblyFullName( _
-                    GetAttributeValue(extensionElement, s_ASM_FULLNAME_ATTRIBUTE_NAME))
+                assemblyFullName = NormalizeAssemblyFullName(
+                    GetAttributeValue(extensionElement, ASM_FULLNAME_ATTRIBUTE_NAME))
 
             Catch ex As XmlException ' Only ignore load or parse error in the XML.
                 Return Nothing
@@ -146,8 +146,8 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         ''' <summary>
         ''' Private constructor to avoid create this class directly.
         ''' </summary>
-        Private Sub New( _
-                id As String, version As Version, _
+        Private Sub New(
+                id As String, version As Version,
                 template As Template, assemblyFullName As String)
 
             Debug.Assert(Not StringIsNullEmptyOrBlank(id), "Invalid id!")
@@ -167,10 +167,10 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         Private ReadOnly _assemblyFullName As String ' Full name of the triggering assembly.
 
         ' Element and attribute names for extension template information in template's custom data.
-        Private Const s_MY_EXTENSION_TEMPLATE_ELEMENT_NAME As String = "VBMyExtensionTemplate"
-        Private Const s_ID_ATTRIBUTE_NAME As String = "ID"
-        Private Const s_VERSION_ATTRIBUTE_NAME As String = "Version"
-        Private Const s_ASM_FULLNAME_ATTRIBUTE_NAME As String = "AssemblyFullName"
+        Private Const MY_EXTENSION_TEMPLATE_ELEMENT_NAME As String = "VBMyExtensionTemplate"
+        Private Const ID_ATTRIBUTE_NAME As String = "ID"
+        Private Const VERSION_ATTRIBUTE_NAME As String = "Version"
+        Private Const ASM_FULLNAME_ATTRIBUTE_NAME As String = "AssemblyFullName"
     End Class
 
 End Namespace

--- a/src/Microsoft.VisualStudio.Editors/PropPages/AdvancedServicesDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AdvancedServicesDialog.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Diagnostics.CodeAnalysis
 Imports System.Xml
@@ -153,7 +153,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     'Either the text has already been set (in which case we're good), or it's the display default message, in which case we should
                     'change it to the default value.
                     If CustomConnectionString.Text = My.Resources.Designer.PPG_Services_connectionStringValueDefaultDisplayValue Then
-                        CustomConnectionString.Text = ServicesPropPageAppConfigHelper.connectionStringValueDefault
+                        CustomConnectionString.Text = ServicesPropPageAppConfigHelper.ConnectionStringValueDefault
                     End If
                     ServicesPropPageAppConfigHelper.SetConnectionStringText(_appConfigDocument, CustomConnectionString.Text, ProjectHierarchy)
                 Case Windows.Forms.CheckState.Unchecked

--- a/src/Microsoft.VisualStudio.Editors/PropPages/AssemblyInfoPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AssemblyInfoPropPage.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel
 Imports VSLangProj80
@@ -15,11 +15,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         'After 65535, the project system doesn't complain, and in theory any value is allowed as
         '  the string version of this, but after this value the numeric version of the file version
         '  no longer matches the string version.
-        Private Const s_maxFileVersionPartValue As UInteger = 65535
+        Private Const MaxFileVersionPartValue As UInteger = 65535
         Friend WithEvents NeutralLanguageComboBox As ComboBox
 
         'After 65535, the project system doesn't complain, but you get a compile error.
-        Private Const s_maxAssemblyVersionPartValue As UInteger = 65534
+        Private Const MaxAssemblyVersionPartValue As UInteger = 65534
 
         Private _neutralLanguageNoneText As String 'Text for "None" in the neutral language combobox (stored in case thread language changes)
 
@@ -151,7 +151,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="Version">[Out] the resulting combined version string, if valid.</param>
         Private Sub ValidateAssemblyVersion(ByRef Version As String)
-            ValidateVersion(_assemblyVersionTextBoxes, s_maxAssemblyVersionPartValue, My.Resources.Designer.PPG_Property_AssemblyVersion, True, Version)
+            ValidateVersion(_assemblyVersionTextBoxes, MaxAssemblyVersionPartValue, My.Resources.Designer.PPG_Property_AssemblyVersion, True, Version)
         End Sub
 
 
@@ -160,7 +160,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="Version">[Out] the resulting combined version string, if valid.</param>
         Private Sub ValidateAssemblyFileVersion(ByRef Version As String)
-            ValidateVersion(_fileVersionTextBoxes, s_maxFileVersionPartValue, My.Resources.Designer.PPG_Property_AssemblyFileVersion, False, Version)
+            ValidateVersion(_fileVersionTextBoxes, MaxFileVersionPartValue, My.Resources.Designer.PPG_Property_AssemblyFileVersion, False, Version)
         End Sub
 
         ''' <summary>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CSharpLanguageVersion.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CSharpLanguageVersion.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
@@ -9,26 +9,26 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
         Private Shared ReadOnly _resources As ComponentModel.ComponentResourceManager = New ComponentModel.ComponentResourceManager(GetType(AdvBuildSettingsPropPage))
 
-        Private Const s_languageVersion_Default As String = "default"
-        Private Const s_languageVersion_Latest As String = "latest"
-        Private Const s_languageVersion_ISO1 As String = "ISO-1"
-        Private Const s_languageVersion_ISO2 As String = "ISO-2"
-        Private Const s_languageVersion_3 As String = "3"
-        Private Const s_languageVersion_DisplayNameFor3 As String = "C# 3"
-        Private Const s_languageVersion_4 As String = "4"
-        Private Const s_languageVersion_DisplayNameFor4 As String = "C# 4"
-        Private Const s_languageVersion_5 As String = "5"
-        Private Const s_languageVersion_DisplayNameFor5 As String = "C# 5"
-        Private Const s_languageVersion_6 As String = "6"
-        Private Const s_languageVersion_DisplayNameFor6 As String = "C# 6"
-        Private Const s_languageVersion_7 As String = "7"
-        Private Const s_languageVersion_DisplayNameFor7 As String = "C# 7.0"
-        Private Const s_languageVersion_7_1 As String = "7.1"
-        Private Const s_languageVersion_DisplayNameFor7_1 As String = "C# 7.1"
-        Private Const s_languageVersion_7_2 As String = "7.2"
-        Private Const s_languageVersion_DisplayNameFor7_2 As String = "C# 7.2"
-        Private Const s_languageVersion_7_3 As String = "7.3"
-        Private Const s_languageVersion_DisplayNameFor7_3 As String = "C# 7.3"
+        Private Const LanguageVersion_Default As String = "default"
+        Private Const LanguageVersion_Latest As String = "latest"
+        Private Const LanguageVersion_ISO1 As String = "ISO-1"
+        Private Const LanguageVersion_ISO2 As String = "ISO-2"
+        Private Const LanguageVersion_3 As String = "3"
+        Private Const LanguageVersion_DisplayNameFor3 As String = "C# 3"
+        Private Const LanguageVersion_4 As String = "4"
+        Private Const LanguageVersion_DisplayNameFor4 As String = "C# 4"
+        Private Const LanguageVersion_5 As String = "5"
+        Private Const LanguageVersion_DisplayNameFor5 As String = "C# 5"
+        Private Const LanguageVersion_6 As String = "6"
+        Private Const LanguageVersion_DisplayNameFor6 As String = "C# 6"
+        Private Const LanguageVersion_7 As String = "7"
+        Private Const LanguageVersion_DisplayNameFor7 As String = "C# 7.0"
+        Private Const LanguageVersion_7_1 As String = "7.1"
+        Private Const LanguageVersion_DisplayNameFor7_1 As String = "C# 7.1"
+        Private Const LanguageVersion_7_2 As String = "7.2"
+        Private Const LanguageVersion_DisplayNameFor7_2 As String = "C# 7.2"
+        Private Const LanguageVersion_7_3 As String = "7.3"
+        Private Const LanguageVersion_DisplayNameFor7_3 As String = "C# 7.3"
 
         ''' <summary>
         ''' Stores the property value corresponding to the language version
@@ -71,7 +71,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         Public Shared ReadOnly Property [Default]() As CSharpLanguageVersion
             Get
-                Static value As New CSharpLanguageVersion(s_languageVersion_Default, _resources.GetString("CSharpLanguageVerison.Default"))
+                Static value As New CSharpLanguageVersion(LanguageVersion_Default, _resources.GetString("CSharpLanguageVerison.Default"))
                 Return value
             End Get
         End Property
@@ -81,7 +81,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         Public Shared ReadOnly Property Latest() As CSharpLanguageVersion
             Get
-                Static value As New CSharpLanguageVersion(s_languageVersion_Latest, _resources.GetString("CSharpLanguageVerison.Latest"))
+                Static value As New CSharpLanguageVersion(LanguageVersion_Latest, _resources.GetString("CSharpLanguageVerison.Latest"))
                 Return value
             End Get
         End Property
@@ -91,7 +91,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         Public Shared ReadOnly Property ISO1() As CSharpLanguageVersion
             Get
-                Static value As New CSharpLanguageVersion(s_languageVersion_ISO1, s_languageVersion_ISO1)
+                Static value As New CSharpLanguageVersion(LanguageVersion_ISO1, LanguageVersion_ISO1)
                 Return value
             End Get
         End Property
@@ -101,7 +101,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         Public Shared ReadOnly Property ISO2() As CSharpLanguageVersion
             Get
-                Static value As New CSharpLanguageVersion(s_languageVersion_ISO2, s_languageVersion_ISO2)
+                Static value As New CSharpLanguageVersion(LanguageVersion_ISO2, LanguageVersion_ISO2)
                 Return value
             End Get
         End Property
@@ -111,7 +111,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         Public Shared ReadOnly Property Version3() As CSharpLanguageVersion
             Get
-                Static value As New CSharpLanguageVersion(s_languageVersion_3, s_languageVersion_DisplayNameFor3)
+                Static value As New CSharpLanguageVersion(LanguageVersion_3, LanguageVersion_DisplayNameFor3)
                 Return value
             End Get
         End Property
@@ -121,7 +121,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         Public Shared ReadOnly Property Version4() As CSharpLanguageVersion
             Get
-                Static value As New CSharpLanguageVersion(s_languageVersion_4, s_languageVersion_DisplayNameFor4)
+                Static value As New CSharpLanguageVersion(LanguageVersion_4, LanguageVersion_DisplayNameFor4)
                 Return value
             End Get
         End Property
@@ -131,7 +131,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         Public Shared ReadOnly Property Version5() As CSharpLanguageVersion
             Get
-                Static value As New CSharpLanguageVersion(s_languageVersion_5, s_languageVersion_DisplayNameFor5)
+                Static value As New CSharpLanguageVersion(LanguageVersion_5, LanguageVersion_DisplayNameFor5)
                 Return value
             End Get
         End Property
@@ -141,7 +141,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         Public Shared ReadOnly Property Version6() As CSharpLanguageVersion
             Get
-                Static value As New CSharpLanguageVersion(s_languageVersion_6, s_languageVersion_DisplayNameFor6)
+                Static value As New CSharpLanguageVersion(LanguageVersion_6, LanguageVersion_DisplayNameFor6)
                 Return value
             End Get
         End Property
@@ -151,7 +151,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         Public Shared ReadOnly Property Version7() As CSharpLanguageVersion
             Get
-                Static value As New CSharpLanguageVersion(s_languageVersion_7, s_languageVersion_DisplayNameFor7)
+                Static value As New CSharpLanguageVersion(LanguageVersion_7, LanguageVersion_DisplayNameFor7)
                 Return value
             End Get
         End Property
@@ -161,7 +161,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         Public Shared ReadOnly Property Version7_1() As CSharpLanguageVersion
             Get
-                Static value As New CSharpLanguageVersion(s_languageVersion_7_1, s_languageVersion_DisplayNameFor7_1)
+                Static value As New CSharpLanguageVersion(LanguageVersion_7_1, LanguageVersion_DisplayNameFor7_1)
                 Return value
             End Get
         End Property
@@ -171,7 +171,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         Public Shared ReadOnly Property Version7_2() As CSharpLanguageVersion
             Get
-                Static value As New CSharpLanguageVersion(s_languageVersion_7_2, s_languageVersion_DisplayNameFor7_2)
+                Static value As New CSharpLanguageVersion(LanguageVersion_7_2, LanguageVersion_DisplayNameFor7_2)
                 Return value
             End Get
         End Property
@@ -181,7 +181,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         Public Shared ReadOnly Property Version7_3() As CSharpLanguageVersion
             Get
-                Static value As New CSharpLanguageVersion(s_languageVersion_7_3, s_languageVersion_DisplayNameFor7_3)
+                Static value As New CSharpLanguageVersion(LanguageVersion_7_3, LanguageVersion_DisplayNameFor7_3)
                 Return value
             End Get
         End Property

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CompilePropPage2.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CompilePropPage2.vb
@@ -33,15 +33,15 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Private _notifyError As String
         Private _notifyNone As String
         Private _notifyWarning As String
-        Private Const s_conditionColumnIndex As Integer = 0
-        Private Const s_notifyColumnIndex As Integer = 1
-        Private Const s_conditionColumnWidthPercentage As Integer = 35 'non-resizable column
-        Private Const s_notifyColumnWidthPercentage As Integer = 100
+        Private Const ConditionColumnIndex As Integer = 0
+        Private Const NotifyColumnIndex As Integer = 1
+        Private Const ConditionColumnWidthPercentage As Integer = 35 'non-resizable column
+        Private Const NotifyColumnWidthPercentage As Integer = 100
 
         'Minimum scrolling widths - widths below which resizing the settings designer will cause a horizontal
         '  scrollbar to appear rather than sizing the column below this size
-        Private Const s_conditionColumnMinScrollingWidth As Integer = 100
-        Private Const s_notifyColumnMinScrollingWidth As Integer = 100 'non-resizable column
+        Private Const ConditionColumnMinScrollingWidth As Integer = 100
+        Private Const NotifyColumnMinScrollingWidth As Integer = 100 'non-resizable column
 
         ' Cached extended objects for all configurations...
         Private _cachedExtendedObjects() As Object
@@ -196,7 +196,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 _enabled = False
             End If
 
-            Dim NotifyColumn As DataGridViewComboBoxColumn = CType(WarningsGridView.Columns.Item(s_notifyColumnIndex), DataGridViewComboBoxColumn)
+            Dim NotifyColumn As DataGridViewComboBoxColumn = CType(WarningsGridView.Columns.Item(NotifyColumnIndex), DataGridViewComboBoxColumn)
             If _enabled AndAlso DisableAllWarningsCheckBox.CheckState = CheckState.Unchecked AndAlso Me.WarningsAsErrorCheckBox.CheckState = CheckState.Unchecked Then
                 For Each column As DataGridViewColumn In WarningsGridView.Columns
                     column.DefaultCellStyle.BackColor = WarningsGridView.DefaultCellStyle.BackColor
@@ -490,8 +490,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' but should *not* include a space when passed to the compiler/set the property value
         ''' </summary>
         ''' <remarks></remarks>
-        Private Const s_anyCPUPropertyValue As String = "AnyCPU"
-        Private Const s_anyCPUPlatformName As String = "Any CPU"
+        Private Const AnyCPUPropertyValue As String = "AnyCPU"
+        Private Const AnyCPUPlatformName As String = "Any CPU"
 
         ''' <summary>
         ''' Customizable processing done before the class has populated controls in the ControlData array
@@ -546,8 +546,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                             hr = cfgProv.GetSupportedPlatformNames(platformCount, platforms, actualPlatformCount)
                             If VSErrorHandler.Succeeded(hr) Then
                                 For platformNo As Integer = 0 To CInt(platformCount - 1)
-                                    If s_anyCPUPlatformName.Equals(platforms(platformNo), StringComparison.Ordinal) Then
-                                        PlatformEntries.Add(s_anyCPUPropertyValue)
+                                    If AnyCPUPlatformName.Equals(platforms(platformNo), StringComparison.Ordinal) Then
+                                        PlatformEntries.Add(AnyCPUPropertyValue)
                                     Else
                                         PlatformEntries.Add(platforms(platformNo))
                                     End If
@@ -651,8 +651,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             New ErrorInfo(My.Resources.Designer.PPG_Compile_42029, "42029,42031", ErrorNotification.None, False, New Integer() {42029, 42031})}
 
         Private Sub PopulateErrorList()
-            Dim NotificationColumn As DataGridViewComboBoxColumn = CType(WarningsGridView.Columns.Item(s_notifyColumnIndex), DataGridViewComboBoxColumn)
-            Dim ConditionColumn As DataGridViewTextBoxColumn = CType(WarningsGridView.Columns.Item(s_conditionColumnIndex), DataGridViewTextBoxColumn)
+            Dim NotificationColumn As DataGridViewComboBoxColumn = CType(WarningsGridView.Columns.Item(NotifyColumnIndex), DataGridViewComboBoxColumn)
+            Dim ConditionColumn As DataGridViewTextBoxColumn = CType(WarningsGridView.Columns.Item(ConditionColumnIndex), DataGridViewTextBoxColumn)
             Dim Index As Integer
             Dim row As DataGridViewRow
 
@@ -666,8 +666,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     ErrorInfo.Index = Index
                 Next
 
-                .AutoResizeColumn(s_conditionColumnIndex, DataGridViewAutoSizeColumnMode.DisplayedCells)
-                .AutoResizeColumn(s_notifyColumnIndex, DataGridViewAutoSizeColumnMode.DisplayedCells)
+                .AutoResizeColumn(ConditionColumnIndex, DataGridViewAutoSizeColumnMode.DisplayedCells)
+                .AutoResizeColumn(NotifyColumnIndex, DataGridViewAutoSizeColumnMode.DisplayedCells)
                 .ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize
                 .RowHeadersWidthSizeMode = DataGridViewRowHeadersWidthSizeMode.DisableResizing
             End With
@@ -745,7 +745,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' We use an empty cell to indicate that levels conflict
         ''' </summary>
         Private Sub WarningsGridView_CellFormatting(sender As Object, e As DataGridViewCellFormattingEventArgs) Handles WarningsGridView.CellFormatting
-            If e.ColumnIndex = s_notifyColumnIndex Then
+            If e.ColumnIndex = NotifyColumnIndex Then
                 ' If either this is in an indeterminate state because we have different warning levels 
                 ' in different configurations, or if the current value is indeterminate (DBNull) because
                 ' only a subset of the values the make up this row's set of warning id's were included in
@@ -861,7 +861,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 For Each ErrorInfo As ErrorInfo In _errorInfos
                     Dim row As DataGridViewRow = rows.Item(ErrorInfo.Index)
 
-                    ComboboxCell = DirectCast(row.Cells(s_notifyColumnIndex), DataGridViewComboBoxCell)
+                    ComboboxCell = DirectCast(row.Cells(NotifyColumnIndex), DataGridViewComboBoxCell)
 
                     'Check for this error in NoWarn.Text or SpecWarnAsErrorTextBox.Text
                     If IsOptionStrictOn() AndAlso ErrorInfo.ErrorOnOptionStrict Then
@@ -1104,7 +1104,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 TargetCPUComboBox.SelectedIndex = -1
             Else
                 If (IsNothing(TryCast(value, String)) OrElse TryCast(value, String) = "") Then
-                    TargetCPUComboBox.SelectedItem = s_anyCPUPropertyValue
+                    TargetCPUComboBox.SelectedItem = AnyCPUPropertyValue
                 Else
                     TargetCPUComboBox.SelectedItem = TryCast(value, String)
                 End If
@@ -1398,7 +1398,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Event handler for value changed events fired from the warnings grid view
         ''' </summary>
         Private Sub NotificationLevelChanged(sender As Object, e As DataGridViewCellEventArgs) Handles WarningsGridView.CellValueChanged
-            If Not m_fInsideInit AndAlso Not _refreshingWarningsList AndAlso e.RowIndex >= 0 AndAlso e.ColumnIndex = s_notifyColumnIndex Then
+            If Not m_fInsideInit AndAlso Not _refreshingWarningsList AndAlso e.RowIndex >= 0 AndAlso e.ColumnIndex = NotifyColumnIndex Then
                 UpdatePropertiesFromCurrentState()
             End If
         End Sub

--- a/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel
 Imports System.Windows.Forms
@@ -14,10 +14,10 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         'After 65535, the project system doesn't complain, and in theory any value is allowed as
         '  the string version of this, but after this value the numeric version of the file version
         '  no longer matches the string version.
-        Private Const s_maxFileVersionPartValue As UInteger = 65535
+        Private Const MaxFileVersionPartValue As UInteger = 65535
 
         'After 65535, the project system doesn't complain, but you get a compile error.
-        Private Const s_maxAssemblyVersionPartValue As UInteger = 65534
+        Private Const MaxAssemblyVersionPartValue As UInteger = 65534
 
         ''' <summary>
         ''' Customizable processing done before the class has populated controls in the ControlData array
@@ -108,7 +108,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="Version">[Out] the resulting combined version string, if valid.</param>
         Private Sub ValidatePackageVersion(ByRef Version As String)
-            ValidateVersion(PackageVersion, s_maxFileVersionPartValue, My.Resources.Designer.PPG_Property_PackageVersion, False, Version)
+            ValidateVersion(PackageVersion, MaxFileVersionPartValue, My.Resources.Designer.PPG_Property_PackageVersion, False, Version)
         End Sub
 
         ''' <summary>
@@ -116,7 +116,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="Version">[Out] the resulting combined version string, if valid.</param>
         Private Sub ValidateAssemblyVersion(ByRef Version As String)
-            ValidateVersion(_assemblyVersionTextBoxes, s_maxAssemblyVersionPartValue, My.Resources.Designer.PPG_Property_AssemblyVersion, True, Version)
+            ValidateVersion(_assemblyVersionTextBoxes, MaxAssemblyVersionPartValue, My.Resources.Designer.PPG_Property_AssemblyVersion, True, Version)
         End Sub
 
         ''' <summary>
@@ -124,7 +124,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="Version">[Out] the resulting combined version string, if valid.</param>
         Private Sub ValidateAssemblyFileVersion(ByRef Version As String)
-            ValidateVersion(_fileVersionTextBoxes, s_maxFileVersionPartValue, My.Resources.Designer.PPG_Property_AssemblyFileVersion, False, Version)
+            ValidateVersion(_fileVersionTextBoxes, MaxFileVersionPartValue, My.Resources.Designer.PPG_Property_AssemblyFileVersion, False, Version)
         End Sub
 
         Private Sub AssemblyVersionLayoutPanel_TextChanged(sender As Object, e As EventArgs) Handles AssemblyVersionMajorTextBox.TextChanged, AssemblyVersionMinorTextBox.TextChanged, AssemblyVersionBuildTextBox.TextChanged, AssemblyVersionRevisionTextBox.TextChanged

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePropPage.vb
@@ -27,12 +27,12 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Implements ISelectionContainer
         Implements IVsWCFReferenceEvents
 
-        Private Const s_REFCOLUMN_NAME As Integer = 0
-        Private Const s_REFCOLUMN_TYPE As Integer = 1
-        Private Const s_REFCOLUMN_VERSION As Integer = 2
-        Private Const s_REFCOLUMN_COPYLOCAL As Integer = 3
-        Private Const s_REFCOLUMN_PATH As Integer = 4
-        Private Const s_REFCOLUMN_MAX As Integer = 4
+        Private Const REFCOLUMN_NAME As Integer = 0
+        Private Const REFCOLUMN_TYPE As Integer = 1
+        Private Const REFCOLUMN_VERSION As Integer = 2
+        Private Const REFCOLUMN_COPYLOCAL As Integer = 3
+        Private Const REFCOLUMN_PATH As Integer = 4
+        Private Const REFCOLUMN_MAX As Integer = 4
 
         Friend WithEvents AddUserImportButton As Button
         Friend WithEvents UpdateUserImportButton As Button
@@ -1551,33 +1551,33 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Dim _handle As IntPtr = ReferenceList.Handle
 
             ' By default size all columns by size of column header text
-            Dim AutoSizeMethod As Integer() = New Integer(s_REFCOLUMN_MAX) {NativeMethods.LVSCW_AUTOSIZE_USEHEADER, NativeMethods.LVSCW_AUTOSIZE_USEHEADER, NativeMethods.LVSCW_AUTOSIZE_USEHEADER, NativeMethods.LVSCW_AUTOSIZE_USEHEADER, NativeMethods.LVSCW_AUTOSIZE_USEHEADER}
+            Dim AutoSizeMethod As Integer() = New Integer(REFCOLUMN_MAX) {NativeMethods.LVSCW_AUTOSIZE_USEHEADER, NativeMethods.LVSCW_AUTOSIZE_USEHEADER, NativeMethods.LVSCW_AUTOSIZE_USEHEADER, NativeMethods.LVSCW_AUTOSIZE_USEHEADER, NativeMethods.LVSCW_AUTOSIZE_USEHEADER}
 
             If ReferenceList.Items.Count > 0 Then
                 ' If there are elements in the listview, size the name, version, and path columns by item text if not empty
                 With ReferenceList.Items(0)
                     ' For the first column, if not offset, check the .text property, otherwise check the subitems
                     If (ColOffset = 0 AndAlso .Text <> "") OrElse
-                        (ColOffset > 0 AndAlso .SubItems(s_REFCOLUMN_NAME + ColOffset).Text <> "") Then
-                        AutoSizeMethod(s_REFCOLUMN_NAME) = NativeMethods.LVSCW_AUTOSIZE
+                        (ColOffset > 0 AndAlso .SubItems(REFCOLUMN_NAME + ColOffset).Text <> "") Then
+                        AutoSizeMethod(REFCOLUMN_NAME) = NativeMethods.LVSCW_AUTOSIZE
                     End If
 
-                    If (.SubItems.Count > s_REFCOLUMN_VERSION + ColOffset AndAlso .SubItems(s_REFCOLUMN_VERSION + ColOffset).Text <> "") Then
-                        AutoSizeMethod(s_REFCOLUMN_VERSION) = NativeMethods.LVSCW_AUTOSIZE
+                    If (.SubItems.Count > REFCOLUMN_VERSION + ColOffset AndAlso .SubItems(REFCOLUMN_VERSION + ColOffset).Text <> "") Then
+                        AutoSizeMethod(REFCOLUMN_VERSION) = NativeMethods.LVSCW_AUTOSIZE
                     End If
 
-                    If (.SubItems.Count > s_REFCOLUMN_PATH + ColOffset AndAlso .SubItems(s_REFCOLUMN_PATH + ColOffset).Text <> "") Then
-                        AutoSizeMethod(s_REFCOLUMN_PATH) = NativeMethods.LVSCW_AUTOSIZE
+                    If (.SubItems.Count > REFCOLUMN_PATH + ColOffset AndAlso .SubItems(REFCOLUMN_PATH + ColOffset).Text <> "") Then
+                        AutoSizeMethod(REFCOLUMN_PATH) = NativeMethods.LVSCW_AUTOSIZE
                     End If
                 End With
             End If
 
             ' Do actual sizing
-            NativeMethods.SendMessage(New HandleRef(owner, _handle), NativeMethods.LVM_SETCOLUMNWIDTH, s_REFCOLUMN_NAME + ColOffset, AutoSizeMethod(s_REFCOLUMN_NAME))
-            NativeMethods.SendMessage(New HandleRef(owner, _handle), NativeMethods.LVM_SETCOLUMNWIDTH, s_REFCOLUMN_TYPE + ColOffset, AutoSizeMethod(s_REFCOLUMN_TYPE))
-            NativeMethods.SendMessage(New HandleRef(owner, _handle), NativeMethods.LVM_SETCOLUMNWIDTH, s_REFCOLUMN_VERSION + ColOffset, AutoSizeMethod(s_REFCOLUMN_VERSION))
-            NativeMethods.SendMessage(New HandleRef(owner, _handle), NativeMethods.LVM_SETCOLUMNWIDTH, s_REFCOLUMN_COPYLOCAL + ColOffset, AutoSizeMethod(s_REFCOLUMN_COPYLOCAL))
-            NativeMethods.SendMessage(New HandleRef(owner, _handle), NativeMethods.LVM_SETCOLUMNWIDTH, s_REFCOLUMN_PATH + ColOffset, AutoSizeMethod(s_REFCOLUMN_PATH))
+            NativeMethods.SendMessage(New HandleRef(owner, _handle), NativeMethods.LVM_SETCOLUMNWIDTH, REFCOLUMN_NAME + ColOffset, AutoSizeMethod(REFCOLUMN_NAME))
+            NativeMethods.SendMessage(New HandleRef(owner, _handle), NativeMethods.LVM_SETCOLUMNWIDTH, REFCOLUMN_TYPE + ColOffset, AutoSizeMethod(REFCOLUMN_TYPE))
+            NativeMethods.SendMessage(New HandleRef(owner, _handle), NativeMethods.LVM_SETCOLUMNWIDTH, REFCOLUMN_VERSION + ColOffset, AutoSizeMethod(REFCOLUMN_VERSION))
+            NativeMethods.SendMessage(New HandleRef(owner, _handle), NativeMethods.LVM_SETCOLUMNWIDTH, REFCOLUMN_COPYLOCAL + ColOffset, AutoSizeMethod(REFCOLUMN_COPYLOCAL))
+            NativeMethods.SendMessage(New HandleRef(owner, _handle), NativeMethods.LVM_SETCOLUMNWIDTH, REFCOLUMN_PATH + ColOffset, AutoSizeMethod(REFCOLUMN_PATH))
         End Sub
 
         Protected Overrides Function GetF1HelpKeyword() As String
@@ -2267,17 +2267,17 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 #Enable Warning CA1067 ' Override Object.Equals(object) when implementing IEquatable<T>
         Implements IEquatable(Of ImportIdentity)
 
-        Private Const s_aliasGroupName As String = "Alias"
-        Private Const s_aliasGroup As String = "(?<" & s_aliasGroupName & ">[^=""'\s]+)"
+        Private Const AliasGroupName As String = "Alias"
+        Private Const AliasGroup As String = "(?<" & AliasGroupName & ">[^=""'\s]+)"
 
         ' Regular expression for parsing XML imports statement (<xmlns[:Alias]='url'>).
         Private Shared s_xmlImportRegex As New Regex(
-            "^\s*\<\s*[xX][mM][lL][nN][sS]\s*(:\s*" & s_aliasGroup & ")?\s*=\s*(""[^""]*""|'[^']*')\s*\>\s*$",
+            "^\s*\<\s*[xX][mM][lL][nN][sS]\s*(:\s*" & AliasGroup & ")?\s*=\s*(""[^""]*""|'[^']*')\s*\>\s*$",
             RegexOptions.Compiled)
 
         ' Regular expression for parsing VB alias imports statement (Alias=Namespace).
         Private Shared s_vbImportRegex As New Regex(
-            "^\s*" & s_aliasGroup & "\s*=\s*.*$",
+            "^\s*" & AliasGroup & "\s*=\s*.*$",
             RegexOptions.Compiled)
 
         ' Kind of import - VB regular, VB Alias, xmlns.
@@ -2307,14 +2307,14 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             If m.Success Then
                 ' If succeeded, set identity to the alias (namespace).
                 _kind = ImportKind.XmlNamespace
-                _identity = m.Groups(s_aliasGroupName).Value
+                _identity = m.Groups(AliasGroupName).Value
             Else
                 ' If failed, match against VB alias import syntax.
                 m = s_vbImportRegex.Match(import)
                 If m.Success Then
                     ' If succeeded, use alias as identity.
                     _kind = ImportKind.VBAlias
-                    _identity = m.Groups(s_aliasGroupName).Value
+                    _identity = m.Groups(AliasGroupName).Value
                 Else
                     ' Otherwise use the whole import string as identity (namespace or invalid syntax).
                     _kind = ImportKind.VBNamespace

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ServicesPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ServicesPropPage.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Private _ignoreLostFocus As Boolean
         Private _appConfigError As Boolean
         Private _frameworkVersionNumber As UInteger
-        Private Const s_requiredFrameworkVersion As UInteger = &H30005
+        Private Const RequiredFrameworkVersion As UInteger = &H30005
 
         Public Sub New()
             InitializeComponent()
@@ -46,7 +46,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     CurrentAppConfigDocument = newDoc
                     If Not _appConfigError Then
                         'If the application is targetting earlier than .NET Framework 3.5 or a client subset of .NET Framework, then disable this tab.
-                        If _frameworkVersionNumber < s_requiredFrameworkVersion OrElse IsClientFrameworkSubset(ProjectHierarchy) Then
+                        If _frameworkVersionNumber < RequiredFrameworkVersion OrElse IsClientFrameworkSubset(ProjectHierarchy) Then
                             SetControlsEnabledProperty(False)
                             EnableApplicationServices.Enabled = False
                         Else
@@ -89,7 +89,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             'DevDiv Bugs 88577, If the user isn't targetting V3.5 or above, bring up
             'an error stating that the functionality is only available for 3.5 or greater.
             'Also, uncheck the checkbox
-            If EnableApplicationServices.Checked AndAlso _frameworkVersionNumber < s_requiredFrameworkVersion Then
+            If EnableApplicationServices.Checked AndAlso _frameworkVersionNumber < RequiredFrameworkVersion Then
                 DesignerFramework.DesignerMessageBox.Show(ServiceProvider, My.Resources.Designer.PPG_Services_VersionWarning, Nothing, MessageBoxButtons.OK, MessageBoxIcon.Warning)
                 _ignoreCheckedChanged = True
                 EnableApplicationServices.Checked = False

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ServicesPropPageConfigHelper.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ServicesPropPageConfigHelper.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.VisualStudio.Shell.Interop
 Imports System.Diagnostics.CodeAnalysis
@@ -17,48 +17,48 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Private Shared ReadOnly s_clientFormsMembershipProviderType As Type = GetType(Web.ClientServices.Providers.ClientFormsAuthenticationMembershipProvider)
         Private Shared ReadOnly s_clientWindowsMembershipProviderType As Type = GetType(Web.ClientServices.Providers.ClientWindowsAuthenticationMembershipProvider)
 
-        Private Const s_systemWeb As String = "system.web"
-        Private Const s_roleManager As String = "roleManager"
-        Private Const s_providers As String = "providers"
-        Private Const s_appSettings As String = "appSettings"
-        Private Const s_connectionString As String = "connectionString"
-        Private Const s_connectionStrings As String = "connectionStrings"
-        Private Const s_membership As String = "membership"
-        Private Const s_configuration As String = "configuration"
-        Private Const s_clientSettingsProviderPrefix As String = "ClientSettingsProvider."
-        Private Const s_defaultProvider As String = "defaultProvider"
+        Private Const SystemWeb As String = "system.web"
+        Private Const RoleManager As String = "roleManager"
+        Private Const Providers As String = "providers"
+        Private Const AppSettings As String = "appSettings"
+        Private Const ConnectionString As String = "connectionString"
+        Private Const ConnectionStrings As String = "connectionStrings"
+        Private Const Membership As String = "membership"
+        Private Const Configuration As String = "configuration"
+        Private Const ClientSettingsProviderPrefix As String = "ClientSettingsProvider."
+        Private Const DefaultProvider As String = "defaultProvider"
 
-        Private Const s_cacheTimeout As String = "cacheTimeout"
-        Private Const s_cacheTimeoutDefault As String = "86400" '86400 seconds = 1 day
+        Private Const CacheTimeout As String = "cacheTimeout"
+        Private Const CacheTimeoutDefault As String = "86400" '86400 seconds = 1 day
 
-        Private Const s_enabled As String = "enabled"
-        Private Const s_enabledDefault As String = "true"
+        Private Const Enabled As String = "enabled"
+        Private Const EnabledDefault As String = "true"
 
-        Private Const s_honorCookieExpiry As String = "honorCookieExpiry"
-        Private Const s_honorCookieExpiryDefault As String = "false"
+        Private Const HonorCookieExpiry As String = "honorCookieExpiry"
+        Private Const HonorCookieExpiryDefault As String = "false"
 
-        Private Const s_serviceUri As String = "serviceUri"
+        Private Const ServiceUri As String = "serviceUri"
         Private Shared ReadOnly s_serviceUriDefault As String = String.Empty
 
-        Private Const s_connectionStringName As String = "connectionStringName"
-        Private Const s_connectionStringNameDefault As String = "DefaultConnection"
-        Friend Const connectionStringValueDefault As String = "Data Source = |SQL/CE|"
+        Private Const ConnectionStringName As String = "connectionStringName"
+        Private Const ConnectionStringNameDefault As String = "DefaultConnection"
+        Friend Const ConnectionStringValueDefault As String = "Data Source = |SQL/CE|"
 
-        Private Const s_credentialsProvider As String = "credentialsProvider"
+        Private Const CredentialsProvider As String = "credentialsProvider"
         Private Shared ReadOnly s_credentialsProviderDefault As String = String.Empty
 
-        Private Const s_savePasswordHashLocally As String = "savePasswordHashLocally"
-        Private Const s_savePasswordHashLocallyDefault As String = "true"
+        Private Const SavePasswordHashLocally As String = "savePasswordHashLocally"
+        Private Const SavePasswordHashLocallyDefault As String = "true"
 
-        Private Const s_add As String = "add"
-        Private Const s_key As String = "key"
-        Private Const s_name As String = "name"
-        Private Const s_type As String = "type"
-        Private Const s_value As String = "value"
-        Private Const s_childPrefix As String = "child::"
+        Private Const Add As String = "add"
+        Private Const Key As String = "key"
+        Private Const Name As String = "name"
+        Private Const Type As String = "type"
+        Private Const Value As String = "value"
+        Private Const ChildPrefix As String = "child::"
 
-        Private Const s_roleManagerDefaultNameDefault As String = "ClientRoleProvider"
-        Private Const s_membershipDefaultNameDefault As String = "ClientAuthenticationMembershipProvider"
+        Private Const RoleManagerDefaultNameDefault As String = "ClientRoleProvider"
+        Private Const MembershipDefaultNameDefault As String = "ClientAuthenticationMembershipProvider"
 
         Private Sub New()
             'Don't create a public constructor
@@ -190,7 +190,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             If path Is Nothing OrElse path.Length = 0 Then Return Nothing
             For i As Integer = 0 To path.Length - 1
                 If currentNode Is Nothing Then Return Nothing
-                currentNode = currentNode.SelectSingleNode(s_childPrefix & path(i))
+                currentNode = currentNode.SelectSingleNode(ChildPrefix & path(i))
             Next
             Return currentNode
         End Function
@@ -204,39 +204,39 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Function
 
         Private Shared Function GetConfigurationNode(doc As XmlDocument) As XmlNode
-            Return GetXmlNode(doc, s_configuration)
+            Return GetXmlNode(doc, Configuration)
         End Function
 
         Private Shared Function GetConnectionStringsNode(doc As XmlDocument) As XmlNode
-            Return GetXmlNode(GetConfigurationNode(doc), s_connectionStrings)
+            Return GetXmlNode(GetConfigurationNode(doc), ConnectionStrings)
         End Function
 
         Private Shared Function GetSystemWebNode(doc As XmlDocument) As XmlNode
-            Return GetXmlNode(GetConfigurationNode(doc), s_systemWeb)
+            Return GetXmlNode(GetConfigurationNode(doc), SystemWeb)
         End Function
 
         Private Shared Function GetRoleManagerNode(doc As XmlDocument) As XmlNode
-            Return GetXmlNode(GetSystemWebNode(doc), s_roleManager)
+            Return GetXmlNode(GetSystemWebNode(doc), RoleManager)
         End Function
 
         Private Shared Function GetRoleManagerProvidersNode(doc As XmlDocument) As XmlNode
-            Return GetXmlNode(GetRoleManagerNode(doc), s_providers)
+            Return GetXmlNode(GetRoleManagerNode(doc), Providers)
         End Function
 
         Private Shared Function GetMembershipNode(doc As XmlDocument) As XmlNode
-            Return GetXmlNode(GetSystemWebNode(doc), s_membership)
+            Return GetXmlNode(GetSystemWebNode(doc), Membership)
         End Function
 
         Private Shared Function GetMembershipProvidersNode(doc As XmlDocument) As XmlNode
-            Return GetXmlNode(GetMembershipNode(doc), s_providers)
+            Return GetXmlNode(GetMembershipNode(doc), Providers)
         End Function
 
         Private Shared Function GetDefaultClientServicesRoleManagerProviderNode(doc As XmlDocument, Optional projectHierarchy As IVsHierarchy = Nothing) As XmlNode
             Dim defaultProviderName As String = GetRoleManagerDefaultProviderName(doc)
             If String.IsNullOrEmpty(defaultProviderName) Then Return Nothing
-            Dim addNodeList As XmlNodeList = GetXmlNodeList(GetRoleManagerProvidersNode(doc), s_add)
-            Dim addNode As XmlNode = GetXmlNodeWithValueFromList(addNodeList, s_name, defaultProviderName)
-            If addNode IsNot Nothing AndAlso IsClientRoleManagerProviderType(GetAttribute(addNode, s_type), projectHierarchy) Then
+            Dim addNodeList As XmlNodeList = GetXmlNodeList(GetRoleManagerProvidersNode(doc), Add)
+            Dim addNode As XmlNode = GetXmlNodeWithValueFromList(addNodeList, Name, defaultProviderName)
+            If addNode IsNot Nothing AndAlso IsClientRoleManagerProviderType(GetAttribute(addNode, Type), projectHierarchy) Then
                 Return addNode
             End If
             Return Nothing
@@ -244,37 +244,37 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
         Private Shared Function GetXmlNodeList(node As XmlNode, listName As String) As XmlNodeList
             If node Is Nothing Then Return Nothing
-            Return node.SelectNodes(s_childPrefix & listName)
+            Return node.SelectNodes(ChildPrefix & listName)
         End Function
 
         Private Shared Function GetDefaultClientServicesMembershipProviderNode(doc As XmlDocument, Optional projectHierarchy As IVsHierarchy = Nothing) As XmlNode
             Dim defaultProviderName As String = GetMembershipDefaultProviderName(doc)
             If String.IsNullOrEmpty(defaultProviderName) Then Return Nothing
-            Dim addNodeList As XmlNodeList = GetXmlNodeList(GetMembershipProvidersNode(doc), s_add)
-            Dim addNode As XmlNode = GetXmlNodeWithValueFromList(addNodeList, s_name, defaultProviderName)
-            If addNode IsNot Nothing AndAlso IsClientMembershipProviderType(GetAttribute(addNode, s_type), projectHierarchy) Then
+            Dim addNodeList As XmlNodeList = GetXmlNodeList(GetMembershipProvidersNode(doc), Add)
+            Dim addNode As XmlNode = GetXmlNodeWithValueFromList(addNodeList, Name, defaultProviderName)
+            If addNode IsNot Nothing AndAlso IsClientMembershipProviderType(GetAttribute(addNode, Type), projectHierarchy) Then
                 Return addNode
             End If
             Return Nothing
         End Function
 
         Private Shared Function GetAppSettingsNode(doc As XmlDocument) As XmlNode
-            Return GetXmlNode(GetConfigurationNode(doc), s_appSettings)
+            Return GetXmlNode(GetConfigurationNode(doc), AppSettings)
         End Function
 
         Private Shared Function GetAppSettingsServiceUriNode(doc As XmlDocument) As XmlNode
-            Dim addList As XmlNodeList = GetXmlNodeList(GetAppSettingsNode(doc), s_add)
-            Return GetXmlNodeWithValueFromList(addList, s_key, AppSettingsName(s_serviceUri))
+            Dim addList As XmlNodeList = GetXmlNodeList(GetAppSettingsNode(doc), Add)
+            Return GetXmlNodeWithValueFromList(addList, Key, AppSettingsName(ServiceUri))
         End Function
 
         Private Shared Function GetAppSettingsConnectionStringNameNode(doc As XmlDocument) As XmlNode
-            Dim addList As XmlNodeList = GetXmlNodeList(GetAppSettingsNode(doc), s_add)
-            Return GetXmlNodeWithValueFromList(addList, s_key, AppSettingsName(s_connectionStringName))
+            Dim addList As XmlNodeList = GetXmlNodeList(GetAppSettingsNode(doc), Add)
+            Return GetXmlNodeWithValueFromList(addList, Key, AppSettingsName(ConnectionStringName))
         End Function
 
         Private Shared Function GetAppSettingsHonorCookieExpiryNode(doc As XmlDocument) As XmlNode
-            Dim addList As XmlNodeList = GetXmlNodeList(GetAppSettingsNode(doc), s_add)
-            Return GetXmlNodeWithValueFromList(addList, s_key, AppSettingsName(s_honorCookieExpiry))
+            Dim addList As XmlNodeList = GetXmlNodeList(GetAppSettingsNode(doc), Add)
+            Return GetXmlNodeWithValueFromList(addList, Key, AppSettingsName(HonorCookieExpiry))
         End Function
 
         Private Shared Function IsClientMembershipWindowsProviderNode(node As XmlNode, Optional projectHierarchy As IVsHierarchy = Nothing) As Boolean
@@ -282,15 +282,15 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Function
 
         Private Shared Function NodeHasTypeAttribute(node As XmlNode, typeToCheck As Type) As Boolean
-            Dim nodeType As String = GetAttribute(node, s_type)
+            Dim nodeType As String = GetAttribute(node, Type)
             Return TypesMatch(nodeType, typeToCheck)
         End Function
 
         Private Shared Sub RemoveProvidersByType(node As XmlNode, typeToRemove As Type)
-            Dim providers As XmlNodeList = GetXmlNodeList(node, s_add)
+            Dim providers As XmlNodeList = GetXmlNodeList(node, Add)
             If providers IsNot Nothing Then
                 For Each provider As XmlNode In providers
-                    Dim providerType As String = GetAttribute(provider, s_type)
+                    Dim providerType As String = GetAttribute(provider, Type)
                     If providerType IsNot Nothing AndAlso (providerType.Equals(typeToRemove.FullName, StringComparison.OrdinalIgnoreCase) OrElse providerType.StartsWith(typeToRemove.FullName + ",", StringComparison.OrdinalIgnoreCase)) Then
                         RemoveNode(node, provider)
                     End If
@@ -303,7 +303,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Friend Shared Function GetDefaultProviderName(node As XmlNode) As String
             If node Is Nothing Then Return Nothing
 
-            Dim defaultProviderAttribute As XmlAttribute = node.Attributes(s_defaultProvider)
+            Dim defaultProviderAttribute As XmlAttribute = node.Attributes(DefaultProvider)
             If defaultProviderAttribute IsNot Nothing Then
                 Return defaultProviderAttribute.Value
             End If
@@ -418,19 +418,19 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             '         />
             '  </providers>
             '</roleManager>
-            Dim configurationNode As XmlNode = EnsureNode(appConfigDocument, s_configuration, appConfigDocument)
-            Dim systemWebNode As XmlNode = EnsureNode(appConfigDocument, s_systemWeb, configurationNode)
-            Dim roleManagerNode As XmlNode = EnsureNode(appConfigDocument, s_roleManager, systemWebNode)
+            Dim configurationNode As XmlNode = EnsureNode(appConfigDocument, Configuration, appConfigDocument)
+            Dim systemWebNode As XmlNode = EnsureNode(appConfigDocument, SystemWeb, configurationNode)
+            Dim roleManagerNode As XmlNode = EnsureNode(appConfigDocument, RoleManager, systemWebNode)
             Dim defaultSettingNode As XmlNode
 
-            Dim defaultProviderAttribute As XmlAttribute = roleManagerNode.Attributes(s_defaultProvider)
+            Dim defaultProviderAttribute As XmlAttribute = roleManagerNode.Attributes(DefaultProvider)
 
             'If we already have a default provider, make sure it's one of ours
             If defaultProviderAttribute IsNot Nothing Then
                 defaultSettingNode = GetDefaultClientServicesRoleManagerProviderNode(appConfigDocument, projectHierarchy)
                 If defaultSettingNode Is Nothing Then
                     'We had a default, and it wasn't one of ours.  Remove the default attribute
-                    RemoveAttribute(roleManagerNode, s_defaultProvider)
+                    RemoveAttribute(roleManagerNode, DefaultProvider)
                     defaultProviderAttribute = Nothing
                 End If
             End If
@@ -439,27 +439,27 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 'Remove any existing provider with the same type as clientRoleManagerType
                 RemoveProvidersByType(GetRoleManagerProvidersNode(appConfigDocument), s_clientRoleManagerType)
                 Dim nameValue As String = GetRoleManagerCreateDefaultProviderName(appConfigDocument)
-                SetAttribute(appConfigDocument, roleManagerNode, s_defaultProvider, nameValue)
-                SetAttribute(appConfigDocument, roleManagerNode, s_enabled, s_enabledDefault)
+                SetAttribute(appConfigDocument, roleManagerNode, DefaultProvider, nameValue)
+                SetAttribute(appConfigDocument, roleManagerNode, Enabled, EnabledDefault)
                 defaultSettingNode = GetDefaultClientServicesRoleManagerProviderNode(appConfigDocument, projectHierarchy)
                 If defaultSettingNode Is Nothing Then
-                    Dim providersNode As XmlNode = EnsureNode(appConfigDocument, s_providers, roleManagerNode)
-                    Dim addNode As XmlNode = CreateNode(appConfigDocument, XmlNodeType.Element, s_add)
-                    SetAttribute(appConfigDocument, addNode, s_name, nameValue)
+                    Dim providersNode As XmlNode = EnsureNode(appConfigDocument, Providers, roleManagerNode)
+                    Dim addNode As XmlNode = CreateNode(appConfigDocument, XmlNodeType.Element, Add)
+                    SetAttribute(appConfigDocument, addNode, Name, nameValue)
                     Dim defaultName As String = DefaultConnectionStringName(appConfigDocument, projectHierarchy)
-                    SetAttributeIfNonNull(appConfigDocument, addNode, s_connectionStringName, defaultName)
-                    SetAttribute(appConfigDocument, addNode, s_type, GetSupportedType(s_clientRoleManagerType, projectHierarchy).AssemblyQualifiedName)
-                    SetAttribute(appConfigDocument, addNode, s_serviceUri, s_serviceUriDefault)
-                    SetAttribute(appConfigDocument, addNode, s_cacheTimeout, s_cacheTimeoutDefault)
-                    SetAttributeIfNonNull(appConfigDocument, addNode, s_honorCookieExpiry, DefaultHonorCookieExpiry(appConfigDocument, projectHierarchy))
+                    SetAttributeIfNonNull(appConfigDocument, addNode, ConnectionStringName, defaultName)
+                    SetAttribute(appConfigDocument, addNode, Type, GetSupportedType(s_clientRoleManagerType, projectHierarchy).AssemblyQualifiedName)
+                    SetAttribute(appConfigDocument, addNode, ServiceUri, s_serviceUriDefault)
+                    SetAttribute(appConfigDocument, addNode, CacheTimeout, CacheTimeoutDefault)
+                    SetAttributeIfNonNull(appConfigDocument, addNode, HonorCookieExpiry, DefaultHonorCookieExpiry(appConfigDocument, projectHierarchy))
                     providersNode.AppendChild(addNode)
                 End If
             End If
         End Sub
 
         Private Shared Function GetRoleManagerCreateDefaultProviderName(doc As XmlDocument) As String
-            Dim addNodeList As XmlNodeList = GetXmlNodeList(GetRoleManagerProvidersNode(doc), s_add)
-            Return FindUniqueValueInList(addNodeList, s_roleManagerDefaultNameDefault, s_name)
+            Dim addNodeList As XmlNodeList = GetXmlNodeList(GetRoleManagerProvidersNode(doc), Add)
+            Return FindUniqueValueInList(addNodeList, RoleManagerDefaultNameDefault, Name)
         End Function
 
         Private Shared Function FindUniqueValueInList(nodeList As XmlNodeList, defaultName As String, attributeName As String) As String
@@ -477,8 +477,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Function
 
         Private Shared Function GetConnectionStringCreateDefaultProviderName(doc As XmlDocument) As String
-            Dim addNodeList As XmlNodeList = GetXmlNodeList(GetConnectionStringsNode(doc), s_add)
-            Return FindUniqueValueInList(addNodeList, s_connectionStringNameDefault, s_name)
+            Dim addNodeList As XmlNodeList = GetXmlNodeList(GetConnectionStringsNode(doc), Add)
+            Return FindUniqueValueInList(addNodeList, ConnectionStringNameDefault, Name)
         End Function
 
         Private Shared Sub EnsureDefaultRoleManagerNodeDoesntExist(appConfigDocument As XmlDocument, Optional projectHierarchy As IVsHierarchy = Nothing)
@@ -490,7 +490,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             'empty, and roleManager if it's now empty.
             Dim defaultSettingNode As XmlNode = GetDefaultClientServicesRoleManagerProviderNode(appConfigDocument, projectHierarchy)
             If defaultSettingNode IsNot Nothing Then
-                RemoveAttribute(roleManagerNode, s_defaultProvider)
+                RemoveAttribute(roleManagerNode, DefaultProvider)
                 'Remove the <add> for the default node
                 RemoveNode(roleManagerProvidersNode, defaultSettingNode)
             End If
@@ -520,19 +520,19 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             '         />
             '  </providers>
             '</roleManager>
-            Dim configurationNode As XmlNode = EnsureNode(appConfigDocument, s_configuration, appConfigDocument)
-            Dim systemWebNode As XmlNode = EnsureNode(appConfigDocument, s_systemWeb, configurationNode)
-            Dim membershipNode As XmlNode = EnsureNode(appConfigDocument, s_membership, systemWebNode)
+            Dim configurationNode As XmlNode = EnsureNode(appConfigDocument, Configuration, appConfigDocument)
+            Dim systemWebNode As XmlNode = EnsureNode(appConfigDocument, SystemWeb, configurationNode)
+            Dim membershipNode As XmlNode = EnsureNode(appConfigDocument, Membership, systemWebNode)
             Dim defaultSettingNode As XmlNode
 
-            Dim defaultProviderAttribute As XmlAttribute = membershipNode.Attributes(s_defaultProvider)
+            Dim defaultProviderAttribute As XmlAttribute = membershipNode.Attributes(DefaultProvider)
 
             'If we already have a default provider, make sure it's one of ours
             If defaultProviderAttribute IsNot Nothing Then
                 defaultSettingNode = GetDefaultClientServicesMembershipProviderNode(appConfigDocument, projectHierarchy)
                 If defaultSettingNode Is Nothing Then
                     'We had a default, and it wasn't one of ours.  Remove the default attribute
-                    RemoveAttribute(membershipNode, s_defaultProvider)
+                    RemoveAttribute(membershipNode, DefaultProvider)
                     defaultProviderAttribute = Nothing
                 End If
             End If
@@ -541,17 +541,17 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 'Remove any existing provider with the same type as clientFormsMembershipProviderType and clientWindowsMembershipProviderType
                 RemoveProvidersByType(GetMembershipProvidersNode(appConfigDocument), s_clientFormsMembershipProviderType)
                 RemoveProvidersByType(GetMembershipProvidersNode(appConfigDocument), s_clientWindowsMembershipProviderType)
-                Dim addNodeList As XmlNodeList = GetXmlNodeList(GetMembershipProvidersNode(appConfigDocument), s_add)
-                Dim nameValue As String = FindUniqueValueInList(addNodeList, s_membershipDefaultNameDefault, s_name)
-                SetAttribute(appConfigDocument, membershipNode, s_defaultProvider, nameValue)
+                Dim addNodeList As XmlNodeList = GetXmlNodeList(GetMembershipProvidersNode(appConfigDocument), Add)
+                Dim nameValue As String = FindUniqueValueInList(addNodeList, MembershipDefaultNameDefault, Name)
+                SetAttribute(appConfigDocument, membershipNode, DefaultProvider, nameValue)
                 defaultSettingNode = GetDefaultClientServicesMembershipProviderNode(appConfigDocument, projectHierarchy)
                 If defaultSettingNode Is Nothing Then
-                    Dim providersNode As XmlNode = EnsureNode(appConfigDocument, s_providers, membershipNode)
-                    Dim addNode As XmlNode = CreateNode(appConfigDocument, XmlNodeType.Element, s_add)
-                    SetAttribute(appConfigDocument, addNode, s_name, nameValue)
-                    SetAttribute(appConfigDocument, addNode, s_type, GetSupportedType(s_clientFormsMembershipProviderType, projectHierarchy).AssemblyQualifiedName)
-                    SetAttributeIfNonNull(appConfigDocument, addNode, s_connectionStringName, DefaultConnectionStringName(appConfigDocument, projectHierarchy))
-                    SetAttribute(appConfigDocument, addNode, s_serviceUri, s_serviceUriDefault)
+                    Dim providersNode As XmlNode = EnsureNode(appConfigDocument, Providers, membershipNode)
+                    Dim addNode As XmlNode = CreateNode(appConfigDocument, XmlNodeType.Element, Add)
+                    SetAttribute(appConfigDocument, addNode, Name, nameValue)
+                    SetAttribute(appConfigDocument, addNode, Type, GetSupportedType(s_clientFormsMembershipProviderType, projectHierarchy).AssemblyQualifiedName)
+                    SetAttributeIfNonNull(appConfigDocument, addNode, ConnectionStringName, DefaultConnectionStringName(appConfigDocument, projectHierarchy))
+                    SetAttribute(appConfigDocument, addNode, ServiceUri, s_serviceUriDefault)
                     providersNode.AppendChild(addNode)
                 End If
             End If
@@ -566,7 +566,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             'empty, and membership if it's now empty.
             Dim defaultSettingNode As XmlNode = GetDefaultClientServicesMembershipProviderNode(appConfigDocument, projectHierarchy)
             If defaultSettingNode IsNot Nothing Then
-                RemoveAttribute(membershipNode, s_defaultProvider)
+                RemoveAttribute(membershipNode, DefaultProvider)
                 'Remove the <add> for the default node
                 If membershipProvidersNode IsNot Nothing Then
                     membershipProvidersNode.RemoveChild(defaultSettingNode)
@@ -583,15 +583,15 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Dim returnValue As String
 
             node = GetDefaultClientServicesRoleManagerProviderNode(appConfigDocument, projectHierarchy)
-            returnValue = GetAttribute(node, s_connectionStringName)
+            returnValue = GetAttribute(node, ConnectionStringName)
             If returnValue IsNot Nothing Then Return returnValue
 
             node = GetDefaultClientServicesMembershipProviderNode(appConfigDocument, projectHierarchy)
-            returnValue = GetAttribute(node, s_connectionStringName)
+            returnValue = GetAttribute(node, ConnectionStringName)
             If returnValue IsNot Nothing Then Return returnValue
 
             node = GetAppSettingsConnectionStringNameNode(appConfigDocument)
-            Return GetAttribute(node, s_value)
+            Return GetAttribute(node, Value)
         End Function
 
         Private Shared Function DefaultHonorCookieExpiry(appConfigDocument As XmlDocument, Optional projectHierarchy As IVsHierarchy = Nothing) As String
@@ -599,11 +599,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Dim returnValue As String
 
             node = GetDefaultClientServicesRoleManagerProviderNode(appConfigDocument, projectHierarchy)
-            returnValue = GetAttribute(node, s_honorCookieExpiry)
+            returnValue = GetAttribute(node, HonorCookieExpiry)
             If returnValue IsNot Nothing Then Return returnValue
 
             node = GetAppSettingsHonorCookieExpiryNode(appConfigDocument)
-            Return GetAttribute(node, s_value)
+            Return GetAttribute(node, Value)
         End Function
 
         Private Shared Sub EnsureAppSettings(appConfigDocument As XmlDocument, enable As Boolean, Optional projectHierarchy As IVsHierarchy = Nothing)
@@ -619,11 +619,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             '<appSettings>
             '  <add key=ClientSettingsProvider.ServiceUri" value=""
             '</appSettings>
-            Dim configurationNode As XmlNode = EnsureNode(appConfigDocument, s_configuration, appConfigDocument)
-            EnsureNode(appConfigDocument, s_appSettings, configurationNode)
+            Dim configurationNode As XmlNode = EnsureNode(appConfigDocument, Configuration, appConfigDocument)
+            EnsureNode(appConfigDocument, AppSettings, configurationNode)
 
             If GetAppSettingsServiceUriNode(appConfigDocument) Is Nothing Then
-                AddAppConfigNode(appConfigDocument, AppSettingsName(s_serviceUri), s_serviceUriDefault)
+                AddAppConfigNode(appConfigDocument, AppSettingsName(ServiceUri), s_serviceUriDefault)
             End If
 
             Dim node As XmlNode
@@ -631,7 +631,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             If Not String.IsNullOrEmpty(currentConnectionStringName) Then
                 node = GetAppSettingsConnectionStringNameNode(appConfigDocument)
                 If node Is Nothing Then
-                    AddAppConfigNode(appConfigDocument, AppSettingsName(s_connectionStringName), currentConnectionStringName)
+                    AddAppConfigNode(appConfigDocument, AppSettingsName(ConnectionStringName), currentConnectionStringName)
                 End If
             End If
 
@@ -639,15 +639,15 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             If honorCookieValue IsNot Nothing Then
                 node = GetAppSettingsHonorCookieExpiryNode(appConfigDocument)
                 If node Is Nothing Then
-                    AddAppConfigNode(appConfigDocument, AppSettingsName(s_honorCookieExpiry), honorCookieValue)
+                    AddAppConfigNode(appConfigDocument, AppSettingsName(HonorCookieExpiry), honorCookieValue)
                 End If
             End If
         End Sub
 
         Private Shared Sub AddAppConfigNode(appConfigDocument As XmlDocument, keyValue As String, valueValue As String)
-            Dim addNode As XmlNode = CreateNode(appConfigDocument, XmlNodeType.Element, s_add)
-            SetAttribute(appConfigDocument, addNode, s_key, keyValue)
-            SetAttribute(appConfigDocument, addNode, s_value, valueValue)
+            Dim addNode As XmlNode = CreateNode(appConfigDocument, XmlNodeType.Element, Add)
+            SetAttribute(appConfigDocument, addNode, Key, keyValue)
+            SetAttribute(appConfigDocument, addNode, Value, valueValue)
             GetAppSettingsNode(appConfigDocument).AppendChild(addNode)
         End Sub
 
@@ -665,7 +665,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
         'Change the input string from "serviceUri" to "ClientSettingsProvider.ServiceUri"
         Private Shared Function AppSettingsName(inputName As String) As String
-            Return String.Concat(s_clientSettingsProviderPrefix, Char.ToUpperInvariant(inputName(0)), inputName.Substring(1))
+            Return String.Concat(ClientSettingsProviderPrefix, Char.ToUpperInvariant(inputName(0)), inputName.Substring(1))
         End Function
 
         Private Shared Function EnsureNode(doc As XmlDocument, nodeName As String, parentNode As XmlNode) As XmlNode
@@ -707,7 +707,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Function
 
         Friend Shared Function GetServiceUri(node As XmlNode) As String
-            Return GetAttribute(node, s_serviceUri)
+            Return GetAttribute(node, ServiceUri)
         End Function
 
         Friend Shared Function AuthenticationServiceUrl(doc As XmlDocument, Optional projectHierarchy As IVsHierarchy = Nothing) As String
@@ -724,7 +724,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Function
 
         Friend Shared Function WebSettingsUrl(doc As XmlDocument) As String
-            Return GetAttribute(GetAppSettingsServiceUriNode(doc), s_value)
+            Return GetAttribute(GetAppSettingsServiceUriNode(doc), Value)
         End Function
 
         Friend Shared Function WebSettingsHost(doc As XmlDocument) As String
@@ -743,19 +743,19 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Function
 
         Friend Shared Function GetSavePasswordHashLocally(doc As XmlDocument, Optional projectHierarchy As IVsHierarchy = Nothing) As Boolean
-            Return TryGettingBooleanAttributeValue(GetDefaultClientServicesMembershipProviderNode(doc, projectHierarchy), s_savePasswordHashLocally, s_savePasswordHashLocallyDefault)
+            Return TryGettingBooleanAttributeValue(GetDefaultClientServicesMembershipProviderNode(doc, projectHierarchy), SavePasswordHashLocally, SavePasswordHashLocallyDefault)
         End Function
 
         'Return value Nothing means the connection strings don't match
         Friend Shared Function GetEffectiveDefaultConnectionString(doc As XmlDocument, ByRef connectionStringSpecified As Boolean, Optional projectHierarchy As IVsHierarchy = Nothing) As String
             Dim appSettingsConnectionStringNode As XmlNode = GetAppSettingsConnectionStringNameNode(doc)
-            Dim appSettingsConnectionStringName As String = GetAttribute(appSettingsConnectionStringNode, s_value)
+            Dim appSettingsConnectionStringName As String = GetAttribute(appSettingsConnectionStringNode, Value)
 
             Dim roleManagerProviderNode As XmlNode = GetDefaultClientServicesRoleManagerProviderNode(doc, projectHierarchy)
-            Dim roleManagerConnectionStringName As String = GetAttribute(roleManagerProviderNode, s_connectionStringName)
+            Dim roleManagerConnectionStringName As String = GetAttribute(roleManagerProviderNode, ConnectionStringName)
 
             Dim membershipProviderNode As XmlNode = GetDefaultClientServicesMembershipProviderNode(doc, projectHierarchy)
-            Dim membershipConnectionStringName As String = GetAttribute(membershipProviderNode, s_connectionStringName)
+            Dim membershipConnectionStringName As String = GetAttribute(membershipProviderNode, ConnectionStringName)
 
             'If no connection strings are specified, use the default
             If appSettingsConnectionStringName Is Nothing AndAlso
@@ -777,31 +777,31 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Function
 
         Friend Shared Function GetConnectionStringNode(doc As XmlDocument, whichString As String) As XmlNode
-            Dim addNodeList As XmlNodeList = GetXmlNodeList(GetConnectionStringsNode(doc), s_add)
-            Return GetXmlNodeWithValueFromList(addNodeList, s_name, whichString)
+            Dim addNodeList As XmlNodeList = GetXmlNodeList(GetConnectionStringsNode(doc), Add)
+            Return GetXmlNodeWithValueFromList(addNodeList, Name, whichString)
         End Function
 
         Friend Shared Function GetConnectionString(doc As XmlDocument, whichString As String) As String
-            Return GetAttribute(GetConnectionStringNode(doc, whichString), s_connectionString)
+            Return GetAttribute(GetConnectionStringNode(doc, whichString), ConnectionString)
         End Function
 
         Private Shared Sub SetConnectionString(doc As XmlDocument, whichString As String, newValue As String)
             Dim node As XmlNode = GetConnectionStringNode(doc, whichString)
             If newValue Is Nothing Then
                 If node IsNot Nothing Then
-                    Dim configurationNode As XmlNode = EnsureNode(doc, s_configuration, doc)
-                    Dim connectionStringsNode As XmlNode = EnsureNode(doc, s_connectionStrings, configurationNode)
+                    Dim configurationNode As XmlNode = EnsureNode(doc, Configuration, doc)
+                    Dim connectionStringsNode As XmlNode = EnsureNode(doc, ConnectionStrings, configurationNode)
                     connectionStringsNode.RemoveChild(node)
                 End If
             Else
                 If node Is Nothing Then
-                    Dim configurationNode As XmlNode = EnsureNode(doc, s_configuration, doc)
-                    Dim connectionStringsNode As XmlNode = EnsureNode(doc, s_connectionStrings, configurationNode)
-                    node = CreateNode(doc, XmlNodeType.Element, s_add)
+                    Dim configurationNode As XmlNode = EnsureNode(doc, Configuration, doc)
+                    Dim connectionStringsNode As XmlNode = EnsureNode(doc, ConnectionStrings, configurationNode)
+                    node = CreateNode(doc, XmlNodeType.Element, Add)
                     connectionStringsNode.AppendChild(node)
-                    SetAttribute(doc, node, s_name, whichString)
+                    SetAttribute(doc, node, Name, whichString)
                 End If
-                SetAttribute(doc, node, s_connectionString, newValue)
+                SetAttribute(doc, node, ConnectionString, newValue)
             End If
         End Sub
 
@@ -811,19 +811,19 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Dim roleManagerHonorCookieExpiry, appConfigHonorCookieExpiry As Boolean
 
             node = GetDefaultClientServicesRoleManagerProviderNode(doc, projectHierarchy)
-            stringValue = GetAttribute(node, s_honorCookieExpiry)
+            stringValue = GetAttribute(node, HonorCookieExpiry)
 
             'If we didn't get a value, parse the default (string) value.
             If stringValue Is Nothing OrElse Not Boolean.TryParse(stringValue, roleManagerHonorCookieExpiry) Then
-                roleManagerHonorCookieExpiry = Boolean.Parse(s_honorCookieExpiryDefault)
+                roleManagerHonorCookieExpiry = Boolean.Parse(HonorCookieExpiryDefault)
             End If
 
             node = GetAppSettingsHonorCookieExpiryNode(doc)
-            stringValue = GetAttribute(node, s_value)
+            stringValue = GetAttribute(node, Value)
 
             'If we didn't get a value, parse the default (string) value.
             If stringValue Is Nothing OrElse Not Boolean.TryParse(stringValue, appConfigHonorCookieExpiry) Then
-                appConfigHonorCookieExpiry = Boolean.Parse(s_honorCookieExpiryDefault)
+                appConfigHonorCookieExpiry = Boolean.Parse(HonorCookieExpiryDefault)
             End If
 
             If roleManagerHonorCookieExpiry = appConfigHonorCookieExpiry Then
@@ -834,7 +834,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
 
         Friend Shared Function GetCacheTimeout(doc As XmlDocument, Optional projectHierarchy As IVsHierarchy = Nothing) As Integer
-            Return TryGettingIntegerAttributeValue(GetDefaultClientServicesRoleManagerProviderNode(doc, projectHierarchy), s_cacheTimeout, s_cacheTimeoutDefault)
+            Return TryGettingIntegerAttributeValue(GetDefaultClientServicesRoleManagerProviderNode(doc, projectHierarchy), CacheTimeout, CacheTimeoutDefault)
         End Function
 
         Private Shared Function TryGettingBooleanAttributeValue(node As XmlNode, attributeName As String, defaultValue As String) As Boolean
@@ -860,7 +860,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Function
 
         Friend Shared Function CustomCredentialProviderType(doc As XmlDocument, Optional projectHierarchy As IVsHierarchy = Nothing) As String
-            Return GetAttribute(GetDefaultClientServicesMembershipProviderNode(doc, projectHierarchy), s_credentialsProvider)
+            Return GetAttribute(GetDefaultClientServicesMembershipProviderNode(doc, projectHierarchy), CredentialsProvider)
         End Function
 
         Friend Shared Function WindowsAuthSelected(doc As XmlDocument, Optional projectHierarchy As IVsHierarchy = Nothing) As Boolean
@@ -869,12 +869,12 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
         'Return whether the value changed
         Friend Shared Function SetAuthenticationServiceUri(doc As XmlDocument, value As String, Optional projectHierarchy As IVsHierarchy = Nothing) As Boolean
-            Return SetAttributeValueAndCheckForChange(doc, GetDefaultClientServicesMembershipProviderNode(doc, projectHierarchy), s_serviceUri, Normalize(value, AuthenticationSuffix))
+            Return SetAttributeValueAndCheckForChange(doc, GetDefaultClientServicesMembershipProviderNode(doc, projectHierarchy), ServiceUri, Normalize(value, AuthenticationSuffix))
         End Function
 
         'Return whether the value changed
         Friend Shared Function SetCustomCredentialProviderType(doc As XmlDocument, value As String, Optional projectHierarchy As IVsHierarchy = Nothing) As Boolean
-            Return SetAttributeValueAndCheckForChange(doc, GetDefaultClientServicesMembershipProviderNode(doc, projectHierarchy), s_credentialsProvider, value)
+            Return SetAttributeValueAndCheckForChange(doc, GetDefaultClientServicesMembershipProviderNode(doc, projectHierarchy), CredentialsProvider, value)
         End Function
 
         'Return whether the value changed
@@ -890,17 +890,17 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Else
                 typeName = GetSupportedType(s_clientFormsMembershipProviderType, projectHierarchy).AssemblyQualifiedName
             End If
-            SetAttribute(doc, node, s_type, typeName)
+            SetAttribute(doc, node, Type, typeName)
             If changeToWindows Then
                 Dim connectionStringNameToUse As String = DefaultConnectionStringName(doc, projectHierarchy)
                 If String.IsNullOrEmpty(connectionStringNameToUse) Then
                     connectionStringNameToUse = GetConnectionStringCreateDefaultProviderName(doc)
                 End If
                 If GetConnectionStringNode(doc, connectionStringNameToUse) Is Nothing Then
-                    SetConnectionStringText(doc, connectionStringValueDefault, projectHierarchy)
+                    SetConnectionStringText(doc, ConnectionStringValueDefault, projectHierarchy)
                 End If
-                SetAttributeIfNull(doc, node, s_connectionStringName, connectionStringNameToUse)
-                SetAttributeIfNull(doc, node, s_credentialsProvider, s_credentialsProviderDefault)
+                SetAttributeIfNull(doc, node, ConnectionStringName, connectionStringNameToUse)
+                SetAttributeIfNull(doc, node, CredentialsProvider, s_credentialsProviderDefault)
             End If
             Return Not Equals(changeToWindows, initialValue)
         End Function
@@ -911,31 +911,31 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
             'Create the connection string node, if we have to.
             If appSettingsConnectionStringNameNode Is Nothing Then
-                Dim configurationNode As XmlNode = EnsureNode(doc, s_configuration, doc)
-                Dim appSettingsNode As XmlNode = EnsureNode(doc, s_appSettings, configurationNode)
-                appSettingsConnectionStringNameNode = CreateNode(doc, XmlNodeType.Element, s_add)
-                SetAttribute(doc, appSettingsConnectionStringNameNode, s_key, AppSettingsName(s_connectionStringName))
+                Dim configurationNode As XmlNode = EnsureNode(doc, Configuration, doc)
+                Dim appSettingsNode As XmlNode = EnsureNode(doc, AppSettings, configurationNode)
+                appSettingsConnectionStringNameNode = CreateNode(doc, XmlNodeType.Element, Add)
+                SetAttribute(doc, appSettingsConnectionStringNameNode, Key, AppSettingsName(ConnectionStringName))
                 connStrName = DefaultConnectionStringName(doc, projectHierarchy)
                 If connStrName Is Nothing Then
                     connStrName = GetConnectionStringCreateDefaultProviderName(doc)
                 End If
 
-                SetAttribute(doc, appSettingsConnectionStringNameNode, s_value, connStrName)
+                SetAttribute(doc, appSettingsConnectionStringNameNode, Value, connStrName)
                 appSettingsNode.AppendChild(appSettingsConnectionStringNameNode)
             Else
-                connStrName = GetAttribute(appSettingsConnectionStringNameNode, s_value)
+                connStrName = GetAttribute(appSettingsConnectionStringNameNode, Value)
             End If
 
             If newConnectionString Is Nothing Then
-                RemoveAttribute(GetDefaultClientServicesRoleManagerProviderNode(doc, projectHierarchy), s_connectionStringName)
-                RemoveAttribute(GetDefaultClientServicesMembershipProviderNode(doc, projectHierarchy), s_connectionStringName)
+                RemoveAttribute(GetDefaultClientServicesRoleManagerProviderNode(doc, projectHierarchy), ConnectionStringName)
+                RemoveAttribute(GetDefaultClientServicesMembershipProviderNode(doc, projectHierarchy), ConnectionStringName)
                 EnsureAppSettingsNodeExists(doc, projectHierarchy)
                 If Not appSettingsConnectionStringNameNode Is Nothing Then
                     GetAppSettingsNode(doc).RemoveChild(appSettingsConnectionStringNameNode)
                 End If
             Else
-                SetAttribute(doc, GetDefaultClientServicesRoleManagerProviderNode(doc, projectHierarchy), s_connectionStringName, connStrName)
-                SetAttribute(doc, GetDefaultClientServicesMembershipProviderNode(doc, projectHierarchy), s_connectionStringName, connStrName)
+                SetAttribute(doc, GetDefaultClientServicesRoleManagerProviderNode(doc, projectHierarchy), ConnectionStringName, connStrName)
+                SetAttribute(doc, GetDefaultClientServicesMembershipProviderNode(doc, projectHierarchy), ConnectionStringName, connStrName)
             End If
 
             SetConnectionString(doc, connStrName, newConnectionString)
@@ -943,33 +943,33 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
         'Return whether the value changed
         Friend Shared Function SetRoleServiceUri(doc As XmlDocument, inputValue As String, Optional projectHierarchy As IVsHierarchy = Nothing) As Boolean
-            Return SetAttributeValueAndCheckForChange(doc, GetDefaultClientServicesRoleManagerProviderNode(doc, projectHierarchy), s_serviceUri, Normalize(inputValue, RolesSuffix))
+            Return SetAttributeValueAndCheckForChange(doc, GetDefaultClientServicesRoleManagerProviderNode(doc, projectHierarchy), ServiceUri, Normalize(inputValue, RolesSuffix))
         End Function
 
         'Return whether the value changed
         Friend Shared Function SetAppServicesServiceUri(doc As XmlDocument, inputValue As String) As Boolean
-            Return SetAttributeValueAndCheckForChange(doc, GetAppSettingsServiceUriNode(doc), s_value, Normalize(inputValue, ProfileSuffix))
+            Return SetAttributeValueAndCheckForChange(doc, GetAppSettingsServiceUriNode(doc), Value, Normalize(inputValue, ProfileSuffix))
         End Function
 
         'Return whether the value changed
         Friend Shared Function SetCacheTimeout(doc As XmlDocument, inputValue As Integer, Optional projectHierarchy As IVsHierarchy = Nothing) As Boolean
-            Return SetAttributeValueAndCheckForChange(doc, GetDefaultClientServicesRoleManagerProviderNode(doc, projectHierarchy), s_cacheTimeout, inputValue)
+            Return SetAttributeValueAndCheckForChange(doc, GetDefaultClientServicesRoleManagerProviderNode(doc, projectHierarchy), CacheTimeout, inputValue)
         End Function
 
         Friend Shared Sub SetHonorCookieExpiry(doc As XmlDocument, inputValue As Boolean, Optional projectHierarchy As IVsHierarchy = Nothing)
             Dim stringInputValue As String = inputValue.ToString(CultureInfo.InvariantCulture)
-            SetAttribute(doc, GetDefaultClientServicesRoleManagerProviderNode(doc, projectHierarchy), s_honorCookieExpiry, stringInputValue)
+            SetAttribute(doc, GetDefaultClientServicesRoleManagerProviderNode(doc, projectHierarchy), HonorCookieExpiry, stringInputValue)
             Dim appSettingsNode As XmlNode = GetAppSettingsHonorCookieExpiryNode(doc)
             If appSettingsNode Is Nothing Then
-                AddAppConfigNode(doc, AppSettingsName(s_honorCookieExpiry), stringInputValue)
+                AddAppConfigNode(doc, AppSettingsName(HonorCookieExpiry), stringInputValue)
             Else
-                SetAttribute(doc, appSettingsNode, s_value, stringInputValue)
+                SetAttribute(doc, appSettingsNode, Value, stringInputValue)
             End If
         End Sub
 
         'Return whether the value changed
         Friend Shared Function SetSavePasswordHashLocally(doc As XmlDocument, inputValue As Boolean, Optional projectHierarchy As IVsHierarchy = Nothing) As Boolean
-            Return SetAttributeValueAndCheckForChange(doc, GetDefaultClientServicesMembershipProviderNode(doc, projectHierarchy), s_savePasswordHashLocally, inputValue)
+            Return SetAttributeValueAndCheckForChange(doc, GetDefaultClientServicesMembershipProviderNode(doc, projectHierarchy), SavePasswordHashLocally, inputValue)
         End Function
 
         Private Shared Function Normalize(val As String, suffix As String) As String

--- a/src/Microsoft.VisualStudio.Editors/PropPages/SingleConfigPropertyControlData.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/SingleConfigPropertyControlData.vb
@@ -30,8 +30,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     Friend Class SingleConfigPropertyControlData
         Inherits PropertyControlData
 
-        Private Const s_releaseConfigName As String = "Release"
-        Private Const s_debugConfigName As String = "Debug"
+        Private Const ReleaseConfigName As String = "Release"
+        Private Const DebugConfigName As String = "Debug"
 
         Public Enum Configs
             Debug
@@ -69,9 +69,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             MyBase.New(id, name, control, setter, getter, flags, AssocControls)
             Select Case Config
                 Case Configs.Debug
-                    _specificConfigName = s_debugConfigName
+                    _specificConfigName = DebugConfigName
                 Case Configs.Release
-                    _specificConfigName = s_releaseConfigName
+                    _specificConfigName = ReleaseConfigName
                 Case Else
                     Debug.Fail("Unrecognized Configs enum value")
                     _specificConfigName = ""

--- a/src/Microsoft.VisualStudio.Editors/PropPages/UnusedReferencePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/UnusedReferencePropPage.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.VisualStudio.Editors.Common
 Imports Microsoft.VisualStudio.Editors.Interop
@@ -12,7 +12,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Inherits PropPageUserControlBase
 
         ' Rate to poll compiler for unused references in milliseconds 
-        Private Const s_pollingRate As Integer = 500
+        Private Const PollingRate As Integer = 500
 
         ' Whether we have generated the list
         Private _unusedReferenceListReady As Boolean
@@ -314,7 +314,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
             ' Get a new timer
             _getUnusedRefsTimer = New Timer
-            _getUnusedRefsTimer.Interval = s_pollingRate
+            _getUnusedRefsTimer.Interval = PollingRate
             AddHandler _getUnusedRefsTimer.Tick, AddressOf OnGetUnusedRefsTimerTick
 
             _lastStatus = ReferenceUsageResult.ReferenceUsageUnknown

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/AppDotXamlDocument.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/AppDotXamlDocument.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.IO
 Imports System.Runtime.InteropServices
@@ -351,9 +351,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
 
 #End Region
 
-        Private Const s_ELEMENT_APPLICATION As String = "Application"
-        Private Const s_PROPERTY_STARTUPURI As String = "StartupUri"
-        Private Const s_PROPERTY_SHUTDOWNMODE As String = "ShutdownMode"
+        Private Const ELEMENT_APPLICATION As String = "Application"
+        Private Const PROPERTY_STARTUPURI As String = "StartupUri"
+        Private Const PROPERTY_SHUTDOWNMODE As String = "ShutdownMode"
 
         'A pointer to the text buffer as IVsTextLines
         Private _vsTextLines As IVsTextLines
@@ -517,12 +517,12 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <remarks></remarks>
         Public Shared Sub MoveToApplicationRootElement(reader As XmlTextReader)
             'XAML files must have only one root element.  For app.xaml, it must be "Application"
-            If reader.MoveToContent() = XmlNodeType.Element And reader.Name = s_ELEMENT_APPLICATION Then
+            If reader.MoveToContent() = XmlNodeType.Element And reader.Name = ELEMENT_APPLICATION Then
                 'Okay
                 Return
             End If
 
-            Throw New XamlReadWriteException(My.Resources.Designer.GetString(My.Resources.Designer.PPG_WPFApp_Xaml_CouldntFindRootElement, s_ELEMENT_APPLICATION))
+            Throw New XamlReadWriteException(My.Resources.Designer.GetString(My.Resources.Designer.PPG_WPFApp_Xaml_CouldntFindRootElement, ELEMENT_APPLICATION))
         End Sub
 
 #Region "CreateXmlTextReader"
@@ -536,7 +536,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         Private Function CreateXmlTextReader() As XmlTextReader
             Debug.Assert(_debugBufferLockCount > 0, "Should be using BufferLock!")
             Dim stringReader As New StringReader(GetAllText())
-            Dim xmlTextReader As xmlTextReader = New xmlTextReader(stringReader)
+            Dim xmlTextReader As XmlTextReader = New XmlTextReader(stringReader)
 
             ' Required by Fxcop rule CA3054 - DoNotAllowDTDXmlTextReader
             xmlTextReader.DtdProcessing = DtdProcessing.Prohibit
@@ -579,8 +579,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
             Const DoubleQuote As Char = """"c
             While index < line.Length
                 'Find the next character of interest
-                index = line.IndexOfAny( _
-                    New Char() {SingleQuote, DoubleQuote, "/"c, ">"c}, _
+                index = line.IndexOfAny(
+                    New Char() {SingleQuote, DoubleQuote, "/"c, ">"c},
                     index)
                 If index < 0 Then
                     Return -1
@@ -590,8 +590,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                 Select Case characterOfInterest
                     Case SingleQuote, DoubleQuote
                         'We have a string.  Skip past it.
-                        Dim closingQuote As Integer = line.IndexOf( _
-                            characterOfInterest, _
+                        Dim closingQuote As Integer = line.IndexOf(
+                            characterOfInterest,
                             index + 1)
                         If closingQuote < 0 Then
                             'String not terminated.
@@ -671,9 +671,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <remarks></remarks>
         Public Function FindApplicationPropertyInXaml(reader As XmlTextReader, propertyName As String) As XamlProperty
             MoveToApplicationRootElement(reader)
-            Dim prop As XamlProperty = FindPropertyAsAttributeInCurrentElement(reader, s_ELEMENT_APPLICATION, propertyName)
+            Dim prop As XamlProperty = FindPropertyAsAttributeInCurrentElement(reader, ELEMENT_APPLICATION, propertyName)
             If prop Is Nothing Then
-                prop = FindPropertyAsChildElementInCurrentElement(reader, s_ELEMENT_APPLICATION, propertyName)
+                prop = FindPropertyAsChildElementInCurrentElement(reader, ELEMENT_APPLICATION, propertyName)
             End If
 
             Return prop
@@ -810,8 +810,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
 
                     'The reader is now right after the empty element tag
                     Dim elementTagEndPlusOne As New Location(reader)
-                    Return New XamlPropertyInPropertyElementSyntaxWithEmptyTag( _
-                        _vsTextLines, fullyQualifiedPropertyName, _
+                    Return New XamlPropertyInPropertyElementSyntaxWithEmptyTag(
+                        _vsTextLines, fullyQualifiedPropertyName,
                         elementTagStart, elementTagEndPlusOne)
                 Else
                     Dim valueStart As Location
@@ -957,9 +957,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
 
             Dim bstrNewText As IntPtr = Marshal.StringToBSTR(newText)
             Try
-                ErrorHandler.ThrowOnFailure(_vsTextLines.ReplaceLines( _
-                    sourceStart.LineIndex, sourceStart.CharIndex, _
-                    sourceEnd.LineIndex, sourceEnd.CharIndex, _
+                ErrorHandler.ThrowOnFailure(_vsTextLines.ReplaceLines(
+                    sourceStart.LineIndex, sourceStart.CharIndex,
+                    sourceEnd.LineIndex, sourceEnd.CharIndex,
                     bstrNewText, newText.Length, Nothing))
             Finally
                 Marshal.FreeBSTR(bstrNewText)
@@ -1014,7 +1014,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <returns></returns>
         ''' <remarks></remarks>
         Public Function GetStartupUri() As String
-            Return GetApplicationPropertyValue(s_PROPERTY_STARTUPURI)
+            Return GetApplicationPropertyValue(PROPERTY_STARTUPURI)
         End Function
 
         ''' <summary>
@@ -1023,7 +1023,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' </summary>
         ''' <remarks></remarks>
         Public Sub SetStartupUri(value As String)
-            SetApplicationPropertyValue(s_PROPERTY_STARTUPURI, value)
+            SetApplicationPropertyValue(PROPERTY_STARTUPURI, value)
         End Sub
 
 #End Region
@@ -1037,7 +1037,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <returns></returns>
         ''' <remarks></remarks>
         Public Function GetShutdownMode() As String
-            Return GetApplicationPropertyValue(s_PROPERTY_SHUTDOWNMODE)
+            Return GetApplicationPropertyValue(PROPERTY_SHUTDOWNMODE)
         End Function
 
         ''' <summary>
@@ -1046,7 +1046,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' </summary>
         ''' <remarks></remarks>
         Public Sub SetShutdownMode(value As String)
-            SetApplicationPropertyValue(s_PROPERTY_SHUTDOWNMODE, value)
+            SetApplicationPropertyValue(PROPERTY_SHUTDOWNMODE, value)
         End Sub
 
 #End Region
@@ -1059,8 +1059,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <param name="location"></param>
         ''' <remarks></remarks>
         Private Sub ThrowUnexpectedFormatException(location As Location)
-            Throw New XamlReadWriteException( _
-                My.Resources.Designer.GetString(My.Resources.Designer.PPG_WPFApp_Xaml_UnexpectedFormat_2Args, _
+            Throw New XamlReadWriteException(
+                My.Resources.Designer.GetString(My.Resources.Designer.PPG_WPFApp_Xaml_UnexpectedFormat_2Args,
                     CStr(location.LineIndex + 1), CStr(location.CharIndex + 1)))
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.VisualStudio.Editors.Common
 Imports Microsoft.VisualStudio.Editors.MyApplication
@@ -32,26 +32,26 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
 
         Protected Const STARTUPOBJECT_SubMain As String = "Sub Main"
 
-        Private Const s_VB_EXTENSION As String = ".vb"
+        Private Const VB_EXTENSION As String = ".vb"
 
-        Private Const s_BUILDACTION_PAGE As String = "Page"
-        Private Const s_BUILDACTION_APPLICATIONDEFINITION As String = "ApplicationDefinition"
+        Private Const BUILDACTION_PAGE As String = "Page"
+        Private Const BUILDACTION_APPLICATIONDEFINITION As String = "ApplicationDefinition"
 
 
 #Region "User-defined properties for this page"
 
-        Private Const s_PROPID_StartupObjectOrUri As Integer = 100
-        Private Const s_PROPNAME_StartupObjectOrUri As String = "StartupObjectOrUri"
+        Private Const PROPID_StartupObjectOrUri As Integer = 100
+        Private Const PROPNAME_StartupObjectOrUri As String = "StartupObjectOrUri"
 
-        Private Const s_PROPID_ShutDownMode As Integer = 101
-        Private Const s_PROPNAME_ShutDownMode As String = "ShutdownMode"
+        Private Const PROPID_ShutDownMode As Integer = 101
+        Private Const PROPNAME_ShutDownMode As String = "ShutdownMode"
 
-        Private Const s_PROPID_UseApplicationFramework As Integer = 102
-        Private Const s_PROPNAME_UseApplicationFramework As String = "UseApplicationFramework"
+        Private Const PROPID_UseApplicationFramework As Integer = 102
+        Private Const PROPNAME_UseApplicationFramework As String = "UseApplicationFramework"
 
         'This property is added by the WPF flavor as an extended property
-        Private Const s_PROPID_HostInBrowser As Integer = 103
-        Private Const s_PROPNAME_HostInBrowser As String = "HostInBrowser"
+        Private Const PROPID_HostInBrowser As Integer = 103
+        Private Const PROPNAME_HostInBrowser As String = "HostInBrowser"
 
 #End Region
 
@@ -183,7 +183,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                     '  will still cause a file checkout, it just won't be grouped together if there are
                     '  any other files needing to be checked out at the same time.
                     list.Add(New PropertyControlData(
-                        s_PROPID_StartupObjectOrUri, s_PROPNAME_StartupObjectOrUri,
+                        PROPID_StartupObjectOrUri, PROPNAME_StartupObjectOrUri,
                         StartupObjectOrUriComboBox,
                         AddressOf SetStartupObjectOrUriIntoUI, AddressOf GetStartupObjectOrUriFromUI,
                         ControlDataFlags.UserPersisted Or ControlDataFlags.NoOptimisticFileCheckout,
@@ -201,7 +201,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
 
                     'ShutdownMode (user-defined)
                     list.Add(New PropertyControlData(
-                        s_PROPID_ShutDownMode, s_PROPNAME_ShutDownMode,
+                        PROPID_ShutDownMode, PROPNAME_ShutDownMode,
                         ShutdownModeComboBox,
                         AddressOf SetShutdownModeIntoUI, AddressOf GetShutdownModeFromUI,
                         ControlDataFlags.UserPersisted Or ControlDataFlags.PersistedInApplicationDefinitionFile,
@@ -210,7 +210,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                     'UseApplicationFramework (user-defined)
                     'Use RefreshAllPropertiesWhenChanged to force other property controls to get re-enabled/disabled when this changes
                     list.Add(New PropertyControlData(
-                        s_PROPID_UseApplicationFramework, s_PROPNAME_UseApplicationFramework, UseApplicationFrameworkCheckBox,
+                        PROPID_UseApplicationFramework, PROPNAME_UseApplicationFramework, UseApplicationFrameworkCheckBox,
                         AddressOf SetUseApplicationFrameworkIntoUI, AddressOf GetUseApplicationFrameworkFromUI,
                         ControlDataFlags.UserPersisted Or ControlDataFlags.RefreshAllPropertiesWhenChanged,
                         New Control() {WindowsAppGroupBox}))
@@ -218,7 +218,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                     'HostInBrowser (Avalon flavor extended property)
                     '  Tells whether the project is an XBAP app
                     list.Add(New PropertyControlData(
-                        s_PROPID_HostInBrowser, s_PROPNAME_HostInBrowser, Nothing,
+                        PROPID_HostInBrowser, PROPNAME_HostInBrowser, Nothing,
                         ControlDataFlags.Hidden))
 
                     ' ApplicationManifest - added simply to enable flavoring visibility of the button
@@ -558,7 +558,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <param name="Enable"></param>
         ''' <remarks></remarks>
         Private Sub EnableUseApplicationFrameworkCheckBox(Enable As Boolean)
-            GetPropertyControlData(s_PROPID_UseApplicationFramework).EnableControls(Enable)
+            GetPropertyControlData(PROPID_UseApplicationFramework).EnableControls(Enable)
         End Sub
 
         Private Enum TriState
@@ -747,7 +747,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                         'We only do this if the build action is actually set to None.  We'll assume if it was set to
                         '  anything else that the user intended it that way.
                         If DTEUtils.GetBuildAction(foundAppDefinition) = VSLangProj.prjBuildAction.prjBuildActionNone Then
-                            DTEUtils.SetBuildActionAsString(foundAppDefinition, s_BUILDACTION_APPLICATIONDEFINITION)
+                            DTEUtils.SetBuildActionAsString(foundAppDefinition, BUILDACTION_APPLICATIONDEFINITION)
                         End If
                     End If
 
@@ -1286,7 +1286,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                 If IO.Path.GetExtension(projectitem.FileNames(1)).Equals(".xaml", StringComparison.OrdinalIgnoreCase) Then
                     'We only want .xaml files with BuildAction="Page"
                     Dim CurrentBuildAction As String = DTEUtils.GetBuildActionAsString(projectitem)
-                    If CurrentBuildAction IsNot Nothing AndAlso s_BUILDACTION_PAGE.Equals(CurrentBuildAction, StringComparison.OrdinalIgnoreCase) Then
+                    If CurrentBuildAction IsNot Nothing AndAlso BUILDACTION_PAGE.Equals(CurrentBuildAction, StringComparison.OrdinalIgnoreCase) Then
                         'Build action is correct.
 
                         'Is the item inside the project folders (instead of, say, a link to an external file)?
@@ -1486,13 +1486,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' </remarks>
         Public Overrides Function GetUserDefinedPropertyDescriptor(PropertyName As String) As PropertyDescriptor
             Select Case PropertyName
-                Case s_PROPNAME_StartupObjectOrUri
+                Case PROPNAME_StartupObjectOrUri
                     Return New UserPropertyDescriptor(PropertyName, GetType(StartupObjectOrUri))
 
-                Case s_PROPNAME_ShutDownMode
+                Case PROPNAME_ShutDownMode
                     Return New UserPropertyDescriptor(PropertyName, GetType(String))
 
-                Case s_PROPNAME_UseApplicationFramework
+                Case PROPNAME_UseApplicationFramework
                     'Note: Need to specify Int32 instead of TriState enum because undo/redo code doesn't
                     '  handle the enum properly.
                     Return New UserPropertyDescriptor(PropertyName, GetType(Integer))
@@ -1516,7 +1516,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
             '  doing a refresh will not re-enable them.  Instead, we show an error value inside the control to the user.
 
             Select Case PropertyName
-                Case s_PROPNAME_StartupObjectOrUri
+                Case PROPNAME_StartupObjectOrUri
                     Try
                         If IsStartupObjectMissing() Then
                             Value = PropertyControlData.MissingProperty
@@ -1531,14 +1531,14 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                         End If
                     End Try
 
-                Case s_PROPNAME_ShutDownMode
+                Case PROPNAME_ShutDownMode
                     Try
                         Value = GetShutdownModeFromStorage()
                     Catch ex As Exception When ReportWithoutCrash(ex, NameOf(ReadUserDefinedProperty), NameOf(ApplicationPropPageVBWPF))
                         Value = ""
                     End Try
 
-                Case s_PROPNAME_UseApplicationFramework
+                Case PROPNAME_UseApplicationFramework
                     Try
                         Value = GetUseApplicationFrameworkFromStorage()
                     Catch ex As Exception When ReportWithoutCrash(ex, NameOf(ReadUserDefinedProperty), NameOf(ApplicationPropPageVBWPF))
@@ -1561,13 +1561,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <remarks></remarks>
         Public Overrides Function WriteUserDefinedProperty(PropertyName As String, Value As Object) As Boolean
             Select Case PropertyName
-                Case s_PROPNAME_StartupObjectOrUri
+                Case PROPNAME_StartupObjectOrUri
                     SetStartupObjectOrUriValueIntoStorage(CType(Value, StartupObjectOrUri))
 
-                Case s_PROPNAME_ShutDownMode
+                Case PROPNAME_ShutDownMode
                     SetShutdownModeIntoStorage(CType(Value, String))
 
-                Case s_PROPNAME_UseApplicationFramework
+                Case PROPNAME_UseApplicationFramework
                     SetUseApplicationFrameworkIntoStorage(CType(Value, TriState))
 
                 Case Else
@@ -1647,7 +1647,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         End Function
 
         Private Function GetExpectedApplicationEventsFileName(appDotXamlFilename As String) As String
-            Return appDotXamlFilename & s_VB_EXTENSION
+            Return appDotXamlFilename & VB_EXTENSION
         End Function
 
         Private Function CreateApplicationEventsFile(parent As ProjectItem) As ProjectItem
@@ -1663,7 +1663,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
 
             'Now find the item that was added (for some reason, AddFromTemplate won't return this
             '  to us).
-            Dim newProjectItem As ProjectItem = FindDependentFile(parent, s_VB_EXTENSION)
+            Dim newProjectItem As ProjectItem = FindDependentFile(parent, VB_EXTENSION)
             If newProjectItem Is Nothing Then
                 Throw New PropertyPageException(My.Resources.Designer.PPG_Unexpected)
             End If
@@ -1682,7 +1682,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                 Dim appXamlProjectItem As ProjectItem = FindApplicationXamlProjectItem(True)
 
                 'Look for a dependent .vb file, this should be the normal case
-                Dim dependentVBItem As ProjectItem = FindDependentFile(appXamlProjectItem, s_VB_EXTENSION)
+                Dim dependentVBItem As ProjectItem = FindDependentFile(appXamlProjectItem, VB_EXTENSION)
 
                 If dependentVBItem Is Nothing Then
                     'If none, then also look for a file with the same name as the Application.xaml file (+ .vb) in either the
@@ -1844,7 +1844,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
 #Region "XBAP projects"
 
         Private Function IsXBAP() As Boolean
-            Dim pcd As PropertyControlData = GetPropertyControlData(s_PROPID_HostInBrowser)
+            Dim pcd As PropertyControlData = GetPropertyControlData(PROPID_HostInBrowser)
             If pcd.IsSpecialValue Then
                 'HostInBrowser property not available.  This shouldn't happen except in
                 '  unit tests.

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/FileWatcher.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/FileWatcher.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -484,7 +484,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             '  notifications, so we receive a single notification rather than 
             '  several (while the file's being written, etc.).  These often come
             '  in multiples.
-            Private Const s_delayInMilliseconds As Integer = 400
+            Private Const DelayInMilliseconds As Integer = 400
 
             Private _listeners As New ArrayList 'Of IFileWatchListener
 
@@ -592,7 +592,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' </summary>
             ''' <remarks></remarks>
             Friend Sub OnFileChanged()
-                Debug.WriteLineIf(Switches.RSEFileWatcher.TraceVerbose, "    FileWatcherEntry: Received file change on main thread: " & ToString & ", Thread = " & Hex(System.Threading.Thread.CurrentThread.GetHashCode) & ", Milliseconds = " & Now.Millisecond)
+                Debug.WriteLineIf(Switches.RSEFileWatcher.TraceVerbose, "    FileWatcherEntry: Received file change on main thread: " & ToString() & ", Thread = " & Hex(System.Threading.Thread.CurrentThread.GetHashCode) & ", Milliseconds = " & Now.Millisecond)
 
                 'It is common to get several notifications about the same file while it's
                 '  being written.  We want to let things settle down a bit before we
@@ -602,14 +602,14 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 If _timer Is Nothing Then
                     'This is the first notification we've seen - create a timer to track the
                     '  delay.
-                    Debug.WriteLineIf(Switches.RSEFileWatcher.TraceVerbose, "        Enabling timer delay of " & s_delayInMilliseconds & "ms.")
+                    Debug.WriteLineIf(Switches.RSEFileWatcher.TraceVerbose, "        Enabling timer delay of " & DelayInMilliseconds & "ms.")
                     _timer = New Timer
-                    _timer.Interval = s_delayInMilliseconds
+                    _timer.Interval = DelayInMilliseconds
                 Else
                     'We already have a timer, so that means we're in the delay stage of
                     '  a previous notification of the same event.  We'll reset the timer
                     '  and keep waiting.
-                    Debug.WriteLineIf(Switches.RSEFileWatcher.TraceVerbose, "        Currently active file change ignored.  Re-enabling timer delay of " & s_delayInMilliseconds & "ms.")
+                    Debug.WriteLineIf(Switches.RSEFileWatcher.TraceVerbose, "        Currently active file change ignored.  Re-enabling timer delay of " & DelayInMilliseconds & "ms.")
                     _timer.Enabled = False
                 End If
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
@@ -2425,9 +2425,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 #Region "ISerialization implementation"
 
         'Our key for the ResXDataNode in the serialization info.
-        Private Const s_SERIALIZATIONKEY_RESXDATANODE As String = "ResXDataNode"
-        Private Const s_SERIALIZATIONKEY_SAVEDFILENAME As String = "SavedFileName"
-        Private Const s_SERIALIZATIONKEY_ORIGINALFILETIMESTAMP As String = "OriginalFileTimeStamp"
+        Private Const SERIALIZATIONKEY_RESXDATANODE As String = "ResXDataNode"
+        Private Const SERIALIZATIONKEY_SAVEDFILENAME As String = "SavedFileName"
+        Private Const SERIALIZATIONKEY_ORIGINALFILETIMESTAMP As String = "OriginalFileTimeStamp"
 
 
         ''' <summary>
@@ -2439,9 +2439,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''See .NET Framework Developer's Guide, "Custom Serialization" for more information
         ''' </remarks>
         Private Sub New(Info As SerializationInfo, Context As StreamingContext)
-            Dim ResXDataNode As ResXDataNode = DirectCast(Info.GetValue(s_SERIALIZATIONKEY_RESXDATANODE, GetType(ResXDataNode)), ResXDataNode)
-            _savedFileName = Info.GetString(s_SERIALIZATIONKEY_SAVEDFILENAME)
-            _originalFileTimeStamp = Info.GetDateTime(s_SERIALIZATIONKEY_ORIGINALFILETIMESTAMP)
+            Dim ResXDataNode As ResXDataNode = DirectCast(Info.GetValue(SERIALIZATIONKEY_RESXDATANODE, GetType(ResXDataNode)), ResXDataNode)
+            _savedFileName = Info.GetString(SERIALIZATIONKEY_SAVEDFILENAME)
+            _originalFileTimeStamp = Info.GetDateTime(SERIALIZATIONKEY_ORIGINALFILETIMESTAMP)
 
             'Hook up TypeNameConverter for fileref object from deserializer
             If ResXDataNode.FileRef IsNot Nothing Then
@@ -2462,9 +2462,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''See .NET Framework Developer's Guide, "Custom Serialization" for more information
         ''' </remarks>
         Private Sub GetObjectData(Info As SerializationInfo, Context As StreamingContext) Implements ISerializable.GetObjectData
-            Info.AddValue(s_SERIALIZATIONKEY_RESXDATANODE, _resXDataNode)
-            Info.AddValue(s_SERIALIZATIONKEY_SAVEDFILENAME, VB.IIf(_savedFileName Is Nothing, "", _savedFileName))
-            Info.AddValue(s_SERIALIZATIONKEY_ORIGINALFILETIMESTAMP, _originalFileTimeStamp)
+            Info.AddValue(SERIALIZATIONKEY_RESXDATANODE, _resXDataNode)
+            Info.AddValue(SERIALIZATIONKEY_SAVEDFILENAME, VB.IIf(_savedFileName Is Nothing, "", _savedFileName))
+            Info.AddValue(SERIALIZATIONKEY_ORIGINALFILETIMESTAMP, _originalFileTimeStamp)
         End Sub
 
 #End Region

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
@@ -135,11 +135,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Private _registryRoot As String
 
         ' Pad around the stringTable/ListView
-        Private Const s_DESIGNER_PADDING As Integer = 14
-        Private Const s_DESIGNER_PADDING_TOP As Integer = 23
+        Private Const DESIGNER_PADDING As Integer = 14
+        Private Const DESIGNER_PADDING_TOP As Integer = 23
 
         ' the seperator character to save multiple extensions in one string
-        Private Const s_SAFE_EXTENSION_SEPERATOR As Char = "|"c
+        Private Const SAFE_EXTENSION_SEPERATOR As Char = "|"c
 
 #End Region
 
@@ -274,17 +274,17 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Inherits AccessModifierCombobox
 
             Private ReadOnly _isInDevice20Project As Boolean
-            Private Const s_framework_2_0 As Integer = 2
+            Private Const Framework_2_0 As Integer = 2
 
             Public Sub New(useVbMyResXCodeGenerator As Boolean, allowNoCodeGeneration As Boolean, rootDesigner As BaseRootDesigner, serviceProvider As IServiceProvider, projectItem As ProjectItem, namespaceToOverrideIfCustomToolIsEmpty As String)
                 MyBase.New(rootDesigner, serviceProvider, projectItem, namespaceToOverrideIfCustomToolIsEmpty)
 
                 _isInDevice20Project = IsInDevice20Project(rootDesigner)
 
-                AddCodeGeneratorEntry(AccessModifierConverter.Access.Friend, IIf(useVbMyResXCodeGenerator, s_VBMYCUSTOMTOOL, s_STANDARDCUSTOMTOOL))
+                AddCodeGeneratorEntry(AccessModifierConverter.Access.Friend, IIf(useVbMyResXCodeGenerator, VBMYCUSTOMTOOL, STANDARDCUSTOMTOOL))
                 If Not _isInDevice20Project Then
                     ' public generator is not supported in Device 2.0 projects
-                    AddCodeGeneratorEntry(AccessModifierConverter.Access.Public, IIf(useVbMyResXCodeGenerator, s_VBMYCUSTOMTOOLPUBLIC, s_STANDARDCUSTOMTOOLPUBLIC))
+                    AddCodeGeneratorEntry(AccessModifierConverter.Access.Public, IIf(useVbMyResXCodeGenerator, VBMYCUSTOMTOOLPUBLIC, STANDARDCUSTOMTOOLPUBLIC))
                 End If
 
                 If allowNoCodeGeneration Then
@@ -296,10 +296,10 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 'Ensure we don't disable the Access Modifier combobox just because the custom tool is set to the
                 '  My.Resources version of the custom tool when the standard version was expected, or vice versa.
                 '  This way all the resx generators are recognized.
-                AddRecognizedCustomToolValue(s_VBMYCUSTOMTOOL)
-                AddRecognizedCustomToolValue(s_VBMYCUSTOMTOOLPUBLIC)
-                AddRecognizedCustomToolValue(s_STANDARDCUSTOMTOOL)
-                AddRecognizedCustomToolValue(s_STANDARDCUSTOMTOOLPUBLIC)
+                AddRecognizedCustomToolValue(VBMYCUSTOMTOOL)
+                AddRecognizedCustomToolValue(VBMYCUSTOMTOOLPUBLIC)
+                AddRecognizedCustomToolValue(STANDARDCUSTOMTOOL)
+                AddRecognizedCustomToolValue(STANDARDCUSTOMTOOLPUBLIC)
             End Sub
 
             Public Shadows Function GetMenuCommandsToRegister() As ICollection
@@ -326,7 +326,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                         Try
                             Dim frameworkVersionNumber As UInteger = GetProjectTargetFrameworkVersion(hierarchy)
                             Dim majorVersionNumber As UInteger = frameworkVersionNumber >> 16
-                            Return majorVersionNumber <= s_framework_2_0
+                            Return majorVersionNumber <= Framework_2_0
                         Catch ex As NotSupportedException
                         Catch ex As NotImplementedException
                         End Try
@@ -679,7 +679,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     RootDesigner,
                     RootDesigner,
                     GetResXProjectItem(),
-                    IIf(IsVBProject(GetProject()), s_CUSTOMTOOLNAMESPACE, Nothing))
+                    IIf(IsVBProject(GetProject()), CUSTOMTOOLNAMESPACE, Nothing))
             End If
 
             'Add our menus (can't do that until we know the root designer)
@@ -971,8 +971,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Try
                 'String table and resource listview
                 ' We leave some white space around them
-                StringTable.Location = New Point(s_DESIGNER_PADDING, _toolbarPanel.Bottom + s_DESIGNER_PADDING_TOP)
-                StringTable.Size = New Size(Width - 2 * s_DESIGNER_PADDING, Height - _toolbarPanel.Height - s_DESIGNER_PADDING - s_DESIGNER_PADDING_TOP)
+                StringTable.Location = New Point(DESIGNER_PADDING, _toolbarPanel.Bottom + DESIGNER_PADDING_TOP)
+                StringTable.Size = New Size(Width - 2 * DESIGNER_PADDING, Height - _toolbarPanel.Height - DESIGNER_PADDING - DESIGNER_PADDING_TOP)
                 _resourceListView.Location = StringTable.Location
                 _resourceListView.Size = StringTable.Size
             Finally
@@ -2611,11 +2611,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
         'This drag/drop format is used by reference-based projects (e.g., C++), where the items in a project are a reference to a file elsewhere on
         '  disk.  The project item is not actually stored in the project itself.
-        Private Const s_CF_VSREFPROJECTITEMS As String = "CF_VSREFPROJECTITEMS"
+        Private Const CF_VSREFPROJECTITEMS As String = "CF_VSREFPROJECTITEMS"
 
         'This drag/drop format is used by storage-based projects (e.g., C#, VB, J#), where the items in a project are generally stored in the project's
         '  directories rather than simply being references.
-        Private Const s_CF_VSSTGPROJECTITEMS As String = "CF_VSSTGPROJECTITEMS"
+        Private Const CF_VSSTGPROJECTITEMS As String = "CF_VSSTGPROJECTITEMS"
 
         'Comma-separated values (Excel and other apps)
         Private ReadOnly _CF_CSV As String = DataFormats.CommaSeparatedValue
@@ -2892,7 +2892,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
             '2) Project explorer drag/drop format (copy only)
             If CopyAllowed AndAlso
-                    (Data.GetDataPresent(s_CF_VSREFPROJECTITEMS) OrElse Data.GetDataPresent(s_CF_VSSTGPROJECTITEMS)) Then
+                    (Data.GetDataPresent(CF_VSREFPROJECTITEMS) OrElse Data.GetDataPresent(CF_VSSTGPROJECTITEMS)) Then
                 ActualEffect = DragDropEffects.Copy
                 ActualFormat = ResourceEditorDataFormats.SolutionExplorer 'Note that we don't care if it was CF_VSSTGPROJECTITEMS or CF_VSREFPROJECTITEMS
                 Return True
@@ -3059,9 +3059,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <remarks>Caller must catch exceptions and display error message</remarks>
         Private Sub DragDropPasteFromSolutionExplorer(Data As IDataObject, CopyFileIfExists As Boolean)
             'Look for either CF_VSREFPROJECTITEMS or CF_VSSTGPROJECTITEMS
-            Dim DataStream As Stream = DirectCast(Data.GetData(s_CF_VSREFPROJECTITEMS), Stream)
+            Dim DataStream As Stream = DirectCast(Data.GetData(CF_VSREFPROJECTITEMS), Stream)
             If DataStream Is Nothing Then
-                DataStream = DirectCast(Data.GetData(s_CF_VSSTGPROJECTITEMS), Stream)
+                DataStream = DirectCast(Data.GetData(CF_VSSTGPROJECTITEMS), Stream)
             End If
 
             If DataStream IsNot Nothing Then
@@ -3528,7 +3528,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                         ' Check the registry setting, which remembers a list of extensions that the customer told us not to pop up a warning dialog again...
                         Dim extraSafeExtensions As String = SafeExtensions
                         If Not String.IsNullOrEmpty(extraSafeExtensions) Then
-                            Dim extensions As String() = extraSafeExtensions.Split(New Char() {s_SAFE_EXTENSION_SEPERATOR})
+                            Dim extensions As String() = extraSafeExtensions.Split(New Char() {SAFE_EXTENSION_SEPERATOR})
                             For Each safeExtension As String In extensions
                                 If String.Equals(fileExtension, safeExtension, StringComparison.OrdinalIgnoreCase) Then
                                     isSafe = True
@@ -3549,7 +3549,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                                     If String.IsNullOrEmpty(extraSafeExtensions) Then
                                         extraSafeExtensions = fileExtension
                                     Else
-                                        extraSafeExtensions = extraSafeExtensions & s_SAFE_EXTENSION_SEPERATOR & fileExtension
+                                        extraSafeExtensions = extraSafeExtensions & SAFE_EXTENSION_SEPERATOR & fileExtension
                                     End If
                                     SafeExtensions = extraSafeExtensions
                                 End If
@@ -5139,15 +5139,15 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
 
         'The custom tool name to use for stand-alone resx files.
-        Private Const s_STANDARDCUSTOMTOOL As String = "ResXFileCodeGenerator"
-        Private Const s_STANDARDCUSTOMTOOLPUBLIC As String = "PublicResXFileCodeGenerator"
+        Private Const STANDARDCUSTOMTOOL As String = "ResXFileCodeGenerator"
+        Private Const STANDARDCUSTOMTOOLPUBLIC As String = "PublicResXFileCodeGenerator"
 
         'The custom tool name to use for the default resx file in VB projects
-        Private Const s_VBMYCUSTOMTOOL As String = "VbMyResourcesResXFileCodeGenerator"
-        Private Const s_VBMYCUSTOMTOOLPUBLIC As String = "PublicVbMyResourcesResXFileCodeGenerator"
+        Private Const VBMYCUSTOMTOOL As String = "VbMyResourcesResXFileCodeGenerator"
+        Private Const VBMYCUSTOMTOOLPUBLIC As String = "PublicVbMyResourcesResXFileCodeGenerator"
 
         'The namespace to use
-        Private Const s_CUSTOMTOOLNAMESPACE As String = "My.Resources"
+        Private Const CUSTOMTOOLNAMESPACE As String = "My.Resources"
 
 
         ''' <summary>
@@ -5299,9 +5299,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             If Not String.IsNullOrEmpty(GeneratedClassName) Then
                 'Find the code element for the generated class
                 Dim FindSettingClassFilter As New SettingsDesigner.ProjectUtils.KnownClassName(GeneratedClassName, SettingsDesigner.ProjectUtils.ClassOrModule.Either)
-                Dim GeneratedClassCodeElement As CodeElement = SettingsDesigner.ProjectUtils.FindElement(ProjItem, _
-                                                                ExpandChildElements:=False, _
-                                                                ExpandChildItems:=True, _
+                Dim GeneratedClassCodeElement As CodeElement = SettingsDesigner.ProjectUtils.FindElement(ProjItem,
+                                                                ExpandChildElements:=False,
+                                                                ExpandChildItems:=True,
                                                                 Filter:=FindSettingClassFilter)
 
                 If GeneratedClassCodeElement Is Nothing Then
@@ -5399,10 +5399,10 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Dim ItemId As UInteger = GetVsItemId()
             Dim UsingVbMyCustomTool As Boolean
 
-            If CurrentCustomTool.Equals(s_STANDARDCUSTOMTOOL, StringComparison.OrdinalIgnoreCase) Then
+            If CurrentCustomTool.Equals(STANDARDCUSTOMTOOL, StringComparison.OrdinalIgnoreCase) Then
                 'This uses our standard single file generator.  We know how it works, so we can go ahead and
                 '  attempt a rename.
-            ElseIf CurrentCustomTool.Equals(s_VBMYCUSTOMTOOL, StringComparison.OrdinalIgnoreCase) Then
+            ElseIf CurrentCustomTool.Equals(VBMYCUSTOMTOOL, StringComparison.OrdinalIgnoreCase) Then
                 'This uses our special My.VB file generator.  We can attempt a rename.
                 UsingVbMyCustomTool = True
             Else

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceListView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceListView.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -43,38 +43,38 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
         'The width of the selection border that we draw around thumbnails in the "Thumbnails"
         '  view.
-        Private Const s_defaultSelectionBorderWidth As Integer = 2
+        Private Const DefaultSelectionBorderWidth As Integer = 2
 
         'The width of the non-selected border around thumbnails in the "Thumbnails" view.
-        Private Const s_defaultBorderWidth As Integer = 1
+        Private Const DefaultBorderWidth As Integer = 1
 
         'The width/height of images in "Thumbnails" view (not including the borders).
-        Private Const s_defaultLargeImageWidthHeight As Integer = 96
+        Private Const DefaultLargeImageWidthHeight As Integer = 96
 
         'The width/height of images in the smaller views ("icons", "details").  No border is used
         '  in these cases.
-        Private Const s_defaultSmallImageWidthHeight As Integer = 20
+        Private Const DefaultSmallImageWidthHeight As Integer = 20
 
         ' The above settings scaled up for High DPI
-        Private ReadOnly _selectionBorderWidth As Integer = DpiHelper.LogicalToDeviceUnitsX(s_defaultSelectionBorderWidth)
-        Private ReadOnly _borderWidth As Integer = DpiHelper.LogicalToDeviceUnitsX(s_defaultBorderWidth)
-        Private ReadOnly _largeImageWidthHeight As Integer = DpiHelper.LogicalToDeviceUnitsX(s_defaultLargeImageWidthHeight)
-        Private ReadOnly _smallImageWidthHeight As Integer = DpiHelper.LogicalToDeviceUnitsX(s_defaultSmallImageWidthHeight)
+        Private ReadOnly _selectionBorderWidth As Integer = DpiHelper.LogicalToDeviceUnitsX(DefaultSelectionBorderWidth)
+        Private ReadOnly _borderWidth As Integer = DpiHelper.LogicalToDeviceUnitsX(DefaultBorderWidth)
+        Private ReadOnly _largeImageWidthHeight As Integer = DpiHelper.LogicalToDeviceUnitsX(DefaultLargeImageWidthHeight)
+        Private ReadOnly _smallImageWidthHeight As Integer = DpiHelper.LogicalToDeviceUnitsX(DefaultSmallImageWidthHeight)
 
         'The default column width for the "Name" column in "Details" view
-        Private Const s_defaultColumnWidthName As Integer = 150 'Includes the size of the thumbnail icon
+        Private Const DefaultColumnWidthName As Integer = 150 'Includes the size of the thumbnail icon
 
         'The default column width for the "Filename" column in "Details" view
-        Private Const s_defaultColumnWidthFilename As Integer = 300
+        Private Const DefaultColumnWidthFilename As Integer = 300
 
         'The default column width for the "Image Type" column in "Details" view
-        Private Const s_defaultColumnWidthImageType As Integer = 150
+        Private Const DefaultColumnWidthImageType As Integer = 150
 
         'The default column width for the "Size" column in "Details" view
-        Private Const s_defaultColumnWidthSize As Integer = 60
+        Private Const DefaultColumnWidthSize As Integer = 60
 
         'The default column width for the "Comment" column in "Details" view
-        Private Const s_defaultColumnWidthComment As Integer = 300
+        Private Const DefaultColumnWidthComment As Integer = 300
 
         'If this is turned on, attempted retrieval of listview items will simply return
         '  a blank entry.  This is useful when the resourc editor is being disposed of.
@@ -84,19 +84,19 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Private _resourceFile As ResourceFile
 
         'The index to the reserved error glyph at the beginning of the imagelist.
-        Private Const s_IMAGELIST_INDEX_ERROR As Integer = 0
+        Private Const IMAGELIST_INDEX_ERROR As Integer = 0
 
         'The index to the reserved SortUp glyph at the beginning of the imagelist.
-        Private Const s_IMAGELIST_INDEX_SORT_UP As Integer = 1
+        Private Const IMAGELIST_INDEX_SORT_UP As Integer = 1
 
         'The index to the reserved SortDown glyph at the beginning of the imagelist.
-        Private Const s_IMAGELIST_INDEX_SORT_DOWN As Integer = 2
+        Private Const IMAGELIST_INDEX_SORT_DOWN As Integer = 2
 
         ' The index means we haven't loaded the image yet
-        Private Const s_IMAGELIST_INDEX_NEED_LOAD As Integer = -1
+        Private Const IMAGELIST_INDEX_NEED_LOAD As Integer = -1
 
         'The index into the state imagelist for the (small) error glyph
-        Private Const s_STATEIMAGELIST_INDEX_ERROR As Integer = 0
+        Private Const STATEIMAGELIST_INDEX_ERROR As Integer = 0
 
         'If true, and label editing fails validation, no messagebox will be shown, it
         '  will just fail silently.
@@ -125,7 +125,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Private _onIdleEnabled As Boolean
 
         ' Detail View Column Count
-        Private Const s_DETAIL_VIEW_COLUMN_COUNT As Integer = 5
+        Private Const DETAIL_VIEW_COLUMN_COUNT As Integer = 5
 
 
 #End Region
@@ -329,11 +329,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
             If Not _columnInitialized Then
 
-                Columns.Add(My.Resources.Designer.RSE_DetailsCol_Name, DpiHelper.LogicalToDeviceUnitsX(s_defaultColumnWidthName), HorizontalAlignment.Left)
-                Columns.Add(My.Resources.Designer.RSE_DetailsCol_Filename, DpiHelper.LogicalToDeviceUnitsX(s_defaultColumnWidthFilename), HorizontalAlignment.Left)
-                Columns.Add(My.Resources.Designer.RSE_DetailsCol_ImageType, DpiHelper.LogicalToDeviceUnitsX(s_defaultColumnWidthImageType), HorizontalAlignment.Left)
-                Columns.Add(My.Resources.Designer.RSE_DetailsCol_Size, DpiHelper.LogicalToDeviceUnitsX(s_defaultColumnWidthSize), HorizontalAlignment.Left)
-                Columns.Add(My.Resources.Designer.RSE_DetailsCol_Comment, DpiHelper.LogicalToDeviceUnitsX(s_defaultColumnWidthComment), HorizontalAlignment.Left)
+                Columns.Add(My.Resources.Designer.RSE_DetailsCol_Name, DpiHelper.LogicalToDeviceUnitsX(DefaultColumnWidthName), HorizontalAlignment.Left)
+                Columns.Add(My.Resources.Designer.RSE_DetailsCol_Filename, DpiHelper.LogicalToDeviceUnitsX(DefaultColumnWidthFilename), HorizontalAlignment.Left)
+                Columns.Add(My.Resources.Designer.RSE_DetailsCol_ImageType, DpiHelper.LogicalToDeviceUnitsX(DefaultColumnWidthImageType), HorizontalAlignment.Left)
+                Columns.Add(My.Resources.Designer.RSE_DetailsCol_Size, DpiHelper.LogicalToDeviceUnitsX(DefaultColumnWidthSize), HorizontalAlignment.Left)
+                Columns.Add(My.Resources.Designer.RSE_DetailsCol_Comment, DpiHelper.LogicalToDeviceUnitsX(DefaultColumnWidthComment), HorizontalAlignment.Left)
 
                 _columnInitialized = True
             End If
@@ -432,7 +432,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             End If
 
             ' Clear old column header sort indicator
-            For columnIndex As Integer = 0 To s_DETAIL_VIEW_COLUMN_COUNT - 1
+            For columnIndex As Integer = 0 To DETAIL_VIEW_COLUMN_COUNT - 1
                 ClearColumnSortImage(columnIndex)
             Next
 
@@ -704,9 +704,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     .fmt = Interop.win.HDF_STRING Or Interop.win.HDF_IMAGE Or Interop.win.HDF_BITMAP_ON_RIGHT
 
                     If inReverseOrder Then
-                        .iImage = s_IMAGELIST_INDEX_SORT_DOWN
+                        .iImage = IMAGELIST_INDEX_SORT_DOWN
                     Else
-                        .iImage = s_IMAGELIST_INDEX_SORT_UP
+                        .iImage = IMAGELIST_INDEX_SORT_UP
                     End If
                 End With
 
@@ -758,9 +758,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             If _thumbnailImageList IsNot Nothing Then
 
                 ' Update sort indicator...
-                _thumbnailImageList.Images.Item(s_IMAGELIST_INDEX_SORT_UP) = MapBitmapColor(ParentView.CachedResources.SortUpGlyph, Color.Black,
+                _thumbnailImageList.Images.Item(IMAGELIST_INDEX_SORT_UP) = MapBitmapColor(ParentView.CachedResources.SortUpGlyph, Color.Black,
                                                                                        Common.ShellUtil.GetVSColor(Shell.Interop.__VSSYSCOLOREX3.VSCOLOR_GRAYTEXT, SystemColors.GrayText, UseVSTheme:=False))
-                _thumbnailImageList.Images.Item(s_IMAGELIST_INDEX_SORT_DOWN) = MapBitmapColor(ParentView.CachedResources.SortDownGlyph, Color.Black,
+                _thumbnailImageList.Images.Item(IMAGELIST_INDEX_SORT_DOWN) = MapBitmapColor(ParentView.CachedResources.SortDownGlyph, Color.Black,
                                                                                              Common.ShellUtil.GetVSColor(Shell.Interop.__VSSYSCOLOREX3.VSCOLOR_GRAYTEXT, SystemColors.GrayText, UseVSTheme:=False))
 
                 ' Reset column header sort indicator
@@ -932,7 +932,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                             If itemRectangle.IntersectsWith(ClientRectangle) Then
                                 Dim Resource As Resource = GetResourceFromVirtualIndex(i)
                                 If Resource IsNot Nothing AndAlso Not _thumbnailCache.IsThumbnailInCache(Resource) Then
-                                    If GetThumbnailIndex(Resource, False) <> s_IMAGELIST_INDEX_NEED_LOAD Then
+                                    If GetThumbnailIndex(Resource, False) <> IMAGELIST_INDEX_NEED_LOAD Then
                                         Invalidate(itemRectangle)
                                     End If
                                     Exit Sub
@@ -1002,7 +1002,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             '  thumbnail.
             Dim ImageListIndex As Integer = GetThumbnailIndex(Resource, True)
 
-            If ImageListIndex = s_IMAGELIST_INDEX_NEED_LOAD Then
+            If ImageListIndex = IMAGELIST_INDEX_NEED_LOAD Then
                 ' Delay load the image...
                 DelayLoadingValue = True
                 If e.ItemIndex >= _imageStartIndex AndAlso e.ItemIndex <= _imageEndIndex Then
@@ -1023,7 +1023,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             If ResourceFile.ResourceHasTasks(Resource) Then
                 'This resource has some task list items.  Need to set its state to
                 '  show the error glyph.
-                e.Item.StateImageIndex = s_STATEIMAGELIST_INDEX_ERROR
+                e.Item.StateImageIndex = STATEIMAGELIST_INDEX_ERROR
             End If
 
             'We also need to fill in the sub items (the additional columns in a details view)
@@ -1132,7 +1132,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Dim ThumbnailSourceImage As Image
             Dim IsSharedImage As Boolean = Resource.ResourceTypeEditor.IsImageForThumbnailShared
             If Not IsSharedImage AndAlso AllowDelayLoading Then
-                Return s_IMAGELIST_INDEX_NEED_LOAD
+                Return IMAGELIST_INDEX_NEED_LOAD
             Else
                 Try
                     ThumbnailSourceImage = Resource.ResourceTypeEditor.GetImageForThumbnail(Resource, BackColor)
@@ -1181,7 +1181,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 If Thumbnail Is Nothing Then
                     'We'd prefer not to use this, but since CreateThumbnail isn't working, we have no choice.  Trouble is,
                     '  every call to GetThumbnailIndex() will retry to create the thumbnail.  But now we have no choice.
-                    Return s_IMAGELIST_INDEX_ERROR
+                    Return IMAGELIST_INDEX_ERROR
                 ElseIf IsSharedImage Then
                     Index = _thumbnailCache.Add(ThumbnailSourceImage, Thumbnail, True)
                     _thumbnailCache.ReuseSharedImage(Resource, Index)
@@ -1293,9 +1293,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
         Private Declare Auto Function SendMessage Lib "User32" (hWnd As IntPtr, msg As Integer, wParam As Integer, ByRef lParam As LVITEM) As IntPtr
 
-        Private Const s_LVIF_STATE As Integer = &H8
-        Private Const s_LVIS_SELECTED As Integer = &H2
-        Private Const s_LVM_SETITEMSTATE As Integer = (&H1000 + 43)
+        Private Const LVIF_STATE As Integer = &H8
+        Private Const LVIS_SELECTED As Integer = &H2
+        Private Const LVM_SETITEMSTATE As Integer = (&H1000 + 43)
 
 
         Private Sub SetItemState(index As Integer, state As Integer, mask As Integer)
@@ -1306,10 +1306,10 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
             If Handle <> IntPtr.Zero Then
                 Dim lvi As New LVITEM
-                lvi.mask = s_LVIF_STATE
+                lvi.mask = LVIF_STATE
                 lvi.state = state
                 lvi.stateMask = mask
-                SendMessage(Handle, s_LVM_SETITEMSTATE, index, lvi)
+                SendMessage(Handle, LVM_SETITEMSTATE, index, lvi)
             End If
         End Sub
 
@@ -1320,9 +1320,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             End If
 
             If Selected Then
-                SetItemState(ResourceIndex, s_LVIS_SELECTED, s_LVIS_SELECTED)
+                SetItemState(ResourceIndex, LVIS_SELECTED, LVIS_SELECTED)
             Else
-                SetItemState(ResourceIndex, 0, s_LVIS_SELECTED)
+                SetItemState(ResourceIndex, 0, LVIS_SELECTED)
             End If
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceSerializationService_Store.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceSerializationService_Store.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -144,8 +144,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 #Region "ISerialization implementation"
 
             'Serialization keys for ISerializable
-            Private Const s_KEY_STATE As String = "State"
-            Private Const s_KEY_OBJECTNAMES As String = "ObjectNames"
+            Private Const KEY_STATE As String = "State"
+            Private Const KEY_OBJECTNAMES As String = "ObjectNames"
 
             ''' <summary>
             '''     Implements the save part of ISerializable.
@@ -155,7 +155,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <param name="context">Serialization context</param>
             ''' <remarks></remarks>
             Private Sub GetObjectData(info As SerializationInfo, context As StreamingContext) Implements ISerializable.GetObjectData
-                info.AddValue(s_KEY_STATE, _serializedState)
+                info.AddValue(KEY_STATE, _serializedState)
 
                 Trace("Serialized store (GetObjectData)")
             End Sub
@@ -169,7 +169,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <param name="Context">Serialization context</param>
             ''' <remarks></remarks>
             Private Sub New(Info As SerializationInfo, Context As StreamingContext)
-                _serializedState = DirectCast(Info.GetValue(s_KEY_STATE, GetType(ArrayList)), ArrayList)
+                _serializedState = DirectCast(Info.GetValue(KEY_STATE, GetType(ArrayList)), ArrayList)
 
                 Trace("Deserialized store from a stream (constructor)")
             End Sub

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -24,7 +24,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Friend Const COLUMN_VALUE As Integer = 2
         Friend Const COLUMN_COMMENT As Integer = 3
 
-        Private Const s_ROW_BORDER_HEIGHT As Integer = 2
+        Private Const ROW_BORDER_HEIGHT As Integer = 2
 
         'A list of all Resource entries that are displayed in this string table (with the exception
         '  of the uncommitted resource, if any)
@@ -58,20 +58,20 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
         'Default column width percentages for each column.  Yes, this adds up to more than 100%
         '  if the type column is visible, but that's okay.
-        Private Const s_defaultColumnWidthPercentage_Name As Integer = 20
-        Private Const s_defaultColumnWidthPercentage_Type As Integer = 25
-        Private Const s_defaultColumnWidthPercentage_Value As Integer = 50
-        Private Const s_defaultColumnWidthPercentage_Comment As Integer = 30
+        Private Const DefaultColumnWidthPercentage_Name As Integer = 20
+        Private Const DefaultColumnWidthPercentage_Type As Integer = 25
+        Private Const DefaultColumnWidthPercentage_Value As Integer = 50
+        Private Const DefaultColumnWidthPercentage_Comment As Integer = 30
 
         'Minimum scrolling widths
-        Private Const s_columnMinScrollingWidth_Name As Integer = 100
-        Private Const s_columnMinScrollingWidth_Type As Integer = 60
-        Private Const s_columnMinScrollingWidth_Value As Integer = 150
-        Private Const s_columnMinScrollingWidth_Comment As Integer = 80
+        Private Const ColumnMinScrollingWidth_Name As Integer = 100
+        Private Const ColumnMinScrollingWidth_Type As Integer = 60
+        Private Const ColumnMinScrollingWidth_Value As Integer = 150
+        Private Const ColumnMinScrollingWidth_Comment As Integer = 80
 
         'The error glyphs don't show up if the row height is below the glyph size.  We don't want that
         '  to happen, so restrict the minimum height.
-        Private Const s_rowMinimumHeight As Integer = 20
+        Private Const RowMinimumHeight As Integer = 20
 
         ' Current sorter
         Private _sorter As StringTableSorter
@@ -218,12 +218,12 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ' ==== Name Column
 
             Dim ColumnWidth As Integer
-            ColumnWidth = DpiHelper.LogicalToDeviceUnitsX(s_columnMinScrollingWidth_Name)
+            ColumnWidth = DpiHelper.LogicalToDeviceUnitsX(ColumnMinScrollingWidth_Name)
             Dim NameColumn As New DataGridViewTextBoxColumn
             With NameColumn
                 .AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill
                 .CellTemplate = New ResourceStringTextBoxCell()
-                .FillWeight = s_defaultColumnWidthPercentage_Name
+                .FillWeight = DefaultColumnWidthPercentage_Name
                 .MinimumWidth = ColumnWidth
                 .Name = My.Resources.Designer.RSE_ResourceNameColumn
                 .Width = ColumnWidth
@@ -234,12 +234,12 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
             ' ==== Type Column
 
-            ColumnWidth = DpiHelper.LogicalToDeviceUnitsX(s_columnMinScrollingWidth_Type)
+            ColumnWidth = DpiHelper.LogicalToDeviceUnitsX(ColumnMinScrollingWidth_Type)
             Dim TypeColumn As New DataGridViewTextBoxColumn
             With TypeColumn
                 .AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill
                 .CellTemplate = New ResourceStringTextBoxCell()
-                .FillWeight = s_defaultColumnWidthPercentage_Type
+                .FillWeight = DefaultColumnWidthPercentage_Type
                 .MinimumWidth = ColumnWidth
                 .Name = My.Resources.Designer.RSE_TypeColumn
                 .ReadOnly = True 'Can't modify the Type column - just for info
@@ -254,12 +254,12 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             '... By specifying DataGridViewTextBoxColumn here, we're indicating that user-added rows
             '      (i.e., through the "new row" at the bottom of the DataGridView) will be of type
             '      ResourceStringTextBoxCell.
-            ColumnWidth = DpiHelper.LogicalToDeviceUnitsX(s_columnMinScrollingWidth_Value)
+            ColumnWidth = DpiHelper.LogicalToDeviceUnitsX(ColumnMinScrollingWidth_Value)
             Dim ValueColumn As New DataGridViewTextBoxColumn
             With ValueColumn
                 .AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill
                 .CellTemplate = New ResourceStringTextBoxCell()
-                .FillWeight = s_defaultColumnWidthPercentage_Value
+                .FillWeight = DefaultColumnWidthPercentage_Value
                 .MinimumWidth = ColumnWidth
                 .Name = My.Resources.Designer.RSE_ResourceColumn
                 .Width = ColumnWidth
@@ -269,12 +269,12 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Columns.Add(ValueColumn)
 
             ' ==== Comment Column
-            ColumnWidth = DpiHelper.LogicalToDeviceUnitsX(s_columnMinScrollingWidth_Comment)
+            ColumnWidth = DpiHelper.LogicalToDeviceUnitsX(ColumnMinScrollingWidth_Comment)
             Dim CommentColumn As New DataGridViewTextBoxColumn
             With CommentColumn
                 .AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill
                 .CellTemplate = New ResourceStringTextBoxCell()
-                .FillWeight = s_defaultColumnWidthPercentage_Comment
+                .FillWeight = DefaultColumnWidthPercentage_Comment
                 .MinimumWidth = ColumnWidth
                 .Name = My.Resources.Designer.RSE_CommentColumn
                 .Width = ColumnWidth
@@ -368,7 +368,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
             'The error glyphs don't show up if the row height is below the glyph size.  We don't want that
             '  to happen, so restrict the minimum height.
-            NewRow.MinimumHeight = Math.Max(DpiHelper.LogicalToDeviceUnitsY(s_rowMinimumHeight), Font.Height + DpiHelper.LogicalToDeviceUnitsY(s_ROW_BORDER_HEIGHT))
+            NewRow.MinimumHeight = Math.Max(DpiHelper.LogicalToDeviceUnitsY(RowMinimumHeight), Font.Height + DpiHelper.LogicalToDeviceUnitsY(ROW_BORDER_HEIGHT))
 
             'Build up the new row (with blank values) cell by cell
 
@@ -1173,7 +1173,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             '  show up at all.
             'See CreateNewResourceRow().  Currently you can't create a row for OnNewRowNeeded, there's
             '  supposed to be a template row to be able to use for this later in m3, if needed.
-            e.Row.MinimumHeight = Math.Max(DpiHelper.LogicalToDeviceUnitsY(s_rowMinimumHeight), Font.Height + DpiHelper.LogicalToDeviceUnitsY(s_ROW_BORDER_HEIGHT))
+            e.Row.MinimumHeight = Math.Max(DpiHelper.LogicalToDeviceUnitsY(RowMinimumHeight), Font.Height + DpiHelper.LogicalToDeviceUnitsY(ROW_BORDER_HEIGHT))
 
             If ResourceFile Is Nothing Then
                 Debug.Fail("No resource file")

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourcesFolderService.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourcesFolderService.vb
@@ -74,16 +74,16 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
 
         'The default name to use for the Resources file unless the registry says otherwise.
-        Private Const s_DEFAULT_RESOURCE_FOLDER_NAME As String = "Resources"
+        Private Const DEFAULT_RESOURCE_FOLDER_NAME As String = "Resources"
 
         'Name of the "Projects" key in the Visual Studio registry subtree
-        Private Const s_KEYPATH_PROJECTS As String = "Projects"
+        Private Const KEYPATH_PROJECTS As String = "Projects"
 
         'Name of the key in the registry that indicates what add-to-project behavior to use for a particular project
-        Private Const s_KEYNAME_RESOURCESFOLDERBEHAVIOR As String = "ResourcesFolderBehavior"
+        Private Const KEYNAME_RESOURCESFOLDERBEHAVIOR As String = "ResourcesFolderBehavior"
 
         'Name of the key in the registry that indicates the name of the Resources folder for a particular project
-        Private Const s_KEYNAME_RESOURCESFOLDERNAME As String = "ResourcesFolderName"
+        Private Const KEYNAME_RESOURCESFOLDERNAME As String = "ResourcesFolderName"
 
 #End Region
 
@@ -133,7 +133,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Message">The message to displaying, including optional formatting parameters "{0}" etc.</param>
         ''' <param name="FormatArguments">Arguments for "{0}", "{1}", etc.</param>
         ''' <remarks></remarks>
-        <Conditional("DEBUG")> _
+        <Conditional("DEBUG")>
         Friend Shared Sub Trace(Message As String, ParamArray FormatArguments() As Object)
             If FormatArguments.Length > 0 Then
                 'Only use String.Format when we have specific format arguments, although we might accidently break on something like a stray "{" in a filename
@@ -623,7 +623,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
             'We currently don't support anything but the default Resources folder name ("Resources")
             '  However, this could be changed later to be optionally pulled from the Registry.
-            ResourcesFolderName = s_DEFAULT_RESOURCE_FOLDER_NAME
+            ResourcesFolderName = DEFAULT_RESOURCE_FOLDER_NAME
 
             If Project Is Nothing OrElse IsMiscellaneousProject(Project) Then
                 'If there's no project or it's the miscellaneous files project, we simply get AddNone behavior.
@@ -646,7 +646,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 If VsRootKeyPath <> "" AndAlso Not VsRootKeyPath.EndsWith("\") Then
                     VSProjectsKeyPath.Append("\")
                 End If
-                VSProjectsKeyPath.Append(s_KEYPATH_PROJECTS)
+                VSProjectsKeyPath.Append(KEYPATH_PROJECTS)
                 VSProjectsKeyPath.Append("\")
                 VSProjectsKeyPath.Append(Project.Kind)
 
@@ -655,8 +655,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 If VsProjectsKey IsNot Nothing Then
                     Try
                         'Read the values
-                        Dim DesiredBehavior As ResourcesFolderBehavior = DirectCast(VsProjectsKey.GetValue(s_KEYNAME_RESOURCESFOLDERBEHAVIOR, ResourcesFolderBehavior.AddNone), ResourcesFolderBehavior)
-                        Dim DesiredResourcesFolderName As String = DirectCast(VsProjectsKey.GetValue(s_KEYNAME_RESOURCESFOLDERNAME, ResourcesFolderName), String)
+                        Dim DesiredBehavior As ResourcesFolderBehavior = DirectCast(VsProjectsKey.GetValue(KEYNAME_RESOURCESFOLDERBEHAVIOR, ResourcesFolderBehavior.AddNone), ResourcesFolderBehavior)
+                        Dim DesiredResourcesFolderName As String = DirectCast(VsProjectsKey.GetValue(KEYNAME_RESOURCESFOLDERNAME, ResourcesFolderName), String)
 
                         'Validate the behavior from the registry
                         If [Enum].IsDefined(GetType(ResourcesFolderBehavior), DesiredBehavior) Then

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/SerializableEncoding.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/SerializableEncoding.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -24,7 +24,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Private _encoding As Encoding
 
         'Key for serialization
-        Private Const s_KEY_NAME As String = "Name"
+        Private Const KEY_NAME As String = "Name"
 
 
         ''' <summary>
@@ -44,7 +44,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="context"></param>
         ''' <remarks></remarks>
         Private Sub New(info As SerializationInfo, context As StreamingContext)
-            Dim EncodingName As String = info.GetString(s_KEY_NAME)
+            Dim EncodingName As String = info.GetString(KEY_NAME)
             If EncodingName <> "" Then
                 _encoding = Encoding.GetEncoding(EncodingName)
             End If
@@ -89,9 +89,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <remarks></remarks>
         Private Sub GetObjectData(info As SerializationInfo, context As StreamingContext) Implements ISerializable.GetObjectData
             If _encoding IsNot Nothing Then
-                info.AddValue(s_KEY_NAME, _encoding.WebName)
+                info.AddValue(KEY_NAME, _encoding.WebName)
             Else
-                info.AddValue(s_KEY_NAME, "")
+                info.AddValue(KEY_NAME, "")
             End If
         End Sub
     End Class

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DesignTimeSettingInstance.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DesignTimeSettingInstance.vb
@@ -1110,38 +1110,38 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
 #Region "ISerializable implementation"
 
-        Private Const s_SERIALIZATION_DESCRIPTION As String = "Description"
-        Private Const s_SERIALIZATION_GENERATE_DEFAULT_VALUE_IN_CODE As String = "GenerateDefaultValueInCode"
-        Private Const s_SERIALIZATION_IS_ROAMING As String = "Roaming"
-        Private Const s_SERIALIZATION_NAME As String = "Name"
-        Private Const s_SERIALIZATION_PROVIDER As String = "Provider"
-        Private Const s_SERIALIZATION_TYPE As String = "SerializedType"
-        Private Const s_SERIALIZATION_VALUE As String = "SerializedValue"
-        Private Const s_SERIALIZATION_SCOPE As String = "Scope"
+        Private Const SERIALIZATION_DESCRIPTION As String = "Description"
+        Private Const SERIALIZATION_GENERATE_DEFAULT_VALUE_IN_CODE As String = "GenerateDefaultValueInCode"
+        Private Const SERIALIZATION_IS_ROAMING As String = "Roaming"
+        Private Const SERIALIZATION_NAME As String = "Name"
+        Private Const SERIALIZATION_PROVIDER As String = "Provider"
+        Private Const SERIALIZATION_TYPE As String = "SerializedType"
+        Private Const SERIALIZATION_VALUE As String = "SerializedValue"
+        Private Const SERIALIZATION_SCOPE As String = "Scope"
 
         'See .NET Framework Developer's Guide, "Custom Serialization" for more information
         Protected Sub New(Info As System.Runtime.Serialization.SerializationInfo, Context As System.Runtime.Serialization.StreamingContext)
-            _description = Info.GetString(s_SERIALIZATION_DESCRIPTION)
-            _generateDefaultValueInCode = Info.GetBoolean(s_SERIALIZATION_GENERATE_DEFAULT_VALUE_IN_CODE)
-            _name = Info.GetString(s_SERIALIZATION_NAME)
-            _roaming = Info.GetBoolean(s_SERIALIZATION_IS_ROAMING)
-            _provider = Info.GetString(s_SERIALIZATION_PROVIDER)
-            _settingTypeName = Info.GetString(s_SERIALIZATION_TYPE)
-            _serializedValue = Info.GetString(s_SERIALIZATION_VALUE)
-            _settingScope = CType(Info.GetInt32(s_SERIALIZATION_SCOPE), SettingScope)
+            _description = Info.GetString(SERIALIZATION_DESCRIPTION)
+            _generateDefaultValueInCode = Info.GetBoolean(SERIALIZATION_GENERATE_DEFAULT_VALUE_IN_CODE)
+            _name = Info.GetString(SERIALIZATION_NAME)
+            _roaming = Info.GetBoolean(SERIALIZATION_IS_ROAMING)
+            _provider = Info.GetString(SERIALIZATION_PROVIDER)
+            _settingTypeName = Info.GetString(SERIALIZATION_TYPE)
+            _serializedValue = Info.GetString(SERIALIZATION_VALUE)
+            _settingScope = CType(Info.GetInt32(SERIALIZATION_SCOPE), SettingScope)
         End Sub
 
 
-        <Security.Permissions.SecurityPermission(Security.Permissions.SecurityAction.Demand, SerializationFormatter:=True)> _
+        <Security.Permissions.SecurityPermission(Security.Permissions.SecurityAction.Demand, SerializationFormatter:=True)>
         Private Sub GetObjectData(Info As System.Runtime.Serialization.SerializationInfo, Context As System.Runtime.Serialization.StreamingContext) Implements System.Runtime.Serialization.ISerializable.GetObjectData
-            Info.AddValue(s_SERIALIZATION_DESCRIPTION, _description)
-            Info.AddValue(s_SERIALIZATION_GENERATE_DEFAULT_VALUE_IN_CODE, _generateDefaultValueInCode)
-            Info.AddValue(s_SERIALIZATION_NAME, _name)
-            Info.AddValue(s_SERIALIZATION_IS_ROAMING, _roaming)
-            Info.AddValue(s_SERIALIZATION_PROVIDER, _provider)
-            Info.AddValue(s_SERIALIZATION_TYPE, _settingTypeName)
-            Info.AddValue(s_SERIALIZATION_VALUE, _serializedValue)
-            Info.AddValue(s_SERIALIZATION_SCOPE, CType(_settingScope, Integer))
+            Info.AddValue(SERIALIZATION_DESCRIPTION, _description)
+            Info.AddValue(SERIALIZATION_GENERATE_DEFAULT_VALUE_IN_CODE, _generateDefaultValueInCode)
+            Info.AddValue(SERIALIZATION_NAME, _name)
+            Info.AddValue(SERIALIZATION_IS_ROAMING, _roaming)
+            Info.AddValue(SERIALIZATION_PROVIDER, _provider)
+            Info.AddValue(SERIALIZATION_TYPE, _settingTypeName)
+            Info.AddValue(SERIALIZATION_VALUE, _serializedValue)
+            Info.AddValue(SERIALIZATION_SCOPE, CType(_settingScope, Integer))
         End Sub
 
 #End Region

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesigner.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesigner.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel.Design
 
@@ -20,7 +20,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         Friend Const ApplicationScopeName As String = "Application"
         Friend Const UserScopeName As String = "User"
         Friend Const CultureInvariantDefaultProfileName As String = "(Default)"
-        Private Const s_specialClassName As String = "MySettings"
+        Private Const SpecialClassName As String = "MySettings"
 
         ' Our view
         Private _settingsDesignerViewProperty As SettingsDesignerView
@@ -223,7 +223,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                         End If
 
                         If Settings.UseSpecialClassName Then
-                            Return s_specialClassName
+                            Return SpecialClassName
                         End If
                     Catch ex As Exception When Common.ReportWithoutCrash(ex, String.Format("Failed to crack open {0} to determine if we were supposed to use the ""Special"" settings class name", FullPath), NameOf(SettingsDesigner))
                     End Try

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerLoader.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel.Design
 Imports System.ComponentModel.Design.Serialization
@@ -28,7 +28,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
         Private _flushing As Boolean
 
-        Private Const s_prjKindVenus As String = "{E24C65DC-7377-472b-9ABA-BC803B73C61A}"
+        Private Const PrjKindVenus As String = "{E24C65DC-7377-472b-9ABA-BC803B73C61A}"
 
         ' Set flag if we make changes to the settings object during load that should
         ' set the docdata to dirty immediately after we have loaded.

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel
 Imports System.ComponentModel.Design
@@ -32,10 +32,10 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         Implements IVsWindowPaneCommit
         Implements IVsBroadcastMessageEvents
 
-        Private Const s_nameColumnNo As Integer = 0
-        Private Const s_typeColumnNo As Integer = 1
-        Private Const s_scopeColumnNo As Integer = 2
-        Private Const s_valueColumnNo As Integer = 3
+        Private Const NameColumnNo As Integer = 0
+        Private Const TypeColumnNo As Integer = 1
+        Private Const ScopeColumnNo As Integer = 2
+        Private Const ValueColumnNo As Integer = 3
         Private _menuCommands As ArrayList
         Private _accessModifierCombobox As SettingsDesignerAccessModifierCombobox
 
@@ -56,8 +56,8 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             End Sub
 
             Public Shadows Function GetMenuCommandsToRegister() As ICollection
-                Return MyBase.GetMenuCommandsToRegister( _
-                    Constants.MenuConstants.CommandIDSettingsDesignerAccessModifierCombobox, _
+                Return MyBase.GetMenuCommandsToRegister(
+                    Constants.MenuConstants.CommandIDSettingsDesignerAccessModifierCombobox,
                     Constants.MenuConstants.CommandIDSettingsDesignerGetAccessModifierOptions)
             End Function
 
@@ -69,7 +69,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                     Return False
                 End If
 
-                Return designerLoader.InDesignMode AndAlso Not DesignerLoader.IsReadOnly
+                Return designerLoader.InDesignMode AndAlso Not designerLoader.IsReadOnly
             End Function
         End Class
 
@@ -101,7 +101,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
         ' Padding used to calculate width of comboboxes to avoid getting the text
         ' truncated...
-        Private Const s_internalComboBoxPadding As Integer = 10
+        Private Const InternalComboBoxPadding As Integer = 10
 
         Private WithEvents _dataGridViewTextBoxColumn1 As DataGridViewTextBoxColumn
         Private WithEvents _dataGridViewComboBoxColumn1 As DataGridViewComboBoxColumn
@@ -159,12 +159,12 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
             _settingsTableLayoutPanel.SuspendLayout()
 
-            _settingsGridView.Columns(s_nameColumnNo).HeaderText = My.Resources.Designer.SD_GridViewNameColumnHeaderText
-            _settingsGridView.Columns(s_nameColumnNo).CellTemplate = New DesignerDataGridView.EditOnClickDataGridViewTextBoxCell()
-            _settingsGridView.Columns(s_typeColumnNo).HeaderText = My.Resources.Designer.SD_GridViewTypeColumnHeaderText
-            _settingsGridView.Columns(s_typeColumnNo).CellTemplate = New DesignerDataGridView.EditOnClickDataGridViewComboBoxCell()
-            _settingsGridView.Columns(s_scopeColumnNo).HeaderText = My.Resources.Designer.SD_GridViewScopeColumnHeaderText
-            _settingsGridView.Columns(s_scopeColumnNo).CellTemplate = New DesignerDataGridView.EditOnClickDataGridViewComboBoxCell()
+            _settingsGridView.Columns(NameColumnNo).HeaderText = My.Resources.Designer.SD_GridViewNameColumnHeaderText
+            _settingsGridView.Columns(NameColumnNo).CellTemplate = New DesignerDataGridView.EditOnClickDataGridViewTextBoxCell()
+            _settingsGridView.Columns(TypeColumnNo).HeaderText = My.Resources.Designer.SD_GridViewTypeColumnHeaderText
+            _settingsGridView.Columns(TypeColumnNo).CellTemplate = New DesignerDataGridView.EditOnClickDataGridViewComboBoxCell()
+            _settingsGridView.Columns(ScopeColumnNo).HeaderText = My.Resources.Designer.SD_GridViewScopeColumnHeaderText
+            _settingsGridView.Columns(ScopeColumnNo).CellTemplate = New DesignerDataGridView.EditOnClickDataGridViewComboBoxCell()
 
             Dim TypeEditorCol As New DataGridViewUITypeEditorColumn
             TypeEditorCol.AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill
@@ -394,10 +394,10 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             TypeColumn.Items.Add(_typeNameResolver.PersistedSettingTypeNameToTypeDisplayName(SettingsSerializer.CultureInvariantVirtualTypeNameWebReference))
             TypeColumn.Items.Add(_typeNameResolver.PersistedSettingTypeNameToTypeDisplayName(SettingsSerializer.CultureInvariantVirtualTypeNameConnectionString))
             TypeColumn.Items.Add(My.Resources.Designer.SD_ComboBoxItem_BrowseType)
-            TypeColumn.Width = DpiHelper.LogicalToDeviceUnitsX(TypeColumn.GetPreferredWidth(DataGridViewAutoSizeColumnMode.AllCells, False) + SystemInformation.VerticalScrollBarWidth + s_internalComboBoxPadding)
+            TypeColumn.Width = DpiHelper.LogicalToDeviceUnitsX(TypeColumn.GetPreferredWidth(DataGridViewAutoSizeColumnMode.AllCells, False) + SystemInformation.VerticalScrollBarWidth + InternalComboBoxPadding)
 
 
-            ScopeColumn.Width = DpiHelper.LogicalToDeviceUnitsX(ScopeColumn.GetPreferredWidth(DataGridViewAutoSizeColumnMode.AllCells, False) + SystemInformation.VerticalScrollBarWidth + s_internalComboBoxPadding)
+            ScopeColumn.Width = DpiHelper.LogicalToDeviceUnitsX(ScopeColumn.GetPreferredWidth(DataGridViewAutoSizeColumnMode.AllCells, False) + SystemInformation.VerticalScrollBarWidth + InternalComboBoxPadding)
 
             'Hook up for broadcast messages
             If _cookieBroadcastMessages = 0 Then
@@ -517,7 +517,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                         ' We want to give the name column a reasonable start width. If we did this by using auto fill/fill weight, 
                         ' changing the value column would change the size of the name column, which looks weird. We'll just default the
                         ' size to 1/3 of the value column's width and leave it at that (the user can resize if (s)he wants to)
-                        _settingsGridView.Columns(s_nameColumnNo).Width = CInt(TypeColumn.Width / 2)
+                        _settingsGridView.Columns(NameColumnNo).Width = CInt(TypeColumn.Width / 2)
                     End If
                 End If
             End Set
@@ -688,8 +688,8 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             Else
                 Dim NewInstance As New DesignTimeSettingInstance
                 Row.Tag = NewInstance
-                NewInstance.SetName(Row.Cells(s_nameColumnNo).FormattedValue.ToString())
-                NewInstance.SetScope(CType(Row.Cells(s_scopeColumnNo).Value, DesignTimeSettingInstance.SettingScope))
+                NewInstance.SetName(Row.Cells(NameColumnNo).FormattedValue.ToString())
+                NewInstance.SetScope(CType(Row.Cells(ScopeColumnNo).Value, DesignTimeSettingInstance.SettingScope))
                 If NewInstance.Name = "" Then
                     NewInstance.SetName(Settings.CreateUniqueName())
                 End If
@@ -793,7 +793,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <remarks></remarks>
         Private ReadOnly Property TypeColumn() As DataGridViewComboBoxColumn
             Get
-                Return DirectCast(_settingsGridView.Columns(s_typeColumnNo), DataGridViewComboBoxColumn)
+                Return DirectCast(_settingsGridView.Columns(TypeColumnNo), DataGridViewComboBoxColumn)
             End Get
         End Property
 
@@ -804,7 +804,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <remarks></remarks>
         Private ReadOnly Property ScopeColumn() As DataGridViewComboBoxColumn
             Get
-                Return DirectCast(_settingsGridView.Columns(s_scopeColumnNo), DataGridViewComboBoxColumn)
+                Return DirectCast(_settingsGridView.Columns(ScopeColumnNo), DataGridViewComboBoxColumn)
             End Get
         End Property
 
@@ -850,12 +850,12 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="Row"></param>
         ''' <remarks></remarks>
         Private Sub SetUIRowValues(Row As DataGridViewRow, Instance As DesignTimeSettingInstance)
-            Row.Cells(s_nameColumnNo).Value = Instance.Name
-            Row.Cells(s_nameColumnNo).ReadOnly = DesignTimeSettingInstance.IsNameReadOnly(Instance)
+            Row.Cells(NameColumnNo).Value = Instance.Name
+            Row.Cells(NameColumnNo).ReadOnly = DesignTimeSettingInstance.IsNameReadOnly(Instance)
 
             ' Update type combobox, adding the instance's type if it isn't already included in the
             ' list
-            Dim TypeCell As DataGridViewComboBoxCell = CType(Row.Cells(s_typeColumnNo), DataGridViewComboBoxCell)
+            Dim TypeCell As DataGridViewComboBoxCell = CType(Row.Cells(TypeColumnNo), DataGridViewComboBoxCell)
             Dim SettingTypeDisplayType As String = _typeNameResolver.PersistedSettingTypeNameToTypeDisplayName(Instance.SettingTypeName)
             If Not TypeColumn.Items.Contains(SettingTypeDisplayType) Then
                 TypeColumn.Items.Insert(TypeColumn.Items.Count() - 1, SettingTypeDisplayType)
@@ -865,9 +865,9 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             UpdateComboBoxCell(TypeCell)
             TypeCell.ReadOnly = DesignTimeSettingInstance.IsTypeReadOnly(Instance)
 
-            Row.Cells(s_scopeColumnNo).ReadOnly = DesignTimeSettingInstance.IsScopeReadOnly(Instance, _projectSystemSupportsUserScope)
+            Row.Cells(ScopeColumnNo).ReadOnly = DesignTimeSettingInstance.IsScopeReadOnly(Instance, _projectSystemSupportsUserScope)
 
-            Row.Cells(s_scopeColumnNo).Value = Instance.Scope
+            Row.Cells(ScopeColumnNo).Value = Instance.Scope
 
             UpdateUIValueColumn(Row)
         End Sub
@@ -879,7 +879,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <remarks></remarks>
         Private Sub UpdateUIValueColumn(row As DataGridViewRow)
             Dim Instance As DesignTimeSettingInstance = CType(row.Tag, DesignTimeSettingInstance)
-            Dim Cell As DataGridViewUITypeEditorCell = CType(row.Cells(s_valueColumnNo), DataGridViewUITypeEditorCell)
+            Dim Cell As DataGridViewUITypeEditorCell = CType(row.Cells(ValueColumnNo), DataGridViewUITypeEditorCell)
             If Instance IsNot Nothing Then
                 Dim settingType As Type = _settingTypeCache.GetSettingType(Instance.SettingTypeName)
                 If settingType IsNot Nothing AndAlso Not SettingTypeValidator.IsTypeObsolete(settingType) Then
@@ -1045,14 +1045,14 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         Private Function ValidateCell(FormattedValue As Object, RowIndex As Integer, ColumnIndex As Integer) As Boolean
             Dim Instance As DesignTimeSettingInstance = TryCast(_settingsGridView.Rows(RowIndex).Tag, DesignTimeSettingInstance)
             Select Case ColumnIndex
-                Case s_nameColumnNo
+                Case NameColumnNo
                     Debug.Assert(TypeOf FormattedValue Is String, "Unknown type of formatted value for name")
                     Return ValidateName(DirectCast(FormattedValue, String), Instance)
-                Case s_typeColumnNo
+                Case TypeColumnNo
                     ' We don't want to commit the "Browse..." value at any time... we also don't want to allow an empty string for type name
                     Debug.Assert(TypeOf FormattedValue Is String, "Unknown type of formatted value for name")
                     Return Not (TryCast(FormattedValue, String) = "" OrElse String.Equals(My.Resources.Designer.SD_ComboBoxItem_BrowseType, TryCast(FormattedValue, String), StringComparison.Ordinal))
-                Case s_scopeColumnNo
+                Case ScopeColumnNo
                     Return TryCast(FormattedValue, String) <> ""
                 Case Else
                     Return True
@@ -1165,19 +1165,19 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
                 Try
                     Select Case e.ColumnIndex
-                        Case s_nameColumnNo
+                        Case NameColumnNo
                             Debug.WriteLineIf(SettingsDesigner.TraceSwitch.TraceVerbose, "Changing name of setting " & Instance.Name)
                             ' Don't use SetName since that won't fire a component change notification...
                             Instance.NameProperty.SetValue(Instance, CellText)
-                        Case s_typeColumnNo
+                        Case TypeColumnNo
                             ' Changing the type is a remove/add operation
                             If Not CellText.Equals(Instance.SettingTypeName, StringComparison.Ordinal) AndAlso Not CellText.Equals(My.Resources.Designer.SD_ComboBoxItem_BrowseType, StringComparison.Ordinal) Then
                                 ChangeSettingType(Row, CellText)
                             End If
-                        Case s_scopeColumnNo
+                        Case ScopeColumnNo
                             Debug.WriteLineIf(SettingsDesigner.TraceSwitch.TraceVerbose, "Changing scope of setting " & Instance.Name)
                             Instance.ScopeProperty.SetValue(Instance, cell.Value)
-                        Case s_valueColumnNo
+                        Case ValueColumnNo
                             ' It seems that we get a cell validated event even if we haven't edited the text in the cell....
                             If Not String.Equals(Instance.SerializedValue, CellText, StringComparison.Ordinal) Then
                                 ' We only set the value in if the text in the validated cell
@@ -1210,7 +1210,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         Private Sub OnSettingsGridViewCellFormatting(sender As Object, e As DataGridViewCellFormattingEventArgs) Handles _settingsGridView.CellFormatting
             ' If the column is the Scope column, check the
             ' value.
-            If e.ColumnIndex = s_scopeColumnNo Then
+            If e.ColumnIndex = ScopeColumnNo Then
                 If Not DBNull.Value.Equals(e.Value) AndAlso e.Value IsNot Nothing Then
                     Dim row As DataGridViewRow = _settingsGridView.Rows(e.RowIndex)
                     Dim instance As DesignTimeSettingInstance = TryCast(row.Tag, DesignTimeSettingInstance)
@@ -1255,7 +1255,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 e.Cancel = True
             Else
                 Select Case e.ColumnIndex
-                    Case s_nameColumnNo
+                    Case NameColumnNo
                         '
                         ' If this is the name of a web reference setting, we need to check out the project file since the name of
                         ' the setting that contains the web service URL is stored in the project file.
@@ -1278,7 +1278,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                                 End If
                             End If
                         End If
-                    Case s_valueColumnNo
+                    Case ValueColumnNo
                         Dim cell As DataGridViewUITypeEditorCell = TryCast(
                                         _settingsGridView.Rows(e.RowIndex).Cells(e.ColumnIndex),
                                         DataGridViewUITypeEditorCell)
@@ -1427,7 +1427,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="e"></param>
         ''' <remarks>Kind of hacky...</remarks>
         Private Sub OnSettingsGridViewCurrentCellDirtyStateChanged(sender As Object, e As EventArgs) Handles _settingsGridView.CurrentCellDirtyStateChanged
-            If _settingsGridView.CurrentCellAddress.X = s_typeColumnNo Then
+            If _settingsGridView.CurrentCellAddress.X = TypeColumnNo Then
                 Dim cell As DataGridViewCell = _settingsGridView.CurrentCell
                 If cell IsNot Nothing Then
                     If My.Resources.Designer.SD_ComboBoxItem_BrowseType.Equals(cell.EditedFormattedValue) Then
@@ -1458,9 +1458,9 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         Private Sub OnSettingsGridViewOnDataError(sender As Object, e As DataGridViewDataErrorEventArgs) Handles _settingsGridView.DataError
             If Not _suppressValidationUI Then
                 Select Case e.ColumnIndex
-                    Case s_valueColumnNo
-                        ReportError(My.Resources.Designer.GetString(My.Resources.Designer.SD_ERR_InvalidValue_2Arg, _settingsGridView.CurrentCell.GetEditedFormattedValue(e.RowIndex, DataGridViewDataErrorContexts.Display), _settingsGridView.Rows(_settingsGridView.CurrentCell.RowIndex).Cells(s_typeColumnNo).FormattedValue), HelpIDs.Err_FormatValue)
-                    Case s_nameColumnNo
+                    Case ValueColumnNo
+                        ReportError(My.Resources.Designer.GetString(My.Resources.Designer.SD_ERR_InvalidValue_2Arg, _settingsGridView.CurrentCell.GetEditedFormattedValue(e.RowIndex, DataGridViewDataErrorContexts.Display), _settingsGridView.Rows(_settingsGridView.CurrentCell.RowIndex).Cells(TypeColumnNo).FormattedValue), HelpIDs.Err_FormatValue)
+                    Case NameColumnNo
                         ReportError(My.Resources.Designer.GetString(My.Resources.Designer.SD_ERR_InvalidIdentifier_1Arg, _settingsGridView.CurrentCell.GetEditedFormattedValue(e.RowIndex, DataGridViewDataErrorContexts.Display)), HelpIDs.Err_InvalidName)
                     Case Else
                         ' For some reason, we get data errors when we don't have a value for a specific row 
@@ -1980,7 +1980,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="e"></param>
         ''' <remarks></remarks>
         Private Sub MenuAddSetting(sender As Object, e As EventArgs)
-            _settingsGridView.CurrentCell = _settingsGridView.Rows(_settingsGridView.Rows.Count - 1).Cells(s_nameColumnNo)
+            _settingsGridView.CurrentCell = _settingsGridView.Rows(_settingsGridView.Rows.Count - 1).Cells(NameColumnNo)
             Debug.Assert(_settingsGridView.CurrentRow.Tag Is Nothing, "Adding a new setting failed - there is already a setting associated with the new row!?")
             _settingsGridView.BeginEdit(True)
         End Sub
@@ -2078,7 +2078,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         Private Sub TypeComboBoxSelectedIndexChanged()
             Dim ptCurrent As Drawing.Point = _settingsGridView.CurrentCellAddress
 
-            If ptCurrent.X <> s_typeColumnNo Then
+            If ptCurrent.X <> TypeColumnNo Then
                 Debug.Fail("We shouldn't browse for a type when the current cell isn't the type cell!")
                 Return
             End If
@@ -2118,7 +2118,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' the value that we get passed in every for perf. reasons...
         ''' </remarks>
         Private Sub OnSettingsGridViewSortCompare(sender As Object, e As DataGridViewSortCompareEventArgs) Handles _settingsGridView.SortCompare
-            If e.Column.Index = s_valueColumnNo OrElse e.Column.Index = s_scopeColumnNo Then
+            If e.Column.Index = ValueColumnNo OrElse e.Column.Index = ScopeColumnNo Then
                 Dim strVal1 As String = TryCast(_settingsGridView.Rows(e.RowIndex1).Cells(e.Column.Index).EditedFormattedValue, String)
                 Dim strVal2 As String = TryCast(_settingsGridView.Rows(e.RowIndex2).Cells(e.Column.Index).EditedFormattedValue, String)
                 If strVal1 Is Nothing Then strVal1 = ""

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel
 Imports System.Runtime.InteropServices
@@ -24,24 +24,24 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         Private _serviceProvider As ServiceProvider
 
 
-        Private Const s_addedHandlerFieldName As String = "addedHandler"
-        Private Const s_addedHandlerLockObjectFieldName As String = "addedHandlerLockObject"
-        Private Const s_autoSaveSubName As String = "AutoSaveSettings"
+        Private Const addedHandlerFieldName As String = "addedHandler"
+        Private Const addedHandlerLockObjectFieldName As String = "addedHandlerLockObject"
+        Private Const autoSaveSubName As String = "AutoSaveSettings"
         Friend Const DefaultInstanceFieldName As String = "defaultInstance"
         Friend Const DefaultInstancePropertyName As String = "Default"
 
         Friend Const MyNamespaceName As String = "My"
-        Private Const s_mySettingsModuleName As String = "MySettingsProperty"
-        Private Const s_mySettingsPropertyName As String = "Settings"
+        Private Const mySettingsModuleName As String = "MySettingsProperty"
+        Private Const mySettingsPropertyName As String = "Settings"
 
-        Private Const s_myTypeWinFormsDefineConstant_If As String = "#If _MyType = ""WindowsForms"" Then"
-        Private Const s_myTypeWinFormsDefineConstant_EndIf As String = "#End If"
+        Private Const myTypeWinFormsDefineConstant_If As String = "#If _MyType = ""WindowsForms"" Then"
+        Private Const myTypeWinFormsDefineConstant_EndIf As String = "#End If"
 
-        Private Const s_hideAutoSaveRegionBegin As String = "#Region ""{0}"""
-        Private Const s_hideAutoSaveRegionEnd As String = "#End Region"
+        Private Const hideAutoSaveRegionBegin As String = "#Region ""{0}"""
+        Private Const hideAutoSaveRegionEnd As String = "#End Region"
 
-        Private Const s_docCommentSummaryStart As String = "<summary>"
-        Private Const s_docCommentSummaryEnd As String = "</summary>"
+        Private Const docCommentSummaryStart As String = "<summary>"
+        Private Const docCommentSummaryEnd As String = "</summary>"
 
         Friend Const DesignerGeneratedFileSuffix As String = ".Designer"
 
@@ -423,16 +423,16 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
                 AutoSaveSnippet.Value =
                     Environment.NewLine &
-                    s_myTypeWinFormsDefineConstant_If & Environment.NewLine &
-                    "               If Not " & s_addedHandlerFieldName & " Then" & Environment.NewLine &
-                    "                    SyncLock " & s_addedHandlerLockObjectFieldName & Environment.NewLine &
-                    "                        If Not " & s_addedHandlerFieldName & " Then" & Environment.NewLine &
-                    "                            AddHandler My.Application.Shutdown, AddressOf " & s_autoSaveSubName & Environment.NewLine &
-                    "                            " & s_addedHandlerFieldName & " = True" & Environment.NewLine &
+                    myTypeWinFormsDefineConstant_If & Environment.NewLine &
+                    "               If Not " & addedHandlerFieldName & " Then" & Environment.NewLine &
+                    "                    SyncLock " & addedHandlerLockObjectFieldName & Environment.NewLine &
+                    "                        If Not " & addedHandlerFieldName & " Then" & Environment.NewLine &
+                    "                            AddHandler My.Application.Shutdown, AddressOf " & autoSaveSubName & Environment.NewLine &
+                    "                            " & addedHandlerFieldName & " = True" & Environment.NewLine &
                     "                        End If" & Environment.NewLine &
                     "                    End SyncLock" & Environment.NewLine &
                     "                End If" & Environment.NewLine &
-                    s_myTypeWinFormsDefineConstant_EndIf
+                    myTypeWinFormsDefineConstant_EndIf
 
                 CodeProperty.GetStatements.Add(AutoSaveSnippet)
             End If
@@ -499,9 +499,9 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 attr.Arguments.Add(New CodeAttributeArgument(New CodePrimitiveExpression(Instance.Description)))
                 CodeProperty.CustomAttributes.Add(attr)
 
-                CodeProperty.Comments.Add(New CodeCommentStatement(s_docCommentSummaryStart, True))
+                CodeProperty.Comments.Add(New CodeCommentStatement(docCommentSummaryStart, True))
                 CodeProperty.Comments.Add(New CodeCommentStatement(Security.SecurityElement.Escape(Instance.Description), True))
-                CodeProperty.Comments.Add(New CodeCommentStatement(s_docCommentSummaryEnd, True))
+                CodeProperty.Comments.Add(New CodeCommentStatement(docCommentSummaryEnd, True))
             End If
 
             ' Add DebuggerNonUserCode attribute
@@ -694,20 +694,20 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             '
             Dim AutoSaveCode As New CodeSnippetTypeMember()
             AutoSaveCode.Text =
-                String.Format(s_hideAutoSaveRegionBegin, My.Resources.Designer.SD_SFG_AutoSaveRegionText) & Environment.NewLine &
-                s_myTypeWinFormsDefineConstant_If & Environment.NewLine &
-                "    Private Shared " & s_addedHandlerFieldName & " As Boolean" & Environment.NewLine &
+                String.Format(hideAutoSaveRegionBegin, My.Resources.Designer.SD_SFG_AutoSaveRegionText) & Environment.NewLine &
+                myTypeWinFormsDefineConstant_If & Environment.NewLine &
+                "    Private Shared " & addedHandlerFieldName & " As Boolean" & Environment.NewLine &
                 Environment.NewLine &
-                "    Private Shared " & s_addedHandlerLockObjectFieldName & " As New Object" & Environment.NewLine &
+                "    Private Shared " & addedHandlerLockObjectFieldName & " As New Object" & Environment.NewLine &
                 Environment.NewLine &
                 "    <Global.System.Diagnostics.DebuggerNonUserCodeAttribute(), Global.System.ComponentModel.EditorBrowsableAttribute(Global.System.ComponentModel.EditorBrowsableState.Advanced)> _" & Environment.NewLine &
-                "    Private Shared Sub " & s_autoSaveSubName & "(sender As Global.System.Object, e As Global.System.EventArgs)" & Environment.NewLine &
+                "    Private Shared Sub " & autoSaveSubName & "(sender As Global.System.Object, e As Global.System.EventArgs)" & Environment.NewLine &
                 "        If My.Application.SaveMySettingsOnExit Then" & Environment.NewLine &
-                "            " & MyNamespaceName & "." & s_mySettingsPropertyName & ".Save()" & Environment.NewLine &
+                "            " & MyNamespaceName & "." & mySettingsPropertyName & ".Save()" & Environment.NewLine &
                 "        End If" & Environment.NewLine &
                 "    End Sub" & Environment.NewLine &
-                s_myTypeWinFormsDefineConstant_EndIf & Environment.NewLine &
-                s_hideAutoSaveRegionEnd
+                myTypeWinFormsDefineConstant_EndIf & Environment.NewLine &
+                hideAutoSaveRegionEnd
 
             GeneratedType.Members.Add(AutoSaveCode)
 
@@ -718,7 +718,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ' Create a property named Settings
             '
             Dim SettingProperty As New CodeMemberProperty
-            SettingProperty.Name = s_mySettingsPropertyName
+            SettingProperty.Name = mySettingsPropertyName
             SettingProperty.HasGet = True
             SettingProperty.HasSet = False
 
@@ -750,7 +750,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             '    Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute()>  _
             '   Module MySettingsProperty
             '        
-            Dim ModuleDecl As New CodeTypeDeclaration(s_mySettingsModuleName)
+            Dim ModuleDecl As New CodeTypeDeclaration(mySettingsModuleName)
             ModuleDecl.UserData("Module") = True
             ModuleDecl.TypeAttributes = TypeAttributes.Sealed Or TypeAttributes.NestedAssembly
             ModuleDecl.CustomAttributes.Add(New CodeAttributeDeclaration(CreateGlobalCodeTypeReference(GetType(HideModuleNameAttribute))))

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypeEditorHostControl.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypeEditorHostControl.vb
@@ -865,7 +865,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 DropDown = 1
             End Enum
 
-            Private Const s_dotDotDotString As String = "..."
+            Private Const DotDotDotString As String = "..."
 
             ' Current style to draw
             Private _paintStyle As PaintStyles = PaintStyles.DotDotDot
@@ -928,7 +928,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                     Case PaintStyles.DotDotDot
                         Dim drawRect As Rectangle = ClientRectangle
                         drawRect.Offset(FlatAppearance.BorderSize, 0)
-                        TextRenderer.DrawText(pevent.Graphics, s_dotDotDotString, Font, drawRect, ForeColor)
+                        TextRenderer.DrawText(pevent.Graphics, DotDotDotString, Font, drawRect, ForeColor)
                     Case PaintStyles.DropDown
                         If ComboBoxRenderer.IsSupported Then
                             Dim drawstyle As VisualStyles.ComboBoxState

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypePickerDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypePickerDialog.vb
@@ -503,27 +503,27 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
             Private ReadOnly _nodeType As NodeType
 
-            Private Const s_DUMMY_ITEM_TEXT As String = " THIS IS THE DUMMY ITEM "
-            Private Const s_assemblyImageIndex As Integer = 0
-            Private Const s_selectedAssemblyImageIndex As Integer = 0
-            Private Const s_namespaceImageIndex As Integer = 1
-            Private Const s_selectedNamespaceImageIndex As Integer = 1
-            Private Const s_typeImageIndex As Integer = 2
-            Private Const s_selectedTypeImageIndex As Integer = 2
+            Private Const DUMMY_ITEM_TEXT As String = " THIS IS THE DUMMY ITEM "
+            Private Const AssemblyImageIndex As Integer = 0
+            Private Const SelectedAssemblyImageIndex As Integer = 0
+            Private Const NamespaceImageIndex As Integer = 1
+            Private Const SelectedNamespaceImageIndex As Integer = 1
+            Private Const TypeImageIndex As Integer = 2
+            Private Const SelectedTypeImageIndex As Integer = 2
 
             Public Sub New(nodeType As NodeType)
                 _nodeType = nodeType
 
                 Select Case nodeType
                     Case NodeType.ASSEMBLY_NODE
-                        ImageIndex = s_assemblyImageIndex
-                        SelectedImageIndex = s_selectedAssemblyImageIndex
+                        ImageIndex = AssemblyImageIndex
+                        SelectedImageIndex = SelectedAssemblyImageIndex
                     Case NodeType.NAMESPACE_NODE
-                        ImageIndex = s_namespaceImageIndex
-                        SelectedImageIndex = s_selectedNamespaceImageIndex
+                        ImageIndex = NamespaceImageIndex
+                        SelectedImageIndex = SelectedNamespaceImageIndex
                     Case NodeType.TYPE_NODE
-                        ImageIndex = s_typeImageIndex
-                        SelectedImageIndex = s_selectedTypeImageIndex
+                        ImageIndex = TypeImageIndex
+                        SelectedImageIndex = SelectedTypeImageIndex
                 End Select
 
             End Sub
@@ -536,7 +536,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
             Public ReadOnly Property HasDummyNode() As Boolean
                 Get
-                    Return Nodes.ContainsKey(s_DUMMY_ITEM_TEXT)
+                    Return Nodes.ContainsKey(DUMMY_ITEM_TEXT)
                 End Get
             End Property
 
@@ -555,13 +555,13 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
             Public Sub AddDummyNode()
                 If IsAssemblyNode() AndAlso Nodes.Count = 0 Then
-                    Nodes.Add(s_DUMMY_ITEM_TEXT, s_DUMMY_ITEM_TEXT)
+                    Nodes.Add(DUMMY_ITEM_TEXT, DUMMY_ITEM_TEXT)
                 End If
             End Sub
 
             Public Sub RemoveDummyNode()
-                If IsAssemblyNode() AndAlso Nodes.ContainsKey(s_DUMMY_ITEM_TEXT) Then
-                    Nodes.RemoveByKey(s_DUMMY_ITEM_TEXT)
+                If IsAssemblyNode() AndAlso Nodes.ContainsKey(DUMMY_ITEM_TEXT) Then
+                    Nodes.RemoveByKey(DUMMY_ITEM_TEXT)
                 End If
             End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/XmlIntellisense/XmlIntellisense.vb
+++ b/src/Microsoft.VisualStudio.Editors/XmlIntellisense/XmlIntellisense.vb
@@ -108,11 +108,11 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
     Friend NotInheritable Class XmlIntellisenseSchemas
         Implements IXmlIntellisenseSchemas
 
-        Private Const s_maxPollInterval As Integer = 60 * 1000 ' 1 minutes
-        Private Const s_minPollInterval As Integer = 1000 ' 1 second
+        Private Const MaxPollInterval As Integer = 60 * 1000 ' 1 minutes
+        Private Const MinPollInterval As Integer = 1000 ' 1 second
 
         ' Number of calls into AsyncCompile prior to terminating inital compilation loop
-        Private Const s_compilationLevel As Integer = 2
+        Private Const CompilationLevel As Integer = 2
 
         Private _data As XmlIntellisenseSchemasData
         '--------------------------------------------------------------------------
@@ -124,7 +124,7 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
             _data.m_Container = Container
             _data.m_SchemaService = SchemaService
             _data.m_ProjectGuid = ProjectGuid
-            _data.m_CompilationLevel = s_compilationLevel
+            _data.m_CompilationLevel = CompilationLevel
             _data.m_SchemasFound = 0
 
             ' Get VS project
@@ -258,7 +258,7 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
 
         Private Shared Async Sub CompileCallBack(data As XmlIntellisenseSchemasData)
             Dim ProjectSchemas As IList(Of XmlSchemaReference)
-            Dim pollInterval As Integer = s_minPollInterval
+            Dim pollInterval As Integer = MinPollInterval
             Dim iteration As Integer = 0
 
             If data.m_CompilationLevel > 0 OrElse iteration = 0 Then
@@ -273,8 +273,8 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
                     Else
                         pollInterval = pollInterval * 2
 
-                        If pollInterval > s_maxPollInterval Then
-                            pollInterval = s_maxPollInterval
+                        If pollInterval > MaxPollInterval Then
+                            pollInterval = MaxPollInterval
                         End If
                     End If
 

--- a/src/Microsoft.VisualStudio.Editors/interop/NativeMethods.vb
+++ b/src/Microsoft.VisualStudio.Editors/interop/NativeMethods.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Runtime.InteropServices
 Imports Microsoft.VisualStudio.OLE.Interop
@@ -8,8 +8,8 @@ Namespace Microsoft.VisualStudio.Editors.Interop
     <ComVisible(False)> _
     Friend NotInheritable Class NativeMethods
 
-        Private Const s_VB_COMPILER_GUID As String = "019971d6-4685-11d2-b48a-0000f87572eb"
-        Friend Shared ReadOnly VBCompilerGuid As Guid = New Guid(s_VB_COMPILER_GUID)
+        Private Const VB_COMPILER_GUID As String = "019971d6-4685-11d2-b48a-0000f87572eb"
+        Friend Shared ReadOnly VBCompilerGuid As Guid = New Guid(VB_COMPILER_GUID)
 
         '/ <summary>
         '/     Handle type for HDC's that count against the Win98 limit of five DC's.  HDC's

--- a/src/Microsoft.VisualStudio.Editors/package/VBPackage.vb
+++ b/src/Microsoft.VisualStudio.Editors/package/VBPackage.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Runtime.InteropServices
 Imports System.ComponentModel.Design
@@ -40,7 +40,7 @@ Namespace Microsoft.VisualStudio.Editors
         Private _userConfigCleaner As UserConfigCleaner
         Private _addImportsDialogService As AddImports.AddImportsDialogService
 
-        Private Const s_projectDesignerSUOKey As String = "ProjectDesigner"
+        Private Const ProjectDesignerSUOKey As String = "ProjectDesigner"
 
         ' Map between unique project GUID and the last viewed tab in the project designer...
         Private _lastViewedProjectDesignerTab As Dictionary(Of Guid, Byte)
@@ -51,7 +51,7 @@ Namespace Microsoft.VisualStudio.Editors
         ''' <remarks></remarks>
         Public Sub New()
             ' Make sure we persist this 
-            AddOptionKey(s_projectDesignerSUOKey)
+            AddOptionKey(ProjectDesignerSUOKey)
         End Sub
 
         ''' <summary>
@@ -242,7 +242,7 @@ Namespace Microsoft.VisualStudio.Editors
         ''' <param name="stream">Stream to read from</param>
         ''' <remarks></remarks>
         Protected Overrides Sub OnLoadOptions(key As String, stream As IO.Stream)
-            If String.Equals(key, s_projectDesignerSUOKey, StringComparison.Ordinal) Then
+            If String.Equals(key, ProjectDesignerSUOKey, StringComparison.Ordinal) Then
                 Dim reader As New IO.BinaryReader(stream)
                 Dim buf(15) As Byte ' Space enough for a GUID - 16 bytes...
                 Try
@@ -269,7 +269,7 @@ Namespace Microsoft.VisualStudio.Editors
         ''' <param name="stream">Stream to read data from</param>
         ''' <remarks></remarks>
         Protected Overrides Sub OnSaveOptions(key As String, stream As IO.Stream)
-            If String.Equals(key, s_projectDesignerSUOKey, StringComparison.Ordinal) Then
+            If String.Equals(key, ProjectDesignerSUOKey, StringComparison.Ordinal) Then
                 ' This is the project designer's last active tab
                 If _lastViewedProjectDesignerTab IsNot Nothing Then
                     Dim hier As IVsHierarchy = Nothing


### PR DESCRIPTION
Visual Basic projects are not following the editorconfig rules, this is the first a few PRs fixing them up to follow it.

Filed the following bugs while doing this:

https://github.com/dotnet/roslyn/issues/26556
https://github.com/dotnet/roslyn/issues/26580
