### PR TITLE
Change the default hive to "Exp"

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,7 +32,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 
     <VSSDKTargetPlatformRegRootSuffix Condition="'$(RootSuffix)' != ''">$(RootSuffix)</VSSDKTargetPlatformRegRootSuffix>
-    <VSSDKTargetPlatformRegRootSuffix Condition="'$(VSSDKTargetPlatformRegRootSuffix)' == ''">ProjectSystem</VSSDKTargetPlatformRegRootSuffix>
+    <VSSDKTargetPlatformRegRootSuffix Condition="'$(VSSDKTargetPlatformRegRootSuffix)' == ''">Exp</VSSDKTargetPlatformRegRootSuffix>
 
     <MoqPublicKey>0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7</MoqPublicKey>
 

--- a/Launch.cmd
+++ b/Launch.cmd
@@ -4,4 +4,4 @@ set VisualBasicDesignTimeTargetsPath=%VisualStudioXamlRulesDir%Microsoft.VisualB
 set FSharpDesignTimeTargetsPath=%VisualStudioXamlRulesDir%Microsoft.FSharp.DesignTime.targets
 set CSharpDesignTimeTargetsPath=%VisualStudioXamlRulesDir%Microsoft.CSharp.DesignTime.targets
 
-devenv /rootsuffix ProjectSystem
+devenv /rootsuffix Exp

--- a/build.cmd
+++ b/build.cmd
@@ -48,7 +48,7 @@ echo   Build options:
 echo     /restore-only           Restore dependencies only
 echo     /skiptests              Does not run unit tests
 echo     /diagnostic             Turns on logging to a binlog
-echo     /rootsuffix             Visual Studio hive to deploy VSIX extensions to (default is ProjectSystem)
+echo     /rootsuffix             Visual Studio hive to deploy VSIX extensions to (default is Exp)
 echo     /no-deploy-extension    Does not deploy VSIX extensions when building the solution
 echo     /integrationtests       Runs integration tests
 goto :eof


### PR DESCRIPTION
CPS always deploys to "Exp" to enable testing project system and CPS together have them deploy to the same hive.