### PR TITLE
Add support for metafiles to the Resx editor

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorBitmap.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorBitmap.vb
@@ -23,7 +23,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             EXT_GIF,
             EXT_JPEG, EXT_JPG,
             EXT_PNG,
-            EXT_TIF, EXT_TIFF}
+            EXT_TIF, EXT_TIFF,
+            EXT_EMF, EXT_WMF}
 
         ' Extensions supported in a device project
         ' NOTE: WinCE does not support TIF file...

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorImageBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorImageBase.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Option Explicit On
 Option Strict On
@@ -9,7 +9,7 @@ Imports System.Drawing.Imaging
 Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
     ''' <summary>
-    ''' A base class for resource type editors that handle classes derived from Image (bitmaps and theoretically metafiles).
+    ''' A base class for resource type editors that handle classes derived from Image (bitmaps and metafiles).
     ''' </summary>
     ''' <remarks>Must be inherited.</remarks>
     Friend MustInherit Class ResourceTypeEditorImageBase
@@ -17,12 +17,14 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
         'File extension constants (should be treated as non-case-sensitive)
         Public Const EXT_BMP As String = ".bmp"
+        Public Const EXT_EMF As String = ".emf"
         Public Const EXT_JPG As String = ".jpg"
         Public Const EXT_JPEG As String = ".jpeg"
         Public Const EXT_PNG As String = ".png"
         Public Const EXT_TIF As String = ".tif"
         Public Const EXT_TIFF As String = ".tiff"
         Public Const EXT_GIF As String = ".gif"
+        Public Const EXT_WMF As String = ".wmf"
 
 
 
@@ -83,7 +85,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             If ImageFormat.Equals(ImageFormat.Bmp) Then
                 Return EXT_BMP
             ElseIf ImageFormat.Equals(ImageFormat.Emf) Then
-                Debug.Fail("How did we get an EMF image?")
+                Return EXT_EMF
             ElseIf ImageFormat.Equals(ImageFormat.Exif) Then
                 Return EXT_JPG 'EXIF doesn't have an extension - it's just a JPEG
             ElseIf ImageFormat.Equals(ImageFormat.Gif) Then
@@ -97,7 +99,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ElseIf ImageFormat.Equals(ImageFormat.Tiff) Then
                 Return EXT_TIF
             ElseIf ImageFormat.Equals(ImageFormat.Wmf) Then
-                Debug.Fail("How did we get a WMF image?")
+                Return EXT_WMF
             Else
                 Debug.Fail("Unrecognized raw image format of image")
             End If
@@ -121,7 +123,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             If ImageFormat.Equals(ImageFormat.Bmp) Then
                 Return My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_Type_BMP
             ElseIf ImageFormat.Equals(ImageFormat.Emf) Then
-                Debug.Fail("How did we get an EMF image?")
+                Return My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_Type_EMF
             ElseIf ImageFormat.Equals(ImageFormat.Exif) Then
                 Return My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_Type_EXIF
             ElseIf ImageFormat.Equals(ImageFormat.Gif) Then
@@ -135,7 +137,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ElseIf ImageFormat.Equals(ImageFormat.Tiff) Then
                 Return My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_Type_TIFF
             ElseIf ImageFormat.Equals(ImageFormat.Wmf) Then
-                Debug.Fail("How did we get a WMF image?")
+                Return My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_Type_WMF
             Else
                 Debug.Fail("Unrecognized raw image format of image")
             End If

--- a/src/Microsoft.VisualStudio.Editors/Resources/Microsoft.VisualStudio.Editors.Designer.Designer.vb
+++ b/src/Microsoft.VisualStudio.Editors/Resources/Microsoft.VisualStudio.Editors.Designer.Designer.vb
@@ -4069,6 +4069,15 @@ Namespace My.Resources
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to Extended Metafile.
+        '''</summary>
+        Friend Shared ReadOnly Property RSE_Type_EMF() As String
+            Get
+                Return ResourceManager.GetString("RSE_Type_EMF", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to EXIF Image.
         '''</summary>
         Friend Shared ReadOnly Property RSE_Type_EXIF() As String
@@ -4146,6 +4155,15 @@ Namespace My.Resources
         Friend Shared ReadOnly Property RSE_Type_Wave() As String
             Get
                 Return ResourceManager.GetString("RSE_Type_Wave", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Windows Metafile.
+        '''</summary>
+        Friend Shared ReadOnly Property RSE_Type_WMF() As String
+            Get
+                Return ResourceManager.GetString("RSE_Type_WMF", resourceCulture)
             End Get
         End Property
         

--- a/src/Microsoft.VisualStudio.Editors/Resources/Microsoft.VisualStudio.Editors.Designer.resx
+++ b/src/Microsoft.VisualStudio.Editors/Resources/Microsoft.VisualStudio.Editors.Designer.resx
@@ -1964,4 +1964,10 @@ Do you want to update the value in the .settings file?</value>
     <value>Unable to load '{0}' because it is not trusted.</value>
     <comment>{0} is resx file name that is blocked</comment>
   </data>
+  <data name="RSE_Type_WMF" xml:space="preserve">
+    <value>Windows Metafile</value>
+  </data>
+  <data name="RSE_Type_EMF" xml:space="preserve">
+    <value>Extended Metafile</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.cs.xlf
@@ -2768,6 +2768,16 @@ Chcete aktualizovat hodnotu v souboru .settings?</target>
         <target state="translated">Položku {0} nejde načíst, protože není důvěryhodná.</target>
         <note>{0} is resx file name that is blocked</note>
       </trans-unit>
+      <trans-unit id="RSE_Type_WMF">
+        <source>Windows Metafile</source>
+        <target state="new">Windows Metafile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RSE_Type_EMF">
+        <source>Extended Metafile</source>
+        <target state="new">Extended Metafile</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.de.xlf
@@ -2768,6 +2768,16 @@ Möchten Sie den Wert in der SETTINGS-Datei aktualisieren?</target>
         <target state="translated">"{0}" kann nicht geladen werden, weil die Datei nicht als vertrauenswürdig eingestuft wird.</target>
         <note>{0} is resx file name that is blocked</note>
       </trans-unit>
+      <trans-unit id="RSE_Type_WMF">
+        <source>Windows Metafile</source>
+        <target state="new">Windows Metafile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RSE_Type_EMF">
+        <source>Extended Metafile</source>
+        <target state="new">Extended Metafile</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.es.xlf
@@ -2768,6 +2768,16 @@ El nuevo valor del archivo app.config es '{1}'
         <target state="translated">No se puede cargar "{0}" porque no es de confianza.</target>
         <note>{0} is resx file name that is blocked</note>
       </trans-unit>
+      <trans-unit id="RSE_Type_WMF">
+        <source>Windows Metafile</source>
+        <target state="new">Windows Metafile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RSE_Type_EMF">
+        <source>Extended Metafile</source>
+        <target state="new">Extended Metafile</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.fr.xlf
@@ -2768,6 +2768,16 @@ Voulez-vous mettre à jour la valeur dans le fichier .settings ?</target>
         <target state="translated">Impossible de charger '{0}' parce qu'il n'est pas approuvé.</target>
         <note>{0} is resx file name that is blocked</note>
       </trans-unit>
+      <trans-unit id="RSE_Type_WMF">
+        <source>Windows Metafile</source>
+        <target state="new">Windows Metafile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RSE_Type_EMF">
+        <source>Extended Metafile</source>
+        <target state="new">Extended Metafile</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.it.xlf
@@ -2768,6 +2768,16 @@ Aggiornare il valore nel file .settings?</target>
         <target state="translated">Non è possibile caricare '{0}' perché non è attendibile.</target>
         <note>{0} is resx file name that is blocked</note>
       </trans-unit>
+      <trans-unit id="RSE_Type_WMF">
+        <source>Windows Metafile</source>
+        <target state="new">Windows Metafile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RSE_Type_EMF">
+        <source>Extended Metafile</source>
+        <target state="new">Extended Metafile</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ja.xlf
@@ -2768,6 +2768,16 @@ app.config ファイルでの新しい値は '{1}' です
         <target state="translated">'{0}' は信頼されていないため、読み込めません。</target>
         <note>{0} is resx file name that is blocked</note>
       </trans-unit>
+      <trans-unit id="RSE_Type_WMF">
+        <source>Windows Metafile</source>
+        <target state="new">Windows Metafile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RSE_Type_EMF">
+        <source>Extended Metafile</source>
+        <target state="new">Extended Metafile</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ko.xlf
@@ -2768,6 +2768,16 @@ app.config 파일의 새 값은 '{1}'입니다.
         <target state="translated">'{0}'을(를) 신뢰할 수 없으므로 로드할 수 없습니다.</target>
         <note>{0} is resx file name that is blocked</note>
       </trans-unit>
+      <trans-unit id="RSE_Type_WMF">
+        <source>Windows Metafile</source>
+        <target state="new">Windows Metafile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RSE_Type_EMF">
+        <source>Extended Metafile</source>
+        <target state="new">Extended Metafile</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.pl.xlf
@@ -2768,6 +2768,16 @@ Czy chcesz zaktualizować wartość w pliku settings?</target>
         <target state="translated">Nie można załadować elementu „{0}”, ponieważ nie jest on zaufany.</target>
         <note>{0} is resx file name that is blocked</note>
       </trans-unit>
+      <trans-unit id="RSE_Type_WMF">
+        <source>Windows Metafile</source>
+        <target state="new">Windows Metafile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RSE_Type_EMF">
+        <source>Extended Metafile</source>
+        <target state="new">Extended Metafile</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.pt-BR.xlf
@@ -2768,6 +2768,16 @@ Deseja atualizar o valor no arquivo .settings?</target>
         <target state="translated">Não é possível carregar '{0}' porque não é confiável.</target>
         <note>{0} is resx file name that is blocked</note>
       </trans-unit>
+      <trans-unit id="RSE_Type_WMF">
+        <source>Windows Metafile</source>
+        <target state="new">Windows Metafile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RSE_Type_EMF">
+        <source>Extended Metafile</source>
+        <target state="new">Extended Metafile</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ru.xlf
@@ -2768,6 +2768,16 @@ Do you want to update the value in the .settings file?</source>
         <target state="translated">Невозможно загрузить "{0}" из-за отсутствия доверия.</target>
         <note>{0} is resx file name that is blocked</note>
       </trans-unit>
+      <trans-unit id="RSE_Type_WMF">
+        <source>Windows Metafile</source>
+        <target state="new">Windows Metafile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RSE_Type_EMF">
+        <source>Extended Metafile</source>
+        <target state="new">Extended Metafile</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.tr.xlf
@@ -2768,6 +2768,16 @@ app.config dosyasındaki yeni değer: '{1}'
         <target state="translated">'{0}' dosyasına güvenilmediğinden dosya yüklenemiyor.</target>
         <note>{0} is resx file name that is blocked</note>
       </trans-unit>
+      <trans-unit id="RSE_Type_WMF">
+        <source>Windows Metafile</source>
+        <target state="new">Windows Metafile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RSE_Type_EMF">
+        <source>Extended Metafile</source>
+        <target state="new">Extended Metafile</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.zh-Hans.xlf
@@ -2768,6 +2768,16 @@ app.config 文件中的新值为“{1}”
         <target state="translated">无法加载“{0}”，因为它不受信任。</target>
         <note>{0} is resx file name that is blocked</note>
       </trans-unit>
+      <trans-unit id="RSE_Type_WMF">
+        <source>Windows Metafile</source>
+        <target state="new">Windows Metafile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RSE_Type_EMF">
+        <source>Extended Metafile</source>
+        <target state="new">Extended Metafile</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.zh-Hant.xlf
@@ -2768,6 +2768,16 @@ app.config 檔的新值是 '{1}'
         <target state="translated">因為 '{0}' 不受信任，所以無法予以載入。</target>
         <note>{0} is resx file name that is blocked</note>
       </trans-unit>
+      <trans-unit id="RSE_Type_WMF">
+        <source>Windows Metafile</source>
+        <target state="new">Windows Metafile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RSE_Type_EMF">
+        <source>Extended Metafile</source>
+        <target state="new">Extended Metafile</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Does just what the title says. I tested it with a metafile of my own creation, and it is added to the resx file, and from there to a PictureBox on a Form, with no issues.

Note: If you need a metafile to test with, just run `sc Sample.wmf $null` at a PowerShell prompt, then double-click the resulting empty file to open it in Paint. Add some content, then save, and poof: you now have a valid WMF file.

Fixes #3795.