### PR TITLE
Accessibility fixes

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
@@ -80,6 +80,11 @@
                         <Binding Path="DoesNotHaveErrors" Mode="OneWay"/>
                     </MultiBinding>
                 </ComboBox.IsEnabled>
+                <ComboBox.ItemContainerStyle>
+                    <Style TargetType="ComboBoxItem">
+                        <Setter Property="AutomationProperties.Name" Value="{Binding Path=Name}"/>
+                    </Style>
+                </ComboBox.ItemContainerStyle>
             </ComboBox>
             <StackPanel
                 Grid.Row="0"
@@ -133,6 +138,11 @@
                 IsReadOnly="True"
                 IsEditable="False"
                 AutomationProperties.Name="{x:Static Member=local:PropertyPageResources.Launch}">
+                <ComboBox.ItemContainerStyle>
+                    <Style TargetType="ComboBoxItem">
+                        <Setter Property="AutomationProperties.Name" Value="{Binding Path=Name}"/>
+                    </Style>
+                </ComboBox.ItemContainerStyle>
             </ComboBox>
             <Label 
                 Grid.Row="2"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/GetProfileNameDialog.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/GetProfileNameDialog.xaml
@@ -28,8 +28,21 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"></RowDefinition>
             </Grid.RowDefinitions>
-            <TextBlock x:Uid="NameLabel" Margin="10,10" Grid.Row="0" Grid.Column="0"  TextWrapping="NoWrap" Text="{x:Static Member=local:PropertyPageResources.ProfileName}" />
-            <TextBox x:Name="ProfileNameTextBox" Uid="ProfileNameTextBox" Margin="10,10" Grid.Row="0" Grid.Column="1" Text="{Binding UpdateSourceTrigger=PropertyChanged, Path=ProfileName}" />
+            <TextBlock 
+                x:Uid="NameLabel"
+                Margin="10,10"
+                Grid.Row="0"
+                Grid.Column="0"
+                TextWrapping="NoWrap"
+                Text="{x:Static Member=local:PropertyPageResources.ProfileName}"/>
+            <TextBox
+                x:Name="ProfileNameTextBox"
+                Uid="ProfileNameTextBox"
+                Margin="10,10"
+                Grid.Row="0"
+                Grid.Column="1"
+                Text="{Binding UpdateSourceTrigger=PropertyChanged, Path=ProfileName}"
+                AutomationProperties.Name="{x:Static Member=local:PropertyPageResources.ProfileName}"/>
         </Grid>
         <Grid x:Uid="ButtonGrid" Grid.Row="1" Margin="5" HorizontalAlignment="Right" >
             <Grid.RowDefinitions>


### PR DESCRIPTION
Fixes these VS bugs:
- [622217](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/622217)
- [622211](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/622211)

Fix description: 
1. today we do not set the `AutomationProperties.Name` for our combo boxes making it impossible for screen readers to pick up the name of individual items in the each.  This PR adds `AutomationProperties.Name` properties for all combo boxes in the project system.
2. The text field in `GetProfileNameDialog.xaml` didn't have `AutomationProperties.Name` so screen readers could not find a name for it.  This PR adds the name to match the label.