### PR TITLE
Apply code fixes

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectItemTree.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectItemTree.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.ProjectSystem.Properties;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    partial class ProjectTreeParser
+    internal partial class ProjectTreeParser
     {
         private class MutableProjectItemTree : MutableProjectTree, IProjectItemTree2
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectPropertiesContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectPropertiesContext.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.ProjectSystem.Properties;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    partial class ProjectTreeParser
+    internal partial class ProjectTreeParser
     {
         private class MutableProjectPropertiesContext : IProjectPropertiesContext
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectTree.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectTree.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.ProjectSystem.Properties;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    partial class ProjectTreeParser
+    internal partial class ProjectTreeParser
     {
         private class MutableProjectTree : IProjectTree2
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
@@ -26,8 +26,7 @@ namespace Microsoft.VisualStudio.IO
 
         private Dictionary<string, FileData> _files = new Dictionary<string, FileData>(StringComparer.OrdinalIgnoreCase);
         private HashSet<string> _folders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        string _currentDirectory;
+        private string _currentDirectory;
 
         public Dictionary<string, FileData> Files { get => _files; }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -58,8 +58,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 var mockSerializer = new Mock<ILaunchSettingsSerializationProvider>();
                 return mockSerializer.Object;
             }, mockIJsonSection.Object, true);
-            var settingsProviders = new OrderPrecedenceImportCollection<ILaunchSettingsSerializationProvider, IJsonSection>(ImportOrderPrecedenceComparer.PreferenceOrder.PreferredComesFirst, (UnconfiguredProject)null);
-            settingsProviders.Add(new Lazy<ILaunchSettingsSerializationProvider, IJsonSection>(() => lazyProvider.Value, mockIJsonSection.Object));
+            var settingsProviders = new OrderPrecedenceImportCollection<ILaunchSettingsSerializationProvider, IJsonSection>(ImportOrderPrecedenceComparer.PreferenceOrder.PreferredComesFirst, (UnconfiguredProject)null)
+            {
+                new Lazy<ILaunchSettingsSerializationProvider, IJsonSection>(() => lazyProvider.Value, mockIJsonSection.Object)
+            };
             provider.SetSettingsProviderCollection(settingsProviders);
 
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.EvaluationCommandLineHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.EvaluationCommandLineHandler.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.ProjectSystem.Logging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
-    partial class AbstractEvaluationCommandLineHandlerTests
+    public partial class AbstractEvaluationCommandLineHandlerTests
     {
         private class EvaluationCommandLineHandler : AbstractEvaluationCommandLineHandler
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/LanguageServiceErrorListProvider.ErrorListDetails.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/LanguageServiceErrorListProvider.ErrorListDetails.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
 {
-    partial class LanguageServiceErrorListProvider
+    internal partial class LanguageServiceErrorListProvider
     {
         /// <summary>
         /// Captures details from various types of MSBuild events.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/PackageRestoreInitiator.PackageRestoreInitiatorInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/PackageRestoreInitiator.PackageRestoreInitiatorInstance.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
 {
     using TIdentityDictionary = IImmutableDictionary<NamedIdentity, IComparable>;
 
-    partial class PackageRestoreInitiator
+    internal partial class PackageRestoreInitiator
     {
         private class PackageRestoreInitiatorInstance : AbstractProjectDynamicLoadInstance
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractProjectDynamicLoadComponent.AbstractProjectDynamicLoadInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractProjectDynamicLoadComponent.AbstractProjectDynamicLoadInstance.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    partial class AbstractProjectDynamicLoadComponent
+    internal partial class AbstractProjectDynamicLoadComponent
     {
         /// <summary>
         ///     Represents an instance that is automatically initialized when its parent

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ContextHandlerProvider.Handlers.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ContextHandlerProvider.Handlers.cs
@@ -4,7 +4,7 @@ using System.Collections.Immutable;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
-    partial class ContextHandlerProvider
+    internal partial class ContextHandlerProvider
     {
         private class Handlers
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.VersionedProjectChangeDiff.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.VersionedProjectChangeDiff.cs
@@ -5,7 +5,7 @@ using System.Diagnostics;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
-    partial class AbstractEvaluationCommandLineHandler
+    internal partial class AbstractEvaluationCommandLineHandler
     {
         /// <summary>
         ///     Represents a set of differences made to a project along with a version.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/ProjectLoggerExtensions.ProjectLoggerBatch.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/ProjectLoggerExtensions.ProjectLoggerBatch.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Logging
 {
-    partial class ProjectLoggerExtensions
+    internal partial class ProjectLoggerExtensions
     {
         private class ProjectLoggerBatch : IProjectLoggerBatch
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AdditionalFiles.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AdditionalFiles.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class AdditionalFiles
+    internal partial class AdditionalFiles
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AnalyzerReference.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AnalyzerReference.xaml.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class AnalyzerReference
+    internal partial class AnalyzerReference
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AppDesigner.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AppDesigner.xaml.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class AppDesigner
+    internal partial class AppDesigner
     {
         internal static string[] SchemaNameArray = new string[] { SchemaName };
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ApplicationDefinition.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ApplicationDefinition.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class ApplicationDefinition
+    internal partial class ApplicationDefinition
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AssemblyReference.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AssemblyReference.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class AssemblyReference
+    internal partial class AssemblyReference
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/COMReference.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/COMReference.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class ComReference
+    internal partial class ComReference
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Compile.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Compile.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class Compile
+    internal partial class Compile
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CompilerCommandLineArgs.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CompilerCommandLineArgs.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class CompilerCommandLineArgs
+    internal partial class CompilerCommandLineArgs
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class ConfigurationGeneral
+    internal partial class ConfigurationGeneral
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfiguredBrowseObject.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfiguredBrowseObject.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class ConfiguredBrowseObject
+    internal partial class ConfiguredBrowseObject
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Content.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Content.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class Content
+    internal partial class Content
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CopyUpToDateMarker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CopyUpToDateMarker.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class CopyUpToDateMarker
+    internal partial class CopyUpToDateMarker
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DebuggerGeneral.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DebuggerGeneral.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class DebuggerGeneralProperties
+    internal partial class DebuggerGeneralProperties
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DotNetCliToolReference.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DotNetCliToolReference.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class DotNetCliToolReference
+    internal partial class DotNetCliToolReference
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/EmbeddedResource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/EmbeddedResource.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class EmbeddedResource
+    internal partial class EmbeddedResource
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Folder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Folder.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class Folder
+    internal partial class Folder
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class ConfigurationGeneralBrowseObject
+    internal partial class ConfigurationGeneralBrowseObject
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/None.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/None.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class None
+    internal partial class None
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class NuGetRestore
+    internal partial class NuGetRestore
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class PackageReference
+    internal partial class PackageReference
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Page.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Page.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class Page
+    internal partial class Page
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectDebugger.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectDebugger.xaml.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class ProjectDebugger
+    internal partial class ProjectDebugger
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class ProjectReference
+    internal partial class ProjectReference
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAnalyzerReference.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAnalyzerReference.xaml.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class ResolvedAnalyzerReference
+    internal partial class ResolvedAnalyzerReference
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAssemblyReference.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAssemblyReference.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class ResolvedAssemblyReference
+    internal partial class ResolvedAssemblyReference
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedCOMReference.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedCOMReference.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class ResolvedCOMReference
+    internal partial class ResolvedCOMReference
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedCompilationReference.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedCompilationReference.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class ResolvedCompilationReference
+    internal partial class ResolvedCompilationReference
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedPackageReference.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedPackageReference.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class ResolvedPackageReference
+    internal partial class ResolvedPackageReference
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedProjectReference.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedProjectReference.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class ResolvedProjectReference
+    internal partial class ResolvedProjectReference
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedSdkReference.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedSdkReference.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class ResolvedSdkReference
+    internal partial class ResolvedSdkReference
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SdkReference.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SdkReference.xaml.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class SdkReference
+    internal partial class SdkReference
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SourceControl.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SourceControl.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class SourceControl
+    internal partial class SourceControl
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SpecialFolder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SpecialFolder.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class SpecialFolder
+    internal partial class SpecialFolder
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SubProject.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SubProject.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class SubProject
+    internal partial class SubProject
     {
 
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckBuilt.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckBuilt.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class UpToDateCheckBuilt
+    internal partial class UpToDateCheckBuilt
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckInput.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class UpToDateCheckInput
+    internal partial class UpToDateCheckInput
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckOutput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckOutput.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
-    partial class UpToDateCheckOutput
+    internal partial class UpToDateCheckOutput
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/SemaphoreSlimExtensions.SemaphoreDisposer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/SemaphoreSlimExtensions.SemaphoreDisposer.cs
@@ -5,7 +5,7 @@ using System.Threading;
 
 namespace Microsoft.VisualStudio.Threading
 {
-    partial class SemaphoreSlimExtensions
+    internal partial class SemaphoreSlimExtensions
     {
         internal struct SemaphoreDisposer : IDisposable
         {


### PR DESCRIPTION
- Collection initialization can be simplified
- Apply accessible modifiers on partial classes
  - Usually we don't apply modifiers on partial declarations other than the main one, but until dotnet/roslyn#27837 is implemented we cannot enforce modifiers everywhere but these cases, so we just enforce them everywhere.