### PR TITLE
Turn off IDE0001 in test code due to regression

### DIFF
--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -19,7 +19,10 @@
     <Rule Id="RS0023" Action="None" />
   </Rules>
    <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
-     <!-- Naming styles is too noisy as it fires on all async tests -->
+    <!-- Too noisy due to https://github.com/dotnet/roslyn/issues/27819 -->
+    <Rule Id="IDE0001" Action="None" />                       <!-- Simplify names                               System.Version version;                             Version version;                      -->
+
+     <!-- Naming styles is too noisy as it fires on all async tests -->     
     <Rule Id="IDE1006" Action="None" />                       <!-- Naming styles                                Task Open()                                         Task OpenAsync()                      -->
     <Rule Id="IDE1006WithoutSuggestion" Action="None" />
   </Rules>


### PR DESCRIPTION
'Var' usage in test code is marked as "refactoring-only" but due to https://github.com/dotnet/roslyn/issues/27819, all explicit type usage is marked as an error.