### PR TITLE
[Language Service] Turn evaluation/command line handlers into MEF components

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/BuildOptionsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/BuildOptionsFactory.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
+{
+    internal static class BuildOptionsFactory
+    {
+        public static BuildOptions CreateEmpty()
+        {
+            return new BuildOptions(ImmutableArray<CommandLineSourceFile>.Empty, 
+                                    ImmutableArray<CommandLineSourceFile>.Empty, 
+                                    ImmutableArray<CommandLineReference>.Empty, 
+                                    ImmutableArray<CommandLineAnalyzerReference>.Empty);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandlerTests.cs
@@ -1,0 +1,115 @@
+﻿using System;
+
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Logging;
+
+using Moq;
+
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
+{
+    [Trait("UnitTest", "ProjectSystem")]
+    public class AdditionalFilesItemHandlerTests
+    {
+        [Fact]
+        public void Constructor_NullAsProject_ThrowsArgumentNull()
+        {
+            var context = IWorkspaceProjectContextFactory.Create();
+
+            Assert.Throws<ArgumentNullException>("project", () =>
+            {
+                new AdditionalFilesItemHandler((UnconfiguredProject)null, context);
+            });
+        }
+
+        [Fact]
+        public void Handle_NullAsVersion_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var added = BuildOptionsFactory.CreateEmpty();
+            var removed = BuildOptionsFactory.CreateEmpty();
+            var logger = Mock.Of<IProjectLogger>();
+
+            Assert.Throws<ArgumentNullException>("version", () =>
+            {
+                handler.Handle((IComparable)null, added, removed, true, logger);
+            });
+        }
+
+        [Fact]
+        public void Handle_NullAsAdded_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var removed = BuildOptionsFactory.CreateEmpty();
+            var logger = Mock.Of<IProjectLogger>();
+
+            Assert.Throws<ArgumentNullException>("added", () =>
+            {
+                handler.Handle(10, (BuildOptions)null, removed, true, logger);
+            });
+        }
+
+        [Fact]
+        public void Handle_NullAsRemoved_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var added = BuildOptionsFactory.CreateEmpty();
+            var logger = Mock.Of<IProjectLogger>();
+
+            Assert.Throws<ArgumentNullException>("removed", () =>
+            {
+                handler.Handle(10, added, (BuildOptions)null, true, logger);
+            });
+        }
+
+        [Fact]
+        public void Handle_NullAsLogger_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var added = BuildOptionsFactory.CreateEmpty();
+            var removed = BuildOptionsFactory.CreateEmpty();
+
+            Assert.Throws<ArgumentNullException>("logger", () =>
+            {
+                handler.Handle(10, added, removed, true, (IProjectLogger)null);
+            });
+        }
+
+        [Fact]
+        public void Handle_WhenNotInitialized_ThrowsInvalidOperation()
+        {
+            var handler = CreateInstance();
+            var added = BuildOptionsFactory.CreateEmpty();
+            var removed = BuildOptionsFactory.CreateEmpty();
+            var logger = Mock.Of<IProjectLogger>();
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                handler.Handle(10, added, removed, true, logger);
+            });
+        }
+
+        [Fact]
+        public void Initialize_WhenAlreadyInitialized_ThrowsInvalidOperation()
+        {
+            var handler = CreateInstance();
+
+            var workspaceContext = IWorkspaceProjectContextFactory.Create();
+
+            handler.Initialize(workspaceContext);
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                handler.Initialize(workspaceContext);
+            });
+        }
+
+        private MetadataReferenceItemHandler CreateInstance(UnconfiguredProject project = null, IWorkspaceProjectContext context = null)
+        {
+            project = project ?? UnconfiguredProjectFactory.Create();
+
+            return new MetadataReferenceItemHandler(project, context);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandlerTests.cs
@@ -1,16 +1,13 @@
 ﻿using System;
 
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
-using Microsoft.VisualStudio.ProjectSystem.Logging;
-
-using Moq;
 
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
     [Trait("UnitTest", "ProjectSystem")]
-    public class AdditionalFilesItemHandlerTests
+    public class AdditionalFilesItemHandlerTests : CommandLineHandlerTestBase
     {
         [Fact]
         public void Constructor_NullAsProject_ThrowsArgumentNull()
@@ -23,86 +20,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             });
         }
 
-        [Fact]
-        public void Handle_NullAsVersion_ThrowsArgumentNull()
+        internal override ICommandLineHandler CreateInstance()
         {
-            var handler = CreateInstance();
-            var added = BuildOptionsFactory.CreateEmpty();
-            var removed = BuildOptionsFactory.CreateEmpty();
-            var logger = Mock.Of<IProjectLogger>();
-
-            Assert.Throws<ArgumentNullException>("version", () =>
-            {
-                handler.Handle((IComparable)null, added, removed, true, logger);
-            });
-        }
-
-        [Fact]
-        public void Handle_NullAsAdded_ThrowsArgumentNull()
-        {
-            var handler = CreateInstance();
-            var removed = BuildOptionsFactory.CreateEmpty();
-            var logger = Mock.Of<IProjectLogger>();
-
-            Assert.Throws<ArgumentNullException>("added", () =>
-            {
-                handler.Handle(10, (BuildOptions)null, removed, true, logger);
-            });
-        }
-
-        [Fact]
-        public void Handle_NullAsRemoved_ThrowsArgumentNull()
-        {
-            var handler = CreateInstance();
-            var added = BuildOptionsFactory.CreateEmpty();
-            var logger = Mock.Of<IProjectLogger>();
-
-            Assert.Throws<ArgumentNullException>("removed", () =>
-            {
-                handler.Handle(10, added, (BuildOptions)null, true, logger);
-            });
-        }
-
-        [Fact]
-        public void Handle_NullAsLogger_ThrowsArgumentNull()
-        {
-            var handler = CreateInstance();
-            var added = BuildOptionsFactory.CreateEmpty();
-            var removed = BuildOptionsFactory.CreateEmpty();
-
-            Assert.Throws<ArgumentNullException>("logger", () =>
-            {
-                handler.Handle(10, added, removed, true, (IProjectLogger)null);
-            });
-        }
-
-        [Fact]
-        public void Handle_WhenNotInitialized_ThrowsInvalidOperation()
-        {
-            var handler = CreateInstance();
-            var added = BuildOptionsFactory.CreateEmpty();
-            var removed = BuildOptionsFactory.CreateEmpty();
-            var logger = Mock.Of<IProjectLogger>();
-
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                handler.Handle(10, added, removed, true, logger);
-            });
-        }
-
-        [Fact]
-        public void Initialize_WhenAlreadyInitialized_ThrowsInvalidOperation()
-        {
-            var handler = CreateInstance();
-
-            var workspaceContext = IWorkspaceProjectContextFactory.Create();
-
-            handler.Initialize(workspaceContext);
-
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                handler.Initialize(workspaceContext);
-            });
+            return CreateInstance(null, null);
         }
 
         private MetadataReferenceItemHandler CreateInstance(UnconfiguredProject project = null, IWorkspaceProjectContext context = null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandlerTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             Assert.Throws<ArgumentNullException>("project", () =>
             {
-                new AdditionalFilesItemHandler((UnconfiguredProject)null, context);
+                new AdditionalFilesItemHandler((UnconfiguredProject)null);
             });
         }
 
@@ -25,11 +25,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             return CreateInstance(null, null);
         }
 
-        private MetadataReferenceItemHandler CreateInstance(UnconfiguredProject project = null, IWorkspaceProjectContext context = null)
+        private AdditionalFilesItemHandler CreateInstance(UnconfiguredProject project = null, IWorkspaceProjectContext context = null)
         {
             project = project ?? UnconfiguredProjectFactory.Create();
 
-            return new MetadataReferenceItemHandler(project, context);
+            var handler = new AdditionalFilesItemHandler(project);
+            if (context != null)
+                handler.Initialize(context);
+
+            return handler;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandlerTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             Assert.Throws<ArgumentNullException>("project", () =>
             {
-                new AnalyzerItemHandler(null, context);
+                new AnalyzerItemHandler((UnconfiguredProject)null);
             });
         }
 
