### PR TITLE
Use Per Branch Build Folder

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -6,7 +6,7 @@ queue:
   demands: Cmd
 variables:
   BuildConfiguration: Release
-  TeamName: Roslyn-Project-System
+  TeamName: DotNet-Project-System
   BuildPlatform: any cpu
   DropRoot: \\cpvsbuild\drops\Roslyn
   
@@ -44,7 +44,7 @@ steps:
 - task: PublishSymbols@1
   displayName: Create Symbol Index
   inputs:
-    SymbolsPath: '$(DropRoot)\$(TeamName)\$(Build.DefinitionName)\$(Build.BuildNumber)\Symbols'
+    SymbolsPath: '$(DropRoot)\$(TeamName)\$(Build.SourceBranchName)\$(Build.BuildNumber)\Symbols'
     SearchPattern: '**/*.pdb;**/*.dll;**/*.exe'
     SymbolsFolder: '$(Build.SourcesDirectory)\artifacts\$(BuildConfiguration)\SymStore'
     SkipIndexing: true
@@ -58,7 +58,7 @@ steps:
   inputs:
     symbolServiceURI: 'https://microsoft.artifacts.visualstudio.com/DefaultCollection'
     requestName: '$(system.teamProject)/$(Build.DefinitionName)/$(Build.BuildNumber)/$(Build.BuildId)'
-    sourcePath: '$(DropRoot)\$(TeamName)\$(Build.DefinitionName)\$(Build.BuildNumber)\Symbols'
+    sourcePath: '$(DropRoot)\$(TeamName)\$(Build.SourceBranchName)\$(Build.BuildNumber)\Symbols'
     usePat: false
     
 - task: ms-vseng.MicroBuildTasks.4305a8de-ba66-4d8b-b2d1-0dc4ecbbf5e8.MicroBuildUploadVstsDropFolder@1
@@ -77,7 +77,7 @@ steps:
      artifacts\$(BuildConfiguration)\VSSetup
     ArtifactName: '$(Build.BuildNumber)'
     ArtifactType: FilePath
-    TargetPath: '$(DropRoot)\$(TeamName)\$(Build.DefinitionName)'
+    TargetPath: '$(DropRoot)\$(TeamName)\$(Build.SourceBranchName)'
   condition: succeededOrFailed()
 
 - task: NuGetPublisher@0
@@ -105,5 +105,5 @@ steps:
     PathtoPublish: '$(Build.StagingDirectory)\MicroBuild\Output'
     ArtifactName: '$(Build.BuildNumber)'
     publishLocation: FilePath
-    TargetPath: '$(DropRoot)\$(TeamName)\$(Build.DefinitionName)'
+    TargetPath: '$(DropRoot)\$(TeamName)\$(Build.SourceBranchName)'
   condition: succeededOrFailed()


### PR DESCRIPTION
place builds in
`\\CPVSBUILD\drops\Roslyn\DotNet-Project-System\$(SourceBranchName)\$(Build.BuildNumber)` instead of
`\\CPVSBUILD\drops\Roslyn\Roslyn-Project-System\DotNet-Project-System\$(Build.BuildNumber)`

Example:
`\\CPVSBUILD\drops\Roslyn\DotNet-Project-System\master\20180808.1`
vs.
`\\CPVSBUILD\drops\Roslyn\Roslyn-Project-System\DotNet-Project-System\20180808.1`