### PR TITLE
Fix Resources Designer crashes under Italian

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.it.xlf
@@ -1367,7 +1367,7 @@ Errore:</target>
       </trans-unit>
       <trans-unit id="RSE_Err_BadIdentifier_2Arg">
         <source>The name of the resource '{0}' cannot be used as a valid identifier, because it contains one or more invalid characters: '{1}'.  Please remove or replace those characters and try again.</source>
-        <target state="translated">Il nome della risorsa '{0}' non può essere usato come identificatore valido perché contiene uno o più caratteri non validi: \'{1\}'. Rimuovere o sostituire tali caratteri e riprovare.</target>
+        <target state="translated">Il nome della risorsa '{0}' non può essere usato come identificatore valido perché contiene uno o più caratteri non validi: '{1}'. Rimuovere o sostituire tali caratteri e riprovare.</target>
         <note>{0} = Resource name</note>
       </trans-unit>
       <trans-unit id="RSE_Err_MaxFilesLimitation">


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/653172.

Italian had a bad placeholder causing this path to crash when you entered a resource with a bad identifier.