### PR TITLE
Add binding redirects check box to property pages

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.Designer.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.Designer.vb
@@ -29,6 +29,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Friend WithEvents TopHalfLayoutPanel As System.Windows.Forms.TableLayoutPanel
         Friend WithEvents TargetFramework As System.Windows.Forms.ComboBox
         Friend WithEvents TargetFrameworkLabel As System.Windows.Forms.Label
+        Friend WithEvents AutoGenerateBindingRedirects As System.Windows.Forms.CheckBox
         Friend WithEvents overarchingLayoutPanel As System.Windows.Forms.TableLayoutPanel
         Friend WithEvents ManifestExplanationLabel As System.Windows.Forms.TextBox
         Friend WithEvents iconTableLayoutPanel As System.Windows.Forms.TableLayoutPanel
@@ -47,6 +48,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Me.AssemblyInfoButton = New System.Windows.Forms.Button()
             Me.TargetFrameworkLabel = New System.Windows.Forms.Label()
             Me.TargetFramework = New System.Windows.Forms.ComboBox()
+            Me.AutoGenerateBindingRedirects = New System.Windows.Forms.CheckBox()
             Me.ResourcesGroupBox = New System.Windows.Forms.GroupBox()
             Me.iconTableLayoutPanel = New System.Windows.Forms.TableLayoutPanel()
             Me.ResourcesLabel = New System.Windows.Forms.Label()
@@ -83,6 +85,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Me.TopHalfLayoutPanel.Controls.Add(Me.AssemblyInfoButton, 1, 7)
             Me.TopHalfLayoutPanel.Controls.Add(Me.TargetFrameworkLabel, 0, 2)
             Me.TopHalfLayoutPanel.Controls.Add(Me.TargetFramework, 0, 3)
+            Me.TopHalfLayoutPanel.Controls.Add(Me.AutoGenerateBindingRedirects, 0, 4)
             Me.TopHalfLayoutPanel.Name = "TopHalfLayoutPanel"
             '
             'AssemblyNameLabel
@@ -147,6 +150,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Me.TargetFramework.FormattingEnabled = True
             Me.TargetFramework.Name = "TargetFramework"
             Me.TargetFramework.Sorted = True
+            '
+            'AutoGenerateBindingRedirects
+            resources.ApplyResources(Me.AutoGenerateBindingRedirects, "AutoGenerateBindingRedirects")
+            Me.AutoGenerateBindingRedirects.Name = "AutoGenerateBindingRedirects"
+            '
             '
             'ResourcesGroupBox
             '

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.resx
@@ -328,7 +328,7 @@
     <value>80, 13</value>
   </data>
   <data name="StartupObjectLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="StartupObjectLabel.Text" xml:space="preserve">
     <value>Startup &amp;object:</value>
@@ -361,7 +361,7 @@
     <value>253, 21</value>
   </data>
   <data name="StartupObject.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+    <value>10</value>
   </data>
   <data name="&gt;&gt;StartupObject.Name" xml:space="preserve">
     <value>StartupObject</value>
@@ -394,7 +394,7 @@
     <value>155, 23</value>
   </data>
   <data name="AssemblyInfoButton.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
+    <value>11</value>
   </data>
   <data name="AssemblyInfoButton.Text" xml:space="preserve">
     <value>Assembly &amp;Information...</value>
@@ -502,7 +502,7 @@
     <value>1</value>
   </data>
   <data name="TopHalfLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="AssemblyNameLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="AssemblyName" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="RootNamespaceLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="RootNameSpace" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="OutputTypeLabel" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="OutputType" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="StartupObjectLabel" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="StartupObject" Row="7" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="AssemblyInfoButton" Row="7" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="TargetFrameworkLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="TargetFramework" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,20,AutoSize,20,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,20,AutoSize,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="AssemblyNameLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="AssemblyName" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="RootNamespaceLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="RootNameSpace" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="OutputTypeLabel" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="OutputType" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="StartupObjectLabel" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="StartupObject" Row="7" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="AssemblyInfoButton" Row="7" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="TargetFrameworkLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="TargetFramework" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,20,AutoSize,20,AutoSize,20,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,20,AutoSize,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="ResourcesGroupBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1040,5 +1040,38 @@
   </data>
   <data name="AppIconBrowse.AccessibleName" xml:space="preserve">
     <value>Browse for icon</value>
