### PR TITLE
[WIP] First approach at simplifying package reference usage across the tree

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
   <Import Project="build\RepoToolset\RestoreSources.props"/>
 
   <ItemGroup>
-    <PackageReference Include="RoslynTools.RepoToolset" Version="$(RoslynToolsRepoToolsetVersion)" />
+    <PackageReference Include="RoslynTools.RepoToolset" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,4 @@
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
+  <Import Project="build\Packages.targets"/>
+</Project>

--- a/build/Codecov.proj
+++ b/build/Codecov.proj
@@ -31,4 +31,6 @@
     <Exec Condition="'$(UseCodecov)' == 'true'"
           Command="&quot;$(_CodecovPath)&quot; @(_CodecovArgs, ' ')" />
   </Target>
+
+  <Import Project="..\Packages.targets" />
 </Project>

--- a/build/Internal/Toolset.csproj
+++ b/build/Internal/Toolset.csproj
@@ -7,6 +7,7 @@
     <RestoreSources/>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.IBCMerge" Version="[$(MicrosoftDotNetIBCMergeVersion)]" />
+    <PackageReference Include="Microsoft.DotNet.IBCMerge" />
   </ItemGroup>
+  <Import Project="..\Packages.targets" />
 </Project>

--- a/build/Packages.targets
+++ b/build/Packages.targets
@@ -1,0 +1,119 @@
+<Project>
+
+  <PropertyGroup>
+    <RestoreSources>
+      $(RestoreSources);
+      https://vside.myget.org/F/devcore/api/v3/index.json;
+      https://dotnet.myget.org/F/msbuild/api/v3/index.json;
+      https://dotnet.myget.org/F/nuget-build/api/v3/index.json;
+      https://dotnet.myget.org/F/roslyn/api/v3/index.json;
+      https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json;
+      https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json;
+      https://dotnet.myget.org/F/templating/api/v3/index.json;
+    </RestoreSources>
+  </PropertyGroup>
+
+  <ItemGroup>
+
+    <!-- Toolset -->
+    <PackageReference Update="RoslynTools.RepoToolset" Version="$(RoslynToolsRepoToolsetVersion)" />
+    <PackageReference Update="RoslynTools.VsixExpInstaller" Version="$(RoslynToolsVsixExpInstallerVersion)" />
+    <PackageReference Update="RoslynDependencies.ProjectSystem.OptimizationData" Version="$(RoslynDependenciesProjectSystemOptimizationDataVersion)" />
+    <PackageReference Update="Microsoft.DotNet.IBCMerge" Version="[$(MicrosoftDotNetIBCMergeVersion)]" />
+    <PackageReference Update="Microsoft.DiaSymReader.Pdb2Pdb" Version="$(MicrosoftDiaSymReaderPdb2PdbVersion)" />
+    <PackageReference Update="OpenCover" Version="$(OpenCoverVersion)" />
+    <PackageReference Update="Codecov" Version="$(CodecovVersion)" />
+
+    <!-- VS SDK -->
+    <PackageReference Update="Microsoft.VisualStudio.ComponentModelHost" Version="15.0.26606"/>
+    <PackageReference Update="Microsoft.VisualStudio.CoreUtility" Version="15.0.26606" />
+    <PackageReference Update="Microsoft.VisualStudio.Data.Core" Version="9.0.21022" />
+    <PackageReference Update="Microsoft.VisualStudio.DataDesign.Common" Version="15.0.26606-alpha"/>
+    <PackageReference Update="Microsoft.VisualStudio.Data.Services" Version="9.0.21022" />
+    <PackageReference Update="Microsoft.VisualStudio.DataTools.Interop" Version="15.0.26606-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.Designer.Interfaces" Version="1.1.4322" />
+    <PackageReference Update="Microsoft.VisualStudio.Diagnostics.PerformanceProvider" Version="15.0.26606-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.Editor" Version="15.0.26606" />
+    <PackageReference Update="Microsoft.VisualStudio.GraphModel" Version="15.0.26606-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.ImageCatalog" Version="15.0.26606" />
+    <PackageReference Update="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" Version="14.3.25407"/>
+    <PackageReference Update="Microsoft.VisualStudio.ManagedInterfaces" Version="8.0.50727" />
+    <PackageReference Update="Microsoft.VisualStudio.Telemetry" Version="15.3.799-masterDDDBA9E4" />
+    <PackageReference Update="Microsoft.VisualStudio.Text.Data" Version="15.0.26606" />
+    <PackageReference Update="Microsoft.VisualStudio.Text.UI" Version="15.0.26606" />
+    <PackageReference Update="Microsoft.VisualStudio.Text.UI.Wpf" Version="15.0.26606" />
+    <PackageReference Update="Microsoft.VisualStudio.Text.UI.Wpf" Version="15.0.26606" />
+    <PackageReference Update="Microsoft.VisualStudio.Text.Logic" Version="15.0.26606" />
+    <PackageReference Update="Microsoft.VisualStudio.TextManager.Interop.9.0" Version="9.0.30729" />
+    <PackageReference Update="Microsoft.VisualStudio.TextManager.Interop.10.0" Version="10.0.30319" />
+    <PackageReference Update="Microsoft.VisualStudio.TextManager.Interop.12.0" Version="12.0.30110" />
+    <PackageReference Update="Microsoft.VisualStudio.TextManager.Interop.12.1.DesignTime" Version="12.1.30328" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.15.0" Version="15.0.26606" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Design" Version="15.0.26606" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Framework" Version="15.0.26606" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.9.0" Version="9.0.30729" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.10.0" Version="10.0.30319" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.11.0" Version="11.0.61030" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.12.1.DesignTime" Version="12.1.30328" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime" Version="14.3.25407" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime" Version="15.0.26201" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime" Version="15.0.26606" />
+    <PackageReference Update="Microsoft.VisualStudio.TemplateWizardInterface" Version="8.0.0-alpha"/>
+    <PackageReference Update="Microsoft.VisualStudio.Threading" Version="15.5.24" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="15.5.13-beta" />
+    <PackageReference Update="Microsoft.VisualStudio.Utilities" Version="15.0.26607" />
+    <PackageReference Update="Microsoft.VisualStudio.Validation" Version="15.3.32" />
+    <PackageReference Update="Microsoft.VisualStudio.VSHelp" Version="15.0.26606-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.WCFReference.Interop" Version="9.0.30729" />
+    <PackageReference Update="Microsoft.VisualStudio.XmlEditor" Version="15.0.26606-alpha" />
+    <PackageReference Update="Microsoft.VSDesigner" Version="15.0.26606-alpha" />
+    <PackageReference Update="VsWebSite.Interop" Version="8.0.0-alpha"/>
+    <PackageReference Update="VSLangProj" Version="7.0.3300" />
+    <PackageReference Update="VSLangProj2" Version="7.0.5000" />
+    <PackageReference Update="VSLangProj80" Version="8.0.50727" />
+    <PackageReference Update="VSLangProj90" Version="9.0.30729" />
+    <PackageReference Update="VSLangProj100" Version="10.0.30319" />
+    <PackageReference Update="VSLangProj110" Version="11.0.61030" />
+    <PackageReference Update="EnvDTE" Version="8.0.1" />
+    <PackageReference Update="EnvDTE80" Version="8.0.1" />
+    <PackageReference Update="EnvDTE90" Version="9.0.1" />
+    
+    <!-- CPS -->
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK" Version="15.7.117-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers" Version="15.7.117-pre" />
+    
+    <!-- Roslyn -->
+    <PackageReference Update="Microsoft.VisualStudio.LanguageServices" Version="2.6.0-beta1-62113-02" />
+    <PackageReference Update="Microsoft.VisualStudio.IntegrationTest.Utilities" Version="2.6.0-beta1-62113-02" />
+    <PackageReference Update="Microsoft.Net.RoslynDiagnostics" Version="2.6.1-beta1-62702-01" />
+    
+    <!-- NuGet -->
+    <PackageReference Update="NuGet.SolutionRestoreManager.Interop" Version="4.3.0" />
+    <PackageReference Update="NuGet.VisualStudio" Version="4.3.0" />
+
+    <!-- MSBuild -->
+    <PackageReference Update="Microsoft.Build" Version="15.6.0-preview-000010-1174357"/>
+    <PackageReference Update="Microsoft.Build.Utilities.Core" Version="15.6.0-preview-000010-1174357"/>
+    <PackageReference Update="Microsoft.Build.Engine" Version="15.6.0-preview-000010-1174357"/>
+    <PackageReference Update="Microsoft.Build.Tasks.Core" Version="15.6.0-preview-000010-1174357"/>
+    
+    <!-- Libraries -->
+    <PackageReference Update="Newtonsoft.Json" Version="9.0.1"/>
+    
+    <!-- Tests -->
+    <PackageReference Update="Moq" Version="4.7.99"/>
+    <PackageReference Update="xunit" Version="$(XUnitVersion)" />
+    <PackageReference Update="xunit.assert" Version="$(XunitVersion)" />
+    <PackageReference Update="xunit.extensibility.core" Version="$(XunitVersion)" />
+    <PackageReference Update="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioVersion)" />
+    <PackageReference Update="xunit.runner.console" Version="$(XUnitVersion)" />
+    <PackageReference Update="xunit.analyzers" Version="0.8.0"/>
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
+    
+    <PackageReference Update="Microsoft.DotNet.Test.ProjectTemplates.1.x" Version="$(MicrosoftDotNetProjectTemplatesVersion)" />
+    <PackageReference Update="Microsoft.DotNet.Common.ProjectTemplates.1.x" Version="$(MicrosoftDotNetProjectTemplatesVersion)" />
+    
+  </ItemGroup>
+  
+
+</Project>

