### PR TITLE
Rename AbstractProjectDynamicLoadComponent to AbstractMultiLifetimeComponent

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/AbstractMultiLifetimeComponentFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/AbstractMultiLifetimeComponentFactory.cs
@@ -6,28 +6,28 @@ using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    internal class AbstractProjectDynamicLoadComponentFactory
+    internal class AbstractMultiLifetimeComponentFactory
     {
-        public static ProjectDynamicLoadComponent Create()
+        public static MultiLifetimeComponent Create()
         {
             var joinableTaskContextNode = JoinableTaskContextNodeFactory.Create();
 
-            return new ProjectDynamicLoadComponent(joinableTaskContextNode);
+            return new MultiLifetimeComponent(joinableTaskContextNode);
         }
 
-        public class ProjectDynamicLoadComponent : AbstractProjectDynamicLoadComponent
+        public class MultiLifetimeComponent : AbstractMultiLifetimeComponent
         {
             private readonly JoinableTaskContextNode _joinableTaskContextNode;
 
-            public ProjectDynamicLoadComponent(JoinableTaskContextNode joinableTaskContextNode) 
+            public MultiLifetimeComponent(JoinableTaskContextNode joinableTaskContextNode) 
                 : base(joinableTaskContextNode)
             {
                 _joinableTaskContextNode = joinableTaskContextNode;
             }
 
-            protected override AbstractProjectDynamicLoadInstance CreateInstance()
+            protected override AbstractMultiLifetimeInstance CreateInstance()
             {
-                return new ProjectDynamicLoadComponentInstance(_joinableTaskContextNode);
+                return new MultiLifetimeInstance(_joinableTaskContextNode);
             }
 
             public new bool IsInitialized
@@ -35,9 +35,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 get { return base.IsInitialized; }
             }
 
-            public class ProjectDynamicLoadComponentInstance : AbstractProjectDynamicLoadInstance
+            public class MultiLifetimeInstance : AbstractMultiLifetimeInstance
             {
-                public ProjectDynamicLoadComponentInstance(JoinableTaskContextNode joinableTaskContextNode) 
+                public MultiLifetimeInstance(JoinableTaskContextNode joinableTaskContextNode) 
                     : base(joinableTaskContextNode)
                 {
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/AbstractMultiLifetimeComponentTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/AbstractMultiLifetimeComponentTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    public class AbstractProjectDynamicLoadComponentTests
+    public class AbstractMultiLifetimeComponentTests
     {
         [Fact]
         public async Task LoadAsync_Initializes()
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             await component.LoadAsync();
 
-            var result = (AbstractProjectDynamicLoadComponentFactory.ProjectDynamicLoadComponent.ProjectDynamicLoadComponentInstance)component.Instance;
+            var result = (AbstractMultiLifetimeComponentFactory.MultiLifetimeComponent.MultiLifetimeInstance)component.Instance;
 
             Assert.True(result.IsInitialized);
         }
@@ -117,9 +117,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
             Assert.True(instance.IsDisposed);
         }
 
-        private static AbstractProjectDynamicLoadComponentFactory.ProjectDynamicLoadComponent CreateInstance()
+        private static AbstractMultiLifetimeComponentFactory.MultiLifetimeComponent CreateInstance()
         {
-            return AbstractProjectDynamicLoadComponentFactory.Create();
+            return AbstractMultiLifetimeComponentFactory.Create();
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/PackageRestoreInitiator.PackageRestoreInitiatorInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/PackageRestoreInitiator.PackageRestoreInitiatorInstance.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
 
     internal partial class PackageRestoreInitiator
     {
-        private class PackageRestoreInitiatorInstance : AbstractProjectDynamicLoadInstance
+        private class PackageRestoreInitiatorInstance : AbstractMultiLifetimeInstance
         {
             private readonly IUnconfiguredProjectVsServices _projectVsServices;
             private readonly IVsSolutionRestoreService _solutionRestoreService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/PackageRestoreInitiator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/PackageRestoreInitiator.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
     /// </summary>
     [Export(ExportContractNames.Scopes.UnconfiguredProject, typeof(IProjectDynamicLoadComponent))]
     [AppliesTo(ProjectCapability.PackageReferences)]
-    internal partial class PackageRestoreInitiator : AbstractMultiLifetimeComponent
+    internal partial class PackageRestoreInitiator : AbstractMultiLifetimeComponent, IProjectDynamicLoadComponent
     {
         private readonly IUnconfiguredProjectVsServices _projectVsServices;
         private readonly IVsSolutionRestoreService _solutionRestoreService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/PackageRestoreInitiator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/PackageRestoreInitiator.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
     /// </summary>
     [Export(ExportContractNames.Scopes.UnconfiguredProject, typeof(IProjectDynamicLoadComponent))]
     [AppliesTo(ProjectCapability.PackageReferences)]
-    internal partial class PackageRestoreInitiator : AbstractProjectDynamicLoadComponent
+    internal partial class PackageRestoreInitiator : AbstractMultiLifetimeComponent
     {
         private readonly IUnconfiguredProjectVsServices _projectVsServices;
         private readonly IVsSolutionRestoreService _solutionRestoreService;
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             _logger = logger;
         }
 
-        protected override AbstractProjectDynamicLoadInstance CreateInstance()
+        protected override AbstractMultiLifetimeInstance CreateInstance()
         {
             return new PackageRestoreInitiatorInstance(_projectVsServices, _solutionRestoreService, _activeConfiguredProjectSubscriptionService, _activeConfigurationGroupService, _logger);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractMultiLifetimeComponent.AbstractMultiLifetimeInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractMultiLifetimeComponent.AbstractMultiLifetimeInstance.cs
@@ -7,22 +7,21 @@ using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    internal partial class AbstractProjectDynamicLoadComponent
+    internal partial class AbstractMultiLifetimeComponent
     {
         /// <summary>
-        ///     Represents an instance that is automatically initialized when its parent
-        ///     <see cref="IProjectDynamicLoadComponent"/> instance's capabilities requirements are 
-        ///     satisfied, or disposed when they are not.
+        ///     Represents an instance that is automatically initialized when its parent <see cref="AbstractMultiLifetimeComponent"/>
+        ///     is loaded, or disposed when it is unloaded.
         /// </summary>
-        public abstract class AbstractProjectDynamicLoadInstance : OnceInitializedOnceDisposedAsync
+        public abstract class AbstractMultiLifetimeInstance : OnceInitializedOnceDisposedAsync
         {
-            protected AbstractProjectDynamicLoadInstance(JoinableTaskContextNode joinableTaskContextNode)
+            protected AbstractMultiLifetimeInstance(JoinableTaskContextNode joinableTaskContextNode)
                 : base(joinableTaskContextNode)
             {
             }
 
             /// <summary>
-            ///     Initializes the <see cref="AbstractProjectDynamicLoadInstance"/>.
+            ///     Initializes the <see cref="AbstractMultiLifetimeInstance"/>.
             /// </summary>
             public Task InitializeAsync()
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractMultiLifetimeComponent.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractMultiLifetimeComponent.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
     ///     An <see langword="abstract"/> base class that simplifies the lifetime of 
     ///     a component that is loaded and unloaded multiple times.
     /// </summary>
-    internal abstract partial class AbstractMultiLifetimeComponent : OnceInitializedOnceDisposedAsync, IProjectDynamicLoadComponent
+    internal abstract partial class AbstractMultiLifetimeComponent : OnceInitializedOnceDisposedAsync
     {
         private readonly object _lock = new object();
 #pragma warning disable CA2213 // OnceInitializedOnceDisposedAsync are not tracked correctly by the IDisposeable analyzer

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractMultiLifetimeComponent.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractMultiLifetimeComponent.cs
@@ -8,22 +8,22 @@ using Microsoft.VisualStudio.Threading;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     /// <summary>
-    ///     An <see langword="abstract"/> base class that simplifies the lifetime of a
-    ///     <see cref="IProjectDynamicLoadComponent"/> implementation.
+    ///     An <see langword="abstract"/> base class that simplifies the lifetime of 
+    ///     a component that is loaded and unloaded multiple times.
     /// </summary>
-    internal abstract partial class AbstractProjectDynamicLoadComponent : OnceInitializedOnceDisposedAsync, IProjectDynamicLoadComponent
+    internal abstract partial class AbstractMultiLifetimeComponent : OnceInitializedOnceDisposedAsync, IProjectDynamicLoadComponent
     {
         private readonly object _lock = new object();
 #pragma warning disable CA2213 // OnceInitializedOnceDisposedAsync are not tracked correctly by the IDisposeable analyzer
-        private AbstractProjectDynamicLoadInstance _instance;
+        private AbstractMultiLifetimeInstance _instance;
 #pragma warning restore CA2213
 
-        protected AbstractProjectDynamicLoadComponent(JoinableTaskContextNode joinableTaskContextNode)
+        protected AbstractMultiLifetimeComponent(JoinableTaskContextNode joinableTaskContextNode)
             : base(joinableTaskContextNode)
         {
         }
 
-        public AbstractProjectDynamicLoadInstance Instance
+        public AbstractMultiLifetimeInstance Instance
         {
             get { return _instance; }
         }
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         private Task LoadCoreAsync()
         {
-            AbstractProjectDynamicLoadInstance instance;
+            AbstractMultiLifetimeInstance instance;
             lock (_lock)
             {
                 if (_instance == null)
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public Task UnloadAsync()
         {
-            AbstractProjectDynamicLoadInstance instance = null;
+            AbstractMultiLifetimeInstance instance = null;
 
             lock (_lock)
             {
@@ -83,8 +83,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         /// <summary>
-        ///     Creates a new instance of the underlying <see cref="AbstractProjectDynamicLoadInstance"/>.
+        ///     Creates a new instance of the underlying <see cref="AbstractMultiLifetimeInstance"/>.
         /// </summary>
-        protected abstract AbstractProjectDynamicLoadInstance CreateInstance();
+        protected abstract AbstractMultiLifetimeInstance CreateInstance();
     }
 }


### PR DESCRIPTION
This component is being/will be used by IProjectDynamicLoadComponent and IImplicitlyActiveService instances.