### PR TITLE
Do not use GlobalProvider off the UI thread

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
@@ -34,17 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         [ImportingConstructor]
         public StartupProjectRegistrar(
             UnconfiguredProject project,
-            IProjectThreadingService threadingService,
-            ISafeProjectGuidService projectGuidService,
-            IActiveConfiguredProjectSubscriptionService projectSubscriptionService,
-            ActiveConfiguredProject<DebuggerLaunchProviders> launchProviders)
-            : this(project, AsyncServiceProvider.GlobalProvider, threadingService, projectGuidService, projectSubscriptionService, launchProviders)
-        {
-        }
-
-        public StartupProjectRegistrar(
-            UnconfiguredProject project,
-            IAsyncServiceProvider serviceProvider,
+            [Import(typeof(SAsyncServiceProvider))]IAsyncServiceProvider serviceProvider,
             IProjectThreadingService threadingService,
             ISafeProjectGuidService projectGuidService,
             IActiveConfiguredProjectSubscriptionService projectSubscriptionService,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
@@ -47,22 +47,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
 
         [ImportingConstructor]
         public ProjectAssetFileWatcher(
+            [Import(typeof(SAsyncServiceProvider))]IAsyncServiceProvider asyncServiceProvider,
             [Import(ContractNames.ProjectTreeProviders.FileSystemDirectoryTree)] IProjectTreeProvider fileSystemTreeProvider,
-            IUnconfiguredProjectCommonServices projectServices,
-            IUnconfiguredProjectTasksService projectTasksService,
-            IActiveConfiguredProjectSubscriptionService activeConfiguredProjectSubscriptionService)
-            : this(
-                  AsyncServiceProvider.GlobalProvider,
-                  fileSystemTreeProvider,
-                  projectServices,
-                  projectTasksService,
-                  activeConfiguredProjectSubscriptionService)
-        {
-        }
-
-        public ProjectAssetFileWatcher(
-            IAsyncServiceProvider asyncServiceProvider,
-            IProjectTreeProvider fileSystemTreeProvider,
             IUnconfiguredProjectCommonServices projectServices,
             IUnconfiguredProjectTasksService projectTasksService,
             IActiveConfiguredProjectSubscriptionService activeConfiguredProjectSubscriptionService)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
@@ -37,17 +37,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
     internal class DependenciesGraphProvider : OnceInitializedOnceDisposedAsync, IGraphProvider, IDependenciesGraphBuilder
     {
         [ImportingConstructor]
-        public DependenciesGraphProvider(IAggregateDependenciesSnapshotProvider aggregateSnapshotProvider)
-            : this(aggregateSnapshotProvider,
-                   AsyncServiceProvider.GlobalProvider,
-                   new JoinableTaskContextNode(ThreadHelper.JoinableTaskContext))
-        {
-        }
-
         public DependenciesGraphProvider(IAggregateDependenciesSnapshotProvider aggregateSnapshotProvider,
-                                         IAsyncServiceProvider serviceProvider,
-                                         JoinableTaskContextNode joinableTaskContextNode)
-            : base(joinableTaskContextNode)
+                                         [Import(typeof(SAsyncServiceProvider))]IAsyncServiceProvider serviceProvider)
+            : base(new JoinableTaskContextNode(ThreadHelper.JoinableTaskContext))
         {
             AggregateSnapshotProvider = aggregateSnapshotProvider;
             ServiceProvider = serviceProvider;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
@@ -38,8 +38,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
     {
         [ImportingConstructor]
         public DependenciesGraphProvider(IAggregateDependenciesSnapshotProvider aggregateSnapshotProvider,
-                                         [Import(typeof(SAsyncServiceProvider))]IAsyncServiceProvider serviceProvider)
-            : base(new JoinableTaskContextNode(ThreadHelper.JoinableTaskContext))
+                                         [Import(typeof(SAsyncServiceProvider))]IAsyncServiceProvider serviceProvider,
+                                         JoinableTaskContext joinableTaskContext)
+            : base(new JoinableTaskContextNode(joinableTaskContext))
         {
             AggregateSnapshotProvider = aggregateSnapshotProvider;
             ServiceProvider = serviceProvider;


### PR DESCRIPTION
GlobaProvider returns a provider per-thread, if you are called off the UI thread - you are going to have empty services. Graph Providers are now instantiated off the UI thread, based on the changes that were made to load them async by platform. Just import the new async service provider that was exported in 15.8.