### PR TITLE
Turn off "CA2213: Disposable fields should be disposed" due to noise

### DIFF
--- a/build/Default.ruleset
+++ b/build/Default.ruleset
@@ -48,6 +48,7 @@
     <Rule Id="CA1815" Action="None" />
     <Rule Id="CA2007" Action="Warning" />
     <Rule Id="CA2211" Action="None" />
+    <Rule Id="CA2213" Action="None" /> <!-- https://github.com/dotnet/roslyn-analyzers/issues/1796 -->
     <Rule Id="CA2218" Action="None" />
     <Rule Id="CA2222" Action="None" />
     <Rule Id="CA2224" Action="None" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
@@ -22,9 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         private readonly ActiveConfiguredProject<DebuggerLaunchProviders> _launchProviders;
         
         private Guid _projectGuid;
-#pragma warning disable CA2213 // OnceInitializedOnceDisposedAsync are not tracked corretly by the IDisposeable analyzer
         private IDisposable _subscription;
-#pragma warning restore CA2213
 
         [ImportingConstructor]
         public StartupProjectRegistrar(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/PackageRestoreInitiator.PackageRestoreInitiatorInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/PackageRestoreInitiator.PackageRestoreInitiatorInstance.cs
@@ -29,10 +29,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             private readonly IActiveConfigurationGroupService _activeConfigurationGroupService;
             private readonly IActiveConfiguredProjectSubscriptionService _activeConfiguredProjectSubscriptionService;
             private readonly IProjectLogger _logger;
-#pragma warning disable CA2213 // OnceInitializedOnceDisposedAsync are not tracked correctly by the IDisposeable analyzer
             private IDisposable _configurationsSubscription;
             private DisposableBag _designTimeBuildSubscriptionLink;
-#pragma warning restore CA2213
 
             private static readonly ImmutableHashSet<string> s_designTimeBuildWatchedRules = Empty.OrdinalIgnoreCaseStringSet
                 .Add(NuGetRestore.SchemaName)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
@@ -33,11 +33,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         private readonly IActiveConfiguredProjectSubscriptionService _activeConfiguredProjectSubscriptionService;
         private readonly IProjectTreeProvider _fileSystemTreeProvider;
 
-#pragma warning disable CA2213 // OnceInitializedOnceDisposedAsync are not tracked corretly by the IDisposeable analyzer
         private CancellationTokenSource _watchedFileResetCancellationToken;
         private ITaskDelayScheduler _taskDelayScheduler;
         private IDisposable _treeWatcher;
-#pragma warning restore CA2213
         private uint _filechangeCookie;
         private string _fileBeingWatched;
         private byte[] _previousContentsHash;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractMultiLifetimeComponent.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractMultiLifetimeComponent.cs
@@ -14,9 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
     internal abstract partial class AbstractMultiLifetimeComponent : OnceInitializedOnceDisposedAsync
     {
         private readonly object _lock = new object();
-#pragma warning disable CA2213 // OnceInitializedOnceDisposedAsync are not tracked correctly by the IDisposeable analyzer
         private AbstractMultiLifetimeInstance _instance;
-#pragma warning restore CA2213
 
         protected AbstractMultiLifetimeComponent(JoinableTaskContextNode joinableTaskContextNode)
             : base(joinableTaskContextNode)


### PR DESCRIPTION
Per https://github.com/dotnet/project-system/pull/3908#discussion_r212955729, this rule is mostly noise for project-system because we derive from OnceInitializedOnceDisposed/OnceInitializedOnceDisposedAsync.

There's other usages of `#pragma warning disable` that I left because they aren't actually disposing the field that has been suppressed, such as https://github.com/dotnet/project-system/blob/dfe534a3e7803efb763ba9dcd35c5ce60c9104a5/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetRuleSubscriberBase.cs#L20. 

Note, that even after we dispose these usages, the rule will still fire - hence why we're turning it off. I left these suppressions so that we can find them, and using https://github.com/dotnet/project-system/issues/3927 to track fixing them.