+  </data>
+  <data name="AutoGenerateBindingRedirects.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="AutoGenerateBindingRedirects.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="AutoGenerateBindingRedirects.Location" type="System.Drawing.Point, System.Drawing">
+    <value>14, 128</value>
+  </data>
+  <data name="AutoGenerateBindingRedirects.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 6, 3, 0</value>
+  </data>
+  <data name="AutoGenerateBindingRedirects.Size" type="System.Drawing.Size, System.Drawing">
+    <value>142, 17</value>
+  </data>
+  <data name="AutoGenerateBindingRedirects.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="AutoGenerateBindingRedirects.Text" xml:space="preserve">
+    <value>&amp;Auto-generate binding redirects</value>
+  </data>
+  <data name="&gt;&gt;AutoGenerateBindingRedirects.Name" xml:space="preserve">
+    <value>AutoGenerateBindingRedirects</value>
+  </data>
+  <data name="&gt;&gt;AutoGenerateBindingRedirects.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;AutoGenerateBindingRedirects.Parent" xml:space="preserve">
+    <value>TopHalfLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;AutoGenerateBindingRedirects.ZOrder" xml:space="preserve">
+    <value>13</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.vb
@@ -101,6 +101,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     datalist.Add(data)
                     data = New PropertyControlData(VsProjPropId90.VBPROJPROPID_ApplicationManifest, "ApplicationManifest", ApplicationManifest, AddressOf ApplicationManifestSet, AddressOf ApplicationManifestGet, ControlDataFlags.UserHandledEvents, New Control() {ApplicationManifest, ApplicationManifestLabel})
                     datalist.Add(data)
+                    data = New PropertyControlData(17100, "AutoGenerateBindingRedirects", AutoGenerateBindingRedirects)
+                    datalist.Add(data)
                     datalist.Add(TargetFrameworkPropertyControlData)
                     m_ControlData = datalist.ToArray()
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBWinForms.Designer.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBWinForms.Designer.vb
@@ -12,6 +12,7 @@
         Friend WithEvents RootNamespaceTextBox As System.Windows.Forms.TextBox
         Friend WithEvents TargetFrameworkLabel As System.Windows.Forms.Label
         Friend WithEvents TargetFrameworkComboBox As System.Windows.Forms.ComboBox
+        Friend WithEvents AutoGenerateBindingRedirectsCheckBox As System.Windows.Forms.CheckBox
         Friend WithEvents ApplicationTypeLabel As System.Windows.Forms.Label
         Friend WithEvents ApplicationTypeComboBox As System.Windows.Forms.ComboBox
         Friend WithEvents AssemblyInfoButton As System.Windows.Forms.Button
@@ -45,6 +46,7 @@
             Me.RootNamespaceTextBox = New System.Windows.Forms.TextBox
             Me.TargetFrameworkLabel = New System.Windows.Forms.Label
             Me.TargetFrameworkComboBox = New System.Windows.Forms.ComboBox
+            Me.AutoGenerateBindingRedirectsCheckBox = New System.Windows.Forms.CheckBox
             Me.StartupObjectComboBox = New System.Windows.Forms.ComboBox
             Me.StartupObjectLabel = New System.Windows.Forms.Label
             Me.ApplicationTypeLabel = New System.Windows.Forms.Label
@@ -88,13 +90,14 @@
             Me.TopHalfLayoutPanel.Controls.Add(Me.TargetFrameworkComboBox, 0, 3)
             Me.TopHalfLayoutPanel.Controls.Add(Me.ApplicationTypeLabel, 1, 2)
             Me.TopHalfLayoutPanel.Controls.Add(Me.ApplicationTypeComboBox, 1, 3)
