### PR TITLE
Fixed F# project error when pasting items outside of a project into a project

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/PasteOrdering.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/PasteOrdering.cs
@@ -67,6 +67,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 
         public bool CanHandleDataObject(object dataObject, IProjectTree dropTarget, IProjectTreeProvider currentProvider)
         {
+            _dropTarget = dropTarget;
             return PasteProcessor.CanHandleDataObject(dataObject, dropTarget, currentProvider);
         }
 


### PR DESCRIPTION
This fixes this issue: https://github.com/dotnet/project-system/issues/3752

Basically, I forgot to capture the drop target in this case.