### PR TITLE
Resx string editor quality-of-life improvements

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerDataGridView.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerDataGridView.vb
@@ -202,6 +202,17 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             End If
         End Function
 
+        Protected Overrides Function ProcessDataGridViewKey(e As KeyEventArgs) As Boolean
+
+            ' SHIFT+Space usually selects entire row in DataGridView, prevent 
+            ' that in it in edit mode so that it behaves like a usual text box
+            If e.KeyCode = Keys.Space AndAlso e.Shift AndAlso IsCurrentCellInEditMode Then
+                Return False
+            Else
+                Return MyBase.ProcessDataGridViewKey(e)
+            End If
+
+        End Function
 
 
         ''' <summary>

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
@@ -1870,14 +1870,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             End Sub
         End Class
 
-        Protected Overrides Function ProcessDataGridViewKey(e As KeyEventArgs) As Boolean
-            If e.KeyCode = Keys.Space AndAlso e.Shift AndAlso IsCurrentCellInEditMode Then
-                Return False
-            Else
-                Return MyBase.ProcessDataGridViewKey(e)
-            End If
-        End Function
-
     End Class
 
 End Namespace

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
@@ -87,6 +87,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             AllowUserToDeleteRows = False
             EditMode = DataGridViewEditMode.EditOnKeystrokeOrF2
             AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill
+            AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.AllCells
             DefaultCellStyle.WrapMode = DataGridViewTriState.True
 
             ' when the NullValue set to empty string, DataGridView will compare input string with it by using String.Compare.

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
@@ -1869,6 +1869,14 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             End Sub
         End Class
 
+        Protected Overrides Function ProcessDataGridViewKey(e As KeyEventArgs) As Boolean
+            If e.KeyCode = Keys.Space AndAlso e.Shift Then
+                Return False
+            Else
+                Return MyBase.ProcessDataGridViewKey(e)
+            End If
+        End Function
+
     End Class
 
 End Namespace

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
@@ -1871,7 +1871,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         End Class
 
         Protected Overrides Function ProcessDataGridViewKey(e As KeyEventArgs) As Boolean
-            If e.KeyCode = Keys.Space AndAlso e.Shift Then
+            If e.KeyCode = Keys.Space AndAlso e.Shift AndAlso IsCurrentCellInEditMode Then
                 Return False
             Else
                 Return MyBase.ProcessDataGridViewKey(e)


### PR DESCRIPTION
This PR does two things:

1. Fixes the bug described in #2881.
2. Changes the `ResourceStringTable` to automatically change the size of its rows to show the complete cell value immediately upon committing edits to a cell; previously you had to manually click out of and back into an affected cell to have the row resize. This makes editing long strings in resx files much less annoying.

If there is a way to ensure that the text box used to edit the value itself similarly resizes to fit its text, I'm all ears, but I don't know if that is possible. Thanks!