### PR TITLE
Make Resource Editor "Add Existing File..." default path more intuitive

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
@@ -4177,19 +4177,19 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 ' If we can't check out the resource file, do not pop up any dialog...
                 RootDesigner.DesignerLoader.ManualCheckOut()
 
-                Dim resxItemId As UInteger = GetVsItemId()
+                Dim resourcePathAndName As String = RootDesigner.GetResXFileNameAndPath()
                 Dim projectGuid As Guid = VBPackage.Instance.ProjectGUID(GetVsHierarchy())
                 Dim addExistingFilePath As String = String.Empty
-                Dim resxDictionary As Dictionary(Of UInteger, String) = Nothing
+                Dim resxDictionary As Dictionary(Of String, String) = Nothing
 
                 If VBPackage.Instance.StickyProjectResourcePaths.TryGetValue(projectGuid, resxDictionary) Then
-                    If Not resxDictionary.TryGetValue(resxItemId, addExistingFilePath) Then
+                    If Not resxDictionary.TryGetValue(resourcePathAndName, addExistingFilePath) Then
                         addExistingFilePath = ResourceFile.BasePath
                     End If
                 Else
                     addExistingFilePath = ResourceFile.BasePath
-                    resxDictionary = New Dictionary(Of UInteger, String)
-                    resxDictionary.Item(resxItemId) = addExistingFilePath
+                    resxDictionary = New Dictionary(Of String, String)
+                    resxDictionary.Item(resourcePathAndName) = addExistingFilePath
                     VBPackage.Instance.StickyProjectResourcePaths.Item(projectGuid) = resxDictionary
                 End If
 
@@ -4201,7 +4201,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 End If
 
                 ' BUGFIX: Dev11#35824: Save the directory where the user add existing resource file for the next time.
-                resxDictionary.Item(resxItemId) = Path.GetDirectoryName(CType(FilesToAdd(0), String))
+                resxDictionary.Item(resourcePathAndName) = Path.GetDirectoryName(CType(FilesToAdd(0), String))
 
                 '... and them them as resources.
                 'NOTE: we update the existing item as bug 382459 said.

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Strict On
 Option Explicit On
@@ -4179,6 +4179,10 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Try
                 ' If we can't check out the resource file, do not pop up any dialog...
                 RootDesigner.DesignerLoader.ManualCheckOut()
+
+                If String.IsNullOrEmpty(StickyAddExistingFilePath) Then
+                    StickyAddExistingFilePath = ResourceFile.BasePath
+                End If
 
                 'Ask the user to point to the file(s) to add
                 Dim FilesToAdd() As String = ShowOpenFileDialog(UserCanceled, Title, Filter, FilterIndex, MultiSelect:=True, DefaultPath:=StickyAddExistingFilePath)

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
@@ -4180,17 +4180,17 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 Dim resourcePathAndName As String = RootDesigner.GetResXFileNameAndPath()
                 Dim projectGuid As Guid = VBPackage.Instance.ProjectGUID(GetVsHierarchy())
                 Dim addExistingFilePath As String = String.Empty
-                Dim resxDictionary As Dictionary(Of String, String) = Nothing
+                Dim resxFileToAddExistingBasePath As Dictionary(Of String, String) = Nothing
 
-                If VBPackage.Instance.StickyProjectResourcePaths.TryGetValue(projectGuid, resxDictionary) Then
-                    If Not resxDictionary.TryGetValue(resourcePathAndName, addExistingFilePath) Then
+                If VBPackage.Instance.StickyProjectResourcePaths.TryGetValue(projectGuid, resxFileToAddExistingBasePath) Then
+                    If Not resxFileToAddExistingBasePath.TryGetValue(resourcePathAndName, addExistingFilePath) Then
                         addExistingFilePath = ResourceFile.BasePath
                     End If
                 Else
                     addExistingFilePath = ResourceFile.BasePath
-                    resxDictionary = New Dictionary(Of String, String)
-                    resxDictionary.Item(resourcePathAndName) = addExistingFilePath
-                    VBPackage.Instance.StickyProjectResourcePaths.Item(projectGuid) = resxDictionary
+                    resxFileToAddExistingBasePath = New Dictionary(Of String, String)
+                    resxFileToAddExistingBasePath.Item(resourcePathAndName) = addExistingFilePath
+                    VBPackage.Instance.StickyProjectResourcePaths.Item(projectGuid) = resxFileToAddExistingBasePath
                 End If
 
                 'Ask the user to point to the file(s) to add
@@ -4201,7 +4201,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 End If
 
                 ' BUGFIX: Dev11#35824: Save the directory where the user add existing resource file for the next time.
-                resxDictionary.Item(resourcePathAndName) = Path.GetDirectoryName(CType(FilesToAdd(0), String))
+                resxFileToAddExistingBasePath.Item(resourcePathAndName) = Path.GetDirectoryName(CType(FilesToAdd(0), String))
 
                 '... and them them as resources.
                 'NOTE: we update the existing item as bug 382459 said.

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
@@ -4171,28 +4171,37 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Dim Filter As String = GetFileDialogFilterForCategories(_categories, _currentCategory, FilterIndex)
             Dim UserCanceled As Boolean
 
-            'Last location that the user chose to add existing resource.
-            Static StickyAddExistingFilePath As String
-
             CommitPendingChanges()
 
             Try
                 ' If we can't check out the resource file, do not pop up any dialog...
                 RootDesigner.DesignerLoader.ManualCheckOut()
 