-            Me.TopHalfLayoutPanel.Controls.Add(Me.StartupObjectComboBox, 0, 5)
-            Me.TopHalfLayoutPanel.Controls.Add(Me.StartupObjectLabel, 0, 4)
-            Me.TopHalfLayoutPanel.Controls.Add(Me.IconLabel, 1, 4)
-            Me.TopHalfLayoutPanel.Controls.Add(Me.IconPicturebox, 2, 5)
-            Me.TopHalfLayoutPanel.Controls.Add(Me.IconCombobox, 1, 5)
-            Me.TopHalfLayoutPanel.Controls.Add(Me.UseApplicationFrameworkCheckBox, 0, 7)
-            Me.TopHalfLayoutPanel.Controls.Add(Me.TableLayoutPanel1, 0, 6)
+            Me.TopHalfLayoutPanel.Controls.Add(Me.AutoGenerateBindingRedirectsCheckBox, 0, 4)
+            Me.TopHalfLayoutPanel.Controls.Add(Me.StartupObjectComboBox, 0, 6)
+            Me.TopHalfLayoutPanel.Controls.Add(Me.StartupObjectLabel, 0, 5)
+            Me.TopHalfLayoutPanel.Controls.Add(Me.IconLabel, 1, 5)
+            Me.TopHalfLayoutPanel.Controls.Add(Me.IconPicturebox, 2, 6)
+            Me.TopHalfLayoutPanel.Controls.Add(Me.IconCombobox, 1, 6)
+            Me.TopHalfLayoutPanel.Controls.Add(Me.UseApplicationFrameworkCheckBox, 0, 8)
+            Me.TopHalfLayoutPanel.Controls.Add(Me.TableLayoutPanel1, 0, 7)
             Me.TopHalfLayoutPanel.Name = "TopHalfLayoutPanel"
             '
             'AssemblyNameLabel
@@ -129,6 +132,12 @@
             Me.TargetFrameworkComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
             Me.TargetFrameworkComboBox.FormattingEnabled = True
             Me.TargetFrameworkComboBox.Name = "TargetFrameworkComboBox"
+            '
+            'AutoGenerateBindingRedirectsCheckBox
+            '
+            resources.ApplyResources(Me.AutoGenerateBindingRedirectsCheckBox, "AutoGenerateBindingRedirectsCheckBox")
+            Me.TopHalfLayoutPanel.SetColumnSpan(Me.AutoGenerateBindingRedirectsCheckBox, 2)
+            Me.AutoGenerateBindingRedirectsCheckBox.Name = "AutoGenerateBindingRedirectsCheckBox"
             '
             'StartupObjectComboBox
             '

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBWinForms.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBWinForms.resx
@@ -319,7 +319,7 @@
     <value>253, 21</value>
   </data>
   <data name="StartupObjectComboBox.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+    <value>10</value>
   </data>
   <data name="&gt;&gt;StartupObjectComboBox.Name" xml:space="preserve">
     <value>StartupObjectComboBox</value>
@@ -349,7 +349,7 @@
     <value>76, 13</value>
   </data>
   <data name="StartupObjectLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="StartupObjectLabel.Text" xml:space="preserve">
     <value>Startup &amp;object:</value>
@@ -442,7 +442,7 @@
     <value>31, 13</value>
   </data>
   <data name="IconLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
+    <value>11</value>
   </data>
   <data name="IconLabel.Text" xml:space="preserve">
     <value>&amp;Icon:</value>
@@ -502,7 +502,7 @@
     <value>215, 21</value>
   </data>
   <data name="IconCombobox.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
+    <value>12</value>
   </data>
   <data name="&gt;&gt;IconCombobox.Name" xml:space="preserve">
     <value>IconCombobox</value>
@@ -532,7 +532,7 @@
     <value>165, 17</value>
   </data>
   <data name="UseApplicationFrameworkCheckBox.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
+    <value>15</value>
   </data>
   <data name="UseApplicationFrameworkCheckBox.Text" xml:space="preserve">
     <value>Enable application framewor&amp;k</value>
@@ -616,7 +616,7 @@
     <value>0, 0, 0, 14</value>
   </data>
   <data name="TopHalfLayoutPanel.RowCount" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="TopHalfLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
     <value>518, 199</value>