@@ -29,7 +29,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         {
             project = project ?? UnconfiguredProjectFactory.Create();
 
-            return new AnalyzerItemHandler(project, context);
+            var handler = new AnalyzerItemHandler(project);
+            if (context != null)
+                handler.Initialize(context);
+
+            return handler;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandlerTests.cs
@@ -1,16 +1,13 @@
 ﻿using System;
 
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
-using Microsoft.VisualStudio.ProjectSystem.Logging;
-
-using Moq;
 
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
     [Trait("UnitTest", "ProjectSystem")]
-    public class AnalyzerItemHandlerTests
+    public class AnalyzerItemHandlerTests : CommandLineHandlerTestBase
     {
         [Fact]
         public void Constructor_NullAsProject_ThrowsArgumentNull()
@@ -23,86 +20,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             });
         }
 
-        [Fact]
-        public void Handle_NullAsVersion_ThrowsArgumentNull()
+        internal override ICommandLineHandler CreateInstance()
         {
-            var handler = CreateInstance();
-            var added = BuildOptionsFactory.CreateEmpty();
-            var removed = BuildOptionsFactory.CreateEmpty();
-            var logger = Mock.Of<IProjectLogger>();
-
-            Assert.Throws<ArgumentNullException>("version", () =>
-            {
-                handler.Handle((IComparable)null, added, removed, true, logger);
-            });
-        }
-
-        [Fact]
-        public void Handle_NullAsAdded_ThrowsArgumentNull()
-        {
-            var handler = CreateInstance();
-            var removed = BuildOptionsFactory.CreateEmpty();
-            var logger = Mock.Of<IProjectLogger>();
-
-            Assert.Throws<ArgumentNullException>("added", () =>
-            {
-                handler.Handle(10, (BuildOptions)null, removed, true, logger);
-            });
-        }
-
-        [Fact]
-        public void Handle_NullAsRemoved_ThrowsArgumentNull()
-        {
-            var handler = CreateInstance();
-            var added = BuildOptionsFactory.CreateEmpty();
-            var logger = Mock.Of<IProjectLogger>();
-
-            Assert.Throws<ArgumentNullException>("removed", () =>
-            {
-                handler.Handle(10, added, (BuildOptions)null, true, logger);
-            });
-        }
-
-        [Fact]
-        public void Handle_NullAsLogger_ThrowsArgumentNull()
-        {
-            var handler = CreateInstance();
-            var added = BuildOptionsFactory.CreateEmpty();
-            var removed = BuildOptionsFactory.CreateEmpty();
-
-            Assert.Throws<ArgumentNullException>("logger", () =>
-            {
-                handler.Handle(10, added, removed, true, (IProjectLogger)null);
-            });
-        }
-
-        [Fact]
-        public void Handle_WhenNotInitialized_ThrowsInvalidOperation()
-        {
-            var handler = CreateInstance();
-            var added = BuildOptionsFactory.CreateEmpty();
-            var removed = BuildOptionsFactory.CreateEmpty();
-            var logger = Mock.Of<IProjectLogger>();
-
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                handler.Handle(10, added, removed, true, logger);
-            });
-        }
-
-        [Fact]
-        public void Initialize_WhenAlreadyInitialized_ThrowsInvalidOperation()
-        {
-            var handler = CreateInstance();
-
-            var workspaceContext = IWorkspaceProjectContextFactory.Create();
-
-            handler.Initialize(workspaceContext);
-
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                handler.Initialize(workspaceContext);
-            });
+            return CreateInstance(null, null);
         }
 
         private AnalyzerItemHandler CreateInstance(UnconfiguredProject project = null, IWorkspaceProjectContext context = null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandlerTests.cs
@@ -1,0 +1,115 @@
+﻿using System;
+
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Logging;
+
+using Moq;
+
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
+{
+    [Trait("UnitTest", "ProjectSystem")]
+    public class AnalyzerItemHandlerTests
+    {
+        [Fact]
+        public void Constructor_NullAsProject_ThrowsArgumentNull()
+        {
+            var context = IWorkspaceProjectContextFactory.Create();
+
+            Assert.Throws<ArgumentNullException>("project", () =>
+            {
+                new AnalyzerItemHandler(null, context);
+            });
+        }
+
+        [Fact]
+        public void Handle_NullAsVersion_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var added = BuildOptionsFactory.CreateEmpty();
+            var removed = BuildOptionsFactory.CreateEmpty();
+            var logger = Mock.Of<IProjectLogger>();
+
+            Assert.Throws<ArgumentNullException>("version", () =>
+            {
+                handler.Handle((IComparable)null, added, removed, true, logger);
+            });
+        }
+
+        [Fact]
+        public void Handle_NullAsAdded_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var removed = BuildOptionsFactory.CreateEmpty();
+            var logger = Mock.Of<IProjectLogger>();
+
+            Assert.Throws<ArgumentNullException>("added", () =>
+            {
+                handler.Handle(10, (BuildOptions)null, removed, true, logger);
+            });
+        }
+
+        [Fact]
+        public void Handle_NullAsRemoved_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var added = BuildOptionsFactory.CreateEmpty();
+            var logger = Mock.Of<IProjectLogger>();
+
+            Assert.Throws<ArgumentNullException>("removed", () =>
+            {
+                handler.Handle(10, added, (BuildOptions)null, true, logger);
+            });
+        }
+
+        [Fact]
+        public void Handle_NullAsLogger_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var added = BuildOptionsFactory.CreateEmpty();
+            var removed = BuildOptionsFactory.CreateEmpty();
+
+            Assert.Throws<ArgumentNullException>("logger", () =>
+            {
+                handler.Handle(10, added, removed, true, (IProjectLogger)null);
+            });
+        }
+
+        [Fact]
+        public void Handle_WhenNotInitialized_ThrowsInvalidOperation()
+        {
+            var handler = CreateInstance();
+            var added = BuildOptionsFactory.CreateEmpty();
+            var removed = BuildOptionsFactory.CreateEmpty();
+            var logger = Mock.Of<IProjectLogger>();
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                handler.Handle(10, added, removed, true, logger);
+            });
+        }
+
+        [Fact]
+        public void Initialize_WhenAlreadyInitialized_ThrowsInvalidOperation()
+        {
+            var handler = CreateInstance();
+
+            var workspaceContext = IWorkspaceProjectContextFactory.Create();
+
+            handler.Initialize(workspaceContext);
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                handler.Initialize(workspaceContext);
+            });
+        }
+
+        private AnalyzerItemHandler CreateInstance(UnconfiguredProject project = null, IWorkspaceProjectContext context = null)
+        {
+            project = project ?? UnconfiguredProjectFactory.Create();
+
+            return new AnalyzerItemHandler(project, context);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/CommandLineHandlerTestBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/CommandLineHandlerTestBase.cs
@@ -2,8 +2,12 @@
 
 
 using System;
+
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.Logging;
+
 using Moq;
+
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
@@ -74,6 +78,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Assert.Throws<InvalidOperationException>(() =>
             {
                 handler.Handle(10, added, removed, true, logger);
+            });
+        }
+
+        [Fact]
+        public void Initialize_NullAsContext_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+
+            Assert.Throws<ArgumentNullException>("context", () =>
+            {
+                handler.Initialize((IWorkspaceProjectContext)null);
             });
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/CommandLineHandlerTestBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/CommandLineHandlerTestBase.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+
+using System;
+using Microsoft.VisualStudio.ProjectSystem.Logging;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
+{
+    public abstract class CommandLineHandlerTestBase
+    {
+        [Fact]
+        public void Handle_NullAsVersion_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var added = BuildOptionsFactory.CreateEmpty();
+            var removed = BuildOptionsFactory.CreateEmpty();
+            var logger = Mock.Of<IProjectLogger>();
+
+            Assert.Throws<ArgumentNullException>("version", () =>
+            {
+                handler.Handle((IComparable)null, added, removed, true, logger);
+            });
+        }
+
+        [Fact]
+        public void Handle_NullAsAdded_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var removed = BuildOptionsFactory.CreateEmpty();
+            var logger = Mock.Of<IProjectLogger>();
+
+            Assert.Throws<ArgumentNullException>("added", () =>
+            {
+                handler.Handle(10, (BuildOptions)null, removed, true, logger);
+            });
+        }
+
+        [Fact]
+        public void Handle_NullAsRemoved_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var added = BuildOptionsFactory.CreateEmpty();
+            var logger = Mock.Of<IProjectLogger>();
+
+            Assert.Throws<ArgumentNullException>("removed", () =>
+            {
+                handler.Handle(10, added, (BuildOptions)null, true, logger);
+            });
+        }
+
+        [Fact]
+        public void Handle_NullAsLogger_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var added = BuildOptionsFactory.CreateEmpty();
+            var removed = BuildOptionsFactory.CreateEmpty();
+
+            Assert.Throws<ArgumentNullException>("logger", () =>
+            {
+                handler.Handle(10, added, removed, true, (IProjectLogger)null);
+            });
+        }
+
+        [Fact]
+        public void Handle_WhenNotInitialized_ThrowsInvalidOperation()
+        {
+            var handler = CreateInstance();
+            var added = BuildOptionsFactory.CreateEmpty();
+            var removed = BuildOptionsFactory.CreateEmpty();
+            var logger = Mock.Of<IProjectLogger>();
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                handler.Handle(10, added, removed, true, logger);
+            });
+        }
+
+        [Fact]
+        public void Initialize_WhenAlreadyInitialized_ThrowsInvalidOperation()
+        {
+            var handler = CreateInstance();
+
+            var workspaceContext = IWorkspaceProjectContextFactory.Create();
+
+            handler.Initialize(workspaceContext);
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                handler.Initialize(workspaceContext);
+            });
+        }
+
+        internal abstract ICommandLineHandler CreateInstance();
+        
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/EvaluationHandlerTestBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/EvaluationHandlerTestBase.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+
+using System;
+using Microsoft.VisualStudio.ProjectSystem.Logging;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
+{
+    public abstract class EvaluationHandlerTestBase
+    {
+        [Fact]
+        public void Handle_NullAsVersion_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var projectChange = IProjectChangeDescriptionFactory.Create();
+            var logger = Mock.Of<IProjectLogger>();
+
+            Assert.Throws<ArgumentNullException>("version", () =>
+            {
+                handler.Handle((IComparable)null, projectChange, true, logger);
+            });
+        }
+
+        [Fact]
+        public void Handle_NullAsProjectChange_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var logger = Mock.Of<IProjectLogger>();
+
+            Assert.Throws<ArgumentNullException>("projectChange", () =>
+            {
+                handler.Handle(10, (IProjectChangeDescription)null, true, logger);
+            });
+        }
+
+        [Fact]
+        public void Handle_NullAsLogger_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var projectChange = IProjectChangeDescriptionFactory.Create();
+
+            Assert.Throws<ArgumentNullException>("logger", () =>
+            {
+                handler.Handle(10, projectChange, true, (IProjectLogger)null);
+            });
+        }
+
+        [Fact]
+        public void Handle_WhenNotInitialized_ThrowsInvalidOperation()
+        {
+            var handler = CreateInstance();
+            var projectChange = IProjectChangeDescriptionFactory.Create();
+            var logger = Mock.Of<IProjectLogger>();
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                handler.Handle(10, projectChange, true, logger);
+            });
+        }
+
+        [Fact]
+        public void Initialize_WhenAlreadyInitialized_ThrowsInvalidOperation()
+        {
+            var handler = CreateInstance();
+
+            var workspaceContext = IWorkspaceProjectContextFactory.Create();
+
+            handler.Initialize(workspaceContext);
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                handler.Initialize(workspaceContext);
+            });
+        }
+
+        internal abstract IEvaluationHandler CreateInstance();
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandlerTests.cs
@@ -13,7 +13,7 @@ using Xunit;
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
     [Trait("UnitTest", "ProjectSystem")]
