### PR TITLE
Centralize telemetry events

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
@@ -22,11 +21,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     [AppliesTo(ProjectCapability.DependenciesTree)]
     internal class DependencyTreeTelemetryService : IDependencyTreeTelemetryService
     {
-        private const string TelemetryEventName = "TreeUpdated";
-        private const string UnresolvedLabel = "Unresolved";
-        private const string ResolvedLabel = "Resolved";
-        private const string ProjectProperty = "Project";
-        private const string ObservedAllRulesProperty = "ObservedAllRules";
         private const int MaxEventCount = 10;
 
         private readonly UnconfiguredProject _project;
@@ -113,13 +107,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 InitializeProjectId();
             }
 
-            _telemetryService.PostProperties(
-                FormattableString.Invariant($"{TelemetryEventName}/{(hasUnresolvedDependency ? UnresolvedLabel : ResolvedLabel)}"),
-                new List<(string, object)>
+            if (hasUnresolvedDependency)
+            {
+                _telemetryService.PostProperties(TelemetryEventName.TreeUpdatedUnresolved, new[] 
                 {
-                    (ProjectProperty, _projectId),
-                    (ObservedAllRulesProperty, observedAllRules)
+                    (TelemetryPropertyName.TreeUpdatedUnresolvedProject, (object)_projectId),
+                    (TelemetryPropertyName.TreeUpdatedUnresolvedObservedAllRules, observedAllRules)
                 });
+            }
+            else
+            {
+                _telemetryService.PostProperties(TelemetryEventName.TreeUpdatedResolved, new[] 
+                {
+                    (TelemetryPropertyName.TreeUpdatedResolvedProject, (object)_projectId),
+                    (TelemetryPropertyName.TreeUpdatedResolvedObservedAllRules, observedAllRules)
+                });
+            }
         }
 
         private void InitializeProjectId()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/DesignTimeTelemetryLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/DesignTimeTelemetryLogger.cs
@@ -67,10 +67,10 @@ namespace Microsoft.VisualStudio.Telemetry
 
             string targetResults = builder.ToString();
 
-            _telemetryService.PostProperties("DesignTimeBuildComplete", new[]
+            _telemetryService.PostProperties(TelemetryEventName.DesignTimeBuildComplete, new[]
             {
-                ("Succeeded", (object)_succeeded),
-                ("Targets", targetResults)
+                (TelemetryPropertyName.DesignTimeBuildCompleteSucceeded, (object)_succeeded),
+                (TelemetryPropertyName.DesignTimeBuildCompleteTargets, targetResults)
             });
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/VsTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/VsTelemetryService.cs
@@ -42,10 +42,7 @@ namespace Microsoft.VisualStudio.Telemetry
             return fullPropertyName;
         }
 
-        /// <summary>
-        /// Post an event with the event name.
-        /// </summary>
-        /// <param name="eventName">Name of the event.</param>
+  
         public void PostEvent(string eventName)
         {
             Requires.NotNullOrEmpty(eventName, nameof(eventName));
@@ -54,12 +51,6 @@ namespace Microsoft.VisualStudio.Telemetry
             TelemetryService.DefaultSession.PostEvent(telemetryEvent);
         }
 
-        /// <summary>
-        /// Post an event with the event name also with the corresponding Property name and Property value.
-        /// </summary>
-        /// <param name="eventName">Name of the event.</param>
-        /// <param name="propertyName">Property name to be reported.</param>
-        /// <param name="propertyValue">Property value to be reported.</param>
         public void PostProperty(string eventName, string propertyName, object propertyValue)
         {
             Requires.NotNullOrEmpty(eventName, nameof(eventName));
@@ -70,12 +61,7 @@ namespace Microsoft.VisualStudio.Telemetry
             telemetryEvent.Properties.Add(BuildPropertyName(eventName, propertyName), propertyValue);
             TelemetryService.DefaultSession.PostEvent(telemetryEvent);
         }
-
-        /// <summary>
-        /// Post an event with the event name also with the corresponding Property names and Property values.
-        /// </summary>
-        /// <param name="eventName">Name of the event.</param>
-        /// <param name="properties">List of Property name and corresponding values. PropertyName and PropertyValue cannot be null or empty.</param>
+      
         public void PostProperties(string eventName, IEnumerable<(string propertyName, object propertyValue)> properties)
         {
             Requires.NotNullOrEmpty(eventName, nameof(eventName));
@@ -90,11 +76,6 @@ namespace Microsoft.VisualStudio.Telemetry
             TelemetryService.DefaultSession.PostEvent(telemetryEvent);
         }
 
