### PR TITLE
Fixed inability for F# files to be added in ASP .NET Core projects

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelperTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelperTests.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
+using System.IO;
+using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
 using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
 using Xunit;
@@ -13,13 +16,43 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         private static void AssertEqualProject(string expected, Project project)
         {
             var actual = string.Empty;
-            using (var writer = new System.IO.StringWriter())
+            using (var writer = new StringWriter())
             {
                 project.Save(writer);
                 actual = writer.ToString();
             }
 
             Assert.Equal(expected, actual);
+        }
+
+        private static (string tempPath, string testPropsFile) CreateTempPropsFilePath()
+        {
+            var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var testPropsFile = Path.Combine(tempPath, "test.props");
+            return (tempPath, testPropsFile);
+        }
+
+        private static Project CreateProjectWithImport(ProjectRootElement projectRootElement, ProjectRootElement projectImportElement, string tempPath, string testPropsFile)
+        {
+            try
+            {
+                Directory.CreateDirectory(tempPath);
+                projectImportElement.Save(testPropsFile);
+
+                return new Project(projectRootElement);
+            }
+            finally
+            {
+                if (Directory.Exists(tempPath))
+                {
+                    Directory.Delete(tempPath, true);
+                }
+
+                if (File.Exists(testPropsFile))
+                {
+                    File.Delete(testPropsFile);
+                }
+            }
         }
 
         [Fact]
@@ -625,6 +658,194 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
     <Compile Include=""test3.fs"" />
   </ItemGroup>
 </Project>";
