### PR TITLE
Change ProjectAssertFileWatcher to call through IProjectAccessor

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectAccessorFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectAccessorFactory.cs
@@ -35,6 +35,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 _evaluationProject = project;
             }
 
+            public Task EnterWriteLockAsync(Func<ProjectCollection, CancellationToken, Task> action, CancellationToken cancellationToken = default)
+            {
+                throw new NotImplementedException();
+            }
+
             public Task<TResult> OpenProjectForReadAsync<TResult>(ConfiguredProject project, Func<Project, TResult> action, CancellationToken cancellationToken = default)
             {
                 var result = action(_evaluationProject);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IUnconfiguredProjectCommonServicesFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IUnconfiguredProjectCommonServicesFactory.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public static IUnconfiguredProjectCommonServices Create(UnconfiguredProject project = null, IPhysicalProjectTree projectTree = null, IProjectThreadingService threadingService = null,
                                                                 ConfiguredProject configuredProject = null, ProjectProperties projectProperties = null,
-                                                                IProjectLockService projectLockService = null)
+                                                                IProjectAccessor projectAccessor = null)
         {
             var mock = new Mock<IUnconfiguredProjectCommonServices>();
 
@@ -39,9 +39,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 mock.Setup(s => s.ActiveConfiguredProjectProperties)
                     .Returns(projectProperties);
 
-            if (projectLockService != null)
-                mock.Setup(s => s.ProjectLockService)
-                    .Returns(projectLockService);
+            if (projectAccessor != null)
+                mock.Setup(s => s.ProjectAccessor)
+                    .Returns(projectAccessor);
 
             return mock.Object;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UnconfiguredProjectCommonServicesTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UnconfiguredProjectCommonServicesTests.cs
@@ -18,9 +18,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var projectProperties = ProjectPropertiesFactory.Create(project);
             var activeConfiguredProject = ActiveConfiguredProjectFactory.ImplementValue(() => projectProperties.ConfiguredProject);
             var activeConfiguredProjectProperties = ActiveConfiguredProjectFactory.ImplementValue(() => projectProperties);
-            var projectLockService = new Lazy<IProjectLockService>(() => IProjectLockServiceFactory.Create());
+            var projectAccessor = new Lazy<IProjectAccessor>(() => IProjectAccessorFactory.Create());
 
-            var services = new UnconfiguredProjectCommonServices(project, projectTree, threadingService, activeConfiguredProject, activeConfiguredProjectProperties, projectLockService);
+            var services = new UnconfiguredProjectCommonServices(project, projectTree, threadingService, activeConfiguredProject, activeConfiguredProjectProperties, projectAccessor);
 
             Assert.Same(project, services.Project);
         }
@@ -34,9 +34,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var projectProperties = ProjectPropertiesFactory.Create(project);
             var activeConfiguredProject = ActiveConfiguredProjectFactory.ImplementValue(() => projectProperties.ConfiguredProject);
             var activeConfiguredProjectProperties = ActiveConfiguredProjectFactory.ImplementValue(() => projectProperties);
-            var projectLockService = new Lazy<IProjectLockService>(() => IProjectLockServiceFactory.Create());
+            var projectAccessor = new Lazy<IProjectAccessor>(() => IProjectAccessorFactory.Create());
 
-            var services = new UnconfiguredProjectCommonServices(project, projectTree, threadingService, activeConfiguredProject, activeConfiguredProjectProperties, projectLockService);
+            var services = new UnconfiguredProjectCommonServices(project, projectTree, threadingService, activeConfiguredProject, activeConfiguredProjectProperties, projectAccessor);
 
             Assert.Same(projectTree.Value, services.ProjectTree);
         }
@@ -50,9 +50,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var projectProperties = ProjectPropertiesFactory.Create(project);
             var activeConfiguredProject = ActiveConfiguredProjectFactory.ImplementValue(() => projectProperties.ConfiguredProject);
             var activeConfiguredProjectProperties = ActiveConfiguredProjectFactory.ImplementValue(() => projectProperties);
-            var projectLockService = new Lazy<IProjectLockService>(() => IProjectLockServiceFactory.Create());
+            var projectAccessor = new Lazy<IProjectAccessor>(() => IProjectAccessorFactory.Create());
 
-            var services = new UnconfiguredProjectCommonServices(project, projectTree, threadingService, activeConfiguredProject, activeConfiguredProjectProperties, projectLockService);
+            var services = new UnconfiguredProjectCommonServices(project, projectTree, threadingService, activeConfiguredProject, activeConfiguredProjectProperties, projectAccessor);
 
             Assert.Same(threadingService.Value, services.ThreadingService);
         }
@@ -66,9 +66,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var projectProperties = ProjectPropertiesFactory.Create(project);
             var activeConfiguredProject = ActiveConfiguredProjectFactory.ImplementValue(() => projectProperties.ConfiguredProject);
             var activeConfiguredProjectProperties = ActiveConfiguredProjectFactory.ImplementValue(() => projectProperties);
