### PR TITLE
Get Visual Studio code coverage working

### DIFF
--- a/src/CodeCoverage.runsettings
+++ b/src/CodeCoverage.runsettings
@@ -45,11 +45,7 @@ Included items must then not match any entries in the exclude list to remain inc
                 <ModulePath>.*\.exe$</ModulePath>
               </Include>
               <Exclude>
-                <ModulePath>.*CPPUnitTestFramework.*</ModulePath>
-                <ModulePath>.*TestAdapter.*</ModulePath>
-                <ModulePath>.*UnitTests.*</ModulePath>
-                <ModulePath>.*xunit.*</ModulePath>
-                <ModulePath>.*threading.*</ModulePath>  
+
               </Exclude>
             </ModulePaths>
 
@@ -75,9 +71,6 @@ Included items must then not match any entries in the exclude list to remain inc
                 <Attribute>^System.Runtime.CompilerServices.CompilerGeneratedAttribute$</Attribute>
                 <Attribute>^System.CodeDom.Compiler.GeneratedCodeAttribute$</Attribute>
                 <Attribute>^System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute$</Attribute>
-                <Attribute>^NUnit.Framework.TestFixtureAttribute$</Attribute>
-                <Attribute>^Xunit.FactAttribute$</Attribute>
-                <Attribute>^Microsoft.VisualStudio.TestTools.UnitTesting.TestClassAttribute$</Attribute>
               </Exclude>
             </Attributes>
 
@@ -89,6 +82,7 @@ Included items must then not match any entries in the exclude list to remain inc
                 <Source>.*\\public\\sdk\\.*</Source>
                 <Source>.*\\microsoft sdks\\.*</Source>
                 <Source>.*\\vc\\include\\.*</Source>
+                <Source>.*\\Mocks\\.*</Source>
               </Exclude>
             </Sources>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -10,6 +10,13 @@
   <Import Project="$(RepoToolsetDir)Settings.props" Condition="'$(RepoToolsetDir)' != ''" />
   <Import Project="..\build\VisualStudio.XamlRules.props" />
 
+  <PropertyGroup>
+    <_IsVisualStudioDeveloperBuild Condition="'$(OfficialBuild)' != 'true' AND $(CIBuild) != 'true' AND '$(BuildingInsideVisualStudio)' == 'true'">true</_IsVisualStudioDeveloperBuild>
+
+    <!-- Code Coverage doesn't currently work for portable/embedded PDBs - force to full inside Visual Studio builds -->
+    <DebugType Condition="'$(_IsVisualStudioDeveloperBuild)' == 'true'">full</DebugType>
+  </PropertyGroup>
+  
   <PropertyGroup Condition="'$(Language)' == 'C#'">
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
     <LangVersion>7.2</LangVersion>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,7 +11,7 @@
   <Import Project="..\build\VisualStudio.XamlRules.props" />
 
   <PropertyGroup>
-    <_IsVisualStudioDeveloperBuild Condition="'$(OfficialBuild)' != 'true' AND $(CIBuild) != 'true' AND '$(BuildingInsideVisualStudio)' == 'true'">true</_IsVisualStudioDeveloperBuild>
+    <_IsVisualStudioDeveloperBuild Condition="'$(OfficialBuild)' != 'true' AND '$(CIBuild)' != 'true' AND '$(BuildingInsideVisualStudio)' == 'true'">true</_IsVisualStudioDeveloperBuild>
 
     <!-- Code Coverage doesn't currently work for portable/embedded PDBs - force to full inside Visual Studio builds -->
     <DebugType Condition="'$(_IsVisualStudioDeveloperBuild)' == 'true'">full</DebugType>


### PR DESCRIPTION
This makes Code Coverage work in Visual Studio again, also updated code coverage settings to match CodeCov.