-    public class MetadataReferenceItemHandlerTests
+    public class MetadataReferenceItemHandlerTests : CommandLineHandlerTestBase
     {
         [Fact]
         public void Constructor_NullAsProject_ThrowsArgumentNull()
@@ -23,88 +23,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Assert.Throws<ArgumentNullException>("project", () =>
             {
                 new MetadataReferenceItemHandler((UnconfiguredProject)null, context);
-            });
-        }
-
-        [Fact]
-        public void Handle_NullAsVersion_ThrowsArgumentNull()
-        {
-            var handler = CreateInstance();
-            var added = BuildOptionsFactory.CreateEmpty();
-            var removed = BuildOptionsFactory.CreateEmpty();
-            var logger = Mock.Of<IProjectLogger>();
-
-            Assert.Throws<ArgumentNullException>("version", () =>
-            {
-                handler.Handle((IComparable)null, added, removed, true, logger);
-            });
-        }
-
-        [Fact]
-        public void Handle_NullAsAdded_ThrowsArgumentNull()
-        {
-            var handler = CreateInstance();
-            var removed = BuildOptionsFactory.CreateEmpty();
-            var logger = Mock.Of<IProjectLogger>();
-
-            Assert.Throws<ArgumentNullException>("added", () =>
-            {
-                handler.Handle(10, (BuildOptions)null, removed, true, logger);
-            });
-        }
-
-        [Fact]
-        public void Handle_NullAsRemoved_ThrowsArgumentNull()
-        {
-            var handler = CreateInstance();
-            var added = BuildOptionsFactory.CreateEmpty();
-            var logger = Mock.Of<IProjectLogger>();
-
-            Assert.Throws<ArgumentNullException>("removed", () =>
-            {
-                handler.Handle(10, added, (BuildOptions)null, true, logger);
-            });
-        }
-
-        [Fact]
-        public void Handle_NullAsLogger_ThrowsArgumentNull()
-        {
-            var handler = CreateInstance();
-            var added = BuildOptionsFactory.CreateEmpty();
-            var removed = BuildOptionsFactory.CreateEmpty();
-
-            Assert.Throws<ArgumentNullException>("logger", () =>
-            {
-                handler.Handle(10, added, removed, true, (IProjectLogger)null);
-            });
-        }
-
-        [Fact]
-        public void Handle_WhenNotInitialized_ThrowsInvalidOperation()
-        {
-            var handler = CreateInstance();
-            var added = BuildOptionsFactory.CreateEmpty();
-            var removed = BuildOptionsFactory.CreateEmpty();
-            var logger = Mock.Of<IProjectLogger>();
-
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                handler.Handle(10, added, removed, true, logger);
-            });
-        }
-
-        [Fact]
-        public void Initialize_WhenAlreadyInitialized_ThrowsInvalidOperation()
-        {
-            var handler = CreateInstance();
-
-            var workspaceContext = IWorkspaceProjectContextFactory.Create();
-
-            handler.Initialize(workspaceContext);
-
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                handler.Initialize(workspaceContext);
             });
         }
 
@@ -159,6 +77,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Assert.Contains(@"C:\ProjectFolder\Assembly1.dll", referencesPushedToWorkspace);
             Assert.Contains(@"C:\ProjectFolder\Assembly2.dll", referencesPushedToWorkspace);
             Assert.Contains(@"C:\ProjectFolder\Assembly3.dll", referencesPushedToWorkspace);
+        }
+        
+        internal override ICommandLineHandler CreateInstance()
+        {
+            return CreateInstance(null, null);
         }
 
         private MetadataReferenceItemHandler CreateInstance(UnconfiguredProject project = null, IWorkspaceProjectContext context = null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandlerTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             Assert.Throws<ArgumentNullException>("project", () =>
             {
-                new MetadataReferenceItemHandler((UnconfiguredProject)null, context);
+                new MetadataReferenceItemHandler((UnconfiguredProject)null);
             });
         }
 
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             var context = IWorkspaceProjectContextFactory.CreateForMetadataReferences(project, onReferenceAdded, onReferenceRemoved);
             var logger = Mock.Of<IProjectLogger>();
 
-            var handler = new MetadataReferenceItemHandler(project, context);
+            var handler = CreateInstance(project, context);
             var projectDir = Path.GetDirectoryName(project.FullPath);
             var added = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"/reference:C:\Assembly1.dll", @"/reference:C:\Assembly2.dll", @"/reference:C:\Assembly1.dll" }, baseDirectory: projectDir, sdkDirectory: null));
             var empty = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null));
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             var context = IWorkspaceProjectContextFactory.CreateForMetadataReferences(project, onReferenceAdded, onReferenceRemoved);
             var logger = Mock.Of<IProjectLogger>();
 
-            var handler = new MetadataReferenceItemHandler(project, context);
+            var handler = CreateInstance(project, context);
             var projectDir = Path.GetDirectoryName(project.FullPath);
             var added = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"/reference:Assembly1.dll", @"/reference:C:\ProjectFolder\Assembly2.dll", @"/reference:..\ProjectFolder\Assembly3.dll" }, baseDirectory: projectDir, sdkDirectory: null));
             var removed = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null));
@@ -88,7 +88,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         {
             project = project ?? UnconfiguredProjectFactory.Create();
 
-            return new MetadataReferenceItemHandler(project, context);
+            var handler = new MetadataReferenceItemHandler(project);
+            if (context != null)
+                handler.Initialize(context);
+
+            return handler;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandlerTests.cs
@@ -27,13 +27,84 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         }
 
         [Fact]