--- a/build/Toolset.proj
+++ b/build/Toolset.proj
@@ -9,11 +9,11 @@
     <RestoreSources>https://api.nuget.org/v3/index.json;https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json;https://dotnet.myget.org/F/symreader-converter/api/v3/index.json</RestoreSources>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="RoslynTools.RepoToolset" Version="$(RoslynToolsRepoToolsetVersion)" />
-    <PackageReference Include="RoslynTools.VsixExpInstaller" Version="$(RoslynToolsVsixExpInstallerVersion)" />
-    <PackageReference Include="Codecov" Version="$(CodecovVersion)" />
-    <PackageReference Include="OpenCover" Version="$(OpenCoverVersion)" />
-    <PackageReference Include="Microsoft.DiaSymReader.Pdb2Pdb" Version="$(MicrosoftDiaSymReaderPdb2PdbVersion)" />
+    <PackageReference Include="RoslynTools.RepoToolset" />
+    <PackageReference Include="RoslynTools.VsixExpInstaller" />
+    <PackageReference Include="Codecov" />
+    <PackageReference Include="OpenCover" />
+    <PackageReference Include="Microsoft.DiaSymReader.Pdb2Pdb" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -61,4 +61,6 @@
     
     <Message Text="Done deploying VSIXes." Importance="high" />
   </Target>
