### PR TITLE
Avoid picking up implicit output path

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
@@ -36,7 +36,12 @@
       <DataSource Persistence="ProjectFile" PersistedName="WarningsAsErrors" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="OutputPath" DisplayName="Output Path" Visible="False"/>
+  <StringProperty Name="OutputPath" DisplayName="Output Path" Visible="False">
+    <StringProperty.DataSource>
+      <!-- We mark BeforeContext to avoid picking up implicit output appending to avoid #2177. -->
+      <DataSource Persistence="ProjectFile" HasConfigurationCondition="True" SourceOfDefaultValue="BeforeContext"/>
+    </StringProperty.DataSource>
+  </StringProperty>
   <StringProperty Name="DocumentationFile" DisplayName="Documentation file" Visible="False"/>
   <EnumProperty Name="GenerateSerializationAssemblies" DisplayName="Generate serialization assemblies" Visible="False">
     <EnumValue Name="Auto" DisplayName="Auto" IsDefault="True" />


### PR DESCRIPTION
Fixes: #2177

The SDK automatically appends to OutputPath with implicit framework and runtime values, when we attempt to read the value at the end of project file ("AfterContext") we think that user's value is set to include those and pick these up in the dialog which sets the property.

Instead move to reading the value at the point it was defined in the project file, which causes us to ignore any values that the SDK appends.