-            var projectLockService = new Lazy<IProjectLockService>(() => IProjectLockServiceFactory.Create());
+            var projectAccessor = new Lazy<IProjectAccessor>(() => IProjectAccessorFactory.Create());
 
-            var services = new UnconfiguredProjectCommonServices(project, projectTree, threadingService, activeConfiguredProject, activeConfiguredProjectProperties, projectLockService);
+            var services = new UnconfiguredProjectCommonServices(project, projectTree, threadingService, activeConfiguredProject, activeConfiguredProjectProperties, projectAccessor);
 
             Assert.Same(projectProperties.ConfiguredProject, services.ActiveConfiguredProject);
         }
@@ -82,11 +82,27 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var projectProperties = ProjectPropertiesFactory.Create(project);
             var activeConfiguredProject = ActiveConfiguredProjectFactory.ImplementValue(() => projectProperties.ConfiguredProject);
             var activeConfiguredProjectProperties = ActiveConfiguredProjectFactory.ImplementValue(() => projectProperties);
-            var projectLockService = new Lazy<IProjectLockService>(() => IProjectLockServiceFactory.Create());
+            var projectAccessor = new Lazy<IProjectAccessor>(() => IProjectAccessorFactory.Create());
 
-            var services = new UnconfiguredProjectCommonServices(project, projectTree, threadingService, activeConfiguredProject, activeConfiguredProjectProperties, projectLockService);
+            var services = new UnconfiguredProjectCommonServices(project, projectTree, threadingService, activeConfiguredProject, activeConfiguredProjectProperties, projectAccessor);
 
             Assert.Same(projectProperties, services.ActiveConfiguredProjectProperties);
+        }
+
+        [Fact]
+        public void Constructor_ValueAsProjectAccessor_SetsProjectAccessorProperty()
+        {
+            var project = UnconfiguredProjectFactory.Create();
+            var projectTree = new Lazy<IPhysicalProjectTree>(() => IPhysicalProjectTreeFactory.Create());
+            var threadingService = new Lazy<IProjectThreadingService>(() => IProjectThreadingServiceFactory.Create());
+            var projectProperties = ProjectPropertiesFactory.Create(project);
+            var activeConfiguredProject = ActiveConfiguredProjectFactory.ImplementValue(() => projectProperties.ConfiguredProject);
+            var activeConfiguredProjectProperties = ActiveConfiguredProjectFactory.ImplementValue(() => projectProperties);
+            var projectAccessor = new Lazy<IProjectAccessor>(() => IProjectAccessorFactory.Create());
+
+            var services = new UnconfiguredProjectCommonServices(project, projectTree, threadingService, activeConfiguredProject, activeConfiguredProjectProperties, projectAccessor);
+
+            Assert.Same(projectAccessor.Value, services.ProjectAccessor);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/UnconfiguredProjectVsServicesTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/UnconfiguredProjectVsServicesTests.cs
@@ -92,6 +92,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             Assert.Same(projectProperties, vsServices.ActiveConfiguredProjectProperties);
         }
 
+        [Fact]
+        public void Constructor_ValueAsCommonServices_SetsProjectAccessorToCommonServicesProjectAccessor()
+        {
+            var projectAccessor = IProjectAccessorFactory.Create();
+            var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(projectAccessor: projectAccessor);
+
+            var vsServices = CreateInstance(commonServices);
+
+            Assert.Same(projectAccessor, vsServices.ProjectAccessor);
+        }
+
+
         private static UnconfiguredProjectVsServices CreateInstance(IUnconfiguredProjectCommonServices commonServices)
         {
             return new UnconfiguredProjectVsServices(commonServices);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UnconfiguredProjectVsServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UnconfiguredProjectVsServices.cs
@@ -57,9 +57,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             get { return _commonServices.ActiveConfiguredProjectProperties; }
         }
 