-                If String.IsNullOrEmpty(StickyAddExistingFilePath) Then
-                    StickyAddExistingFilePath = ResourceFile.BasePath
+                Dim resxItemId As UInteger = GetVsItemId()
+                Dim projectGuid As Guid = VBPackage.Instance.ProjectGUID(GetVsHierarchy())
+                Dim addExistingFilePath As String = String.Empty
+                Dim resxDictionary As Dictionary(Of UInteger, String) = Nothing
+
+                If VBPackage.Instance.StickyProjectResourcePaths.TryGetValue(projectGuid, resxDictionary) Then
+                    If Not resxDictionary.TryGetValue(resxItemId, addExistingFilePath) Then
+                        addExistingFilePath = ResourceFile.BasePath
+                    End If
+                Else
+                    addExistingFilePath = ResourceFile.BasePath
+                    resxDictionary = New Dictionary(Of UInteger, String)
+                    resxDictionary.Item(resxItemId) = addExistingFilePath
+                    VBPackage.Instance.StickyProjectResourcePaths.Item(projectGuid) = resxDictionary
                 End If
 
                 'Ask the user to point to the file(s) to add
-                Dim FilesToAdd() As String = ShowOpenFileDialog(UserCanceled, Title, Filter, FilterIndex, MultiSelect:=True, DefaultPath:=StickyAddExistingFilePath)
+                Dim FilesToAdd() As String = ShowOpenFileDialog(UserCanceled, Title, Filter, FilterIndex, MultiSelect:=True, DefaultPath:=addExistingFilePath)
 
                 If UserCanceled OrElse FilesToAdd Is Nothing OrElse FilesToAdd.Length = 0 Then
                     Exit Sub
                 End If
 
                 ' BUGFIX: Dev11#35824: Save the directory where the user add existing resource file for the next time.
-                StickyAddExistingFilePath = Path.GetDirectoryName(CType(FilesToAdd(0), String))
+                resxDictionary.Item(resxItemId) = Path.GetDirectoryName(CType(FilesToAdd(0), String))
 
                 '... and them them as resources.
                 'NOTE: we update the existing item as bug 382459 said.

--- a/src/Microsoft.VisualStudio.Editors/package/VBPackage.vb
+++ b/src/Microsoft.VisualStudio.Editors/package/VBPackage.vb
@@ -46,9 +46,9 @@ Namespace Microsoft.VisualStudio.Editors
         Private _lastViewedProjectDesignerTab As Dictionary(Of Guid, Byte)
 
         'Resource File Sticky Paths per project
-        Private _stickyProjectResourcePaths As Dictionary(Of Guid, Dictionary(Of UInteger, String))
+        Private _stickyProjectResourcePaths As Dictionary(Of Guid, Dictionary(Of String, String))
 
-        Public ReadOnly Property StickyProjectResourcePaths() As Dictionary(Of Guid, Dictionary(Of UInteger, String))
+        Public ReadOnly Property StickyProjectResourcePaths() As Dictionary(Of Guid, Dictionary(Of String, String))
             Get
                 Return _stickyProjectResourcePaths
             End Get
@@ -59,7 +59,7 @@ Namespace Microsoft.VisualStudio.Editors
         ''' </summary>
         ''' <remarks></remarks>
         Public Sub New()
-            _stickyProjectResourcePaths = New Dictionary(Of Guid, Dictionary(Of UInteger, String))
+            _stickyProjectResourcePaths = New Dictionary(Of Guid, Dictionary(Of String, String))
 
             ' Make sure we persist this 
             AddOptionKey(s_projectDesignerSUOKey)

--- a/src/Microsoft.VisualStudio.Editors/package/VBPackage.vb
+++ b/src/Microsoft.VisualStudio.Editors/package/VBPackage.vb
@@ -45,21 +45,13 @@ Namespace Microsoft.VisualStudio.Editors
         ' Map between unique project GUID and the last viewed tab in the project designer...
         Private _lastViewedProjectDesignerTab As Dictionary(Of Guid, Byte)
 
-        'Resource File Sticky Paths per project
-        Private _stickyProjectResourcePaths As Dictionary(Of Guid, Dictionary(Of String, String))
-
-        Public ReadOnly Property StickyProjectResourcePaths() As Dictionary(Of Guid, Dictionary(Of String, String))
-            Get
-                Return _stickyProjectResourcePaths
-            End Get
-        End Property
+        Public ReadOnly Property StickyProjectResourcePaths() As New Dictionary(Of Guid, Dictionary(Of String, String))
 
         ''' <summary>
         ''' Constructor
         ''' </summary>
         ''' <remarks></remarks>
         Public Sub New()
-            _stickyProjectResourcePaths = New Dictionary(Of Guid, Dictionary(Of String, String))
 
             ' Make sure we persist this 
             AddOptionKey(s_projectDesignerSUOKey)
@@ -427,7 +419,7 @@ Namespace Microsoft.VisualStudio.Editors
             Public Function OnAfterCloseSolution(pUnkReserved As Object) As Integer Implements IVsSolutionEvents.OnAfterCloseSolution
                 SettingsDesigner.SettingsDesigner.DeleteFilesAndDirectories(_filesToCleanUp, Nothing)
                 _filesToCleanUp.Clear()
-                Instance._stickyProjectResourcePaths.Clear()
+                Instance.StickyProjectResourcePaths.Clear()
                 Return Interop.NativeMethods.S_OK
             End Function
 


### PR DESCRIPTION
This addresses the issue reported in #3492 by defaulting the path to the path of the resource file.

This also caches the last selected path for the resource on a per project basis in the ```VBPackage``` so that it does not reset if you close and re-open the resource editor.

The cache is cleared on solution/project close, project unload and on closing VS.