-        public void Constructor_NullAsContext_ThrowsArgumentNull()
+        public void Handle_NullAsVersion_ThrowsArgumentNull()
         {
-            var project = UnconfiguredProjectFactory.Create();
+            var handler = CreateInstance();
+            var added = BuildOptionsFactory.CreateEmpty();
+            var removed = BuildOptionsFactory.CreateEmpty();
+            var logger = Mock.Of<IProjectLogger>();
 
-            Assert.Throws<ArgumentNullException>("context", () =>
+            Assert.Throws<ArgumentNullException>("version", () =>
             {
-                new MetadataReferenceItemHandler(project, (IWorkspaceProjectContext)null);
+                handler.Handle((IComparable)null, added, removed, true, logger);
+            });
+        }
+
+        [Fact]
+        public void Handle_NullAsAdded_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var removed = BuildOptionsFactory.CreateEmpty();
+            var logger = Mock.Of<IProjectLogger>();
+
+            Assert.Throws<ArgumentNullException>("added", () =>
+            {
+                handler.Handle(10, (BuildOptions)null, removed, true, logger);
+            });
+        }
+
+        [Fact]
+        public void Handle_NullAsRemoved_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var added = BuildOptionsFactory.CreateEmpty();
+            var logger = Mock.Of<IProjectLogger>();
+
+            Assert.Throws<ArgumentNullException>("removed", () =>
+            {
+                handler.Handle(10, added, (BuildOptions)null, true, logger);
+            });
+        }
+
+        [Fact]
+        public void Handle_NullAsLogger_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var added = BuildOptionsFactory.CreateEmpty();
+            var removed = BuildOptionsFactory.CreateEmpty();
+
+            Assert.Throws<ArgumentNullException>("logger", () =>
+            {
+                handler.Handle(10, added, removed, true, (IProjectLogger)null);
+            });
+        }
+
+        [Fact]
+        public void Handle_WhenNotInitialized_ThrowsInvalidOperation()
+        {
+            var handler = CreateInstance();
+            var added = BuildOptionsFactory.CreateEmpty();
+            var removed = BuildOptionsFactory.CreateEmpty();
+            var logger = Mock.Of<IProjectLogger>();
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                handler.Handle(10, added, removed, true, logger);
+            });
+        }
+
+        [Fact]
+        public void Initialize_WhenAlreadyInitialized_ThrowsInvalidOperation()
+        {
+            var handler = CreateInstance();
+
+            var workspaceContext = IWorkspaceProjectContextFactory.Create();
+
+            handler.Initialize(workspaceContext);
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                handler.Initialize(workspaceContext);
             });
         }
 
@@ -88,6 +159,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Assert.Contains(@"C:\ProjectFolder\Assembly1.dll", referencesPushedToWorkspace);
             Assert.Contains(@"C:\ProjectFolder\Assembly2.dll", referencesPushedToWorkspace);
             Assert.Contains(@"C:\ProjectFolder\Assembly3.dll", referencesPushedToWorkspace);
+        }
+
+        private MetadataReferenceItemHandler CreateInstance(UnconfiguredProject project = null, IWorkspaceProjectContext context = null)
+        {
+            project = project ?? UnconfiguredProjectFactory.Create();
+
+            return new MetadataReferenceItemHandler(project, context);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandlerTests.cs
@@ -1,0 +1,98 @@
+﻿using System;
+
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Logging;
+
+using Moq;
+
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
+{
+    [Trait("UnitTest", "ProjectSystem")]
+    public class ProjectPropertiesItemHandlerTests
+    {
+        [Fact]
+        public void Constructor_NullAsProject_ThrowsArgumentNull()
+        {
+            var context = IWorkspaceProjectContextFactory.Create();
+
+            Assert.Throws<ArgumentNullException>("project", () =>
+            {
+                new ProjectPropertiesItemHandler((UnconfiguredProject)null, context);
+            });
+        }
+
+        [Fact]
+        public void Handle_NullAsVersion_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var projectChange = IProjectChangeDescriptionFactory.Create();
+            var logger = Mock.Of<IProjectLogger>();
+
+            Assert.Throws<ArgumentNullException>("version", () =>
+            {
+                handler.Handle((IComparable)null, projectChange, true, logger);
+            });
+        }
+
+        [Fact]
+        public void Handle_NullAsProjectChange_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var logger = Mock.Of<IProjectLogger>();
+
+            Assert.Throws<ArgumentNullException>("projectChange", () =>
+            {
+                handler.Handle(10, (IProjectChangeDescription)null, true, logger);
+            });
+        }
+
+        [Fact]
+        public void Handle_NullAsLogger_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var projectChange = IProjectChangeDescriptionFactory.Create();
+
+            Assert.Throws<ArgumentNullException>("logger", () =>
+            {
+                handler.Handle(10, projectChange, true, (IProjectLogger)null);
+            });
+        }
+
+        [Fact]
+        public void Handle_WhenNotInitialized_ThrowsInvalidOperation()
+        {
+            var handler = CreateInstance();
+            var projectChange = IProjectChangeDescriptionFactory.Create();
+            var logger = Mock.Of<IProjectLogger>();
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                handler.Handle(10, projectChange, true, logger);
+            });
+        }
+
+        [Fact]
+        public void Initialize_WhenAlreadyInitialized_ThrowsInvalidOperation()
+        {
+            var handler = CreateInstance();
+
+            var workspaceContext = IWorkspaceProjectContextFactory.Create();
+
+            handler.Initialize(workspaceContext);
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                handler.Initialize(workspaceContext);
+            });
+        }
+
+        private ProjectPropertiesItemHandler CreateInstance(UnconfiguredProject project = null, IWorkspaceProjectContext context = null)
+        {
+            project = project ?? UnconfiguredProjectFactory.Create();
+
+            return new ProjectPropertiesItemHandler(project, context);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandlerTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             Assert.Throws<ArgumentNullException>("project", () =>
             {
-                new ProjectPropertiesItemHandler((UnconfiguredProject)null, context);
+                new ProjectPropertiesItemHandler((UnconfiguredProject)null);
             });
         }
 
@@ -29,7 +29,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         {
             project = project ?? UnconfiguredProjectFactory.Create();
 
-            return new ProjectPropertiesItemHandler(project, context);
+            var handler = new ProjectPropertiesItemHandler(project);
+            if (context != null)
+                handler.Initialize(context);
+
+            return handler;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemHandlerTests.cs
@@ -29,18 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         }
 
         [Fact]
-        public void Constructor_NullAsContext_ThrowsArgumentNull()
-        {
-            var project = UnconfiguredProjectFactory.Create();
-
-            Assert.Throws<ArgumentNullException>("context", () =>
-            {
-                new SourceItemHandler(project, (IWorkspaceProjectContext)null);
-            });
-        }
-
-        [Fact]
-        public void Handle_NullAsVersion_ThrowsArgumentNull()
+        public void Handle1_NullAsVersion_ThrowsArgumentNull()
         {
             var handler = CreateInstance();
             var projectChange = IProjectChangeDescriptionFactory.Create();
@@ -53,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         }
 
         [Fact]
-        public void Handle_NullAsProjectChange_ThrowsArgumentNull()
+        public void Handle1_NullAsProjectChange_ThrowsArgumentNull()
         {
             var handler = CreateInstance();
             var logger = Mock.Of<IProjectLogger>();
@@ -65,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         }
 
         [Fact]
