### PR TITLE
Enabling NuGet project lock file options for NetCore SDK projects

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -134,4 +134,16 @@
                     Visible="False" 
                     ReadOnly="True" />
 
+    <StringProperty Name="RestorePackagesWithLockFile"
+                    Visible="False"
+                    ReadOnly="True" />
+
+    <StringProperty Name="RestoreLockedMode"
+                    Visible="False"
+                    ReadOnly="True" />
+
+    <StringProperty Name="NuGetLockFilePath"
+                    Visible="False"
+                    ReadOnly="True" />
+
 </Rule>


### PR DESCRIPTION
Since We (NuGet) is working on enabling NuGet project lock file for VS 15.9, this PR is to SDK projects to pass lock file options during nomination for restore.

Feature Spec - https://github.com/NuGet/Home/wiki/Enable-repeatable-package-restore-using-lock-file#extensibility

Let me know if this isn't the right branch to target 15.9. Also, the feature is already approved for 15.9.