### PR TITLE
[Language Service] Add IImplicitlyActiveDimensionProvider

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/StringExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/StringExtensions.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft
+{
+    internal static class StringExtensions
+    {
+        public static string[] SplitReturningEmptyIfEmpty(this string value, char separator)
+        {
+            string[] values = value.Split(separator);
+
+            if (values.Length == 1 && string.IsNullOrEmpty(value))
+                return Array.Empty<string>();
+
+            return values;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IConfigurationDimensionDescriptionMetadataViewFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IConfigurationDimensionDescriptionMetadataViewFactory.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Configuration
+{
+    internal static class IConfigurationDimensionDescriptionMetadataViewFactory
+    {
+        public static IConfigurationDimensionDescriptionMetadataView Create(string[] dimensionNames, bool[] isVariantDimension)
+        {
+            var mock = new Mock<IConfigurationDimensionDescriptionMetadataView>();
+            mock.SetupGet(v => v.DimensionName)
+                .Returns(dimensionNames);
+
+            mock.SetupGet(v => v.IsVariantDimension)
+                .Returns(isVariantDimension);
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ImplicitlyActiveDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ImplicitlyActiveDimensionProviderTests.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Configuration
+{
+    public class ImplicitlyActiveDimensionProviderTests
+    {
+        [Fact]
+        public void GetImplicitlyActiveDimensions_NullAsDimensionNames_ThrowsArgumentNull()
+        {
+            var provider = CreateInstance();
+
+            Assert.Throws<ArgumentNullException>("dimensionNames", () =>
+            {
+                provider.GetImplicitlyActiveDimensions((IEnumerable<string>)null);
+            });
+        }
+
+        [Fact]
+        public void GetImplicitlyActiveDimensions_EmptyAsDimensionNames_ReturnsEmpty()
+        {
+            var provider = CreateInstance();
+
+            var result = provider.GetImplicitlyActiveDimensions(Enumerable.Empty<string>());
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void GetImplicitlyActiveDimensions_WhenNoProviders_ReturnsEmpty()
+        {
+            var provider = CreateInstance();
+
+            var result = provider.GetImplicitlyActiveDimensions(new string[] { "Configuration", "Platform" });
+
+            Assert.Empty(result);
+        }
+
+        [Theory]    // Input                                    All Dimensions                                                  Variant dimensions                        Expected
+        [InlineData("Configuration",                            "Configuration;Platform",                                       new[] { false, false },                   "")]
+        [InlineData("Configuration",                            "Configuration;Platform",                                       new[] { true, false },                    "Configuration")]
+        [InlineData("Configuration;Platform",                   "Configuration;Platform;TargetFramework",                       new[] { false, false, true },             "")]
+        [InlineData("Configuration;Platform;TargetFramework",   "Configuration;Platform;TargetFramework",                       new[] { false, false, true },             "TargetFramework")]
+        [InlineData("Configuration;Platform;TargetFramework",   "Configuration;Platform;TargetFramework",                       new[] { true, false, true },              "Configuration;TargetFramework")]
+        [InlineData("Configuration;Platform;TargetFramework",   "Configuration;Platform;TargetFramework",                       new[] { true, true, true },               "Configuration;Platform;TargetFramework")]
+        [InlineData("Configuration",                            "Configuration;Platform;TargetFramework",                       new[] { true, true, true },               "Configuration")]
+        [InlineData("Configuration;Platform",                   "Configuration;Platform;TargetFramework",                       new[] { true, true, true },               "Configuration;Platform")]
+        [InlineData("Configuration;Platform",                   "Configuration;Platform;TargetFramework;TargetFramework",       new[] { true, true, true, true },         "Configuration;Platform")]
+        public void GetImplicitlyActiveDimensions_ReturnsImplicitlyActiveDimensions(string dimensionNames, string allDimensionsNames, bool[] isVariantDimension, string expected)
+        {
+            var metadata = IConfigurationDimensionDescriptionMetadataViewFactory.Create(allDimensionsNames.SplitReturningEmptyIfEmpty(';'), isVariantDimension);
+
+            var provider = CreateInstance();
+            provider.DimensionProviders.Add(new Lazy<IProjectConfigurationDimensionsProvider, IConfigurationDimensionDescriptionMetadataView>(metadata));
+
+            var result = provider.GetImplicitlyActiveDimensions(dimensionNames.SplitReturningEmptyIfEmpty(';'));
+
+            Assert.Equal(expected.SplitReturningEmptyIfEmpty(';'), result);
+        }
+
+        private static ImplicitlyActiveDimensionProvider CreateInstance()
+        {
+            var project = UnconfiguredProjectFactory.Create();
+
+            return new ImplicitlyActiveDimensionProvider(project);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/IConfigurationDimensionDescriptionMetadataView.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/IConfigurationDimensionDescriptionMetadataView.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+
+namespace Microsoft.VisualStudio.ProjectSystem.Configuration
+{
+    /// <summary>
+    /// Provides a customized view to extract configuration dimension description data from <see cref="ConfigurationDimensionDescriptionAttribute"/>.
+    /// </summary>
+    public interface IConfigurationDimensionDescriptionMetadataView : IOrderPrecedenceMetadataView
+    {
+#pragma warning disable CA1819 // Properties should not return arrays
+
+        /// <summary>
+        /// Dimension names.
+        /// This must match <see cref="ConfigurationDimensionDescriptionAttribute.DimensionName"/>.
+        /// </summary>
+        string[] DimensionName { get; }
+
+
+        /// <summary>
+        /// Whether it is a dimension to calculate configuration groups.
+        /// This must match <see cref="ConfigurationDimensionDescriptionAttribute.IsVariantDimension"/>.
+        /// </summary>
+        bool[] IsVariantDimension { get; }
+
+#pragma warning restore CA1819 // Properties should not return arrays
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/IImplicitlyActiveDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/IImplicitlyActiveDimensionProvider.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Configuration
+{
+    /// <summary>
+    ///     Provides the implicitly active dimensions from a list of dimension names. 
+    /// </summary>
+    internal interface IImplicitlyActiveDimensionProvider
+    {
+        /// <summary>
+        ///     Returns the implicitly active dimension names from the specified dimension names.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="dimensionNames"/> is <see langword="null"/>.
+        /// </exception>
+        /// <remarks>
+        ///     NOTE: The returned order matches the order in which the dimension names and values 
+        ///     should be displayed to the user.
+        /// </remarks>
+        IEnumerable<string> GetImplicitlyActiveDimensions(IEnumerable<string> dimensionNames);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/ImplicitlyActiveDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/ImplicitlyActiveDimensionProvider.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Linq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Configuration
+{
+    /// <summary>
+    ///     Provides an implementation of <see cref="IImplicitlyActiveDimensionProvider"/> that bases
+    ///     itself on <see cref="IProjectConfigurationDimensionsProvider"/> instances.
+    /// </summary>
+    [Export(typeof(IImplicitlyActiveDimensionProvider))]
+    internal class ImplicitlyActiveDimensionProvider : IImplicitlyActiveDimensionProvider
+    {
+        private readonly Lazy<ImmutableArray<string>> _builtInImplicitlyActiveDimensions;
+
+        [ImportingConstructor]
+        public ImplicitlyActiveDimensionProvider(UnconfiguredProject project)
+        {
+            _builtInImplicitlyActiveDimensions = new Lazy<ImmutableArray<string>>(CalculateBuiltInImplicitlyActiveDimensions);
+
+            DimensionProviders = new OrderPrecedenceImportCollection<IProjectConfigurationDimensionsProvider, IConfigurationDimensionDescriptionMetadataView>(projectCapabilityCheckProvider: project);
+        }
+
+        [ImportMany]
+        internal OrderPrecedenceImportCollection<IProjectConfigurationDimensionsProvider, IConfigurationDimensionDescriptionMetadataView> DimensionProviders
+        {
+            get;
+        }
+
+        public IEnumerable<string> GetImplicitlyActiveDimensions(IEnumerable<string> dimensionNames)
+        {
+            Requires.NotNull(dimensionNames, nameof(dimensionNames));
+
+            ImmutableArray<string> builtInDimensions = _builtInImplicitlyActiveDimensions.Value;
+
+            // NOTE: Order matters; this must be in the order in which the providers are
+            // prioritized in 'builtInDimensions', of which Enumerable.Intersect guarantees.
+            return builtInDimensions.Intersect(dimensionNames, StringComparers.ConfigurationDimensionNames);
+        }
+
+        private ImmutableArray<string> CalculateBuiltInImplicitlyActiveDimensions()
+        {
+            var implicitlyActiveDimensions = ImmutableArray.CreateBuilder<string>();
+
+            foreach (Lazy<IProjectConfigurationDimensionsProvider, IConfigurationDimensionDescriptionMetadataView> provider in DimensionProviders)
+            {
+                for (int i = 0; i < provider.Metadata.IsVariantDimension.Length; i++)
+                {
+                    if (provider.Metadata.IsVariantDimension[i])
+                    {
+                        if (!implicitlyActiveDimensions.Contains(provider.Metadata.DimensionName[i], StringComparers.ConfigurationDimensionNames))
+                            implicitlyActiveDimensions.Add(provider.Metadata.DimensionName[i]);
+                    }
+                }
+            }
+
+            return implicitlyActiveDimensions.ToImmutable();
+        }
+    }
+}


### PR DESCRIPTION
Returns a set of implicitly active dimensions from specified set of dimensions, which can be used for disambiguation purposes. For example, in multi-targeting projects, the language service will use it in the context switch to distinguish in the following cases:

ClassLibrary (net45)
ClassLibrary (net46)

Consumption comes in a later PR.