### PR TITLE
 Avoid blocking thread on releasing write lock

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectAccessorFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectAccessorFactory.cs
@@ -35,6 +35,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 _evaluationProject = project;
             }
 
+            public Task EnterWriteLockAsync(Func<ProjectCollection, CancellationToken, Task> action, CancellationToken cancellationToken = default)
+            {
+                throw new NotImplementedException();
+            }
+
             public Task<TResult> OpenProjectForReadAsync<TResult>(ConfiguredProject project, Func<Project, TResult> action, CancellationToken cancellationToken = default)
             {
                 var result = action(_evaluationProject);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectAccessor.cs
@@ -18,6 +18,26 @@ namespace Microsoft.VisualStudio.ProjectSystem
     internal interface IProjectAccessor
     {
         /// <summary>
+        ///     Obtains a write lock, asynchronously awaiting for the lock if it is not immediately available.
+        /// </summary>
+        /// <param name="action">
+        ///     The <see cref="Func{T1, T2, TResult}"/> to run while holding the lock.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A token whose cancellation signals lost interest in the result.
+        /// </param>
+        /// <returns>
+        ///     The result of executing <paramref name="action"/> over the <see cref="ProjectCollection"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="action"/> is <see langword="null"/>.
+        /// </exception>
+        /// <remarks>
+        ///     NOTE: To avoid deadlocks, do not call arbitrary services or asynchronous code other than methods on <see cref="IProjectAccessor"/> within <paramref name="action"/>.
+        /// </remarks>
+        Task EnterWriteLockAsync(Func<ProjectCollection, CancellationToken, Task> action, CancellationToken cancellationToken = default);
+
+        /// <summary>
         ///     Opens the MSBuild project construction model for the specified project, passing it to the specified action for reading.
         /// </summary>
         /// <param name="project">
@@ -51,7 +71,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         ///     The <see cref="UnconfiguredProject"/> whose underlying MSBuild object model is required.
         /// </param>
         /// <param name="action">
-        ///     The <see cref="Func{T, TResult}"/> to run while holding the lock.
+        ///     The <see cref="Func{T1, T2, TResult}"/> to run while holding the lock.
         /// </param>
         /// <param name="cancellationToken">
         ///     A token whose cancellation signals lost interest in the result.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectAccessor.cs
@@ -28,6 +28,17 @@ namespace Microsoft.VisualStudio.ProjectSystem
             _projectLockService = projectLockService;
         }
 
+        public async Task EnterWriteLockAsync(Func<ProjectCollection, CancellationToken, Task> action, CancellationToken cancellationToken = default)
+        {
+            Requires.NotNull(action, nameof(action));
+
+            using (ProjectWriteLockReleaser access = await _projectLockService.WriteLockAsync(cancellationToken))
+            {
+                // Only async to let the caller call one of the other project accessor methods
+                await action(access.ProjectCollection, cancellationToken).ConfigureAwait(true);
+            }
+        }
+
         public async Task<TResult> OpenProjectForReadAsync<TResult>(ConfiguredProject project, Func<Project, TResult> action, CancellationToken cancellationToken = default)
         {
             Requires.NotNull(project, nameof(project));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectAccessor.cs
@@ -36,6 +36,10 @@ namespace Microsoft.VisualStudio.ProjectSystem
             {
                 // Only async to let the caller call one of the other project accessor methods
                 await action(access.ProjectCollection, cancellationToken).ConfigureAwait(true);
+
+                // Avoid blocking thread on Dispose
+                await access.ReleaseAsync()
+                            .ConfigureAwait(true);
             }
         }
 
@@ -103,6 +107,10 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 // Deliberately not async to reduce the type of
                 // code you can run while holding the lock.
                 action(rootElement);
+
+                // Avoid blocking thread on Dispose
+                await access.ReleaseAsync()
+                            .ConfigureAwait(true);
             }
         }
 
@@ -122,6 +130,10 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 // Deliberately not async to reduce the type of
                 // code you can run while holding the lock.
                 action(evaluatedProject);
+
+                // Avoid blocking thread on Dispose
+                await access.ReleaseAsync()
+                            .ConfigureAwait(true);
             }
         }
     }


### PR DESCRIPTION
Note: This includes https://github.com/dotnet/project-system/pull/3725, so only review https://github.com/dotnet/project-system/commit/66dfc46402d700a94723a3a32b7bdcce39bd176d.

Dispose synchronously blocks the thread until the write lock is released. Under the covers the project service yields on this path, which under thread pool exhaustion situations can cause Dispose to be blocked for a long time, exacerbating the problem. Await on ReleaseAsync so that the current thread isn't blocked and can be released back to the pool.

See https://devdiv.visualstudio.com/DevDiv/_git/CPS/pullrequest/132369 for the CPS-version of this change.