### PR TITLE
echo devenv.exe location from Launch.cmd

### DIFF
--- a/Launch.cmd
+++ b/Launch.cmd
@@ -19,7 +19,10 @@ if /I "%1" == "/rootsuffix" set ROOTSUFFIX=%2&&shift&&shift&& goto :ParseArgumen
 call :Usage && exit /b 1
 :DoneParsing
 
+for /f "tokens=*" %%i in ('where devenv.exe') do set DevEnvPath=%%i
+
 echo Launching Visual Studio under the '!ROOTSUFFIX!' hive
+echo %DevEnvPath%
 devenv /rootsuffix !ROOTSUFFIX!
 exit /b %ERRORLEVEL%
 


### PR DESCRIPTION
From:

    Launching Visual Studio under the 'Exp' hive

To:

    Launching Visual Studio under the 'Exp' hive
    C:\Program Files (x86)\Microsoft Visual Studio\15.9stg\Enterprise\Common7\IDE\devenv.exe

I have lots of VS versions installed, it helps to know which was was launched.