### PR TITLE
Propagate cancellation via IProjectSystemOptions

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectSystemOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectSystemOptions.cs
@@ -49,12 +49,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         public async Task<bool> GetIsFastUpToDateCheckEnabledAsync(CancellationToken cancellationToken = default)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+
             return _settingsManager.Value?.GetValueOrDefault(FastUpToDateEnabledSettingKey, true) ?? true;
         }
 
         public async Task<LogLevel> GetFastUpToDateLoggingLevelAsync(CancellationToken cancellationToken = default)
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+
             return _settingsManager.Value?.GetValueOrDefault(FastUpToDateLogLevelSettingKey, LogLevel.None) ?? LogLevel.None;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectSystemOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectSystemOptions.cs
@@ -3,6 +3,7 @@
 using System;
 using System.ComponentModel.Composition;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
@@ -45,15 +46,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             }
         }
 
-        public async Task<bool> GetIsFastUpToDateCheckEnabledAsync()
+        public async Task<bool> GetIsFastUpToDateCheckEnabledAsync(CancellationToken cancellationToken = default)
         {
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
             return _settingsManager.Value?.GetValueOrDefault(FastUpToDateEnabledSettingKey, true) ?? true;
         }
 
-        public async Task<LogLevel> GetFastUpToDateLoggingLevelAsync()
+        public async Task<LogLevel> GetFastUpToDateLoggingLevelAsync(CancellationToken cancellationToken = default)
         {
-            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
             return _settingsManager.Value?.GetValueOrDefault(FastUpToDateLogLevelSettingKey, LogLevel.None) ?? LogLevel.None;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectSystemOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectSystemOptions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.ProjectSystem
@@ -23,17 +24,23 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// <summary>
         ///     Gets a value indicating if the project fast up to date check is enabled.
         /// </summary>
+        /// <param name="cancellationToken">
+        ///     A token whose cancellation signals lost interest in the result.
+        /// </param>
         /// <value>
         ///     <see langword="true"/> if the project fast up to date check is enabled; otherwise, <see langword="false"/>
         /// </value>
-        Task<bool> GetIsFastUpToDateCheckEnabledAsync();
+        Task<bool> GetIsFastUpToDateCheckEnabledAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Gets a value indicating the level of fast up to date check logging.
         /// </summary>
+        /// <param name="cancellationToken">
+        ///     A token whose cancellation signals lost interest in the result.
+        /// </param>
         /// <value>
         ///     The level of fast up to date check logging.
         /// </value>
-        Task<LogLevel> GetFastUpToDateLoggingLevelAsync();
+        Task<LogLevel> GetFastUpToDateLoggingLevelAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -577,7 +577,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             EnsureInitialized();
 
-            LogLevel requestedLogLevel = await _projectSystemOptions.GetFastUpToDateLoggingLevelAsync().ConfigureAwait(false);
+            LogLevel requestedLogLevel = await _projectSystemOptions.GetFastUpToDateLoggingLevelAsync(cancellationToken).ConfigureAwait(false);
             var logger = new BuildUpToDateCheckLogger(logWriter, requestedLogLevel, _configuredProject.UnconfiguredProject.FullPath);
 
             if (!CheckGlobalConditions(buildAction, logger))
@@ -646,6 +646,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         }
 
         public async Task<bool> IsUpToDateCheckEnabledAsync(CancellationToken cancellationToken = default) =>
-            await _projectSystemOptions.GetIsFastUpToDateCheckEnabledAsync().ConfigureAwait(false);
+            await _projectSystemOptions.GetIsFastUpToDateCheckEnabledAsync(cancellationToken).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
The implementations don't do much, but in case of cancellation it may avoid an operation on the main thread.