### PR TITLE
TFS611255 add UsePreviewSdk option

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -42,6 +42,7 @@
     <MicrosoftVisualStudioTextManagerInterop10Version>10.0.30319</MicrosoftVisualStudioTextManagerInterop10Version>
     <MicrosoftVisualStudioTextManagerInterop12Version>12.0.30110</MicrosoftVisualStudioTextManagerInterop12Version>
     <MicrosoftVisualStudioTextManagerInterop121DesignTimeVersion>12.1.30328</MicrosoftVisualStudioTextManagerInterop121DesignTimeVersion>
+    <MicrosoftVisualStudioSetupConfigurationVersion>1.16.30</MicrosoftVisualStudioSetupConfigurationVersion>
     <MicrosoftVisualStudioShell15Version>15.0.26606</MicrosoftVisualStudioShell15Version>
     <MicrosoftVisualStudioShellDesignVersion>15.0.26606</MicrosoftVisualStudioShellDesignVersion>
     <MicrosoftVisualStudioShellFrameworkVersion>15.0.26606</MicrosoftVisualStudioShellFrameworkVersion>

--- a/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
@@ -1687,6 +1687,8 @@ Namespace Microsoft.VisualStudio.Editors.Common
         Public Class TelemetryLogger
 
             Private Const InputXmlFormEventName As String = "vs/projectsystem/editors/inputxmlform"
+            Private Const UsePreviewSdkEventName As String = "vs/projectsystem/options/usepreviewsdk"
+
             Public Enum InputXmlFormEvent
                 FormOpened
                 FromFileButtonClicked
@@ -1703,6 +1705,14 @@ Namespace Microsoft.VisualStudio.Editors.Common
             Public Shared Sub LogInputXmlFormException(ex As Exception)
                 TelemetryService.DefaultSession.PostFault(InputXmlFormEventName, "Exception encountered during Xml Schema Inference", ex)
             End Sub
+
+            Public Shared Sub LogUsePreviewSdkEvent(usePreviewSdk As Boolean, isPreview As Boolean)
+                Dim userTask = New UserTaskEvent(UsePreviewSdkEventName, TelemetryResult.Success)
+                userTask.Properties("vs.projectsystem.options.usepreviewsdk") = usePreviewSdk
+                userTask.Properties("vs.projectsystem.options.ispreview") = isPreview
+                TelemetryService.DefaultSession.PostEvent(userTask)
+            End Sub
+
         End Class
 #End Region
     End Module

--- a/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
+++ b/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
@@ -16,6 +16,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="$(MicrosoftVisualStudioLanguageServicesVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="$(MicrosoftVisualStudioSetupConfigurationVersion)" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageControl.xaml
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageControl.xaml
@@ -14,6 +14,11 @@
                     </StackPanel>
                 </StackPanel>
             </GroupBox>
+            <GroupBox x:Uid="SdkGroupBox" Header="{x:Static r:GeneralOptionPageResources.General_Sdk_Title}">
+                <StackPanel Orientation="Horizontal">
+                    <CheckBox x:Name="UsePreviewSdk" x:Uid="General_UsePreviewSdk" Content="{x:Static r:GeneralOptionPageResources.General_UsePreviewSdk}" Margin="0" />
+                </StackPanel>
+            </GroupBox>
         </StackPanel>
     </ScrollViewer>
 </local:OptionPageControl>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageControl.xaml
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageControl.xaml
@@ -14,11 +14,9 @@
                     </StackPanel>
                 </StackPanel>
             </GroupBox>
-            <GroupBox x:Uid="SdkGroupBox" Header="{x:Static r:GeneralOptionPageResources.General_Sdk_Title}">
-                <StackPanel Orientation="Horizontal">
-                    <CheckBox x:Name="UsePreviewSdk" x:Uid="General_UsePreviewSdk" Content="{x:Static r:GeneralOptionPageResources.General_UsePreviewSdk}" Margin="0" />
-                </StackPanel>
-            </GroupBox>
+            <StackPanel Orientation="Horizontal">
+                <CheckBox x:Name="UsePreviewSdk" x:Uid="General_UsePreviewSdk" Content="{x:Static r:GeneralOptionPageResources.General_UsePreviewSdk}" Margin="13, 10" />
+            </StackPanel>
         </StackPanel>
     </ScrollViewer>
 </local:OptionPageControl>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageControl.xaml.vb
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageControl.xaml.vb
@@ -40,6 +40,15 @@ Namespace Microsoft.VisualStudio.Editors.OptionPages
 
             bindingExpression = FastUpToDateLogLevel.SetBinding(Selector.SelectedIndexProperty, binding)
             AddBinding(bindingExpression)
