### PR TITLE
[Language Service]  Rename "EnsureInitialized" to "VerifyInitialized"

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractWorkspaceContextHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractWorkspaceContextHandler.cs
@@ -34,10 +34,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             _context = context;
         }
 
-        protected void EnsureInitialized()
+        protected void VerifyInitialized()
         {
-            if (_context == null)
-                throw new InvalidOperationException("Initialize must be called before calling this method.");
+            Verify.Operation(_context != null, "Must call Initialize(IWorkspaceProjectContext) first.");
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Requires.NotNull(removed, nameof(removed));
             Requires.NotNull(logger, nameof(logger));
 
-            EnsureInitialized();
+            VerifyInitialized();
 
             foreach (CommandLineSourceFile additionalFile in removed.AdditionalFiles)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Requires.NotNull(removed, nameof(removed));
             Requires.NotNull(logger, nameof(logger));
 
-            EnsureInitialized();
+            VerifyInitialized();
 
             foreach (CommandLineAnalyzerReference analyzer in removed.AnalyzerReferences)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Requires.NotNull(removed, nameof(removed));
             Requires.NotNull(logger, nameof(logger));
 
-            EnsureInitialized();
+            VerifyInitialized();
 
             foreach (CommandLineReference reference in removed.MetadataReferences)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Requires.NotNull(projectChange, nameof(projectChange));
             Requires.NotNull(logger, nameof(logger));
 
-            EnsureInitialized();
+            VerifyInitialized();
 
             // The language service wants both the intermediate (bin\obj) and output (bin\debug)) paths
             // so that it can automatically hook up project-to-project references. It does this by matching the 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Requires.NotNull(projectChange, nameof(projectChange));
             Requires.NotNull(logger, nameof(logger));
 
-            EnsureInitialized();
+            VerifyInitialized();
 
             ApplyEvaluationChanges(version, projectChange.Difference, projectChange.After.Items, isActiveContext, logger);
         }
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Requires.NotNull(removed, nameof(removed));
             Requires.NotNull(logger, nameof(logger));
 
-            EnsureInitialized();
+            VerifyInitialized();
 
             IProjectChangeDiff difference = ConvertToProjectDiff(added, removed);
 


### PR DESCRIPTION
We already use EnsureInitialized in OnceInitializedOnceDisposed to mean "initialize this instance if its not already", not "make sure we're initialized, otherwise, throw".