### PR TITLE
fixing tab ordering in debug options page

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
@@ -70,6 +70,8 @@
                 VerticalContentAlignment="Center"
                 MinHeight="23"
                 Margin="5,6,2,7"
+                IsTabStop="True"
+                TabIndex="0"
                 ItemsSource="{Binding Path=LaunchProfiles, Mode=OneWay}"
                 SelectedValue="{Binding Path=SelectedDebugProfile}"
                 AutomationProperties.Name="{x:Static Member=local:PropertyPageResources.Profile}">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
@@ -70,7 +70,6 @@
                 VerticalContentAlignment="Center"
                 MinHeight="23"
                 Margin="5,6,2,7"
-                IsTabStop="True"
                 TabIndex="0"
                 ItemsSource="{Binding Path=LaunchProfiles, Mode=OneWay}"
                 SelectedValue="{Binding Path=SelectedDebugProfile}"


### PR DESCRIPTION
Fixes this VS bug: 
- [622505](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/622505)

Fix description:

- Today we do not set the tab ordering for the debug page.  This change sets the first item on the debug page as a place for tab ordering to stop at as well as indicating that it should be first in the tab order