### PR TITLE
[Language Service] Add ProjectFilePathAndDisplayNameEvaluationHandler

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IImplicitlyActiveDimensionProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IImplicitlyActiveDimensionProviderFactory.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Configuration
+{
+    internal static class IImplicitlyActiveDimensionProviderFactory
+    {
+        public static IImplicitlyActiveDimensionProvider Create()
+        {
+            return Mock.Of<IImplicitlyActiveDimensionProvider>();
+        }
+
+        public static IImplicitlyActiveDimensionProvider ImplementGetImplicitlyActiveDimensions(Func<IEnumerable<string>, IEnumerable<string>> action)
+        {
+            var mock = new Mock<IImplicitlyActiveDimensionProvider>();
+            mock.Setup(p => p.GetImplicitlyActiveDimensions(It.IsAny<IEnumerable<string>>()))
+                .Returns(action);
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectChangeDiffFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectChangeDiffFactory.cs
@@ -72,12 +72,12 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
     internal class IProjectChangeDiffModel : JsonModel<IProjectChangeDiff>, IProjectChangeDiff
     {
-        public IImmutableSet<string> AddedItems { get; set; }
+        public IImmutableSet<string> AddedItems { get; set; } = ImmutableHashSet<string>.Empty;
         public bool AnyChanges { get; set; }
-        public IImmutableSet<string> ChangedItems { get; set; }
-        public IImmutableSet<string> ChangedProperties { get; set; }
-        public IImmutableSet<string> RemovedItems { get; set; }
-        public IImmutableDictionary<string, string> RenamedItems { get; set; }
+        public IImmutableSet<string> ChangedItems { get; set; } = ImmutableHashSet<string>.Empty;
+        public IImmutableSet<string> ChangedProperties { get; set; } = ImmutableHashSet<string>.Empty;
+        public IImmutableSet<string> RemovedItems { get; set; } = ImmutableHashSet<string>.Empty;
+        public IImmutableDictionary<string, string> RenamedItems { get; set; } = ImmutableDictionary<string, string>.Empty;
 
         public override IProjectChangeDiff ToActualModel()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectConfigurationFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectConfigurationFactory.cs
@@ -13,6 +13,21 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return new StandardProjectConfiguration(name, dimensions);
         }
 
+        public static ProjectConfiguration Create(string dimensionNames, string dimensionValues)
+        {
+            var dimensionsBuilder = ImmutableDictionary.CreateBuilder<string, string>();
+
+            string[] dimensionNamesArray = dimensionNames.Split('|');
+            string[] dimensionValuesArray = dimensionValues.Split('|');
+
+            for (int i = 0; i < dimensionNamesArray.Length; i++)
+            {
+                dimensionsBuilder.Add(dimensionNamesArray[i], dimensionValuesArray[i]);
+            }
+
+            return Create(dimensionValues, dimensionsBuilder.ToImmutable());
+        }
+
         public static ProjectConfiguration Create(string configuration)
         {
             var dimensionsBuilder = ImmutableDictionary.CreateBuilder<string, string>();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/EvaluationHandlerTestBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/EvaluationHandlerTestBase.cs
@@ -75,6 +75,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             });
         }
 
+        internal static void Handle(IEvaluationHandler handler, IProjectChangeDescription projectChange)
+        {
+            handler.Handle(1, projectChange, false, IProjectLoggerFactory.Create());
+        }
+
         internal abstract IEvaluationHandler CreateInstance();
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/ProjectFilePathAndDisplayNameEvaluationHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/ProjectFilePathAndDisplayNameEvaluationHandlerTests.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Configuration;
+
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
+{
+    [Trait("UnitTest", "ProjectSystem")]
+    public class ProjectFilePathAndDisplayNameEvaluationHandlerTests : EvaluationHandlerTestBase
+    {
+        [Fact]
+        public void Handle_WhenMSBuildProjectFullPathPropertyNotChanged_DoesNothing()
+        {
+            var context = IWorkspaceProjectContextFactory.Create();
+            context.ProjectFilePath = @"ProjectFilePath";
+            context.DisplayName = "DisplayName";
+
+            var handler = CreateInstance(context: context);
+            
+            var projectChange = IProjectChangeDescriptionFactory.FromJson(
+@"{
+    ""Difference"": { 
+        ""AnyChanges"": true
+    }
+}");
+
+            Handle(handler, projectChange);
+
+            Assert.Equal(@"ProjectFilePath", context.ProjectFilePath);
+            Assert.Equal(@"DisplayName", context.DisplayName);
+        }
+
+        [Fact]
+        public void Handle_WhenMSBuildProjectFullPathPropertyChanged_SetsProjectFilePath()
+        {
+            var context = IWorkspaceProjectContextFactory.Create();
+            context.ProjectFilePath = @"ProjectFilePath";
+
+            var handler = CreateInstance(context: context);
+
+            var projectChange = IProjectChangeDescriptionFactory.FromJson(
+@"{
+    ""Difference"": { 
+        ""AnyChanges"": true,
+        ""ChangedProperties"": [ ""MSBuildProjectFullPath"" ]
+    },
+    ""After"": { 
+        ""Properties"": {
+            ""MSBuildProjectFullPath"": ""NewProjectFilePath""
+        }
+    }
+}");
+            Handle(handler, projectChange);
+
+            Assert.Equal(@"NewProjectFilePath", context.ProjectFilePath);
+        }
+
+        [Fact]
+        public void Handle_WhenMSBuildProjectFullPathPropertyChanged_SetsDisplayNameToFileNameWithoutExtension()
+        {
+            var context = IWorkspaceProjectContextFactory.Create();
+
+            var handler = CreateInstance(context: context);
+
+            var projectChange = IProjectChangeDescriptionFactory.FromJson(
+@"{
+    ""Difference"": { 
+        ""AnyChanges"": true,
+        ""ChangedProperties"": [ ""MSBuildProjectFullPath"" ]
+    },
+    ""After"": { 
+        ""Properties"": {
+            ""MSBuildProjectFullPath"": ""C:\\Project\\Project.csproj""
+        }
+    }
+}");
+            Handle(handler, projectChange);
+
+            Assert.Equal(@"Project", context.DisplayName);
+        }
+
+
+        [Theory] // Dimension Names                             Dimension Values       Implicit Dimension Names,                 Expected
+        [InlineData("Configuration",                            "Debug",               "",                                       "Project")]
+        [InlineData("Configuration",                            "Debug",               "Configuration",                          "Project (Debug)")]
+        [InlineData("Configuration|Platform",                   "Debug|AnyCPU",        "",                                       "Project")]
+        [InlineData("Configuration|Platform",                   "Debug|AnyCPU",        "Configuration",                          "Project (Debug)")]
+        [InlineData("Configuration|Platform",                   "Debug|AnyCPU",        "Configuration|Platform",                 "Project (Debug, AnyCPU)")]
+        [InlineData("Configuration|Platform|TargetFramework",   "Debug|AnyCPU|net45",  "",                                       "Project")]
+        [InlineData("Configuration|Platform|TargetFramework",   "Debug|AnyCPU|net45",  "Configuration",                          "Project (Debug)")]
+        [InlineData("Configuration|Platform|TargetFramework",   "Debug|AnyCPU|net45",  "Configuration|Platform",                 "Project (Debug, AnyCPU)")]
+        [InlineData("Configuration|Platform|TargetFramework",   "Debug|AnyCPU|net45",  "Configuration|Platform|TargetFramework", "Project (Debug, AnyCPU, net45)")]
+        [InlineData("Configuration|Platform|TargetFramework",   "Debug|AnyCPU|net45",  "TargetFramework",                        "Project (net45)")]
+        public void Handle_WhenMSBuildProjectFullPathPropertyChangedAndMultitargeting_IncludeDimensionValuesInDisplayName(string dimensionNames, string dimensionValues, string implicitDimensionNames, string expected)
+        {
+            var context = IWorkspaceProjectContextFactory.Create();
+            var implicitlyActiveDimensionProvider = IImplicitlyActiveDimensionProviderFactory.ImplementGetImplicitlyActiveDimensions(n => implicitDimensionNames.SplitReturningEmptyIfEmpty('|'));
+            var configuration = ProjectConfigurationFactory.Create(dimensionNames, dimensionValues);
+            var handler = CreateInstance(configuration, implicitlyActiveDimensionProvider, context);
+
+            var projectChange = IProjectChangeDescriptionFactory.FromJson(
+@"{
+    ""Difference"": { 
+        ""AnyChanges"": true,
+        ""ChangedProperties"": [ ""MSBuildProjectFullPath"" ]
+    },
+    ""After"": { 
+        ""Properties"": {
+            ""MSBuildProjectFullPath"": ""C:\\Project\\Project.csproj""
+        }
+    }
+}");
+            Handle(handler, projectChange);
+
+            Assert.Equal(expected, context.DisplayName);
+        }
+
+        internal override IEvaluationHandler CreateInstance()
+        {
+            return CreateInstance(null, null);
+        }
+
+        private ProjectFilePathAndDisplayNameEvaluationHandler CreateInstance(ProjectConfiguration configuration = null, IImplicitlyActiveDimensionProvider implicitlyActiveDimensionProvider = null, IWorkspaceProjectContext context = null)
+        {
+            var project = ConfiguredProjectFactory.ImplementProjectConfiguration(configuration ?? ProjectConfigurationFactory.Create("Debug|AnyCPU"));
+            implicitlyActiveDimensionProvider = implicitlyActiveDimensionProvider ?? IImplicitlyActiveDimensionProviderFactory.Create();
+
+            var handler = new ProjectFilePathAndDisplayNameEvaluationHandler(project, implicitlyActiveDimensionProvider);
+            if (context != null)
+                handler.Initialize(context);
+
+            return handler;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectFilePathAndDisplayNameEvaluationHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectFilePathAndDisplayNameEvaluationHandler.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Linq;
+
+using Microsoft.VisualStudio.ProjectSystem.Configuration;
+using Microsoft.VisualStudio.ProjectSystem.Logging;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
+{
+    /// <summary>
+    ///     Handles changes to the project file, and updates <see cref="IWorkspaceProjectContext.ProjectFilePath"/> 
+    ///     and <see cref="IWorkspaceProjectContext.DisplayName"/>.
+    /// </summary>
+    [Export(typeof(IWorkspaceContextHandler))]
+    internal class ProjectFilePathAndDisplayNameEvaluationHandler : AbstractWorkspaceContextHandler, IEvaluationHandler
+    {
+        private readonly ConfiguredProject _project;
+        private readonly IImplicitlyActiveDimensionProvider _implicitlyActiveDimensionProvider;
+
+        [ImportingConstructor]
+        public ProjectFilePathAndDisplayNameEvaluationHandler(ConfiguredProject project, IImplicitlyActiveDimensionProvider implicitlyActiveDimensionProvider)
+        {
+            _project = project;
+            _implicitlyActiveDimensionProvider = implicitlyActiveDimensionProvider;
+        }
+
+        public string EvaluationRule
+        {
+            get { return ConfigurationGeneral.SchemaName; }
+        }
+
+        public void Handle(IComparable version, IProjectChangeDescription projectChange, bool isActiveContext, IProjectLogger logger)
+        {
+            Requires.NotNull(version, nameof(version));
+            Requires.NotNull(projectChange, nameof(projectChange));
+            Requires.NotNull(logger, nameof(logger));
+
+            VerifyInitialized();
+
+            if (projectChange.Difference.ChangedProperties.Contains(ConfigurationGeneral.MSBuildProjectFullPathProperty))
+            {
+                string projectFilePath = projectChange.After.Properties[ConfigurationGeneral.MSBuildProjectFullPathProperty];
+                string displayName = GetDisplayName(projectFilePath);
+
+                logger.WriteLine("DisplayName: {0}", displayName);
+                logger.WriteLine("ProjectFilePath: {0}", projectFilePath);
+                
+                Context.ProjectFilePath = projectFilePath;
+                Context.DisplayName = displayName;
+            }
+        }
+
+        private string GetDisplayName(string projectFilePath)
+        {
+            // Calculate the display name to use for the editor context switch and project column
+            // in the Error List.
+            //
+            // When multi-targeting, we want to include the implicit dimension values in 
+            // the name to disambiguate it from other contexts in the same project. For example:
+            //
+            // ClassLibrary (net45)
+            // ClassLibrary (net46)
+
+            string projectName = Path.GetFileNameWithoutExtension(projectFilePath);
+
+            ProjectConfiguration configuration = _project.ProjectConfiguration;
+
+            IEnumerable<string> dimensionNames = _implicitlyActiveDimensionProvider.GetImplicitlyActiveDimensions(configuration.Dimensions.Keys);
+
+            string disambiguation = string.Join(", ", dimensionNames.Select(dimensionName => configuration.Dimensions[dimensionName]));
+            if (disambiguation.Length == 0)
+                return projectName;
+
+            return $"{projectName} ({disambiguation})";
+        }
+    }
+}


### PR DESCRIPTION
Handles changing the file name and display name in reaction to a project file being renamed. This unifies all logic of setting touching IWorkspaceProjectContext in handlers, which lets us coordinate changes and prevent overlapping.