@@ -637,7 +637,7 @@
     <value>0</value>
   </data>
   <data name="TopHalfLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="AssemblyNameLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="AssemblyNameTextBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="RootNamespaceLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="RootNamespaceTextBox" Row="1" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="TargetFrameworkLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="TargetFrameworkComboBox" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="StartupObjectComboBox" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="StartupObjectLabel" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="ApplicationTypeLabel" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="ApplicationTypeComboBox" Row="3" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="IconLabel" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="IconPicturebox" Row="5" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="IconCombobox" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="UseApplicationFrameworkCheckBox" Row="7" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="TableLayoutPanel1" Row="6" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="AssemblyNameLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="AssemblyNameTextBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="RootNamespaceLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="RootNamespaceTextBox" Row="1" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="TargetFrameworkLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="TargetFrameworkComboBox" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="AutoGenerateBindingRedirectsCheckBox" Row="4" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="StartupObjectComboBox" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="StartupObjectLabel" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="ApplicationTypeLabel" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="ApplicationTypeComboBox" Row="3" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="IconLabel" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="IconPicturebox" Row="6" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="IconCombobox" Row="6" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="UseApplicationFrameworkCheckBox" Row="8" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="TableLayoutPanel1" Row="7" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="AssemblyInfoButton.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1169,5 +1169,38 @@
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="AutoGenerateBindingRedirectsCheckBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="AutoGenerateBindingRedirectsCheckBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="AutoGenerateBindingRedirectsCheckBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 182</value>
+  </data>
+  <data name="AutoGenerateBindingRedirectsCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 9, 3, 0</value>
+  </data>
+  <data name="AutoGenerateBindingRedirectsCheckBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>165, 17</value>
+  </data>
+  <data name="AutoGenerateBindingRedirectsCheckBox.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="AutoGenerateBindingRedirectsCheckBox.Text" xml:space="preserve">
+    <value>Auto-generate &amp;binding redirects</value>
+  </data>
+  <data name="&gt;&gt;AutoGenerateBindingRedirectsCheckBox.Name" xml:space="preserve">
+    <value>AutoGenerateBindingRedirectsCheckBox</value>
+  </data>
+  <data name="&gt;&gt;AutoGenerateBindingRedirectsCheckBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;AutoGenerateBindingRedirectsCheckBox.Parent" xml:space="preserve">
+    <value>TopHalfLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;AutoGenerateBindingRedirectsCheckBox.ZOrder" xml:space="preserve">
+    <value>11</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBWinForms.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBWinForms.vb
@@ -190,6 +190,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
                     datalist.Add(TargetFrameworkPropertyControlData)
 
+                    data = New PropertyControlData(17100, "AutoGenerateBindingRedirects", AutoGenerateBindingRedirectsCheckBox)
+                    datalist.Add(data)
+
                     m_ControlData = datalist.ToArray()
                 End If
                 Return m_ControlData

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.Designer.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.Designer.vb
@@ -10,6 +10,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         Friend WithEvents RootNamespaceTextBox As System.Windows.Forms.TextBox
         Friend WithEvents TargetFrameworkLabel As System.Windows.Forms.Label
         Friend WithEvents TargetFrameworkComboBox As System.Windows.Forms.ComboBox
+        Friend WithEvents AutoGenerateBindingRedirectsCheckBox As System.Windows.Forms.CheckBox
         Friend WithEvents ApplicationTypeLabel As System.Windows.Forms.Label
         Friend WithEvents ApplicationTypeComboBox As System.Windows.Forms.ComboBox
         Friend WithEvents AssemblyInfoButton As System.Windows.Forms.Button
@@ -43,6 +44,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
             Me.RootNamespaceTextBox = New System.Windows.Forms.TextBox
             Me.TargetFrameworkLabel = New System.Windows.Forms.Label
             Me.TargetFrameworkComboBox = New System.Windows.Forms.ComboBox
+            Me.AutoGenerateBindingRedirectsCheckBox = New System.Windows.Forms.CheckBox
             Me.StartupObjectOrUriComboBox = New System.Windows.Forms.ComboBox
             Me.StartupObjectOrUriLabel = New System.Windows.Forms.Label
             Me.ApplicationTypeLabel = New System.Windows.Forms.Label
@@ -69,7 +71,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
             'TopHalfLayoutPanel
             '
             resources.ApplyResources(Me.TopHalfLayoutPanel, "TopHalfLayoutPanel")
-            Me.TopHalfLayoutPanel.Controls.Add(Me.ButtonsLayoutPanel, 0, 6)
+            Me.TopHalfLayoutPanel.Controls.Add(Me.ButtonsLayoutPanel, 0, 7)
             Me.TopHalfLayoutPanel.Controls.Add(Me.AssemblyNameLabel, 0, 0)
             Me.TopHalfLayoutPanel.Controls.Add(Me.AssemblyNameTextBox, 0, 1)
             Me.TopHalfLayoutPanel.Controls.Add(Me.RootNamespaceLabel, 1, 0)
@@ -78,12 +80,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
             Me.TopHalfLayoutPanel.Controls.Add(Me.TargetFrameworkComboBox, 0, 3)
             Me.TopHalfLayoutPanel.Controls.Add(Me.ApplicationTypeLabel, 1, 2)
             Me.TopHalfLayoutPanel.Controls.Add(Me.ApplicationTypeComboBox, 1, 3)
