### PR TITLE
Simplify VsContainedLanguageComponentsFactory logic

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectPropertiesFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectPropertiesFactory.cs
@@ -18,6 +18,23 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return Create(UnconfiguredProjectFactory.Create());
         }
 
+        public static ProjectProperties Create(string category, string propertyName, string value)
+        {
+            var data = new PropertyPageData()
+            {
+                Category = category,
+                PropertyName = propertyName,
+                Value = value,
+            };
+
+            return Create(data);
+        }
+
+        public static ProjectProperties Create(params PropertyPageData[] data)
+        {
+            return Create(UnconfiguredProjectFactory.Create(), data);
+        }
+               
         public static ProjectProperties Create(UnconfiguredProject project, params PropertyPageData[] data)
         {
             var catalog = CreateCatalog(CreateCatalogLookup(data));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IConfiguredProjectHostObjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IConfiguredProjectHostObjectFactory.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Shell.Interop;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
+{
+    internal static class IConfiguredProjectHostObjectFactory
+    {
+        public static IConfiguredProjectHostObject Create()
+        {
+            var mock = new Mock<IVsHierarchy>();
+
+            return mock.As<IConfiguredProjectHostObject>()
+                       .Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IOleAsyncServiceProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IOleAsyncServiceProviderFactory.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+using Moq;
+
+using IOleAsyncServiceProvider = Microsoft.VisualStudio.Shell.Interop.IAsyncServiceProvider;
+
+namespace Microsoft.VisualStudio.Shell.Interop
+{
+    internal static class IOleAsyncServiceProviderFactory
+    {
+        public static IOleAsyncServiceProvider ImplementQueryServiceAsync(object service, Guid clsid)
+        {
+            var mock = new Mock<IOleAsyncServiceProvider>();
+
+            mock.Setup(p => p.QueryServiceAsync(ref clsid))
+                .Returns(IVsTaskFactory.FromResult(service));
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectHostProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectHostProviderFactory.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
+{
+    internal static class IProjectHostProviderFactory
+    {
+        public static IProjectHostProvider Create()
+        {
+            return ImplementActiveIntellisenseProjectHostObject(null);
+        }
+
+        public static IProjectHostProvider ImplementActiveIntellisenseProjectHostObject(IConfiguredProjectHostObject hostObject)
+        {
+            var hostObjectMock = new Mock<IUnconfiguredProjectHostObject>();
+            hostObjectMock.Setup(o => o.ActiveIntellisenseProjectHostObject)
+                      .Returns(hostObject);
+
+            var mock = new Mock<IProjectHostProvider>();
+            mock.Setup(p => p.UnconfiguredProjectHostObject)
+                .Returns(hostObjectMock.Object);
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IUnconfiguredProjectVsServicesMock.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IUnconfiguredProjectVsServicesMock.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Shell.Interop;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    internal class IUnconfiguredProjectVsServicesMock : AbstractMock<IUnconfiguredProjectVsServices>
+    {
+        public IUnconfiguredProjectVsServicesMock ImplementVsProject(IVsProject4 project)
+        {
+            SetupGet(m => m.VsProject)
+                .Returns(project);
+
+            return this;
+        }
+
+        public IUnconfiguredProjectVsServicesMock ImplementThreadingService(IProjectThreadingService threadingService)
+        {
+            SetupGet(m => m.ThreadingService)
+                .Returns(threadingService);
+
+            return this;
+        }
+
+        public IUnconfiguredProjectVsServicesMock ImplementActiveConfiguredProjectProperties(ProjectProperties projectProperties)
+        {
+            SetupGet(m => m.ActiveConfiguredProjectProperties)
+                .Returns(projectProperties);
+
+            return this;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsContainedLanguageFactoryFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsContainedLanguageFactoryFactory.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Moq;
+
+namespace Microsoft.VisualStudio.TextManager.Interop
+{
+    internal static class IVsContainedLanguageFactoryFactory
+    {
+        public static IVsContainedLanguageFactory Create()
+        {
+            return Mock.Of<IVsContainedLanguageFactory>();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsProject_Factory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsProject_Factory.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-
+using Microsoft.VisualStudio.ProjectSystem.VS;
 using Moq;
 
 namespace Microsoft.VisualStudio.Shell.Interop
@@ -10,6 +10,26 @@ namespace Microsoft.VisualStudio.Shell.Interop
     // class.
     internal static class IVsProject_Factory
     {
+        public static IVsProject4 ImplementIsDocumentInProject(int hr)
+        {
+            return ImplementIsDocumentInProject(hr, found: 0, itemid: 0);
+        }
+
+        public static IVsProject4 ImplementIsDocumentInProject(bool found, uint itemid = 0)
+        {
+            return ImplementIsDocumentInProject(HResult.OK, found: found ? 1 : 0, itemid: itemid);
+        }
+
+        public static IVsProject4 ImplementIsDocumentInProject(int hr, int found, uint itemid)
+        {
+            var mock = new Mock<IVsProject4>();
+
+            mock.Setup(p => p.IsDocumentInProject(It.IsAny<string>(), out found, It.IsAny<VSDOCUMENTPRIORITY[]>(), out itemid))
+                .Returns(hr);
+
+            return mock.Object;
+        }
+
         public static void ImplementOpenItemWithSpecific(this IVsProject4 project, Guid editorType, Guid logicalView, int hr)
         {
             IVsWindowFrame frame;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsTaskFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsTaskFactory.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Moq;
+
+namespace Microsoft.VisualStudio.Shell.Interop
+{
+    internal static class IVsTaskFactory
+    {
+        public static IVsTask FromResult(object result)
+        {
+            var mock = new Mock<IVsTask>();
+
+            mock.Setup(t => t.IsCompleted)
+                .Returns(true);
+            mock.Setup(t => t.GetResult())
+                .Returns(result);
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactoryTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactoryTests.cs
@@ -1,0 +1,138 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.TextManager.Interop;
+
+using Xunit;
+
+using IOleAsyncServiceProvider = Microsoft.VisualStudio.Shell.Interop.IAsyncServiceProvider;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
+{
+    public class VsContainedLanguageComponentsFactoryTests
+    {
+        private const string LanguageServiceId = "{517FA117-46EB-4402-A0D5-D4B7D89FCC33}";
+
+        [Fact]
+        public void GetContainedLanguageFactoryForFile_WhenIsDocumentInProjectFails_ReturnE_FAIL()
+        {
+            var project = IVsProject_Factory.ImplementIsDocumentInProject(HResult.Fail);
+
+            var factory = CreateInstance(project: project);
+
+            var result = factory.GetContainedLanguageFactoryForFile("FilePath", out var hierarchyResult, out var itemIdResult, out var containedLanguageFactoryResult);
+
+            AssertFailed(result, hierarchyResult, itemIdResult, containedLanguageFactoryResult);
+        }
+
+        [Fact]
+        public void GetContainedLanguageFactoryForFile_WhenFilePathNotFound_ReturnE_FAIL()
+        {
+            var project = IVsProject_Factory.ImplementIsDocumentInProject(found: false);
+
+            var factory = CreateInstance(project: project);
+
+            var result = factory.GetContainedLanguageFactoryForFile("FilePath", out var hierarchyResult, out var itemIdResult, out var containedLanguageFactoryResult);
+
+            AssertFailed(result, hierarchyResult, itemIdResult, containedLanguageFactoryResult);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("ABC")]
+        [InlineData("ABCD-ABC")]
+        public void GetContainedLanguageFactoryForFile_WhenLanguageServiceIdEmptyOrInvalid_ReturnE_FAIL(string languageServiceId)
+        {
+            var project = IVsProject_Factory.ImplementIsDocumentInProject(found: true);
+            var properties = ProjectPropertiesFactory.Create(ConfigurationGeneral.SchemaName, ConfigurationGeneral.LanguageServiceIdProperty, languageServiceId);
+            var hostObject = IConfiguredProjectHostObjectFactory.Create();
+
+            var factory = CreateInstance(hostObject: hostObject, project: project, properties: properties);
+
+            var result = factory.GetContainedLanguageFactoryForFile("FilePath", out var hierarchyResult, out var itemIdResult, out var containedLanguageFactoryResult);
+
+            AssertFailed(result, hierarchyResult, itemIdResult, containedLanguageFactoryResult);
+        }
+
+        [Fact]
+        public void GetContainedLanguageFactoryForFile_WhenNoContainedLanguageFactory_ReturnE_FAIL()
+        {
+            var project = IVsProject_Factory.ImplementIsDocumentInProject(found: true);
+            var properties = ProjectPropertiesFactory.Create(ConfigurationGeneral.SchemaName, ConfigurationGeneral.LanguageServiceIdProperty, LanguageServiceId);
+            var hostObject = IConfiguredProjectHostObjectFactory.Create();
+
+            var factory = CreateInstance((IVsContainedLanguageFactory)null, hostObject: hostObject, project: project, properties: properties);
+
+            var result = factory.GetContainedLanguageFactoryForFile("FilePath", out var hierarchyResult, out var itemIdResult, out var containedLanguageFactoryResult);
+
+            AssertFailed(result, hierarchyResult, itemIdResult, containedLanguageFactoryResult);
+        }
+
+        [Fact]
+        public void GetContainedLanguageFactoryForFile_WhenNoActiveIntellisenseProjectHostObject_ReturnsE_FAIL()
+        {
+            var project = IVsProject_Factory.ImplementIsDocumentInProject(found: true);
+            var properties = ProjectPropertiesFactory.Create(ConfigurationGeneral.SchemaName, ConfigurationGeneral.LanguageServiceIdProperty, LanguageServiceId);
+            var containedLanguageFactory = IVsContainedLanguageFactoryFactory.Create();
+
+            var factory = CreateInstance(containedLanguageFactory, hostObject: null, project: project, properties: properties);
+
+            var result = factory.GetContainedLanguageFactoryForFile("FilePath", out var hierarchyResult, out var itemIdResult, out var containedLanguageFactoryResult);
+
+            AssertFailed(result, hierarchyResult, itemIdResult, containedLanguageFactoryResult);
+        }
+
+        [Fact]
+        public void GetContainedLanguageFactoryForFile_WhenReturnsResult_ReturnsS_OK()
+        {
+            var project = IVsProject_Factory.ImplementIsDocumentInProject(found: true, itemid: 1);
+            var properties = ProjectPropertiesFactory.Create(ConfigurationGeneral.SchemaName, ConfigurationGeneral.LanguageServiceIdProperty, LanguageServiceId);
+            var hostObject = IConfiguredProjectHostObjectFactory.Create();
+            var containedLanguageFactory = IVsContainedLanguageFactoryFactory.Create();
+            
+            var factory = CreateInstance(containedLanguageFactory, hostObject: hostObject, project: project, properties: properties);
+
+            var result = factory.GetContainedLanguageFactoryForFile("FilePath", out var hierarchyResult, out var itemIdResult, out var containedLanguageFactoryResult);
+
+            Assert.Equal(VSConstants.S_OK, result);
+            Assert.Same(hostObject, hierarchyResult);
+            Assert.Same(containedLanguageFactory, containedLanguageFactoryResult);
+            Assert.Equal(1u, itemIdResult);
+        }
+
+        private static void AssertFailed(int result, IVsHierarchy hierarchy, uint itemid, IVsContainedLanguageFactory containedLanguageFactory)
+        {
+            Assert.Equal(VSConstants.E_FAIL, result);
+            Assert.Null(hierarchy);
+            Assert.Null(containedLanguageFactory);
+            Assert.Equal((uint)VSConstants.VSITEMID.Nil, itemid);
+        }
+
+        private static VsContainedLanguageComponentsFactory CreateInstance(IVsContainedLanguageFactory containedLanguageFactory = null, IVsProject4 project = null, ProjectProperties properties = null, IConfiguredProjectHostObject hostObject = null, ILanguageServiceHost languageServiceHost = null)
+        {
+            var hostProvider = IProjectHostProviderFactory.ImplementActiveIntellisenseProjectHostObject(hostObject);
+            var serviceProvider = IOleAsyncServiceProviderFactory.ImplementQueryServiceAsync(containedLanguageFactory, new Guid(LanguageServiceId));
+
+            var projectVsServices = new IUnconfiguredProjectVsServicesMock();
+            projectVsServices.ImplementVsProject(project);
+            projectVsServices.ImplementThreadingService(new IProjectThreadingServiceMock());
+            projectVsServices.ImplementActiveConfiguredProjectProperties(properties);
+
+            return CreateInstance(serviceProvider, projectVsServices.Object, hostProvider, languageServiceHost);
+        }
+
+        private static VsContainedLanguageComponentsFactory CreateInstance(IOleAsyncServiceProvider serviceProvider = null, IUnconfiguredProjectVsServices projectVsServices = null, IProjectHostProvider projectHostProvider = null, ILanguageServiceHost languageServiceHost = null)
+        {
+            projectVsServices = projectVsServices ?? IUnconfiguredProjectVsServicesFactory.Create();
+            projectHostProvider = projectHostProvider ?? IProjectHostProviderFactory.Create();
+            languageServiceHost = languageServiceHost ?? ILanguageServiceHostFactory.Create();
+
+            return new VsContainedLanguageComponentsFactory(IVsServiceFactory.Create<SAsyncServiceProvider, IOleAsyncServiceProvider>(serviceProvider),
+                                                            projectVsServices,
+                                                            projectHostProvider,
+                                                            languageServiceHost);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
@@ -99,13 +99,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
                 : VSConstants.S_OK;
         }
 
-        public async Task<Guid?> GetLanguageServiceId()
+        private async Task<Guid?> GetLanguageServiceId()
         {
             ConfigurationGeneral properties = await _projectVsServices.ActiveConfiguredProjectProperties.GetConfigurationGeneralPropertiesAsync()
-                                                                                       .ConfigureAwait(false);
+                                                                                                        .ConfigureAwait(true);
 
             string languageServiceIdString = (string)await properties.LanguageServiceId.GetValueAsync()
-                                                                                    .ConfigureAwait(false);
+                                                                                       .ConfigureAwait(true);
             if (string.IsNullOrEmpty(languageServiceIdString))
                 return null;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
@@ -5,6 +5,7 @@ using System.ComponentModel.Composition;
 using System.Threading.Tasks;
 
 using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TextManager.Interop;
@@ -93,17 +94,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             ConfigurationGeneral properties = await _projectVsServices.ActiveConfiguredProjectProperties.GetConfigurationGeneralPropertiesAsync()
                                                                                                         .ConfigureAwait(true);
 
-            string languageServiceIdString = (string)await properties.LanguageServiceId.GetValueAsync()
-                                                                                       .ConfigureAwait(true);
-            if (string.IsNullOrEmpty(languageServiceIdString))
-                return Guid.Empty;
-
-            if (!Guid.TryParse(languageServiceIdString, out Guid languageServiceId))
-            {
-                return Guid.Empty;
-            }
-
-            return languageServiceId;
+            return await properties.LanguageServiceId.GetValueAsGuidAsync()
+                                                     .ConfigureAwait(true);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
@@ -49,15 +49,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             return Task.CompletedTask;
         }
 
-        /// <summary>
-        ///     Gets an object that represents a host-specific IVsContainedLanguageFactory implementation and
-        ///     IVsHierarchy and itemId specific to currently active target framework.
-        /// </summary>
-        /// <param name="filePath">Path to a file</param>
-        /// <param name="hierarchy">Project hierarchy containing given file for current language service</param>
-        /// <param name="itemid">item id of the given file</param>
-        /// <param name="containedLanguageFactory">an instance of IVsContainedLanguageFactory specific for current language service</param>
-        /// <returns></returns>
         public int GetContainedLanguageFactoryForFile(string filePath,
                                                       out IVsHierarchy hierarchy,
                                                       out uint itemid,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
@@ -31,16 +31,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         public VsContainedLanguageComponentsFactory(
             IUnconfiguredProjectCommonServices commonServices,
             IAsyncServiceProvider serviceProvider,
-            IUnconfiguredProjectVsServices projectServices,
+            IUnconfiguredProjectVsServices projectVsServices,
             IProjectHostProvider projectHostProvider,
             ILanguageServiceHost languageServiceHost)
         {
             _serviceProvider = serviceProvider;
-            _projectVsServices = projectServices;
+            _projectVsServices = projectVsServices;
             _projectHostProvider = projectHostProvider;
             _languageServiceHost = languageServiceHost;
 
-            _containedLanguageFactory = new AsyncLazy<IVsContainedLanguageFactory>(GetContainedLanguageFactoryAsync, projectServices.ThreadingService.JoinableTaskFactory);
+            _containedLanguageFactory = new AsyncLazy<IVsContainedLanguageFactory>(GetContainedLanguageFactoryAsync, projectVsServices.ThreadingService.JoinableTaskFactory);
         }
 
         public int GetContainedLanguageFactoryForFile(string filePath,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
@@ -26,11 +26,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         private readonly AsyncLazy<IVsContainedLanguageFactory> _containedLanguageFactory;
 
         [ImportingConstructor]
-        public VsContainedLanguageComponentsFactory(
-            IVsService<SAsyncServiceProvider, IOleAsyncServiceProvider> serviceProvider,
-            IUnconfiguredProjectVsServices projectVsServices,
-            IProjectHostProvider projectHostProvider,
-            ILanguageServiceHost languageServiceHost)
+        public VsContainedLanguageComponentsFactory(IVsService<SAsyncServiceProvider, IOleAsyncServiceProvider> serviceProvider,
+                                                    IUnconfiguredProjectVsServices projectVsServices,
+                                                    IProjectHostProvider projectHostProvider,
+                                                    ILanguageServiceHost languageServiceHost)
         {
             _serviceProvider = serviceProvider;
             _projectVsServices = projectVsServices;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
 
         [ImportingConstructor]
         public VsContainedLanguageComponentsFactory(
-            IAsyncServiceProvider serviceProvider,
+            [Import(typeof(SAsyncServiceProvider))]IAsyncServiceProvider serviceProvider,
             IUnconfiguredProjectVsServices projectVsServices,
             IProjectHostProvider projectHostProvider,
             ILanguageServiceHost languageServiceHost)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
@@ -52,12 +52,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             IVsHierarchy myHierarchy = null;
             IVsContainedLanguageFactory myContainedLanguageFactory = null;
 
-            _projectVsServices.ThreadingService.JoinableTaskFactory.Run(async () =>
+            _projectVsServices.ThreadingService.ExecuteSynchronously(async () =>
             {
                 await _languageServiceHost.InitializeAsync()
                                           .ConfigureAwait(true);
 
-                await _projectVsServices.ThreadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
+                await _projectVsServices.ThreadingService.SwitchToUIThread();
 
                 var priority = new VSDOCUMENTPRIORITY[1];
                 HResult result = _projectVsServices.VsProject.IsDocumentInProject(filePath,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
@@ -29,7 +29,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
 
         [ImportingConstructor]
         public VsContainedLanguageComponentsFactory(
-            IUnconfiguredProjectCommonServices commonServices,
             IAsyncServiceProvider serviceProvider,
             IUnconfiguredProjectVsServices projectVsServices,
             IProjectHostProvider projectHostProvider,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.ComponentModel.Composition;
-using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
@@ -13,7 +12,6 @@ using Microsoft.VisualStudio.Threading;
 
 using IAsyncServiceProvider = Microsoft.VisualStudio.Shell.IAsyncServiceProvider;
 using IOleAsyncServiceProvider = Microsoft.VisualStudio.Shell.Interop.IAsyncServiceProvider;
-using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
@@ -45,14 +45,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
                                                       out uint itemid,
                                                       out IVsContainedLanguageFactory containedLanguageFactory)
         {
-            var result = _projectVsServices.ThreadingService.ExecuteSynchronously(() =>
+            (hierarchy, itemid, containedLanguageFactory) = _projectVsServices.ThreadingService.ExecuteSynchronously(() =>
             {
                 return GetContainedLanguageFactoryForFileAsync(filePath);
             });
-
-            hierarchy = result.hierarchy;
-            itemid = result.itemid;
-            containedLanguageFactory = result.containedLanguageFactory;
 
             return (hierarchy == null || containedLanguageFactory == null) ? HResult.Fail : HResult.OK;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
@@ -90,11 +90,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
 
             object service = await serviceProvider.QueryServiceAsync(ref languageServiceId);
 
-            await _projectVsServices.ThreadingService.SwitchToUIThread();
-
             // NOTE: While this type is implemented in Roslyn, we force the cast on 
             // the UI thread because they are free to change this to an STA object
             // which would result in an RPC call from a background thread.
+            await _projectVsServices.ThreadingService.SwitchToUIThread();
+
             return (IVsContainedLanguageFactory)service;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
@@ -85,7 +85,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             if (languageServiceId == Guid.Empty)
                 return null;
 
-            object service = await _serviceProvider.Value.QueryServiceAsync(ref languageServiceId);
+            IOleAsyncServiceProvider serviceProvider = await _serviceProvider.GetValueAsync()
+                                                                             .ConfigureAwait(true);
+
+            object service = await serviceProvider.QueryServiceAsync(ref languageServiceId);
 
             await _projectVsServices.ThreadingService.SwitchToUIThread();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/PropertyExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/PropertyExtensions.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties
+{
+    /// <summary>
+    ///     Provides extension methods for <see cref="IProperty"/> instances.
+    /// </summary>
+    internal static class PropertyExtensions
+    {
+        /// <summary>
+        ///     Returns the value of the specific <see cref="IProperty"/> as <see cref="Guid"/>
+        ///     or <see cref="Guid.Empty"/> if the value cannot be parsed.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="property"/> is <see langword="null"/>.
+        /// </exception>
+        public static async Task<Guid> GetValueAsGuidAsync(this IProperty property)
+        {
+            Requires.NotNull(property, nameof(property));
+
+            string value = (string)await property.GetValueAsync()
+                                                 .ConfigureAwait(true);
+
+            if (Guid.TryParse(value, out Guid result))
+            {
+                return result;
+            }
+
+            return Guid.Empty;
+        }
+    }
+}


### PR DESCRIPTION
- Only look up IVsContainedLanguageFactory/LanguageServiceId once
- Remove base class, only need to just wait on InitializeAsync from the language service
- Move to CPS pattern of sync method calling async method

Tests forecoming as it doesn't have any. Confirmed that Razor plays nicely with these changes.