### PR TITLE
Make LangVersion configuration-agnostic

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
@@ -43,9 +43,14 @@
   <!-- Advanced Build Page Properties -->
   <EnumProperty Name="LanguageVersion" DisplayName="Language version" Visible="False">
     <EnumProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="LangVersion" SourceOfDefaultValue="AfterContext"/>
+      <DataSource Persistence="ProjectFile" PersistedName="LangVersion" SourceOfDefaultValue="AfterContext" HasConfigurationCondition="False" />
     </EnumProperty.DataSource>
   </EnumProperty>
+  <StringProperty Name="LangVersion" DisplayName="Language version" Visible="False" >
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" HasConfigurationCondition="False" />
+    </StringProperty.DataSource>
+  </StringProperty>
   <EnumProperty Name="ErrorReport" DisplayName="Error report" Visible="False"/>
   <EnumProperty Name="DebugInfo" DisplayName="Debug Info" Visible="False">
     <EnumProperty.DataSource>
@@ -124,8 +129,6 @@
     <EnumValue Name="OnOutputUpdated" DisplayName="When the build updates the project output" />
   </EnumProperty>
 
-  <!-- CSharp Project Configuration Properties-->
-  <StringProperty Name="LangVersion" DisplayName="CSharp Language Version" Visible="False"/>
   <StringProperty Name="CodeAnalysisRuleSet" DisplayName=" Code Analysis Rule set" Visible="False"/>
 
   <!-- F# specific properties-->

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.cs.xlf
@@ -72,11 +72,6 @@
         <target state="translated">Vypnuto</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|LanguageVersion|DisplayName">
-        <source>Language version</source>
-        <target state="translated">Jazyková verze</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|ErrorReport|DisplayName">
         <source>Error report</source>
         <target state="translated">Sestava chyb</target>
@@ -232,14 +227,19 @@
         <target state="translated">Když sestavení aktualizuje výstup projektu</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|LangVersion|DisplayName">
-        <source>CSharp Language Version</source>
-        <target state="translated">Verze jazyka CSharp</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|CodeAnalysisRuleSet|DisplayName">
         <source> Code Analysis Rule set</source>
         <target state="translated"> Sada pravidel analýzy kódu</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LanguageVersion|DisplayName">
+        <source>Language version</source>
+        <target state="new">Language version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|LangVersion|DisplayName">
+        <source>Language version</source>
+        <target state="new">Language version</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.de.xlf
@@ -72,11 +72,6 @@
         <target state="translated">Aus</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|LanguageVersion|DisplayName">
-        <source>Language version</source>
-        <target state="translated">Sprachversion</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|ErrorReport|DisplayName">
         <source>Error report</source>
         <target state="translated">Fehlerbericht</target>
@@ -232,14 +227,19 @@
         <target state="translated">Bei der Aktualisierung der Projektausgabe während der Erstellung</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|LangVersion|DisplayName">
-        <source>CSharp Language Version</source>
-        <target state="translated">CSharp-Sprachversion</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|CodeAnalysisRuleSet|DisplayName">
         <source> Code Analysis Rule set</source>
         <target state="translated"> Codeanalyseregel festgelegt</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LanguageVersion|DisplayName">
+        <source>Language version</source>
+        <target state="new">Language version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|LangVersion|DisplayName">
+        <source>Language version</source>
+        <target state="new">Language version</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.es.xlf
@@ -72,11 +72,6 @@
         <target state="translated">Desactivar</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|LanguageVersion|DisplayName">
-        <source>Language version</source>
-        <target state="translated">Versión del lenguaje</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|ErrorReport|DisplayName">
         <source>Error report</source>
         <target state="translated">Informe de errores</target>
@@ -232,14 +227,19 @@
         <target state="translated">Cuando la compilación actualiza los resultados del proyecto</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|LangVersion|DisplayName">
-        <source>CSharp Language Version</source>
-        <target state="translated">Versión de lenguaje CSharp</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|CodeAnalysisRuleSet|DisplayName">
         <source> Code Analysis Rule set</source>
         <target state="translated"> Conjunto de reglas de análisis de código</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LanguageVersion|DisplayName">
+        <source>Language version</source>
+        <target state="new">Language version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|LangVersion|DisplayName">
+        <source>Language version</source>
+        <target state="new">Language version</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.fr.xlf
@@ -72,11 +72,6 @@
         <target state="translated">Désactivé</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|LanguageVersion|DisplayName">
-        <source>Language version</source>
-        <target state="translated">Version du langage</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|ErrorReport|DisplayName">
         <source>Error report</source>
         <target state="translated">Rapport d'erreurs</target>
@@ -232,14 +227,19 @@
         <target state="translated">Lorsque la build met à jour la sortie du projet</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|LangVersion|DisplayName">
