### PR TITLE
Do not fail IVsQueryDebuggableProjectCfg.QueryDebugTargets when called on library

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
@@ -359,6 +359,64 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         }
 
         [Fact]
+        public async Task QueryDebugTargetsAsync_WhenLibraryWithRunCommand_ReturnsRunCommand()
+        {
+            var properties = new Dictionary<string, string>() {
+                {"RunCommand", @"C:\dotnet.exe"},
+                {"TargetFrameworkIdentifier", @".NETFramework" }
+                };
+
+            _mockFS.WriteAllText(@"C:\dotnet.exe", string.Empty);
+
+            var debugger = GetDebugTargetsProvider("Library", properties);
+
+            var activeProfile = new LaunchProfile() { Name = "Name", CommandName = "Project" };
+
+            var targets = await debugger.QueryDebugTargetsAsync(0, activeProfile);
+
+            Assert.Single(targets);
+            Assert.Equal(@"C:\dotnet.exe", targets[0].Executable);
+        }
+
+        [Fact]
+        public async Task QueryDebugTargetsAsync_WhenLibraryWithoutRunCommand_ReturnsTargetPath()
+        { 
+            var properties = new Dictionary<string, string>() {
+                {"TargetPath", @"C:\library.dll"},
+                {"TargetFrameworkIdentifier", @".NETFramework" }
+                };
+
+            _mockFS.WriteAllText(@"C:\library.dll", string.Empty);
+
+            var debugger = GetDebugTargetsProvider("Library", properties);
+
+            var activeProfile = new LaunchProfile() { Name = "Name", CommandName = "Project" };
+
+            var targets = await debugger.QueryDebugTargetsAsync(0, activeProfile);
+
+            Assert.Single(targets);
+            Assert.Equal(@"C:\library.dll", targets[0].Executable);
+        }
+
+        [Fact]
+        public async Task QueryDebugTargetsForDebugLaunchAsync_WhenLibrary_Throws()
+        {
+            var properties = new Dictionary<string, string>() {
+                {"TargetPath", @"C:\library.dll"},
+                {"TargetFrameworkIdentifier", @".NETFramework" }
+                };
+
+            var debugger = GetDebugTargetsProvider("Library", properties);
+
+            var activeProfile = new LaunchProfile() { Name = "Name", CommandName = "Project" };
+
+            await Assert.ThrowsAsync<Exception>(() =>
+            {
+                return debugger.QueryDebugTargetsForDebugLaunchAsync(0, activeProfile);
+            });
+        }
+
+        [Fact]
         public void ValidateSettings_WhenNoExe_Throws()
         {
             string executable = null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
@@ -366,8 +366,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 {"TargetFrameworkIdentifier", @".NETFramework" }
                 };
 
-            _mockFS.WriteAllText(@"C:\dotnet.exe", string.Empty);
-
             var debugger = GetDebugTargetsProvider("Library", properties);
 
             var activeProfile = new LaunchProfile() { Name = "Name", CommandName = "Project" };
@@ -386,8 +384,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 {"TargetFrameworkIdentifier", @".NETFramework" }
                 };
 
-            _mockFS.WriteAllText(@"C:\library.dll", string.Empty);
-
             var debugger = GetDebugTargetsProvider("Library", properties);
 
             var activeProfile = new LaunchProfile() { Name = "Name", CommandName = "Project" };
@@ -399,12 +395,32 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         }
 
         [Fact]
+        public async Task QueryDebugTargetsAsync_WhenLibraryWithoutRunCommand_DoesNotManipulateTargetPath()
+        {
+            var properties = new Dictionary<string, string>() {
+                {"TargetPath", @"library.dll"},
+                {"TargetFrameworkIdentifier", @".NETFramework" }
+                };
+
+            var debugger = GetDebugTargetsProvider("Library", properties);
+
+            var activeProfile = new LaunchProfile() { Name = "Name", CommandName = "Project" };
+
+            var targets = await debugger.QueryDebugTargetsAsync(0, activeProfile);
+
+            Assert.Single(targets);
+            Assert.Equal(@"library.dll", targets[0].Executable);
+        }
+
+        [Fact]
         public async Task QueryDebugTargetsForDebugLaunchAsync_WhenLibrary_Throws()
         {
             var properties = new Dictionary<string, string>() {
                 {"TargetPath", @"C:\library.dll"},
                 {"TargetFrameworkIdentifier", @".NETFramework" }
                 };
+
+            _mockFS.WriteAllText(@"C:\library.dll", string.Empty);
 
             var debugger = GetDebugTargetsProvider("Library", properties);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
@@ -141,7 +141,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         }
 
         [Fact]
-        public async Task QueryDebugTargets_ProjectProfileAsyncF5()
+        public async Task QueryDebugTargetsAsync_ProjectProfileAsyncF5()
         {
             var debugger = GetDebugTargetsProvider();
 
@@ -159,7 +159,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         }
 
         [Fact]
