### PR TITLE
Remove workaround in DesignTimeAssemblyResolution

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/DesignTimeAssemblyResolution.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/DesignTimeAssemblyResolution.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
     /// <summary>
     ///     Provides an implementation of <see cref="IVsDesignTimeAssemblyResolution"/> that sits over the top of VSLangProj.References.
     /// </summary>
-    [Export]
+    [ExportProjectNodeComService(typeof(IVsDesignTimeAssemblyResolution))]  // Need to override CPS's version, which it implements on the project node as IVsDesignTimeAssemblyResolution
     [ExportVsProfferedProjectService(typeof(SVsDesignTimeAssemblyResolution))]
     [AppliesTo(ProjectCapability.DotNet)]
     [Order(Order.Default)] // Before CPS's version
@@ -47,16 +47,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             Requires.NotNull(projectVsServices, nameof(projectVsServices));
 
             _projectVsServices = projectVsServices;
-        }
-
-        // BUG (https://devdiv.visualstudio.com/DevDiv/_workitems?id=367916): VS MEF rejects a part marked 
-        // with two Export/Metadata attributes where one is AllowMultiple=false
-        [ExportProjectNodeComService(typeof(IVsDesignTimeAssemblyResolution))]  // Need to override CPS's version, which it implements on the project node as IVsDesignTimeAssemblyResolution
-        [AppliesTo(ProjectCapability.DotNet)]
-        [Order(Order.Default)] // Before CPS's version
-        public IVsDesignTimeAssemblyResolution ComService
-        {
-            get { return this; }
         }
 
         public int GetTargetFramework(out string ppTargetFramework)


### PR DESCRIPTION
The bug the workaround was referrring to was fixed in 15.3 and verified that the part no longer gets rejected.