### PR TITLE
Updated fallback message for partially supported .NET Core versions

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
@@ -427,7 +427,7 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Visual Studio 2017 version 15.7 or newer is recommended for .NET Core {0}.{1} projects..
+        ///   Looks up a localized string similar to A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}..
         /// </summary>
         internal static string PartialSupportedDotNetCoreProject {
             get {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
@@ -283,7 +283,7 @@ In order to debug this project, add an executable project to this solution which
     <value>Project</value>
   </data>
   <data name="PartialSupportedDotNetCoreProject" xml:space="preserve">
-    <value>Visual Studio 2017 version 15.7 or newer is recommended for .NET Core {0}.{1} projects.</value>
+    <value>A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}.</value>
   </data>
   <data name="NotSupportedDotNetCoreProject" xml:space="preserve">
     <value>Projects targeting versions newer than .NET Core {0}.{1} are not supported by this version of Visual Studio.</value>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
@@ -282,8 +282,8 @@ Pokud chcete projekt ladit, přidejte do řešení spustitelný projekt, který 
         <note />
       </trans-unit>
       <trans-unit id="PartialSupportedDotNetCoreProject">
-        <source>Visual Studio 2017 version 15.7 or newer is recommended for .NET Core {0}.{1} projects.</source>
-        <target state="translated">Pro projekty .NET Core {0}.{1} se doporučuje Visual Studio 2017 verze 15.7 nebo novější.</target>
+        <source>A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}.</source>
+        <target state="needs-review-translation">Pro projekty .NET Core {0}.{1} se doporučuje Visual Studio 2017 verze 15.7 nebo novější.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotSupportedDotNetCoreProject">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
@@ -282,8 +282,8 @@ Um das Projekt zu debuggen, fügen Sie dieser Projektmappe ein ausführbares Pro
         <note />
       </trans-unit>
       <trans-unit id="PartialSupportedDotNetCoreProject">
-        <source>Visual Studio 2017 version 15.7 or newer is recommended for .NET Core {0}.{1} projects.</source>
-        <target state="translated">Für .NET Core {0}.{1}-Projekte wird Visual Studio 2017, Version 15.7 oder höher, empfohlen.</target>
+        <source>A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}.</source>
+        <target state="needs-review-translation">Für .NET Core {0}.{1}-Projekte wird Visual Studio 2017, Version 15.7 oder höher, empfohlen.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotSupportedDotNetCoreProject">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
@@ -282,8 +282,8 @@ Para depurar este proyecto, agregue un proyecto ejecutable a esta solución con 
         <note />
       </trans-unit>
       <trans-unit id="PartialSupportedDotNetCoreProject">
-        <source>Visual Studio 2017 version 15.7 or newer is recommended for .NET Core {0}.{1} projects.</source>
-        <target state="translated">Para los proyectos de .NET Core {0}.{1}, se recomienda Visual Studio 2017 versión 15.7 o superior.</target>
+        <source>A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}.</source>
+        <target state="needs-review-translation">Para los proyectos de .NET Core {0}.{1}, se recomienda Visual Studio 2017 versión 15.7 o superior.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotSupportedDotNetCoreProject">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
@@ -282,8 +282,8 @@ Pour déboguer ce projet, ajoutez à cette solution un projet exécutable qui fa
         <note />
       </trans-unit>
       <trans-unit id="PartialSupportedDotNetCoreProject">
-        <source>Visual Studio 2017 version 15.7 or newer is recommended for .NET Core {0}.{1} projects.</source>
-        <target state="translated">Visual Studio 2017 version 15.7 ou ultérieur est recommandé pour les projets .NET Core {0}.{1}.</target>
+        <source>A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}.</source>
+        <target state="needs-review-translation">Visual Studio 2017 version 15.7 ou ultérieur est recommandé pour les projets .NET Core {0}.{1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotSupportedDotNetCoreProject">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
@@ -282,8 +282,8 @@ Per eseguire il debug del progetto, aggiungere a questa soluzione un progetto es
         <note />
       </trans-unit>
       <trans-unit id="PartialSupportedDotNetCoreProject">
-        <source>Visual Studio 2017 version 15.7 or newer is recommended for .NET Core {0}.{1} projects.</source>
-        <target state="translated">Per i progetti .NET Core {0}.{1} è consigliato Visual Studio 2017 15.7 o versioni successive.</target>
+        <source>A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}.</source>
+        <target state="needs-review-translation">Per i progetti .NET Core {0}.{1} è consigliato Visual Studio 2017 15.7 o versioni successive.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotSupportedDotNetCoreProject">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
@@ -282,8 +282,8 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="PartialSupportedDotNetCoreProject">
-        <source>Visual Studio 2017 version 15.7 or newer is recommended for .NET Core {0}.{1} projects.</source>
-        <target state="translated">.NET Core {0}.{1} プロジェクトでは、Visual Studio 2017 バージョン 15.7 以降が推奨されています。</target>
+        <source>A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}.</source>
+        <target state="needs-review-translation">.NET Core {0}.{1} プロジェクトでは、Visual Studio 2017 バージョン 15.7 以降が推奨されています。</target>
         <note />
       </trans-unit>
       <trans-unit id="NotSupportedDotNetCoreProject">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