-        public async Task QueryDebugTargets_ProjectProfileAsyncF5_NativeDebugging()
+        public async Task QueryDebugTargetsAsync_ProjectProfileAsyncF5_NativeDebugging()
         {
             var debugger = GetDebugTargetsProvider();
 
@@ -184,7 +184,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         }
 
         [Fact]
-        public async Task QueryDebugTargets_ProjectProfileAsyncCtrlF5()
+        public async Task QueryDebugTargetsAsync_ProjectProfileAsyncCtrlF5()
         {
             var debugger = GetDebugTargetsProvider();
 
@@ -203,7 +203,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         }
 
         [Fact]
-        public async Task QueryDebugTargets_ProjectProfileAsyncProfile()
+        public async Task QueryDebugTargetsAsync_ProjectProfileAsyncProfile()
         {
             var debugger = GetDebugTargetsProvider();
 
@@ -217,7 +217,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         }
 
         [Fact]
-        public async Task QueryDebugTargets_ExeProfileAsyncF5()
+        public async Task QueryDebugTargetsAsync_ExeProfileAsyncF5()
         {
             var debugger = GetDebugTargetsProvider();
 
@@ -231,7 +231,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         }
 
         [Fact]
-        public async Task QueryDebugTargets_ExeProfileAsyncCtrlF5()
+        public async Task QueryDebugTargetsAsync_ExeProfileAsyncCtrlF5()
         {
             var debugger = GetDebugTargetsProvider();
 
@@ -253,7 +253,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         [InlineData(@"bin\")]
         [InlineData(@"doesntExist\")]
         [InlineData(null)]
-        public async Task QueryDebugTargets_ExeProfileAsyncExeRelativeNoWorkingDir(string outdir)
+        public async Task QueryDebugTargetsAsync_ExeProfileAsyncExeRelativeNoWorkingDir(string outdir)
         {
             var properties = new Dictionary<string, string>() {
                     {"RunCommand", @"dotnet"},
@@ -286,7 +286,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         [Theory]
         [InlineData(@"c:\WorkingDir")]
         [InlineData(@"\WorkingDir")]
-        public async Task QueryDebugTargets_ExeProfileAsyncExeRelativeToWorkingDir(string workingDir)
+        public async Task QueryDebugTargetsAsync_ExeProfileAsyncExeRelativeToWorkingDir(string workingDir)
         {
             var debugger = GetDebugTargetsProvider();
 
@@ -302,7 +302,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         }
 
         [Fact]
-        public async Task QueryDebugTargets_ExeProfileAsyncExeRelativeToWorkingDir_AlternateSlash()
+        public async Task QueryDebugTargetsAsync_ExeProfileAsyncExeRelativeToWorkingDir_AlternateSlash()
         {
             var debugger = GetDebugTargetsProvider();
 
@@ -319,7 +319,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         [Theory]
         [InlineData("dotnet")]
         [InlineData("dotnet.exe")]
-        public async Task QueryDebugTargets_ExeProfileExeRelativeToPath(string exeName)
+        public async Task QueryDebugTargetsAsync_ExeProfileExeRelativeToPath(string exeName)
         {
             var debugger = GetDebugTargetsProvider();
 
@@ -333,7 +333,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         [Theory]
         [InlineData("myexe")]
         [InlineData("myexe.exe")]
-        public async Task QueryDebugTargets_ExeProfileExeRelativeToCurrentDirectory(string exeName)
+        public async Task QueryDebugTargetsAsync_ExeProfileExeRelativeToCurrentDirectory(string exeName)
         {
             var debugger = GetDebugTargetsProvider();
             _mockFS.WriteAllText(@"c:\CurrentDirectory\myexe.exe", string.Empty);
@@ -347,7 +347,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         }
 
         [Fact]
-        public async Task QueryDebugTargets_ExeProfileExeIsRootedWithNoDrive()
+        public async Task QueryDebugTargetsAsync_ExeProfileExeIsRootedWithNoDrive()
         {
             var debugger = GetDebugTargetsProvider();
             _mockFS.WriteAllText(@"e:\myexe.exe", string.Empty);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
@@ -64,15 +64,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
             var delegateProvider = IProjectPropertiesProviderFactory.Create(null, delegatePropertiesMock.Object);
 
-            IConfiguredProjectServices configuredProjectServices = Mock.Of<IConfiguredProjectServices>(o =>
+            var configuredProjectServices = Mock.Of<IConfiguredProjectServices>(o =>
                 o.ProjectPropertiesProvider == delegateProvider);
 
-            ConfiguredProject configuredProject = Mock.Of<ConfiguredProject>(o =>
+            var configuredProject = Mock.Of<ConfiguredProject>(o =>
                 o.UnconfiguredProject == project &&
                 o.Services == configuredProjectServices);
             _mockTokenReplace.Setup(s => s.ReplaceTokensInProfileAsync(It.IsAny<ILaunchProfile>())).Returns<ILaunchProfile>(p => Task.FromResult(p));
 
-            IActiveDebugFrameworkServices activeDebugFramework = Mock.Of<IActiveDebugFrameworkServices>(o =>
+            var activeDebugFramework = Mock.Of<IActiveDebugFrameworkServices>(o =>
                o.GetConfiguredProjectForActiveFrameworkAsync() == Task.FromResult(configuredProject));
             var debugProvider = new ConsoleDebugTargetsProvider(
                                             configuredProject,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
@@ -34,8 +34,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             _mockFS.CreateDirectory(@"c:\test\Project\bin\");
             _mockFS.WriteAllText(@"c:\program files\dotnet\dotnet.exe", "");
 
-            var activeProfile = new LaunchProfile() { Name = "MyApplication", CommandLineArgs = "--someArgs", ExecutablePath = @"c:\test\Project\someapp.exe" };
-
             _mockEnvironment.Setup(s => s.GetEnvironmentVariable("Path")).Returns(() => _Path);
 
             var project = UnconfiguredProjectFactory.Create(null, null, _ProjectFile);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
@@ -290,8 +290,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 }
             }
 
-            // Now validate the executable path and working directory exist
-            ValidateSettings(executable, workingDir, resolvedProfile.Name);
+            if (forDebugLaunch)
+            {
+                ValidateSettings(executable, workingDir, resolvedProfile.Name);
+            }
+
             GetExeAndArguments(useCmdShell, executable, arguments, out string finalExecutable, out string finalArguments);
 
             // Apply environment variables.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
@@ -96,7 +96,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
         public Task<IReadOnlyList<IDebugLaunchSettings>> QueryDebugTargetsForDebugLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile activeProfile)
         {
-            return QueryDebugTargetsAsync(launchOptions, activeProfile, forDebugLaunch: true);
+            return QueryDebugTargetsAsync(launchOptions, activeProfile, validateSettings: true);
         }
 
         /// <summary>
@@ -105,10 +105,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// </summary>
         public Task<IReadOnlyList<IDebugLaunchSettings>> QueryDebugTargetsAsync(DebugLaunchOptions launchOptions, ILaunchProfile activeProfile)
         {
-            return QueryDebugTargetsAsync(launchOptions, activeProfile, forDebugLaunch: false);
+            return QueryDebugTargetsAsync(launchOptions, activeProfile, validateSettings: false);
         }
 
-        private async Task<IReadOnlyList<IDebugLaunchSettings>> QueryDebugTargetsAsync(DebugLaunchOptions launchOptions, ILaunchProfile activeProfile, bool forDebugLaunch)
+        private async Task<IReadOnlyList<IDebugLaunchSettings>> QueryDebugTargetsAsync(DebugLaunchOptions launchOptions, ILaunchProfile activeProfile, bool validateSettings)
         {
             var launchSettings = new List<DebugLaunchSettings>();
 
@@ -121,7 +121,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                     IsRunProjectCommand(resolvedProfile) &&
                     (launchOptions & (DebugLaunchOptions.NoDebug | DebugLaunchOptions.Profiling)) == DebugLaunchOptions.NoDebug;
 
-            DebugLaunchSettings consoleTarget = await GetConsoleTargetForProfile(resolvedProfile, launchOptions, useCmdShell, forDebugLaunch).ConfigureAwait(false);
+            DebugLaunchSettings consoleTarget = await GetConsoleTargetForProfile(resolvedProfile, launchOptions, useCmdShell, validateSettings).ConfigureAwait(false);
 
             launchSettings.Add(consoleTarget);
 
@@ -181,7 +181,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// of project.
         /// </summary>
         private async Task<DebugLaunchSettings> GetConsoleTargetForProfile(ILaunchProfile resolvedProfile, DebugLaunchOptions launchOptions,
-                                                                           bool useCmdShell, bool forDebugLaunch)
+                                                                           bool useCmdShell, bool validateSettings)
         {
             var settings = new DebugLaunchSettings(launchOptions);
 
@@ -215,7 +215,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             if (IsRunProjectCommand(resolvedProfile))
             {
                 // If we're launching for debug purposes, prevent someone F5'ing a class library
-                if (forDebugLaunch && await GetIsClassLibraryAsync().ConfigureAwait(false))
+                if (validateSettings && await GetIsClassLibraryAsync().ConfigureAwait(false))
                 {
                     throw new Exception(VSResources.ProjectNotRunnableDirectly);
                 }
@@ -290,7 +290,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 }
             }
 
-            if (forDebugLaunch)
+            if (validateSettings)
             {
                 ValidateSettings(executable, workingDir, resolvedProfile.Name);
             }


### PR DESCRIPTION
When called on a library, IVsQueryDebuggableProjectCfg.QueryDebugTargets was failing preventing Test Explorer from pulling the current debug settings.

QueryDebugTargetsAsync is called in two situations:

- When launching
- When someone queries the available debug targets

Similar to legacy project system, only fail when called during launch so that we can continue to show an error on F5'ing a library, but also be able to hand back launch data to consumers, such as Test Explorer.

Fixes: #3647.

Note, we now fall back the target path similar if RunCommand is not specified. This brings the behavior in line with legacy when called on a library.