### PR TITLE
Fix reliability of CancelPendingUpdates_PendingTasksAreNotRun

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Threading/Tasks/TaskDelaySchedulerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Threading/Tasks/TaskDelaySchedulerTests.cs
@@ -96,34 +96,21 @@ namespace Microsoft.VisualStudio.Threading.Tasks
         }
 
         [Fact]
-        public void CancelPendingUpdates_PendingTasksAreCanceled()
+        public async Task CancelPendingUpdates_PendingTasksAreNotRun()
         {
-            var scheduler = new TaskDelayScheduler(TimeSpan.FromMilliseconds(50), new IProjectThreadingServiceMock(), CancellationToken.None);
+            var scheduler = new TaskDelayScheduler(TimeSpan.FromMilliseconds(500), new IProjectThreadingServiceMock(), CancellationToken.None);
 
             bool taskRan = false;
-            var task1 = scheduler.ScheduleAsyncTask((ct) =>
+            var task = scheduler.ScheduleAsyncTask((ct) =>
             {
                 taskRan = true;
-                int count = 50;
-                while (count != 0)
-                {
-                    ct.ThrowIfCancellationRequested();
-                    Thread.Sleep(20);
-                    --count;
-                }
                 return Task.CompletedTask;
             });
 
             scheduler.CancelPendingUpdates();
 
-            try
-            {
-                task1.Task.Wait();
-                Assert.False(taskRan);
-            }
-            catch (OperationCanceledException)
-            {
-            }
+            await task;
+            Assert.False(taskRan);
         }
     }
 }


### PR DESCRIPTION
On the build server this test was failing because the scheduled task delay was too short, causing us to start running the task before we'd cancelled.

Also simplified the test - it looked like it was attempting to test something as well, but OperationCancelledException was never thrown in any circumstances; if we'd already started running the task, CancelPendingUpdates would not cancel the token.

@BillHiebert On this - CancelPendingUpdates, is that supposed to cancel running tasks? Because the logic inside TaskDelayScheduler does not do that.

