### PR TITLE
version the .vsman insertion files

### DIFF
--- a/setup/Microsoft.VisualStudio.NetCore.ProjectTemplates.1.x/Microsoft.VisualStudio.NetCore.ProjectTemplates.1.x.csproj
+++ b/setup/Microsoft.VisualStudio.NetCore.ProjectTemplates.1.x/Microsoft.VisualStudio.NetCore.ProjectTemplates.1.x.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <!-- VS Insertion -->
     <VisualStudioInsertionComponent>$(MSBuildProjectName)</VisualStudioInsertionComponent>
+    <ManifestBuildVersion>$(VsixVersion)</ManifestBuildVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.Common.ProjectTemplates.1.x" Version="$(MicrosoftDotNetProjectTemplatesVersion)" />

--- a/setup/Microsoft.VisualStudio.ProjectSystem.Managed.CommonFiles/Microsoft.VisualStudio.ProjectSystem.Managed.CommonFiles.csproj
+++ b/setup/Microsoft.VisualStudio.ProjectSystem.Managed.CommonFiles/Microsoft.VisualStudio.ProjectSystem.Managed.CommonFiles.csproj
@@ -3,6 +3,7 @@
    <PropertyGroup>
     <!-- VS Insertion -->
     <VisualStudioInsertionComponent>Microsoft.VisualStudio.ProjectSystem.Managed</VisualStudioInsertionComponent>
+    <ManifestBuildVersion>$(VsixVersion)</ManifestBuildVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Depend on projects producing XAML rules included in this Willow package -->

--- a/src/ProjectSystemSetup/ProjectSystemSetup.csproj
+++ b/src/ProjectSystemSetup/ProjectSystemSetup.csproj
@@ -13,6 +13,7 @@
 
     <!-- VS Insertion -->
     <VisualStudioInsertionComponent>Microsoft.VisualStudio.ProjectSystem.Managed</VisualStudioInsertionComponent>
+    <ManifestBuildVersion>$(VsixVersion)</ManifestBuildVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="RoslynDependencies.ProjectSystem.OptimizationData" Version="$(RoslynDependenciesProjectSystemOptimizationDataVersion)" />

--- a/src/Templates/Directory.Build.props
+++ b/src/Templates/Directory.Build.props
@@ -16,6 +16,7 @@
 
     <!-- VS Setup -->
     <VisualStudioInsertionComponent>Microsoft.VisualStudio.NetCore.ProjectTemplates</VisualStudioInsertionComponent>
+    <ManifestBuildVersion>$(VsixVersion)</ManifestBuildVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include="source.extension.vsixmanifest" />

--- a/src/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
+++ b/src/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
@@ -12,6 +12,7 @@
 
     <!-- VS Setup -->
     <VisualStudioInsertionComponent>Microsoft.VisualStudio.Editors</VisualStudioInsertionComponent>
+    <ManifestBuildVersion>$(VsixVersion)</ManifestBuildVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.AppDesigner\Microsoft.VisualStudio.AppDesigner.vbproj">


### PR DESCRIPTION
### The following criteria must be met before this can be merged: ###

1.  dotnet/roslyn-tools#280 must be completed.
2.  This repo must be updated to the latest version of the RepoToolset containing the changes in dotnet/roslyn-tools#280.
3.  Run a full-signed build with these changes and verify that the following files specify a `info/buildVersion` property (mentioned below):
    - `[internal-drop-location]\VSSetup\Insertion\Microsoft.VisualStudio.Editors.vsman`
    - `[internal-drop-location]\VSSetup\Insertion\Microsoft.VisualStudio.NetCore.ProjectTemplates.vsman`
    - `[internal-drop-location]\VSSetup\Insertion\Microsoft.VisualStudio.NetCore.ProjectTemplates.1.x.vsman`
    - `[internal-drop-location]\VSSetup\Insertion\Microsoft.VisualStudio.ProjectSystem.Managed.vsman`

### What this does: ###

To help make our internal automation easier, we need to publish a version number with the insertion component.  The net result of this is the `artifacts\Release\VSSetup\Insertion\*.vsman` files will be modified to this:

``` javascript
{
  // ...
  "info": {
    // ...
    "buildVersion": "2.8.0.6302101", // <-- added this line
    // ...
  }
  // ...
}
```