+
+            AssertEqualProject(expected, project);
+        }
+
+        [Fact]
+        public void AddFile_WithImportedFileAtTop()
+        {
+            var tree = ProjectTreeParser.Parse(@"
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
+    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
+");
+
+            var updatedTree = ProjectTreeParser.Parse(@"
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
+    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 2, ItemName: ""test3.fs""
+");
+
+            var (tempPath, testPropsFile) = CreateTempPropsFilePath();
+
+            var projectRootElement = string.Format(@"
+<Project>
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <Import Project=""{0}"" />
+
+  <ItemGroup>
+    <Compile Include=""test2.fs"" />
+    <Compile Include=""test3.fs"" />
+  </ItemGroup>
+
+</Project>
+", testPropsFile).AsProjectRootElement();
+
+            var projectImportElement = @"
+<Project>
+  <ItemGroup>
+    <Compile Include=""test1.fs"" />
+  </ItemGroup>
+</Project>
+".AsProjectRootElement();
+
+            var project = CreateProjectWithImport(projectRootElement, projectImportElement, tempPath, testPropsFile);
+
+            var elements =
+                OrderingHelper.GetItemElements(project, updatedTree.Children[0], ImmutableArray<string>.Empty)
+                .AddRange(OrderingHelper.GetItemElements(project, updatedTree.Children[2], ImmutableArray<string>.Empty));
+
+            Assert.True(OrderingHelper.TryMoveElementsToTop(project, elements, tree), "TryMoveElementsToTop returned false.");
+            Assert.True(project.IsDirty);
+
+            var expected = string.Format(@"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <Import Project=""{0}"" />
+  <ItemGroup>
+    <Compile Include=""test3.fs"" />
+    <Compile Include=""test2.fs"" />
+  </ItemGroup>
+</Project>", testPropsFile);
+
+            AssertEqualProject(expected, project);
+        }
+
+        [Fact]
+        public void MoveFileUp_WithImportedFileInterspersed()
+        {
+            var tree = ProjectTreeParser.Parse(@"
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
+    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 2, ItemName: ""test3.fs""
+");
+
+            var (tempPath, testPropsFile) = CreateTempPropsFilePath();
+
+            var projectRootElement = string.Format(@"
+<Project>
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include=""test1.fs"" />
+  </ItemGroup>
+
+  <Import Project=""{0}"" />
+
+  <ItemGroup>
+    <Compile Include=""test3.fs"" />
+  </ItemGroup>
+
+</Project>
+", testPropsFile).AsProjectRootElement();
+
+            var projectImportElement = @"
+<Project>
+  <ItemGroup>
+    <Compile Include=""test2.fs"" />
+  </ItemGroup>
+</Project>
+".AsProjectRootElement();
+
+            var project = CreateProjectWithImport(projectRootElement, projectImportElement, tempPath, testPropsFile);
+
+            Assert.True(OrderingHelper.TryMoveUp(project, tree.Children[2]));
+            Assert.True(project.IsDirty);
+
+            // The expected result here may not be the desired behavior, but it is the current behavior that we need to test for.
+            // Moving test3.fs up, skips the import, but also moves above test1.fs, that is due to skipping imports during manipulation.
+            var expected = string.Format(@"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include=""test3.fs"" />
+    <Compile Include=""test1.fs"" />
+  </ItemGroup>
+  <Import Project=""{0}"" />
+  <ItemGroup />
+</Project>", testPropsFile);
+
+            AssertEqualProject(expected, project);
+        }
+
+        [Fact]
+        public void MoveFileDown_WithImportedFileAtBottom()
+        {
+            var tree = ProjectTreeParser.Parse(@"
+Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
+    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
+    File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 2, ItemName: ""test3.fs""
+");
+
+            var (tempPath, testPropsFile) = CreateTempPropsFilePath();
+
+            var projectRootElement = string.Format(@"
+<Project>
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include=""test1.fs"" />
+    <Compile Include=""test2.fs"" />
+  </ItemGroup>
+
+  <Import Project=""{0}"" />
+
+</Project>
+", testPropsFile).AsProjectRootElement();
+
+            var projectImportElement = @"
+<Project>
+  <ItemGroup>
+    <Compile Include=""test3.fs"" />
+  </ItemGroup>
+</Project>
+".AsProjectRootElement();
+
+            var project = CreateProjectWithImport(projectRootElement, projectImportElement, tempPath, testPropsFile);
+
+            // Assert false as nothing should change because we can't move over an import file that is at the very bottom.
+            Assert.False(OrderingHelper.TryMoveDown(project, tree.Children[1]));
+            Assert.False(project.IsDirty);
+
+            var expected = string.Format(@"<?xml version=""1.0"" encoding=""utf-16""?>
+<Project>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include=""test1.fs"" />
+    <Compile Include=""test2.fs"" />
+  </ItemGroup>
+  <Import Project=""{0}"" />
+</Project>", testPropsFile);
 
             AssertEqualProject(expected, project);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
@@ -132,6 +132,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             Requires.NotNull(target, nameof(target));
 
             var referenceElement = TryGetReferenceElement(project, target, ImmutableArray<string>.Empty, MoveAction.Above);
+            if (referenceElement == null)
+            {
+                return false;
+            }
+
             return TryMoveElements(elements, referenceElement, MoveAction.Above);
         }
 
@@ -144,6 +149,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             Requires.NotNull(target, nameof(target));
 
             var referenceElement = TryGetReferenceElement(project, target, ImmutableArray<string>.Empty, MoveAction.Below);
+            if (referenceElement == null)
+            {
+                return false;
+            }
+
             return TryMoveElements(elements, referenceElement, MoveAction.Below);
         }
 
@@ -155,31 +165,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             Requires.NotNull(project, nameof(project));
             Requires.NotNull(target, nameof(target));
 
-            // Get the target's first child. We use that child as our reference to move.
-            var targetChild = GetChildren(target).FirstOrDefault();
+            var newTarget = target;
 
-            // If we didn't find a child and our target is an empty folder and not the project root, let's walk up the tree to find a new target child.
-            // Empty folders do not have a valid display order currently in CPS. If they ever do, we have to make changes to this.
-            if (targetChild == null && target.IsFolder && !target.Flags.Contains(ProjectTreeFlags.ProjectRoot))
+            // This is to handle adding files to empty folders since empty folders do not have a valid display order yet.
+            // We need to find a target up the tree that has a valid display order, because it most likely will have our reference element that we want.
+            while (!HasValidDisplayOrder(newTarget) && !newTarget.Flags.Contains(ProjectTreeFlags.ProjectRoot))
             {
-                var referenceTarget = target;
-                while (targetChild == null && !referenceTarget.Flags.Contains(ProjectTreeFlags.ProjectRoot))
-                {
-                    referenceTarget = referenceTarget.Parent;
-                    targetChild = GetChildren(referenceTarget).FirstOrDefault();
-                }
+                newTarget = newTarget.Parent;
             }
 
-            if (targetChild == null)
-            {
-                // The project is empty, we don't need to move anything.
-                return false;
-            }
-
-            // Make sure we exclude the moving elements when trying to find a reference element; this prevents us from choosing a reference element that is part of the moving elements.
-            var referenceElement = TryGetReferenceElement(project, targetChild, elements.Select(x => x.Include).ToImmutableArray(), MoveAction.Above);
-
-            // If we couldn't find a reference element, we can't move the elements and we don't need to.
+            var excludeIncludes = elements.Select(x => x.Include).ToImmutableArray();
+            var referenceElement = GetChildren(newTarget).Select(x => TryGetReferenceElement(project, x, excludeIncludes, MoveAction.Above)).FirstOrDefault(x => x != null);
             if (referenceElement == null)
             {
                 return false;
@@ -217,7 +213,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
                 var item = project.GetItemsByEvaluatedInclude(include).FirstOrDefault();
 
                 // We only care about adding one item associated with the evaluated include.
-                if (item?.Xml is ProjectItemElement element)
+                if (item?.Xml is ProjectItemElement element && !item.IsImported)
                 {
                     elements.Add(element);
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
@@ -483,7 +483,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             return project.AllEvaluatedItems
                 // We are excluding folder elements until CPS allows empty folders to be part of the order; when they do, we can omit checking the item type for "Folder".
                 // Related changes will also need to happen in TryMoveElementsToTop when CPS allows empty folders in ordering.
-                .Where(x => !previousIncludes.Contains(x.EvaluatedInclude, StringComparer.OrdinalIgnoreCase) && !x.ItemType.Equals("Folder", StringComparison.OrdinalIgnoreCase))
+                // Don't choose items that were imported. Most likely won't happen on added elements, but just in case for sanity.
+                .Where(x => !previousIncludes.Contains(x.EvaluatedInclude, StringComparer.OrdinalIgnoreCase) && !x.ItemType.Equals("Folder", StringComparison.OrdinalIgnoreCase) && !x.IsImported)
                 .Select(x => x.Xml)
                 .ToImmutableArray();
         }


### PR DESCRIPTION
This fixes the issue with F# files not able to be added in the ASP .NET Core projects. The cause was due to the ASP .NET Core project including a file that was part of props file, and our ordering logic did not account for files that are not associated with the main project. We now, simply skip them when doing ordering, but their display order will still be correct.

Changes in the PR:

- Skipping item elements if they are imported when getting elements 
- Defensive null checks in other places where we call TryGetReferenceElement
- Greatly simplified TryMoveElementsToTop that accounts for skipping imported item elements

Here is the reported bug:
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/612703

Here is the F# issue:
https://github.com/Microsoft/visualfsharp/issues/4851