-        /// <summary>
-        /// Hashes personally identifiable information for telemetry consumption.
-        /// </summary>
-        /// <param name="value">Value to hashed.</param>
-        /// <returns>Hashed value.</returns>
         public string HashValue(string value)
         {
             // Don't hash PII for internal users since we don't need to.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -24,7 +24,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         private const string CopyToOutputDirectory = "CopyToOutputDirectory";
         private const string PreserveNewest = "PreserveNewest";
         private const string Always = "Always";
-        private const string TelemetryEventName = "UpToDateCheck";
         private const string Link = "Link";
 
         private static ImmutableHashSet<string> ReferenceSchemas => ImmutableStringHashSet.EmptyOrdinal
@@ -313,7 +312,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         private bool Fail(BuildUpToDateCheckLogger logger, string message, string reason)
         {
             logger.Info(message);
-            _telemetryService.PostProperty($"{TelemetryEventName}/Fail", "Reason", reason);
+            _telemetryService.PostProperty(TelemetryEventName.UpToDateCheckFail, TelemetryPropertyName.UpToDateCheckFailReason, reason);
             return false;
         }
 
@@ -622,23 +621,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             if (!markersUpToDate)
             {
-                _telemetryService.PostProperty($"{TelemetryEventName}/Fail", "Reason", "Marker");
+                _telemetryService.PostProperty(TelemetryEventName.UpToDateCheckFail, TelemetryPropertyName.UpToDateCheckFailReason, "Marker");
             }
             else if (!outputsUpToDate)
             {
-                _telemetryService.PostProperty($"{TelemetryEventName}/Fail", "Reason", "Outputs");
+                _telemetryService.PostProperty(TelemetryEventName.UpToDateCheckFail, TelemetryPropertyName.UpToDateCheckFailReason, "Outputs");
             }
             else if (!copyToOutputDirectoryUpToDate)
             {
-                _telemetryService.PostProperty($"{TelemetryEventName}/Fail", "Reason", "CopyToOutputDirectory");
+                _telemetryService.PostProperty(TelemetryEventName.UpToDateCheckFail, TelemetryPropertyName.UpToDateCheckFailReason, "CopyToOutputDirectory");
             }
             else if (!copiedOutputUpToDate)
             {
-                _telemetryService.PostProperty($"{TelemetryEventName}/Fail", "Reason", "CopyOutput");
+                _telemetryService.PostProperty(TelemetryEventName.UpToDateCheckFail, TelemetryPropertyName.UpToDateCheckFailReason, "CopyOutput");
             }
             else
             {
-                _telemetryService.PostEvent($"{TelemetryEventName}/Success");
+                _telemetryService.PostEvent(TelemetryEventName.UpToDateCheckSuccess);
             }
 
             logger.Info("Project is{0} up to date.", !isUpToDate ? " not" : "");

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ITelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ITelemetryService.cs
@@ -6,9 +6,32 @@ namespace Microsoft.VisualStudio.Telemetry
 {
     internal interface ITelemetryService
     {
+        /// <summary>
+        /// Post an event with the event name.
+        /// </summary>
+        /// <param name="eventName">Name of the event.</param>
         void PostEvent(string eventName);
+
+        /// <summary>
+        /// Post an event with the event name also with the corresponding Property name and Property value.
+        /// </summary>
+        /// <param name="eventName">Name of the event.</param>
+        /// <param name="propertyName">Property name to be reported.</param>
+        /// <param name="propertyValue">Property value to be reported.</param>
         void PostProperty(string eventName, string propertyName, object propertyValue);
+
+        /// <summary>
+        /// Post an event with the event name also with the corresponding Property names and Property values.
+        /// </summary>
+        /// <param name="eventName">Name of the event.</param>
+        /// <param name="properties">List of Property name and corresponding values. PropertyName and PropertyValue cannot be null or empty.</param>
         void PostProperties(string eventName, IEnumerable<(string propertyName, object propertyValue)> properties);
+
+        /// <summary>
+        /// Hashes personally identifiable information for telemetry consumption.
+        /// </summary>
+        /// <param name="value">Value to hashed.</param>
+        /// <returns>Hashed value.</returns>
         string HashValue(string value);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryEventName.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryEventName.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.Telemetry
+{
+    /// <summary>
+    ///     Provides telemetry event names used throughout this project.
+    /// </summary>
+    internal static class TelemetryEventName
+    {
+        /// <summary>
+        ///     Indicates the prefix (vs/projectsystem/managed/) of all event names throughout this project.
+        /// </summary>
+        public const string Prefix = "vs/projectsystem/managed";
+
+        /// <summary>
+        ///     Indicates that a project's last build is considered up-to-date.
+        /// </summary>
+        public static readonly string UpToDateCheckSuccess = BuildEventName("UpToDateCheck/Success");
+
+        /// <summary>
+        ///     Indicates that a project's last build is considered out-of-date.
+        /// </summary>
+        public static readonly string UpToDateCheckFail = BuildEventName("UpToDateCheck/Fail");
+
+        /// <summary>
+        ///     Indicates that the dependency tree was updated with unresolved dependencies.
+        /// </summary>
+        public static readonly string TreeUpdatedUnresolved = BuildEventName("TreeUpdated/Unresolved");
+
+        /// <summary>
+        ///     Indicates that the dependency tree was updated with all resolved dependencies.
+        /// </summary>
+        public static readonly string TreeUpdatedResolved = BuildEventName("TreeUpdated/Resolved");
+
+        /// <summary>
+        ///     Inidicate that a design-time build has completed.
+        /// </summary>
+        public static readonly string DesignTimeBuildComplete = BuildEventName("DesignTimeBuildComplete");
+
+        private static string BuildEventName(string eventName)
+        {
+            return Prefix + "/" + eventName.ToLowerInvariant();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryPropertyName.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryPropertyName.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.Telemetry
+{
+    /// <summary>
+    ///     Provides telemetry property names used throughout this project.
+    /// </summary>
+    internal static class TelemetryPropertyName
+    {
+        /// <summary>
+        ///     Indicates the prefix (vs.projectsystem.managed) of all property names throughout this project.
+        /// </summary>
+        public const string Prefix = "vs.projectsystem.managed";
+
+        /// <summary>
+        ///     Indicates the reason that a project's last build is considered out-of-date.
+        /// </summary>
+        public static readonly string UpToDateCheckFailReason = BuildPropertyName(TelemetryEventName.UpToDateCheckFail, "Reason");
+
+        /// <summary>
+        ///     Indicates the project when the dependency tree is updated with all resolved dependencies.
+        /// </summary>
+        public static readonly string TreeUpdatedResolvedProject = BuildPropertyName(TelemetryEventName.TreeUpdatedResolved, "Project");
+
+        /// <summary>
+        ///     Indicates the project when when the dependency tree is updated with unresolved dependencies.
+        /// </summary>
+        public static readonly string TreeUpdatedUnresolvedProject = BuildPropertyName(TelemetryEventName.TreeUpdatedUnresolved, "Project");
+
+        /// <summary>
+        ///     Indicates whether seen all rules initialized when the dependency tree is updated with all resolved dependencies.
+        /// </summary>
+        public static readonly string TreeUpdatedResolvedObservedAllRules = BuildPropertyName(TelemetryEventName.TreeUpdatedResolved, "ObservedAllRules");
+
+        /// <summary>
+        ///      Indicates whether seen all rules initialized when the dependency tree is updated with unresolved dependencies.
+        /// </summary>
+        public static readonly string TreeUpdatedUnresolvedObservedAllRules = BuildPropertyName(TelemetryEventName.TreeUpdatedUnresolved, "ObservedAllRules");
+
+        /// <summary>
+        ///     Indicates whether a design-time build has completed without errors.
+        /// </summary>
+        public static readonly string DesignTimeBuildCompleteSucceeded = BuildPropertyName(TelemetryEventName.DesignTimeBuildComplete, "Succeeded");
+
+        /// <summary>
+        ///     Indicates the targets and their times during a design-time build.
+        /// </summary>
+        public static readonly string DesignTimeBuildCompleteTargets = BuildPropertyName(TelemetryEventName.DesignTimeBuildComplete, "Targets");
+
+        private static string BuildPropertyName(string eventName, string propertyName)
+        {
+            // Property names use the event names, but with slashes replaced by periods.
+            // For example, vs/myevent would translate to vs.myevent.myproperty.
+            string prefix = eventName.Replace('/', '.');
+
+            Assumes.False(prefix.EndsWith("."));
+
+            return prefix + "." + propertyName.ToLowerInvariant();
+        }
+    }
+}


### PR DESCRIPTION
We have complicated logic inside VsTelemetryService to avoid allocating event and property names, centralize all names into a static class.