### PR TITLE
Set LanguageServiceId property for F#

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.FSharp.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.FSharp.DesignTime.targets
@@ -14,6 +14,7 @@
     <AppDesignerFolder Condition="'$(AppDesignerFolder)' == ''">Properties</AppDesignerFolder>
     <AppDesignerFolderContentsVisibleOnlyInShowAllFiles Condition="'$(AppDesignerFolderContentsVisibleOnlyInShowAllFiles)' == ''">false</AppDesignerFolderContentsVisibleOnlyInShowAllFiles>
     <LanguageServiceName Condition="'$(LanguageServiceName)' == ''">F#</LanguageServiceName>
+    <LanguageServiceId Condition="'$(LanguageServiceId)'==''">{BC6DD5A5-D4D6-4DAB-A00D-A51242DBAF1B}</LanguageServiceId>
     <TemplateLanguage Condition="'$(TemplateLanguage)' == ''">FSharp</TemplateLanguage>
     <AddItemTemplatesGuid Condition="'$(AddItemTemplatesGuid)' == ''">{F2A71F9B-5D33-465A-A702-920D77279786}</AddItemTemplatesGuid>
   </PropertyGroup>


### PR DESCRIPTION
We're making a change in CPS to start pulling from this property to start populating VSHPROPID_PreferredLanguageSID, make sure F# returns the correct value.