-            Me.TopHalfLayoutPanel.Controls.Add(Me.StartupObjectOrUriComboBox, 0, 5)
-            Me.TopHalfLayoutPanel.Controls.Add(Me.StartupObjectOrUriLabel, 0, 4)
-            Me.TopHalfLayoutPanel.Controls.Add(Me.UseApplicationFrameworkCheckBox, 0, 7)
-            Me.TopHalfLayoutPanel.Controls.Add(Me.IconLabel, 1, 4)
-            Me.TopHalfLayoutPanel.Controls.Add(Me.IconPicturebox, 2, 5)
-            Me.TopHalfLayoutPanel.Controls.Add(Me.IconCombobox, 1, 5)
+            Me.TopHalfLayoutPanel.Controls.Add(Me.AutoGenerateBindingRedirectsCheckBox, 0, 4)
+            Me.TopHalfLayoutPanel.Controls.Add(Me.StartupObjectOrUriComboBox, 0, 6)
+            Me.TopHalfLayoutPanel.Controls.Add(Me.StartupObjectOrUriLabel, 0, 5)
+            Me.TopHalfLayoutPanel.Controls.Add(Me.UseApplicationFrameworkCheckBox, 0, 8)
+            Me.TopHalfLayoutPanel.Controls.Add(Me.IconLabel, 1, 5)
+            Me.TopHalfLayoutPanel.Controls.Add(Me.IconPicturebox, 2, 6)
+            Me.TopHalfLayoutPanel.Controls.Add(Me.IconCombobox, 1, 6)
             Me.TopHalfLayoutPanel.Name = "TopHalfLayoutPanel"
             '
             'ButtonsLayoutPanel
@@ -137,6 +140,12 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
             Me.TargetFrameworkComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
             Me.TargetFrameworkComboBox.FormattingEnabled = True
             Me.TargetFrameworkComboBox.Name = "TargetFrameworkComboBox"
+            '
+            'AutoGenerateBindingRedirectsCheckBox
+            '
+            resources.ApplyResources(Me.AutoGenerateBindingRedirectsCheckBox, "AutoGenerateBindingRedirectsCheckBox")
+            Me.TopHalfLayoutPanel.SetColumnSpan(Me.AutoGenerateBindingRedirectsCheckBox, 2)
+            Me.AutoGenerateBindingRedirectsCheckBox.Name = "AutoGenerateBindingRedirectsCheckBox"
             '
             'StartupObjectOrUriComboBox
             '

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.resx
@@ -379,7 +379,7 @@
     <value>253, 21</value>
   </data>
   <data name="StartupObjectOrUriComboBox.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+    <value>10</value>
   </data>
   <data name="&gt;&gt;StartupObjectOrUriComboBox.Name" xml:space="preserve">
     <value>StartupObjectOrUriComboBox</value>
@@ -409,7 +409,7 @@
     <value>14, 13</value>
   </data>
   <data name="StartupObjectOrUriLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="StartupObjectOrUriLabel.Text" xml:space="preserve">
     <value>#</value>
@@ -502,7 +502,7 @@
     <value>165, 17</value>
   </data>
   <data name="UseApplicationFrameworkCheckBox.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
+    <value>15</value>
   </data>
   <data name="UseApplicationFrameworkCheckBox.Text" xml:space="preserve">
     <value>Enable application framewor&amp;k</value>
@@ -568,7 +568,7 @@
     <value>CenterImage</value>
   </data>
   <data name="IconPicturebox.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
+    <value>13</value>
   </data>
   <data name="&gt;&gt;IconPicturebox.Name" xml:space="preserve">
     <value>IconPicturebox</value>
@@ -616,7 +616,7 @@
     <value>0, 0, 0, 14</value>
   </data>
   <data name="TopHalfLayoutPanel.RowCount" type="System.Int32, mscorlib">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="TopHalfLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
     <value>518, 199</value>
