### PR TITLE
Look up single file generators and set CmdUIContext via legacy locations

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.CSharp.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.CSharp.DesignTime.targets
@@ -17,6 +17,7 @@
     <LanguageServiceId Condition="'$(LanguageServiceId)'==''">{694DD9B6-B865-4C5B-AD85-86356E9C88DC}</LanguageServiceId>
     <TemplateLanguage Condition="'$(TemplateLanguage)' == ''">CSharp</TemplateLanguage>
     <AddItemTemplatesGuid Condition="'$(AddItemTemplatesGuid)' == ''">{FAE04EC0-301F-11d3-BF4B-00C04F79EFBC}</AddItemTemplatesGuid>
+    <CmdUIContextGuid Condition="'$(CmdUIContextGuid)' == ''">{FAE04EC1-301F-11d3-BF4B-00C04F79EFBC}</CmdUIContextGuid>
     <GeneratorsTypeGuid Condition="'$(GeneratorsTypeGuid)' == ''">{FAE04EC1-301F-11d3-BF4B-00C04F79EFBC}</GeneratorsTypeGuid>
   
     <!-- Turn off rules and capabilities that are defined in MSBuild so that we can import our own below -->

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.CSharp.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.CSharp.DesignTime.targets
@@ -17,6 +17,7 @@
     <LanguageServiceId Condition="'$(LanguageServiceId)'==''">{694DD9B6-B865-4C5B-AD85-86356E9C88DC}</LanguageServiceId>
     <TemplateLanguage Condition="'$(TemplateLanguage)' == ''">CSharp</TemplateLanguage>
     <AddItemTemplatesGuid Condition="'$(AddItemTemplatesGuid)' == ''">{FAE04EC0-301F-11d3-BF4B-00C04F79EFBC}</AddItemTemplatesGuid>
+    <GeneratorsTypeGuid Condition="'$(GeneratorsTypeGuid)' == ''">{FAE04EC1-301F-11d3-BF4B-00C04F79EFBC}</GeneratorsTypeGuid>
   
     <!-- Turn off rules and capabilities that are defined in MSBuild so that we can import our own below -->
     <DefineCSharpItemSchemas>false</DefineCSharpItemSchemas>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.FSharp.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.FSharp.DesignTime.targets
@@ -17,6 +17,7 @@
     <LanguageServiceId Condition="'$(LanguageServiceId)'==''">{BC6DD5A5-D4D6-4DAB-A00D-A51242DBAF1B}</LanguageServiceId>
     <TemplateLanguage Condition="'$(TemplateLanguage)' == ''">FSharp</TemplateLanguage>
     <AddItemTemplatesGuid Condition="'$(AddItemTemplatesGuid)' == ''">{F2A71F9B-5D33-465A-A702-920D77279786}</AddItemTemplatesGuid>
+    <GeneratorsTypeGuid Condition="'$(GeneratorsTypeGuid)' == ''">{F2A71F9B-5D33-465A-A702-920D77279786}</GeneratorsTypeGuid>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.FSharp.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.FSharp.DesignTime.targets
@@ -17,6 +17,7 @@
     <LanguageServiceId Condition="'$(LanguageServiceId)'==''">{BC6DD5A5-D4D6-4DAB-A00D-A51242DBAF1B}</LanguageServiceId>
     <TemplateLanguage Condition="'$(TemplateLanguage)' == ''">FSharp</TemplateLanguage>
     <AddItemTemplatesGuid Condition="'$(AddItemTemplatesGuid)' == ''">{F2A71F9B-5D33-465A-A702-920D77279786}</AddItemTemplatesGuid>
+    <CmdUIContextGuid Condition="'$(CmdUIContextGuid)' == ''">{F2A71F9B-5D33-465A-A702-920D77279786}</CmdUIContextGuid>
     <GeneratorsTypeGuid Condition="'$(GeneratorsTypeGuid)' == ''">{F2A71F9B-5D33-465A-A702-920D77279786}</GeneratorsTypeGuid>
   </PropertyGroup>
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.VisualBasic.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.VisualBasic.DesignTime.targets
@@ -17,6 +17,7 @@
     <LanguageServiceId Condition="'$(LanguageServiceId)'==''">{E34ACDC0-BAAE-11D0-88BF-00A0C9110049}</LanguageServiceId>
     <TemplateLanguage Condition="'$(TemplateLanguage)' == ''">VisualBasic</TemplateLanguage>
     <AddItemTemplatesGuid Condition="'$(AddItemTemplatesGuid)' == ''">{F184B08F-C81C-45F6-A57F-5ABD9991F28F}</AddItemTemplatesGuid>
+    <GeneratorsTypeGuid Condition="'$(GeneratorsTypeGuid)' == ''">{164B10B9-B200-11d0-8C61-00A0C91E29D5}</GeneratorsTypeGuid>
 
     <!-- Turn off rules and capabilities that are defined in MSBuild so that we can import our own below -->
     <DefineVisualBasicItemSchemas>false</DefineVisualBasicItemSchemas>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.VisualBasic.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.VisualBasic.DesignTime.targets
@@ -17,6 +17,7 @@
     <LanguageServiceId Condition="'$(LanguageServiceId)'==''">{E34ACDC0-BAAE-11D0-88BF-00A0C9110049}</LanguageServiceId>
     <TemplateLanguage Condition="'$(TemplateLanguage)' == ''">VisualBasic</TemplateLanguage>
     <AddItemTemplatesGuid Condition="'$(AddItemTemplatesGuid)' == ''">{F184B08F-C81C-45F6-A57F-5ABD9991F28F}</AddItemTemplatesGuid>
+    <CmdUIContextGuid Condition="'$(CmdUIContextGuid)' == ''">{164B10B9-B200-11d0-8C61-00A0C91E29D5}</CmdUIContextGuid>
     <GeneratorsTypeGuid Condition="'$(GeneratorsTypeGuid)' == ''">{164B10B9-B200-11d0-8C61-00A0C91E29D5}</GeneratorsTypeGuid>
 
     <!-- Turn off rules and capabilities that are defined in MSBuild so that we can import our own below -->


### PR DESCRIPTION
### Look up single file generators using legacy location
Fixes: #3535.

For C# and Visual Basic, generators in the legacy project system are looked up based on their package (not project type) - use that GUID.

For F#, generators in the legacy project system are looked up based on project type, use that.


### Activate legacy UI context for project is active
C# and VB activate a UI context (VSHPROPID_CmdUIGuid) that matches their package GUID (not their project type) when the project is active.

F# activates a UI context that matches its project type GUID when the project is active.

This is blocked on: https://devdiv.visualstudio.com/DevDiv/_git/CPS/pullrequest/122410?_a=overview.