-        <source>CSharp Language Version</source>
-        <target state="translated">Version du langage CSharp</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|CodeAnalysisRuleSet|DisplayName">
         <source> Code Analysis Rule set</source>
         <target state="translated"> Ensemble de règles d'analyse du code</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LanguageVersion|DisplayName">
+        <source>Language version</source>
+        <target state="new">Language version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|LangVersion|DisplayName">
+        <source>Language version</source>
+        <target state="new">Language version</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.it.xlf
@@ -72,11 +72,6 @@
         <target state="translated">No</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|LanguageVersion|DisplayName">
-        <source>Language version</source>
-        <target state="translated">Versione del linguaggio</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|ErrorReport|DisplayName">
         <source>Error report</source>
         <target state="translated">Segnalazione errori</target>
@@ -232,14 +227,19 @@
         <target state="translated">Quando la compilazione aggiorna l'output del progetto</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|LangVersion|DisplayName">
-        <source>CSharp Language Version</source>
-        <target state="translated">Versione del linguaggio CSharp</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|CodeAnalysisRuleSet|DisplayName">
         <source> Code Analysis Rule set</source>
         <target state="translated"> Set di regole di analisi codice</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LanguageVersion|DisplayName">
+        <source>Language version</source>
+        <target state="new">Language version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|LangVersion|DisplayName">
+        <source>Language version</source>
+        <target state="new">Language version</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.ja.xlf
@@ -72,11 +72,6 @@
         <target state="translated">オフ</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|LanguageVersion|DisplayName">
-        <source>Language version</source>
-        <target state="translated">言語バージョン</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|ErrorReport|DisplayName">
         <source>Error report</source>
         <target state="translated">エラー レポート</target>
@@ -232,14 +227,19 @@
         <target state="translated">ビルドがプロジェクト出力を更新したとき</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|LangVersion|DisplayName">
-        <source>CSharp Language Version</source>
-        <target state="translated">CSharp 言語バージョン</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|CodeAnalysisRuleSet|DisplayName">
         <source> Code Analysis Rule set</source>
         <target state="translated"> コード分析規則セット</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LanguageVersion|DisplayName">
+        <source>Language version</source>
+        <target state="new">Language version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|LangVersion|DisplayName">
+        <source>Language version</source>
+        <target state="new">Language version</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.ko.xlf
@@ -72,11 +72,6 @@
         <target state="translated">해제</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|LanguageVersion|DisplayName">
-        <source>Language version</source>
-        <target state="translated">언어 버전</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|ErrorReport|DisplayName">
         <source>Error report</source>
         <target state="translated">오류 보고서</target>
@@ -232,14 +227,19 @@
         <target state="translated">빌드에서 프로젝트 출력을 업데이트한 경우</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|LangVersion|DisplayName">
-        <source>CSharp Language Version</source>
-        <target state="translated">CSharp 언어 버전</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|CodeAnalysisRuleSet|DisplayName">
         <source> Code Analysis Rule set</source>
         <target state="translated"> 코드 분석 규칙 집합</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LanguageVersion|DisplayName">
+        <source>Language version</source>
+        <target state="new">Language version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|LangVersion|DisplayName">
+        <source>Language version</source>
+        <target state="new">Language version</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.pl.xlf
@@ -72,11 +72,6 @@
         <target state="translated">Wyłączony</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|LanguageVersion|DisplayName">
-        <source>Language version</source>
-        <target state="translated">Wersja językowa</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|ErrorReport|DisplayName">
         <source>Error report</source>
         <target state="translated">Raport o błędach</target>
@@ -232,14 +227,19 @@
         <target state="translated">Gdy kompilacja aktualizuje wyjście projektu</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|LangVersion|DisplayName">
-        <source>CSharp Language Version</source>
-        <target state="translated">Wersja języka CSharp</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|CodeAnalysisRuleSet|DisplayName">
         <source> Code Analysis Rule set</source>
         <target state="translated"> Zestaw reguł analizy kodu</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LanguageVersion|DisplayName">
+        <source>Language version</source>
+        <target state="new">Language version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|LangVersion|DisplayName">
+        <source>Language version</source>
+        <target state="new">Language version</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.pt-BR.xlf
@@ -72,11 +72,6 @@
         <target state="translated">Desligado</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|LanguageVersion|DisplayName">
-        <source>Language version</source>
-        <target state="translated">Versão do idioma</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|ErrorReport|DisplayName">
         <source>Error report</source>
         <target state="translated">Relatório de erros</target>
@@ -232,14 +227,19 @@
         <target state="translated">Quando a compilação atualizar a saída do projeto</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|LangVersion|DisplayName">
