### PR TITLE
Remove unused "capabilities" argument

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/UnconfiguredProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/UnconfiguredProjectFactory.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -17,12 +15,10 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return Create(filePath: fullPath);
         }
 
-        public static UnconfiguredProject Create(object hostObject = null, IEnumerable<string> capabilities = null, string filePath = null,
+        public static UnconfiguredProject Create(object hostObject = null, string filePath = null,
             IProjectConfigurationsService projectConfigurationsService = null, ConfiguredProject configuredProject = null, Encoding projectEncoding = null,
             IProjectCapabilitiesScope scope = null)
         {
-            capabilities = capabilities ?? Enumerable.Empty<string>();
-
             var service = IProjectServiceFactory.Create();
 
             var unconfiguredProjectServices = new Mock<IUnconfiguredProjectServices>();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             };
 
             var specialFilesManager = ActiveConfiguredProjectFactory.ImplementValue(() => AppDesignerFolderSpecialFileProviderFactory.ImplementGetFile(appDesignerFolder));
-            var project = UnconfiguredProjectFactory.Create(null, null, @"c:\test\Project1\Project1.csproj");
+            var project = UnconfiguredProjectFactory.Create(filePath: @"c:\test\Project1\Project1.csproj");
             var properties = ProjectPropertiesFactory.Create(project, new[] { debuggerData });
             var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(project, null, IProjectThreadingServiceFactory.Create(), null, properties);
             var projectServices = IUnconfiguredProjectServicesFactory.Create(IProjectAsynchronousTasksServiceFactory.Create());
@@ -75,9 +75,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Theory]
-        [InlineData(@"C:\Properties",                @"C:\Properties\launchSettings.json")]
-        [InlineData(@"C:\Project\Properties",        @"C:\Project\Properties\launchSettings.json")]
-        [InlineData(@"C:\Project\My Project",        @"C:\Project\My Project\launchSettings.json")]
+        [InlineData(@"C:\Properties", @"C:\Properties\launchSettings.json")]
+        [InlineData(@"C:\Project\Properties", @"C:\Project\Properties\launchSettings.json")]
+        [InlineData(@"C:\Project\My Project", @"C:\Project\My Project\launchSettings.json")]
         public async Task WhenAppDesignerFolder_LaunchSettingsIsInAppDesignerFolder(string appDesignerFolder, string expected)
         {
             var provider = GetLaunchSettingsProvider(null, appDesignerFolder: appDesignerFolder);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Imaging/ProjectImageProviderAggregatorTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Imaging/ProjectImageProviderAggregatorTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Imaging
             Assert.Throws<ArgumentNullException>("key", () =>
             {
 
-                aggregator.GetProjectImage((string)null);
+                aggregator.GetProjectImage(null);
             });
         }
 
@@ -45,11 +45,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Imaging
         [Fact]
         public void GetImageKey_SingleImageProviderReturningNull_ReturnsNull()
         {
-            var project = UnconfiguredProjectFactory.Create(capabilities: new[] { "CSharp" });
+            var project = UnconfiguredProjectFactory.Create();
             var provider = IProjectImageProviderFactory.ImplementGetProjectImage((key) => null);
             var aggregator = CreateInstance(project);
 
-            aggregator.ImageProviders.Add(provider, "CSharp");
+            aggregator.ImageProviders.Add(provider);
 
             var result = aggregator.GetProjectImage("key");
 
@@ -61,11 +61,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Imaging
         {
             var moniker = new ProjectImageMoniker(Guid.NewGuid(), 0);
 
-            var project = UnconfiguredProjectFactory.Create(capabilities: new[] { "CSharp" });
+            var project = UnconfiguredProjectFactory.Create();
             var provider = IProjectImageProviderFactory.ImplementGetProjectImage((key) => moniker);
             var aggregator = CreateInstance(project);
 
-            aggregator.ImageProviders.Add(provider, "CSharp");
+            aggregator.ImageProviders.Add(provider);
 
             var result = aggregator.GetProjectImage("key");
 
@@ -78,13 +78,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Imaging
             var moniker1 = new ProjectImageMoniker(Guid.NewGuid(), 0);
             var moniker2 = new ProjectImageMoniker(Guid.NewGuid(), 0);
 
-            var project = UnconfiguredProjectFactory.Create(capabilities: new[] { "CSharp" });
+            var project = UnconfiguredProjectFactory.Create();
             var provider1 = IProjectImageProviderFactory.ImplementGetProjectImage((key) => moniker1);
             var provider2 = IProjectImageProviderFactory.ImplementGetProjectImage((key) => moniker2);
             var aggregator = CreateInstance(project);
 
-            aggregator.ImageProviders.Add(provider2, "CSharp", 0);  // Lowest
-            aggregator.ImageProviders.Add(provider1, "CSharp", 10); // Highest
+            aggregator.ImageProviders.Add(provider2, orderPrecedence: 0);  // Lowest
+            aggregator.ImageProviders.Add(provider1, orderPrecedence: 10); // Highest
 
             var result = aggregator.GetProjectImage("key");
 
@@ -96,13 +96,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Imaging
         {
             var moniker = new ProjectImageMoniker(Guid.NewGuid(), 0);
 
-            var project = UnconfiguredProjectFactory.Create(capabilities: new[] { "CSharp" });
+            var project = UnconfiguredProjectFactory.Create();
             var provider1 = IProjectImageProviderFactory.ImplementGetProjectImage((key) => null);
             var provider2 = IProjectImageProviderFactory.ImplementGetProjectImage((key) => moniker);
             var aggregator = CreateInstance(project);
 
-            aggregator.ImageProviders.Add(provider1, "CSharp", 0);
-            aggregator.ImageProviders.Add(provider2, "CSharp", 10);
+            aggregator.ImageProviders.Add(provider1, orderPrecedence: 0);
+            aggregator.ImageProviders.Add(provider2, orderPrecedence: 10);
 
             var result = aggregator.GetProjectImage("key");
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
             _mockEnvironment.Setup(s => s.GetEnvironmentVariable("Path")).Returns(() => _Path);
 
-            var project = UnconfiguredProjectFactory.Create(null, null, _ProjectFile);
+            var project = UnconfiguredProjectFactory.Create(filePath: _ProjectFile);
 
             var outputTypeEnum = new PageEnumValue(new EnumValue() { Name = outputType });
             var data = new PropertyPageData()
@@ -378,7 +378,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
         [Fact]
         public async Task QueryDebugTargetsAsync_WhenLibraryWithoutRunCommand_ReturnsTargetPath()
-        { 
+        {
             var properties = new Dictionary<string, string>() {
                 {"TargetPath", @"C:\library.dll"},
                 {"TargetFrameworkIdentifier", @".NETFramework" }


### PR DESCRIPTION
Fixes: https://github.com/dotnet/project-system/issues/2015.

We were never actually verifying that project was being consulted for capabilities. Stop pretending that we are.