### PR TITLE
Add timeouts to renaming tests

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Rename/CSharpSimpleRenamerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Rename/CSharpSimpleRenamerTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -53,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
             var userNotificationServices = IUserNotificationServicesFactory.Create();
             var roslynServices = IRoslynServicesFactory.Implement(new CSharpSyntaxFactsService(null));
 
-            await RenameAsync(soureCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, LanguageNames.CSharp);
+            await RenameAsync(soureCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, LanguageNames.CSharp).TimeoutAfter(TimeSpan.FromSeconds(1));
 
             Mock.Get(userNotificationServices).Verify(h => h.Confirm(It.IsAny<string>()), Times.Never);
             Mock.Get(roslynServices).Verify(h => h.RenameSymbolAsync(It.IsAny<Solution>(), It.IsAny<ISymbol>(), It.IsAny<string>()), Times.Never);
@@ -71,7 +72,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
                 var environmentOptionsFactory = IEnvironmentOptionsFactory.Implement((string category, string page, string property, bool defaultValue) => { return true; });
 
                 var renamer = new Renamer(ws, IProjectThreadingServiceFactory.Create(), userNotificationServices, environmentOptionsFactory, roslynServices, project, oldFilePath, newFilePath);
-                await renamer.RenameAsync(project);
+                await renamer.RenameAsync(project)
+                             .TimeoutAfter(TimeSpan.FromSeconds(1));
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/Threading/Tasks/TaskTimeoutExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/Threading/Tasks/TaskTimeoutExtensions.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace System.Threading.Tasks
+{
+    public static class TaskTimeoutExtensions
+    {
+        public static async Task TimeoutAfter(this Task task, TimeSpan timeout)
+        {
+            using (var cts = new CancellationTokenSource())
+            {
+                Task timeoutTask = Task.Delay(timeout, cts.Token);
+                Task completedTask = await Task.WhenAny(task, timeoutTask)
+                                              .ConfigureAwait(false);
+
+                if (timeoutTask == completedTask)
+                    throw new TimeoutException($"Task timed out after {timeout.TotalMilliseconds} ms");
+
+                cts.Cancel();
+                await task.ConfigureAwait(false);
+            }
+        }
+
+        public static async Task<TResult> TimeoutAfter<TResult>(this Task<TResult> task, TimeSpan timeout)
+        {
+            using (var cts = new CancellationTokenSource())
+            {
+                Task timeoutTask = Task.Delay(timeout, cts.Token);
+                Task completedTask = await Task.WhenAny(task, timeoutTask)
+                                              .ConfigureAwait(false);
+
+                if (timeoutTask == completedTask)
+                    throw new TimeoutException($"Task timed out after {timeout.TotalMilliseconds} ms");
+
+                cts.Cancel();
+                return await task.ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Rename/VisualBasicSimpleRenameTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Rename/VisualBasicSimpleRenameTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis;
@@ -134,7 +135,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
                 var environmentOptionsFactory = IEnvironmentOptionsFactory.Implement((string category, string page, string property, bool defaultValue) => { return true; });
 
                 var renamer = new Renamer(ws, IProjectThreadingServiceFactory.Create(), userNotificationServices, environmentOptionsFactory, roslynServices, project, oldFilePath, newFilePath);
-                await renamer.RenameAsync(project);
+                await renamer.RenameAsync(project)
+                             .TimeoutAfter(TimeSpan.FromSeconds(1));
             }
         }
     }


### PR DESCRIPTION
I suspect the renaming tests are blocking runs, this will at least help chase down the cause - and prevent runs being blocked for 60 minutes.