@@ -637,7 +637,7 @@
     <value>0</value>
   </data>
   <data name="TopHalfLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="ButtonsLayoutPanel" Row="6" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="AssemblyNameLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="AssemblyNameTextBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="RootNamespaceLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="RootNamespaceTextBox" Row="1" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="TargetFrameworkLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="TargetFrameworkComboBox" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="StartupObjectOrUriComboBox" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="StartupObjectOrUriLabel" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="ApplicationTypeLabel" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="ApplicationTypeComboBox" Row="3" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="UseApplicationFrameworkCheckBox" Row="7" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="IconLabel" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="IconPicturebox" Row="5" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="IconCombobox" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="AssemblyNameLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="AssemblyNameTextBox" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="RootNamespaceLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="RootNamespaceTextBox" Row="1" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="TargetFrameworkLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="TargetFrameworkComboBox" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="AutoGenerateBindingRedirectsCheckBox" Row="4" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="StartupObjectComboBox" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="StartupObjectLabel" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="ApplicationTypeLabel" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="ApplicationTypeComboBox" Row="3" RowSpan="1" Column="1" ColumnSpan="2" /&gt;&lt;Control Name="IconLabel" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="IconPicturebox" Row="6" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="IconCombobox" Row="6" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="UseApplicationFrameworkCheckBox" Row="8" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="TableLayoutPanel1" Row="7" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="AssemblyInfoButton.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -1040,5 +1040,38 @@
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="AutoGenerateBindingRedirectsCheckBox.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="AutoGenerateBindingRedirectsCheckBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="AutoGenerateBindingRedirectsCheckBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 182</value>
+  </data>
+  <data name="AutoGenerateBindingRedirectsCheckBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 9, 3, 0</value>
+  </data>
+  <data name="AutoGenerateBindingRedirectsCheckBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>165, 17</value>
+  </data>
+  <data name="AutoGenerateBindingRedirectsCheckBox.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="AutoGenerateBindingRedirectsCheckBox.Text" xml:space="preserve">
+    <value>Auto-generate &amp;binding redirects</value>
+  </data>
+  <data name="&gt;&gt;AutoGenerateBindingRedirectsCheckBox.Name" xml:space="preserve">
+    <value>AutoGenerateBindingRedirectsCheckBox</value>
+  </data>
+  <data name="&gt;&gt;AutoGenerateBindingRedirectsCheckBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;AutoGenerateBindingRedirectsCheckBox.Parent" xml:space="preserve">
+    <value>TopHalfLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;AutoGenerateBindingRedirectsCheckBox.ZOrder" xml:space="preserve">
+    <value>11</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
@@ -239,6 +239,10 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
 
                     list.Add(TargetFrameworkPropertyControlData)
 
+                    'AutoGenerateBindingRedirects
+                    data = New PropertyControlData(17100, "AutoGenerateBindingRedirects", AutoGenerateBindingRedirectsCheckBox)
+                    list.Add(data)
+
                     m_ControlData = list.ToArray()
                 End If
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/xlf/ApplicationPropPageVBWPF.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/xlf/ApplicationPropPageVBWPF.cs.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Režim vy&amp;pnutí:</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirectsCheckBox.Text">
+        <source>Auto-generate &amp;binding redirects</source>
+        <target state="new">Auto-generate &amp;binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/xlf/ApplicationPropPageVBWPF.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/xlf/ApplicationPropPageVBWPF.de.xlf
@@ -67,6 +67,11 @@
         <target state="translated">M&amp;odus für das Herunterfahren:</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirectsCheckBox.Text">
+        <source>Auto-generate &amp;binding redirects</source>
+        <target state="new">Auto-generate &amp;binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/xlf/ApplicationPropPageVBWPF.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/xlf/ApplicationPropPageVBWPF.es.xlf
@@ -67,6 +67,11 @@
         <target state="translated">&amp;Modo de apagado:</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirectsCheckBox.Text">
+        <source>Auto-generate &amp;binding redirects</source>
+        <target state="new">Auto-generate &amp;binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/xlf/ApplicationPropPageVBWPF.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/xlf/ApplicationPropPageVBWPF.fr.xlf
@@ -67,6 +67,11 @@
         <target state="translated">M&amp;ode d'arrêt :</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirectsCheckBox.Text">
+        <source>Auto-generate &amp;binding redirects</source>
+        <target state="new">Auto-generate &amp;binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/xlf/ApplicationPropPageVBWPF.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/xlf/ApplicationPropPageVBWPF.it.xlf
@@ -67,6 +67,11 @@
         <target state="translated">M&amp;odalità di arresto:</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirectsCheckBox.Text">
+        <source>Auto-generate &amp;binding redirects</source>
+        <target state="new">Auto-generate &amp;binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/xlf/ApplicationPropPageVBWPF.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/xlf/ApplicationPropPageVBWPF.ja.xlf
@@ -67,6 +67,11 @@
         <target state="translated">シャットダウン モード(&amp;O):</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirectsCheckBox.Text">
