### PR TITLE
URL-escape percent signs in pre/post build events

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
@@ -638,5 +638,96 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
         }
+
+        [Fact]
+        public static async Task EscapeValue_Read_CheckEscaped()
+        {
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
+    <Exec Command=""echo %25DATE%"" />
+  </Target>
+</Project>
+".AsProjectRootElement();
+
+            const string expected = "echo %DATE%";
+            string actual = await systemUnderTest.GetPropertyAsync(root, emptyProjectProperties);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static async Task EscapeValue_Read_CheckNotDoubleEscaped()
+        {
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
+    <Exec Command=""echo %2525DATE%"" />
+  </Target>
+</Project>
+".AsProjectRootElement();
+
+            const string expected = "echo %25DATE%";
+            string actual = await systemUnderTest.GetPropertyAsync(root, emptyProjectProperties);
+            Assert.Equal(expected, actual);
+        }
+
+
+        [Fact]
+        public static async Task EscapeValue_Write_CheckEscaped()
+        {
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+</Project>
+".AsProjectRootElement();
+
+            const string expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
+    <Exec Command=""echo %25DATE%25"" />
+  </Target>
+</Project>";
+
+            await systemUnderTest.SetPropertyAsync("echo %DATE%", emptyProjectProperties, root);
+            var actual = root.SaveAndGetChanges();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static async Task EscapeValue_Write_CheckNotDoubleEscaped()
+        {
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+</Project>
+".AsProjectRootElement();
+
+            const string expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
+    <Exec Command=""echo %2525DATE%25"" />
+  </Target>
+</Project>";
+
+            await systemUnderTest.SetPropertyAsync("echo %25DATE%", emptyProjectProperties, root);
+            var actual = root.SaveAndGetChanges();
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
@@ -643,5 +643,96 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
         }
+
+        [Fact]
+        public static async Task EscapeValue_Read_CheckEscaped()
+        {
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
+    <Exec Command=""echo %25DATE%"" />
+  </Target>
+</Project>
+".AsProjectRootElement();
+
+            const string expected = "echo %DATE%";
+            string actual = await systemUnderTest.GetPropertyAsync(root, emptyProjectProperties);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static async Task EscapeValue_Read_CheckNotDoubleEscaped()
+        {
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
+    <Exec Command=""echo %2525DATE%"" />
+  </Target>
+</Project>
+".AsProjectRootElement();
+
+            const string expected = "echo %25DATE%";
+            string actual = await systemUnderTest.GetPropertyAsync(root, emptyProjectProperties);
+            Assert.Equal(expected, actual);
+        }
+
+
+        [Fact]
+        public static async Task EscapeValue_Write_CheckEscaped()
+        {
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+</Project>
+".AsProjectRootElement();
+
+            const string expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
+    <Exec Command=""echo %25DATE%25"" />
+  </Target>
+</Project>";
+
+            await systemUnderTest.SetPropertyAsync("echo %DATE%", emptyProjectProperties, root);
+            var actual = root.SaveAndGetChanges();
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static async Task EscapeValue_Write_CheckNotDoubleEscaped()
+        {
+            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+</Project>
+".AsProjectRootElement();
+
+            const string expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
+    <Exec Command=""echo %2525DATE%25"" />
+  </Target>
+</Project>";
+
+            await systemUnderTest.SetPropertyAsync("echo %25DATE%", emptyProjectProperties, root);
+            var actual = root.SaveAndGetChanges();
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.AbstractBuildEventHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.AbstractBuildEventHelper.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectProperties
@@ -78,7 +79,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
 
                 if (execTask.Parameters.TryGetValue(Command, out string commandText))
                 {
-                    return commandText;
+                    return ProjectCollection.Unescape(commandText);
                 }
 
                 return null; // exec task as written in the project file is invalid, we should be resilient to this case.
@@ -149,7 +150,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
             }
 
             private static void SetExecParameter(ProjectTaskElement execTask, string unevaluatedPropertyValue)
-                => execTask.SetParameter(Command, unevaluatedPropertyValue);
+                => execTask.SetParameter(Command, ProjectCollection.Escape(unevaluatedPropertyValue));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.AbstractBuildEventHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.AbstractBuildEventHelper.cs
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
 
                 if (execTask.Parameters.TryGetValue(Command, out string commandText))
                 {
-                    return ProjectCollection.Unescape(commandText);
+                    return commandText.Replace("%25", "%");
                 }
 
                 return null; // exec task as written in the project file is invalid, we should be resilient to this case.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.AbstractBuildEventHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.AbstractBuildEventHelper.cs
@@ -150,7 +150,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
             }
 
             private static void SetExecParameter(ProjectTaskElement execTask, string unevaluatedPropertyValue)
-                => execTask.SetParameter(Command, ProjectCollection.Escape(unevaluatedPropertyValue));
+                => execTask.SetParameter(Command, unevaluatedPropertyValue.Replace("%", "%25"));
         }
     }
 }


### PR DESCRIPTION
This PR fixes the AbstractBuildEventValueProvider to properly escape MSBuild metachraacters signs added to the pre-build or post-build event strings in the Project Properties window of a .NET Core project.

Fixes #3506.