### PR TITLE
Never report up-to-date if CopyAlways item exists

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -349,8 +349,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             (string Path, string Link, CopyToOutputDirectoryType CopyType) copyAlwaysItem = _items.SelectMany(kvp => kvp.Value).FirstOrDefault(item => item.CopyType == CopyToOutputDirectoryType.CopyAlways);
             if (copyAlwaysItem.Path != null)
             {
-                logger.Info("Item '{0}' has CopyToOutputDirectory set to 'Always', not up to date.", copyAlwaysItem.Path);
-                return false;
+                return Fail(logger, $"Item '{copyAlwaysItem.Path}' has CopyToOutputDirectory set to 'Always', not up to date.", "CopyAlwaysItemExists");
             }
 
             return true;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -350,6 +350,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             if (copyAlwaysItem.Path != null)
             {
                 logger.Info("Item '{0}' has CopyToOutputDirectory set to 'Always', not up to date.", copyAlwaysItem.Path);
+                return false;
             }
 
             return true;


### PR DESCRIPTION
Fixes #3568 

Prior code logged the fact that the project was not up to date, but didn't signal that information back to the calling method. If any items are `CopyAlways` then the up-to-date check can be short circuited.

Questions for reviewers:

1. Code in checks immediately above this change use the `Fail` method to capture a telemetry event. Should this also happen when we detect a `CopyAlways` item?
1. Unit tests... I looked into adding tests for this class. It's quite a meaty one with substantial dependencies, and I'm new to the code. Please advise!