### PR TITLE
ClickOnce provider should throw from Publish/ShowPublishPromptAsync

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Build/PublishableProjectConfigProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Build/PublishableProjectConfigProviderTests.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Build
+{
+    [Trait("UnitTest", "ProjectSystem")]
+    public class PublishableProjectConfigProviderTests
+    {
+        [Fact]
+        public async Task IsPublishSupportedAsync_ReturnsFalse()
+        {
+            var provider = CreateInstance();
+
+            var result = await provider.IsPublishSupportedAsync();
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task PublishAsync_ThrowsInvalidOperation()
+        {
+            var provider = CreateInstance();
+            var writer = new StringWriter();
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            {
+                return provider.PublishAsync(CancellationToken.None, writer);
+            });
+        }
+
+        [Fact]
+        public async Task ShowPublishPromptAsync_ThrowsInvalidOperation()
+        {
+            var provider = CreateInstance();
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            {
+                return provider.ShowPublishPromptAsync();
+            });
+        }
+
+        private static PublishableProjectConfigProvider CreateInstance()
+        {
+            return new PublishableProjectConfigProvider();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/PublishableProjectConfigProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/PublishableProjectConfigProvider.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.ComponentModel.Composition;
 using System.IO;
 using System.Threading;
@@ -24,13 +25,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Build
 
         public Task PublishAsync(CancellationToken cancellationToken, TextWriter outputPaneWriter)
         {
-            // No-op for now.
-            return Task.CompletedTask;
+            throw new InvalidOperationException();
         }
 
         public Task<bool> ShowPublishPromptAsync()
         {
-            return TaskResult.False;
+            throw new InvalidOperationException();
         }
     }
 }


### PR DESCRIPTION
It's never valid to call a IPublishProvider if IsPublishSupportedAsync returns false.