### PR TITLE
Avoid picking implicit framework defines

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
@@ -18,7 +18,13 @@
   </Rule.DataSource>
 
   <!-- Build Page Properties -->
-  <StringProperty Name="DefineConstants" DisplayName="Define Constants" Visible="False"/>
+  <StringProperty Name="DefineConstants" DisplayName="Define Constants" Visible="False">
+    <StringProperty.DataSource>
+      <!-- We mark BeforeContext to avoid picking up implicit framework defines to avoid #2720. -->
+      <DataSource Persistence="ProjectFile" HasConfigurationCondition="True" SourceOfDefaultValue="BeforeContext"/>
+    </StringProperty.DataSource>
+  </StringProperty>
+  
   <EnumProperty Name="PlatformTarget" DisplayName="Platform Target" Visible="False"/>
   <BoolProperty Name="Prefer32Bit" DisplayName="Prefer 32Bit" Visible="False"/>
   <BoolProperty Name="AllowUnsafeBlocks"  Default="False"  DisplayName="Allow unsafe code" Visible="False"/>


### PR DESCRIPTION
Fixes: #2720

The SDK automatically appends to DefineConstants with implicit constants after the project's definition of DefineConstant. When we attempt to read the value at the end of project file ("AfterContext") we think that user's value is set to include those and pick these up in the dialog which sets the property.

Instead move to reading the value *at the point* it was defined in the project file, which causes us to ignore framework implicit defines.