+        <source>Auto-generate &amp;binding redirects</source>
+        <target state="new">Auto-generate &amp;binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/xlf/ApplicationPropPageVBWPF.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/xlf/ApplicationPropPageVBWPF.ko.xlf
@@ -67,6 +67,11 @@
         <target state="translated">종료 모드(&amp;O):</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirectsCheckBox.Text">
+        <source>Auto-generate &amp;binding redirects</source>
+        <target state="new">Auto-generate &amp;binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/xlf/ApplicationPropPageVBWPF.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/xlf/ApplicationPropPageVBWPF.pl.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Tr&amp;yb zamknięcia:</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirectsCheckBox.Text">
+        <source>Auto-generate &amp;binding redirects</source>
+        <target state="new">Auto-generate &amp;binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/xlf/ApplicationPropPageVBWPF.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/xlf/ApplicationPropPageVBWPF.pt-BR.xlf
@@ -67,6 +67,11 @@
         <target state="translated">M&amp;odo de desligamento:</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirectsCheckBox.Text">
+        <source>Auto-generate &amp;binding redirects</source>
+        <target state="new">Auto-generate &amp;binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/xlf/ApplicationPropPageVBWPF.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/xlf/ApplicationPropPageVBWPF.ru.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Режи&amp;м завершения работы:</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirectsCheckBox.Text">
+        <source>Auto-generate &amp;binding redirects</source>
+        <target state="new">Auto-generate &amp;binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/xlf/ApplicationPropPageVBWPF.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/xlf/ApplicationPropPageVBWPF.tr.xlf
@@ -67,6 +67,11 @@
         <target state="translated">Kapatma m&amp;odu:</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirectsCheckBox.Text">
+        <source>Auto-generate &amp;binding redirects</source>
+        <target state="new">Auto-generate &amp;binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/xlf/ApplicationPropPageVBWPF.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/xlf/ApplicationPropPageVBWPF.zh-Hans.xlf
@@ -67,6 +67,11 @@
         <target state="translated">关机模式(&amp;O):</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirectsCheckBox.Text">
+        <source>Auto-generate &amp;binding redirects</source>
+        <target state="new">Auto-generate &amp;binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/xlf/ApplicationPropPageVBWPF.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/xlf/ApplicationPropPageVBWPF.zh-Hant.xlf
@@ -67,6 +67,11 @@
         <target state="translated">程式關閉模式(&amp;O):</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirectsCheckBox.Text">
+        <source>Auto-generate &amp;binding redirects</source>
+        <target state="new">Auto-generate &amp;binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.cs.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Vyhledat ikonu</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirects.Text">
+        <source>&amp;Auto-generate binding redirects</source>
+        <target state="new">&amp;Auto-generate binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.de.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Nach Symbol suchen</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirects.Text">
+        <source>&amp;Auto-generate binding redirects</source>
+        <target state="new">&amp;Auto-generate binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.es.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Buscar icono</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirects.Text">
+        <source>&amp;Auto-generate binding redirects</source>
+        <target state="new">&amp;Auto-generate binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.fr.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Rechercher l'icône</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirects.Text">
+        <source>&amp;Auto-generate binding redirects</source>
+        <target state="new">&amp;Auto-generate binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.it.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Cerca icona</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirects.Text">
+        <source>&amp;Auto-generate binding redirects</source>
+        <target state="new">&amp;Auto-generate binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.ja.xlf
@@ -82,6 +82,11 @@
         <target state="translated">アイコンの参照</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirects.Text">
+        <source>&amp;Auto-generate binding redirects</source>
+        <target state="new">&amp;Auto-generate binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.ko.xlf
@@ -82,6 +82,11 @@
         <target state="translated">아이콘 찾아보기</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirects.Text">
+        <source>&amp;Auto-generate binding redirects</source>
+        <target state="new">&amp;Auto-generate binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.pl.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Przeglądaj w poszukiwaniu ikony</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirects.Text">
+        <source>&amp;Auto-generate binding redirects</source>
+        <target state="new">&amp;Auto-generate binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.pt-BR.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Procurar ícone</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirects.Text">
+        <source>&amp;Auto-generate binding redirects</source>
+        <target state="new">&amp;Auto-generate binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.ru.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Поиск значка</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirects.Text">
+        <source>&amp;Auto-generate binding redirects</source>
+        <target state="new">&amp;Auto-generate binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.tr.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Simgeye gözat</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirects.Text">
+        <source>&amp;Auto-generate binding redirects</source>
+        <target state="new">&amp;Auto-generate binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.zh-Hans.xlf
@@ -82,6 +82,11 @@
         <target state="translated">浏览图标</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirects.Text">
