### PR TITLE
[LanguageService] Fix ApplyChangesToWorkspaceContext MEF rejection

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContextTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContextTests.cs
@@ -572,7 +572,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var factories = handlers.Select(h => ExportFactoryFactory.ImplementCreateValueWithAutoDispose(() => h))
                                     .ToArray();
 
-            return new ApplyChangesToWorkspaceContext(project, commandLineParser, logger, factories);
+            var applyChangesToWorkspaceContext = new ApplyChangesToWorkspaceContext(project, logger, factories);
+
+            applyChangesToWorkspaceContext.CommandLineParsers.Add(commandLineParser);
+
+            return applyChangesToWorkspaceContext;
         }
     }
 }


### PR DESCRIPTION
ApplyChangesToWorkspaceContext was being rejected because each language provides a command-line parser, import them as an ImportMany.