+
+  <Import Project="..\Directory.Build.targets" />
 </Project>

--- a/build/Versions.props
+++ b/build/Versions.props
@@ -91,7 +91,7 @@
     <XUnitAnalyzersVersion>0.8.0</XUnitAnalyzersVersion>
   </PropertyGroup>
 
-  <PropertyGroup>
+    <PropertyGroup>
     <RestoreSources>
       $(RestoreSources);
       https://vside.myget.org/F/devcore/api/v3/index.json;

--- a/setup/Directory.Build.targets
+++ b/setup/Directory.Build.targets
@@ -1,5 +1,6 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project>
+  <Import Project="..\Directory.Build.targets"/>
   <Import Project="$(RepoToolsetDir)Imports.targets" Condition="'$(RepoToolsetDir)' != ''" />
   
   <Target Name="Build" DependsOnTargets="ResolveProjectReferences">

--- a/setup/Microsoft.VisualStudio.NetCore.ProjectTemplates.1.x/Microsoft.VisualStudio.NetCore.ProjectTemplates.1.x.csproj
+++ b/setup/Microsoft.VisualStudio.NetCore.ProjectTemplates.1.x/Microsoft.VisualStudio.NetCore.ProjectTemplates.1.x.csproj
@@ -5,8 +5,8 @@
     <VisualStudioInsertionComponent>$(MSBuildProjectName)</VisualStudioInsertionComponent>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Common.ProjectTemplates.1.x" Version="$(MicrosoftDotNetProjectTemplatesVersion)" />
