### PR TITLE
Add IProjectAccessor.EnterWriteLockAsync

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectAccessorFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectAccessorFactory.cs
@@ -35,6 +35,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 _evaluationProject = project;
             }
 
+            public Task EnterWriteLockAsync(Func<ProjectCollection, CancellationToken, Task> action, CancellationToken cancellationToken = default)
+            {
+                throw new NotImplementedException();
+            }
+
             public Task<TResult> OpenProjectForReadAsync<TResult>(ConfiguredProject project, Func<Project, TResult> action, CancellationToken cancellationToken = default)
             {
                 var result = action(_evaluationProject);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectAccessor.cs
@@ -18,6 +18,26 @@ namespace Microsoft.VisualStudio.ProjectSystem
     internal interface IProjectAccessor
     {
         /// <summary>
+        ///     Obtains a write lock, asynchronously awaiting for the lock if it is not immediately available.
+        /// </summary>
+        /// <param name="action">
+        ///     The <see cref="Func{T1, T2, TResult}"/> to run while holding the lock.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A token whose cancellation signals lost interest in the result.
+        /// </param>
+        /// <returns>
+        ///     The result of executing <paramref name="action"/> over the <see cref="ProjectCollection"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="action"/> is <see langword="null"/>.
+        /// </exception>
+        /// <remarks>
+        ///     NOTE: To avoid deadlocks, do not call arbitrary services or asynchronous code other than methods on <see cref="IProjectAccessor"/> within <paramref name="action"/>.
+        /// </remarks>
+        Task EnterWriteLockAsync(Func<ProjectCollection, CancellationToken, Task> action, CancellationToken cancellationToken = default);
+
+        /// <summary>
         ///     Opens the MSBuild project construction model for the specified project, passing it to the specified action for reading.
         /// </summary>
         /// <param name="project">
@@ -51,7 +71,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         ///     The <see cref="UnconfiguredProject"/> whose underlying MSBuild object model is required.
         /// </param>
         /// <param name="action">
-        ///     The <see cref="Func{T, TResult}"/> to run while holding the lock.
+        ///     The <see cref="Func{T1, T2, TResult}"/> to run while holding the lock.
         /// </param>
         /// <param name="cancellationToken">
         ///     A token whose cancellation signals lost interest in the result.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectAccessor.cs
@@ -28,6 +28,17 @@ namespace Microsoft.VisualStudio.ProjectSystem
             _projectLockService = projectLockService;
         }
 
+        public async Task EnterWriteLockAsync(Func<ProjectCollection, CancellationToken, Task> action, CancellationToken cancellationToken = default)
+        {
+            Requires.NotNull(action, nameof(action));
+
+            using (ProjectWriteLockReleaser access = await _projectLockService.WriteLockAsync(cancellationToken))
+            {
+                // Only async to let the caller call one of the other project accessor methods
+                await action(access.ProjectCollection, cancellationToken).ConfigureAwait(true);
+            }
+        }
+
         public async Task<TResult> OpenProjectForReadAsync<TResult>(ConfiguredProject project, Func<Project, TResult> action, CancellationToken cancellationToken = default)
         {
             Requires.NotNull(project, nameof(project));


### PR DESCRIPTION
Adds the last usage of WriteLockAsync under a unit testable mockable method.

There will be follow-up PRs that consume this. Centralizing all write locks usage let's us react to this change in an easier way than CPS: https://devdiv.visualstudio.com/DevDiv/_git/CPS/pullrequest/132369.