### PR TITLE
Replace ImplicitlyActivated/Deactivated events with IImplicitlyActiveService

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IImplicitlyActiveServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IImplicitlyActiveServiceFactory.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft.All Rights Reserved.Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class IImplicitlyActiveServiceFactory
+    {
+        public static IImplicitlyActiveService ImplementActivateAsync(Action action)
+        {
+            var mock = new Mock<IImplicitlyActiveService>();
+
+            mock.Setup(a => a.ActivateAsync())
+                .ReturnsAsync(action);
+
+            return mock.Object;
+        }
+
+        public static IImplicitlyActiveService ImplementDeactivateAsync(Action action)
+        {
+            var mock = new Mock<IImplicitlyActiveService>();
+
+            mock.Setup(a => a.DeactivateAsync())
+                .ReturnsAsync(action);
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IConfiguredProjectImplicitActivationTracking.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IConfiguredProjectImplicitActivationTracking.cs
@@ -3,7 +3,6 @@
 using System.Threading.Tasks;
 
 using Microsoft.VisualStudio.Composition;
-using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
@@ -13,16 +12,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
     [ProjectSystemContract(ProjectSystemContractScope.ConfiguredProject, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
     internal interface IConfiguredProjectImplicitActivationTracking
     {
-        /// <summary>
-        ///     Occurs when the current <see cref="ConfiguredProject"/> becomes implicitly active.
-        /// </summary>
-        event AsyncEventHandler ImplicitlyActivated;
-
-        /// <summary>
-        ///     Occurs when the current <see cref="ConfiguredProject"/> is no longer implicitly active.
-        /// </summary>
-        event AsyncEventHandler ImplicitlyDeactivated;
-
         /// <summary>
         ///     Gets a value indicating whether the current <see cref="ConfiguredProject"/> 
         ///     is implicitly active.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IImplicitlyActiveService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IImplicitlyActiveService.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Composition;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    /// <summary>
+    ///     A configured-project service which will be activated when its configured project becomes implicitly active, or deactivated when it not.
+    /// </summary>
+    [ProjectSystemContract(ProjectSystemContractScope.ConfiguredProject, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ZeroOrMore)]
+    internal interface IImplicitlyActiveService
+    {
+        /// <summary>
+        ///     Activates the service.
+        /// </summary>
+        Task ActivateAsync();
+
+        /// <summary>
+        ///     Deactivates the service.
+        /// </summary>
+        Task DeactivateAsync();
+    }
+}


### PR DESCRIPTION
See: https://github.com/dotnet/project-system/pull/3423/files#r178951672.

It became clear that consuming the activated/deactivated events in a manner that was thread-safe was difficult. Instead replace it with an service interface that automatically gets Activated/Deactivated when the configured project becomes implicitly activate or deactivated.