+        <source>&amp;Auto-generate binding redirects</source>
+        <target state="new">&amp;Auto-generate binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPage.zh-Hant.xlf
@@ -82,6 +82,11 @@
         <target state="translated">瀏覽圖示</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirects.Text">
+        <source>&amp;Auto-generate binding redirects</source>
+        <target state="new">&amp;Auto-generate binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPageVBWinForms.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPageVBWinForms.cs.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Vlastnosti aplikačního frameworku Windows</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirectsCheckBox.Text">
+        <source>Auto-generate &amp;binding redirects</source>
+        <target state="new">Auto-generate &amp;binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPageVBWinForms.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPageVBWinForms.de.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Eigenschaften des Windows-Anwendungsframeworks</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirectsCheckBox.Text">
+        <source>Auto-generate &amp;binding redirects</source>
+        <target state="new">Auto-generate &amp;binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPageVBWinForms.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPageVBWinForms.es.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Propiedades del marco de trabajo de la aplicación de Windows</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirectsCheckBox.Text">
+        <source>Auto-generate &amp;binding redirects</source>
+        <target state="new">Auto-generate &amp;binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPageVBWinForms.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPageVBWinForms.fr.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Propriétés du framework d'application Windows</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirectsCheckBox.Text">
+        <source>Auto-generate &amp;binding redirects</source>
+        <target state="new">Auto-generate &amp;binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPageVBWinForms.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPageVBWinForms.it.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Proprietà del framework applicazione Windows</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirectsCheckBox.Text">
+        <source>Auto-generate &amp;binding redirects</source>
+        <target state="new">Auto-generate &amp;binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPageVBWinForms.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPageVBWinForms.ja.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Windows アプリケーション フレームワーク プロパティ</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirectsCheckBox.Text">
+        <source>Auto-generate &amp;binding redirects</source>
+        <target state="new">Auto-generate &amp;binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPageVBWinForms.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPageVBWinForms.ko.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Windows 응용 프로그램 프레임워크 속성</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirectsCheckBox.Text">
+        <source>Auto-generate &amp;binding redirects</source>
+        <target state="new">Auto-generate &amp;binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPageVBWinForms.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPageVBWinForms.pl.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Właściwości platformy aplikacji systemu Windows</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirectsCheckBox.Text">
+        <source>Auto-generate &amp;binding redirects</source>
+        <target state="new">Auto-generate &amp;binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPageVBWinForms.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPageVBWinForms.pt-BR.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Propriedades da estrutura do aplicativo do Windows</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirectsCheckBox.Text">
+        <source>Auto-generate &amp;binding redirects</source>
+        <target state="new">Auto-generate &amp;binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPageVBWinForms.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPageVBWinForms.ru.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Свойства исполняющей среды приложений Windows</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirectsCheckBox.Text">
+        <source>Auto-generate &amp;binding redirects</source>
+        <target state="new">Auto-generate &amp;binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPageVBWinForms.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPageVBWinForms.tr.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Windows uygulama çerçevesi özellikleri</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirectsCheckBox.Text">
+        <source>Auto-generate &amp;binding redirects</source>
+        <target state="new">Auto-generate &amp;binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPageVBWinForms.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPageVBWinForms.zh-Hans.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Windows 应用程序框架属性</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirectsCheckBox.Text">
+        <source>Auto-generate &amp;binding redirects</source>
+        <target state="new">Auto-generate &amp;binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPageVBWinForms.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/ApplicationPropPageVBWinForms.zh-Hant.xlf
@@ -87,6 +87,11 @@
         <target state="translated">Windows 應用程式架構屬性</target>
         <note />
       </trans-unit>
+      <trans-unit id="AutoGenerateBindingRedirectsCheckBox.Text">
+        <source>Auto-generate &amp;binding redirects</source>
+        <target state="new">Auto-generate &amp;binding redirects</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Add the "Auto-generate binding redirects" check box to the various incarnations of the Application property page.

This covers the "base" implementation of the property page, as well as the VB-WinForms- and VB-WPF-specific implementations. This does *not* cover UWP, as binding redirects are meaningless there.