### PR TITLE
Use object initialization

### DIFF
--- a/src/Common/ManagedCodeMarkers.vb
+++ b/src/Common/ManagedCodeMarkers.vb
@@ -247,13 +247,13 @@ Namespace Microsoft.Internal.Performance
     ' This type name was originally defined in the VSO first.
     Friend Enum RoslynCodeMarkerEvent
 
-        perfMSVSEditorsShowTabBegin = 8400
-        perfMSVSEditorsShowTabEnd = 8401
-        perfMSVSEditorsActivateLogicalViewStart = 8402
-        perfMSVSEditorsActivateLogicalViewEnd = 8403
+        PerfMSVSEditorsShowTabBegin = 8400
+        PerfMSVSEditorsShowTabEnd = 8401
+        PerfMSVSEditorsActivateLogicalViewStart = 8402
+        PerfMSVSEditorsActivateLogicalViewEnd = 8403
 
-        perfMSVSEditorsReferencePageWCFAdded = 8413
-        perfMSVSEditorsReferencePagePostponedUIRefreshDone = 8414
+        PerfMSVSEditorsReferencePageWCFAdded = 8413
+        PerfMSVSEditorsReferencePagePostponedUIRefreshDone = 8414
     End Enum
 
 End Namespace

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerView.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerView.vb
@@ -1024,7 +1024,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                 Common.Switches.TracePDPerfBegin("ApplicationDesignerView.ShowTab")
                 Common.Switches.TracePDFocus(TraceLevel.Error, "CodeMarker: perfMSVSEditorsShowTabBegin")
                 Common.Switches.TracePDPerf("CodeMarker: perfMSVSEditorsShowTabBegin")
-                CodeMarkers.Instance.CodeMarker(RoslynCodeMarkerEvent.perfMSVSEditorsShowTabBegin)
+                CodeMarkers.Instance.CodeMarker(RoslynCodeMarkerEvent.PerfMSVSEditorsShowTabBegin)
 
                 Dim NewCurrentPanel As ApplicationDesignerPanel = _designerPanels(Index)
                 Dim ErrorMessage As String = Nothing
@@ -1164,7 +1164,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                 'We may have opened a new page, need to verify all dirty states
                 DelayRefreshDirtyIndicators()
 
-                CodeMarkers.Instance.CodeMarker(RoslynCodeMarkerEvent.perfMSVSEditorsShowTabEnd)
+                CodeMarkers.Instance.CodeMarker(RoslynCodeMarkerEvent.PerfMSVSEditorsShowTabEnd)
                 Common.Switches.TracePDFocus(TraceLevel.Error, "CodeMarker: perfMSVSEditorsShowTabEnd")
                 Common.Switches.TracePDPerf("CodeMarker: perfMSVSEditorsShowTabEnd")
                 Common.Switches.TracePDPerfEnd("ApplicationDesignerView.ShowTab")

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerWindowPane.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerWindowPane.vb
@@ -182,13 +182,15 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                         childView.Dispose()
                     End If
 
-                    childView = New ErrorControl()
-                    childView.Text = My.Resources.Designer.GetString(My.Resources.Designer.APPDES_ErrorLoading_Msg, message)
+                    childView = New ErrorControl With {
+                        .Text = My.Resources.Designer.GetString(My.Resources.Designer.APPDES_ErrorLoading_Msg, message)
+                    }
                 End Try
 
                 If (childView Is Nothing) Then
-                    childView = New ErrorControl()
-                    childView.Text = My.Resources.Designer.GetString(My.Resources.Designer.APPDES_ErrorLoading_Msg, "")
+                    childView = New ErrorControl With {
+                        .Text = My.Resources.Designer.GetString(My.Resources.Designer.APPDES_ErrorLoading_Msg, "")
+                    }
                 End If
 
                 'If we haven't added the viewChild to m_View yet, do so now.
@@ -247,7 +249,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         Public Function ActivateLogicalView(ByRef rguidLogicalView As Guid) As Integer Implements IVsMultiViewDocumentView.ActivateLogicalView
             Common.Switches.TracePDFocus(TraceLevel.Warning, "CodeMarker: perfMSVSEditorsActivateLogicalViewStart")
             Common.Switches.TracePDPerf("CodeMarker: perfMSVSEditorsActivateLogicalViewStart")
-            CodeMarkers.Instance.CodeMarker(RoslynCodeMarkerEvent.perfMSVSEditorsActivateLogicalViewStart)
+            CodeMarkers.Instance.CodeMarker(RoslynCodeMarkerEvent.PerfMSVSEditorsActivateLogicalViewStart)
 
             If AppDesignerView Is Nothing Then
                 PopulateView(rguidLogicalView)
@@ -261,7 +263,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                 End If
             End If
 
