### PR TITLE
[WIP] Don't show the "unresolved" icon on the root "Dependencies" node

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IMockDependenciesViewModelFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IMockDependenciesViewModelFactory.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             if (getDependenciesRootIcon != null && getDependenciesRootIcon.HasValue)
             {
-                mock.Setup(x => x.GetDependenciesRootIcon(It.IsAny<bool>())).Returns(getDependenciesRootIcon.Value);
+                mock.Setup(x => x.GetDependenciesRootIcon()).Returns(getDependenciesRootIcon.Value);
             }
 
             if (createRootViewModel != null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DependenciesViewModelFactoryTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DependenciesViewModelFactoryTests.cs
@@ -88,8 +88,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var project = UnconfiguredProjectFactory.Create();
             var factory = new DependenciesViewModelFactory(project);
 
-            Assert.Equal(ManagedImageMonikers.ReferenceGroup, factory.GetDependenciesRootIcon(hasUnresolvedDependencies: false));
-            Assert.Equal(ManagedImageMonikers.ReferenceGroupWarning, factory.GetDependenciesRootIcon(hasUnresolvedDependencies: true));
+            Assert.Equal(ManagedImageMonikers.ReferenceGroup, factory.GetDependenciesRootIcon());
         }
 
         private class TestableDependenciesViewModelFactory : DependenciesViewModelFactory

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GroupedByTargetTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GroupedByTargetTreeViewProvider.cs
@@ -122,7 +122,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             dependenciesTree = CleanupOldNodes(dependenciesTree, currentTopLevelNodes);
 
             // now update root Dependencies node status
-            ProjectImageMoniker rootIcon = ViewModelFactory.GetDependenciesRootIcon(snapshot.HasUnresolvedDependency).ToProjectSystemType();
+            ProjectImageMoniker rootIcon = ViewModelFactory.GetDependenciesRootIcon().ToProjectSystemType();
             return dependenciesTree.SetProperties(icon: rootIcon, expandedIcon: rootIcon);
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DependenciesViewModelFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DependenciesViewModelFactory.cs
@@ -38,11 +38,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             return dependencyModel.ToViewModel(hasUnresolvedDependency);
         }
 
-        public ImageMoniker GetDependenciesRootIcon(bool hasUnresolvedDependencies)
+        public ImageMoniker GetDependenciesRootIcon()
         {
-            return hasUnresolvedDependencies
-                ? ManagedImageMonikers.ReferenceGroupWarning
-                : ManagedImageMonikers.ReferenceGroup;
+            return ManagedImageMonikers.ReferenceGroup;
         }
 
         private IProjectDependenciesSubTreeProvider GetProvider(string providerType)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/IDependenciesViewModelFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/IDependenciesViewModelFactory.cs
@@ -9,6 +9,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
     {
         IDependencyViewModel CreateTargetViewModel(ITargetedDependenciesSnapshot snapshot);
         IDependencyViewModel CreateRootViewModel(string providerType, bool hasUnresolvedDependency);
-        ImageMoniker GetDependenciesRootIcon(bool hasUnresolvedDependencies);
+        ImageMoniker GetDependenciesRootIcon();
     }
 }


### PR DESCRIPTION
This more closely matches the behavior of .csproj, where you don't
see these warnings unless you go looking for them.

(@etbyrd and I paired on this)