### PR TITLE
Fixed inability to add F# files to ASP .NET Core projects

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/MoveDownCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/MoveDownCommandTests.cs
@@ -4,7 +4,7 @@ using System.Collections.Immutable;
 using System.Threading.Tasks;
 
 using Microsoft.VisualStudio.Packaging;
-
+using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
@@ -15,12 +15,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         [Fact]
         public async Task GetCommandStatusAsync_File_ReturnsStatusEnabled()
         {
-            var command = CreateAbstractInstance();
+            var projectRootElement = @"
+<Project>
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include=""test1.fs"" />
+    <Compile Include=""test2.fs"" />
+  </ItemGroup>
+
+</Project>
+".AsProjectRootElement();
+
+            var command = CreateAbstractInstance(accessor: IProjectAccessorFactory.Create(projectRootElement));
 
             var tree = ProjectTreeParser.Parse(@"
 Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2
+    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
 ");
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]); // test1.fs
@@ -34,12 +49,27 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         [Fact]
         public async Task GetCommandStatusAsync_File_ReturnsStatusNinched()
         {
-            var command = CreateAbstractInstance();
+            var projectRootElement = @"
+<Project>
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include=""test1.fs"" />
+    <Compile Include=""test2.fs"" />
+  </ItemGroup>
+
+</Project>
+".AsProjectRootElement();
+
+            var command = CreateAbstractInstance(accessor: IProjectAccessorFactory.Create(projectRootElement));
 
             var tree = ProjectTreeParser.Parse(@"
 Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2
+    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
 ");
 
             var nodes = ImmutableHashSet.Create(tree.Children[1]); // test2.fs
@@ -53,15 +83,32 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         [Fact]
         public async Task GetCommandStatusAsync_FileInFolder_ReturnsStatusEnabled()
         {
-            var command = CreateAbstractInstance();
+            var projectRootElement = @"
+<Project>
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include=""test1.fs"" />
+    <Compile Include=""test2.fs"" />
+    <Compile Include=""test\test3.fs"" />
+    <Compile Include=""test\test4.fs"" />
+  </ItemGroup>
+
+</Project>
+".AsProjectRootElement();
+
+            var command = CreateAbstractInstance(accessor: IProjectAccessorFactory.Create(projectRootElement));
 
             var tree = ProjectTreeParser.Parse(@"
 Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2
+    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
     Folder (flags: {Folder}), DisplayOrder: 3
-        File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 4
-        File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 5
+        File (flags: {}), FilePath: ""C:\Foo\test\test3.fs"", DisplayOrder: 4, ItemName: ""test\test3.fs""
+        File (flags: {}), FilePath: ""C:\Foo\test\test4.fs"", DisplayOrder: 5, ItemName: ""test\test4.fs""
 ");
 
             var nodes = ImmutableHashSet.Create(tree.Children[2].Children[0]); // test3.fs
@@ -75,15 +122,32 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         [Fact]
         public async Task GetCommandStatusAsync_FileInFolder_ReturnsStatusNinched()
         {
-            var command = CreateAbstractInstance();
+            var projectRootElement = @"
+<Project>
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include=""test1.fs"" />
+    <Compile Include=""test2.fs"" />
+    <Compile Include=""test\test3.fs"" />
+    <Compile Include=""test\test4.fs"" />
+  </ItemGroup>
+
+</Project>
+".AsProjectRootElement();
+
+            var command = CreateAbstractInstance(accessor: IProjectAccessorFactory.Create(projectRootElement));
 
             var tree = ProjectTreeParser.Parse(@"
 Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2
+    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
     Folder (flags: {Folder}), DisplayOrder: 3
-        File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 4
-        File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 5
+        File (flags: {}), FilePath: ""C:\Foo\test\test3.fs"", DisplayOrder: 4, ItemName: ""test\test3.fs""
+        File (flags: {}), FilePath: ""C:\Foo\test\test4.fs"", DisplayOrder: 5, ItemName: ""test\test4.fs""
 ");
 
             var nodes = ImmutableHashSet.Create(tree.Children[2].Children[1]); // test4.fs
@@ -97,18 +161,37 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         [Fact]
         public async Task GetCommandStatusAsync_FolderOverFolder_ReturnsStatusEnabled()
         {
-            var command = CreateAbstractInstance();
+            var projectRootElement = @"
+<Project>
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include=""test1.fs"" />
+    <Compile Include=""test2.fs"" />
+    <Compile Include=""test\test3.fs"" />
+    <Compile Include=""test\test4.fs"" />
+    <Compile Include=""test2\test5.fs"" />
+    <Compile Include=""test2\test6.fs"" />
+  </ItemGroup>
+
+</Project>
+".AsProjectRootElement();
+
+            var command = CreateAbstractInstance(accessor: IProjectAccessorFactory.Create(projectRootElement));
 
             var tree = ProjectTreeParser.Parse(@"
 Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2
+    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
     Folder (flags: {Folder}), DisplayOrder: 3
-        File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 4
-        File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 5
+        File (flags: {}), FilePath: ""C:\Foo\test\test3.fs"", DisplayOrder: 4, ItemName: ""test\test3.fs""
+        File (flags: {}), FilePath: ""C:\Foo\test\test4.fs"", DisplayOrder: 5, ItemName: ""test\test4.fs""
     Folder (flags: {Folder}), DisplayOrder: 6
-        File (flags: {}), FilePath: ""C:\Foo\test5.fs"", DisplayOrder: 7
-        File (flags: {}), FilePath: ""C:\Foo\test6.fs"", DisplayOrder: 8
+        File (flags: {}), FilePath: ""C:\Foo\test2\test5.fs"", DisplayOrder: 7, ItemName: ""test2\test5.fs""
+        File (flags: {}), FilePath: ""C:\Foo\test2\test6.fs"", DisplayOrder: 8, ItemName: ""test2\test6.fs""
 ");
 
             var nodes = ImmutableHashSet.Create(tree.Children[2]); // first folder
@@ -122,18 +205,37 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         [Fact]
         public async Task GetCommandStatusAsync_FolderOverFile_ReturnsStatusEnabled()
         {
-            var command = CreateAbstractInstance();
+            var projectRootElement = @"
+<Project>
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include=""test\test3.fs"" />
+    <Compile Include=""test\test4.fs"" />
+    <Compile Include=""test1.fs"" />
+    <Compile Include=""test2.fs"" />
+    <Compile Include=""test2\test5.fs"" />
+    <Compile Include=""test2\test6.fs"" />
+  </ItemGroup>
+
+</Project>
+".AsProjectRootElement();
+
+            var command = CreateAbstractInstance(accessor: IProjectAccessorFactory.Create(projectRootElement));
 
             var tree = ProjectTreeParser.Parse(@"
 Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
     Folder (flags: {Folder}), DisplayOrder: 1
-        File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 2
-        File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 3
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 4
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 5
+        File (flags: {}), FilePath: ""C:\Foo\test\test3.fs"", DisplayOrder: 2, ItemName: ""test\test3.fs""
+        File (flags: {}), FilePath: ""C:\Foo\test\test4.fs"", DisplayOrder: 3, ItemName: ""test\test4.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 4, ItemName: ""test1.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 5, ItemName: ""test2.fs""
     Folder (flags: {Folder}), DisplayOrder: 6
-        File (flags: {}), FilePath: ""C:\Foo\test5.fs"", DisplayOrder: 7
-        File (flags: {}), FilePath: ""C:\Foo\test6.fs"", DisplayOrder: 8
+        File (flags: {}), FilePath: ""C:\Foo\test2\test5.fs"", DisplayOrder: 7, ItemName: ""test2\test5.fs""
+        File (flags: {}), FilePath: ""C:\Foo\test2\test6.fs"", DisplayOrder: 8, ItemName: ""test2\test6.fs""
 ");
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]); // first folder
@@ -147,16 +249,33 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         [Fact]
         public async Task GetCommandStatusAsync_Folder_ReturnsStatusNinched()
         {
-            var command = CreateAbstractInstance();
+            var projectRootElement = @"
+<Project>
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include=""test\test3.fs"" />
+    <Compile Include=""test\test4.fs"" />
+    <Compile Include=""test2\test5.fs"" />
+    <Compile Include=""test2\test6.fs"" />
+  </ItemGroup>
+
+</Project>
+".AsProjectRootElement();
+
+            var command = CreateAbstractInstance(accessor: IProjectAccessorFactory.Create(projectRootElement));
 
             var tree = ProjectTreeParser.Parse(@"
 Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
     Folder (flags: {Folder}), DisplayOrder: 1
-        File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 2
-        File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 3
+        File (flags: {}), FilePath: ""C:\Foo\test\test3.fs"", DisplayOrder: 2, ItemName: ""test\test3.fs""
+        File (flags: {}), FilePath: ""C:\Foo\test\test4.fs"", DisplayOrder: 3, ItemName: ""test\test4.fs""
     Folder (flags: {Folder}), DisplayOrder: 4
-        File (flags: {}), FilePath: ""C:\Foo\test5.fs"", DisplayOrder: 5
-        File (flags: {}), FilePath: ""C:\Foo\test6.fs"", DisplayOrder: 6
+        File (flags: {}), FilePath: ""C:\Foo\test2\test5.fs"", DisplayOrder: 5, ItemName: ""test2\test5.fs""
+        File (flags: {}), FilePath: ""C:\Foo\test2\test6.fs"", DisplayOrder: 6, ItemName: ""test2\test6.fs""
 ");
 
             var nodes = ImmutableHashSet.Create(tree.Children[1]); // second folder

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/MoveUpCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/MoveUpCommandTests.cs
@@ -4,7 +4,7 @@ using System.Collections.Immutable;
 using System.Threading.Tasks;
 
 using Microsoft.VisualStudio.Packaging;
-
+using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
@@ -15,12 +15,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         [Fact]
         public async Task GetCommandStatusAsync_File_ReturnsStatusEnabled()
         {
-            var command = CreateAbstractInstance();
+            var projectRootElement = @"
+<Project>
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include=""test1.fs"" />
+    <Compile Include=""test2.fs"" />
+  </ItemGroup>
+
+</Project>
+".AsProjectRootElement();
+
+            var command = CreateAbstractInstance(accessor: IProjectAccessorFactory.Create(projectRootElement));
 
             var tree = ProjectTreeParser.Parse(@"
 Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2
+    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
 ");
 
             var nodes = ImmutableHashSet.Create(tree.Children[1]); // test2.fs
@@ -34,12 +49,27 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         [Fact]
         public async Task GetCommandStatusAsync_File_ReturnsStatusNinched()
         {
-            var command = CreateAbstractInstance();
+            var projectRootElement = @"
+<Project>
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include=""test1.fs"" />
+    <Compile Include=""test2.fs"" />
+  </ItemGroup>
+
+</Project>
+".AsProjectRootElement();
+
+            var command = CreateAbstractInstance(accessor: IProjectAccessorFactory.Create(projectRootElement));
 
             var tree = ProjectTreeParser.Parse(@"
 Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2
+    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
 ");
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]); // test1.fs
@@ -53,15 +83,32 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         [Fact]
         public async Task GetCommandStatusAsync_FileInFolder_ReturnsStatusEnabled()
         {
-            var command = CreateAbstractInstance();
+            var projectRootElement = @"
+<Project>
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include=""test1.fs"" />
+    <Compile Include=""test2.fs"" />
+    <Compile Include=""test\test3.fs"" />
+    <Compile Include=""test\test4.fs"" />
+  </ItemGroup>
+
+</Project>
+".AsProjectRootElement();
+
+            var command = CreateAbstractInstance(accessor: IProjectAccessorFactory.Create(projectRootElement));
 
             var tree = ProjectTreeParser.Parse(@"
 Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2
+    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
     Folder (flags: {Folder}), DisplayOrder: 3
-        File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 4
-        File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 5
+        File (flags: {}), FilePath: ""C:\Foo\test\test3.fs"", DisplayOrder: 4, ItemName: ""test\test3.fs""
+        File (flags: {}), FilePath: ""C:\Foo\test\test4.fs"", DisplayOrder: 5, ItemName: ""test\test4.fs""
 ");
 
             var nodes = ImmutableHashSet.Create(tree.Children[2].Children[1]); // test4.fs
@@ -75,15 +122,32 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         [Fact]
         public async Task GetCommandStatusAsync_FileInFolder_ReturnsStatusNinched()
         {
-            var command = CreateAbstractInstance();
+            var projectRootElement = @"
+<Project>
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include=""test1.fs"" />
+    <Compile Include=""test2.fs"" />
+    <Compile Include=""test\test3.fs"" />
+    <Compile Include=""test\test4.fs"" />
+  </ItemGroup>
+
+</Project>
+".AsProjectRootElement();
+
+            var command = CreateAbstractInstance(accessor: IProjectAccessorFactory.Create(projectRootElement));
 
             var tree = ProjectTreeParser.Parse(@"
 Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2
+    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
     Folder (flags: {Folder}), DisplayOrder: 3
-        File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 4
-        File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 5
+        File (flags: {}), FilePath: ""C:\Foo\test\test3.fs"", DisplayOrder: 4, ItemName: ""test\test3.fs""
+        File (flags: {}), FilePath: ""C:\Foo\test\test4.fs"", DisplayOrder: 5, ItemName: ""test\test4.fs""
 ");
 
             var nodes = ImmutableHashSet.Create(tree.Children[2].Children[0]); // test3.fs
@@ -97,18 +161,37 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         [Fact]
         public async Task GetCommandStatusAsync_FolderOverFolder_ReturnsStatusEnabled()
         {
-            var command = CreateAbstractInstance();
+            var projectRootElement = @"
+<Project>
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include=""test1.fs"" />
+    <Compile Include=""test2.fs"" />
+    <Compile Include=""test\test3.fs"" />
+    <Compile Include=""test\test4.fs"" />
+    <Compile Include=""test2\test5.fs"" />
+    <Compile Include=""test2\test6.fs"" />
+  </ItemGroup>
+
+</Project>
+".AsProjectRootElement();
+
+            var command = CreateAbstractInstance(accessor: IProjectAccessorFactory.Create(projectRootElement));
 
             var tree = ProjectTreeParser.Parse(@"
 Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2
+    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
     Folder (flags: {Folder}), DisplayOrder: 3
-        File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 4
-        File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 5
+        File (flags: {}), FilePath: ""C:\Foo\test\test3.fs"", DisplayOrder: 4, ItemName: ""test\test3.fs""
+        File (flags: {}), FilePath: ""C:\Foo\test\test4.fs"", DisplayOrder: 5, ItemName: ""test\test4.fs""
     Folder (flags: {Folder}), DisplayOrder: 6
-        File (flags: {}), FilePath: ""C:\Foo\test5.fs"", DisplayOrder: 7
-        File (flags: {}), FilePath: ""C:\Foo\test6.fs"", DisplayOrder: 8
+        File (flags: {}), FilePath: ""C:\Foo\test2\test5.fs"", DisplayOrder: 7, ItemName: ""test2\test5.fs""
+        File (flags: {}), FilePath: ""C:\Foo\test2\test6.fs"", DisplayOrder: 8, ItemName: ""test2\test6.fs""
 ");
 
             var nodes = ImmutableHashSet.Create(tree.Children[3]); // second folder
@@ -122,18 +205,37 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         [Fact]
         public async Task GetCommandStatusAsync_FolderOverFile_ReturnsStatusEnabled()
         {
-            var command = CreateAbstractInstance();
+            var projectRootElement = @"
+<Project>
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include=""test1.fs"" />
+    <Compile Include=""test2.fs"" />
+    <Compile Include=""test\test3.fs"" />
+    <Compile Include=""test\test4.fs"" />
+    <Compile Include=""test2\test5.fs"" />
+    <Compile Include=""test2\test6.fs"" />
+  </ItemGroup>
+
+</Project>
+".AsProjectRootElement();
+
+            var command = CreateAbstractInstance(accessor: IProjectAccessorFactory.Create(projectRootElement));
 
             var tree = ProjectTreeParser.Parse(@"
 Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2
+    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
     Folder (flags: {Folder}), DisplayOrder: 3
-        File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 4
-        File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 5
+        File (flags: {}), FilePath: ""C:\Foo\test\test3.fs"", DisplayOrder: 4, ItemName: ""test\test3.fs""
+        File (flags: {}), FilePath: ""C:\Foo\test\test4.fs"", DisplayOrder: 5, ItemName: ""test\test4.fs""
     Folder (flags: {Folder}), DisplayOrder: 6
-        File (flags: {}), FilePath: ""C:\Foo\test5.fs"", DisplayOrder: 7
-        File (flags: {}), FilePath: ""C:\Foo\test6.fs"", DisplayOrder: 8
+        File (flags: {}), FilePath: ""C:\Foo\test2\test5.fs"", DisplayOrder: 7, ItemName: ""test2\test5.fs""
+        File (flags: {}), FilePath: ""C:\Foo\test2\test6.fs"", DisplayOrder: 8, ItemName: ""test2\test6.fs""
 ");
 
             var nodes = ImmutableHashSet.Create(tree.Children[2]); // first folder
@@ -147,16 +249,33 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         [Fact]
         public async Task GetCommandStatusAsync_Folder_ReturnsStatusNinched()
         {
-            var command = CreateAbstractInstance();
+            var projectRootElement = @"
+<Project>
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include=""test\test3.fs"" />
+    <Compile Include=""test\test4.fs"" />
+    <Compile Include=""test2\test5.fs"" />
+    <Compile Include=""test2\test6.fs"" />
+  </ItemGroup>
+
+</Project>
+".AsProjectRootElement();
+
+            var command = CreateAbstractInstance(accessor: IProjectAccessorFactory.Create(projectRootElement));
 
             var tree = ProjectTreeParser.Parse(@"
 Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
     Folder (flags: {Folder}), DisplayOrder: 1
-        File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 2
-        File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 3
+        File (flags: {}), FilePath: ""C:\Foo\test\test3.fs"", DisplayOrder: 2, ItemName: ""test\test3.fs""
+        File (flags: {}), FilePath: ""C:\Foo\test\test4.fs"", DisplayOrder: 3, ItemName: ""test\test4.fs""
     Folder (flags: {Folder}), DisplayOrder: 4
-        File (flags: {}), FilePath: ""C:\Foo\test5.fs"", DisplayOrder: 5
-        File (flags: {}), FilePath: ""C:\Foo\test6.fs"", DisplayOrder: 6
+        File (flags: {}), FilePath: ""C:\Foo\test2\test5.fs"", DisplayOrder: 5, ItemName: ""test2\test5.fs""
+        File (flags: {}), FilePath: ""C:\Foo\test2\test6.fs"", DisplayOrder: 6, ItemName: ""test2\test6.fs""
 ");
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]); // first folder

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AbstractAddItemAboveBelowCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AbstractAddItemAboveBelowCommand.cs
@@ -1,21 +1,17 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Immutable;
 using System.ComponentModel.Composition;
+using System.Linq;
 using Microsoft.Build.Evaluation;
-using Microsoft.VisualStudio.Input;
-using Microsoft.VisualStudio.ProjectSystem.Input;
 using Microsoft.VisualStudio.Shell;
-using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
-    [ProjectCommand(CommandGroup.VisualStudioStandard97, (long)VSConstants.VSStd97CmdID.AddNewItem)]
-    [AppliesTo(ProjectCapability.SortByDisplayOrder)]
-    [Order(5000)]
-    internal class AddNewItemCommand : AbstractAddItemCommand
+    internal abstract class AbstractAddItemAboveBelowCommand : AbstractAddItemCommand
     {
         [ImportingConstructor]
-        public AddNewItemCommand(
+        public AbstractAddItemAboveBelowCommand(
             IPhysicalProjectTree projectTree,
             IUnconfiguredProjectVsServices projectVsServices,
             SVsServiceProvider serviceProvider,
@@ -26,14 +22,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         {
         }
 
-        protected override Task OnAddingNodesAsync(IProjectTree nodeToAddTo)
-        {
-            return ShowAddNewFileDialogAsync(nodeToAddTo);
-        }
-
         protected override bool CanAdd(Project project, IProjectTree target)
         {
-            return true;
+            // Check to make sure the target has valid backing xml elements that are part of the project, if it does we can move.
+            return OrderingHelper.HasValidDisplayOrder(target) && OrderingHelper.GetItemElements(project, target, ImmutableArray<string>.Empty).Any();
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemAboveCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemAboveCommand.cs
@@ -10,26 +10,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
     [ProjectCommand(ManagedProjectSystemPackage.ManagedProjectSystemOrderCommandSet, ManagedProjectSystemPackage.AddExistingItemAboveCmdId)]
     [AppliesTo(ProjectCapability.SortByDisplayOrder)]
-    internal class AddExistingItemAboveCommand : AbstractAddItemCommand
+    internal class AddExistingItemAboveCommand : AbstractAddItemAboveBelowCommand
     {
         [ImportingConstructor]
         public AddExistingItemAboveCommand(
             IPhysicalProjectTree projectTree,
             IUnconfiguredProjectVsServices projectVsServices,
             SVsServiceProvider serviceProvider,
-            OrderAddItemHintReceiver orderAddItemHintReceiver) :
-            base(projectTree, projectVsServices, serviceProvider, orderAddItemHintReceiver)
+            OrderAddItemHintReceiver orderAddItemHintReceiver,
+            ConfiguredProject configuredProject,
+            IProjectAccessor accessor) :
+            base(projectTree, projectVsServices, serviceProvider, orderAddItemHintReceiver, configuredProject, accessor)
         {
         }
 
         protected override Task OnAddingNodesAsync(IProjectTree nodeToAddTo)
         {
             return ShowAddExistingFilesDialogAsync(nodeToAddTo);
-        }
-
-        protected override bool CanAdd(IProjectTree target)
-        {
-            return OrderingHelper.HasValidDisplayOrder(target);
         }
 
         protected override OrderingMoveAction Action => OrderingMoveAction.MoveAbove;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemBelowCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemBelowCommand.cs
@@ -10,26 +10,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
     [ProjectCommand(ManagedProjectSystemPackage.ManagedProjectSystemOrderCommandSet, ManagedProjectSystemPackage.AddExistingItemBelowCmdId)]
     [AppliesTo(ProjectCapability.SortByDisplayOrder)]
-    internal class AddExistingItemBelowCommand : AbstractAddItemCommand
+    internal class AddExistingItemBelowCommand : AbstractAddItemAboveBelowCommand
     {
         [ImportingConstructor]
         public AddExistingItemBelowCommand(
             IPhysicalProjectTree projectTree,
             IUnconfiguredProjectVsServices projectVsServices,
-            SVsServiceProvider serviceProvider, 
-            OrderAddItemHintReceiver orderAddItemHintReceiver) :
-            base(projectTree, projectVsServices, serviceProvider, orderAddItemHintReceiver)
+            SVsServiceProvider serviceProvider,
+            OrderAddItemHintReceiver orderAddItemHintReceiver,
+            ConfiguredProject configuredProject,
+            IProjectAccessor accessor) :
+            base(projectTree, projectVsServices, serviceProvider, orderAddItemHintReceiver, configuredProject, accessor)
         {
         }
 
         protected override Task OnAddingNodesAsync(IProjectTree nodeToAddTo)
         {
             return ShowAddExistingFilesDialogAsync(nodeToAddTo);
-        }
-
-        protected override bool CanAdd(IProjectTree target)
-        {
-            return OrderingHelper.HasValidDisplayOrder(target);
         }
 
         protected override OrderingMoveAction Action => OrderingMoveAction.MoveBelow;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemCommand.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.ComponentModel.Composition;
+using Microsoft.Build.Evaluation;
 using Microsoft.VisualStudio.Input;
 using Microsoft.VisualStudio.ProjectSystem.Input;
 using Microsoft.VisualStudio.Shell;
@@ -17,9 +18,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         public AddExistingItemCommand(
             IPhysicalProjectTree projectTree, 
             IUnconfiguredProjectVsServices projectVsServices, 
-            SVsServiceProvider serviceProvider, 
-            OrderAddItemHintReceiver orderAddItemHintReceiver) : 
-            base(projectTree, projectVsServices, serviceProvider, orderAddItemHintReceiver)
+            SVsServiceProvider serviceProvider,
+            OrderAddItemHintReceiver orderAddItemHintReceiver,
+            ConfiguredProject configuredProject,
+            IProjectAccessor accessor) :
+            base(projectTree, projectVsServices, serviceProvider, orderAddItemHintReceiver, configuredProject, accessor)
         {
         }
 
@@ -28,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             return ShowAddExistingFilesDialogAsync(nodeToAddTo);
         }
 
-        protected override bool CanAdd(IProjectTree target)
+        protected override bool CanAdd(Project project, IProjectTree target)
         {
             return true;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemAboveCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemAboveCommand.cs
@@ -10,26 +10,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
     [ProjectCommand(ManagedProjectSystemPackage.ManagedProjectSystemOrderCommandSet, ManagedProjectSystemPackage.AddNewItemAboveCmdId)]
     [AppliesTo(ProjectCapability.SortByDisplayOrder)]
-    internal class AddNewItemAboveCommand : AbstractAddItemCommand
+    internal class AddNewItemAboveCommand : AbstractAddItemAboveBelowCommand
     {
         [ImportingConstructor]
         public AddNewItemAboveCommand(
             IPhysicalProjectTree projectTree,
             IUnconfiguredProjectVsServices projectVsServices,
             SVsServiceProvider serviceProvider,
-            OrderAddItemHintReceiver orderAddItemHintReceiver) :
-            base(projectTree, projectVsServices, serviceProvider, orderAddItemHintReceiver)
+            OrderAddItemHintReceiver orderAddItemHintReceiver,
+            ConfiguredProject configuredProject,
+            IProjectAccessor accessor) :
+            base(projectTree, projectVsServices, serviceProvider, orderAddItemHintReceiver, configuredProject, accessor)
         {
         }
 
         protected override Task OnAddingNodesAsync(IProjectTree nodeToAddTo)
         {
             return ShowAddNewFileDialogAsync(nodeToAddTo);
-        }
-
-        protected override bool CanAdd(IProjectTree target)
-        {
-            return OrderingHelper.HasValidDisplayOrder(target);
         }
 
         protected override OrderingMoveAction Action => OrderingMoveAction.MoveAbove;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemBelowCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemBelowCommand.cs
@@ -10,26 +10,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
     [ProjectCommand(ManagedProjectSystemPackage.ManagedProjectSystemOrderCommandSet, ManagedProjectSystemPackage.AddNewItemBelowCmdId)]
     [AppliesTo(ProjectCapability.SortByDisplayOrder)]
-    internal class AddNewItemBelowCommand : AbstractAddItemCommand
+    internal class AddNewItemBelowCommand : AbstractAddItemAboveBelowCommand
     {
         [ImportingConstructor]
         public AddNewItemBelowCommand(
             IPhysicalProjectTree projectTree,
             IUnconfiguredProjectVsServices projectVsServices,
             SVsServiceProvider serviceProvider,
-            OrderAddItemHintReceiver orderAddItemHintReceiver) :
-            base(projectTree, projectVsServices, serviceProvider, orderAddItemHintReceiver)
+            OrderAddItemHintReceiver orderAddItemHintReceiver,
+            ConfiguredProject configuredProject,
+            IProjectAccessor accessor) :
+            base(projectTree, projectVsServices, serviceProvider, orderAddItemHintReceiver, configuredProject, accessor)
         {
         }
 
         protected override Task OnAddingNodesAsync(IProjectTree nodeToAddTo)
         {
             return ShowAddNewFileDialogAsync(nodeToAddTo);
-        }
-
-        protected override bool CanAdd(IProjectTree target)
-        {
-            return OrderingHelper.HasValidDisplayOrder(target);
         }
 
         protected override OrderingMoveAction Action => OrderingMoveAction.MoveBelow;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/MoveDownCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/MoveDownCommand.cs
@@ -17,9 +17,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         {
         }
 
-        protected override bool CanMove(IProjectTree node)
+        protected override bool CanMove(Project project, IProjectTree node)
         {
-            return OrderingHelper.CanMoveDown(node);
+            return OrderingHelper.CanMoveDown(project, node);
         }
 
         protected override bool TryMove(Project project, IProjectTree node)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/MoveUpCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/MoveUpCommand.cs
@@ -17,9 +17,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         {
         }
 
-        protected override bool CanMove(IProjectTree node)
+        protected override bool CanMove(Project project, IProjectTree node)
         {
-            return OrderingHelper.CanMoveUp(node);
+            return OrderingHelper.CanMoveUp(project, node);
         }
 
         protected override bool TryMove(Project project, IProjectTree node)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
@@ -281,7 +281,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// <param name="projectTree">the given project tree</param>
         /// <param name="returnSibling">passes the index of the given project tree from the given ordered sequence, expecting to return a sibling</param>
         /// <returns>a sibling</returns>
-        private static IProjectTree2 GetSiblingByDisplayOrder(Project project, IProjectTree projectTree, Func<int, ImmutableArray<IProjectTree>, IProjectTree2> returnSibling)
+        private static IProjectTree2 TryGetSiblingByDisplayOrder(Project project, IProjectTree projectTree, Func<int, ImmutableArray<IProjectTree>, IProjectTree2> returnSibling)
         {
             var parent = projectTree.Parent;
             var displayOrder = GetDisplayOrder(projectTree);
@@ -307,9 +307,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// <summary>
         /// Gets the previous sibling of the given project tree, if there is any. Can return null.
         /// </summary>
-        private static IProjectTree2 GetPreviousSibling(Project project, IProjectTree projectTree)
+        private static IProjectTree2 TryGetPreviousSibling(Project project, IProjectTree projectTree)
         {
-            return GetSiblingByDisplayOrder(project, projectTree, (i, orderedChildren) =>
+            return TryGetSiblingByDisplayOrder(project, projectTree, (i, orderedChildren) =>
             {
                 if (i == 0)
                 {
@@ -323,9 +323,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// <summary>
         /// Gets the next sibling of the given project tree, if there is any. Can return null.
         /// </summary>
-        private static IProjectTree2 GetNextSibling(Project project, IProjectTree projectTree)
+        private static IProjectTree2 TryGetNextSibling(Project project, IProjectTree projectTree)
         {
-            return GetSiblingByDisplayOrder(project, projectTree, (i, orderedChildren) =>
+            return TryGetSiblingByDisplayOrder(project, projectTree, (i, orderedChildren) =>
             {
                 if (i == (orderedChildren.Length - 1))
                 {
@@ -344,10 +344,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             switch (moveAction)
             {
                 case MoveAction.Above:
-                    return GetPreviousSibling(project, projectTree);
+                    return TryGetPreviousSibling(project, projectTree);
 
                 case MoveAction.Below:
-                    return GetNextSibling(project, projectTree);
+                    return TryGetNextSibling(project, projectTree);
             }
 
             return null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
@@ -84,11 +84,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// <summary>
         /// Checks if the given project tree can move up over one of its siblings.
         /// </summary>
-        public static bool CanMoveUp(IProjectTree projectTree)
+        public static bool CanMoveUp(Project project, IProjectTree projectTree)
         {
             Requires.NotNull(projectTree, nameof(projectTree));
 
-            return GetSiblingByMoveAction(projectTree, MoveAction.Above) != null;
+            return GetSiblingByMoveAction(project, projectTree, MoveAction.Above) != null;
         }
 
         /// <summary>
@@ -105,11 +105,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// <summary>
         /// Checks if the given project tree can move down over one of its siblings.
         /// </summary>
-        public static bool CanMoveDown(IProjectTree projectTree)
+        public static bool CanMoveDown(Project project, IProjectTree projectTree)
         {
             Requires.NotNull(projectTree, nameof(projectTree));
 
-            return GetSiblingByMoveAction(projectTree, MoveAction.Below) != null;
+            return GetSiblingByMoveAction(project, projectTree, MoveAction.Below) != null;
         }
 
         /// <summary>
@@ -156,7 +156,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             Requires.NotNull(target, nameof(target));
 
             // Get the target's first child. We use that child as our reference to move.
-            var targetChild = GetChildren(target).FirstOrDefault();
+            var targetChild = GetChildren(project, target).FirstOrDefault();
 
             // If we didn't find a child and our target is an empty folder and not the project root, let's walk up the tree to find a new target child.
             // Empty folders do not have a valid display order currently in CPS. If they ever do, we have to make changes to this.
@@ -166,7 +166,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
                 while (targetChild == null && !referenceTarget.Flags.Contains(ProjectTreeFlags.ProjectRoot))
                 {
                     referenceTarget = referenceTarget.Parent;
-                    targetChild = GetChildren(referenceTarget).FirstOrDefault();
+                    targetChild = GetChildren(project, referenceTarget).FirstOrDefault();
                 }
             }
 
@@ -189,7 +189,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         }
 
         /// <summary>
-        /// Get project item elements based on the project tree. Will not include elements that are not associated with the given project.
+        /// Get project item elements based on the project tree. Will not include elements that are not associated with the given project, such as .props or .targets files.
         /// Project tree can be a folder or item.
         /// </summary>
         public static ImmutableArray<ProjectItemElement> GetItemElements(Project project, IProjectTree projectTree, ImmutableArray<string> excludeIncludes)
@@ -259,9 +259,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// Gets a collection a project tree's children. 
         /// The children will only have a valid display order, and the collection will be in order by their display order.
         /// </summary>
-        private static ImmutableArray<IProjectTree> GetChildren(IProjectTree projectTree)
+        private static ImmutableArray<IProjectTree> GetChildren(Project project, IProjectTree projectTree)
         {
-            return projectTree.Children.Where(x => HasValidDisplayOrder(x)).OrderBy(x => GetDisplayOrder(x)).ToImmutableArray();
+            return projectTree.Children.Where(x =>
+            {
+                var hasValidDisplayOrder = HasValidDisplayOrder(x);
+                if (!hasValidDisplayOrder)
+                {
+                    return false;
+                }
+
+                // Make sure we have a valid backing xml element that is not part of a .props or .targets files.
+                return GetItemElements(project, x, ImmutableArray<string>.Empty).Any();
+            }
+            ).OrderBy(x => GetDisplayOrder(x)).ToImmutableArray();
         }
 
         /// <summary>
@@ -270,7 +281,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// <param name="projectTree">the given project tree</param>
         /// <param name="returnSibling">passes the index of the given project tree from the given ordered sequence, expecting to return a sibling</param>
         /// <returns>a sibling</returns>
-        private static IProjectTree2 GetSiblingByDisplayOrder(IProjectTree projectTree, Func<int, ImmutableArray<IProjectTree>, IProjectTree2> returnSibling)
+        private static IProjectTree2 GetSiblingByDisplayOrder(Project project, IProjectTree projectTree, Func<int, ImmutableArray<IProjectTree>, IProjectTree2> returnSibling)
         {
             var parent = projectTree.Parent;
             var displayOrder = GetDisplayOrder(projectTree);
@@ -279,7 +290,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
                 return null;
             }
 
-            var orderedChildren = GetChildren(parent);
+            var orderedChildren = GetChildren(project, parent);
 
             for (var i = 0; i < orderedChildren.Length; ++i)
             {
@@ -296,9 +307,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// <summary>
         /// Gets the previous sibling of the given project tree, if there is any. Can return null.
         /// </summary>
-        private static IProjectTree2 GetPreviousSibling(IProjectTree projectTree)
+        private static IProjectTree2 GetPreviousSibling(Project project, IProjectTree projectTree)
         {
-            return GetSiblingByDisplayOrder(projectTree, (i, orderedChildren) =>
+            return GetSiblingByDisplayOrder(project, projectTree, (i, orderedChildren) =>
             {
                 if (i == 0)
                 {
@@ -312,9 +323,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// <summary>
         /// Gets the next sibling of the given project tree, if there is any. Can return null.
         /// </summary>
-        private static IProjectTree2 GetNextSibling(IProjectTree projectTree)
+        private static IProjectTree2 GetNextSibling(Project project, IProjectTree projectTree)
         {
-            return GetSiblingByDisplayOrder(projectTree, (i, orderedChildren) =>
+            return GetSiblingByDisplayOrder(project, projectTree, (i, orderedChildren) =>
             {
                 if (i == (orderedChildren.Length - 1))
                 {
@@ -328,15 +339,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// <summary>
         /// Gets a sibling of the given project tree based on the move action. Can return null.
         /// </summary>
-        private static IProjectTree GetSiblingByMoveAction(IProjectTree projectTree, MoveAction moveAction)
+        private static IProjectTree GetSiblingByMoveAction(Project project, IProjectTree projectTree, MoveAction moveAction)
         {
             switch (moveAction)
             {
                 case MoveAction.Above:
-                    return GetPreviousSibling(projectTree);
+                    return GetPreviousSibling(project, projectTree);
 
                 case MoveAction.Below:
-                    return GetNextSibling(projectTree);
+                    return GetNextSibling(project, projectTree);
             }
 
             return null;
@@ -458,7 +469,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         private static bool TryMove(Project project, IProjectTree projectTree, MoveAction moveAction)
         {
             // Determine what sibling we want to look at based on if we are moving up or down.
-            var sibling = GetSiblingByMoveAction(projectTree, moveAction);
+            var sibling = GetSiblingByMoveAction(project, projectTree, moveAction);
             return TryMove(project, projectTree, sibling, moveAction);
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
@@ -199,7 +199,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 
             var treeQueue = new Queue<IProjectTree>();
 
-            var hashSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var hashSet = new HashSet<string>(excludeIncludes, StringComparer.OrdinalIgnoreCase);
             var includes = new SortedList<int, ProjectItemElement>();
 
             treeQueue.Enqueue(projectTree);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         {
             Requires.NotNull(projectTree, nameof(projectTree));
 
-            return GetSiblingByMoveAction(project, projectTree, MoveAction.Above) != null;
+            return TryGetSiblingByMoveAction(project, projectTree, MoveAction.Above) != null;
         }
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         {
             Requires.NotNull(projectTree, nameof(projectTree));
 
-            return GetSiblingByMoveAction(project, projectTree, MoveAction.Below) != null;
+            return TryGetSiblingByMoveAction(project, projectTree, MoveAction.Below) != null;
         }
 
         /// <summary>
@@ -339,7 +339,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// <summary>
         /// Gets a sibling of the given project tree based on the move action. Can return null.
         /// </summary>
-        private static IProjectTree GetSiblingByMoveAction(Project project, IProjectTree projectTree, MoveAction moveAction)
+        private static IProjectTree TryGetSiblingByMoveAction(Project project, IProjectTree projectTree, MoveAction moveAction)
         {
             switch (moveAction)
             {
@@ -469,7 +469,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         private static bool TryMove(Project project, IProjectTree projectTree, MoveAction moveAction)
         {
             // Determine what sibling we want to look at based on if we are moving up or down.
-            var sibling = GetSiblingByMoveAction(project, projectTree, moveAction);
+            var sibling = TryGetSiblingByMoveAction(project, projectTree, moveAction);
+            if (sibling == null)
+            {
+                return false;
+            }
             return TryMove(project, projectTree, sibling, moveAction);
         }
 


### PR DESCRIPTION
This fixes the issue with F# files not able to be added in the ASP .NET Core projects. The cause was due to the ASP .NET Core project including a file that was part of props file, and our ordering logic did not account for files that are not associated with the main project. We now, simply skip them when doing ordering, but their display order will still be correct.

We are hoping to get this in the next servicing update.

Here is the reported bug:
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/612703