-        <source>CSharp Language Version</source>
-        <target state="translated">Versão da Linguagem CSharp</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|CodeAnalysisRuleSet|DisplayName">
         <source> Code Analysis Rule set</source>
         <target state="translated"> Conjunto de Regras da Análise de Código</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LanguageVersion|DisplayName">
+        <source>Language version</source>
+        <target state="new">Language version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|LangVersion|DisplayName">
+        <source>Language version</source>
+        <target state="new">Language version</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.ru.xlf
@@ -72,11 +72,6 @@
         <target state="translated">Выкл.</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|LanguageVersion|DisplayName">
-        <source>Language version</source>
-        <target state="translated">Версия языка</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|ErrorReport|DisplayName">
         <source>Error report</source>
         <target state="translated">Отчет об ошибках</target>
@@ -232,14 +227,19 @@
         <target state="translated">При обновлении выходных файлов проекта во время сборки</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|LangVersion|DisplayName">
-        <source>CSharp Language Version</source>
-        <target state="translated">Версия языка CSharp</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|CodeAnalysisRuleSet|DisplayName">
         <source> Code Analysis Rule set</source>
         <target state="translated">Набор правил анализа кода</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LanguageVersion|DisplayName">
+        <source>Language version</source>
+        <target state="new">Language version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|LangVersion|DisplayName">
+        <source>Language version</source>
+        <target state="new">Language version</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.tr.xlf
@@ -72,11 +72,6 @@
         <target state="translated">Kapalı</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|LanguageVersion|DisplayName">
-        <source>Language version</source>
-        <target state="translated">Dil sürümü</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|ErrorReport|DisplayName">
         <source>Error report</source>
         <target state="translated">Hata raporu</target>
@@ -232,14 +227,19 @@
         <target state="translated">Oluşturma proje çıkışını güncelleştirdiğinde</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|LangVersion|DisplayName">
-        <source>CSharp Language Version</source>
-        <target state="translated">CSharp Dil Sürümü</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|CodeAnalysisRuleSet|DisplayName">
         <source> Code Analysis Rule set</source>
         <target state="translated"> Kod Analizi Kural Kümesi</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LanguageVersion|DisplayName">
+        <source>Language version</source>
+        <target state="new">Language version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|LangVersion|DisplayName">
+        <source>Language version</source>
+        <target state="new">Language version</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.zh-Hans.xlf
@@ -72,11 +72,6 @@
         <target state="translated">关</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|LanguageVersion|DisplayName">
-        <source>Language version</source>
-        <target state="translated">语言版本</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|ErrorReport|DisplayName">
         <source>Error report</source>
         <target state="translated">错误报告</target>
@@ -232,14 +227,19 @@
         <target state="translated">生成更新项目输出时</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|LangVersion|DisplayName">
-        <source>CSharp Language Version</source>
-        <target state="translated">CSharp 语言版本</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|CodeAnalysisRuleSet|DisplayName">
         <source> Code Analysis Rule set</source>
         <target state="translated">代码分析规则集</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LanguageVersion|DisplayName">
+        <source>Language version</source>
+        <target state="new">Language version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|LangVersion|DisplayName">
+        <source>Language version</source>
+        <target state="new">Language version</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/GeneralConfiguredBrowseObject.xaml.zh-Hant.xlf
@@ -72,11 +72,6 @@
         <target state="translated">關閉</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|LanguageVersion|DisplayName">
-        <source>Language version</source>
-        <target state="translated">語言版本</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|ErrorReport|DisplayName">
         <source>Error report</source>
         <target state="translated">錯誤報告</target>
@@ -232,14 +227,19 @@
         <target state="translated">當組建更新專案輸出時</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|LangVersion|DisplayName">
-        <source>CSharp Language Version</source>
-        <target state="translated">CSharp 語言版本</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|CodeAnalysisRuleSet|DisplayName">
         <source> Code Analysis Rule set</source>
         <target state="translated"> 程式碼分析規則集</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LanguageVersion|DisplayName">
+        <source>Language version</source>
+        <target state="new">Language version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|LangVersion|DisplayName">
+        <source>Language version</source>
+        <target state="new">Language version</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
Fixes: #2732 for the new project system.

I have no idea why we have two properties here; one for consumed by CSharpProjectConfigurationProperties and one consumed by AppDesigner but I left the exercise for a latter time.

Changes:
``` XML
<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
  <LangVersion>latest</LangVersion>
</PropertyGroup>

<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
  <LangVersion>latest</LangVersion>
</PropertyGroup>
```

to

``` XML
<PropertyGroup>
  <LangVersion>latest</LangVersion>
</PropertyGroup>
```

While the code fix still loops configurations, it just overwrites the same property again and again.