-        public void Handle_NullAsLogger_ThrowsArgumentNull()
+        public void Handle1_NullAsLogger_ThrowsArgumentNull()
         {
             var handler = CreateInstance();
             var projectChange = IProjectChangeDescriptionFactory.Create();
@@ -73,6 +62,101 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Assert.Throws<ArgumentNullException>("logger", () =>
             {
                 handler.Handle(10, projectChange, true, (IProjectLogger)null);
+            });
+        }
+
+        [Fact]
+        public void Handle2_NullAsVersion_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var added = BuildOptionsFactory.CreateEmpty();
+            var removed = BuildOptionsFactory.CreateEmpty();
+            var logger = Mock.Of<IProjectLogger>();
+
+            Assert.Throws<ArgumentNullException>("version", () =>
+            {
+                handler.Handle((IComparable)null, added, removed, true, logger);
+            });
+        }
+
+        [Fact]
+        public void Handle2_NullAsAdded_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var removed = BuildOptionsFactory.CreateEmpty();
+            var logger = Mock.Of<IProjectLogger>();
+
+            Assert.Throws<ArgumentNullException>("added", () =>
+            {
+                handler.Handle(10, (BuildOptions)null, removed, true, logger);
+            });
+        }
+
+        [Fact]
+        public void Handle2_NullAsRemoved_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var added = BuildOptionsFactory.CreateEmpty();
+            var logger = Mock.Of<IProjectLogger>();
+
+            Assert.Throws<ArgumentNullException>("removed", () =>
+            {
+                handler.Handle(10, added, (BuildOptions)null, true, logger);
+            });
+        }
+
+        [Fact]
+        public void Handle2_NullAsLogger_ThrowsArgumentNull()
+        {
+            var handler = CreateInstance();
+            var added = BuildOptionsFactory.CreateEmpty();
+            var removed = BuildOptionsFactory.CreateEmpty();
+
+            Assert.Throws<ArgumentNullException>("logger", () =>
+            {
+                handler.Handle(10, added, removed, true, (IProjectLogger)null);
+            });
+        }
+
+        [Fact]
+        public void Handle1_WhenNotInitialized_ThrowsInvalidOperation()
+        {
+            var handler = CreateInstance();
+            var projectChange = IProjectChangeDescriptionFactory.Create();
+            var logger = Mock.Of<IProjectLogger>();
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                handler.Handle(10, projectChange, true, logger);
+            });
+        }
+
+        [Fact]
+        public void Handle2_WhenNotInitialized_ThrowsInvalidOperation()
+        {
+            var handler = CreateInstance();
+            var added = BuildOptionsFactory.CreateEmpty();
+            var removed = BuildOptionsFactory.CreateEmpty();
+            var logger = Mock.Of<IProjectLogger>();
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                handler.Handle(10, added, removed, true, logger);
+            });
+        }
+
+        [Fact]
+        public void Initialize_WhenAlreadyInitialized_ThrowsInvalidOperation()
+        {
+            var handler = CreateInstance();
+
+            var workspaceContext = IWorkspaceProjectContextFactory.Create();
+
+            handler.Initialize(workspaceContext);
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                handler.Initialize(workspaceContext);
             });
         }
 
@@ -130,7 +214,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         private SourceItemHandler CreateInstance(UnconfiguredProject project = null, IWorkspaceProjectContext context = null)
         {
             project = project ?? UnconfiguredProjectFactory.Create();
-            context = context ?? IWorkspaceProjectContextFactory.Create();
 
             return new SourceItemHandler(project, context);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemHandler_CommandLineTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemHandler_CommandLineTests.cs
@@ -3,19 +3,16 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.Logging;
-
 using Moq;
-
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
     [Trait("UnitTest", "ProjectSystem")]
-    public class SourceItemHandlerTests
+    public class SourceItemHandler_CommandTests : CommandLineHandlerTestBase
     {
         [Fact]
         public void Constructor_NullAsProject_ThrowsArgumentNull()
@@ -25,138 +22,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Assert.Throws<ArgumentNullException>("project", () =>
             {
                 new SourceItemHandler((UnconfiguredProject)null, context);
-            });
-        }
-
-        [Fact]
-        public void Handle1_NullAsVersion_ThrowsArgumentNull()
-        {
-            var handler = CreateInstance();
-            var projectChange = IProjectChangeDescriptionFactory.Create();
-            var logger = Mock.Of<IProjectLogger>();
-
-            Assert.Throws<ArgumentNullException>("version", () =>
-            {
-                handler.Handle((IComparable)null, projectChange, true, logger);
-            });
-        }
-
-        [Fact]
-        public void Handle1_NullAsProjectChange_ThrowsArgumentNull()
-        {
-            var handler = CreateInstance();
-            var logger = Mock.Of<IProjectLogger>();
-
-            Assert.Throws<ArgumentNullException>("projectChange", () =>
-            {
-                handler.Handle(10, (IProjectChangeDescription)null, true, logger);
-            });
-        }
-
-        [Fact]
-        public void Handle1_NullAsLogger_ThrowsArgumentNull()
-        {
-            var handler = CreateInstance();
-            var projectChange = IProjectChangeDescriptionFactory.Create();
-
-            Assert.Throws<ArgumentNullException>("logger", () =>
-            {
-                handler.Handle(10, projectChange, true, (IProjectLogger)null);
-            });
-        }
-
-        [Fact]
-        public void Handle2_NullAsVersion_ThrowsArgumentNull()
-        {
-            var handler = CreateInstance();
-            var added = BuildOptionsFactory.CreateEmpty();
-            var removed = BuildOptionsFactory.CreateEmpty();
-            var logger = Mock.Of<IProjectLogger>();
-
-            Assert.Throws<ArgumentNullException>("version", () =>
-            {
-                handler.Handle((IComparable)null, added, removed, true, logger);
-            });
-        }
-
-        [Fact]
-        public void Handle2_NullAsAdded_ThrowsArgumentNull()
-        {
-            var handler = CreateInstance();
-            var removed = BuildOptionsFactory.CreateEmpty();
-            var logger = Mock.Of<IProjectLogger>();
-
-            Assert.Throws<ArgumentNullException>("added", () =>
-            {
-                handler.Handle(10, (BuildOptions)null, removed, true, logger);
-            });
-        }
-
-        [Fact]
-        public void Handle2_NullAsRemoved_ThrowsArgumentNull()
-        {
-            var handler = CreateInstance();
-            var added = BuildOptionsFactory.CreateEmpty();
-            var logger = Mock.Of<IProjectLogger>();
-
-            Assert.Throws<ArgumentNullException>("removed", () =>
-            {
-                handler.Handle(10, added, (BuildOptions)null, true, logger);
-            });
-        }
-
-        [Fact]
-        public void Handle2_NullAsLogger_ThrowsArgumentNull()
-        {
-            var handler = CreateInstance();
-            var added = BuildOptionsFactory.CreateEmpty();
-            var removed = BuildOptionsFactory.CreateEmpty();
-
-            Assert.Throws<ArgumentNullException>("logger", () =>
-            {
-                handler.Handle(10, added, removed, true, (IProjectLogger)null);
-            });
-        }
-
-        [Fact]
-        public void Handle1_WhenNotInitialized_ThrowsInvalidOperation()
-        {
-            var handler = CreateInstance();
-            var projectChange = IProjectChangeDescriptionFactory.Create();
-            var logger = Mock.Of<IProjectLogger>();
-
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                handler.Handle(10, projectChange, true, logger);
-            });
-        }
-
-        [Fact]
-        public void Handle2_WhenNotInitialized_ThrowsInvalidOperation()
-        {
-            var handler = CreateInstance();
-            var added = BuildOptionsFactory.CreateEmpty();
-            var removed = BuildOptionsFactory.CreateEmpty();
-            var logger = Mock.Of<IProjectLogger>();
-
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                handler.Handle(10, added, removed, true, logger);
-            });
-        }
-
-        [Fact]
-        public void Initialize_WhenAlreadyInitialized_ThrowsInvalidOperation()
-        {
-            var handler = CreateInstance();
-
-            var workspaceContext = IWorkspaceProjectContextFactory.Create();
-
-            handler.Initialize(workspaceContext);
-
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                handler.Initialize(workspaceContext);
             });
         }
 
@@ -209,6 +74,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             Assert.Single(sourceFilesPushedToWorkspace);
             Assert.Contains(@"C:\ProjectFolder\file1.cs", sourceFilesPushedToWorkspace);
+        }
+
+        internal override ICommandLineHandler CreateInstance()
+        {
+            return CreateInstance(null, null);
         }
 
         private SourceItemHandler CreateInstance(UnconfiguredProject project = null, IWorkspaceProjectContext context = null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemHandler_CommandLineTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemHandler_CommandLineTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             Assert.Throws<ArgumentNullException>("project", () =>
             {
-                new SourceItemHandler((UnconfiguredProject)null, context);
+                new SourceItemHandler((UnconfiguredProject)null);
             });
         }
 
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             var context = IWorkspaceProjectContextFactory.CreateForSourceFiles(project, onSourceFileAdded, onSourceFileRemoved);
             var logger = Mock.Of<IProjectLogger>();
 
-            var handler = new SourceItemHandler(project, context);
+            var handler = CreateInstance(project, context);
             var projectDir = Path.GetDirectoryName(project.FullPath);
             var added = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"C:\file1.cs", @"C:\file2.cs", @"C:\file1.cs" }, baseDirectory: projectDir, sdkDirectory: null));
             var empty = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null));
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             var context = IWorkspaceProjectContextFactory.CreateForSourceFiles(project, onSourceFileAdded, onSourceFileRemoved);
             var logger = Mock.Of<IProjectLogger>();
 
