### PR TITLE
Return CATID's for project system extenders

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Automation/CSharpExtenderCATIDProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Automation/CSharpExtenderCATIDProviderTests.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.ProjectSystem.VS.Properties;
+using VSLangProj;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
+{
+    [Trait("UnitTest", "ProjectSystem")]
+    public class CSharpExtenderCATIDProviderTests
+    {
+        [Fact]
+        public void GetExtenderCATID_CatIdsUnknown_ReturnsNull()
+        {
+            var provider = CreateInstance();
+
+            var result = provider.GetExtenderCATID(ExtenderCATIDType.Unknown, (IProjectTree)null);
+
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData(ExtenderCATIDType.HierarchyExtensionObject,           PrjCATID.prjCATIDProject)]
+        [InlineData(ExtenderCATIDType.AutomationProject,                  PrjCATID.prjCATIDProject)]
+        [InlineData(ExtenderCATIDType.AutomationProjectItem,              PrjCATID.prjCATIDProjectItem)]
+        [InlineData(ExtenderCATIDType.HierarchyBrowseObject,              PrjBrowseObjectCATID.prjCATIDCSharpProjectBrowseObject)]
+        [InlineData(ExtenderCATIDType.HierarchyConfigurationBrowseObject, PrjBrowseObjectCATID.prjCATIDCSharpProjectConfigBrowseObject)]
+        [InlineData(ExtenderCATIDType.AutomationReference,                PrjBrowseObjectCATID.prjCATIDCSharpReferenceBrowseObject)]
+        [InlineData(ExtenderCATIDType.ReferenceBrowseObject,              PrjBrowseObjectCATID.prjCATIDCSharpReferenceBrowseObject)]
+        [InlineData(ExtenderCATIDType.ProjectBrowseObject,                PrjBrowseObjectCATID.prjCATIDCSharpProjectBrowseObject)]
+        [InlineData(ExtenderCATIDType.ProjectConfigurationBrowseObject,   PrjBrowseObjectCATID.prjCATIDCSharpProjectConfigBrowseObject)]
+        [InlineData(ExtenderCATIDType.FileBrowseObject,                   PrjBrowseObjectCATID.prjCATIDCSharpFileBrowseObject)]
+        [InlineData(ExtenderCATIDType.AutomationFolderProperties,         PrjBrowseObjectCATID.prjCATIDCSharpFolderBrowseObject)]
+        [InlineData(ExtenderCATIDType.FolderBrowseObject,                 PrjBrowseObjectCATID.prjCATIDCSharpFolderBrowseObject)]
+        [InlineData(ExtenderCATIDType.ConfigurationBrowseObject,          PrjBrowseObjectCATID.prjCATIDCSharpConfig)]
+        public void GetExtenderCATID_ReturnsCorrectCadId(ExtenderCATIDType input, string expected)
+        {
+            var provider = CreateInstance();
+
+            var result = provider.GetExtenderCATID(input, (IProjectTree)null);
+
+            Assert.Equal(expected, result);
+        }
+
+        private static CSharpExtenderCATIDProvider CreateInstance()
+        {
+            return new CSharpExtenderCATIDProvider();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Automation/CSharpExtenderCATIDProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Automation/CSharpExtenderCATIDProvider.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+
+using Microsoft.VisualStudio.ProjectSystem.VS.Properties;
+
+using VSLangProj;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
+{
+    [Export(typeof(IExtenderCATIDProvider))]
+    [AppliesTo(ProjectCapability.CSharp)]
+    internal class CSharpExtenderCATIDProvider : AbstractExtenderCATIDProvider
+    {
+        [ImportingConstructor]
+        public CSharpExtenderCATIDProvider()
+        {
+        }
+
+        protected override string GetExtenderCATID(ExtendeeObject extendee)
+        {
+            switch (extendee)
+            {
+                case ExtendeeObject.Project:
+                    return PrjCATID.prjCATIDProject;
+
+                case ExtendeeObject.ProjectBrowseObject:
+                    return PrjBrowseObjectCATID.prjCATIDCSharpProjectBrowseObject;
+
+                case ExtendeeObject.Configuration:
+                    return PrjBrowseObjectCATID.prjCATIDCSharpConfig;
+
+                case ExtendeeObject.ConfigurationBrowseObject:
+                    return PrjBrowseObjectCATID.prjCATIDCSharpProjectConfigBrowseObject;
+
+                case ExtendeeObject.ProjectItem:
+                    return PrjCATID.prjCATIDProjectItem;
+
+                case ExtendeeObject.FolderBrowseObject:
+                    return PrjBrowseObjectCATID.prjCATIDCSharpFolderBrowseObject;
+
+                case ExtendeeObject.ReferenceBrowseObject:
+                    return PrjBrowseObjectCATID.prjCATIDCSharpReferenceBrowseObject;
+
+                case ExtendeeObject.FileBrowseObject:
+                    return PrjBrowseObjectCATID.prjCATIDCSharpFileBrowseObject;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Automation/CSharpExtenderCATIDProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Automation/CSharpExtenderCATIDProvider.cs
@@ -6,6 +6,8 @@ using Microsoft.VisualStudio.ProjectSystem.VS.Properties;
 
 using VSLangProj;
 
+using BCLDebug = System.Diagnostics.Debug;
+
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
 {
     [Export(typeof(IExtenderCATIDProvider))]
@@ -42,11 +44,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
                 case ExtendeeObject.ReferenceBrowseObject:
                     return PrjBrowseObjectCATID.prjCATIDCSharpReferenceBrowseObject;
 
+                default:
                 case ExtendeeObject.FileBrowseObject:
+                    BCLDebug.Assert(extendee == ExtendeeObject.FileBrowseObject);
                     return PrjBrowseObjectCATID.prjCATIDCSharpFileBrowseObject;
             }
-
-            return null;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/AbstractExtenderCATIDProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/AbstractExtenderCATIDProvider.cs
@@ -1,0 +1,112 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.ProjectSystem.VS.Properties;
+
+using BCLDebug = System.Diagnostics.Debug;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
+{
+    /// <summary>
+    ///     An abstract class that maps <see cref="IExtenderCATIDProvider"/> to a more correct model.
+    /// </summary>
+    internal abstract class AbstractExtenderCATIDProvider : IExtenderCATIDProvider
+    {
+        protected AbstractExtenderCATIDProvider()
+        {
+        }
+
+        public string GetExtenderCATID(ExtenderCATIDType extenderCATIDType, IProjectTree treeNode)
+        {
+            // CPS's implementation of ExtenderCATIDType incorrectly treats the same "instances" as distinct items based 
+            // where they are accessed in CPS. It also incorrectly maps "HierarchyExtensionObject" and "HierarchyBrowseObject" 
+            // as only applying to the hierarchy, when they take ITEMIDs indicating the node they apply to.
+            //
+            // See https://docs.microsoft.com/en-us/visualstudio/extensibility/internals/extending-the-object-model-of-the-base-project.
+            //
+            // The latter issue we can do nothing about, however, to address the former, map these types to a truer form it makes 
+            // it easier on implementators and maintainers of this to understand the objects we're talking about.
+
+            switch (extenderCATIDType)
+            {
+                case ExtenderCATIDType.HierarchyExtensionObject:                                // IVsHierarchy.GetProperty(VSITEMID.Root, VSHPROPID_ExtObjectCATID)
+                case ExtenderCATIDType.AutomationProject:                                       // DTE.Project
+                    return GetExtenderCATID(ExtendeeObject.Project);
+
+                case ExtenderCATIDType.HierarchyBrowseObject:                                   // IVsHierarchy.GetProperty(VSHPROPID_BrowseObjectCATID)
+                case ExtenderCATIDType.ProjectBrowseObject:                                     // EnvDTE.Project.Properties
+                    return GetExtenderCATID(ExtendeeObject.ProjectBrowseObject);
+
+                case ExtenderCATIDType.ConfigurationBrowseObject:                               // IVsCfgProvider2.GetCfgProviderProperty(VSCFGPROPID_IntrinsicExtenderCATID)/DTE.Configuraton
+                    return GetExtenderCATID(ExtendeeObject.Configuration);
+
+                case ExtenderCATIDType.HierarchyConfigurationBrowseObject:                      // IVsHierarchy.GetProperty(VSHPROPID_CfgBrowseObjectCATID)
+                case ExtenderCATIDType.ProjectConfigurationBrowseObject:                        // EnvDTE.Configuration.Properties
+                    return GetExtenderCATID(ExtendeeObject.ConfigurationBrowseObject);
+                 
+                case ExtenderCATIDType.AutomationProjectItem:                                   // EnvDTE.ProjectItem
+                    return GetExtenderCATID(ExtendeeObject.ProjectItem);
+
+                case ExtenderCATIDType.AutomationReference:                                     // VSLangProject.Reference
+                case ExtenderCATIDType.ReferenceBrowseObject:                                   // EnvDTE.ProjectItem.Properties (when reference)
+                    return GetExtenderCATID(ExtendeeObject.ReferenceBrowseObject);
+
+                case ExtenderCATIDType.FileBrowseObject:                                        // EnvDTE.ProjectItem.Properties (when file)
+                    return GetExtenderCATID(ExtendeeObject.FileBrowseObject);
+
+                case ExtenderCATIDType.AutomationFolderProperties:                              // FolderProperties
+                case ExtenderCATIDType.FolderBrowseObject:                                      // EnvDTE.ProjectItem.Properties (when folder)
+                    return GetExtenderCATID(ExtendeeObject.FolderBrowseObject);
+
+                default:
+                case ExtenderCATIDType.Unknown:                                                 // EnvDTE.ProjectItem.Properties (when not file, folder, reference)
+                    BCLDebug.Assert(extenderCATIDType == ExtenderCATIDType.Unknown, $"Unrecognized CATID type {extenderCATIDType}");
+                    return null;
+            }
+        }
+
+        protected abstract string GetExtenderCATID(ExtendeeObject extendee);
+
+        protected enum ExtendeeObject
+        {
+            /// <summary>
+            ///     Represents <see cref="EnvDTE.Project"/>.
+            /// </summary>
+            Project,
+
+            /// <summary>
+            ///     Represents <see cref="EnvDTE.Project.Properties"/>.
+            /// </summary>
+            ProjectBrowseObject,
+
+            /// <summary>
+            ///     Represents <see cref="EnvDTE.Configuration"/>.
+            /// </summary>
+            Configuration,
+
+            /// <summary>
+            ///     Represents <see cref="EnvDTE.Configuration.Properties"/>.
+            /// </summary>
+            ConfigurationBrowseObject,
+
+            /// <summary>
+            ///     Represents <see cref="EnvDTE.ProjectItem"/>.
+            /// </summary>
+            ProjectItem,
+
+            /// <summary>
+            ///     Represents <see cref="EnvDTE.ProjectItem.Properties"/> when a file.
+            /// </summary>
+            FileBrowseObject,
+
+            /// <summary>
+            ///     Represents <see cref="EnvDTE.ProjectItem.Properties"/> when a folder.
+            /// </summary>
+            FolderBrowseObject,
+
+            /// <summary>
+            ///     Represents <see cref="VSLangProj.Reference"/> or <see cref="EnvDTE.ProjectItem.Properties"/> when a reference.
+            /// </summary>
+            ReferenceBrowseObject,
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Automation/VisualBasicExtenderCATIDProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Automation/VisualBasicExtenderCATIDProviderTests.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.ProjectSystem.VS.Properties;
+using VSLangProj;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
+{
+    [Trait("UnitTest", "ProjectSystem")]
+    public class VisualBasicExtenderCATIDProviderTests
+    {
+        [Fact]
+        public void GetExtenderCATID_CatIdsUnknown_ReturnsNull()
+        {
+            var provider = CreateInstance();
+
+            var result = provider.GetExtenderCATID(ExtenderCATIDType.Unknown, (IProjectTree)null);
+
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData(ExtenderCATIDType.HierarchyExtensionObject,           PrjCATID.prjCATIDProject)]
+        [InlineData(ExtenderCATIDType.AutomationProject,                  PrjCATID.prjCATIDProject)]
+        [InlineData(ExtenderCATIDType.AutomationProjectItem,              PrjCATID.prjCATIDProjectItem)]
+        [InlineData(ExtenderCATIDType.HierarchyBrowseObject,              PrjBrowseObjectCATID.prjCATIDVBProjectBrowseObject)]
+        [InlineData(ExtenderCATIDType.HierarchyConfigurationBrowseObject, PrjBrowseObjectCATID.prjCATIDVBProjectConfigBrowseObject)]
+        [InlineData(ExtenderCATIDType.AutomationReference,                PrjBrowseObjectCATID.prjCATIDVBReferenceBrowseObject)]
+        [InlineData(ExtenderCATIDType.ReferenceBrowseObject,              PrjBrowseObjectCATID.prjCATIDVBReferenceBrowseObject)]
+        [InlineData(ExtenderCATIDType.ProjectBrowseObject,                PrjBrowseObjectCATID.prjCATIDVBProjectBrowseObject)]
+        [InlineData(ExtenderCATIDType.ProjectConfigurationBrowseObject,   PrjBrowseObjectCATID.prjCATIDVBProjectConfigBrowseObject)]
+        [InlineData(ExtenderCATIDType.FileBrowseObject,                   PrjBrowseObjectCATID.prjCATIDVBFileBrowseObject)]
+        [InlineData(ExtenderCATIDType.AutomationFolderProperties,         PrjBrowseObjectCATID.prjCATIDVBFolderBrowseObject)]
+        [InlineData(ExtenderCATIDType.FolderBrowseObject,                 PrjBrowseObjectCATID.prjCATIDVBFolderBrowseObject)]
+        [InlineData(ExtenderCATIDType.ConfigurationBrowseObject,          PrjBrowseObjectCATID.prjCATIDVBConfig)]
+
+        public void GetExtenderCATID_ReturnsCorrectCadId(ExtenderCATIDType input, string expected)
+        {
+            var provider = CreateInstance();
+
+            var result = provider.GetExtenderCATID(input, (IProjectTree)null);
+
+            Assert.Equal(expected, result);
+        }
+
+        private static VisualBasicExtenderCATIDProvider CreateInstance()
+        {
+            return new VisualBasicExtenderCATIDProvider();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Automation/VisualBasicExtenderCATIDProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Automation/VisualBasicExtenderCATIDProvider.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+
+using Microsoft.VisualStudio.ProjectSystem.VS.Properties;
+
+using VSLangProj;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
+{
+    [Export(typeof(IExtenderCATIDProvider))]
+    [AppliesTo(ProjectCapability.VisualBasic)]
+    internal class VisualBasicExtenderCATIDProvider : AbstractExtenderCATIDProvider
+    {
+        [ImportingConstructor]
+        public VisualBasicExtenderCATIDProvider()
+        {
+        }
+
+        protected override string GetExtenderCATID(ExtendeeObject extendee)
+        {
+            switch (extendee)
+            {
+                case ExtendeeObject.Project:
+                    return PrjCATID.prjCATIDProject;
+
+                case ExtendeeObject.ProjectBrowseObject:
+                    return PrjBrowseObjectCATID.prjCATIDVBProjectBrowseObject;
+
+                case ExtendeeObject.Configuration:
+                    return PrjBrowseObjectCATID.prjCATIDVBConfig;
+
+                case ExtendeeObject.ConfigurationBrowseObject:
+                    return PrjBrowseObjectCATID.prjCATIDVBProjectConfigBrowseObject;
+
+                case ExtendeeObject.ProjectItem:
+                    return PrjCATID.prjCATIDProjectItem;
+
+                case ExtendeeObject.FolderBrowseObject:
+                    return PrjBrowseObjectCATID.prjCATIDVBFolderBrowseObject;
+
+                case ExtendeeObject.ReferenceBrowseObject:
+                    return PrjBrowseObjectCATID.prjCATIDVBReferenceBrowseObject;
+
+                case ExtendeeObject.FileBrowseObject:
+                    return PrjBrowseObjectCATID.prjCATIDVBFileBrowseObject;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Automation/VisualBasicExtenderCATIDProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Automation/VisualBasicExtenderCATIDProvider.cs
@@ -6,6 +6,8 @@ using Microsoft.VisualStudio.ProjectSystem.VS.Properties;
 
 using VSLangProj;
 
+using BCLDebug = System.Diagnostics.Debug;
+
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
 {
     [Export(typeof(IExtenderCATIDProvider))]
@@ -42,11 +44,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
                 case ExtendeeObject.ReferenceBrowseObject:
                     return PrjBrowseObjectCATID.prjCATIDVBReferenceBrowseObject;
 
+                default:
                 case ExtendeeObject.FileBrowseObject:
+                    BCLDebug.Assert(extendee == ExtendeeObject.FileBrowseObject);
                     return PrjBrowseObjectCATID.prjCATIDVBFileBrowseObject;
             }
-
-            return null;
         }
     }
 }


### PR DESCRIPTION
Implement IExtenderCATIDProvider for C#/VB. F# is being tracked by https://github.com/dotnet/project-system/issues/3561.

Also filed https://github.com/dotnet/project-system/issues/3560 to implement support for ProjectConfigurationBrowseObject and implemented ConfigurationBrowseObject here https://devdiv.visualstudio.com/DevDiv/Default/_git/CPS/pullrequest/123753?_a=overview.