### PR TITLE
Handle properties that "Update-Database" script from EntityFramework needs

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsProject_VsLangProjectProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsProject_VsLangProjectProperties.cs
@@ -94,6 +94,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             }
         }
 
+        public string OutputFileName
+        {
+            get
+            {
+                return _threadingService.ExecuteSynchronously(async () =>
+                {
+                    ConfigurationGeneralBrowseObject configurationGeneralProperties = await ProjectProperties.GetConfigurationGeneralBrowseObjectPropertiesAsync().ConfigureAwait(true);
+                    return await configurationGeneralProperties.OutputFileName.GetEvaluatedValueAtEndAsync().ConfigureAwait(true);
+                });
+            }
+        }
+
         public string ExtenderCATID => null;
 
         public string AbsoluteProjectDirectory
@@ -163,8 +175,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
         public prjOptionStrict OptionStrict { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
         public string ReferencePath { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-
-        public string OutputFileName => throw new NotImplementedException();
 
         public prjOptionExplicit OptionExplicit { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AbstractProjectConfigurationProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AbstractProjectConfigurationProperties.cs
@@ -105,12 +105,30 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             }
         }
 
+        public string IntermediatePath
+        {
+            get
+            {
+                return _threadingService.ExecuteSynchronously(async () =>
+                {
+                    ConfiguredBrowseObject browseObjectProperties = await _projectProperties.GetConfiguredBrowseObjectPropertiesAsync().ConfigureAwait(true);
+                    return await browseObjectProperties.IntermediatePath.GetEvaluatedValueAtEndAsync().ConfigureAwait(true);
+                });
+            }
+            set
+            {
+                _threadingService.ExecuteSynchronously(async () =>
+                {
+                    ConfiguredBrowseObject browseObjectProperties = await _projectProperties.GetConfiguredBrowseObjectPropertiesAsync().ConfigureAwait(true);
+                    await browseObjectProperties.IntermediatePath.SetValueAsync(value).ConfigureAwait(true);
+                });
+            }
+        }
         public object ExtenderNames => null;
         public string __id => throw new System.NotImplementedException();
         public bool DebugSymbols { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
         public bool DefineDebug { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
         public bool DefineTrace { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
-        public string IntermediatePath { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
         public string DefineConstants { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
         public bool RemoveIntegerChecks { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
         public uint BaseAddress { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AbstractProjectConfigurationProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AbstractProjectConfigurationProperties.cs
@@ -85,6 +85,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             }
         }
 
+        public string PlatformTarget
+        {
+            get
+            {
+                return _threadingService.ExecuteSynchronously(async () =>
+                {
+                    ConfiguredBrowseObject browseObjectProperties = await _projectProperties.GetConfiguredBrowseObjectPropertiesAsync().ConfigureAwait(true);
+                    return await browseObjectProperties.PlatformTarget.GetEvaluatedValueAtEndAsync().ConfigureAwait(true);
+                });
+            }
+            set
+            {
+                _threadingService.ExecuteSynchronously(async () =>
+                {
+                    ConfiguredBrowseObject browseObjectProperties = await _projectProperties.GetConfiguredBrowseObjectPropertiesAsync().ConfigureAwait(true);
+                    await browseObjectProperties.PlatformTarget.SetValueAsync(value).ConfigureAwait(true);
+                });
+            }
+        }
+
         public object ExtenderNames => null;
         public string __id => throw new System.NotImplementedException();
         public bool DebugSymbols { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
@@ -125,7 +145,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         public string NoWarn { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
         public bool NoStdLib { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
         public string DebugInfo { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
-        public string PlatformTarget { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
         public string TreatSpecificWarningsAsErrors { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
         public bool RunCodeAnalysis { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
         public string CodeAnalysisLogFile { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -47,6 +47,13 @@
         </IntProperty.DataSource>
     </IntProperty>
     <StringProperty Name="OutputName" Visible="False" />
+
+    <StringProperty Name="OutputFileName" ReadOnly="True" Visible="False">
+      <StringProperty.DataSource>
+        <DataSource PersistedName="TargetFileName" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+      </StringProperty.DataSource>
+    </StringProperty>
+  
     <!-- This property is used to provide the value of OutputType through BrowseObject, which is used by Property pages-->
     <IntProperty Name="OutputType" DisplayName="Output Type" Visible="False">
         <IntProperty.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -50,7 +50,7 @@
 
     <StringProperty Name="OutputFileName" ReadOnly="True" Visible="False">
       <StringProperty.DataSource>
-        <DataSource PersistedName="TargetFileName" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+        <DataSource Persistence="ProjectFile" PersistedName="TargetFileName" SourceOfDefaultValue="AfterContext" />
       </StringProperty.DataSource>
     </StringProperty>
   

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
@@ -26,6 +26,13 @@
   </StringProperty>
   
   <EnumProperty Name="PlatformTarget" DisplayName="Platform Target" Visible="False"/>
+  
+  <StringProperty Name="IntermediatePath" Visible="false">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile" PersistedName="IntermediateOutputPath" HasConfigurationCondition="True" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
   <BoolProperty Name="Prefer32Bit" DisplayName="Prefer 32Bit" Visible="False"/>
   <BoolProperty Name="AllowUnsafeBlocks"  Default="False"  DisplayName="Allow unsafe code" Visible="False"/>
   <BoolProperty Name="Optimize" DisplayName="Optimize" Visible="False"/>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
@@ -29,7 +29,7 @@
   
   <StringProperty Name="IntermediatePath" Visible="false">
     <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="IntermediateOutputPath" HasConfigurationCondition="True" />
+      <DataSource Persistence="ProjectFile" PersistedName="IntermediateOutputPath" HasConfigurationCondition="True" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 


### PR DESCRIPTION
Earlier version's of [EF's Update-Database script](https://github.com/aspnet/EntityFrameworkCore/blob/release/2.0/src/EFCore.Tools/tools/EntityFrameworkCore.psm1) did a Project.Kind check to determine if .NET Core and if so read properties directly from via GetCommonProperties. In recent builds this kind changed to return legacy project system, but we missed this usage because it's since been changed to a "CPS" check. Downlevel packages, however, are still broken.

Implement the properties that they need:

#669
#667
#665 

Previous:

```
PM> Install-Package Microsoft.EntityFrameworkCore.Tools -Version 2.0.3
PM> Update-Database
Could not load assembly ''. Ensure it is referenced by the startup project ''.
```

New (which @bricelam tells me indicates that it worked):
```
PM> Install-Package Microsoft.EntityFrameworkCore.Tools -Version 2.0.3
PM> Update-Database
No DbContext was found in assembly 'WebApplication1'. Ensure that you're using the correct assembly and that the type is neither abstract nor generic.
```