-            var handler = new SourceItemHandler(project, context);
+            var handler = CreateInstance(project, context);
             var projectDir = Path.GetDirectoryName(project.FullPath);
             var added = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"file1.cs", @"..\ProjectFolder\file1.cs" }, baseDirectory: projectDir, sdkDirectory: null));
             var removed = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null));
@@ -85,7 +85,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         {
             project = project ?? UnconfiguredProjectFactory.Create();
 
-            return new SourceItemHandler(project, context);
+            var handler = new SourceItemHandler(project);
+            if (context != null)
+                handler.Initialize(context);
+
+            return handler;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemHandler_EvaluationTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemHandler_EvaluationTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             Assert.Throws<ArgumentNullException>("project", () =>
             {
-                new SourceItemHandler((UnconfiguredProject)null, context);
+                new SourceItemHandler((UnconfiguredProject)null);
             });
         }
 
@@ -31,7 +31,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         {
             project = project ?? UnconfiguredProjectFactory.Create();
 
-            return new SourceItemHandler(project, context);
+            var handler = new SourceItemHandler(project);
+            if (context != null)
+                handler.Initialize(context);
+
+            return handler;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemHandler_EvaluationTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemHandler_EvaluationTests.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 
@@ -7,7 +9,7 @@ using Xunit;
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
     [Trait("UnitTest", "ProjectSystem")]
-    public class ProjectPropertiesItemHandlerTests : EvaluationHandlerTestBase
+    public class SourceItemHandler_EvaluationTests : EvaluationHandlerTestBase
     {
         [Fact]
         public void Constructor_NullAsProject_ThrowsArgumentNull()
@@ -16,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             Assert.Throws<ArgumentNullException>("project", () =>
             {
-                new ProjectPropertiesItemHandler((UnconfiguredProject)null, context);
+                new SourceItemHandler((UnconfiguredProject)null, context);
             });
         }
 
@@ -25,11 +27,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             return CreateInstance(null, null);
         }
 
