### PR TITLE
[15.8] Fix telemetry loading configuration too early

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SDKVersionTelemetryServiceComponent.SDKVersionTelemetryServiceInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SDKVersionTelemetryServiceComponent.SDKVersionTelemetryServiceInstance.cs
@@ -42,6 +42,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 // Do not block initialization on reporting the sdk version. It is possible to deadlock.
                 Task.Run(async () =>
                 {
+                    // Wait for the project to be loaded so that we don't prematurally load the active configuration
+                    await _unconfiguredProjectTasksService.ProjectLoadedInHost
+                                                          .ConfigureAwait(false);
+                    
                     await _unconfiguredProjectTasksService.LoadedProjectAsync(async () =>
                     {
                         ConfigurationGeneral projectProperties = await _projectVsServices.ActiveConfiguredProjectProperties.GetConfigurationGeneralPropertiesAsync().ConfigureAwait(false);


### PR DESCRIPTION
The new SDK telemetry started faulting configuration in at a time that it previously wasn't loaded, which uncovered some race conditions. Wait until the project is loaded before we run.

This is considered the least risky change vs fixing the race conditions which we will do at a later time.