### PR TITLE
handle  version number calculation

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -7,9 +7,10 @@
     <!-- 
       15.8 specific workaround for a change to BUILD_BUILDNUMBER format that added two more digits. 
       Any subsequent versions must have the same amount of digits to be considered higher.
-      Updates the version 20180102.03 to 20180102.0003.
+      Updates the version 20180102.03 to 20180102.0003 OR 20180102.3 to 20180102.0003
     -->
     <BUILD_BUILDNUMBER Condition="$(BUILD_BUILDNUMBER.Length) == 11">$(BUILD_BUILDNUMBER.Insert(9, '00'))</BUILD_BUILDNUMBER>
+    <BUILD_BUILDNUMBER Condition="$(BUILD_BUILDNUMBER.Length) == 10">$(BUILD_BUILDNUMBER.Insert(9, '000'))</BUILD_BUILDNUMBER>
 
     <!-- Opt-in repo features -->
     <UsingToolVSSDK>true</UsingToolVSSDK>


### PR DESCRIPTION
As part of this pr (https://github.com/dotnet/project-system/pull/3706) we attempted to pad the version numbers so 15.8 version number would line up correctly.

Unfortunately this logic was wrong as BUILD_BUILDNUMBER can come in one of the two formats:
- 20180102.03
- 20180102.3

This change accounts for the shorter format (10 characters).