### PR TITLE
Opt Shared Projects into ".NET" capability

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -55,6 +55,14 @@
   </PropertyGroup>
 
   <!-- Project Capabilities -->
+
+  <!-- Capabilities shared between shared projects & binary-producing projects.  -->
+  <ItemGroup>
+    <ProjectCapability Include=".NET" />
+  </ItemGroup>
+
+  <!-- Capabilities for binary producing projects -->
+  
   <ItemGroup Condition="'$(DefineCommonManagedCapabilities)' == 'true'">
     <ProjectCapability Include="UseFileGlobs"/>
 


### PR DESCRIPTION
Binary projects were opt'ing into .NET capability previously via the project type. This opts C#/VB Shared Projects into it.

Unblocks: https://github.com/dotnet/project-system/pull/3299