### PR TITLE
Move sets of ImageMonikers into their own type

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SubTreeRootDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SubTreeRootDependencyModelTests.cs
@@ -13,12 +13,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         [Fact]
         public void SubTreeRootDependencyModelTest()
         {
+            var iconSet = new DependencyIconSet(
+                icon: KnownMonikers.AboutBox,
+                expandedIcon: KnownMonikers.AboutBox,
+                unresolvedIcon: KnownMonikers.AbsolutePosition,
+                unresolvedExpandedIcon: KnownMonikers.AbsolutePosition);
             var flag = ProjectTreeFlags.Create("MyCustomFlag");
             var model = new SubTreeRootDependencyModel(
                 "myProvider",
                 "myRoot",
-                KnownMonikers.AboutBox,
-                KnownMonikers.AbsolutePosition,
+                iconSet,
                 flags: flag);
 
             Assert.Equal("myProvider", model.ProviderType);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyIconSet.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyIconSet.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Imaging.Interop;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
+{
+    /// <summary>
+    /// Represents the set of icons associated with a particular dependency.
+    /// In practice dependencies use a relatively small number of distinct icon
+    /// sets; we can save considerable amounts of memory by given the sets their
+    /// own type and sharing instances.
+    /// </summary>
+    internal sealed class DependencyIconSet
+    {
+        public DependencyIconSet(ImageMoniker icon, ImageMoniker expandedIcon, ImageMoniker unresolvedIcon, ImageMoniker unresolvedExpandedIcon)
+        {
+            Icon = icon;
+            ExpandedIcon = expandedIcon;
+            UnresolvedIcon = unresolvedIcon;
+            UnresolvedExpandedIcon = unresolvedExpandedIcon;
+        }
+
+        public ImageMoniker Icon { get; }
+        public ImageMoniker ExpandedIcon { get; }
+        public ImageMoniker UnresolvedIcon { get; }
+        public ImageMoniker UnresolvedExpandedIcon { get; }
+
+        public DependencyIconSet WithIcon(ImageMoniker newIcon)
+        {
+            if (Icon.Id == newIcon.Id && Icon.Guid == newIcon.Guid)
+            {
+                return this;
+            }
+
+            return new DependencyIconSet(newIcon, ExpandedIcon, UnresolvedIcon, UnresolvedExpandedIcon);
+        }
+
+        public DependencyIconSet WithExpandedIcon(ImageMoniker newExpandedIcon)
+        {
+            if (ExpandedIcon.Id == newExpandedIcon.Id && ExpandedIcon.Guid == newExpandedIcon.Guid)
+            {
+                return this;
+            }
+
+            return new DependencyIconSet(Icon, newExpandedIcon, UnresolvedIcon, UnresolvedExpandedIcon);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/AnalyzerDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/AnalyzerDependencyModel.cs
@@ -9,6 +9,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
     internal class AnalyzerDependencyModel : DependencyModel
     {
+        private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
+            icon: KnownMonikers.CodeInformation,
+            expandedIcon: KnownMonikers.CodeInformation,
+            unresolvedIcon: ManagedImageMonikers.CodeInformationWarning,
+            unresolvedExpandedIcon: ManagedImageMonikers.CodeInformationWarning);
+
+        private static readonly DependencyIconSet s_implicitIconSet = new DependencyIconSet(
+            icon: ManagedImageMonikers.CodeInformationPrivate,
+            expandedIcon: ManagedImageMonikers.CodeInformationPrivate,
+            unresolvedIcon: ManagedImageMonikers.CodeInformationWarning,
+            unresolvedExpandedIcon: ManagedImageMonikers.CodeInformationWarning);
+
         public AnalyzerDependencyModel(
             string providerType,
             string path,
@@ -32,10 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 
             SchemaItemType = AnalyzerReference.PrimaryDataSourceItemType;
             Priority = Dependency.AnalyzerNodePriority;
-            Icon = isImplicit ? ManagedImageMonikers.CodeInformationPrivate : KnownMonikers.CodeInformation;
-            ExpandedIcon = Icon;
-            UnresolvedIcon = ManagedImageMonikers.CodeInformationWarning;
-            UnresolvedExpandedIcon = UnresolvedIcon;
+            IconSet = isImplicit ? s_implicitIconSet : s_iconSet;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/AssemblyDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/AssemblyDependencyModel.cs
@@ -10,6 +10,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
     internal class AssemblyDependencyModel : DependencyModel
     {
+        private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
+            icon: KnownMonikers.Reference,
+            expandedIcon: KnownMonikers.Reference,
+            unresolvedIcon: KnownMonikers.ReferenceWarning,
+            unresolvedExpandedIcon: KnownMonikers.ReferenceWarning);
+
+        private static readonly DependencyIconSet s_implicitIconSet = new DependencyIconSet(
+            icon: ManagedImageMonikers.ReferencePrivate,
+            expandedIcon: ManagedImageMonikers.ReferencePrivate,
+            unresolvedIcon: KnownMonikers.ReferenceWarning,
+            unresolvedExpandedIcon: KnownMonikers.ReferenceWarning);
+
         public AssemblyDependencyModel(
             string providerType,
             string path,
@@ -48,10 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 
             SchemaItemType = AssemblyReference.PrimaryDataSourceItemType;
             Priority = Dependency.FrameworkAssemblyNodePriority;
-            Icon = isImplicit ? ManagedImageMonikers.ReferencePrivate : KnownMonikers.Reference;
-            ExpandedIcon = Icon;
-            UnresolvedIcon = KnownMonikers.ReferenceWarning;
-            UnresolvedExpandedIcon = UnresolvedIcon;
+            IconSet = isImplicit ? s_implicitIconSet : s_iconSet;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/ComDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/ComDependencyModel.cs
@@ -8,6 +8,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
     internal class ComDependencyModel : DependencyModel
     {
+        private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
+            icon: ManagedImageMonikers.Component,
+            expandedIcon: ManagedImageMonikers.Component,
+            unresolvedIcon: ManagedImageMonikers.ComponentWarning,
+            unresolvedExpandedIcon: ManagedImageMonikers.ComponentWarning);
+
+        private static readonly DependencyIconSet s_implicitIconSet = new DependencyIconSet(
+            icon: ManagedImageMonikers.ComponentPrivate,
+            expandedIcon: ManagedImageMonikers.ComponentPrivate,
+            unresolvedIcon: ManagedImageMonikers.ComponentWarning,
+            unresolvedExpandedIcon: ManagedImageMonikers.ComponentWarning);
+
         public ComDependencyModel(
             string providerType,
             string path,
@@ -31,10 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 
             SchemaItemType = ComReference.PrimaryDataSourceItemType;
             Priority = Dependency.ComNodePriority;
-            Icon = isImplicit ? ManagedImageMonikers.ComponentPrivate : ManagedImageMonikers.Component;
-            ExpandedIcon = Icon;
-            UnresolvedIcon = ManagedImageMonikers.ComponentWarning;
-            UnresolvedExpandedIcon = UnresolvedIcon;
+            IconSet = isImplicit ? s_implicitIconSet : s_iconSet;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DependencyModel.cs
@@ -64,13 +64,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
         public bool Implicit { get; protected set; } = false;
         public bool Visible { get; protected set; } = true;
         public int Priority { get; protected set; } = 0;
-        public ImageMoniker Icon { get; protected set; }
-        public ImageMoniker ExpandedIcon { get; protected set; }
-        public ImageMoniker UnresolvedIcon { get; protected set; }
-        public ImageMoniker UnresolvedExpandedIcon { get; protected set; }
+        public ImageMoniker Icon => IconSet.Icon;
+        public ImageMoniker ExpandedIcon => IconSet.ExpandedIcon;
+        public ImageMoniker UnresolvedIcon => IconSet.UnresolvedIcon;
+        public ImageMoniker UnresolvedExpandedIcon => IconSet.UnresolvedExpandedIcon;
         public IImmutableDictionary<string, string> Properties { get; protected set; }
         public IImmutableList<string> DependencyIDs { get; protected set; } = ImmutableList<string>.Empty;
         public ProjectTreeFlags Flags { get; protected set; } = ProjectTreeFlags.Empty;
+
+        public DependencyIconSet IconSet { get; protected set; }
 
         private string _id;
         public virtual string Id

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DiagnosticDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DiagnosticDependencyModel.cs
@@ -15,6 +15,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 
     internal class DiagnosticDependencyModel : DependencyModel
     {
+        private static readonly DependencyIconSet s_errorIconSet = new DependencyIconSet(
+            icon: ManagedImageMonikers.ErrorSmall,
+            expandedIcon: ManagedImageMonikers.ErrorSmall,
+            unresolvedIcon: ManagedImageMonikers.ErrorSmall,
+            unresolvedExpandedIcon: ManagedImageMonikers.ErrorSmall);
+
+        private static readonly DependencyIconSet s_warningIconSet = new DependencyIconSet(
+            icon: ManagedImageMonikers.WarningSmall,
+            expandedIcon: ManagedImageMonikers.WarningSmall,
+            unresolvedIcon: ManagedImageMonikers.WarningSmall,
+            unresolvedExpandedIcon: ManagedImageMonikers.WarningSmall);
+
         public DiagnosticDependencyModel(
             string providerType,
             string originalItemSpec,
@@ -38,20 +50,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 
             if (severity == DiagnosticMessageSeverity.Error)
             {
-                Icon = ManagedImageMonikers.ErrorSmall;
+                IconSet = s_errorIconSet;
                 Flags = Flags.Union(DependencyTreeFlags.DiagnosticErrorNodeFlags);
                 Priority = Dependency.DiagnosticsErrorNodePriority;
             }
             else
             {
-                Icon = ManagedImageMonikers.WarningSmall;
+                IconSet = s_warningIconSet;
                 Flags = Flags.Union(DependencyTreeFlags.DiagnosticWarningNodeFlags);
                 Priority = Dependency.DiagnosticsWarningNodePriority;
             }
-
-            ExpandedIcon = Icon;
-            UnresolvedIcon = Icon;
-            UnresolvedExpandedIcon = Icon;
         }
 
         private string _id;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageAnalyzerAssemblyDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageAnalyzerAssemblyDependencyModel.cs
@@ -11,6 +11,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
     internal class PackageAnalyzerAssemblyDependencyModel : DependencyModel
     {
+        private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
+            icon: KnownMonikers.CodeInformation,
+            expandedIcon: KnownMonikers.CodeInformation,
+            unresolvedIcon: ManagedImageMonikers.CodeInformationWarning,
+            unresolvedExpandedIcon: ManagedImageMonikers.CodeInformationWarning);
+
         public PackageAnalyzerAssemblyDependencyModel(
             string providerType,
             string path,
@@ -27,10 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             Name = name;
             Caption = name;
             TopLevel = false;
-            Icon = KnownMonikers.CodeInformation;
-            ExpandedIcon = Icon;
-            UnresolvedIcon = ManagedImageMonikers.CodeInformationWarning;
-            UnresolvedExpandedIcon = UnresolvedIcon;
+            IconSet = s_iconSet;
 
             if (dependenciesIDs != null && dependenciesIDs.Any())
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageAssemblyDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageAssemblyDependencyModel.cs
@@ -11,6 +11,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
     internal class PackageAssemblyDependencyModel : DependencyModel
     {
+        private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
+            icon: KnownMonikers.Reference,
+            expandedIcon: KnownMonikers.Reference,
+            unresolvedIcon: KnownMonikers.ReferenceWarning,
+            unresolvedExpandedIcon: KnownMonikers.ReferenceWarning);
+
         public PackageAssemblyDependencyModel(
             string providerType,
             string path,
@@ -27,10 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             Name = name;
             Caption = name;
             TopLevel = false;
-            Icon = KnownMonikers.Reference;
-            ExpandedIcon = Icon;
-            UnresolvedIcon = KnownMonikers.ReferenceWarning;
-            UnresolvedExpandedIcon = UnresolvedIcon;
+            IconSet = s_iconSet;
 
             if (dependenciesIDs != null && dependenciesIDs.Any())
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageDependencyModel.cs
@@ -10,6 +10,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
     internal class PackageDependencyModel : DependencyModel
     {
+        private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
+            icon: ManagedImageMonikers.NuGetGrey,
+            expandedIcon: ManagedImageMonikers.NuGetGrey,
+            unresolvedIcon: ManagedImageMonikers.NuGetGreyWarning,
+            unresolvedExpandedIcon: ManagedImageMonikers.NuGetGreyWarning);
+
+        private static readonly DependencyIconSet s_implicitIconSet = new DependencyIconSet(
+            icon: ManagedImageMonikers.NuGetGreyPrivate,
+            expandedIcon: ManagedImageMonikers.NuGetGreyPrivate,
+            unresolvedIcon: ManagedImageMonikers.NuGetGreyWarning,
+            unresolvedExpandedIcon: ManagedImageMonikers.NuGetGreyWarning);
+
         public PackageDependencyModel(
             string providerType,
             string path,
@@ -33,10 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             TopLevel = isTopLevel;
             Visible = isVisible;
             SchemaItemType = PackageReference.PrimaryDataSourceItemType;
-            Icon = isImplicit ? ManagedImageMonikers.NuGetGreyPrivate : ManagedImageMonikers.NuGetGrey;
-            ExpandedIcon = Icon;
-            UnresolvedIcon = ManagedImageMonikers.NuGetGreyWarning;
-            UnresolvedExpandedIcon = UnresolvedIcon;
+            IconSet = isImplicit ? s_implicitIconSet : s_iconSet;
 
             if (dependenciesIDs != null && dependenciesIDs.Any())
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageUnknownDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageUnknownDependencyModel.cs
@@ -11,6 +11,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
     internal class PackageUnknownDependencyModel : DependencyModel
     {
+        private readonly static DependencyIconSet s_iconSet = new DependencyIconSet(
+            icon: KnownMonikers.QuestionMark,
+            expandedIcon: KnownMonikers.QuestionMark,
+            unresolvedIcon: KnownMonikers.QuestionMark,
+            unresolvedExpandedIcon: KnownMonikers.QuestionMark);
+
         public PackageUnknownDependencyModel(
             string providerType,
             string path,
@@ -27,10 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             Name = name;
             Caption = name;
             TopLevel = false;
-            Icon = KnownMonikers.QuestionMark;
-            ExpandedIcon = Icon;
-            UnresolvedIcon = KnownMonikers.QuestionMark;
-            UnresolvedExpandedIcon = UnresolvedIcon;
+            IconSet = s_iconSet;
             Priority = Dependency.UnresolvedReferenceNodePriority;
 
             if (dependenciesIDs != null && dependenciesIDs.Any())

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/ProjectDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/ProjectDependencyModel.cs
@@ -9,6 +9,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
     internal class ProjectDependencyModel : DependencyModel
     {
+        private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
+            icon: KnownMonikers.Application,
+            expandedIcon: KnownMonikers.Application,
+            unresolvedIcon: ManagedImageMonikers.ApplicationWarning,
+            unresolvedExpandedIcon: ManagedImageMonikers.ApplicationWarning);
+
+        private static readonly DependencyIconSet s_implicitIconSet = new DependencyIconSet(
+            icon: ManagedImageMonikers.ApplicationPrivate,
+            expandedIcon: ManagedImageMonikers.ApplicationPrivate,
+            unresolvedIcon: ManagedImageMonikers.ApplicationWarning,
+            unresolvedExpandedIcon: ManagedImageMonikers.ApplicationWarning);
+
         public ProjectDependencyModel(
             string providerType,
             string path,
@@ -33,10 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             Caption = System.IO.Path.GetFileNameWithoutExtension(Name);
             SchemaItemType = ProjectReference.PrimaryDataSourceItemType;
             Priority = Dependency.ProjectNodePriority;
-            Icon = isImplicit ? ManagedImageMonikers.ApplicationPrivate : KnownMonikers.Application;
-            ExpandedIcon = Icon;
-            UnresolvedIcon = ManagedImageMonikers.ApplicationWarning;
-            UnresolvedExpandedIcon = UnresolvedIcon;
+            IconSet = isImplicit ? s_implicitIconSet : s_iconSet;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/SdkDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/SdkDependencyModel.cs
@@ -11,6 +11,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
     internal class SdkDependencyModel : DependencyModel
     {
+        private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
+            icon: ManagedImageMonikers.Sdk,
+            expandedIcon: ManagedImageMonikers.Sdk,
+            unresolvedIcon: ManagedImageMonikers.SdkWarning,
+            unresolvedExpandedIcon: ManagedImageMonikers.SdkWarning);
+
+        private static readonly DependencyIconSet s_implicitIconSet = new DependencyIconSet(
+            icon: ManagedImageMonikers.SdkPrivate,
+            expandedIcon: ManagedImageMonikers.SdkPrivate,
+            unresolvedIcon: ManagedImageMonikers.SdkWarning,
+            unresolvedExpandedIcon: ManagedImageMonikers.SdkWarning);
+
         public SdkDependencyModel(
             string providerType,
             string path,
@@ -34,10 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 
             SchemaItemType = SdkReference.PrimaryDataSourceItemType;
             Priority = Dependency.SdkNodePriority;
-            Icon = isImplicit ? ManagedImageMonikers.SdkPrivate : ManagedImageMonikers.Sdk;
-            ExpandedIcon = Icon;
-            UnresolvedIcon = ManagedImageMonikers.SdkWarning;
-            UnresolvedExpandedIcon = UnresolvedIcon;
+            IconSet = isImplicit ? s_implicitIconSet : s_iconSet;
             Version = properties != null && properties.ContainsKey(ProjectItemMetadata.Version)
                         ? properties[ProjectItemMetadata.Version] : string.Empty;
             string baseCaption = Path.Split(Delimiter.Comma, StringSplitOptions.RemoveEmptyEntries)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/SharedProjectDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/SharedProjectDependencyModel.cs
@@ -9,6 +9,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
     internal class SharedProjectDependencyModel : DependencyModel
     {
+        private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
+            icon: KnownMonikers.SharedProject,
+            expandedIcon: KnownMonikers.SharedProject,
+            unresolvedIcon: ManagedImageMonikers.SharedProjectWarning,
+            unresolvedExpandedIcon: ManagedImageMonikers.SharedProjectWarning);
+
+        private static readonly DependencyIconSet s_implicitIconSet = new DependencyIconSet(
+            icon: ManagedImageMonikers.SharedProjectPrivate,
+            expandedIcon: ManagedImageMonikers.SharedProjectPrivate,
+            unresolvedIcon: ManagedImageMonikers.SharedProjectWarning,
+            unresolvedExpandedIcon: ManagedImageMonikers.SharedProjectWarning);
+
         public SharedProjectDependencyModel(
             string providerType,
             string path,
@@ -33,10 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             Caption = System.IO.Path.GetFileNameWithoutExtension(Name);
             Priority = Dependency.ProjectNodePriority;
             SchemaItemType = ProjectReference.PrimaryDataSourceItemType;
-            Icon = isImplicit ? ManagedImageMonikers.SharedProjectPrivate : KnownMonikers.SharedProject;
-            ExpandedIcon = Icon;
-            UnresolvedIcon = ManagedImageMonikers.SharedProjectWarning;
-            UnresolvedExpandedIcon = UnresolvedIcon;
+            IconSet = isImplicit ? s_implicitIconSet : s_iconSet;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/SubTreeRootDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/SubTreeRootDependencyModel.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.VisualStudio.Imaging.Interop;
-
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
     internal class SubTreeRootDependencyModel : DependencyModel
@@ -9,15 +7,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
         public SubTreeRootDependencyModel(
             string providerType,
             string name,
-            ImageMoniker icon,
-            ImageMoniker unresolvedIcon,
+            DependencyIconSet iconSet,
             ProjectTreeFlags flags)
             : base(providerType, name, name, flags, true, false, null)
         {
-            Icon = icon;
-            ExpandedIcon = Icon;
-            UnresolvedIcon = unresolvedIcon;
-            UnresolvedExpandedIcon = UnresolvedIcon;
+            IconSet = iconSet;
             Flags = flags.Union(DependencyTreeFlags.DependencyFlags)
                          .Union(DependencyTreeFlags.SubTreeRootNodeFlags)
                          .Except(DependencyTreeFlags.SupportsRuleProperties)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
@@ -10,6 +10,7 @@ using System.Text;
 
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models;
 using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
 using Microsoft.VisualStudio.Text;
 
@@ -75,7 +76,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 Flags = Flags.Union(DependencyTreeFlags.UnresolvedFlags);
             }
 
-            _iconSet = new DependencyIconSet(dependencyModel.Icon, dependencyModel.ExpandedIcon, dependencyModel.UnresolvedIcon, dependencyModel.UnresolvedExpandedIcon);
+            // If this is one of our implementations of IDependencyModel then we can just reuse the icon
+            // set rather than creating a new one.
+            if (dependencyModel is Dependency dependency)
+            {
+                _iconSet = dependency._iconSet;
+            }
+            else if (dependencyModel is DependencyModel model)
+            {
+                _iconSet = model.IconSet;
+            }
+            else
+            {
+                _iconSet = new DependencyIconSet(dependencyModel.Icon, dependencyModel.ExpandedIcon, dependencyModel.UnresolvedIcon, dependencyModel.UnresolvedExpandedIcon);
+            }
 
             Properties = dependencyModel.Properties ??
                             ImmutableStringDictionary<string>.EmptyOrdinal
@@ -106,9 +120,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             // since this is a clone make the modelId and dependencyIds match the original model
             _modelId = modelId;
             _fullPath = model._fullPath; // Grab the cached value if we've already created it
-
-            // We can also reuse the icon set rather than hanging on to what is effectively a copy.
-            _iconSet = model._iconSet;
 
             if (model.DependencyIDs != null && model.DependencyIDs.Any())
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/AnalyzerRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/AnalyzerRuleHandler.cs
@@ -18,6 +18,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
     {
         public const string ProviderTypeString = "AnalyzerDependency";
 
+        private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
+            icon: KnownMonikers.CodeInformation,
+            expandedIcon: KnownMonikers.CodeInformation,
+            unresolvedIcon: ManagedImageMonikers.CodeInformationWarning,
+            unresolvedExpandedIcon: ManagedImageMonikers.CodeInformationWarning);
+
         protected override string UnresolvedRuleName { get; } = AnalyzerReference.SchemaName;
         protected override string ResolvedRuleName { get; } = ResolvedAnalyzerReference.SchemaName;
         public override string ProviderType { get; } = ProviderTypeString;
@@ -27,8 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             return new SubTreeRootDependencyModel(
                 ProviderType,
                 VSResources.AnalyzersNodeName,
-                KnownMonikers.CodeInformation,
-                ManagedImageMonikers.CodeInformationWarning,
+                s_iconSet,
                 DependencyTreeFlags.AnalyzerSubTreeRootNodeFlags);
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/AssemblyRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/AssemblyRuleHandler.cs
@@ -18,6 +18,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
     {
         public const string ProviderTypeString = "AssemblyDependency";
 
+        private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
+            icon: KnownMonikers.Reference,
+            expandedIcon: KnownMonikers.Reference,
+            unresolvedIcon: KnownMonikers.ReferenceWarning,
+            unresolvedExpandedIcon: KnownMonikers.ReferenceWarning);
+
         protected override string UnresolvedRuleName { get; } = AssemblyReference.SchemaName;
         protected override string ResolvedRuleName { get; } = ResolvedAssemblyReference.SchemaName;
         public override string ProviderType { get; } = ProviderTypeString;
@@ -27,8 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             return new SubTreeRootDependencyModel(
                 ProviderType,
                 VSResources.AssembliesNodeName,
-                KnownMonikers.Reference,
-                KnownMonikers.ReferenceWarning,
+                s_iconSet,
                 DependencyTreeFlags.AssemblySubTreeRootNodeFlags);
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ComRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ComRuleHandler.cs
@@ -17,6 +17,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
     {
         public const string ProviderTypeString = "ComDependency";
 
+        private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
+            icon: ManagedImageMonikers.Component,
+            expandedIcon: ManagedImageMonikers.Component,
+            unresolvedIcon: ManagedImageMonikers.ComponentWarning,
+            unresolvedExpandedIcon: ManagedImageMonikers.ComponentWarning);
+
         protected override string UnresolvedRuleName { get; } = ComReference.SchemaName;
         protected override string ResolvedRuleName { get; } = ResolvedCOMReference.SchemaName;
         public override string ProviderType { get; } = ProviderTypeString;
@@ -26,8 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             return new SubTreeRootDependencyModel(
                 ProviderType,
                 VSResources.ComNodeName,
-                ManagedImageMonikers.Component,
-                ManagedImageMonikers.ComponentWarning,
+                s_iconSet,
                 DependencyTreeFlags.ComSubTreeRootNodeFlags);
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/PackageRuleHandler.cs
@@ -22,6 +22,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
     {
         public const string ProviderTypeString = "NuGetDependency";
 
+        private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
+            icon: ManagedImageMonikers.NuGetGrey,
+            expandedIcon: ManagedImageMonikers.NuGetGrey,
+            unresolvedIcon: ManagedImageMonikers.NuGetGreyWarning,
+            unresolvedExpandedIcon: ManagedImageMonikers.NuGetGreyWarning);
+
         [ImportingConstructor]
         public PackageRuleHandler(ITargetFrameworkProvider targetFrameworkProvider)
         {
@@ -242,8 +248,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             return new SubTreeRootDependencyModel(
                 ProviderType,
                 VSResources.NuGetPackagesNodeName,
-                ManagedImageMonikers.NuGetGrey,
-                ManagedImageMonikers.NuGetGreyWarning,
+                s_iconSet,
                 DependencyTreeFlags.NuGetSubTreeRootNodeFlags);
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ProjectRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ProjectRuleHandler.cs
@@ -22,6 +22,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
     {
         public const string ProviderTypeString = "ProjectDependency";
 
+        private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
+            icon: KnownMonikers.Application,
+            expandedIcon: KnownMonikers.Application,
+            unresolvedIcon: ManagedImageMonikers.ApplicationWarning,
+            unresolvedExpandedIcon: ManagedImageMonikers.ApplicationWarning);
+
         protected override string UnresolvedRuleName { get; } = ProjectReference.SchemaName;
         protected override string ResolvedRuleName { get; } = ResolvedProjectReference.SchemaName;
         public override string ProviderType { get; } = ProviderTypeString;
@@ -50,8 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             return new SubTreeRootDependencyModel(
                 ProviderType,
                 VSResources.ProjectsNodeName,
-                KnownMonikers.Application,
-                ManagedImageMonikers.ApplicationWarning,
+                s_iconSet,
                 DependencyTreeFlags.ProjectSubTreeRootNodeFlags);
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/SdkRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/SdkRuleHandler.cs
@@ -17,6 +17,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
     {
         public const string ProviderTypeString = "SdkDependency";
 
+        private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
+            icon: ManagedImageMonikers.Sdk,
+            expandedIcon: ManagedImageMonikers.Sdk,
+            unresolvedIcon: ManagedImageMonikers.SdkWarning,
+            unresolvedExpandedIcon: ManagedImageMonikers.SdkWarning);
+
         protected override string UnresolvedRuleName { get; } = SdkReference.SchemaName;
         protected override string ResolvedRuleName { get; } = ResolvedSdkReference.SchemaName;
         public override string ProviderType { get; } = ProviderTypeString;
@@ -26,8 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             return new SubTreeRootDependencyModel(
                 ProviderType,
                 VSResources.SdkNodeName,
-                ManagedImageMonikers.Sdk,
-                ManagedImageMonikers.SdkWarning,
+                s_iconSet,
                 DependencyTreeFlags.SdkSubTreeRootNodeFlags);
         }
 


### PR DESCRIPTION
Currently every `Dependency` and `DependencyModel` stores four `ImageMoniker`s specifying the set of icons associated with the dependency. As each `ImageMoniker` is a struct containing a `GUID` and an `int` , each `Dependency` and `DependencyModel` ends up with at least 80 bytes of icon information.

While effectively each `Dependency` instance is unique there aren't that many distinct sets of icons--just one or two per type of dependency. We can thus save a fair bit of memory by breaking the icons out into a new type, `DependencyIconSet`, replacing all 80 bytes of `ImageMonikers`  with references to those sets, and reusing instances of `DependencyIconSet` where possible.

For context, before this change loading the dotnet/project-system solution results in 6,836 instances of `Dependency` at 168 bytes each, requiring a total of 1,122 kilobytes of memory. After this change we end up with the same 6,836 `Dependency` instances at 92 bytes each, plus a mere 14 instances of `DependencyIconSet` at 88 bytes each, for a total size of 615 kilobytes--a 45% reduction in memory.

The gains are even larger for the dotnet/roslyn solution. Before: 35,264 instances of `Dependency` totaling 5,786 kilobytes. After: 35,264 instances of `Dependency` plus 19 instances of `DependencyIconSet` totaling 3,170 kilobytes--another 45% reduction.