@@ -282,8 +282,8 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="PartialSupportedDotNetCoreProject">
-        <source>Visual Studio 2017 version 15.7 or newer is recommended for .NET Core {0}.{1} projects.</source>
-        <target state="translated">.NET Core {0}.{1} 프로젝트에는 Visual Studio 2017 버전 15.7 이상이 권장됩니다.</target>
+        <source>A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}.</source>
+        <target state="needs-review-translation">.NET Core {0}.{1} 프로젝트에는 Visual Studio 2017 버전 15.7 이상이 권장됩니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotSupportedDotNetCoreProject">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
@@ -282,8 +282,8 @@ Aby debugować ten projekt, dodaj projekt wykonywalny do tego rozwiązania, któ
         <note />
       </trans-unit>
       <trans-unit id="PartialSupportedDotNetCoreProject">
-        <source>Visual Studio 2017 version 15.7 or newer is recommended for .NET Core {0}.{1} projects.</source>
-        <target state="translated">Dla projektów platformy .NET Core {0}.{1} zalecany jest program Visual Studio 2017 w wersji 15.7 lub nowszej.</target>
+        <source>A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}.</source>
+        <target state="needs-review-translation">Dla projektów platformy .NET Core {0}.{1} zalecany jest program Visual Studio 2017 w wersji 15.7 lub nowszej.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotSupportedDotNetCoreProject">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
@@ -282,8 +282,8 @@ Para depurar esse projeto, adicione um projeto executável a essa solução que 
         <note />
       </trans-unit>
       <trans-unit id="PartialSupportedDotNetCoreProject">
-        <source>Visual Studio 2017 version 15.7 or newer is recommended for .NET Core {0}.{1} projects.</source>
-        <target state="translated">O Visual Studio 2017 versão 15.7 ou mais recente é recomendado para o .NET Core {0}. Projetos {1}.</target>
+        <source>A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}.</source>
+        <target state="needs-review-translation">O Visual Studio 2017 versão 15.7 ou mais recente é recomendado para o .NET Core {0}. Projetos {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotSupportedDotNetCoreProject">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
@@ -282,8 +282,8 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="PartialSupportedDotNetCoreProject">
-        <source>Visual Studio 2017 version 15.7 or newer is recommended for .NET Core {0}.{1} projects.</source>
-        <target state="translated">Для проектов .NET Core {0}.{1} рекомендуем использовать Visual Studio 2017 версии 15.7 или более новую версию.</target>
+        <source>A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}.</source>
+        <target state="needs-review-translation">Для проектов .NET Core {0}.{1} рекомендуем использовать Visual Studio 2017 версии 15.7 или более новую версию.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotSupportedDotNetCoreProject">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
@@ -282,8 +282,8 @@ Bu projede hata ayıklamak için bu çözüme, kitaplık projesine başvuran bir
         <note />
       </trans-unit>
       <trans-unit id="PartialSupportedDotNetCoreProject">
-        <source>Visual Studio 2017 version 15.7 or newer is recommended for .NET Core {0}.{1} projects.</source>
-        <target state="translated">.NET Core {0}.{1} projeleri için Visual Studio 2017 sürüm 15.7 veya daha yeni bir sürüm önerilir.</target>
+        <source>A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}.</source>
+        <target state="needs-review-translation">.NET Core {0}.{1} projeleri için Visual Studio 2017 sürüm 15.7 veya daha yeni bir sürüm önerilir.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotSupportedDotNetCoreProject">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
@@ -282,8 +282,8 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="PartialSupportedDotNetCoreProject">
-        <source>Visual Studio 2017 version 15.7 or newer is recommended for .NET Core {0}.{1} projects.</source>
-        <target state="translated">.NET Core {0}.{1} 项目建议使用 Visual Studio 2017 版本 15.7 或更新版本。</target>
+        <source>A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}.</source>
+        <target state="needs-review-translation">.NET Core {0}.{1} 项目建议使用 Visual Studio 2017 版本 15.7 或更新版本。</target>
         <note />
       </trans-unit>
       <trans-unit id="NotSupportedDotNetCoreProject">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
@@ -282,8 +282,8 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="PartialSupportedDotNetCoreProject">
-        <source>Visual Studio 2017 version 15.7 or newer is recommended for .NET Core {0}.{1} projects.</source>
-        <target state="translated">建議在 .NET Core {0}.{1} 專案使用 Visual Studio 2017 15.7 以上的版本。</target>
+        <source>A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}.</source>
+        <target state="needs-review-translation">建議在 .NET Core {0}.{1} 專案使用 Visual Studio 2017 15.7 以上的版本。</target>
         <note />
       </trans-unit>
       <trans-unit id="NotSupportedDotNetCoreProject">


### PR DESCRIPTION
Couldn't repro this reliably, partially because the remote json file seems to have been updated, and partially because of other issues, but seems like a fairly obvious change to not hard-code a version number. Used the same wording as the 15.9 case in https://webpifeed.blob.core.windows.net/webpifeed/Partners/DotNetVersionCompatibility.json

Fixes #3910 