-            CodeMarkers.Instance.CodeMarker(RoslynCodeMarkerEvent.perfMSVSEditorsActivateLogicalViewEnd)
+            CodeMarkers.Instance.CodeMarker(RoslynCodeMarkerEvent.PerfMSVSEditorsActivateLogicalViewEnd)
             Common.Switches.TracePDFocus(TraceLevel.Warning, "CodeMarker: perfMSVSEditorsActivateLogicalViewEnd")
             Common.Switches.TracePDPerf("CodeMarker: perfMSVSEditorsActivateLogicalViewEnd")
         End Function

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabControl.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabControl.vb
@@ -103,12 +103,13 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' </summary>
         ''' <remarks></remarks>
         Private Sub Initialize()
-            _hostingPanel = New Panel()
-            _hostingPanel.Visible = True
-            _hostingPanel.Anchor = AnchorStyles.Top Or AnchorStyles.Left Or AnchorStyles.Bottom Or AnchorStyles.Right
-            _hostingPanel.AutoScroll = True
-            _hostingPanel.Text = "HostingPanel" 'For debugging
-            _hostingPanel.AccessibleName = My.Resources.Designer.APPDES_HostingPanelName
+            _hostingPanel = New Panel With {
+                .Visible = True,
+                .Anchor = AnchorStyles.Top Or AnchorStyles.Left Or AnchorStyles.Bottom Or AnchorStyles.Right,
+                .AutoScroll = True,
+                .Text = "HostingPanel", 'For debugging
+                .AccessibleName = My.Resources.Designer.APPDES_HostingPanelName
+            }
 
             'Add any initialization after the InitializeComponent() call
             '
@@ -336,9 +337,10 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             SuspendLayout()
             Dim newIndex As Integer
             Try
-                Dim Button As New ProjectDesignerTabButton()
-                Button.Text = Title
-                Button.Name = AutomationName
+                Dim Button As New ProjectDesignerTabButton With {
+                    .Text = Title,
+                    .Name = AutomationName
+                }
                 _buttonCollection.Add(Button)
                 newIndex = _buttonCollection.Count - 1
                 Controls.Add(Button)

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerView.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerView.vb
@@ -454,8 +454,9 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             SetDialogFont()
 
             Dim menuCommands As New ArrayList()
-            Dim cutCmd As New DesignerMenuCommand(_rootDesigner, Constants.MenuConstants.CommandIDVSStd97cmdidCut, AddressOf DisabledMenuCommandHandler)
-            cutCmd.Enabled = False
+            Dim cutCmd As New DesignerMenuCommand(_rootDesigner, Constants.MenuConstants.CommandIDVSStd97cmdidCut, AddressOf DisabledMenuCommandHandler) With {
+                .Enabled = False
+            }
             menuCommands.Add(cutCmd)
 
             _rootDesigner.RegisterMenuCommands(menuCommands)

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPage.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPage.vb
@@ -651,10 +651,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     ' in order to have scroll bars properly appear in large fonts, wrap
                     ' the page in a usercontrol (since it supports AutoScroll) that won't
                     ' scale with fonts. Move(rect) will set the proper size.
-                    Dim sizingParent As New UserControl()
-                    sizingParent.AutoScaleMode = AutoScaleMode.None
-                    sizingParent.AutoScroll = True
-                    sizingParent.Text = "SizingParent" 'For debugging purposes (Spy++)
+                    Dim sizingParent As New UserControl With {
+                        .AutoScaleMode = AutoScaleMode.None,
+                        .AutoScroll = True,
+                        .Text = "SizingParent" 'For debugging purposes (Spy++)
+                        }
                     _propPage.Parent = sizingParent
                     NativeMethods.SetParent(sizingParent.Handle, hWndParent)
                     _wasSetParentCalled = True

--- a/src/Microsoft.VisualStudio.Editors/AttributeEditor/PermissionSetService.vb
+++ b/src/Microsoft.VisualStudio.Editors/AttributeEditor/PermissionSetService.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Strict On
 Option Explicit On
@@ -81,8 +81,9 @@ Namespace Microsoft.VisualStudio.Editors.VBAttributeEditor
 
                 If (strManifestFileName IsNot Nothing) AndAlso (strManifestFileName.Length > 0) Then
 
-                    Dim manifestInfo As New TrustInfo
-                    manifestInfo.PreserveFullTrustPermissionSet = True
+                    Dim manifestInfo As New TrustInfo With {
+                        .PreserveFullTrustPermissionSet = True
+                    }
 
                     Try
                         Using appManifestDocData As New DocData(_serviceProvider, strManifestFileName)

--- a/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
@@ -206,12 +206,13 @@ Namespace Microsoft.VisualStudio.Editors.Common
 
         Public Function GetImageFromImageService(imageMoniker As ImageMoniker, width As Integer, height As Integer, background As Color) As Image
             If (ImageService IsNot Nothing) Then
-                Dim attributes As New Imaging.Interop.ImageAttributes
-                attributes.StructSize = Marshal.SizeOf(GetType(Imaging.Interop.ImageAttributes))
-                attributes.ImageType = CType(_UIImageType.IT_Bitmap, UInteger)
-                attributes.Format = CType(_UIDataFormat.DF_WinForms, UInteger)
-                attributes.LogicalWidth = width
-                attributes.LogicalHeight = width
+                Dim attributes As New Imaging.Interop.ImageAttributes With {
+                    .StructSize = Marshal.SizeOf(GetType(Imaging.Interop.ImageAttributes)),
+                    .ImageType = CType(_UIImageType.IT_Bitmap, UInteger),
+                    .Format = CType(_UIDataFormat.DF_WinForms, UInteger),
+                    .LogicalWidth = width,
+                    .LogicalHeight = width
+                }
 
                 Dim backgroundValue As UInteger = ConvertColorToUInteger(background)
                 attributes.Background = backgroundValue
@@ -1033,9 +1034,10 @@ Namespace Microsoft.VisualStudio.Editors.Common
                     Dim r As Rectangle = New Rectangle(New Point(0, 0), size)
                     Dim colorMaps As ColorMap() = New ColorMap(0) {}
 
-                    colorMaps(0) = New ColorMap
-                    colorMaps(0).OldColor = originalColor
-                    colorMaps(0).NewColor = newColor
+                    colorMaps(0) = New ColorMap With {
+                        .OldColor = originalColor,
+                        .NewColor = newColor
+                    }
 
                     Dim imageAttributes As Drawing.Imaging.ImageAttributes = New Drawing.Imaging.ImageAttributes()
                     imageAttributes.SetRemapTable(colorMaps, ColorAdjustType.Bitmap)

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerLoader.vb
@@ -506,8 +506,9 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                 End If
             End If
 
-            _sourceCodeControlManager = New SourceCodeControlManager(ServiceProvider, Hierarchy)
-            _sourceCodeControlManager.ManagedFiles = FilesToCheckOut
+            _sourceCodeControlManager = New SourceCodeControlManager(ServiceProvider, Hierarchy) With {
+                .ManagedFiles = FilesToCheckOut
+            }
         End Sub
 
         Public Overrides Sub BeginLoad(host As IDesignerLoaderHost)

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationCodeGenerator.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationCodeGenerator.vb
@@ -179,8 +179,9 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                 '    <Global.System.Diagnostics.DebuggerStepThrough()> _
                 '    Public Sub New()
                 '
-                Dim Constructor As CodeConstructor = New CodeConstructor()
-                Constructor.Attributes = MemberAttributes.Public
+                Dim Constructor As CodeConstructor = New CodeConstructor With {
+                    .Attributes = MemberAttributes.Public
+                }
                 AddAttribute(Constructor, DebuggerStepThroughAttribute, True)
 
                 'Add AuthenticationMode.Windows as an argument to the MyBase.New() call
@@ -254,10 +255,11 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                             Throw New ArgumentException(errorMsg)
                         End If
                     Else
-                        Dim OnCreateMainForm As New CodeMemberMethod()
-                        OnCreateMainForm.Attributes = MemberAttributes.Override Or MemberAttributes.Family
-                        OnCreateMainForm.ReturnType = Nothing
-                        OnCreateMainForm.Name = "OnCreateMainForm"
+                        Dim OnCreateMainForm As New CodeMemberMethod With {
+                            .Attributes = MemberAttributes.Override Or MemberAttributes.Family,
+                            .ReturnType = Nothing,
+                            .Name = "OnCreateMainForm"
+                        }
                         AddAttribute(OnCreateMainForm, DebuggerStepThroughAttribute, True)
                         AddDefaultFormAssignment(OnCreateMainForm, "MainForm", ProjectRootNamespace, MyApplication.MainFormNoRootNS)
                         GeneratedType.Members.Add(OnCreateMainForm)
@@ -286,10 +288,11 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                             Throw New ArgumentException(errorMsg)
                         End If
                     Else
-                        Dim OnCreateSplashScreen As New CodeMemberMethod()
-                        OnCreateSplashScreen.Attributes = MemberAttributes.Override Or MemberAttributes.Family
-                        OnCreateSplashScreen.ReturnType = Nothing
-                        OnCreateSplashScreen.Name = "OnCreateSplashScreen"
+                        Dim OnCreateSplashScreen As New CodeMemberMethod With {
+                            .Attributes = MemberAttributes.Override Or MemberAttributes.Family,
+                            .ReturnType = Nothing,
+                            .Name = "OnCreateSplashScreen"
+                        }
                         AddAttribute(OnCreateSplashScreen, DebuggerStepThroughAttribute, True)
                         AddDefaultFormAssignment(OnCreateSplashScreen, "SplashScreen", ProjectRootNamespace, MyApplication.SplashScreenNoRootNS)
                         GeneratedType.Members.Add(OnCreateSplashScreen)
@@ -329,30 +332,34 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ' Adds a statement to 'Method' in the form of ' FieldName = Expression ' 
         Private Shared Sub AddFieldAssignment(Method As CodeMemberMethod, FieldName As String, Expression As CodeExpression)
             Dim Statement As CodeAssignStatement
-            Statement = New CodeAssignStatement()
-            Statement.Left = New CodeFieldReferenceExpression(New CodeThisReferenceExpression(), FieldName)
-            Statement.Right = Expression
+            Statement = New CodeAssignStatement With {
+                .Left = New CodeFieldReferenceExpression(New CodeThisReferenceExpression(), FieldName),
+                .Right = Expression
+            }
             Method.Statements.Add(Statement)
         End Sub
 
         ' Adds a statement to 'Method' in the form of ' FieldName = Value ' 
         Private Shared Sub AddFieldPrimitiveAssignment(Method As CodeMemberMethod, FieldName As String, Value As Object)
             Dim Statement As CodeAssignStatement
-            Statement = New CodeAssignStatement()
-            Statement.Left = New CodeFieldReferenceExpression(New CodeThisReferenceExpression(), FieldName)
-            Statement.Right = New CodePrimitiveExpression(Value)
+            Statement = New CodeAssignStatement With {
+                .Left = New CodeFieldReferenceExpression(New CodeThisReferenceExpression(), FieldName),
+                .Right = New CodePrimitiveExpression(Value)
+            }
             Method.Statements.Add(Statement)
         End Sub
 
         ' Adds a statement to 'Method' in the form of ' FieldName = EnumType.EnumField ' 
         Private Shared Sub AddFieldAssignment(Method As CodeMemberMethod, FieldName As String, EnumType As Type, EnumFieldName As String)
             Dim Statement As CodeAssignStatement
-            Statement = New CodeAssignStatement()
-            Statement.Left = New CodeFieldReferenceExpression(New CodeThisReferenceExpression(), FieldName)
+            Statement = New CodeAssignStatement With {
+                .Left = New CodeFieldReferenceExpression(New CodeThisReferenceExpression(), FieldName)
+            }
 
             Dim TypeRef As CodeTypeReference
-            TypeRef = New CodeTypeReference(EnumType)
-            TypeRef.Options = CodeTypeReferenceOptions.GlobalReference
+            TypeRef = New CodeTypeReference(EnumType) With {
+                .Options = CodeTypeReferenceOptions.GlobalReference
+            }
 
             Dim value1 As New CodeFieldReferenceExpression(New CodeTypeReferenceExpression(TypeRef), EnumFieldName)
             Statement.Right = value1

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationProperties.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationProperties.vb
@@ -356,8 +356,9 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
             Else
                 'The .myapp file doesn't exist.  Just use default properties.  Don't force create the .myapp file until
                 '  a property is changed that forces us to write to it.
-                _myAppData = New MyApplicationData()
-                _myAppData.IsDirty = False
+                _myAppData = New MyApplicationData With {
+                    .IsDirty = False
+                }
             End If
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/AddMyExtensionsDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/AddMyExtensionsDialog.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Strict On
 Option Explicit On
@@ -48,9 +48,10 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
                 Next
             End If
 
-            _comparer = New ListViewComparer()
-            _comparer.SortColumn = 0
-            _comparer.Sorting = SortOrder.Ascending
+            _comparer = New ListViewComparer With {
+                .SortColumn = 0,
+                .Sorting = SortOrder.Ascending
+            }
             listViewExtensions.ListViewItemSorter = _comparer
             listViewExtensions.Sorting = _comparer.Sorting
             listViewExtensions.Sort()
@@ -94,7 +95,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         ''' <summary>
         ''' Click handler for the Help button. DevDiv Bugs 69458.
         ''' </summary>
