### PR TITLE
Add tests for BuildUpToDateCheck

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
@@ -56,6 +56,16 @@ namespace Microsoft.VisualStudio.IO
             }
         }
 
+        public void AddFile(string path, DateTime? lastWriteTime = null)
+        {
+            _files[path] = new FileData
+            {
+                FileContents = "",
+                FileEncoding = Encoding.UTF8,
+                LastWriteTime = lastWriteTime ?? DateTime.Now
+            };
+        }
+
         public void AddFolder(string path)
         {
             _folders.Add(path);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectItemSchemaFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectItemSchemaFactory.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Linq;
+
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class IProjectItemSchemaFactory
+    {
+        public static IProjectItemSchema Create(IImmutableList<IItemType> itemTypes)
+        {
+            var projectItemSchema = new Mock<IProjectItemSchema>();
+
+            projectItemSchema.Setup(o => o.GetKnownItemTypes())
+                .Returns(() => ImmutableHashSet<string>.Empty.Union(itemTypes.Select(i => i.Name)));
+
+            projectItemSchema.Setup(o => o.GetItemType(It.IsAny<string>()))
+                .Returns((string itemTypeName) => itemTypes.FirstOrDefault(i => i.Name == itemTypeName));
+
+            return projectItemSchema.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectItemSchemaServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectItemSchemaServiceFactory.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks.Dataflow;
+
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class IProjectItemSchemaServiceFactory
+    {
+        public static IProjectItemSchemaService Create()
+        {
+            var projectItemSchemaService = new Mock<IProjectItemSchemaService>();
+
+            projectItemSchemaService.SetupGet(o => o.SourceBlock)
+                .Returns(new BroadcastBlock<IProjectVersionedValue<IProjectItemSchema>>(null));
+
+            return projectItemSchemaService.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ItemType.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ItemType.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal sealed class ItemType : IItemType
+    {
+        public string Name { get; }
+        public string DisplayName => Name;
+        public bool UpToDateCheckInput { get; }
+
+        public ItemType(string name, bool upToDateCheckInput)
+        {
+            Name = name;
+            UpToDateCheckInput = upToDateCheckInput;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -111,7 +111,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 // Run through once so we know things are considered up to date before running further tests.
                 // Most tests will assert that the project is not up to date, so this provides a good baseline.
-                await AssertUpToDate();
+                await AssertUpToDateAsync();
             }
         }
 
@@ -240,7 +240,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             _projectVersion--;
 
-            await AssertUpToDate();
+            await AssertUpToDateAsync();
         }
 
         [Fact]
@@ -390,7 +390,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             writer.Assert();
         }
 
-        private async Task AssertUpToDate()
+        private async Task AssertUpToDateAsync()
         {
             var writer = new AssertWriter { "Project is up to date." };
             Assert.True(await _buildUpToDateCheck.IsUpToDateAsync(BuildAction.Build, writer));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -305,7 +305,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             await SetupAsync(projectSnapshot: projectSnapshot, expectUpToDate: false);
 
             await AssertNotUpToDateAsync(
-                new[] { "Output 'C:\\Dev\\Solution\\Project\\BuiltOutputPath1' does not exist, not up to date.", "Project is not up to date." },
+                "Output 'C:\\Dev\\Solution\\Project\\BuiltOutputPath1' does not exist, not up to date.",
                 "Outputs");
         }
 
@@ -327,11 +327,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             await SetupAsync(projectSnapshot, sourceSnapshot, expectUpToDate: false);
 
             await AssertNotUpToDateAsync(
-                new[]
-                {
-                    "Input 'C:\\Dev\\Solution\\Project\\ItemPath1' does not exist, not up to date.",
-                    "Project is not up to date."
-                },
+                "Input 'C:\\Dev\\Solution\\Project\\ItemPath1' does not exist, not up to date.",
                 "Outputs");
         }
 
@@ -361,11 +357,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             // TODO test other kinds of output (CustomOutputs)
 
             await AssertNotUpToDateAsync(
-                new[]
-                {
-                    $"Input 'C:\\Dev\\Solution\\Project\\ItemPath1' is newer ({inputTime}) than earliest output 'C:\\Dev\\Solution\\Project\\BuiltOutputPath1' ({outputTime}), not up to date.",
-                    "Project is not up to date."
-                },
+                $"Input 'C:\\Dev\\Solution\\Project\\ItemPath1' is newer ({inputTime}) than earliest output 'C:\\Dev\\Solution\\Project\\BuiltOutputPath1' ({outputTime}), not up to date.",
                 "Outputs");
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Composition/DeconstructionExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Composition/DeconstructionExtensions.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace System.Collections.Generic
+{
+    internal static class DeconstructionExtensions
+    {
+        public static void Deconstruct<TKey, TValue>(this KeyValuePair<TKey, TValue> pair, out TKey key, out TValue value)
+        {
+            key = pair.Key;
+            value = pair.Value;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -476,7 +476,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             logger.Verbose("    '{0}'", markerFile);
 
             (DateTime inputMarkerTime, string inputMarkerPath) = GetLatestInput(_copyReferenceInputs, timestampCache);
-            DateTime? outputMarkerTime = GetTimestamp(markerFile, timestampCache);
 
             if (inputMarkerPath != null)
             {
@@ -485,7 +484,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             else
             {
                 logger.Info("No input markers exist, skipping marker check.");
+                return true;
             }
+
+            DateTime? outputMarkerTime = GetTimestamp(markerFile, timestampCache);
 
             if (outputMarkerTime != null)
             {
@@ -494,14 +496,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             else
             {
                 logger.Info("Output marker '{0}' does not exist, skipping marker check.", markerFile);
+                return true;
             }
 
             if (outputMarkerTime <= inputMarkerTime)
             {
-                logger.Info("Input marker is newer than output marker, not up to date.");
+                return Fail(logger, "Marker", "Input marker is newer than output marker, not up to date.");
             }
 
-            return inputMarkerPath == null || outputMarkerTime == null || outputMarkerTime > inputMarkerTime;
+            return true;
         }
 
         private bool CheckCopiedOutputFiles(BuildUpToDateCheckLogger logger, IDictionary<string, DateTime> timestampCache)
@@ -648,7 +651,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             if (!CheckMarkers(logger, timestampCache))
             {
-                _telemetryService.PostProperty(TelemetryEventName.UpToDateCheckFail, TelemetryPropertyName.UpToDateCheckFailReason, "Marker");
                 return false;
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -247,7 +247,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             }
         }
 
-        private void OnChanged(IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectSubscriptionUpdate, IProjectItemSchema>> e)
+        internal void OnChanged(IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectSubscriptionUpdate, IProjectItemSchema>> e)
         {
             OnProjectChanged(e.Value.Item1);
             OnSourceItemChanged(e.Value.Item2, e.Value.Item3);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -329,9 +329,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 }
             }
 
-            foreach (KeyValuePair<string, HashSet<(string Path, string Link, CopyToOutputDirectoryType CopyType)>> pair in _items.Where(kvp => !NonCompilationItemTypes.Contains(kvp.Key)))
+            foreach (KeyValuePair<string, HashSet<(string Path, string Link, CopyToOutputDirectoryType CopyType)>> pair in _items)
             {
-                if (pair.Value.Count != 0)
+                if (pair.Value.Count != 0 && !NonCompilationItemTypes.Contains(pair.Key))
                 {
                     logger.Verbose("Adding {0} inputs:", pair.Key);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -225,7 +225,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             foreach (KeyValuePair<string, IProjectChangeDescription> itemType in e.ProjectChanges.Where(changes => (itemTypesChanged || changes.Value.Difference.AnyChanges) && _itemTypes.Contains(changes.Key)))
             {
                 IEnumerable<(string, string, CopyToOutputDirectoryType)> items = itemType.Value.After.Items
-                    .Select(item => (item.Key, GetLink(item.Value), GetCopyType(item.Value)));
+                    .Select(item => (Path: item.Key, Link: GetLink(item.Value), CopyType: GetCopyType(item.Value)));
                 _items[itemType.Key] = new HashSet<(string, string, CopyToOutputDirectoryType)>(items, UpToDateCheckItemComparer.Instance);
                 _itemsChangedSinceLastCheck = true;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -509,7 +509,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
         private bool CheckCopiedOutputFiles(BuildUpToDateCheckLogger logger, IDictionary<string, DateTime> timestampCache)
         {
-            foreach ((string sourceRelative, string destinationRelative) in _copiedOutputFiles)
+            foreach ((string destinationRelative, string sourceRelative) in _copiedOutputFiles)
             {
                 string source = _configuredProject.UnconfiguredProject.MakeRooted(sourceRelative);
                 string destination = _configuredProject.UnconfiguredProject.MakeRooted(destinationRelative);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -133,16 +133,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 _compilationReferences.Clear();
                 _copyReferenceInputs.Clear();
 
-                foreach (KeyValuePair<string, IImmutableDictionary<string, string>> item in changes.After.Items)
+                foreach (IImmutableDictionary<string, string> item in changes.After.Items.Values)
                 {
-                    _compilationReferences.Add(item.Value[ResolvedCompilationReference.ResolvedPathProperty]);
-                    if (!string.IsNullOrWhiteSpace(item.Value[CopyUpToDateMarker.SchemaName]))
+                    _compilationReferences.Add(item[ResolvedCompilationReference.ResolvedPathProperty]);
+                    if (!string.IsNullOrWhiteSpace(item[CopyUpToDateMarker.SchemaName]))
                     {
-                        _copyReferenceInputs.Add(item.Value[CopyUpToDateMarker.SchemaName]);
+                        _copyReferenceInputs.Add(item[CopyUpToDateMarker.SchemaName]);
                     }
-                    if (!string.IsNullOrWhiteSpace(item.Value[ResolvedCompilationReference.OriginalPathProperty]))
+                    if (!string.IsNullOrWhiteSpace(item[ResolvedCompilationReference.OriginalPathProperty]))
                     {
-                        _copyReferenceInputs.Add(item.Value[ResolvedCompilationReference.OriginalPathProperty]);
+                        _copyReferenceInputs.Add(item[ResolvedCompilationReference.OriginalPathProperty]);
                     }
                 }
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -274,9 +274,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             return time;
         }
 
-        private bool Fail(BuildUpToDateCheckLogger logger, string message, string reason)
+        private bool Fail(BuildUpToDateCheckLogger logger, string reason, string message, params object[] values)
         {
-            logger.Info(message);
+            logger.Info(message, values);
             _telemetryService.PostProperty(TelemetryEventName.UpToDateCheckFail, TelemetryPropertyName.UpToDateCheckFailReason, reason);
             return false;
         }
@@ -293,29 +293,29 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             if (!_tasksService.IsTaskQueueEmpty(ProjectCriticalOperation.Build))
             {
-                return Fail(logger, "Critical build tasks are running, not up to date.", "CriticalTasks");
+                return Fail(logger, "CriticalTasks", "Critical build tasks are running, not up to date.");
             }
 
             if (_lastVersionSeen == null || _configuredProject.ProjectVersion.CompareTo(_lastVersionSeen) > 0)
             {
-                return Fail(logger, "Project information is older than current project version, not up to date.", "ProjectInfoOutOfDate");
+                return Fail(logger, "ProjectInfoOutOfDate", "Project information is older than current project version, not up to date.");
             }
 
             if (itemsChangedSinceLastCheck)
             {
-                return Fail(logger, "The list of source items has changed since the last build, not up to date.", "ItemInfoOutOfDate");
+                return Fail(logger, "ItemInfoOutOfDate", "The list of source items has changed since the last build, not up to date.");
             }
 
             if (_isDisabled)
             {
-                return Fail(logger, "The 'DisableFastUpToDateCheck' property is true, not up to date.", "Disabled");
+                return Fail(logger, "Disabled", "The 'DisableFastUpToDateCheck' property is true, not up to date.");
             }
 
             string copyAlwaysItemPath = _items.SelectMany(kvp => kvp.Value).FirstOrDefault(item => item.copyType == CopyToOutputDirectoryType.CopyAlways).path;
 
             if (copyAlwaysItemPath != null)
             {
-                return Fail(logger, $"Item '{_configuredProject.UnconfiguredProject.MakeRooted(copyAlwaysItemPath)}' has CopyToOutputDirectory set to 'Always', not up to date.", "CopyAlwaysItemExists");
+                return Fail(logger, "CopyAlwaysItemExists", "Item '{0}' has CopyToOutputDirectory set to 'Always', not up to date.", _configuredProject.UnconfiguredProject.MakeRooted(copyAlwaysItemPath));
             }
 
             return true;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -190,7 +190,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             if (e.ProjectChanges.TryGetValue(CopyUpToDateMarker.SchemaName, out IProjectChangeDescription upToDateMarkers) &&
                 upToDateMarkers.Difference.AnyChanges)
             {
-                _markerFile = upToDateMarkers.After.Items.Count == 1 ? _configuredProject.UnconfiguredProject.MakeRooted(upToDateMarkers.After.Items.Single().Key) : null;
+                _markerFile = upToDateMarkers.After.Items.Count == 1 ? upToDateMarkers.After.Items.Single().Key : null;
             }
         }
 
@@ -459,6 +459,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 return true;
             }
 
+            var markerFile = _configuredProject.UnconfiguredProject.MakeRooted(_markerFile);
+
             logger.Verbose("Adding input reference copy markers:");
 
             foreach (string referenceMarkerFile in _copyReferenceInputs)
@@ -467,10 +469,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             }
 
             logger.Verbose("Adding output reference copy marker:");
-            logger.Verbose("    '{0}'", _markerFile);
+            logger.Verbose("    '{0}'", markerFile);
 
             (DateTime inputMarkerTime, string inputMarkerPath) = GetLatestInput(_copyReferenceInputs, timestampCache);
-            DateTime? outputMarkerTime = GetTimestamp(_markerFile, timestampCache);
+            DateTime? outputMarkerTime = GetTimestamp(markerFile, timestampCache);
 
             if (inputMarkerPath != null)
             {
@@ -483,11 +485,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             if (outputMarkerTime != null)
             {
-                logger.Info("Write timestamp on output marker is {0} on '{1}'.", outputMarkerTime, _markerFile);
+                logger.Info("Write timestamp on output marker is {0} on '{1}'.", outputMarkerTime, markerFile);
             }
             else
             {
-                logger.Info("Output marker '{0}' does not exist, skipping marker check.", _markerFile);
+                logger.Info("Output marker '{0}' does not exist, skipping marker check.", markerFile);
             }
 
             if (outputMarkerTime <= inputMarkerTime)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -648,22 +648,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             // Short-lived cache of timestamp by path
             var timestampCache = new Dictionary<string, DateTime>(StringComparers.Paths);
 
-            if (!CheckOutputs(logger, timestampCache))
-            {
-                return false;
-            }
-
-            if (!CheckMarkers(logger, timestampCache))
-            {
-                return false;
-            }
-
-            if (!CheckCopyToOutputDirectoryFiles(logger, timestampCache))
-            {
-                return false;
-            }
-
-            if (!CheckCopiedOutputFiles(logger, timestampCache))
+            if (!CheckOutputs(logger, timestampCache) ||
+                !CheckMarkers(logger, timestampCache) ||
+                !CheckCopyToOutputDirectoryFiles(logger, timestampCache) ||
+                !CheckCopiedOutputFiles(logger, timestampCache))
             {
                 return false;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -42,7 +42,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             .Union(ReferenceSchemas)
             .Union(UpToDateSchemas);
 
-        private static ImmutableHashSet<string> NonCompilationItemTypes => ImmutableStringHashSet.EmptyOrdinal
+        private static ImmutableHashSet<string> NonCompilationItemTypes => ImmutableHashSet<string>.Empty
+            .WithComparer(StringComparers.ItemTypes)
             .Add(None.SchemaName)
             .Add(Content.SchemaName);
 
@@ -64,12 +65,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         private string _outputRelativeOrFullPath;
 
         private readonly HashSet<string> _imports = new HashSet<string>(StringComparers.Paths);
-        private readonly HashSet<string> _itemTypes = new HashSet<string>(StringComparers.Paths);
-        private readonly Dictionary<string, HashSet<(string Path, string Link, CopyToOutputDirectoryType CopyType)>> _items = new Dictionary<string, HashSet<(string, string, CopyToOutputDirectoryType)>>();
+        private readonly HashSet<string> _itemTypes = new HashSet<string>(StringComparers.ItemTypes);
+        private readonly Dictionary<string, HashSet<(string Path, string Link, CopyToOutputDirectoryType CopyType)>> _items = new Dictionary<string, HashSet<(string, string, CopyToOutputDirectoryType)>>(StringComparers.ItemTypes);
         private readonly HashSet<string> _customInputs = new HashSet<string>(StringComparers.Paths);
         private readonly HashSet<string> _customOutputs = new HashSet<string>(StringComparers.Paths);
         private readonly HashSet<string> _builtOutputs = new HashSet<string>(StringComparers.Paths);
-        private readonly Dictionary<string, string> _copiedOutputFiles = new Dictionary<string, string>();
+        private readonly Dictionary<string, string> _copiedOutputFiles = new Dictionary<string, string>(StringComparers.Paths);
         private readonly HashSet<string> _analyzerReferences = new HashSet<string>(StringComparers.Paths);
         private readonly HashSet<string> _compilationReferences = new HashSet<string>(StringComparers.Paths);
         private readonly HashSet<string> _copyReferenceInputs = new HashSet<string>(StringComparers.Paths);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -437,7 +437,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                 if (time == null)
                 {
-                    return (null, null);
+                    return (null, output);
                 }
 
                 if (time < earliest)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -553,10 +553,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             string outputFullPath = Path.Combine(_msBuildProjectDirectory, _outputRelativeOrFullPath);
 
-            foreach ((string path, string link, CopyToOutputDirectoryType copyType) item in items)
+            foreach ((string path, string link, _) in items)
             {
-                string path = _configuredProject.UnconfiguredProject.MakeRooted(item.path);
-                string filename = string.IsNullOrEmpty(item.link) ? path : item.link;
+                string rootedPath = _configuredProject.UnconfiguredProject.MakeRooted(path);
+                string filename = string.IsNullOrEmpty(link) ? rootedPath : link;
 
                 if (string.IsNullOrEmpty(filename))
                 {
@@ -565,17 +565,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                 filename = _configuredProject.UnconfiguredProject.MakeRelative(filename);
 
-                logger.Info("Checking PreserveNewest file '{0}':", path);
+                logger.Info("Checking PreserveNewest file '{0}':", rootedPath);
 
-                DateTime? itemTime = GetTimestamp(path, timestampCache);
+                DateTime? itemTime = GetTimestamp(rootedPath, timestampCache);
 
                 if (itemTime != null)
                 {
-                    logger.Info("    Source {0}: '{1}'.", itemTime, path);
+                    logger.Info("    Source {0}: '{1}'.", itemTime, rootedPath);
                 }
                 else
                 {
-                    logger.Info("Source '{0}' does not exist, not up to date.", path);
+                    logger.Info("Source '{0}' does not exist, not up to date.", rootedPath);
                     return false;
                 }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -575,8 +575,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 }
                 else
                 {
-                    logger.Info("Source '{0}' does not exist, not up to date.", rootedPath);
-                    return false;
+                    return Fail(logger, "CopyToOutputDirectory", "Source '{0}' does not exist, not up to date.", rootedPath);
                 }
 
                 string outputItem = Path.Combine(outputFullPath, filename);
@@ -588,14 +587,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 }
                 else
                 {
-                    logger.Info("Destination '{0}' does not exist, not up to date.", outputItem);
-                    return false;
+                    return Fail(logger, "CopyToOutputDirectory", "Destination '{0}' does not exist, not up to date.", outputItem);
                 }
 
                 if (outputItemTime < itemTime)
                 {
-                    logger.Info("PreserveNewest destination is newer than source, not up to date.");
-                    return false;
+                    return Fail(logger, "CopyToOutputDirectory", "PreserveNewest destination is newer than source, not up to date.");
                 }
             }
 
@@ -653,7 +650,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             if (!CheckCopyToOutputDirectoryFiles(logger, timestampCache))
             {
-                _telemetryService.PostProperty(TelemetryEventName.UpToDateCheckFail, TelemetryPropertyName.UpToDateCheckFailReason, "CopyToOutputDirectory");
                 return false;
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -646,31 +646,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 return Fail(logger, "Outputs", "Output '{0}' does not exist, not up to date.", outputPath);
             }
 
-            bool markersUpToDate = CheckMarkers(logger, timestampCache);
-            bool copyToOutputDirectoryUpToDate = CheckCopyToOutputDirectoryFiles(logger, timestampCache);
-            bool copiedOutputUpToDate = CheckCopiedOutputFiles(logger, timestampCache);
-            bool isUpToDate = markersUpToDate && copyToOutputDirectoryUpToDate && copiedOutputUpToDate;
-
-            if (!markersUpToDate)
+            if (!CheckMarkers(logger, timestampCache))
             {
                 _telemetryService.PostProperty(TelemetryEventName.UpToDateCheckFail, TelemetryPropertyName.UpToDateCheckFailReason, "Marker");
+                return false;
             }
-            else if (!copyToOutputDirectoryUpToDate)
+
+            if (!CheckCopyToOutputDirectoryFiles(logger, timestampCache))
             {
                 _telemetryService.PostProperty(TelemetryEventName.UpToDateCheckFail, TelemetryPropertyName.UpToDateCheckFailReason, "CopyToOutputDirectory");
+                return false;
             }
-            else if (!copiedOutputUpToDate)
+
+            if (!CheckCopiedOutputFiles(logger, timestampCache))
             {
                 _telemetryService.PostProperty(TelemetryEventName.UpToDateCheckFail, TelemetryPropertyName.UpToDateCheckFailReason, "CopyOutput");
-            }
-            else
-            {
-                _telemetryService.PostEvent(TelemetryEventName.UpToDateCheckSuccess);
+                return false;
             }
 
-            logger.Info("Project is{0} up to date.", !isUpToDate ? " not" : "");
-
-            return isUpToDate;
+            _telemetryService.PostEvent(TelemetryEventName.UpToDateCheckSuccess);
+            logger.Info("Project is up to date.");
+            return true;
         }
 
         public async Task<bool> IsUpToDateCheckEnabledAsync(CancellationToken cancellationToken = default) =>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -524,8 +524,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 }
                 else
                 {
-                    logger.Info("Source '{0}' does not exist, not up to date.", source);
-                    return false;
+                    return Fail(logger, "CopyOutput", "Source '{0}' does not exist, not up to date.", source);
                 }
 
                 DateTime? destinationTime = GetTimestamp(destination, timestampCache);
@@ -536,14 +535,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 }
                 else
                 {
-                    logger.Info("Destination '{0}' does not exist, not up to date.", destination);
-                    return false;
+                    return Fail(logger, "CopyOutput", "Destination '{0}' does not exist, not up to date.", destination);
                 }
 
                 if (destinationTime < sourceTime)
                 {
-                    logger.Info("Build output destination is newer than source, not up to date.");
-                    return false;
+                    return Fail(logger, "CopyOutput", "Build output destination is newer than source, not up to date.");
                 }
             }
 
@@ -662,7 +659,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             if (!CheckCopiedOutputFiles(logger, timestampCache))
             {
-                _telemetryService.PostProperty(TelemetryEventName.UpToDateCheckFail, TelemetryPropertyName.UpToDateCheckFailReason, "CopyOutput");
                 return false;
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -169,6 +169,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             if (e.ProjectChanges.TryGetValue(UpToDateCheckBuilt.SchemaName, out IProjectChangeDescription built) &&
                 built.Difference.AnyChanges)
             {
+                _copiedOutputFiles.Clear();
                 _builtOutputs.Clear();
 
                 foreach (KeyValuePair<string, IImmutableDictionary<string, string>> item in built.After.Items)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -516,11 +516,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                 logger.Info("Checking build output file '{0}':", source);
 
-                DateTime? itemTime = GetTimestamp(source, timestampCache);
+                DateTime? sourceTime = GetTimestamp(source, timestampCache);
 
-                if (itemTime != null)
+                if (sourceTime != null)
                 {
-                    logger.Info("    Source {0}: '{1}'.", itemTime, source);
+                    logger.Info("    Source {0}: '{1}'.", sourceTime, source);
                 }
                 else
                 {
@@ -528,11 +528,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     return false;
                 }
 
-                DateTime? outputItemTime = GetTimestamp(destination, timestampCache);
+                DateTime? destinationTime = GetTimestamp(destination, timestampCache);
 
-                if (outputItemTime != null)
+                if (destinationTime != null)
                 {
-                    logger.Info("    Destination {0}: '{1}'.", outputItemTime, destination);
+                    logger.Info("    Destination {0}: '{1}'.", destinationTime, destination);
                 }
                 else
                 {
@@ -540,7 +540,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     return false;
                 }
 
-                if (outputItemTime < itemTime)
+                if (destinationTime < sourceTime)
                 {
                     logger.Info("Build output destination is newer than source, not up to date.");
                     return false;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -308,7 +308,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             if (_isDisabled)
             {
-                return Fail(logger, "The 'DisableFastUpToDateCheckProperty' property is true, not up to date.", "Disabled");
+                return Fail(logger, "The 'DisableFastUpToDateCheck' property is true, not up to date.", "Disabled");
             }
 
             string copyAlwaysItemPath = _items.SelectMany(kvp => kvp.Value).FirstOrDefault(item => item.CopyType == CopyToOutputDirectoryType.CopyAlways).Path;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckItemComparer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckItemComparer.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 {
-    internal class UpToDateCheckItemComparer : IEqualityComparer<(string Path, string Link, CopyToOutputDirectoryType CopyType)>
+    internal class UpToDateCheckItemComparer : IEqualityComparer<(string path, string link, CopyToOutputDirectoryType copyType)>
     {
         public static UpToDateCheckItemComparer Instance = new UpToDateCheckItemComparer();
 
@@ -11,16 +11,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         }
 
         public bool Equals(
-            (string Path, string Link, CopyToOutputDirectoryType CopyType) x,
-            (string Path, string Link, CopyToOutputDirectoryType CopyType) y)
+            (string path, string link, CopyToOutputDirectoryType copyType) x,
+            (string path, string link, CopyToOutputDirectoryType copyType) y)
         {
-            return StringComparers.Paths.Equals(x.Path, y.Path);
+            return StringComparers.Paths.Equals(x.path, y.path);
         }
 
         public int GetHashCode(
-            (string Path, string Link, CopyToOutputDirectoryType CopyType) obj)
+            (string path, string link, CopyToOutputDirectoryType copyType) obj)
         {
-            return StringComparers.Paths.GetHashCode(obj.Path);
+            return StringComparers.Paths.GetHashCode(obj.path);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckItemComparer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckItemComparer.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 {
-    internal class UpToDateCheckItemComparer : IEqualityComparer<(string, string, CopyToOutputDirectoryType)>
+    internal class UpToDateCheckItemComparer : IEqualityComparer<(string Path, string Link, CopyToOutputDirectoryType CopyType)>
     {
         public static UpToDateCheckItemComparer Instance = new UpToDateCheckItemComparer();
 
@@ -10,8 +10,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         {
         }
 
-        public bool Equals((string, string, CopyToOutputDirectoryType) x, (string, string, CopyToOutputDirectoryType) y) => StringComparers.Paths.Equals(x.Item1, y.Item1);
+        public bool Equals(
+            (string Path, string Link, CopyToOutputDirectoryType CopyType) x,
+            (string Path, string Link, CopyToOutputDirectoryType CopyType) y)
+        {
+            return StringComparers.Paths.Equals(x.Path, y.Path);
+        }
 
-        public int GetHashCode((string, string, CopyToOutputDirectoryType) obj) => StringComparers.Paths.GetHashCode(obj.Item1);
+        public int GetHashCode(
+            (string Path, string Link, CopyToOutputDirectoryType CopyType) obj)
+        {
+            return StringComparers.Paths.GetHashCode(obj.Path);
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/StringComparers.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/StringComparers.cs
@@ -39,5 +39,10 @@ namespace Microsoft.VisualStudio
         {
             get { return StringComparer.OrdinalIgnoreCase; }
         }
+
+        public static IEqualityComparer<string> ItemTypes
+        {
+            get { return StringComparer.Ordinal; }
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/StringComparers.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/StringComparers.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio
 
         public static IEqualityComparer<string> ItemTypes
         {
-            get { return StringComparer.Ordinal; }
+            get { return StringComparer.OrdinalIgnoreCase; }
         }
     }
 }


### PR DESCRIPTION
Here's a test suite that gives ~~55%~~ 95% coverage of `BuildToToDateCheck`. ~~I want to add more tests, but also want to get it in front of other eyeballs for feedback.~~ I've now added as many tests as I think are necessary.

Apart from the tests there are a few functional changes I'd like more knowledgable folks to review:

- 98b75a3aaad95172d3dba20a8d9d35aa9788a1e3 introduces `StringComparers.ItemTypes` and uses it in a few places where `Paths` was used previously, or none was specified.
- ea06eea323e09d3178363797d116392221b575b4 clears down the `_copiedOutputFiles` collection upon refreshing, as previously it would only ever be added to.
- 329b5f4937507f703eef8c9458556265461f7635 partially reverts a change I made in #3919 so that a file name appears in the log message correctly (the tests validate the log messages too).

