### PR TITLE
Use Properties Browser instead of Properties Window 

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AdditionalFiles.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AdditionalFiles.xaml
@@ -5,6 +5,7 @@
   DisplayName="Additional File"
   PageTemplate="generic"
   Description="File Properties"
+  PropertyPagesHidden="true"
   xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="AdditionalFiles" SourceOfDefaultValue="AfterContext" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ApplicationDefinition.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ApplicationDefinition.xaml
@@ -5,6 +5,7 @@
     DisplayName="ApplicationDefinition"
     PageTemplate="generic"
     Description="File Properties"
+    PropertyPagesHidden="true"
     xmlns="http://schemas.microsoft.com/build/2009/properties">
     <Rule.DataSource>
         <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="ApplicationDefinition" SourceOfDefaultValue="AfterContext" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Compile.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Compile.BrowseObject.xaml
@@ -5,6 +5,7 @@
   DisplayName="File Properties"
   PageTemplate="generic"
   Description="File Properties"
+  PropertyPagesHidden="true"
   xmlns="http://schemas.microsoft.com/build/2009/properties">
 
   <Rule.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Content.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Content.xaml
@@ -5,6 +5,7 @@
   DisplayName="File Properties"
   PageTemplate="generic"
   Description="File Properties"
+  PropertyPagesHidden="true"
   xmlns="http://schemas.microsoft.com/build/2009/properties">
 
   <Rule.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/EmbeddedResource.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/EmbeddedResource.xaml
@@ -5,6 +5,7 @@
     DisplayName="Embedded Resource"
     PageTemplate="generic"
     Description="File Properties"
+    PropertyPagesHidden="true"
     xmlns="http://schemas.microsoft.com/build/2009/properties">
     <Rule.DataSource>
         <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="EmbeddedResource" SourceOfDefaultValue="AfterContext" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Folder.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Folder.xaml
@@ -5,6 +5,7 @@
   DisplayName="General"
   PageTemplate="generic"
   Description="Folder Properties"
+  PropertyPagesHidden="true"
   xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource Persistence="ProjectFileFolderItems" HasConfigurationCondition="False" ItemType="Folder" SourceOfDefaultValue="AfterContext" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -6,6 +6,7 @@
   PageTemplate="generic"
   Description="Project Properties"
   OverrideMode= "Replace"
+  PropertyPagesHidden="true"
   xmlns="http://schemas.microsoft.com/build/2009/properties">
 
     <Rule.Categories>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
@@ -6,6 +6,7 @@
   PageTemplate="generic"
   Description="General"
   OverrideMode= "Replace"
+  PropertyPagesHidden="true"
   xmlns="http://schemas.microsoft.com/build/2009/properties">
 
   <Rule.Categories>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/None.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/None.xaml
@@ -5,6 +5,7 @@
   DisplayName="General"
   PageTemplate="generic"
   Description="File Properties"
+  PropertyPagesHidden="true"
   xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="None" SourceOfDefaultValue="AfterContext" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Page.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Page.xaml
@@ -5,6 +5,7 @@
     DisplayName="Page"
     PageTemplate="generic"
     Description="File Properties"
+    PropertyPagesHidden="true"
     xmlns="http://schemas.microsoft.com/build/2009/properties">
     <Rule.DataSource>
         <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="Page" SourceOfDefaultValue="AfterContext" />


### PR DESCRIPTION
This causes Properties on files and project to behave exactly like legacy by open the Properties Browser instead of Properties window on **Properties**.

Shell ends up querying browse object, which based on this setting decides whether the Properties Browser is used instead of Properties Window.

~This includes https://github.com/dotnet/project-system/pull/3484 and is blocked on it, so only review https://github.com/dotnet/project-system/commit/a0a636bf8a5087904162914892921e7f4e0d48b2 and https://github.com/dotnet/project-system/pull/3566/commits/faf75b8cf40f3e10805cce62c5a2b656a6d1e32e.~

~We need https://devdiv.visualstudio.com/DevDiv/Default/_git/CPS/pullrequest/124002?_a=overview to make this fix complete~ and fix #3498. This is merged in.