### PR TITLE
Fixed: Incorrect font used for the Debug page on project properties

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WpfBasedPropertyPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WpfBasedPropertyPage.cs
@@ -85,8 +85,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 HorizontalScrollBarVisibility = ScrollBarVisibility.Auto
             };
 
+            // Capture original WPF font
+            var originalFontFamily = viewer.FontFamily;
+            var originalFontSize = viewer.FontSize;
+
             viewer.Content = _control;
             _host.Child = viewer;
+
+            // Parenting viewer to ElementHost removes its default font,
+            // So we restore the font here.
+            viewer.FontFamily = originalFontFamily;
+            viewer.FontSize = originalFontSize;
 
             wpfHostPanel.Dock = DockStyle.Fill;
             wpfHostPanel.Controls.Add(_host);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WpfBasedPropertyPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WpfBasedPropertyPage.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 using System;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Forms;
 
@@ -82,11 +83,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             var viewer = new ScrollViewer
             {
                 VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
-                HorizontalScrollBarVisibility = ScrollBarVisibility.Auto
+                HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
             };
+            // Capture original WPF font
+            var originalFontFamily = viewer.FontFamily;
+            var originalFontSize = viewer.FontSize;
 
             viewer.Content = _control;
             _host.Child = viewer;
+
+            // Parenting viewer to ElementHost removes its default font,
+            // So we restore the font here.
+            viewer.FontFamily = originalFontFamily;
+            viewer.FontSize = originalFontSize;
 
             wpfHostPanel.Dock = DockStyle.Fill;
             wpfHostPanel.Controls.Add(_host);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WpfBasedPropertyPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WpfBasedPropertyPage.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 using System;
 using System.Threading.Tasks;
-using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Forms;
 
@@ -83,19 +82,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             var viewer = new ScrollViewer
             {
                 VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
-                HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
+                HorizontalScrollBarVisibility = ScrollBarVisibility.Auto
             };
-            // Capture original WPF font
-            var originalFontFamily = viewer.FontFamily;
-            var originalFontSize = viewer.FontSize;
 
             viewer.Content = _control;
             _host.Child = viewer;
-
-            // Parenting viewer to ElementHost removes its default font,
-            // So we restore the font here.
-            viewer.FontFamily = originalFontFamily;
-            viewer.FontSize = originalFontSize;
 
             wpfHostPanel.Dock = DockStyle.Fill;
             wpfHostPanel.Controls.Add(_host);


### PR DESCRIPTION
Fixed issue: https://github.com/dotnet/project-system/issues/2122

Adding a WPF control to ElementHost causes its default font to be removed. I think this is an expected behaviour to make WPF control looks the same to Windows form, however, we don't want that in this case.

This fix captures the font before hooking up the property page control with ElementHost, and restores it after.
