### PR TITLE
Remove configuration of IDE0001 severity

### DIFF
--- a/build/Default.ruleset
+++ b/build/Default.ruleset
@@ -122,7 +122,6 @@
   </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
                                                               <!-- Name:                                        Before:                                             After:                                -->
-    <Rule Id="IDE0001" Action="Error" />                      <!-- Simplify names                               System.Version version;                             Version version;                      -->
     <Rule Id="IDE0002" Action="Error" />                      <!-- Simplify (member access)                     System.Version.Equals("1", "2");                    Version.Equals("1", "2");             -->
     <Rule Id="IDE0003" Action="Error" />                      <!-- Remove qualification                         this.X = x;                                         X = x;                                -->
     <Rule Id="IDE0005" Action="Error" />                      <!-- Using directive is unnecessary               using System.Text;                                                                        -->

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -19,9 +19,6 @@
     <Rule Id="RS0023" Action="None" />
   </Rules>
    <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
-    <!-- Too noisy due to https://github.com/dotnet/roslyn/issues/27819 -->
-    <Rule Id="IDE0001" Action="None" />                       <!-- Simplify names                               System.Version version;                             Version version;                      -->
-
      <!-- Naming styles is too noisy as it fires on all async tests -->     
     <Rule Id="IDE1006" Action="None" />                       <!-- Naming styles                                Task Open()                                         Task OpenAsync()                      -->
     <Rule Id="IDE1006WithoutSuggestion" Action="None" />


### PR DESCRIPTION
This diagnostic is not covered by a stable versioning policy (i.e. the behavior of the diagnostic is subject to change between VS releases). It is not intended for use at any severity other than Hidden (the default) or Suggestion. This commit removes the use of a rule set file to set this to Error, since it can (and in some cases does) result in unspecified diagnostic churn between VS updates.