### PR TITLE
Free threaded create and dispose

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
+using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 using Microsoft.VisualStudio.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
@@ -84,8 +85,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
                 usedProjectContexts = _configuredProjectContextsMap.Values.ToImmutableHashSet();
             }
 
-            // TODO: https://github.com/dotnet/roslyn-project-system/issues/353
-            await _commonServices.ThreadingService.SwitchToUIThread();
+            if (!LanguageServiceHost.WorkspaceSupportsBatchingAndFreeThreadedInitialization)
+            {
+                await _commonServices.ThreadingService.SwitchToUIThread();
+            }
 
             // We don't want to dispose the inner workspace contexts that are still being used by other active aggregate contexts.
             bool shouldDisposeInnerContext(ITargetedProjectContext c) => !usedProjectContexts.Contains(c);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetSubscriptionHostBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetSubscriptionHostBase.cs
@@ -255,8 +255,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         {
             Requires.NotNull(newProjectContext, nameof(newProjectContext));
 
-            await _commonServices.ThreadingService.SwitchToUIThread();
-
             await _tasksService.LoadedProjectAsync(() =>
             {
                 lock (_linksLock)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -159,8 +159,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             AggregateWorkspaceProjectContext previousContextToDispose = null;
             return await ExecuteWithinLockAsync(async () =>
             {
-                await _commonServices.ThreadingService.SwitchToUIThread();
-
                 string newTargetFramework = null;
                 ConfigurationGeneral projectProperties = await _commonServices.ActiveConfiguredProjectProperties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(false);
 
@@ -233,7 +231,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         {
             Requires.NotNull(newProjectContext, nameof(newProjectContext));
 
-            await _commonServices.ThreadingService.SwitchToUIThread();
             await _tasksService.LoadedProjectAsync(() =>
             {
                 IEnumerable<string> watchedEvaluationRules = _languageServiceHandlerManager.GetWatchedRules(RuleHandlerType.Evaluation);


### PR DESCRIPTION
If the Workspace supports it, we don't switch to the UI thread before creating or disposing the `IWorkspaceProjectContext`.