### PR TITLE
Added support for launching a class library project using the run project command

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
@@ -413,7 +413,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         }
 
         [Fact]
-        public async Task QueryDebugTargetsForDebugLaunchAsync_WhenLibrary_Throws()
+        public async Task QueryDebugTargetsForDebugLaunchAsync_WhenLibraryAndNoRunCommandSpecified_Throws()
         {
             var properties = new Dictionary<string, string>() {
                 {"TargetPath", @"C:\library.dll"},
@@ -430,6 +430,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             {
                 return debugger.QueryDebugTargetsForDebugLaunchAsync(0, activeProfile);
             });
+        }
+
+        [Fact]
+        public async Task QueryDebugTargetsForDebugLaunchAsync_WhenLibraryAndRunCommandSpecified_ReturnsRunCommand()
+        {
+            var properties = new Dictionary<string, string>() {
+                {"RunCommand", @"C:\dotnet.exe"},
+                {"TargetFrameworkIdentifier", @".NETFramework" }
+                };
+
+            _mockFS.WriteAllText(@"C:\library.dll", string.Empty);
+
+            var debugger = GetDebugTargetsProvider("Library", properties);
+
+            var activeProfile = new LaunchProfile() { Name = "Name", CommandName = "Project" };
+
+            var targets = await debugger.QueryDebugTargetsAsync(0, activeProfile);
+
+            Assert.Single(targets);
+            Assert.Equal(@"C:\dotnet.exe", targets[0].Executable);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #1484

## Changes

- Added support for launching a class library project using the run project command. This allows running a class library project using the `RunCommand` project property without needing to create a launch profile.