### PR TITLE
 Move command groups and ids out of package

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageProjectContextMenuCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageProjectContextMenuCommandTests.cs
@@ -3,7 +3,7 @@
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 
-using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.Input;
 using Microsoft.VisualStudio.ProjectSystem.Build;
 
 using Xunit;
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
     [Trait("UnitTest", "ProjectSystem")]
     public class GenerateNuGetPackageProjectContextMenuCommandTests : AbstractGenerateNuGetPackageCommandTests
     {
-        internal override long GetCommandId() => ManagedProjectSystemPackage.GenerateNuGetPackageProjectContextMenuCmdId;
+        internal override long GetCommandId() => ManagedProjectSystemCommandId.GenerateNuGetPackageProjectContextMenu;
 
         internal override AbstractGenerateNuGetPackageCommand CreateInstanceCore(
             UnconfiguredProject project,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageTopLevelBuildMenuCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageTopLevelBuildMenuCommandTests.cs
@@ -3,7 +3,7 @@
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 
-using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.Input;
 using Microsoft.VisualStudio.ProjectSystem.Build;
 
 using Xunit;
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
     [Trait("UnitTest", "ProjectSystem")]
     public class GenerateNuGetPackageTopLevelBuildMenuCommandTests : AbstractGenerateNuGetPackageCommandTests
     {
-        internal override long GetCommandId() => ManagedProjectSystemPackage.GenerateNuGetPackageTopLevelBuildCmdId;
+        internal override long GetCommandId() => ManagedProjectSystemCommandId.GenerateNuGetPackageTopLevelBuild;
 
         internal override AbstractGenerateNuGetPackageCommand CreateInstanceCore(
             UnconfiguredProject project,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/MoveDownCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/MoveDownCommandTests.cs
@@ -2,8 +2,7 @@
 
 using System.Collections.Immutable;
 using System.Threading.Tasks;
-
-using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.Input;
 
 using Xunit;
 
@@ -167,7 +166,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
             Assert.False(result.Status.HasFlag(CommandStatus.Enabled));
         }
 
-        override internal long GetCommandId() => ManagedProjectSystemPackage.MoveDownCmdId;
+        override internal long GetCommandId() => FSharpProjectCommandId.MoveDown;
 
         override internal AbstractMoveCommand CreateInstance(IPhysicalProjectTree projectTree, Shell.SVsServiceProvider serviceProvider, ConfiguredProject configuredProject, IProjectAccessor accessor)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/MoveUpCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/MoveUpCommandTests.cs
@@ -3,7 +3,7 @@
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 
-using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.Input;
 
 using Xunit;
 
@@ -167,7 +167,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
             Assert.False(result.Status.HasFlag(CommandStatus.Enabled));
         }
 
-        override internal long GetCommandId() => ManagedProjectSystemPackage.MoveUpCmdId;
+        override internal long GetCommandId() => FSharpProjectCommandId.MoveUp;
 
         override internal AbstractMoveCommand CreateInstance(IPhysicalProjectTree projectTree, Shell.SVsServiceProvider serviceProvider, ConfiguredProject configuredProject, IProjectAccessor accessor)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Input/CommandGroup.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Input/CommandGroup.cs
@@ -10,5 +10,8 @@ namespace Microsoft.VisualStudio.Input
         public const string UIHierarchyWindow = VSConstants.CMDSETID.UIHierarchyWindowCommandSet_string;
         public const string VisualStudioStandard97 = VSConstants.CMDSETID.StandardCommandSet97_string;
         public const string VisualStudioStandard2k = VSConstants.CMDSETID.StandardCommandSet2K_string;
+        public const string FSharpProject = "{75AC5611-A912-4195-8A65-457AE17416FB}";
+        public const string ManagedProjectSystemOrder = "{6C4806E9-034E-4B64-99DE-29A6F837B993}";
+        public const string ManagedProjectSystem = "{568ABDF7-D522-474D-9EED-34B5E5095BA5}";
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Input/FSharpProjectCommandId.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Input/FSharpProjectCommandId.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+
+namespace Microsoft.VisualStudio.Input
+{
+    /// <summary>
+    ///     Provides common well-known F# command IDs.
+    /// </summary>
+    internal static class FSharpProjectCommandId
+    {
+        public const int MoveUp = 0x3002;
+        public const int MoveDown = 0x3007;
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Input/ManagedProjectSystemCommandId.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Input/ManagedProjectSystemCommandId.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+
+namespace Microsoft.VisualStudio.Input
+{
+    /// <summary>
+    ///     Provides common well-known project-system command IDs.
+    /// </summary>
+    internal static class ManagedProjectSystemCommandId
+    {
+        public const long GenerateNuGetPackageProjectContextMenu = 0x2000;
+        public const long GenerateNuGetPackageTopLevelBuild = 0x2001;
+        public const int DebugTargetMenuDebugFrameworkMenu = 0x3000;
+        public const int DebugFrameworks = 0x3050;
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Input/ManagedProjectSystemOrderCommandId.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Input/ManagedProjectSystemOrderCommandId.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+
+namespace Microsoft.VisualStudio.Input
+{
+    /// <summary>
+    ///     Provides common well-known project-system order related command IDs.
+    /// </summary>
+    internal static class ManagedProjectSystemOrderCommandId
+    {
+        public const int AddNewItemAbove = 0x2002;
+        public const int AddExistingItemAbove = 0x2003;
+        public const int AddNewItemBelow = 0x2004;
+        public const int AddExistingItemBelow = 0x2005;
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
@@ -47,8 +47,6 @@ namespace Microsoft.VisualStudio.Packaging
         public const int MoveUpCmdId = 0x3002;
         public const int MoveDownCmdId = 0x3007;
 
-        public const string SolutionExplorerGuid = "{3AE79031-E1BC-11D0-8F78-00A0C9110057}";
-
         public const string DefaultCapabilities = ProjectCapability.AppDesigner + "; " +
                                                   ProjectCapability.EditAndContinue + "; " +
                                                   ProjectCapability.HandlesOwnReload + "; " +

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
@@ -30,22 +30,7 @@ namespace Microsoft.VisualStudio.Packaging
     {
         public const string ActivationContextGuid = "E7DF1626-44DD-4E8C-A8A0-92EAB6DDC16E";
         public const string PackageGuid = "A4F9D880-9492-4072-8BF3-2B5EEEDC9E68";
-        public const string ManagedProjectSystemCommandSet = "{568ABDF7-D522-474D-9EED-34B5E5095BA5}";
-        public const long GenerateNuGetPackageProjectContextMenuCmdId = 0x2000;
-        public const long GenerateNuGetPackageTopLevelBuildCmdId = 0x2001;
-        public const int DebugTargetMenuDebugFrameworkMenu = 0x3000;
-        public const int DebugFrameworksCmdId = 0x3050;
 
-        public const string ManagedProjectSystemOrderCommandSet = "{6C4806E9-034E-4B64-99DE-29A6F837B993}";
-        public const int AddNewItemAboveCmdId = 0x2002;
-        public const int AddExistingItemAboveCmdId = 0x2003;
-        public const int AddNewItemBelowCmdId = 0x2004;
-        public const int AddExistingItemBelowCmdId = 0x2005;
-
-        // The guid and values are from the old F# project system, don't change them.
-        public const string FSharpProjectCmdSet = "{75AC5611-A912-4195-8A65-457AE17416FB}";
-        public const int MoveUpCmdId = 0x3002;
-        public const int MoveDownCmdId = 0x3007;
 
         public const string DefaultCapabilities = ProjectCapability.AppDesigner + "; " +
                                                   ProjectCapability.EditAndContinue + "; " +

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/DebugFrameworksDynamicMenuCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/DebugFrameworksDynamicMenuCommand.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.ComponentModel.Design;
 
-using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.Input;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.Shell;
 
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 
         [ImportingConstructor]
         public DebugFrameworksDynamicMenuCommand(IStartupProjectHelper startupProjectHelper)
-          : base(new CommandID(new Guid(ManagedProjectSystemPackage.ManagedProjectSystemCommandSet), ManagedProjectSystemPackage.DebugFrameworksCmdId), MaxFrameworks)
+          : base(new CommandID(new Guid(CommandGroup.ManagedProjectSystem), ManagedProjectSystemCommandId.DebugFrameworks), MaxFrameworks)
         {
             StartupProjectHelper = startupProjectHelper;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/DebugFrameworksMenuTextUpdater.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/DebugFrameworksMenuTextUpdater.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.ComponentModel.Design;
 
-using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.Input;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.Shell;
 
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         public DebugFrameworkPropertyMenuTextUpdater(IStartupProjectHelper startupProjectHelper)
                 : base(ExecHandler, delegate
                 { }, QueryStatusHandler,
-                      new CommandID(new Guid(ManagedProjectSystemPackage.ManagedProjectSystemCommandSet), ManagedProjectSystemPackage.DebugTargetMenuDebugFrameworkMenu))
+                      new CommandID(new Guid(CommandGroup.ManagedProjectSystem), ManagedProjectSystemCommandId.DebugTargetMenuDebugFrameworkMenu))
         {
             StartupProjectHelper = startupProjectHelper;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageProjectContextMenuCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageProjectContextMenuCommand.cs
@@ -2,14 +2,14 @@
 
 using System.ComponentModel.Composition;
 
-using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.Input;
 using Microsoft.VisualStudio.ProjectSystem.Build;
 using Microsoft.VisualStudio.ProjectSystem.Input;
 using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 {
-    [ProjectCommand(ManagedProjectSystemPackage.ManagedProjectSystemCommandSet, ManagedProjectSystemPackage.GenerateNuGetPackageProjectContextMenuCmdId)]
+    [ProjectCommand(CommandGroup.ManagedProjectSystem, ManagedProjectSystemCommandId.GenerateNuGetPackageProjectContextMenu)]
     [AppliesTo(ProjectCapability.Pack)]
     internal class GenerateNuGetPackageProjectContextMenuCommand : AbstractGenerateNuGetPackageCommand
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageTopLevelBuildMenuCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageTopLevelBuildMenuCommand.cs
@@ -3,14 +3,14 @@
 using System.ComponentModel.Composition;
 using System.IO;
 
-using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.Input;
 using Microsoft.VisualStudio.ProjectSystem.Build;
 using Microsoft.VisualStudio.ProjectSystem.Input;
 using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 {
-    [ProjectCommand(ManagedProjectSystemPackage.ManagedProjectSystemCommandSet, ManagedProjectSystemPackage.GenerateNuGetPackageTopLevelBuildCmdId)]
+    [ProjectCommand(CommandGroup.ManagedProjectSystem, ManagedProjectSystemCommandId.GenerateNuGetPackageTopLevelBuild)]
     [AppliesTo(ProjectCapability.Pack)]
     internal class GenerateNuGetPackageTopLevelBuildMenuCommand : AbstractGenerateNuGetPackageCommand
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemAboveCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemAboveCommand.cs
@@ -1,14 +1,16 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.ComponentModel.Composition;
-using Microsoft.VisualStudio.Packaging;
+
+using Microsoft.VisualStudio.Input;
 using Microsoft.VisualStudio.ProjectSystem.Input;
 using Microsoft.VisualStudio.Shell;
+
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
-    [ProjectCommand(ManagedProjectSystemPackage.ManagedProjectSystemOrderCommandSet, ManagedProjectSystemPackage.AddExistingItemAboveCmdId)]
+    [ProjectCommand(CommandGroup.ManagedProjectSystemOrder, ManagedProjectSystemOrderCommandId.AddExistingItemAbove)]
     [AppliesTo(ProjectCapability.SortByDisplayOrder)]
     internal class AddExistingItemAboveCommand : AbstractAddItemCommand
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemBelowCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddExistingItemBelowCommand.cs
@@ -1,14 +1,16 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.ComponentModel.Composition;
-using Microsoft.VisualStudio.Packaging;
+
+using Microsoft.VisualStudio.Input;
 using Microsoft.VisualStudio.ProjectSystem.Input;
 using Microsoft.VisualStudio.Shell;
+
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
-    [ProjectCommand(ManagedProjectSystemPackage.ManagedProjectSystemOrderCommandSet, ManagedProjectSystemPackage.AddExistingItemBelowCmdId)]
+    [ProjectCommand(CommandGroup.ManagedProjectSystemOrder, ManagedProjectSystemOrderCommandId.AddExistingItemBelow)]
     [AppliesTo(ProjectCapability.SortByDisplayOrder)]
     internal class AddExistingItemBelowCommand : AbstractAddItemCommand
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemAboveCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemAboveCommand.cs
@@ -1,14 +1,16 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.ComponentModel.Composition;
-using Microsoft.VisualStudio.Packaging;
+
+using Microsoft.VisualStudio.Input;
 using Microsoft.VisualStudio.ProjectSystem.Input;
 using Microsoft.VisualStudio.Shell;
+
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
-    [ProjectCommand(ManagedProjectSystemPackage.ManagedProjectSystemOrderCommandSet, ManagedProjectSystemPackage.AddNewItemAboveCmdId)]
+    [ProjectCommand(CommandGroup.ManagedProjectSystemOrder, ManagedProjectSystemOrderCommandId.AddNewItemAbove)]
     [AppliesTo(ProjectCapability.SortByDisplayOrder)]
     internal class AddNewItemAboveCommand : AbstractAddItemCommand
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemBelowCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AddNewItemBelowCommand.cs
@@ -1,14 +1,16 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.ComponentModel.Composition;
-using Microsoft.VisualStudio.Packaging;
+
+using Microsoft.VisualStudio.Input;
 using Microsoft.VisualStudio.ProjectSystem.Input;
 using Microsoft.VisualStudio.Shell;
+
 using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
-    [ProjectCommand(ManagedProjectSystemPackage.ManagedProjectSystemOrderCommandSet, ManagedProjectSystemPackage.AddNewItemBelowCmdId)]
+    [ProjectCommand(CommandGroup.ManagedProjectSystemOrder, ManagedProjectSystemOrderCommandId.AddNewItemBelow)]
     [AppliesTo(ProjectCapability.SortByDisplayOrder)]
     internal class AddNewItemBelowCommand : AbstractAddItemCommand
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/MoveDownCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/MoveDownCommand.cs
@@ -1,14 +1,15 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.ComponentModel.Composition;
+
 using Microsoft.Build.Evaluation;
-using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.Input;
 using Microsoft.VisualStudio.ProjectSystem.Input;
 using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
-    [ProjectCommand(ManagedProjectSystemPackage.FSharpProjectCmdSet, ManagedProjectSystemPackage.MoveDownCmdId)]
+    [ProjectCommand(CommandGroup.FSharpProject, FSharpProjectCommandId.MoveDown)]
     [AppliesTo(ProjectCapability.SortByDisplayOrder)]
     internal class MoveDownCommand : AbstractMoveCommand
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/MoveUpCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/MoveUpCommand.cs
@@ -1,14 +1,15 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.ComponentModel.Composition;
+
 using Microsoft.Build.Evaluation;
-using Microsoft.VisualStudio.Packaging;
+using Microsoft.VisualStudio.Input;
 using Microsoft.VisualStudio.ProjectSystem.Input;
 using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
-    [ProjectCommand(ManagedProjectSystemPackage.FSharpProjectCmdSet, ManagedProjectSystemPackage.MoveUpCmdId)]
+    [ProjectCommand(CommandGroup.FSharpProject, FSharpProjectCommandId.MoveUp)]
     [AppliesTo(ProjectCapability.SortByDisplayOrder)]
     internal class MoveUpCommand : AbstractMoveCommand
     {


### PR DESCRIPTION
Commands have nothing to do with the package, move them alongside the command groups and ids.