+
+            binding = New Binding() With {
+                .Source = _generalOptions,
+                .Path = New Windows.PropertyPath(NameOf(GeneralOptions.UsePreviewSdk)),
+                .UpdateSourceTrigger = UpdateSourceTrigger.Explicit
+            }
+
+            bindingExpression = UsePreviewSdk.SetBinding(ToggleButton.IsCheckedProperty, binding)
+            AddBinding(bindingExpression)
         End Sub
     End Class
 End Namespace

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageControl.xaml.vb
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageControl.xaml.vb
@@ -49,6 +49,16 @@ Namespace Microsoft.VisualStudio.Editors.OptionPages
 
             bindingExpression = UsePreviewSdk.SetBinding(ToggleButton.IsCheckedProperty, binding)
             AddBinding(bindingExpression)
+
+            binding = New Binding() With {
+                .Source = _generalOptions,
+                .Path = New Windows.PropertyPath(NameOf(GeneralOptions.CanChangeUsePreviewSdk)),
+                .UpdateSourceTrigger = UpdateSourceTrigger.Explicit
+            }
+
+            bindingExpression = UsePreviewSdk.SetBinding(IsEnabledProperty, binding)
+            AddBinding(bindingExpression)
+
         End Sub
     End Class
 End Namespace

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.Designer.vb
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.Designer.vb
@@ -117,5 +117,23 @@ Namespace My.Resources
                 Return ResourceManager.GetString("General_FastUpToDateCheck_Title", resourceCulture)
             End Get
         End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to SDK.
+        '''</summary>
+        Public Shared ReadOnly Property General_Sdk_Title() As String
+            Get
+                Return ResourceManager.GetString("General_Sdk_Title", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Use previews of the .NET Core SDK.
+        '''</summary>
+        Public Shared ReadOnly Property General_UsePreviewSdk() As String
+            Get
+                Return ResourceManager.GetString("General_UsePreviewSdk", resourceCulture)
+            End Get
+        End Property
     End Class
 End Namespace

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.Designer.vb
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.Designer.vb
@@ -119,15 +119,6 @@ Namespace My.Resources
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to SDK.
-        '''</summary>
-        Public Shared ReadOnly Property General_Sdk_Title() As String
-            Get
-                Return ResourceManager.GetString("General_Sdk_Title", resourceCulture)
-            End Get
-        End Property
-        
-        '''<summary>
         '''  Looks up a localized string similar to Use previews of the .NET Core SDK.
         '''</summary>
         Public Shared ReadOnly Property General_UsePreviewSdk() As String

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.resx
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.resx
@@ -135,9 +135,6 @@
   <data name="General_FastUpToDateCheck_Title" xml:space="preserve">
     <value>Up to Date Checks</value>
   </data>
-  <data name="General_Sdk_Title" xml:space="preserve">
-    <value>SDK</value>
-  </data>
   <data name="General_UsePreviewSdk" xml:space="preserve">
     <value>Use previews of the .NET Core SDK</value>
   </data>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.resx
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.resx
@@ -135,4 +135,10 @@
   <data name="General_FastUpToDateCheck_Title" xml:space="preserve">
     <value>Up to Date Checks</value>
   </data>
+  <data name="General_Sdk_Title" xml:space="preserve">
+    <value>SDK</value>
+  </data>
+  <data name="General_UsePreviewSdk" xml:space="preserve">
+    <value>Use previews of the .NET Core SDK</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptions.vb
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptions.vb
@@ -1,7 +1,13 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Option Strict Off
+
+Imports System.IO
 Imports System.Runtime.InteropServices
+Imports System.Text.RegularExpressions
 Imports Microsoft.VisualStudio.Settings
+Imports Microsoft.VisualStudio.Setup.Configuration
+Imports Microsoft.VisualStudio.Shell.Interop
 
 Namespace Microsoft.VisualStudio.Editors.OptionPages
     Public NotInheritable Class GeneralOptions
@@ -9,10 +15,16 @@ Namespace Microsoft.VisualStudio.Editors.OptionPages
         Private Class SVsSettingsPersistenceManager
         End Class
 