-        Private Sub AddMyExtensionDialog_HelpButtonClicked( _
+        Private Sub AddMyExtensionDialog_HelpButtonClicked(
                 sender As Object, e As CancelEventArgs) _
                 Handles MyBase.HelpButtonClicked
             e.Cancel = True
@@ -135,12 +136,13 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         ''' <summary>
         ''' Return a ListViewItem for the given extension template.
         ''' </summary>
-        Private Shared Function ExtensionTemplateToListViewItem( _
+        Private Shared Function ExtensionTemplateToListViewItem(
                 extensionTemplate As MyExtensionTemplate) As ListViewItem
             Debug.Assert(extensionTemplate IsNot Nothing, "extensionTemplate is NULL!")
 
-            Dim item As New ListViewItem(extensionTemplate.DisplayName)
-            item.Tag = extensionTemplate
+            Dim item As New ListViewItem(extensionTemplate.DisplayName) With {
+                .Tag = extensionTemplate
+            }
             item.SubItems.Add(extensionTemplate.Version.ToString())
             item.SubItems.Add(extensionTemplate.Description)
             Return item

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityPropPage.vb
@@ -216,7 +216,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Sub
 
         Private WithEvents _projectService As MyExtensibilityProjectService = Nothing
-        Private _comparer As ListViewComparer
+        Private ReadOnly _comparer As ListViewComparer
 #End If
 
 #Region "Windows Form Designer generated code"

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityPropPage.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 #Const WINFORMEDITOR = False ' Set to True to open in WinForm Editor. Remember to set it back.
 
@@ -89,9 +89,10 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             InitializeComponent()
 
             ' Support sorting.
-            _comparer = New ListViewComparer()
-            _comparer.SortColumn = 0
-            _comparer.Sorting = SortOrder.Ascending
+            _comparer = New ListViewComparer With {
+                .SortColumn = 0,
+                .Sorting = SortOrder.Ascending
+            }
             listViewExtensions.ListViewItemSorter = _comparer
             listViewExtensions.Sorting = SortOrder.Ascending
 
@@ -167,8 +168,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 As ListViewItem
             Debug.Assert(extensionProjectFile IsNot Nothing)
 
-            Dim listItem As New ListViewItem(extensionProjectFile.DisplayName)
-            listItem.Tag = extensionProjectFile
+            Dim listItem As New ListViewItem(extensionProjectFile.DisplayName) With {
+                .Tag = extensionProjectFile
+            }
             listItem.SubItems.Add(extensionProjectFile.ExtensionVersion.ToString())
             listItem.SubItems.Add(extensionProjectFile.ExtensionDescription)
 

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilitySettings.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilitySettings.vb
@@ -275,10 +275,10 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
             Dim xmlDocument As New XmlDocument()
             Try
                 fileStream = New FileStream(_settingsFilePath, FileMode.Open, FileAccess.Read, FileShare.Read)
-                xmlReader = New XmlTextReader(fileStream)
-
                 ' Required by Fxcop rule CA3054 - DoNotAllowDTDXmlTextReader
-                xmlReader.DtdProcessing = DtdProcessing.Prohibit
+                xmlReader = New XmlTextReader(fileStream) With {
+                    .DtdProcessing = DtdProcessing.Prohibit
+                }
                 While Not xmlReader.EOF
                     Dim xmlNode As XmlNode = xmlDocument.ReadNode(xmlReader)
                     xmlDocument.AppendChild(xmlNode)
@@ -329,10 +329,10 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
             Dim xmlWriter As XmlTextWriter = Nothing
             Try
                 fileStream = New FileStream(_settingsFilePath, FileMode.Create, FileAccess.Write, FileShare.None)
-                xmlWriter = New XmlTextWriter(fileStream, Encoding.UTF8)
-
-                xmlWriter.Formatting = Formatting.Indented
-                xmlWriter.Indentation = 2
+                xmlWriter = New XmlTextWriter(fileStream, Encoding.UTF8) With {
+                    .Formatting = Formatting.Indented,
+                    .Indentation = 2
+                }
 
                 xmlWriter.WriteStartDocument()
                 xmlWriter.WriteStartElement(MY_EXTENSIONS_ELEMENT, MY_EXTENSIONS_ELEMENT_NAMESPACE)

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityUtil.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityUtil.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Strict On
 Option Explicit On
@@ -76,9 +76,10 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
             End If
             Try
                 Dim inputAsmName As New AssemblyName(assemblyFullName)
-                Dim outputAsmName As New AssemblyName()
-                outputAsmName.Name = inputAsmName.Name
-                outputAsmName.Version = inputAsmName.Version
+                Dim outputAsmName As New AssemblyName With {
+                    .Name = inputAsmName.Name,
+                    .Version = inputAsmName.Version
+                }
                 Return outputAsmName.FullName
             Catch ex As Exception When ReportWithoutCrash(ex, NameOf(NormalizeAssemblyFullName), NameOf(MyExtensibilityUtil))
                 Return Nothing

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.vb
@@ -79,19 +79,23 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
                     'StartupObject must be kept at the end of the list because it depends on the initialization of "OutputType" values
                     Dim datalist As List(Of PropertyControlData) = New List(Of PropertyControlData)
-                    Dim data As PropertyControlData = New PropertyControlData(VsProjPropId.VBPROJPROPID_AssemblyName, "AssemblyName", AssemblyName, New Control() {AssemblyNameLabel})
-                    data.DisplayPropertyName = My.Resources.Designer.PPG_Property_AssemblyName
+                    Dim data As PropertyControlData = New PropertyControlData(VsProjPropId.VBPROJPROPID_AssemblyName, "AssemblyName", AssemblyName, New Control() {AssemblyNameLabel}) With {
+                        .DisplayPropertyName = My.Resources.Designer.PPG_Property_AssemblyName
+                    }
                     datalist.Add(data)
-                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_DefaultNamespace, Const_DefaultNamespace, RootNamespaceTextBox, New Control() {RootNamespaceLabel})
-                    data.DisplayPropertyName = My.Resources.Designer.PPG_Property_RootNamespace
+                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_DefaultNamespace, Const_DefaultNamespace, RootNamespaceTextBox, New Control() {RootNamespaceLabel}) With {
+                        .DisplayPropertyName = My.Resources.Designer.PPG_Property_RootNamespace
+                    }
                     datalist.Add(data)
-                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_ApplicationIcon, "ApplicationIcon", ApplicationIcon, AddressOf ApplicationIconSet, AddressOf ApplicationIconGet, ControlDataFlags.UserHandledEvents, New Control() {AppIconImage, AppIconBrowse, IconRadioButton, ApplicationIconLabel})
-                    data.DisplayPropertyName = My.Resources.Designer.PPG_Property_ApplicationIcon
+                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_ApplicationIcon, "ApplicationIcon", ApplicationIcon, AddressOf ApplicationIconSet, AddressOf ApplicationIconGet, ControlDataFlags.UserHandledEvents, New Control() {AppIconImage, AppIconBrowse, IconRadioButton, ApplicationIconLabel}) With {
+                        .DisplayPropertyName = My.Resources.Designer.PPG_Property_ApplicationIcon
+                    }
                     datalist.Add(data)
                     data = New PropertyControlData(VsProjPropId110.VBPROJPROPID_OutputTypeEx, Const_OutputTypeEx, OutputType, AddressOf OutputTypeSet, AddressOf OutputTypeGet, ControlDataFlags.UserHandledEvents, New Control() {OutputTypeLabel})
                     datalist.Add(data)
-                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_StartupObject, "StartupObject", StartupObject, AddressOf StartupObjectSet, AddressOf StartupObjectGet, ControlDataFlags.UserHandledEvents, New Control() {StartupObjectLabel})
-                    data.DisplayPropertyName = My.Resources.Designer.PPG_Property_StartupObject
+                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_StartupObject, "StartupObject", StartupObject, AddressOf StartupObjectSet, AddressOf StartupObjectGet, ControlDataFlags.UserHandledEvents, New Control() {StartupObjectLabel}) With {
+                        .DisplayPropertyName = My.Resources.Designer.PPG_Property_StartupObject
+                    }
                     datalist.Add(data)
                     data = New PropertyControlData(VsProjPropId80.VBPROJPROPID_Win32ResourceFile, "Win32ResourceFile", Win32ResourceFile, AddressOf Win32ResourceSet, AddressOf Win32ResourceGet, ControlDataFlags.None, New Control() {Win32ResourceFileBrowse, Win32ResourceRadioButton})
                     datalist.Add(data)

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBWinForms.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBWinForms.vb
@@ -142,21 +142,25 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     datalist.Add(data)
                     data = New PropertyControlData(MyAppDISPIDs.CustomSubMain, Const_CustomSubMain, UseApplicationFrameworkCheckBox, AddressOf CustomSubMainSet, AddressOf CustomSubMainGet, ControlDataFlags.UserPersisted Or ControlDataFlags.UserHandledEvents Or ControlDataFlags.PersistedInVBMyAppFile)
                     datalist.Add(data)
-                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_RootNamespace, Const_RootNamespace, RootNamespaceTextBox, New Control() {RootNamespaceLabel})
-                    data.DisplayPropertyName = My.Resources.Designer.PPG_Property_RootNamespace
+                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_RootNamespace, Const_RootNamespace, RootNamespaceTextBox, New Control() {RootNamespaceLabel}) With {
+                        .DisplayPropertyName = My.Resources.Designer.PPG_Property_RootNamespace
+                    }
                     datalist.Add(data)
                     data = New PropertyControlData(VsProjPropId110.VBPROJPROPID_OutputTypeEx, Const_OutputTypeEx, Nothing, AddressOf OutputTypeSet, AddressOf OutputTypeGet, ControlDataFlags.None, ControlsThatDependOnOutputTypeProperty)
                     datalist.Add(data)
                     data = New PropertyControlData(MyAppDISPIDs.MainForm, Const_MainFormNoRootNS, MainFormTextboxNoRootNS, AddressOf MainFormNoRootNSSet, Nothing, ControlDataFlags.UserPersisted Or ControlDataFlags.PersistedInVBMyAppFile)
                     datalist.Add(data)
-                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_StartupObject, Const_StartupObject, StartupObjectComboBox, AddressOf StartupObjectSet, AddressOf StartupObjectGet, ControlDataFlags.UserHandledEvents, ControlsThatDependOnStartupObjectProperty)
-                    data.DisplayPropertyName = My.Resources.Designer.PPG_Property_StartupObject
+                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_StartupObject, Const_StartupObject, StartupObjectComboBox, AddressOf StartupObjectSet, AddressOf StartupObjectGet, ControlDataFlags.UserHandledEvents, ControlsThatDependOnStartupObjectProperty) With {
+                        .DisplayPropertyName = My.Resources.Designer.PPG_Property_StartupObject
+                    }
                     datalist.Add(data)
-                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_AssemblyName, "AssemblyName", AssemblyNameTextBox, New Control() {AssemblyNameLabel})
-                    data.DisplayPropertyName = My.Resources.Designer.PPG_Property_AssemblyName
+                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_AssemblyName, "AssemblyName", AssemblyNameTextBox, New Control() {AssemblyNameLabel}) With {
+                        .DisplayPropertyName = My.Resources.Designer.PPG_Property_AssemblyName
+                    }
                     datalist.Add(data)
-                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_ApplicationIcon, "ApplicationIcon", IconCombobox, AddressOf ApplicationIconSet, AddressOf ApplicationIconGet, ControlDataFlags.UserHandledEvents, New Control() {IconLabel, IconPicturebox})
-                    data.DisplayPropertyName = My.Resources.Designer.PPG_Property_ApplicationIcon
+                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_ApplicationIcon, "ApplicationIcon", IconCombobox, AddressOf ApplicationIconSet, AddressOf ApplicationIconGet, ControlDataFlags.UserHandledEvents, New Control() {IconLabel, IconPicturebox}) With {
+                        .DisplayPropertyName = My.Resources.Designer.PPG_Property_ApplicationIcon
+                    }
                     datalist.Add(data)
                     data = New PropertyControlData(VBProjPropId.VBPROJPROPID_MyType, Const_MyType, Nothing, AddressOf MyTypeSet, AddressOf MyTypeGet)
                     datalist.Add(data)

--- a/src/Microsoft.VisualStudio.Editors/PropPages/AssemblyInfoPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AssemblyInfoPropPage.vb
@@ -72,16 +72,19 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     datalist.Add(data)
                     data = New PropertyControlData(VsProjPropId80.VBPROJPROPID_AssemblyTrademark, "Trademark", Trademark, ControlDataFlags.PersistedInAssemblyInfoFile, New Control() {TrademarkLabel})
                     datalist.Add(data)
-                    data = New PropertyControlData(VsProjPropId80.VBPROJPROPID_AssemblyVersion, "AssemblyVersion", AssemblyVersionLayoutPanel, AddressOf VersionSet, AddressOf VersionGet, ControlDataFlags.UserHandledEvents Or ControlDataFlags.PersistedInAssemblyInfoFile, New Control() {AssemblyVersionLabel})
-                    data.DisplayPropertyName = My.Resources.Designer.PPG_Property_AssemblyVersion
+                    data = New PropertyControlData(VsProjPropId80.VBPROJPROPID_AssemblyVersion, "AssemblyVersion", AssemblyVersionLayoutPanel, AddressOf VersionSet, AddressOf VersionGet, ControlDataFlags.UserHandledEvents Or ControlDataFlags.PersistedInAssemblyInfoFile, New Control() {AssemblyVersionLabel}) With {
+                        .DisplayPropertyName = My.Resources.Designer.PPG_Property_AssemblyVersion
+                    }
                     datalist.Add(data)
-                    data = New PropertyControlData(VsProjPropId80.VBPROJPROPID_AssemblyFileVersion, "AssemblyFileVersion", FileVersionLayoutPanel, AddressOf VersionSet, AddressOf VersionGet, ControlDataFlags.UserHandledEvents Or ControlDataFlags.PersistedInAssemblyInfoFile, New Control() {FileVersionLabel})
-                    data.DisplayPropertyName = My.Resources.Designer.PPG_Property_AssemblyFileVersion
+                    data = New PropertyControlData(VsProjPropId80.VBPROJPROPID_AssemblyFileVersion, "AssemblyFileVersion", FileVersionLayoutPanel, AddressOf VersionSet, AddressOf VersionGet, ControlDataFlags.UserHandledEvents Or ControlDataFlags.PersistedInAssemblyInfoFile, New Control() {FileVersionLabel}) With {
+                        .DisplayPropertyName = My.Resources.Designer.PPG_Property_AssemblyFileVersion
+                    }
                     datalist.Add(data)
                     data = New PropertyControlData(VsProjPropId80.VBPROJPROPID_ComVisible, "ComVisible", ComVisibleCheckBox, ControlDataFlags.PersistedInAssemblyInfoFile)
                     datalist.Add(data)
-                    data = New PropertyControlData(VsProjPropId80.VBPROJPROPID_AssemblyGuid, "AssemblyGuid", GuidTextBox, ControlDataFlags.PersistedInAssemblyInfoFile, New Control() {GuidLabel})
-                    data.DisplayPropertyName = My.Resources.Designer.PPG_Property_AssemblyGuid
+                    data = New PropertyControlData(VsProjPropId80.VBPROJPROPID_AssemblyGuid, "AssemblyGuid", GuidTextBox, ControlDataFlags.PersistedInAssemblyInfoFile, New Control() {GuidLabel}) With {
+                        .DisplayPropertyName = My.Resources.Designer.PPG_Property_AssemblyGuid
+                    }
                     datalist.Add(data)
                     data = New PropertyControlData(VsProjPropId80.VBPROJPROPID_NeutralResourcesLanguage, "NeutralResourcesLanguage", NeutralLanguageComboBox, AddressOf NeutralLanguageSet, AddressOf NeutralLanguageGet, ControlDataFlags.PersistedInAssemblyInfoFile, New Control() {NeutralLanguageLabel})
                     datalist.Add(data)

--- a/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel
 Imports System.Windows.Forms
@@ -62,19 +62,22 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     Dim datalist As List(Of PropertyControlData) = New List(Of PropertyControlData)
                     Dim data As PropertyControlData
 
-                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_StartURL, "StartURL", StartURL, ControlDataFlags.PersistedInProjectUserFile)
-                    data.DisplayPropertyName = My.Resources.Designer.PPG_Property_StartURL
+                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_StartURL, "StartURL", StartURL, ControlDataFlags.PersistedInProjectUserFile) With {
+                        .DisplayPropertyName = My.Resources.Designer.PPG_Property_StartURL
+                    }
                     datalist.Add(data)
 
                     data = New PropertyControlData(VsProjPropId.VBPROJPROPID_StartArguments, "StartArguments", StartArguments, ControlDataFlags.PersistedInProjectUserFile, New Control() {CommandLineArgsLabel})
                     datalist.Add(data)
 
-                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_StartWorkingDirectory, "StartWorkingDirectory", StartWorkingDirectory, ControlDataFlags.PersistedInProjectUserFile, New Control() {StartWorkingDirectoryBrowse, WorkingDirLabel})
-                    data.DisplayPropertyName = My.Resources.Designer.PPG_Property_StartWorkingDirectory
+                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_StartWorkingDirectory, "StartWorkingDirectory", StartWorkingDirectory, ControlDataFlags.PersistedInProjectUserFile, New Control() {StartWorkingDirectoryBrowse, WorkingDirLabel}) With {
+                        .DisplayPropertyName = My.Resources.Designer.PPG_Property_StartWorkingDirectory
+                    }
                     datalist.Add(data)
 
-                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_StartProgram, "StartProgram", StartProgram, ControlDataFlags.PersistedInProjectUserFile)
-                    data.DisplayPropertyName = My.Resources.Designer.PPG_Property_StartProgram
+                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_StartProgram, "StartProgram", StartProgram, ControlDataFlags.PersistedInProjectUserFile) With {
+                        .DisplayPropertyName = My.Resources.Designer.PPG_Property_StartProgram
+                    }
                     datalist.Add(data)
 
                     data = New PropertyControlData(VsProjPropId.VBPROJPROPID_StartAction, "StartAction", Nothing,
@@ -88,8 +91,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     data = New PropertyControlData(VsProjPropId.VBPROJPROPID_EnableUnmanagedDebugging, "EnableUnmanagedDebugging", EnableUnmanagedDebugging, ControlDataFlags.PersistedInProjectUserFile)
                     datalist.Add(data)
 
-                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_RemoteDebugMachine, "RemoteDebugMachine", RemoteDebugMachine, ControlDataFlags.PersistedInProjectUserFile)
-                    data.DisplayPropertyName = My.Resources.Designer.PPG_Property_RemoteDebugMachine
+                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_RemoteDebugMachine, "RemoteDebugMachine", RemoteDebugMachine, ControlDataFlags.PersistedInProjectUserFile) With {
+                        .DisplayPropertyName = My.Resources.Designer.PPG_Property_RemoteDebugMachine
+                    }
                     datalist.Add(data)
 
                     data = New PropertyControlData(VsProjPropId.VBPROJPROPID_RemoteDebugEnabled, "RemoteDebugEnabled", RemoteDebugEnabled, ControlDataFlags.PersistedInProjectUserFile)

--- a/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.vb
@@ -211,11 +211,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     datalist.Add(data)
                     data = New PropertyControlData(118, "NeutralLanguage", NeutralLanguageComboBox, AddressOf NeutralLanguageSet, AddressOf NeutralLanguageGet, ControlDataFlags.None, New Control() {NeutralLanguageLabel})
                     datalist.Add(data)
-                    data = New PropertyControlData(119, "AssemblyVersion", AssemblyVersionLayoutPanel, AddressOf VersionSet, AddressOf VersionGet, ControlDataFlags.None, New Control() {AssemblyVersionLabel})
-                    data.DisplayPropertyName = My.Resources.Designer.PPG_Property_AssemblyVersion
+                    data = New PropertyControlData(119, "AssemblyVersion", AssemblyVersionLayoutPanel, AddressOf VersionSet, AddressOf VersionGet, ControlDataFlags.None, New Control() {AssemblyVersionLabel}) With {
+                        .DisplayPropertyName = My.Resources.Designer.PPG_Property_AssemblyVersion
+                    }
                     datalist.Add(data)
-                    data = New PropertyControlData(120, "FileVersion", FileVersionLayoutPanel, AddressOf VersionSet, AddressOf VersionGet, ControlDataFlags.None, New Control() {AssemblyFileVersionLabel})
-                    data.DisplayPropertyName = My.Resources.Designer.PPG_Property_AssemblyFileVersion
+                    data = New PropertyControlData(120, "FileVersion", FileVersionLayoutPanel, AddressOf VersionSet, AddressOf VersionGet, ControlDataFlags.None, New Control() {AssemblyFileVersionLabel}) With {
+                        .DisplayPropertyName = My.Resources.Designer.PPG_Property_AssemblyFileVersion
+                    }
                     datalist.Add(data)
                     m_ControlData = datalist.ToArray()
                 End If

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePropPage.vb
@@ -253,7 +253,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 End Select
 
                 If processedDelayRefreshMessage Then
-                    Internal.Performance.CodeMarkers.Instance.CodeMarker(Internal.Performance.RoslynCodeMarkerEvent.perfMSVSEditorsReferencePagePostponedUIRefreshDone)
+                    Internal.Performance.CodeMarkers.Instance.CodeMarker(Internal.Performance.RoslynCodeMarkerEvent.PerfMSVSEditorsReferencePagePostponedUIRefreshDone)
                 End If
             Catch ex As COMException
                 ' The message pump in the background compiler could process our pending message, and when the compiler is running, we would get E_PENDING failure
@@ -358,8 +358,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
             Dim lvi As ListViewItem
 
-            lvi = New ListViewItem(webRef.Name)
-            lvi.Tag = refObject
+            lvi = New ListViewItem(webRef.Name) With {
+                .Tag = refObject
+            }
 
             lvi.SubItems.Add("WEB") 'Type
             lvi.SubItems.Add("") ' Version
@@ -382,8 +383,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
             Dim lvi As ListViewItem
 
-            lvi = New ListViewItem(serviceReference.[Namespace])
-            lvi.Tag = serviceReference
+            lvi = New ListViewItem(serviceReference.[Namespace]) With {
+                .Tag = serviceReference
+            }
 
             lvi.SubItems.Add("SERVICE") 'Type
             lvi.SubItems.Add("") ' Version
@@ -1124,7 +1126,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                         PopulateReferenceList()
                         PopulateImportsList(True)
 
-                        Internal.Performance.CodeMarkers.Instance.CodeMarker(Internal.Performance.RoslynCodeMarkerEvent.perfMSVSEditorsReferencePageWCFAdded)
+                        Internal.Performance.CodeMarkers.Instance.CodeMarker(Internal.Performance.RoslynCodeMarkerEvent.PerfMSVSEditorsReferencePageWCFAdded)
                     End If
                 Catch ex As Exception When ReportWithoutCrash(ex, NameOf(serviceReferenceToolStripMenuItem_Click), NameOf(ReferencePropPage))
                     If Not IsCheckoutCanceledException(ex) Then

--- a/src/Microsoft.VisualStudio.Editors/PropPages/UnusedReferencePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/UnusedReferencePropPage.vb
@@ -313,8 +313,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Private Sub BeginGetUnusedRefs()
 
             ' Get a new timer
-            _getUnusedRefsTimer = New Timer
-            _getUnusedRefsTimer.Interval = PollingRate
+            _getUnusedRefsTimer = New Timer With {
+                .Interval = PollingRate
+            }
             AddHandler _getUnusedRefsTimer.Tick, AddressOf OnGetUnusedRefsTimerTick
 
             _lastStatus = ReferenceUsageResult.ReferenceUsageUnknown

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/AppDotXamlDocument.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/AppDotXamlDocument.vb
@@ -471,8 +471,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
             End If
 
             Dim sb As New StringBuilder()
-            Dim settings As New XmlWriterSettings
-            settings.ConformanceLevel = ConformanceLevel.Fragment
+            Dim settings As New XmlWriterSettings With {
+                .ConformanceLevel = ConformanceLevel.Fragment
+            }
             Dim xmlWriter As XmlWriter = XmlWriter.Create(sb, settings)
             xmlWriter.WriteString(value)
             xmlWriter.Close()
@@ -498,8 +499,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
             'Make as content of an element
             Dim xml As String = "<a>" & value & "</a>"
             Dim stringReader As New StringReader(xml)
-            Dim settings As New XmlReaderSettings
-            settings.ConformanceLevel = ConformanceLevel.Fragment
+            Dim settings As New XmlReaderSettings With {
+                .ConformanceLevel = ConformanceLevel.Fragment
+            }
             Dim xmlReader As XmlReader = XmlReader.Create(stringReader, settings)
             xmlReader.ReadToFollowing("a")
 
@@ -536,10 +538,10 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         Private Function CreateXmlTextReader() As XmlTextReader
             Debug.Assert(_debugBufferLockCount > 0, "Should be using BufferLock!")
             Dim stringReader As New StringReader(GetAllText())
-            Dim xmlTextReader As XmlTextReader = New XmlTextReader(stringReader)
-
             ' Required by Fxcop rule CA3054 - DoNotAllowDTDXmlTextReader
-            xmlTextReader.DtdProcessing = DtdProcessing.Prohibit
+            Dim xmlTextReader As XmlTextReader = New XmlTextReader(stringReader) With {
+                .DtdProcessing = DtdProcessing.Prohibit
+            }
             Return xmlTextReader
         End Function
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
@@ -161,13 +161,15 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
 
                     'StartupObject.  
                     'StartupObjectOrUri must be kept after OutputType because it depends on the initialization of "OutputType" values
-                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_StartupObject, Const_StartupObject, Nothing, ControlDataFlags.Hidden)
-                    data.DisplayPropertyName = My.Resources.Designer.PPG_Property_StartupObject
+                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_StartupObject, Const_StartupObject, Nothing, ControlDataFlags.Hidden) With {
+                        .DisplayPropertyName = My.Resources.Designer.PPG_Property_StartupObject
+                    }
                     list.Add(data)
 
                     'RootNamespace
-                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_RootNamespace, Const_RootNamespace, RootNamespaceTextBox, New Control() {RootNamespaceLabel})
-                    data.DisplayPropertyName = My.Resources.Designer.PPG_Property_RootNamespace
+                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_RootNamespace, Const_RootNamespace, RootNamespaceTextBox, New Control() {RootNamespaceLabel}) With {
+                        .DisplayPropertyName = My.Resources.Designer.PPG_Property_RootNamespace
+                    }
                     list.Add(data)
 
                     'OutputType
@@ -190,13 +192,15 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                         ControlsThatDependOnStartupObjectOrUriProperty))
 
                     'AssemblyName
-                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_AssemblyName, "AssemblyName", AssemblyNameTextBox, New Control() {AssemblyNameLabel})
-                    data.DisplayPropertyName = My.Resources.Designer.PPG_Property_AssemblyName
+                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_AssemblyName, "AssemblyName", AssemblyNameTextBox, New Control() {AssemblyNameLabel}) With {
+                        .DisplayPropertyName = My.Resources.Designer.PPG_Property_AssemblyName
+                    }
                     list.Add(data)
 
                     'ApplicationIcon
-                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_ApplicationIcon, "ApplicationIcon", IconCombobox, AddressOf ApplicationIconSet, AddressOf ApplicationIconGet, ControlDataFlags.UserHandledEvents, New Control() {IconLabel, IconPicturebox})
-                    data.DisplayPropertyName = My.Resources.Designer.PPG_Property_ApplicationIcon
+                    data = New PropertyControlData(VsProjPropId.VBPROJPROPID_ApplicationIcon, "ApplicationIcon", IconCombobox, AddressOf ApplicationIconSet, AddressOf ApplicationIconGet, ControlDataFlags.UserHandledEvents, New Control() {IconLabel, IconPicturebox}) With {
+                        .DisplayPropertyName = My.Resources.Designer.PPG_Property_ApplicationIcon
+                    }
                     list.Add(data)
 
                     'ShutdownMode (user-defined)
@@ -1741,8 +1745,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
 
             SuspendLayout()
             overarchingTableLayoutPanel.Visible = False
-            _pageErrorControl = New AppDotXamlErrorControl(message)
-            _pageErrorControl.Dock = DockStyle.Fill
+            _pageErrorControl = New AppDotXamlErrorControl(message) With {
+                .Dock = DockStyle.Fill
+            }
             Controls.Add(_pageErrorControl)
             _pageErrorControl.BringToFront()
             _pageErrorControl.Visible = True

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/FileWatcher.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/FileWatcher.vb
@@ -603,8 +603,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     'This is the first notification we've seen - create a timer to track the
                     '  delay.
                     Debug.WriteLineIf(Switches.RSEFileWatcher.TraceVerbose, "        Enabling timer delay of " & DelayInMilliseconds & "ms.")
-                    _timer = New Timer
-                    _timer.Interval = DelayInMilliseconds
+                    _timer = New Timer With {
+                        .Interval = DelayInMilliseconds
+                    }
                 Else
                     'We already have a timer, so that means we're in the delay stage of
                     '  a previous notification of the same event.  We'll reset the timer

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
@@ -565,10 +565,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             '
             ' m_toolbarPanel
             '
-            _toolbarPanel = New DesignerToolbarPanel()
-            _toolbarPanel.Dock = DockStyle.Top
-            _toolbarPanel.Name = "ToolbarPanel"
-            _toolbarPanel.Text = "ToolbarPanel"
+            _toolbarPanel = New DesignerToolbarPanel With {
+                .Dock = DockStyle.Top,
+                .Name = "ToolbarPanel",
+                .Text = "ToolbarPanel"
+            }
             '
             'ResourceEditorView
             '

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceFile.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceFile.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -888,8 +888,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             If _resxService IsNot Nothing Then
                 ResXWriter = _resxService.GetResXResourceWriter(TextWriter, _basePath)
             Else
-                Dim r As New ResXResourceWriter(TextWriter, AddressOf TypeNameConverter)
-                r.BasePath = _basePath
+                Dim r As New ResXResourceWriter(TextWriter, AddressOf TypeNameConverter) With {
+                    .BasePath = _basePath
+                }
 
                 ResXWriter = r
             End If

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceListView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceListView.vb
@@ -453,9 +453,10 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             End If
 
             'Set up the state imagelist (for displaying error glyphs next to the listview items)
-            _stateImageList = New ImageList()
-            _stateImageList.ColorDepth = ColorDepth.Depth8Bit
-            _stateImageList.ImageSize = ParentView.CachedResources.ErrorGlyphState.Size
+            _stateImageList = New ImageList With {
+                .ColorDepth = ColorDepth.Depth8Bit,
+                .ImageSize = ParentView.CachedResources.ErrorGlyphState.Size
+            }
             _stateImageList.Images.Add(ParentView.CachedResources.ErrorGlyphState)
             StateImageList = _stateImageList
 
@@ -1016,10 +1017,10 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             End If
 
             'Create the base ListViewItem with the name and image index
-            e.Item = New ListViewItem(Resource.Name, ImageListIndex)
-
             'Fill in any error information, if this resource has task list items
-            e.Item.ToolTipText = ResourceFile.GetResourceTaskMessages(Resource)
+            e.Item = New ListViewItem(Resource.Name, ImageListIndex) With {
+                .ToolTipText = ResourceFile.GetResourceTaskMessages(Resource)
+            }
             If ResourceFile.ResourceHasTasks(Resource) Then
                 'This resource has some task list items.  Need to set its state to
                 '  show the error glyph.
@@ -1307,10 +1308,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             End If
 
             If Handle <> IntPtr.Zero Then
-                Dim lvi As New LVITEM
-                lvi.mask = LVIF_STATE
-                lvi.state = state
-                lvi.stateMask = mask
+                Dim lvi As New LVITEM With {
+                    .mask = LVIF_STATE,
+                    .state = state,
+                    .stateMask = mask
+                }
                 SendMessage(Handle, LVM_SETITEMSTATE, index, lvi)
             End If
         End Sub

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
@@ -364,11 +364,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <returns></returns>
         ''' <remarks></remarks>
         Private Function CreateNewResourceRow() As DataGridViewRow
-            Dim NewRow As New DataGridViewRow
-
             'The error glyphs don't show up if the row height is below the glyph size.  We don't want that
             '  to happen, so restrict the minimum height.
-            NewRow.MinimumHeight = Math.Max(DpiHelper.LogicalToDeviceUnitsY(RowMinimumHeight), Font.Height + DpiHelper.LogicalToDeviceUnitsY(ROW_BORDER_HEIGHT))
+            Dim NewRow As New DataGridViewRow With {
+                .MinimumHeight = Math.Max(DpiHelper.LogicalToDeviceUnitsY(RowMinimumHeight), Font.Height + DpiHelper.LogicalToDeviceUnitsY(ROW_BORDER_HEIGHT))
+            }
 
             'Build up the new row (with blank values) cell by cell
 

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/AppConfigSerializer.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/AppConfigSerializer.vb
@@ -78,9 +78,10 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 Dim settingType As Type = typeCache.GetSettingType(Instance.SettingTypeName)
                 ' We need a name and a type to be able to serialize this guy... unless it is a connection string, of course!
                 If Instance.Name <> "" AndAlso settingType IsNot Nothing AndAlso settingType IsNot GetType(SerializableConnectionString) Then
-                    Dim NewProp As New SettingsProperty(Instance.Name)
-                    NewProp.PropertyType = settingType
-                    NewProp.SerializeAs = ConfigHelperService.GetSerializeAs(settingType)
+                    Dim NewProp As New SettingsProperty(Instance.Name) With {
+                        .PropertyType = settingType,
+                        .SerializeAs = ConfigHelperService.GetSerializeAs(settingType)
+                    }
                     If Instance.Scope = DesignTimeSettingInstance.SettingScope.Application Then
                         AppScopedSettingProps.Add(NewProp)
                     Else
@@ -92,23 +93,25 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ' Deserialize conenction strings
             '
             ' First, we ask the config helper to read all the connection strings....
-            Dim DeserializedConnectionStrings As ConnectionStringSettingsCollection = _
+            Dim DeserializedConnectionStrings As ConnectionStringSettingsCollection =
                 ConfigHelperService.ReadConnectionStrings(AppConfigDocData.Name, AppConfigDocData, SectionName)
 
             ' Deserialize "normal" app scoped and user scoped settings
-            Dim configFileMap As New ExeConfigurationFileMap
-            configFileMap.ExeConfigFilename = AppConfigDocData.Name
-            Dim DeserializedAppScopedSettingValues As SettingsPropertyValueCollection = _
+            Dim configFileMap As New ExeConfigurationFileMap With {
+                .ExeConfigFilename = AppConfigDocData.Name
+            }
+            Dim DeserializedAppScopedSettingValues As SettingsPropertyValueCollection =
                 ConfigHelperService.ReadSettings(configFileMap, ConfigurationUserLevel.None, AppConfigDocData, SectionName, False, AppScopedSettingProps)
-            Dim DeserializedUserScopedSettingValues As SettingsPropertyValueCollection = _
+            Dim DeserializedUserScopedSettingValues As SettingsPropertyValueCollection =
                 ConfigHelperService.ReadSettings(configFileMap, ConfigurationUserLevel.None, AppConfigDocData, SectionName, True, UserScopedSettingProps)
 
             Dim valueSerializer As New SettingsValueSerializer()
 
             ' Then we go through each read setting to see if we have to add/change the setting
             For Each cs As ConnectionStringSettings In DeserializedConnectionStrings
-                Dim scs As New SerializableConnectionString
-                scs.ConnectionString = cs.ConnectionString
+                Dim scs As New SerializableConnectionString With {
+                    .ConnectionString = cs.ConnectionString
+                }
                 If cs.ProviderName <> "" Then
                     scs.ProviderName = cs.ProviderName
                 End If
@@ -320,11 +323,13 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                             ExistingConnectionStringSettings.Add(conStringSetting)
                         End If
                     Else
-                        Dim Prop As New SettingsProperty(Instance.Name)
-                        Prop.PropertyType = settingType
+                        Dim Prop As New SettingsProperty(Instance.Name) With {
+                            .PropertyType = settingType
+                        }
                         Prop.SerializeAs = ConfigHelperService.GetSerializeAs(Prop.PropertyType)
-                        Dim PropVal As New SettingsPropertyValue(Prop)
-                        PropVal.SerializedValue = Instance.SerializedValue
+                        Dim PropVal As New SettingsPropertyValue(Prop) With {
+                            .SerializedValue = Instance.SerializedValue
+                        }
                         If Instance.Scope = DesignTimeSettingInstance.SettingScope.Application Then
                             ExistingApplicationScopedSettings.Add(PropVal)
                         Else
@@ -335,9 +340,9 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             Next
 
             ' Let us populate the settings with values from app.config file 
-            Dim configFileMap As New ExeConfigurationFileMap
-
-            configFileMap.ExeConfigFilename = AppConfigDocData.Name
+            Dim configFileMap As New ExeConfigurationFileMap With {
+                .ExeConfigFilename = AppConfigDocData.Name
+            }
             ConfigHelperService.WriteConnectionStrings(AppConfigDocData.Name, AppConfigDocData, SectionName, ExistingConnectionStringSettings)
             ConfigHelperService.WriteSettings(configFileMap, ConfigurationUserLevel.None, AppConfigDocData, SectionName, True, ExistingUserScopedSettings)
             ConfigHelperService.WriteSettings(configFileMap, ConfigurationUserLevel.None, AppConfigDocData, SectionName, False, ExistingApplicationScopedSettings)
@@ -466,14 +471,15 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <returns></returns>
         ''' <remarks></remarks>
         Private Shared Function LoadAppConfigDocument(Reader As TextReader) As XmlDocument
-            Dim AppConfigXmlDoc As New XmlDocument()
-            AppConfigXmlDoc.PreserveWhitespace = False
+            Dim AppConfigXmlDoc As New XmlDocument With {
+                .PreserveWhitespace = False
+            }
             ' Load App.Config into XML Doc
-            Dim XmlAppConfigReader As New XmlTextReader(Reader)
-
             ' Required by Fxcop rule CA3054 - DoNotAllowDTDXmlTextReader
-            XmlAppConfigReader.DtdProcessing = DtdProcessing.Prohibit
-            XmlAppConfigReader.WhitespaceHandling = WhitespaceHandling.All
+            Dim XmlAppConfigReader As New XmlTextReader(Reader) With {
+                .DtdProcessing = DtdProcessing.Prohibit,
+                .WhitespaceHandling = WhitespaceHandling.All
+            }
             AppConfigXmlDoc.Load(XmlAppConfigReader)
             Return AppConfigXmlDoc
         End Function

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ConnectionStringUITypeEditor.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ConnectionStringUITypeEditor.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.drawing.Design
 Imports Microsoft.VisualStudio.Data.Core
@@ -146,9 +146,11 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                     If (dataConnectionDialog.SaveSelection) Then
                         dataConnectionDialog.SaveSourceSelection()
                     End If
-                    Dim newValue As New SerializableConnectionString
-                    newValue.ProviderName = GetInvariantProviderNameFromGuid(providerMapper, dataConnectionDialog.SelectedProvider)
-                    newValue.ConnectionString = GetConnectionString(ServiceProvider, dataConnectionDialog, Not containedSensitiveData)
+
+                    Dim newValue As New SerializableConnectionString With {
+                        .ProviderName = GetInvariantProviderNameFromGuid(providerMapper, dataConnectionDialog.SelectedProvider),
+                        .ConnectionString = GetConnectionString(ServiceProvider, dataConnectionDialog, Not containedSensitiveData)
+                    }
                     If dteProj IsNot Nothing AndAlso connectionStringConverter IsNot Nothing Then
                         ' Go back to the runtime representation of the string...
                         newValue.ConnectionString = connectionStringConverter.ToRunTime(dteProj, newValue.ConnectionString, newValue.ProviderName)

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DataGridViewUITypeEditorCell.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DataGridViewUITypeEditorCell.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel
 Imports System.Drawing
@@ -182,8 +182,9 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
             ' Draw the formatted value
             If formattedValue IsNot Nothing Then
-                Dim sf As New StringFormat
-                sf.LineAlignment = StringAlignment.Center
+                Dim sf As New StringFormat With {
+                    .LineAlignment = StringAlignment.Center
+                }
                 Using ForeColorBrush As New SolidBrush(DrawForeColor)
                     graphics.DrawString(formattedValue.ToString(), cellStyle.Font, ForeColorBrush, StringBounds, sf)
                 End Using

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSerializer.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSerializer.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.IO
 Imports System.Xml
@@ -114,8 +114,9 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ' CONSIDER, should I throw here to prevent the designer loader from blowing up / loading only part
             ' of the file and clobber it on the next write
 
-            Dim xmlReader As XmlTextReader = New XmlTextReader(Reader)
-            xmlReader.Normalization = False
+            Dim xmlReader As XmlTextReader = New XmlTextReader(Reader) With {
+                .Normalization = False
+            }
 
             XmlDoc.Load(xmlReader)
 
@@ -187,8 +188,8 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 If Not Settings.IsValidName(newSettingName) Then
                     Throw New SettingsSerializerException(My.Resources.Designer.GetString(My.Resources.Designer.SD_ERR_InvalidIdentifier_1Arg, nameAttr.Value))
                 End If
-                Dim Instance As DesignTimeSettingInstance = Settings.AddNew(typeAttr.Value, _
-                                                                            newSettingName, _
+                Dim Instance As DesignTimeSettingInstance = Settings.AddNew(typeAttr.Value,
+                                                                            newSettingName,
                                                                             True)
                 If scopeAttr.Value.Equals(SettingsDesigner.ApplicationScopeName, StringComparison.Ordinal) Then
                     Instance.SetScope(DesignTimeSettingInstance.SettingScope.Application)
@@ -247,9 +248,10 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ' Gotta store the namespace here in case it changes from under us!
             Settings.PersistedNamespace = GeneratedClassNameSpace
 
-            Dim SettingsWriter As New XmlTextWriter(Writer)
-            SettingsWriter.Formatting = Formatting.Indented
-            SettingsWriter.Indentation = 2
+            Dim SettingsWriter As New XmlTextWriter(Writer) With {
+                .Formatting = Formatting.Indented,
+                .Indentation = 2
+            }
             ' NOTE, VsWhidbey 294747, Can I assume UTF-8 encoding? Nope, it seems that the DocDataTextWriter uses
             ' Unicode.Default! Probably should file a bug / change request for this... gotta make 100%
             ' sure what encoding is actually used first!

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
@@ -279,11 +279,11 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ' Create the strongly typed settings class
             ' VsWhidbey 234144, Make sure this is a valid class name
             '
-            generatedType = New CodeTypeDeclaration(SettingsDesigner.GeneratedClassName(Hierarchy, VSITEMID.NIL, Settings, FilePath))
-
             ' pick up the default visibility
             '
-            generatedType.TypeAttributes = GeneratedClassVisibility
+            generatedType = New CodeTypeDeclaration(SettingsDesigner.GeneratedClassName(Hierarchy, VSITEMID.NIL, Settings, FilePath)) With {
+                .TypeAttributes = GeneratedClassVisibility
+            }
 
             ' Set the base class
             '
@@ -389,12 +389,13 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             '
             '   Public Shared ReadOnly Property [Default]() As Settings
             '
-            Dim CodeProperty As New CodeMemberProperty
-            CodeProperty.Attributes = MemberAttributes.Public Or MemberAttributes.Static
-            CodeProperty.Name = DefaultInstancePropertyName
-            CodeProperty.Type = SettingsClassTypeReference
-            CodeProperty.HasGet = True
-            CodeProperty.HasSet = False
+            Dim CodeProperty As New CodeMemberProperty With {
+                .Attributes = MemberAttributes.Public Or MemberAttributes.Static,
+                .Name = DefaultInstancePropertyName,
+                .Type = SettingsClassTypeReference,
+                .HasGet = True,
+                .HasSet = False
+            }
 
             ' We should hook up the My.Application.Shutdown event if told to auto save the 
             ' settings (only applicable for the main settings file & only applicable for VB)
@@ -419,9 +420,8 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
                 ' Add the AddHandler call that hooks My.Application.Shutdown inside the default-instance getter
                 '
-                Dim AutoSaveSnippet As New CodeSnippetExpression()
-
-                AutoSaveSnippet.Value =
+                Dim AutoSaveSnippet As New CodeSnippetExpression With {
+                    .Value =
                     Environment.NewLine &
                     MyTypeWinFormsDefineConstant_If & Environment.NewLine &
                     "               If Not " & AddedHandlerFieldName & " Then" & Environment.NewLine &
@@ -433,6 +433,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                     "                    End SyncLock" & Environment.NewLine &
                     "                End If" & Environment.NewLine &
                     MyTypeWinFormsDefineConstant_EndIf
+                }
 
                 CodeProperty.GetStatements.Add(AutoSaveSnippet)
             End If
@@ -441,8 +442,9 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             '
             '   Return defaultInstance
             '
-            Dim ValueReference As New CodeFieldReferenceExpression()
-            ValueReference.FieldName = DefaultInstanceFieldName
+            Dim ValueReference As New CodeFieldReferenceExpression With {
+                .FieldName = DefaultInstanceFieldName
+            }
             CodeProperty.GetStatements.Add(New CodeMethodReturnStatement(ValueReference))
 
             ' And last, add the property to the class we're generating
@@ -458,13 +460,15 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         '@ <returns></returns>
         '@ <remarks></remarks>
         Private Shared Function CodeDomPropertyFromSettingInstance(TypeNameResolver As SettingTypeNameResolutionService, Instance As DesignTimeSettingInstance, IsDesignTime As Boolean, GenerateProgress As IVsGeneratorProgress) As CodeMemberProperty
-            Dim CodeProperty As New CodeMemberProperty
-            CodeProperty.Attributes = SettingsPropertyVisibility
-            CodeProperty.Name = Instance.Name
+            Dim CodeProperty As New CodeMemberProperty With {
+                .Attributes = SettingsPropertyVisibility,
+                .Name = Instance.Name
+            }
             Dim fxTypeName As String = TypeNameResolver.PersistedSettingTypeNameToFxTypeName(Instance.SettingTypeName)
 
-            CodeProperty.Type = New CodeTypeReference(fxTypeName)
-            CodeProperty.Type.Options = CodeTypeReferenceOptions.GlobalReference
+            CodeProperty.Type = New CodeTypeReference(fxTypeName) With {
+                .Options = CodeTypeReferenceOptions.GlobalReference
+            }
 
             CodeProperty.HasGet = True
             CodeProperty.GetStatements.AddRange(GenerateGetterStatements(Instance, CodeProperty.Type))
@@ -692,8 +696,8 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             '    Private Shared addedHandler As Boolean
             ' #End If
             '
-            Dim AutoSaveCode As New CodeSnippetTypeMember()
-            AutoSaveCode.Text =
+            Dim AutoSaveCode As New CodeSnippetTypeMember With {
+                .Text =
                 String.Format(HideAutoSaveRegionBegin, My.Resources.Designer.SD_SFG_AutoSaveRegionText) & Environment.NewLine &
                 MyTypeWinFormsDefineConstant_If & Environment.NewLine &
                 "    Private Shared " & AddedHandlerFieldName & " As Boolean" & Environment.NewLine &
@@ -708,6 +712,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 "    End Sub" & Environment.NewLine &
                 MyTypeWinFormsDefineConstant_EndIf & Environment.NewLine &
                 HideAutoSaveRegionEnd
+            }
 
             GeneratedType.Members.Add(AutoSaveCode)
 
@@ -717,13 +722,15 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
             ' Create a property named Settings
             '
-            Dim SettingProperty As New CodeMemberProperty
-            SettingProperty.Name = MySettingsPropertyName
-            SettingProperty.HasGet = True
-            SettingProperty.HasSet = False
+            Dim SettingProperty As New CodeMemberProperty With {
+                .Name = MySettingsPropertyName,
+                .HasGet = True,
+                .HasSet = False
+            }
 
-            Dim fullTypeReference As CodeTypeReference = New CodeTypeReference(GetFullTypeName(projectRootNamespace, defaultNamespace, GeneratedType.Name))
-            fullTypeReference.Options = CodeTypeReferenceOptions.GlobalReference
+            Dim fullTypeReference As CodeTypeReference = New CodeTypeReference(GetFullTypeName(projectRootNamespace, defaultNamespace, GeneratedType.Name)) With {
+                .Options = CodeTypeReferenceOptions.GlobalReference
+            }
             SettingProperty.Type = fullTypeReference
             SettingProperty.Attributes = MemberAttributes.Assembly Or MemberAttributes.Final
 
@@ -921,8 +928,9 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <returns></returns>
         ''' <remarks></remarks>
         Private Shared Function CreateGlobalCodeTypeReference(type As Type) As CodeTypeReference
-            Dim ctr As New CodeTypeReference(type)
-            ctr.Options = CodeTypeReferenceOptions.GlobalReference
+            Dim ctr As New CodeTypeReference(type) With {
+                .Options = CodeTypeReferenceOptions.GlobalReference
+            }
             Return ctr
         End Function
 

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsValueSerializer.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsValueSerializer.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel
 Imports System.Configuration
@@ -22,9 +22,10 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 Return serializedValue
             End If
 
-            Dim Prop As New SettingsProperty("") ' We don't care about the name for the setting.... 
-            Prop.ThrowOnErrorDeserializing = True
-            Prop.PropertyType = ValueType
+            Dim Prop As New SettingsProperty("") With {
+                .ThrowOnErrorDeserializing = True,
+                .PropertyType = ValueType
+            } ' We don't care about the name for the setting.... 
             Dim propVal As New SettingsPropertyValue(Prop)
             If ValueType IsNot Nothing Then
                 Try
@@ -68,9 +69,10 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
             ' Yet again we have some special handling for connection strings...
             If ValueType Is GetType(VSDesigner.VSDesignerPackage.SerializableConnectionString) AndAlso serializedValue <> "" Then
-                Dim scs As New VSDesigner.VSDesignerPackage.SerializableConnectionString
-                scs.ConnectionString = serializedValue
-                scs.ProviderName = ""
+                Dim scs As New VSDesigner.VSDesignerPackage.SerializableConnectionString With {
+                    .ConnectionString = serializedValue,
+                    .ProviderName = ""
+                }
                 Return scs
             End If
 

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypeEditorHostControl.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypeEditorHostControl.vb
@@ -578,14 +578,15 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 Get
                     Dim BaseParams As CreateParams = MyBase.CreateParams
 
-                    Dim Params As New CreateParams
-                    Params.ClassStyle = 0
-                    Params.Style = Constants.WS_VISIBLE Or Constants.WS_POPUP Or Constants.WS_BORDER
-                    Params.ExStyle = Constants.WS_EX_TOPMOST Or Constants.WS_EX_TOOLWINDOW
-                    Params.Height = Height
-                    Params.Width = Width
-                    Params.X = Left
-                    Params.Y = Top
+                    Dim Params As New CreateParams With {
+                        .ClassStyle = 0,
+                        .Style = Constants.WS_VISIBLE Or Constants.WS_POPUP Or Constants.WS_BORDER,
+                        .ExStyle = Constants.WS_EX_TOPMOST Or Constants.WS_EX_TOOLWINDOW,
+                        .Height = Height,
+                        .Width = Width,
+                        .X = Left,
+                        .Y = Top
+                    }
                     Return Params
                 End Get
             End Property

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypePickerDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypePickerDialog.vb
@@ -39,9 +39,10 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             End If
 
             'Add any initialization after the InitializeComponent() call
-            _typeTreeView = New TypeTV
-            _typeTreeView.AccessibleName = My.Resources.Designer.SD_SelectATypeTreeView_AccessibleName
-            _typeTreeView.Dock = DockStyle.Fill
+            _typeTreeView = New TypeTV With {
+                .AccessibleName = My.Resources.Designer.SD_SelectATypeTreeView_AccessibleName,
+                .Dock = DockStyle.Fill
+            }
             AddHandler _typeTreeView.AfterSelect, AddressOf TypeTreeViewAfterSelectHandler
             AddHandler _typeTreeView.BeforeExpand, AddressOf TypeTreeViewBeforeExpandHandler
             _treeViewPanel.Controls.Add(_typeTreeView)
@@ -368,7 +369,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <returns></returns>
         ''' <remarks></remarks>
         Private Function NormalizeTypeName(displayName As String) As String
-            Dim typeNameResolutionService As SettingTypeNameResolutionService = _
+            Dim typeNameResolutionService As SettingTypeNameResolutionService =
                 DirectCast(GetService(GetType(SettingTypeNameResolutionService)), SettingTypeNameResolutionService)
 
             Debug.Assert(typeNameResolutionService IsNot Nothing, "The settingsdesignerloader should have added a typenameresolutioncomponent service!")
@@ -454,9 +455,10 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
             Public Sub AddAssemblyNode(assemblyName As String)
                 If Not String.IsNullOrEmpty(assemblyName) AndAlso Not Nodes.ContainsKey(assemblyName) Then
-                    Dim asNode As TypeTVNode = New TypeTVNode(NodeType.ASSEMBLY_NODE)
-                    asNode.Text = assemblyName
-                    asNode.Name = assemblyName
+                    Dim asNode As TypeTVNode = New TypeTVNode(NodeType.ASSEMBLY_NODE) With {
+                        .Text = assemblyName,
+                        .Name = assemblyName
+                    }
                     Nodes.Add(asNode)
                     asNode.AddDummyNode()
                 End If
@@ -473,17 +475,19 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                     Dim nsNode As TypeTVNode
 
                     If Not nodes.ContainsKey(nsName) Then
-                        nsNode = New TypeTVNode(NodeType.NAMESPACE_NODE)
-                        nsNode.Text = nsName
-                        nsNode.Name = nsName
+                        nsNode = New TypeTVNode(NodeType.NAMESPACE_NODE) With {
+                            .Text = nsName,
+                            .Name = nsName
+                        }
                         nodes.Add(nsNode)
                     Else
                         nsNode = DirectCast(nodes(nsName), TypeTVNode)
                     End If
                     If Not String.IsNullOrEmpty(typName) AndAlso Not nsNode.Nodes.ContainsKey(typName) Then
-                        Dim typNode As TypeTVNode = New TypeTVNode(NodeType.TYPE_NODE)
-                        typNode.Text = typName
-                        typNode.Name = typName
+                        Dim typNode As TypeTVNode = New TypeTVNode(NodeType.TYPE_NODE) With {
+                            .Text = typName,
+                            .Name = typName
+                        }
                         nsNode.Nodes.Add(typNode)
                     End If
                 End If

--- a/src/Microsoft.VisualStudio.Editors/SettingsGlobalObject/SettingsGlobalObjectProvider.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsGlobalObject/SettingsGlobalObjectProvider.vb
@@ -1378,10 +1378,10 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
             '
             ScrubCompileUnit(ccu)
 
-            Dim builder As New VirtualTypeBuilder()
-
-            builder.BaseType = GetType(ApplicationSettingsBase)
-            builder.Implementor = New SettingsFileTypeImplementor(Me)
+            Dim builder As New VirtualTypeBuilder With {
+                .BaseType = GetType(ApplicationSettingsBase),
+                .Implementor = New SettingsFileTypeImplementor(Me)
+            }
 
             ' We have to make sure that the type resolver is referencing the assembly where the applicationsettingsbase
             ' is defined, otherwise bad things will happen when you try to build the virtual type.
@@ -1578,7 +1578,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
 #If DEBUG Then
                     Debug.WriteLineIf(SettingsGlobalObjectProvider.GlobalSettings.TraceVerbose, "SettingsFileGlobalObject.LoadSettings(" & CStr(_className) & ") -- editLocks=" & editLocks & ", readLocks=" & readLocks & "...")
 #End If
-                Catch Ex As Exception When Common.ReportWithoutCrash(ex, "Failed to get document info for document", NameOf(SettingsGlobalObjectProvider))
+                Catch Ex As Exception When Common.ReportWithoutCrash(Ex, "Failed to get document info for document", NameOf(SettingsGlobalObjectProvider))
                     Throw
                 End Try
 
@@ -1911,7 +1911,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
                 Try
                     Dim projSpecialFiles As IVsProjectSpecialFiles = TryCast(_hierarchy, IVsProjectSpecialFiles)
                     Debug.Assert(projSpecialFiles IsNot Nothing, "Failed to get IVsProjectSpecialFiles from hierarchy!")
-                    VSErrorHandler.ThrowOnFailure( _
+                    VSErrorHandler.ThrowOnFailure(
                         projSpecialFiles.GetFile(__PSFFILEID.PSFFILEID_AppConfig, CUInt(__PSFFLAGS.PSFF_FullPath), appConfigItemid, AppConfigFileName))
                     If appConfigItemid = VSITEMID.NIL Then
                         ' If the file didn't exist in the project, we should save it
@@ -1919,8 +1919,8 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
                     Else
                         ' The the file *is* in the project, we only save it if we can't find the associated
                         ' docdata in the RDT...
-                        VSErrorHandler.ThrowOnFailure( _
-                            _provider.RunningDocTable.FindAndLockDocument(rdtLockType, AppConfigFileName, appConfigHier, appConfigItemid, pAppConfigUnkDocData, appConfigCookie) _
+                        VSErrorHandler.ThrowOnFailure(
+                            _provider.RunningDocTable.FindAndLockDocument(rdtLockType, AppConfigFileName, appConfigHier, appConfigItemid, pAppConfigUnkDocData, appConfigCookie)
                             )
                         '... and the way we decide that is by checking the returned native docdata
                         shouldSaveAppConfig = (pAppConfigUnkDocData = IntPtr.Zero)
@@ -1940,13 +1940,13 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
                         Using appConfigDocData
                             Using appConfigChangeMarker As IDisposable = appConfigDocData.CreateChangeMarker()
                                 ' let's serialize the contents of this guy...
-                                AppConfigSerializer.Serialize(Settings, _
-                                                            _typeCache, _
-                                                            _valueCache, _
-                                                            GeneratedClassName, _
-                                                            GeneratedNamespace, _
-                                                            appConfigDocData, _
-                                                            _hierarchy, _
+                                AppConfigSerializer.Serialize(Settings,
+                                                            _typeCache,
+                                                            _valueCache,
+                                                            GeneratedClassName,
+                                                            GeneratedNamespace,
+                                                            appConfigDocData,
+                                                            _hierarchy,
                                                             True)
                                 If shouldSaveAppConfig Then
                                     If appConfigItemid = VSITEMID.NIL OrElse appConfigCookie = 0 Then
@@ -2018,7 +2018,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' This class is the code serializer for SettingsFile global object.
         ''' </summary>
         ''' <remarks></remarks>
-        <Serializable()> _
+        <Serializable()>
         Private NotInheritable Class SettingsFileCodeDomSerializer
             Inherits CodeDomSerializer
 
@@ -2204,8 +2204,8 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
                                         ' DesignerSerializerAttribute  
                                         '
                                         If (attributes(GetType(SettingsGlobalObjectValueAttribute)) Is Nothing OrElse attributes(GetType(DesignTimeVisibleAttribute)) Is Nothing) Then
-                                            TypeDescriptor.AddAttributes(value, _
-                                                                        New DesignTimeVisibleAttribute(False), _
+                                            TypeDescriptor.AddAttributes(value,
+                                                                        New DesignTimeVisibleAttribute(False),
                                                                         New SettingsGlobalObjectValueAttribute(_globalObject, setting.Name))
                                         End If
                                     End If
@@ -2324,7 +2324,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' 
         ''' </summary>
         ''' <remarks></remarks>
-        <Serializable()> _
+        <Serializable()>
         Private Class ConcreteApplicationSettings
             Inherits ApplicationSettingsBase
 
@@ -2403,8 +2403,9 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
 #End If
                 For Each instance As DesignTimeSettingInstance In globalObject.Settings
                     Dim prop As SettingsProperty
-                    prop = New SettingsProperty(instance.Name)
-                    prop.PropertyType = globalObject.ResolveType(instance.SettingTypeName)
+                    prop = New SettingsProperty(instance.Name) With {
+                        .PropertyType = globalObject.ResolveType(instance.SettingTypeName)
+                    }
                     Add(prop)
                 Next
                 Debug.Assert(globalObject IsNot Nothing, "")

--- a/src/Microsoft.VisualStudio.Editors/XmlIntellisense/XmlIntellisense.vb
+++ b/src/Microsoft.VisualStudio.Editors/XmlIntellisense/XmlIntellisense.vb
@@ -120,12 +120,13 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
         '   Initialize the class.
         '--------------------------------------------------------------------------
         Friend Sub New(Container As IServiceContainer, SchemaService As XmlSchemaService, ProjectGuid As Guid)
-            _data = New XmlIntellisenseSchemasData()
-            _data.Container = Container
-            _data.SchemaService = SchemaService
-            _data.ProjectGuid = ProjectGuid
-            _data.CompilationLevel = CompilationLevel
-            _data.SchemasFound = 0
+            _data = New XmlIntellisenseSchemasData With {
+                .Container = Container,
+                .SchemaService = SchemaService,
+                .ProjectGuid = ProjectGuid,
+                .CompilationLevel = CompilationLevel,
+                .SchemasFound = 0
+            }
 
             ' Get VS project
             Dim Solution As IVsSolution = DirectCast(Container.GetService(GetType(IVsSolution)), IVsSolution)
@@ -518,8 +519,9 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
         End Sub
 
         Public Shared Function AnyElement() As XmlIntellisenseMember
-            Dim Member As XmlIntellisenseMember = New XmlIntellisenseMember(XmlQualifiedName.Empty, Flags.IsElement)
-            Member.Children = s_any
+            Dim Member As XmlIntellisenseMember = New XmlIntellisenseMember(XmlQualifiedName.Empty, Flags.IsElement) With {
+                .Children = s_any
+            }
             Return Member
         End Function
 

--- a/src/Microsoft.VisualStudio.Editors/XmlToSchema/InputXmlForm.vb
+++ b/src/Microsoft.VisualStudio.Editors/XmlToSchema/InputXmlForm.vb
@@ -174,10 +174,10 @@ Namespace Microsoft.VisualStudio.Editors.XmlToSchema
         End Sub
 
         Private Function GetXmlTextReaderWithDtdProcessingProhibited(element As String) As XmlTextReader
-            Dim reader As XmlTextReader = New XmlTextReader(element)
-
             ' Required by Fxcop rule CA3054 - DoNotAllowDTDXmlTextReader
-            reader.DtdProcessing = DtdProcessing.Prohibit
+            Dim reader As XmlTextReader = New XmlTextReader(element) With {
+                .DtdProcessing = DtdProcessing.Prohibit
+            }
         End Function
 
         Private Sub _listViewKeyPress(o As Object, e As KeyEventArgs) Handles _listView.KeyDown

--- a/src/Microsoft.VisualStudio.Editors/XmlToSchema/Wizard.vb
+++ b/src/Microsoft.VisualStudio.Editors/XmlToSchema/Wizard.vb
@@ -67,8 +67,9 @@ Namespace Microsoft.VisualStudio.Editors.XmlToSchema
                     Return
                 End If
 
-                Dim inputForm As New InputXmlForm(acitveProject, savePath, fileName)
-                inputForm.ServiceProvider = Common.ShellUtil.GetServiceProvider(dte)
+                Dim inputForm As New InputXmlForm(acitveProject, savePath, fileName) With {
+                    .ServiceProvider = Common.ShellUtil.GetServiceProvider(dte)
+                }
                 Dim uiService As IUIService = CType(inputForm.ServiceProvider.GetService(GetType(IUIService)), IUIService)
                 uiService.ShowDialog(inputForm)
 


### PR DESCRIPTION
This leaves ~10 instances of editor config warnings/errors/messages left.