### PR TITLE
generate dependent assembly versions for insertion tool

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -72,6 +72,7 @@ steps:
     CopyRoot: '$(Build.SourcesDirectory)'
     Contents: |
      artifacts\$(BuildConfiguration)\bin
+     artifacts\$(BuildConfiguration)\DevDivInsertionFiles
      artifacts\$(BuildConfiguration)\log
      artifacts\$(BuildConfiguration)\packages
      artifacts\$(BuildConfiguration)\VSSetup

--- a/build/Versions.props
+++ b/build/Versions.props
@@ -1,7 +1,9 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VersionBase Condition="'$(UseVisualStudioVersion)' == 'true'">16.0.0</VersionBase>
-    <VersionBase Condition="'$(UseVisualStudioVersion)' != 'true'">2.11.0</VersionBase>
+    <VisualStudioVersion>16.0.0</VisualStudioVersion>
+    <ProjectSystemVersion>2.11.0</ProjectSystemVersion>
+    <VersionBase Condition="'$(UseVisualStudioVersion)' == 'true'">$(VisualStudioVersion)</VersionBase>
+    <VersionBase Condition="'$(UseVisualStudioVersion)' != 'true'">$(ProjectSystemVersion)</VersionBase>
     <PreReleaseVersionLabel>beta2</PreReleaseVersionLabel>
 
     <!-- Opt-in repo features -->

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -140,6 +140,21 @@ function Clear-NuGetCache() {
   }
 }
 
+function GenerateDependentAssemblyVersionFile() {
+  $vsAssemblyName = "Microsoft.VisualStudio.Editors"
+  $visualStudioVersion = GetVersion("VisualStudioVersion")
+  $projectSystemAssemblyName = "Microsoft.VisualStudio.ProjectSystem.Managed"
+  $projectSystemVersion = GetVersion("ProjectSystemVersion")
+  $devDivInsertionFiles = Join-Path (Join-Path $ArtifactsDir $configuration) "DevDivInsertionFiles"
+  $dependentAssemblyVersionsCsv = Join-Path $devDivInsertionFiles "DependentAssemblyVersions.csv"
+  $csv =@"
+$vsAssemblyName, $visualStudioVersion.0
+$projectSystemAssemblyName, $projectSystemVersion.0
+"@
+  & mkdir $devDivInsertionFiles
+  $csv >> $dependentAssemblyVersionsCsv
+}
+
 try {
   $InVSEnvironment = !($env:VS150COMNTOOLS -eq $null) -and (Test-Path $env:VS150COMNTOOLS)
   $RepoRoot = Join-Path $PSScriptRoot "..\"
@@ -191,6 +206,11 @@ try {
   }
 
   Build
+  
+  if ($pack) {
+    GenerateDependentAssemblyVersionFile
+  }
+  
   exit $lastExitCode
 }
 catch {


### PR DESCRIPTION
Initial work needed to get https://github.com/dotnet/project-system/issues/3646 fixed.