+        Private Const PreviewChannelPattern As String = "VisualStudio\.[0-9]+\.Preview/"
+        Private Const UsePreviewSdkMarkerFileName As String = "sdk.txt"
         Private Const FastUpToDateEnabledSettingKey As String = "ManagedProjectSystem\FastUpToDateCheckEnabled"
         Private Const FastUpToDateLogLevelSettingKey As String = "ManagedProjectSystem\FastUpToDateLogLevel"
+        Private Const UsePreviewSdkSettingKey As String = "ManagedProjectSystem\UsePreviewSdk"
 
         Private ReadOnly _settingsManager As ISettingsManager
+        Private ReadOnly _shell As IVsShell
+        Private ReadOnly _localAppData As String
+        Private ReadOnly _isPreview As Boolean
 
         Public Property FastUpToDateCheckEnabled As Boolean
             Get
@@ -32,8 +44,110 @@ Namespace Microsoft.VisualStudio.Editors.OptionPages
             End Set
         End Property
 
+        ''' <summary>
+        ''' This setting has dynamic default value:
+        '''     - true if VS was installed from Preview channel
+        '''     - false if VS was installed from Release channel.
+        ''' When default setting value is changed by user, we write current value to a marker file 
+        ''' located under local AppData VS instance folder to be used by out-proc components.
+        ''' If there no marker file there, it measn VS is having default setting value which was 
+        ''' never changed by user manually. Out-proc components should treat absense of the file as 
+        ''' default option value and check the channel using same setup API we use here. 
+        ''' This absense=default logic is needed for the case VS is installed, was never started yet,
+        ''' but user runs msbuild form dev command line to build solution. In this case msbuild 
+        ''' components should have a way to figure out default setting on their own.
+        ''' 
+        ''' Note: This setting is not roamed. After chatting with shell team, we decided not to roam 
+        ''' it due to stability issues.
+        ''' </summary>
+        ''' <returns></returns>
+        Public Property UsePreviewSdk As Boolean
+            Get
+                Return If(_settingsManager?.GetValueOrDefault(UsePreviewSdkSettingKey, _isPreview), _isPreview)
+            End Get
+            Set
+                _settingsManager.SetValueAsync(UsePreviewSdkSettingKey, Value, isMachineLocal:=False)
+                UpdateSdkMarkerFile(Value)
+            End Set
+        End Property
+
         Public Sub New(serviceProvider As IServiceProvider)
             _settingsManager = CType(serviceProvider.GetService(GetType(SVsSettingsPersistenceManager)), ISettingsManager)
+            _shell = CType(serviceProvider.GetService(GetType(SVsShell)), IVsShell)
+
+            Dim oPath As Object = Nothing
+            If (Not VSErrorHandler.Failed(_shell.GetProperty(__VSSPROPID4.VSSPROPID_LocalAppDataDir, oPath))) And
+                (oPath IsNot Nothing) And
+                (TypeOf oPath Is String) Then
+                _localAppData = CType(oPath, String)
+            End If
+
+            _isPreview = IsPreview()
+        End Sub
+
+        ''' <summary>
+        ''' Uses VS setup API, to determine if current VS instance came from Preview channel or not.
+        ''' Note: we depend here on channel manifest format. If it changes, we could be broken. There is
+        ''' an integration test in WTE repo to be executed in nightly vendors' runs to protect form manifest 
+        ''' format changes.
+        ''' </summary>
+        ''' <returns></returns>
+        Private Function IsPreview() As Boolean
+            Dim vsSetupConfig = New SetupConfiguration()
+            Dim installedInstances As List(Of ISetupInstance) = New List(Of ISetupInstance)()
+            Dim installationPath As Object = Nothing
+
+            If (Not VSErrorHandler.Failed(_shell.GetProperty(__VSSPROPID.VSSPROPID_InstallDirectory, installationPath))) AndAlso
+                (installationPath IsNot Nothing) AndAlso
+                (TypeOf installationPath Is String) AndAlso
+                (Not String.IsNullOrEmpty(installationPath)) Then
+
+                Dim instances = vsSetupConfig.EnumAllInstances()
+                Dim foundInstance As ISetupInstance2 = Nothing
+                Dim instanceBuffer() As ISetupInstance = New ISetupInstance(0) {}
+                Dim fetched As Integer
+
+                Do
+                    fetched = 0
+                    instances.Next(1, instanceBuffer, fetched)
+
+                    If ((fetched > 0) AndAlso
+                        installationPath.StartsWith(instanceBuffer(0).GetInstallationPath() + "\", StringComparison.OrdinalIgnoreCase)) Then
+                        foundInstance = CType(instanceBuffer(0), ISetupInstance2)
+                    End If
+                Loop While ((fetched > 0) And (foundInstance Is Nothing))
+
+                If (foundInstance IsNot Nothing) Then
+                    ' Manifest takes form of: "VisualStudio.15.Preview/15.8.0-pre.2.0+27714.3000.d15.8stg"
+                    Dim channelManifest = foundInstance.GetProperties().GetValue("channelManifestId").ToString()
+                    Return Regex.IsMatch(channelManifest, PreviewChannelPattern, RegexOptions.IgnoreCase)
+                End If
+            End If
+
+            Return False
+        End Function
+
+        ''' <summary>
+        ''' This method creates a marker file containing a value for UsePreviewSdk setting to be used 
+        ''' out-proc (msbuild Sdk Resolver). Marker file is stored into current instance folder under 
+        ''' local AppData.
+        ''' </summary>
+        ''' <param name="usePreviews"></param>
+        Private Sub UpdateSdkMarkerFile(usePreviews As Boolean)
+            If (String.IsNullOrEmpty(_localAppData)) Then
+                Return
+            End If
+
+            Dim sdkTxtPath As String = Path.Combine(_localAppData, UsePreviewSdkMarkerFileName)
+            Dim attempts As Integer = 3
+            Do While (attempts > 0)
+                Try
+                    File.WriteAllText(sdkTxtPath, $"UsePreviews={usePreviews}")
+                    attempts = 0
+                Catch ex As IOException
+                    attempts = attempts - 1
+                End Try
+            Loop
         End Sub
     End Class
 End Namespace

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptions.vb
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptions.vb
@@ -71,6 +71,12 @@ Namespace Microsoft.VisualStudio.Editors.OptionPages
             End Set
         End Property
 
+        Public ReadOnly Property CanChangeUsePreviewSdk As Boolean
+            Get
+                Return Not _isPreview
+            End Get
+        End Property
+
         Public Sub New(serviceProvider As IServiceProvider)
             _settingsManager = DirectCast(serviceProvider.GetService(GetType(SVsSettingsPersistenceManager)), ISettingsManager)
             Dim shell = DirectCast(serviceProvider.GetService(GetType(SVsShell)), IVsShell)

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptions.vb
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptions.vb
@@ -72,14 +72,14 @@ Namespace Microsoft.VisualStudio.Editors.OptionPages
         End Property
 
         Public Sub New(serviceProvider As IServiceProvider)
-            _settingsManager = CType(serviceProvider.GetService(GetType(SVsSettingsPersistenceManager)), ISettingsManager)
-            Dim shell = CType(serviceProvider.GetService(GetType(SVsShell)), IVsShell)
+            _settingsManager = DirectCast(serviceProvider.GetService(GetType(SVsSettingsPersistenceManager)), ISettingsManager)
+            Dim shell = DirectCast(serviceProvider.GetService(GetType(SVsShell)), IVsShell)
 
             Dim oPath As Object = Nothing
             If (Not VSErrorHandler.Failed(shell.GetProperty(__VSSPROPID4.VSSPROPID_LocalAppDataDir, oPath))) And
                 (oPath IsNot Nothing) And
                 (TypeOf oPath Is String) Then
-                _localAppData = CType(oPath, String)
+                _localAppData = DirectCast(oPath, String)
             End If
 
             _isPreview = IsPreview()
@@ -92,7 +92,7 @@ Namespace Microsoft.VisualStudio.Editors.OptionPages
         Private Function IsPreview() As Boolean
             Dim vsSetupConfig = New SetupConfiguration()
             Dim setupInstance = vsSetupConfig.GetInstanceForCurrentProcess()
-            Dim setupInstanceCatalog = CType(setupInstance, ISetupInstanceCatalog)
+            Dim setupInstanceCatalog = DirectCast(setupInstance, ISetupInstanceCatalog)
 
             ' Release: false. Others: true.
             Return setupInstanceCatalog.IsPrerelease()
@@ -115,7 +115,7 @@ Namespace Microsoft.VisualStudio.Editors.OptionPages
                 Try
                     File.WriteAllText(sdkTxtPath, $"UsePreviews={usePreviews}")
                     attempts = 0
-                Catch ex As IOException
+                Catch ex As Exception
                     attempts = attempts - 1
                 End Try
             Loop

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.cs.xlf
@@ -37,11 +37,6 @@
         <target state="new">Use previews of the .NET Core SDK</target>
         <note />
       </trans-unit>
-      <trans-unit id="General_Sdk_Title">
-        <source>SDK</source>
-        <target state="new">SDK</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.cs.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Kontroly aktuálnosti</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_UsePreviewSdk">
+        <source>Use previews of the .NET Core SDK</source>
+        <target state="new">Use previews of the .NET Core SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="General_Sdk_Title">
+        <source>SDK</source>
+        <target state="new">SDK</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.de.xlf
@@ -37,11 +37,6 @@
         <target state="new">Use previews of the .NET Core SDK</target>
         <note />
       </trans-unit>
-      <trans-unit id="General_Sdk_Title">
-        <source>SDK</source>
-        <target state="new">SDK</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.de.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Aktualitätsprüfungen</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_UsePreviewSdk">
+        <source>Use previews of the .NET Core SDK</source>
+        <target state="new">Use previews of the .NET Core SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="General_Sdk_Title">
+        <source>SDK</source>
+        <target state="new">SDK</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.es.xlf
@@ -37,11 +37,6 @@
         <target state="new">Use previews of the .NET Core SDK</target>
         <note />
       </trans-unit>
-      <trans-unit id="General_Sdk_Title">
-        <source>SDK</source>
-        <target state="new">SDK</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.es.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Comprobaciones de actualizaciones</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_UsePreviewSdk">
+        <source>Use previews of the .NET Core SDK</source>
+        <target state="new">Use previews of the .NET Core SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="General_Sdk_Title">
+        <source>SDK</source>
+        <target state="new">SDK</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.fr.xlf
@@ -37,11 +37,6 @@
         <target state="new">Use previews of the .NET Core SDK</target>
         <note />
       </trans-unit>
-      <trans-unit id="General_Sdk_Title">
-        <source>SDK</source>
-        <target state="new">SDK</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.fr.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Contrôles de mise à jour</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_UsePreviewSdk">
+        <source>Use previews of the .NET Core SDK</source>
+        <target state="new">Use previews of the .NET Core SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="General_Sdk_Title">
+        <source>SDK</source>
+        <target state="new">SDK</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.it.xlf
@@ -37,11 +37,6 @@
         <target state="new">Use previews of the .NET Core SDK</target>
         <note />
       </trans-unit>
-      <trans-unit id="General_Sdk_Title">
-        <source>SDK</source>
-        <target state="new">SDK</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.it.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Controlli aggiornamenti</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_UsePreviewSdk">
+        <source>Use previews of the .NET Core SDK</source>
+        <target state="new">Use previews of the .NET Core SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="General_Sdk_Title">
+        <source>SDK</source>
+        <target state="new">SDK</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.ja.xlf
@@ -37,11 +37,6 @@
         <target state="new">Use previews of the .NET Core SDK</target>
         <note />
       </trans-unit>
-      <trans-unit id="General_Sdk_Title">
-        <source>SDK</source>
-        <target state="new">SDK</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.ja.xlf
@@ -32,6 +32,16 @@
         <target state="translated">最新状態チェック</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_UsePreviewSdk">
+        <source>Use previews of the .NET Core SDK</source>
+        <target state="new">Use previews of the .NET Core SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="General_Sdk_Title">
+        <source>SDK</source>
+        <target state="new">SDK</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.ko.xlf
@@ -37,11 +37,6 @@
         <target state="new">Use previews of the .NET Core SDK</target>
         <note />
       </trans-unit>
-      <trans-unit id="General_Sdk_Title">
-        <source>SDK</source>
-        <target state="new">SDK</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.ko.xlf
@@ -32,6 +32,16 @@
         <target state="translated">최신 검사</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_UsePreviewSdk">
+        <source>Use previews of the .NET Core SDK</source>
+        <target state="new">Use previews of the .NET Core SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="General_Sdk_Title">
+        <source>SDK</source>
+        <target state="new">SDK</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.pl.xlf
@@ -37,11 +37,6 @@
         <target state="new">Use previews of the .NET Core SDK</target>
         <note />
       </trans-unit>
-      <trans-unit id="General_Sdk_Title">
-        <source>SDK</source>
-        <target state="new">SDK</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.pl.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Testy aktualności</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_UsePreviewSdk">
+        <source>Use previews of the .NET Core SDK</source>
+        <target state="new">Use previews of the .NET Core SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="General_Sdk_Title">
+        <source>SDK</source>
+        <target state="new">SDK</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.pt-BR.xlf
@@ -37,11 +37,6 @@
         <target state="new">Use previews of the .NET Core SDK</target>
         <note />
       </trans-unit>
-      <trans-unit id="General_Sdk_Title">
-        <source>SDK</source>
-        <target state="new">SDK</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.pt-BR.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Verificações atualizadas</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_UsePreviewSdk">
+        <source>Use previews of the .NET Core SDK</source>
+        <target state="new">Use previews of the .NET Core SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="General_Sdk_Title">
+        <source>SDK</source>
+        <target state="new">SDK</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.ru.xlf
@@ -37,11 +37,6 @@
         <target state="new">Use previews of the .NET Core SDK</target>
         <note />
       </trans-unit>
-      <trans-unit id="General_Sdk_Title">
-        <source>SDK</source>
-        <target state="new">SDK</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.ru.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Проверки наличия обновлений</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_UsePreviewSdk">
+        <source>Use previews of the .NET Core SDK</source>
+        <target state="new">Use previews of the .NET Core SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="General_Sdk_Title">
+        <source>SDK</source>
+        <target state="new">SDK</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.tr.xlf
@@ -37,11 +37,6 @@
         <target state="new">Use previews of the .NET Core SDK</target>
         <note />
       </trans-unit>
-      <trans-unit id="General_Sdk_Title">
-        <source>SDK</source>
-        <target state="new">SDK</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.tr.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Güncellik Denetimleri</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_UsePreviewSdk">
+        <source>Use previews of the .NET Core SDK</source>
+        <target state="new">Use previews of the .NET Core SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="General_Sdk_Title">
+        <source>SDK</source>
+        <target state="new">SDK</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.zh-Hans.xlf
@@ -37,11 +37,6 @@
         <target state="new">Use previews of the .NET Core SDK</target>
         <note />
       </trans-unit>
-      <trans-unit id="General_Sdk_Title">
-        <source>SDK</source>
-        <target state="new">SDK</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.zh-Hans.xlf
@@ -32,6 +32,16 @@
         <target state="translated">最新检查</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_UsePreviewSdk">
+        <source>Use previews of the .NET Core SDK</source>
+        <target state="new">Use previews of the .NET Core SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="General_Sdk_Title">
+        <source>SDK</source>
+        <target state="new">SDK</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.zh-Hant.xlf
@@ -37,11 +37,6 @@
         <target state="new">Use previews of the .NET Core SDK</target>
         <note />
       </trans-unit>
-      <trans-unit id="General_Sdk_Title">
-        <source>SDK</source>
-        <target state="new">SDK</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.zh-Hant.xlf
@@ -32,6 +32,16 @@
         <target state="translated">最新版檢查</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_UsePreviewSdk">
+        <source>Use previews of the .NET Core SDK</source>
+        <target state="new">Use previews of the .NET Core SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="General_Sdk_Title">
+        <source>SDK</source>
+        <target state="new">SDK</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/VisualStudio.props
+++ b/src/VisualStudio.props
@@ -68,7 +68,8 @@
   <Target Name="CustomLinkVSSDKEmbeddableAssemblies" AfterTargets="LinkVSSDKEmbeddableAssemblies">
     <ItemGroup>
       <ReferencePath Condition="
-              '%(FileName)' == 'Microsoft.VisualStudio.Shell.Embeddable'
+              '%(FileName)' == 'Microsoft.VisualStudio.Setup.Configuration.Interop'
+           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Embeddable'
            or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.12.0'
            or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.12.1.DesignTime'
            or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime'


### PR DESCRIPTION
- Adding UserPreviewSdk option to .Net Core options page. 
- This setting has dynamic default value depending if VS was installed from Preview or Release channel.
- When user changing setting value, we create a sdk.txt file in the local AppData VS instance folder containing UsePreviews=True|False with current setting value. Absence of the file means setting has default value. Out-proc components will be able to determine default value by checking VS channel in the same way we do here.