-        public IProjectLockService ProjectLockService
+        public IProjectAccessor ProjectAccessor
         {
-            get { return _commonServices.ProjectLockService; }
+            get { return _commonServices.ProjectAccessor; }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectAccessor.cs
@@ -18,6 +18,26 @@ namespace Microsoft.VisualStudio.ProjectSystem
     internal interface IProjectAccessor
     {
         /// <summary>
+        ///     Obtains a write lock, asynchronously awaiting for the lock if it is not immediately available.
+        /// </summary>
+        /// <param name="action">
+        ///     The <see cref="Func{T1, T2, TResult}"/> to run while holding the lock.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A token whose cancellation signals lost interest in the result.
+        /// </param>
+        /// <returns>
+        ///     The result of executing <paramref name="action"/> over the <see cref="ProjectCollection"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="action"/> is <see langword="null"/>.
+        /// </exception>
+        /// <remarks>
+        ///     NOTE: To avoid deadlocks, do not call arbitrary services or asynchronous code other than methods on <see cref="IProjectAccessor"/> within <paramref name="action"/>.
+        /// </remarks>
+        Task EnterWriteLockAsync(Func<ProjectCollection, CancellationToken, Task> action, CancellationToken cancellationToken = default);
+
+        /// <summary>
         ///     Opens the MSBuild project construction model for the specified project, passing it to the specified action for reading.
         /// </summary>
         /// <param name="project">
@@ -51,7 +71,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         ///     The <see cref="UnconfiguredProject"/> whose underlying MSBuild object model is required.
         /// </param>
         /// <param name="action">
-        ///     The <see cref="Func{T, TResult}"/> to run while holding the lock.
+        ///     The <see cref="Func{T1, T2, TResult}"/> to run while holding the lock.
         /// </param>
         /// <param name="cancellationToken">
         ///     A token whose cancellation signals lost interest in the result.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IUnconfiguredProjectCommonServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IUnconfiguredProjectCommonServices.cs
@@ -48,9 +48,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         /// <summary>
-        ///     Gets the project lock service     
+        ///     Gets the <see cref="IProjectAccessor"/> which provides access to MSBuild evaluation and construction models for a project.
         /// </summary>
-        IProjectLockService ProjectLockService
+        IProjectAccessor ProjectAccessor
         {
             get;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectAccessor.cs
@@ -28,6 +28,17 @@ namespace Microsoft.VisualStudio.ProjectSystem
             _projectLockService = projectLockService;
         }
 
+        public async Task EnterWriteLockAsync(Func<ProjectCollection, CancellationToken, Task> action, CancellationToken cancellationToken = default)
+        {
+            Requires.NotNull(action, nameof(action));
+
+            using (ProjectWriteLockReleaser access = await _projectLockService.WriteLockAsync(cancellationToken))
+            {
+                // Only async to let the caller call one of the other project accessor methods
+                await action(access.ProjectCollection, cancellationToken).ConfigureAwait(true);
+            }
+        }
+
         public async Task<TResult> OpenProjectForReadAsync<TResult>(ConfiguredProject project, Func<Project, TResult> action, CancellationToken cancellationToken = default)
         {
             Requires.NotNull(project, nameof(project));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectAccessor.cs
@@ -36,6 +36,10 @@ namespace Microsoft.VisualStudio.ProjectSystem
             {
                 // Only async to let the caller call one of the other project accessor methods
                 await action(access.ProjectCollection, cancellationToken).ConfigureAwait(true);
+
+                // Avoid blocking thread on Dispose
+                await access.ReleaseAsync()
+                            .ConfigureAwait(true);
             }
         }
 
@@ -103,6 +107,10 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 // Deliberately not async to reduce the type of
                 // code you can run while holding the lock.
                 action(rootElement);
+
+                // Avoid blocking thread on Dispose
+                await access.ReleaseAsync()
+                            .ConfigureAwait(true);
             }
         }
 
@@ -122,6 +130,10 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 // Deliberately not async to reduce the type of
                 // code you can run while holding the lock.
                 action(evaluatedProject);
+
+                // Avoid blocking thread on Dispose
+                await access.ReleaseAsync()
+                            .ConfigureAwait(true);
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectCommonServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectCommonServices.cs
@@ -14,21 +14,21 @@ namespace Microsoft.VisualStudio.ProjectSystem
         private readonly UnconfiguredProject _project;
         private readonly Lazy<IPhysicalProjectTree> _projectTree;
         private readonly Lazy<IProjectThreadingService> _threadingService;
-        private readonly Lazy<IProjectLockService> _projectLockService;
+        private readonly Lazy<IProjectAccessor> _projectAccessor;
         private readonly ActiveConfiguredProject<ConfiguredProject> _activeConfiguredProject;
         private readonly ActiveConfiguredProject<ProjectProperties> _activeConfiguredProjectProperties;
 
         [ImportingConstructor]
         public UnconfiguredProjectCommonServices(UnconfiguredProject project, Lazy<IPhysicalProjectTree> projectTree, Lazy<IProjectThreadingService> threadingService,
                                                  ActiveConfiguredProject<ConfiguredProject> activeConfiguredProject, ActiveConfiguredProject<ProjectProperties> activeConfiguredProjectProperties,
-                                                 Lazy<IProjectLockService> projectLockService)
+                                                 Lazy<IProjectAccessor> projectAccessor)
         {
             _project = project;
             _projectTree = projectTree;
             _threadingService = threadingService;
             _activeConfiguredProject = activeConfiguredProject;
             _activeConfiguredProjectProperties = activeConfiguredProjectProperties;
-            _projectLockService = projectLockService;
+            _projectAccessor = projectAccessor;
         }
 
         public IProjectThreadingService ThreadingService
@@ -56,9 +56,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
             get { return _activeConfiguredProjectProperties.Value; }
         }
 
-        public IProjectLockService ProjectLockService
+        public IProjectAccessor ProjectAccessor
         {
-            get { return _projectLockService.Value; }
+            get { return _projectAccessor.Value; }
         }
     }
 }


### PR DESCRIPTION
This includes https://github.com/dotnet/project-system/pull/3726 and https://github.com/dotnet/project-system/pull/3725, so only review https://github.com/dotnet/project-system/commit/c7fac9f3723f0ef23cd7fb07acd477d33114d313.

Change ProjectAssertFileWatcher to call through IProjectAccessor and removed last direct usage of IProjectLockService.