### PR TITLE
Make sure we initialize when calling LoadAsync in AbstractProjectDynamicLoadComponent

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/AbstractProjectDynamicLoadComponentFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/AbstractProjectDynamicLoadComponentFactory.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal class AbstractProjectDynamicLoadComponentFactory
+    {
+        public static ProjectDynamicLoadComponent Create()
+        {
+            var joinableTaskContextNode = JoinableTaskContextNodeFactory.Create();
+
+            return new ProjectDynamicLoadComponent(joinableTaskContextNode);
+        }
+
+        public class ProjectDynamicLoadComponent : AbstractProjectDynamicLoadComponent
+        {
+            private readonly JoinableTaskContextNode _joinableTaskContextNode;
+
+            public ProjectDynamicLoadComponent(JoinableTaskContextNode joinableTaskContextNode) 
+                : base(joinableTaskContextNode)
+            {
+                _joinableTaskContextNode = joinableTaskContextNode;
+            }
+
+            protected override AbstractProjectDynamicLoadInstance CreateInstance()
+            {
+                return new ProjectDynamicLoadComponentInstance(_joinableTaskContextNode);
+            }
+
+            public new bool IsInitialized
+            {
+                get { return base.IsInitialized; }
+            }
+
+            public class ProjectDynamicLoadComponentInstance : AbstractProjectDynamicLoadInstance
+            {
+                public ProjectDynamicLoadComponentInstance(JoinableTaskContextNode joinableTaskContextNode) 
+                    : base(joinableTaskContextNode)
+                {
+                }
+
+                protected override Task DisposeCoreAsync(bool initialized)
+                {
+                    return Task.CompletedTask;
+                }
+
+                protected override Task InitializeCoreAsync(CancellationToken cancellationToken)
+                {
+                    return Task.CompletedTask;
+                }
+
+                public new bool IsInitialized
+                {
+                    get { return base.IsInitialized; }
+                }
+            }
+        }
+    }
+
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/JoinableTaskContextNodeFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/JoinableTaskContextNodeFactory.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.Threading
+{
+    internal class JoinableTaskContextNodeFactory
+    {
+        public static JoinableTaskContextNode Create()
+        {
+            var context = new JoinableTaskContext();
+
+            return new JoinableTaskContextNode(context);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/AbstractProjectDynamicLoadComponentTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/AbstractProjectDynamicLoadComponentTests.cs
@@ -1,0 +1,125 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    public class AbstractProjectDynamicLoadComponentTests
+    {
+        [Fact]
+        public async Task LoadAsync_Initializes()
+        {
+            var component = CreateInstance();
+
+            await component.LoadAsync();
+
+            Assert.True(component.IsInitialized);
+        }
+
+        [Fact]
+        public async Task LoadAsync_InitializesUnderlyingInstance()
+        {
+            var component = CreateInstance();
+
+            await component.LoadAsync();
+
+            var result = (AbstractProjectDynamicLoadComponentFactory.ProjectDynamicLoadComponent.ProjectDynamicLoadComponentInstance)component.Instance;
+
+            Assert.True(result.IsInitialized);
+        }
+
+        [Fact]
+        public async Task LoadAsync_WhenAlreadyLoaded_DoesNotCreateNewInstance()
+        {
+            var component = CreateInstance();
+
+            await component.LoadAsync();
+
+            var instance = component.Instance;
+
+            await component.LoadAsync();
+
+            Assert.Same(instance, component.Instance);
+        }
+
+        [Fact]
+        public async Task LoadAsync_WhenUnloaded_CreatesNewInstance()
+        {
+            var component = CreateInstance();
+
+            await component.LoadAsync();
+
+            var instance = component.Instance;
+
+            await component.UnloadAsync();
+
+            // We should create a new instance here
+            await component.LoadAsync();
+
+            Assert.NotSame(instance, component.Instance);
+        }
+
+        [Fact]
+        public async Task UnloadAsync_WhenLoaded_DisposesUnderlyingInstance()
+        {
+            var component = CreateInstance();
+
+            await component.LoadAsync();
+            var instance = component.Instance;
+
+            await component.UnloadAsync();
+
+            Assert.Null(component.Instance);
+            Assert.True(instance.IsDisposed);
+        }
+
+        [Fact]
+        public async Task UnloadAsync_WhenNotLoaded_DoesNothing()
+        {
+            var component = CreateInstance();
+
+            await component.UnloadAsync();
+
+            Assert.Null(component.Instance);
+        }
+
+        [Fact]
+        public async Task UnloadAsync_DoesNotDispose()
+        {
+            var component = CreateInstance();
+
+            await component.UnloadAsync();
+
+            Assert.False(component.IsDisposed);
+        }
+
+        [Fact]
+        public void Dispose_WhenNotLoaded_DoesNothing()
+        {
+            var component = CreateInstance();
+            component.Dispose();
+
+            Assert.True(component.IsDisposed);
+        }
+
+        [Fact]
+        public async Task Dispose_WhenLoaded_DisposesUnderlyingInstance()
+        {
+            var component = CreateInstance();
+
+            await component.LoadAsync();
+            var instance = component.Instance;
+
+            component.Dispose();
+
+            Assert.True(instance.IsDisposed);
+        }
+
+        private static AbstractProjectDynamicLoadComponentFactory.ProjectDynamicLoadComponent CreateInstance()
+        {
+            return AbstractProjectDynamicLoadComponentFactory.Create();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractProjectDynamicLoadComponent.AbstractProjectDynamicLoadInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractProjectDynamicLoadComponent.AbstractProjectDynamicLoadInstance.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         ///     <see cref="IProjectDynamicLoadComponent"/> instance's capabilities requirements are 
         ///     satisfied, or disposed when they are not.
         /// </summary>
-        protected abstract class AbstractProjectDynamicLoadInstance : OnceInitializedOnceDisposedAsync
+        public abstract class AbstractProjectDynamicLoadInstance : OnceInitializedOnceDisposedAsync
         {
             protected AbstractProjectDynamicLoadInstance(JoinableTaskContextNode joinableTaskContextNode)
                 : base(joinableTaskContextNode)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractProjectDynamicLoadComponent.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractProjectDynamicLoadComponent.cs
@@ -28,7 +28,14 @@ namespace Microsoft.VisualStudio.ProjectSystem
             get { return _instance; }
         }
 
-        public Task LoadAsync()
+        public async Task LoadAsync()
+        {
+            await InitializeAsync().ConfigureAwait(false);
+
+            await LoadCoreAsync().ConfigureAwait(false);
+        }
+
+        private Task LoadCoreAsync()
         {
             AbstractProjectDynamicLoadInstance instance;
             lock (_lock)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractProjectDynamicLoadComponent.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractProjectDynamicLoadComponent.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
     internal abstract partial class AbstractProjectDynamicLoadComponent : OnceInitializedOnceDisposedAsync, IProjectDynamicLoadComponent
     {
         private readonly object _lock = new object();
-#pragma warning disable CA2213 // OnceInitializedOnceDisposedAsync are not tracked corretly by the IDisposeable analyzer
+#pragma warning disable CA2213 // OnceInitializedOnceDisposedAsync are not tracked correctly by the IDisposeable analyzer
         private AbstractProjectDynamicLoadInstance _instance;
 #pragma warning restore CA2213
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractProjectDynamicLoadComponent.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractProjectDynamicLoadComponent.cs
@@ -23,6 +23,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
         }
 
+        public AbstractProjectDynamicLoadInstance Instance
+        {
+            get { return _instance; }
+        }
+
         public Task LoadAsync()
         {
             AbstractProjectDynamicLoadInstance instance;


### PR DESCRIPTION
We weren't initializing the "outer" object, which I ran into the language service hookup rewrite.

Also filled out the tests.