-        private ProjectPropertiesItemHandler CreateInstance(UnconfiguredProject project = null, IWorkspaceProjectContext context = null)
+        private SourceItemHandler CreateInstance(UnconfiguredProject project = null, IWorkspaceProjectContext context = null)
         {
             project = project ?? UnconfiguredProjectFactory.Create();
 
-            return new ProjectPropertiesItemHandler(project, context);
+            return new SourceItemHandler(project, context);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ContextHandlerProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ContextHandlerProvider.cs
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             ((project, context) => new SourceItemHandler(project, context), Compile.SchemaName),                // <Compile /> item
 
             // Evaluation only
-            ((project, context) => new ProjectPropertiesItemHandler(context), ConfigurationGeneral.SchemaName),   // <ProjectGuid>, <TargetPath> properties
+            ((project, context) => new ProjectPropertiesItemHandler(project, context), ConfigurationGeneral.SchemaName),   // <ProjectGuid>, <TargetPath> properties
 
             // Command-line only
             ((project, context) => new MetadataReferenceItemHandler(project, context), null),                              // <ProjectReference />, <Reference /> items

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ContextHandlerProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ContextHandlerProvider.cs
@@ -61,7 +61,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             foreach ((HandlerFactory factory, string evaluationRuleName) factory in s_handlerFactories)
             {
-                object handler = factory.factory(_project, context);
+                IWorkspaceContextHandler handler = factory.factory(_project);
+                handler.Initialize(context);
 
                 // NOTE: Handlers can be both IEvaluationHandler and ICommandLineHandler
                 if (handler is IEvaluationHandler evaluationHandler)
@@ -82,18 +83,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         {
             return ImmutableArray.Create<(HandlerFactory factory, string evaluationRuleName)>(
 
-            // Factory                                                                      EvalautionRuleName                  Description
+            // Factory                                             EvaluationRuleName                  Description
 
             // Evaluation and Command-line
-            ((project, context) => new SourceItemHandler(project, context), Compile.SchemaName),                // <Compile /> item
+            (project => new SourceItemHandler(project),            Compile.SchemaName),                // <Compile /> item
 
             // Evaluation only
-            ((project, context) => new ProjectPropertiesItemHandler(project, context), ConfigurationGeneral.SchemaName),   // <ProjectGuid>, <TargetPath> properties
+            (project => new ProjectPropertiesItemHandler(project), ConfigurationGeneral.SchemaName),   // <ProjectGuid>, <TargetPath> properties
 
             // Command-line only
-            ((project, context) => new MetadataReferenceItemHandler(project, context), null),                              // <ProjectReference />, <Reference /> items
-            ((project, context) => new AnalyzerItemHandler(project, context), null),                              // <Analyzer /> item
-            ((project, context) => new AdditionalFilesItemHandler(project, context), null)                               // <AdditionalFiles /> item
+            (project => new MetadataReferenceItemHandler(project), null),                              // <ProjectReference />, <Reference /> items
+            (project => new AnalyzerItemHandler(project),          null),                              // <Analyzer /> item
+            (project => new AdditionalFilesItemHandler(project),   null)                               // <AdditionalFiles /> item
             );
         }
 
@@ -105,6 +106,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                                      .ToImmutableArray();
         }
 
-        private delegate object HandlerFactory(UnconfiguredProject project, IWorkspaceProjectContext context);
+        private delegate IWorkspaceContextHandler HandlerFactory(UnconfiguredProject project);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     ///     Responsible for coordinating changes and conflicts between evaluation and design-time builds, and pushing those changes
     ///     onto Roslyn via a <see cref="IWorkspaceProjectContext"/>.
     /// </summary>
-    internal abstract partial class AbstractEvaluationCommandLineHandler
+    internal abstract partial class AbstractEvaluationCommandLineHandler : AbstractWorkspaceContextHandler
     {
         // This class is not thread-safe, and the assumption is that the caller will make sure that evaluations and design-time builds do 
         // overlap inside the class at the same time.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractWorkspaceContextHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractWorkspaceContextHandler.cs
@@ -26,6 +26,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
         public void Initialize(IWorkspaceProjectContext context)
         {
+            Requires.NotNull(context, nameof(context));
+
             if (_context != null)
                 throw new InvalidOperationException();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractWorkspaceContextHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractWorkspaceContextHandler.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
+{
+    internal class AbstractWorkspaceContextHandler : IWorkspaceContextHandler
+    {
+        private IWorkspaceProjectContext _context;
+
+        protected AbstractWorkspaceContextHandler()
+        {
+        }
+
+        protected IWorkspaceProjectContext Context
+        {
+            get
+            {
+                Assumes.NotNull(_context);
+
+                return _context;
+            }
+        }
+
+        public void Initialize(IWorkspaceProjectContext context)
+        {
+            if (_context != null)
+                throw new InvalidOperationException();
+
+            _context = context;
+        }
+
+        protected void EnsureInitialized()
+        {
+            if (_context == null)
+                throw new InvalidOperationException("Initialize must be called before calling this method.");
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.Collections.Generic;
-
+using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.Logging;
@@ -12,6 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     /// <summary>
     ///     Handles changes to the  &lt;AdditionalFiles/&gt; item during design-time builds.
     /// </summary>
+    [Export(typeof(IWorkspaceContextHandler))]
     internal class AdditionalFilesItemHandler : ICommandLineHandler
     {
         // WORKAROUND: To avoid Roslyn throwing when we add duplicate additonal files, we remember what 
@@ -19,15 +20,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         // See: https://github.com/dotnet/project-system/issues/2230
 
         private readonly UnconfiguredProject _project;
-        private readonly IWorkspaceProjectContext _context;
+        private IWorkspaceProjectContext _context;
         private readonly HashSet<string> _paths = new HashSet<string>(StringComparers.Paths);
+
+        [ImportingConstructor]
+        public AdditionalFilesItemHandler(UnconfiguredProject project)
+            : this(project, null)
+        {
+        }
 
         public AdditionalFilesItemHandler(UnconfiguredProject project, IWorkspaceProjectContext context)
         {
             Requires.NotNull(project, nameof(project));
-            Requires.NotNull(context, nameof(context));
-
+            
             _project = project;
+            _context = context;
+        }
+
+        public void Initialize(IWorkspaceProjectContext context)
+        {
+            if (_context != null)
+                throw new InvalidOperationException();
+
             _context = context;
         }
 
@@ -37,6 +51,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Requires.NotNull(added, nameof(added));
             Requires.NotNull(removed, nameof(removed));
             Requires.NotNull(logger, nameof(logger));
+
+            if (_context == null)
+                throw new InvalidOperationException();
 
             foreach (CommandLineSourceFile additionalFile in removed.AdditionalFiles)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
@@ -25,16 +25,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
         [ImportingConstructor]
         public AdditionalFilesItemHandler(UnconfiguredProject project)
-            : this(project, null)
-        {
-        }
-
-        public AdditionalFilesItemHandler(UnconfiguredProject project, IWorkspaceProjectContext context)
         {
             Requires.NotNull(project, nameof(project));
-            
+
             _project = project;
-            _context = context;
         }
 
         public void Initialize(IWorkspaceProjectContext context)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
@@ -25,16 +25,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
         [ImportingConstructor]
         public AnalyzerItemHandler(UnconfiguredProject project)
-            : this(project, null)
-        {
-        }
-
-        public AnalyzerItemHandler(UnconfiguredProject project, IWorkspaceProjectContext context)
         {
             Requires.NotNull(project, nameof(project));
 
             _project = project;
-            _context = context;
         }
 
         public void Initialize(IWorkspaceProjectContext context)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.Collections.Generic;
-
+using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.Logging;
@@ -12,6 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     /// <summary>
     ///     Handles changes to the  &lt;Analyzer/&gt; item during design-time builds.
     /// </summary>
+    [Export(typeof(IWorkspaceContextHandler))]
     internal class AnalyzerItemHandler : ICommandLineHandler
     {
         // WORKAROUND: To avoid Roslyn throwing when we add duplicate analyzers, we remember what 
@@ -19,15 +20,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
         // See: https://github.com/dotnet/project-system/issues/2230
         private readonly UnconfiguredProject _project;
-        private readonly IWorkspaceProjectContext _context;
+        private IWorkspaceProjectContext _context;
         private readonly HashSet<string> _paths = new HashSet<string>(StringComparers.Paths);
+
+        [ImportingConstructor]
+        public AnalyzerItemHandler(UnconfiguredProject project)
+            : this(project, null)
+        {
+        }
 
         public AnalyzerItemHandler(UnconfiguredProject project, IWorkspaceProjectContext context)
         {
             Requires.NotNull(project, nameof(project));
-            Requires.NotNull(context, nameof(context));
 
             _project = project;
+            _context = context;
+        }
+
+        public void Initialize(IWorkspaceProjectContext context)
+        {
+            if (_context != null)
+                throw new InvalidOperationException();
+
             _context = context;
         }
 
@@ -37,6 +51,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Requires.NotNull(added, nameof(added));
             Requires.NotNull(removed, nameof(removed));
             Requires.NotNull(logger, nameof(logger));
+
+            if (_context == null)
+                throw new InvalidOperationException();
 
             foreach (CommandLineAnalyzerReference analyzer in removed.AnalyzerReferences)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-
+using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.Logging;
@@ -13,6 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     /// <summary>
     ///     Handles changes to references that are passed to the compiler during design-time builds.
     /// </summary>
+    [Export(typeof(IWorkspaceContextHandler))]
     internal class MetadataReferenceItemHandler : ICommandLineHandler
     {
         // WORKAROUND: The language services through IWorkspaceProjectContext doesn't expect to see AddMetadataReference called more than
@@ -20,15 +21,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         // See: https://github.com/dotnet/project-system/issues/2230
 
         private readonly UnconfiguredProject _project;
-        private readonly IWorkspaceProjectContext _context;
+        private IWorkspaceProjectContext _context;
         private readonly Dictionary<string, MetadataReferenceProperties> _addedPathsWithMetadata = new Dictionary<string, MetadataReferenceProperties>(StringComparers.Paths);
+
+        [ImportingConstructor]
+        public MetadataReferenceItemHandler(UnconfiguredProject project)
+            : this(project, null)
+        {
+        }
 
         public MetadataReferenceItemHandler(UnconfiguredProject project, IWorkspaceProjectContext context)
         {
             Requires.NotNull(project, nameof(project));
-            Requires.NotNull(context, nameof(context));
 
             _project = project;
+            _context = context;
+        }
+
+        public void Initialize(IWorkspaceProjectContext context)
+        {
+            if (_context != null)
+                throw new InvalidOperationException();
+
             _context = context;
         }
 
@@ -38,6 +52,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Requires.NotNull(added, nameof(added));
             Requires.NotNull(removed, nameof(removed));
             Requires.NotNull(logger, nameof(logger));
+
+            if (_context == null)
+                throw new InvalidOperationException();
 
             foreach (CommandLineReference reference in removed.MetadataReferences)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
@@ -4,8 +4,8 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
+
 using Microsoft.CodeAnalysis;
-using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.Logging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
@@ -14,14 +14,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     ///     Handles changes to references that are passed to the compiler during design-time builds.
     /// </summary>
     [Export(typeof(IWorkspaceContextHandler))]
-    internal class MetadataReferenceItemHandler : ICommandLineHandler
+    internal class MetadataReferenceItemHandler : AbstractWorkspaceContextHandler, ICommandLineHandler
     {
         // WORKAROUND: The language services through IWorkspaceProjectContext doesn't expect to see AddMetadataReference called more than
         // once with the same path and different properties. This dedups the references to work around this limitation.
         // See: https://github.com/dotnet/project-system/issues/2230
 
         private readonly UnconfiguredProject _project;
-        private IWorkspaceProjectContext _context;
         private readonly Dictionary<string, MetadataReferenceProperties> _addedPathsWithMetadata = new Dictionary<string, MetadataReferenceProperties>(StringComparers.Paths);
 
         [ImportingConstructor]
@@ -32,14 +31,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             _project = project;
         }
 
-        public void Initialize(IWorkspaceProjectContext context)
-        {
-            if (_context != null)
-                throw new InvalidOperationException();
-
-            _context = context;
-        }
-
         public void Handle(IComparable version, BuildOptions added, BuildOptions removed, bool isActiveContext, IProjectLogger logger)
         {
             Requires.NotNull(version, nameof(version));
@@ -47,8 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Requires.NotNull(removed, nameof(removed));
             Requires.NotNull(logger, nameof(logger));
 
-            if (_context == null)
-                throw new InvalidOperationException();
+            EnsureInitialized();
 
             foreach (CommandLineReference reference in removed.MetadataReferences)
             {
@@ -74,7 +64,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
                 // The reference has already been added previously. The current implementation of IWorkspaceProjectContext
                 // presumes that we'll only called AddMetadataReference once for a given path. Thus we have to remove the
                 // existing one, compute merged properties, and add the new one.
-                _context.RemoveMetadataReference(fullPath);
+                Context.RemoveMetadataReference(fullPath);
 
                 ImmutableArray<string> combinedAliases = GetEmptyIfGlobalAlias(GetGlobalAliasIfEmpty(existingProperties.Aliases).AddRange(GetGlobalAliasIfEmpty(properties.Aliases)));
                 properties = properties.WithAliases(combinedAliases);
@@ -82,7 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             logger.WriteLine("Adding {0} '{1}'", properties.EmbedInteropTypes ? "link" : "reference", fullPath);
 
-            _context.AddMetadataReference(fullPath, properties);
+            Context.AddMetadataReference(fullPath, properties);
             _addedPathsWithMetadata[fullPath] = properties;
         }
 
@@ -92,7 +82,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             {
                 logger.WriteLine("Removing {0} '{1}'", properties.EmbedInteropTypes ? "link" : "reference", fullPath);
 
-                _context.RemoveMetadataReference(fullPath);
+                Context.RemoveMetadataReference(fullPath);
 
                 // Subtract any existing aliases out. This will be an empty list if we should remove the reference entirely
                 ImmutableArray<string> resultantAliases = GetGlobalAliasIfEmpty(existingProperties.Aliases).RemoveRange(GetGlobalAliasIfEmpty(properties.Aliases));
@@ -108,7 +98,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
                     resultantAliases = GetEmptyIfGlobalAlias(resultantAliases);
                     properties = properties.WithAliases(resultantAliases);
                     logger.WriteLine("Adding {0} '{1}' back with remaining aliases", properties.EmbedInteropTypes ? "link" : "reference", fullPath);
-                    _context.AddMetadataReference(fullPath, properties);
+                    Context.AddMetadataReference(fullPath, properties);
                     _addedPathsWithMetadata[fullPath] = properties;
                 }
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
@@ -26,16 +26,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
         [ImportingConstructor]
         public MetadataReferenceItemHandler(UnconfiguredProject project)
-            : this(project, null)
-        {
-        }
-
-        public MetadataReferenceItemHandler(UnconfiguredProject project, IWorkspaceProjectContext context)
         {
             Requires.NotNull(project, nameof(project));
 
             _project = project;
-            _context = context;
         }
 
         public void Initialize(IWorkspaceProjectContext context)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
@@ -17,15 +17,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
         [ImportingConstructor]
         public ProjectPropertiesItemHandler(UnconfiguredProject project)
-            : this(project, null)
-        {
-        }
-
-        public ProjectPropertiesItemHandler(UnconfiguredProject project, IWorkspaceProjectContext context)
         {
             Requires.NotNull(project, nameof(project));
-
-            _context = context;
         }
 
         public string EvaluationRule

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.ComponentModel.Composition;
-using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+
 using Microsoft.VisualStudio.ProjectSystem.Logging;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
@@ -11,10 +11,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     ///     Handles changes to the project and makes sure the language service is aware of them.
     /// </summary>
     [Export(typeof(IWorkspaceContextHandler))]
-    internal class ProjectPropertiesItemHandler : IEvaluationHandler
+    internal class ProjectPropertiesItemHandler : AbstractWorkspaceContextHandler, IEvaluationHandler
     {
-        private IWorkspaceProjectContext _context;
-
         [ImportingConstructor]
         public ProjectPropertiesItemHandler(UnconfiguredProject project)
         {
@@ -26,22 +24,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             get { return ConfigurationGeneral.SchemaName; }
         }
 
-        public void Initialize(IWorkspaceProjectContext context)
-        {
-            if (_context != null)
-                throw new InvalidOperationException();
-
-            _context = context;
-        }
-
         public void Handle(IComparable version, IProjectChangeDescription projectChange, bool isActiveContext, IProjectLogger logger)
         {
             Requires.NotNull(version, nameof(version));
             Requires.NotNull(projectChange, nameof(projectChange));
             Requires.NotNull(logger, nameof(logger));
 
-            if (_context == null)
-                throw new InvalidOperationException();
+            EnsureInitialized();
 
             // The language service wants both the intermediate (bin\obj) and output (bin\debug)) paths
             // so that it can automatically hook up project-to-project references. It does this by matching the 
@@ -56,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
                 if (!string.IsNullOrEmpty(newBinOutputPath))
                 {
                     logger.WriteLine("BinOutputPath: {0}", newBinOutputPath);
-                    _context.BinOutputPath = newBinOutputPath;
+                    Context.BinOutputPath = newBinOutputPath;
                 }
             }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-
+using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.Logging;
 
@@ -10,13 +10,33 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     /// <summary>
     ///     Handles changes to the project and makes sure the language service is aware of them.
     /// </summary>
+    [Export(typeof(IWorkspaceContextHandler))]
     internal class ProjectPropertiesItemHandler : IEvaluationHandler
     {
-        private readonly IWorkspaceProjectContext _context;
+        private IWorkspaceProjectContext _context;
 
-        public ProjectPropertiesItemHandler(IWorkspaceProjectContext context)
+        [ImportingConstructor]
+        public ProjectPropertiesItemHandler(UnconfiguredProject project)
+            : this(project, null)
         {
-            Requires.NotNull(context, nameof(context));
+        }
+
+        public ProjectPropertiesItemHandler(UnconfiguredProject project, IWorkspaceProjectContext context)
+        {
+            Requires.NotNull(project, nameof(project));
+
+            _context = context;
+        }
+
+        public string EvaluationRule
+        {
+            get { return ConfigurationGeneral.SchemaName; }
+        }
+
+        public void Initialize(IWorkspaceProjectContext context)
+        {
+            if (_context != null)
+                throw new InvalidOperationException();
 
             _context = context;
         }
@@ -26,6 +46,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Requires.NotNull(version, nameof(version));
             Requires.NotNull(projectChange, nameof(projectChange));
             Requires.NotNull(logger, nameof(logger));
+
+            if (_context == null)
+                throw new InvalidOperationException();
 
             // The language service wants both the intermediate (bin\obj) and output (bin\debug)) paths
             // so that it can automatically hook up project-to-project references. It does this by matching the 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.ComponentModel.Composition;
 using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
@@ -14,18 +15,37 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     ///     Handles changes to sources files during project evaluations and sources files that are passed
     ///     to the compiler during design-time builds.
     /// </summary>
+    [Export(typeof(IWorkspaceContextHandler))]
     internal partial class SourceItemHandler : AbstractEvaluationCommandLineHandler, IEvaluationHandler, ICommandLineHandler
     {
         private readonly UnconfiguredProject _project;
-        private readonly IWorkspaceProjectContext _context;
+        private IWorkspaceProjectContext _context;
+
+        [ImportingConstructor]
+        public SourceItemHandler(UnconfiguredProject project)
+            : this(project, null)
+        {
+        }
 
         public SourceItemHandler(UnconfiguredProject project, IWorkspaceProjectContext context)
             : base(project)
         {
             Requires.NotNull(project, nameof(project));
-            Requires.NotNull(context, nameof(context));
 
             _project = project;
+            _context = context;
+        }
+
+        public string EvaluationRule
+        {
+            get { return Compile.SchemaName; }
+        }
+
+        public void Initialize(IWorkspaceProjectContext context)
+        {
+            if (_context != null)
+                throw new InvalidOperationException();
+
             _context = context;
         }
 
@@ -34,6 +54,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Requires.NotNull(version, nameof(version));
             Requires.NotNull(projectChange, nameof(projectChange));
             Requires.NotNull(logger, nameof(logger));
+
+            if (_context == null)
+                throw new InvalidOperationException();
 
             ApplyEvaluationChanges(version, projectChange.Difference, projectChange.After.Items, isActiveContext, logger);
         }
@@ -44,6 +67,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Requires.NotNull(added, nameof(added));
             Requires.NotNull(removed, nameof(removed));
             Requires.NotNull(logger, nameof(logger));
+
+            if (_context == null)
+                throw new InvalidOperationException();
 
             IProjectChangeDiff difference = ConvertToProjectDiff(added, removed);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -23,17 +23,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
         [ImportingConstructor]
         public SourceItemHandler(UnconfiguredProject project)
-            : this(project, null)
-        {
-        }
-
-        public SourceItemHandler(UnconfiguredProject project, IWorkspaceProjectContext context)
             : base(project)
         {
-            Requires.NotNull(project, nameof(project));
-
             _project = project;
-            _context = context;
         }
 
         public string EvaluationRule

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ICommandLineHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ICommandLineHandler.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     ///     Handles changes within the command-line, and applies them to a 
     ///     <see cref="IWorkspaceProjectContext"/> instance.
     /// </summary>
-    internal interface ICommandLineHandler
+    internal interface ICommandLineHandler : IWorkspaceContextHandler
     {
         /// <summary>
         ///     Handles the specified added and removed command-line arguments, and applies 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IEvaluationHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IEvaluationHandler.cs
@@ -10,8 +10,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     ///     Handles changes to a language service rule, and applies them to a
     ///     <see cref="IWorkspaceProjectContext"/> instance.
     /// </summary>
-    internal interface IEvaluationHandler
+    internal interface IEvaluationHandler : IWorkspaceContextHandler
     {
+        /// <summary>
+        ///     Gets the evaluation rule that the <see cref="IEvaluationHandler"/> handles.
+        /// </summary>
+        string EvaluationRule
+        {
+            get;
+        }
+
         /// <summary>
         ///     Handles the specified set of changes to a rule, and applies them
         ///     to the underlying <see cref="IWorkspaceProjectContext"/>.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IWorkspaceContextHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IWorkspaceContextHandler.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
+{
+    /// <summary>
+    ///     Represents a marker interface for types that apply changes to <see cref="IWorkspaceProjectContext"/> instances.
+    /// </summary>
+    internal interface IWorkspaceContextHandler
+    {
+        /// <summary>
+        ///     Initializes the handler with the specified <see cref="IWorkspaceProjectContext"/>.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="context"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///     <see cref="Initialize(IWorkspaceProjectContext)"/> has already been called.
+        /// </exception>
+        void Initialize(IWorkspaceProjectContext context);
+    }
+}


### PR DESCRIPTION
The new language service hookup MEF imports the handlers, whereas the old version still manually creates them. Support both versions.