-    <PackageReference Include="Microsoft.DotNet.Test.ProjectTemplates.1.x" Version="$(MicrosoftDotNetProjectTemplatesVersion)" />
+    <PackageReference Include="Microsoft.DotNet.Common.ProjectTemplates.1.x" />
+    <PackageReference Include="Microsoft.DotNet.Test.ProjectTemplates.1.x" />
   </ItemGroup>
   <ItemGroup>
     <SwrProperty Include="Version=$(VsixVersion)" />

--- a/src/DeployIntegrationDependencies/DeployIntegrationDependencies.csproj
+++ b/src/DeployIntegrationDependencies/DeployIntegrationDependencies.csproj
@@ -6,11 +6,11 @@
     <PublishOutputToSymStore>false</PublishOutputToSymStore>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.IntegrationTest.Utilities" Version="$(MicrosoftVisualStudioIntegrationTestUtilitiesVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="$(MicrosoftVisualStudioLanguageServicesVersion)" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
-    <PackageReference Include="xunit" Version="$(XUnitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioVersion)" />
-    <PackageReference Include="xunit.runner.console" Version="$(XUnitVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.IntegrationTest.Utilities" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="xunit.runner.console" />
   </ItemGroup>
 </Project>

--- a/src/DeployTestDependencies/DeployTestDependencies.csproj
+++ b/src/DeployTestDependencies/DeployTestDependencies.csproj
@@ -18,10 +18,10 @@
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.VisualBasic\Microsoft.VisualStudio.ProjectSystem.VisualBasic.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
-    <PackageReference Include="xunit" Version="$(XUnitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioVersion)" />
-    <PackageReference Include="xunit.runner.console" Version="$(XUnitVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="xunit.runner.console" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Readme.txt" />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,5 +1,6 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project>
+  <Import Project="..\Directory.Build.targets" />
   <Import Project="$(RepoToolsetDir)Imports.targets" Condition="'$(RepoToolsetDir)' != ''" />
   <Import Project="..\build\VisualStudio.XamlRules.targets"/>
   

--- a/src/HostAgnostic.props
+++ b/src/HostAgnostic.props
@@ -10,28 +10,28 @@
     <Reference Include="PresentationFramework" />
 
     <!-- CPS and Roslyn -->
-    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" Version="$(MicrosoftVisualStudioProjectSystemSDKVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="$(MicrosoftVisualStudioLanguageServicesVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Validation" Version="$(MicrosoftVisualStudioValidationVersion)" />    
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" />
-    <PackageReference Include="Microsoft.Net.RoslynDiagnostics" Version="$(MicrosoftNetRoslynDiagnosticsVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Analyzers" Version="$(MicrosoftVisualStudioProjectSystemAnalyzersVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" />
+    <PackageReference Include="Microsoft.VisualStudio.Validation" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" />
+    <PackageReference Include="Microsoft.Net.RoslynDiagnostics" />
+    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Analyzers" />
 
     <!-- Msbuild -->
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Engine" Version="$(MicrosoftBuildVersion)" />
+    <PackageReference Include="Microsoft.Build" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" />
+    <PackageReference Include="Microsoft.Build.Engine" />
 
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' == 'true'" >
-    <PackageReference Include="Moq" Version="$(MoqVersion)"/>
-    <PackageReference Include="xunit.analyzers" Version="$(XUnitAnalyzersVersion)"/>
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit.analyzers" />
 
     <!-- TODO: Some tests need this. Seems wrong. -->
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell15Version)" />
-    <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="$(MicrosoftVisualStudioTextUIVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.UI" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj
@@ -5,9 +5,9 @@
     <PublishOutputToSymStore>false</PublishOutputToSymStore>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Moq" Version="$(MoqVersion)" />
-    <PackageReference Include="xunit.assert" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.extensibility.core" Version="$(XunitVersion)" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit.assert" />
+    <PackageReference Include="xunit.extensibility.core" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests" />

--- a/src/VisualStudio.props
+++ b/src/VisualStudio.props
@@ -1,60 +1,60 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="VSLangProj" Version="7.0.3300" />
-    <PackageReference Include="VSLangProj2" Version="7.0.5000" />
-    <PackageReference Include="VSLangProj80" Version="8.0.50727" />
-    <PackageReference Include="VSLangProj90" Version="9.0.30729" />
-    <PackageReference Include="VSLangProj100" Version="10.0.30319" />
-    <PackageReference Include="VSLangProj110" Version="11.0.61030" />
-    
-    <PackageReference Include="EnvDTE" Version="8.0.1" />
-    <PackageReference Include="EnvDTE80" Version="8.0.1" />
-    <PackageReference Include="EnvDTE90" Version="9.0.1" />
-    <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="$(MicrosoftVisualStudioComponentModelHostVersion)"/>
-    <PackageReference Include="Microsoft.VisualStudio.CoreUtility" Version="$(MicrosoftVisualStudioCoreUtilityVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Data.Core" Version="$(MicrosoftVisualStudioDataCoreVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Data.Services" Version="$(MicrosoftVisualStudioDataServicesVersion)" />
+    <PackageReference Include="VSLangProj" />
+    <PackageReference Include="VSLangProj2" />
+    <PackageReference Include="VSLangProj80" />
+    <PackageReference Include="VSLangProj90" />
+    <PackageReference Include="VSLangProj100" />
+    <PackageReference Include="VSLangProj110" />
+
+    <PackageReference Include="EnvDTE" />
+    <PackageReference Include="EnvDTE80" />
+    <PackageReference Include="EnvDTE90" />
+    <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" />
+    <PackageReference Include="Microsoft.VisualStudio.CoreUtility" />
+    <PackageReference Include="Microsoft.VisualStudio.Data.Core" />
+    <PackageReference Include="Microsoft.VisualStudio.Data.Services" />
 
     <!--
        Microsoft.VisualStudio.Diagnostics.PerformanceProvider.dll is needed by GraphProvider unit tests.
        if it is not provided here, tests fail to load this assembly at runtime.
     -->
-    <PackageReference Include="Microsoft.VisualStudio.DataTools.Interop" Version="$(MicrosoftVisualStudioDataToolsInteropVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Diagnostics.PerformanceProvider" Version="$(MicrosoftVisualStudioDiagnosticsPerformanceProviderVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Designer.Interfaces" Version="$(MicrosoftVisualStudioDesignerInterfacesVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.GraphModel" Version="$(MicrosoftVisualStudioGraphModelVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Editor" Version="$(MicrosoftVisualStudioEditorVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" Version="$(MicrosoftVisualStudioImageCatalogVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" Version="$(MicrosoftVisualStudioImagingInterop140DesignTimeVersion)"/>
-    <PackageReference Include="Microsoft.VisualStudio.ManagedInterfaces" Version="$(MicrosoftVisualStudioManagedInterfacesVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="$(MicrosoftVisualStudioTextDataVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Text.Logic" Version="$(MicrosoftVisualStudioTextLogicVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="$(MicrosoftVisualStudioTextUIVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(MicrosoftVisualStudioTextUIWpfVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.10.0" Version="$(MicrosoftVisualStudioTextManagerInterop10Version)" />
-    <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.12.0" Version="$(MicrosoftVisualStudioTextManagerInterop12Version)" />
-    <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.12.1.DesignTime" Version="$(MicrosoftVisualStudioTextManagerInterop121DesignTimeVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="$(MicrosoftVisualStudioThreadingAnalyzersVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.9.0" Version="$(MicrosoftVisualStudioShellInterop9Version)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.10.0" Version="$(MicrosoftVisualStudioShellInterop10Version)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.11.0" Version="$(MicrosoftVisualStudioShellInterop11Version)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.12.1.DesignTime" Version="$(MicrosoftVisualStudioShellInterop121DesignTimeVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime" Version="$(MicrosoftVisualStudioShellInterop140DesignTimeVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime" Version="$(MicrosoftVisualStudioShellInterop150DesignTimeVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime" Version="$(MicrosoftVisualStudioShellInterop153DesignTimeVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Design" Version="$(MicrosoftVisualStudioShellDesignVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell15Version)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" Version="$(MicrosoftVisualStudioShellFrameworkVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Telemetry" Version="$(MicrosoftVisualStudioTelemetryVersion)" ExcludeAssets="Build" />
-    <PackageReference Include="Microsoft.VisualStudio.Utilities" Version="$(MicrosoftVisualStudioUtilitiesVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Validation" Version="$(MicrosoftVisualStudioValidationVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.VSHelp" Version="$(MicrosoftVisualStudioVsHelpVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.XmlEditor" Version="$(MicrosoftVisualStudioXmlEditorVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.WCFReference.Interop" Version="$(MicrosoftVisualStudioWCFReferenceInteropVersion)" />
-    <PackageReference Include="Microsoft.VSDesigner" Version="$(MicrosoftVsDesignerVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.DataTools.Interop" />
+    <PackageReference Include="Microsoft.VisualStudio.Diagnostics.PerformanceProvider" />
+    <PackageReference Include="Microsoft.VisualStudio.Designer.Interfaces" />
+    <PackageReference Include="Microsoft.VisualStudio.GraphModel" />
+    <PackageReference Include="Microsoft.VisualStudio.Editor" />
+    <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" />
+    <PackageReference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" />
+    <PackageReference Include="Microsoft.VisualStudio.ManagedInterfaces" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.Data" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.Logic" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.UI" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" />
+    <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.10.0" />
+    <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.12.0" />
+    <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.12.1.DesignTime" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.9.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.10.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.11.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.12.1.DesignTime"/>
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime"/>
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime"/>
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime"/>
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Design" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" />
+    <PackageReference Include="Microsoft.VisualStudio.Telemetry" />
+    <PackageReference Include="Microsoft.VisualStudio.Utilities" />
+    <PackageReference Include="Microsoft.VisualStudio.Validation" />
+    <PackageReference Include="Microsoft.VisualStudio.VSHelp" />
+    <PackageReference Include="Microsoft.VisualStudio.XmlEditor" />
+    <PackageReference Include="Microsoft.VisualStudio.WCFReference.Interop" />
+    <PackageReference Include="Microsoft.VSDesigner" />
 
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
This is the first approach at simplifying our package references across tree by following these strategies: https://github.com/davkean/maket & https://github.com/jeffkl/MSBuildSdks/blob/4cf8305df105b1751127c2b01df749c8e299005b/src/CentralPackageVersions/README.md. This is very similar to the what we're looking at productizing with MSBuild/NuGet.

The intention to is get rid of the majority of versions in Versions.props - and leave only those that are used in other contexts other than `<PackageReference />`.