### PR TITLE
Add an icon set cache

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyFactory.cs
@@ -42,6 +42,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                                             IImmutableList<string> setPropertiesDependencyIDs = null,
                                             string setPropertiesSchemaName = null,
                                             ITargetFramework targetFramework = null,
+                                            DependencyIconSet iconSet = null,
+                                            DependencyIconSet setPropertiesIconSet = null,
                                             MockBehavior? mockBehavior = null)
         {
             var behavior = mockBehavior ?? MockBehavior.Strict;
@@ -117,11 +119,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 mock.Setup(x => x.TargetFramework).Returns(targetFramework);
             }
 
+            if (iconSet != null)
+            {
+                mock.Setup(x => x.IconSet).Returns(iconSet);
+            }
+
             if (setPropertiesCaption != null
                 || setPropertiesDependencyIDs != null
                 || setPropertiesResolved != null
                 || setPropertiesFlags != null
-                || setPropertiesImplicit != null)
+                || setPropertiesImplicit != null
+                || setPropertiesIconSet != null)
             {
                 mock.Setup(x => x.SetProperties(
                             setPropertiesCaption,
@@ -129,8 +137,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                             setPropertiesFlags,
                             setPropertiesSchemaName,
                             setPropertiesDependencyIDs,
-                            It.IsAny<ImageMoniker>(),
-                            It.IsAny<ImageMoniker>(),
+                            setPropertiesIconSet,
                             setPropertiesImplicit))
                     .Returns(mock.Object);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyIconSetTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyIconSetTests.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Imaging;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
+{
+    [Trait("UnitTest", "ProjectSystem")]
+    public class DependencyIconSetTests
+    {
+        [Fact]
+        public void WhenIconSetsHaveSameIcons_ShouldBeEqual()
+        {
+            var iconSet1 = new DependencyIconSet(
+                icon: KnownMonikers.AboutBox,
+                expandedIcon: KnownMonikers.AboutBox,
+                unresolvedIcon: KnownMonikers.AbsolutePosition,
+                unresolvedExpandedIcon: KnownMonikers.AbsolutePosition);
+            var iconSet2 = new DependencyIconSet(
+                icon: KnownMonikers.AboutBox,
+                expandedIcon: KnownMonikers.AboutBox,
+                unresolvedIcon: KnownMonikers.AbsolutePosition,
+                unresolvedExpandedIcon: KnownMonikers.AbsolutePosition);
+
+            Assert.True(iconSet1.Equals(iconSet2));
+        }
+
+        [Fact]
+        public void WhenIconSetsHaveSameIcons_ShouldHaveSameHashCode()
+        {
+            var iconSet1 = new DependencyIconSet(
+                icon: KnownMonikers.AboutBox,
+                expandedIcon: KnownMonikers.AboutBox,
+                unresolvedIcon: KnownMonikers.AbsolutePosition,
+                unresolvedExpandedIcon: KnownMonikers.AbsolutePosition);
+            var iconSet2 = new DependencyIconSet(
+                icon: KnownMonikers.AboutBox,
+                expandedIcon: KnownMonikers.AboutBox,
+                unresolvedIcon: KnownMonikers.AbsolutePosition,
+                unresolvedExpandedIcon: KnownMonikers.AbsolutePosition);
+
+            Assert.True(iconSet1.GetHashCode() == iconSet2.GetHashCode());
+        }
+
+        [Fact]
+        public void WhenIconSetsHaveDifferentIcons_ShouldNotBeEqual()
+        {
+            var iconSet1 = new DependencyIconSet(
+                icon: KnownMonikers.AboutBox,
+                expandedIcon: KnownMonikers.AboutBox,
+                unresolvedIcon: KnownMonikers.AbsolutePosition,
+                unresolvedExpandedIcon: KnownMonikers.AbsolutePosition);
+            var iconSet2 = new DependencyIconSet(
+                icon: KnownMonikers.PackageReference,
+                expandedIcon: KnownMonikers.AboutBox,
+                unresolvedIcon: KnownMonikers.AbsolutePosition,
+                unresolvedExpandedIcon: KnownMonikers.AbsolutePosition);
+
+            Assert.False(iconSet1.Equals(iconSet2));
+        }
+
+        [Fact]
+        public void WhenIconSetsHaveDifferentIcons_ShouldHaveDifferentHashCode()
+        {
+            var iconSet1 = new DependencyIconSet(
+                icon: KnownMonikers.AboutBox,
+                expandedIcon: KnownMonikers.AboutBox,
+                unresolvedIcon: KnownMonikers.AbsolutePosition,
+                unresolvedExpandedIcon: KnownMonikers.AbsolutePosition);
+            var iconSet2 = new DependencyIconSet(
+                icon: KnownMonikers.PackageReference,
+                expandedIcon: KnownMonikers.AboutBox,
+                unresolvedIcon: KnownMonikers.AbsolutePosition,
+                unresolvedExpandedIcon: KnownMonikers.AbsolutePosition);
+
+            Assert.False(iconSet1.GetHashCode() == iconSet2.GetHashCode());
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyTests.cs
@@ -296,5 +296,72 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.True(dependency.HasUnresolvedDependency(mockSnapshot));
             Assert.True(dependency.IsOrHasUnresolvedDependency(mockSnapshot));
         }
+
+        [Fact]
+        public void WhenSettingProperties_ExistingIconSetInstanceIsReused()
+        {
+            var mockModel = IDependencyModelFactory.Implement(
+                providerType: "providerType",
+                id: "someId");
+
+            var dependency = (new Dependency(mockModel, ITargetFrameworkFactory.Implement("tfm1"), @"C:\Foo\Project.csproj"))
+                .SetProperties(iconSet: new DependencyIconSet(KnownMonikers.Reference, KnownMonikers.Reference, KnownMonikers.Reference, KnownMonikers.Reference));
+
+            var dependencyWithUpdatedIconSet = dependency.SetProperties(iconSet: new DependencyIconSet(KnownMonikers.Reference, KnownMonikers.Reference, KnownMonikers.Reference, KnownMonikers.Reference));
+
+            Assert.True(ReferenceEquals(dependency.IconSet, dependencyWithUpdatedIconSet.IconSet));
+        }
+
+        [Fact]
+        public void WhenCreatingADependencyFromAnotherDependency_ExistingIconSetInstanceIsReused()
+        {
+            var mockModel = IDependencyModelFactory.Implement(
+                providerType: "providerType",
+                id: "someId");
+
+            var dependency = new Dependency(mockModel, ITargetFrameworkFactory.Implement("tfm1"), @"C:\Foo\Project.csproj")
+                .SetProperties(iconSet: new DependencyIconSet(KnownMonikers.Reference, KnownMonikers.Reference, KnownMonikers.Reference, KnownMonikers.Reference));
+
+            var newDependency = new Dependency(dependency, ITargetFrameworkFactory.Implement("tfm2"), @"C:\Foo\Project.csproj");
+
+            Assert.True(ReferenceEquals(dependency.IconSet, newDependency.IconSet));
+        }
+
+        [Fact]
+        public void WhenCreatingUnrelatedDependenciesWithSameIcons_BothUseSameIconSet()
+        {
+            const string jsonModel1 = @"
+{
+    ""ProviderType"": ""alpha"",
+    ""Id"": ""modelOne"",
+}";
+
+            const string jsonModel2 = @"
+{
+    ""ProviderType"": ""beta"",
+    ""Id"": ""modelTwo"",
+}";
+
+            var model1 = IDependencyModelFactory.FromJson(
+                jsonModel1,
+                icon: KnownMonikers.Path,
+                expandedIcon: KnownMonikers.PathIcon,
+                unresolvedIcon: KnownMonikers.PathListBox,
+                unresolvedExpandedIcon: KnownMonikers.PathListBoxItem);
+
+            var model2 = IDependencyModelFactory.FromJson(
+                jsonModel2,
+                icon: KnownMonikers.Path,
+                expandedIcon: KnownMonikers.PathIcon,
+                unresolvedIcon: KnownMonikers.PathListBox,
+                unresolvedExpandedIcon: KnownMonikers.PathListBoxItem);
+
+            var targetFramework = ITargetFrameworkFactory.Implement("Tfm1");
+
+            var dependency1 = new Dependency(model1, targetFramework, @"C:\Foo\Project.csproj");
+            var dependency2 = new Dependency(model2, targetFramework, @"C:\Foo\Project.csproj");
+
+            Assert.True(ReferenceEquals(dependency1.IconSet, dependency2.IconSet));
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/ImplicitTopLevelDependenciesSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/ImplicitTopLevelDependenciesSnapshotFilterTests.cs
@@ -185,7 +185,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 resolved: true,
                 flags: DependencyTreeFlags.GenericDependencyFlags,
                 originalItemSpec: "myprojectitem",
-                setPropertiesImplicit: true);
+                setPropertiesImplicit: true,
+                iconSet: new DependencyIconSet(KnownMonikers.Reference, KnownMonikers.Reference, KnownMonikers.Reference, KnownMonikers.Reference),
+                setPropertiesIconSet: new DependencyIconSet(KnownMonikers.Abbreviation, KnownMonikers.Abbreviation, KnownMonikers.Reference, KnownMonikers.Reference));
 
             var worldBuilder = new Dictionary<string, IDependency>()
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependency.cs
@@ -41,6 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         public string Id { get; set; }
         public string Alias { get; set; }
         public ITargetFramework TargetFramework { get; set; }
+        public DependencyIconSet IconSet { get; set; }
 
         public IDependency SetProperties(
             string caption = null,
@@ -48,8 +49,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             ProjectTreeFlags? flags = null,
             string schemaName = null,
             IImmutableList<string> dependencyIDs = null,
-            ImageMoniker icon = default,
-            ImageMoniker expandedIcon = default,
+            DependencyIconSet iconSet = null,
             bool? isImplicit = null)
         {
             return this;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyIconSet.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyIconSet.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using Microsoft.VisualStudio.Imaging.Interop;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
@@ -10,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     /// sets; we can save considerable amounts of memory by given the sets their
     /// own type and sharing instances.
     /// </summary>
-    internal sealed class DependencyIconSet
+    internal sealed class DependencyIconSet : IEquatable<DependencyIconSet>
     {
         public DependencyIconSet(ImageMoniker icon, ImageMoniker expandedIcon, ImageMoniker unresolvedIcon, ImageMoniker unresolvedExpandedIcon)
         {
@@ -43,6 +44,37 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             }
 
             return new DependencyIconSet(Icon, newExpandedIcon, UnresolvedIcon, UnresolvedExpandedIcon);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as DependencyIconSet);
+        }
+
+        public bool Equals(DependencyIconSet other)
+        {
+            return other != null
+                && Icon.Id == other.Icon.Id
+                && ExpandedIcon.Id == other.ExpandedIcon.Id
+                && UnresolvedIcon.Id == other.UnresolvedIcon.Id
+                && UnresolvedExpandedIcon.Id == other.UnresolvedExpandedIcon.Id
+                && Icon.Guid == other.Icon.Guid
+                && ExpandedIcon.Guid == other.ExpandedIcon.Guid
+                && UnresolvedIcon.Guid == other.UnresolvedIcon.Guid
+                && UnresolvedExpandedIcon.Guid == other.UnresolvedExpandedIcon.Guid;
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = Icon.Id.GetHashCode();
+            hashCode = hashCode * -1521134295 + Icon.Guid.GetHashCode();
+            hashCode = hashCode * -1521134295 + ExpandedIcon.Id.GetHashCode();
+            hashCode = hashCode * -1521134295 + ExpandedIcon.Guid.GetHashCode();
+            hashCode = hashCode * -1521134295 + UnresolvedIcon.Id.GetHashCode();
+            hashCode = hashCode * -1521134295 + UnresolvedIcon.Guid.GetHashCode();
+            hashCode = hashCode * -1521134295 + UnresolvedExpandedIcon.Id.GetHashCode();
+            hashCode = hashCode * -1521134295 + UnresolvedExpandedIcon.Guid.GetHashCode();
+            return hashCode;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyIconSet.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyIconSet.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     /// <summary>
     /// Represents the set of icons associated with a particular dependency.
     /// In practice dependencies use a relatively small number of distinct icon
-    /// sets; we can save considerable amounts of memory by given the sets their
+    /// sets; we can save considerable amounts of memory by giving the sets their
     /// own type and sharing instances.
     /// </summary>
     internal sealed class DependencyIconSet : IEquatable<DependencyIconSet>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyIconSetCache.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyIconSetCache.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Concurrent;
+using Microsoft.VisualStudio.Imaging.Interop;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
+{
+    /// <summary>
+    /// Caches and reuses <see cref="DependencyIconSet"/> instances.
+    /// In practice dependencies use a relatively small number of distinct icon
+    /// sets; we can save considerable amounts of memory by ensuring that the same
+    /// logical sets are represented with the same instances.
+    /// </summary>
+    internal sealed class DependencyIconSetCache
+    {
+        private readonly ConcurrentDictionary<DependencyIconSet, DependencyIconSet> _iconSets = new ConcurrentDictionary<DependencyIconSet, DependencyIconSet>();
+
+        public DependencyIconSet GetOrAddIconSet(DependencyIconSet iconSet)
+        {
+            return _iconSets.GetOrAdd(iconSet, set => set);
+        }
+
+        public DependencyIconSet GetOrAddIconSet(ImageMoniker icon, ImageMoniker expandedIcon, ImageMoniker unresolvedIcon, ImageMoniker unresolvedExpandedIcon)
+        {
+            return GetOrAddIconSet(new DependencyIconSet(icon, expandedIcon, unresolvedIcon, unresolvedExpandedIcon));
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
@@ -20,6 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
     internal class Dependency : IDependency
     {
         private static readonly ConcurrentBag<StringBuilder> s_builderPool = new ConcurrentBag<StringBuilder>();
+        private static readonly DependencyIconSetCache s_iconSetCache = new DependencyIconSetCache();
 
         // These priorities are for graph nodes only and are used to group graph nodes 
         // appropriately in order groups predefined order instead of alphabetically.
@@ -80,15 +81,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             // set rather than creating a new one.
             if (dependencyModel is Dependency dependency)
             {
-                _iconSet = dependency._iconSet;
+                IconSet = dependency.IconSet;
             }
             else if (dependencyModel is DependencyModel model)
             {
-                _iconSet = model.IconSet;
+                IconSet = model.IconSet;
             }
             else
             {
-                _iconSet = new DependencyIconSet(dependencyModel.Icon, dependencyModel.ExpandedIcon, dependencyModel.UnresolvedIcon, dependencyModel.UnresolvedExpandedIcon);
+                IconSet = s_iconSetCache.GetOrAddIconSet(dependencyModel.Icon, dependencyModel.ExpandedIcon, dependencyModel.UnresolvedIcon, dependencyModel.UnresolvedExpandedIcon);
             }
 
             Properties = dependencyModel.Properties ??
@@ -196,15 +197,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         public bool Implicit { get; private set; }
         public bool Visible { get; }
 
-        // Not readonly because SetProperties needs to mutate the clone.
-        private DependencyIconSet _iconSet;
 
-        public ImageMoniker Icon => _iconSet.Icon;
-        public ImageMoniker ExpandedIcon => _iconSet.ExpandedIcon;
-        public ImageMoniker UnresolvedIcon => _iconSet.UnresolvedIcon;
-        public ImageMoniker UnresolvedExpandedIcon => _iconSet.UnresolvedExpandedIcon;
+        public ImageMoniker Icon => IconSet.Icon;
+        public ImageMoniker ExpandedIcon => IconSet.ExpandedIcon;
+        public ImageMoniker UnresolvedIcon => IconSet.UnresolvedIcon;
+        public ImageMoniker UnresolvedExpandedIcon => IconSet.UnresolvedExpandedIcon;
 
-        public DependencyIconSet IconSet => _iconSet;
+        public DependencyIconSet IconSet { get; private set; }
 
         public int Priority { get; }
         public ProjectTreeFlags Flags { get; set; }
@@ -255,9 +254,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 clone.DependencyIDs = dependencyIDs;
             }
 
-            if (iconSet != null && !_iconSet.Equals(iconSet))
+            if (iconSet != null)
             {
-                _iconSet = iconSet;
+                clone.IconSet = s_iconSetCache.GetOrAddIconSet(iconSet);
             }
 
             if (isImplicit != null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
@@ -204,6 +204,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         public ImageMoniker UnresolvedIcon => _iconSet.UnresolvedIcon;
         public ImageMoniker UnresolvedExpandedIcon => _iconSet.UnresolvedExpandedIcon;
 
+        public DependencyIconSet IconSet => _iconSet;
+
         public int Priority { get; }
         public ProjectTreeFlags Flags { get; set; }
 
@@ -223,8 +225,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             ProjectTreeFlags? flags = null,
             string schemaName = null,
             IImmutableList<string> dependencyIDs = null,
-            ImageMoniker icon = default,
-            ImageMoniker expandedIcon = default,
+            DependencyIconSet iconSet = null,
             bool? isImplicit = null)
         {
             var clone = new Dependency(this, _modelId);
@@ -254,14 +255,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 clone.DependencyIDs = dependencyIDs;
             }
 
-            if (icon.Id != 0 && icon.Guid != Guid.Empty)
+            if (iconSet != null && !_iconSet.Equals(iconSet))
             {
-                _iconSet = _iconSet.WithIcon(icon);
-            }
-
-            if (expandedIcon.Id != 0 && expandedIcon.Guid != Guid.Empty)
-            {
-                _iconSet = _iconSet.WithExpandedIcon(expandedIcon);
+                _iconSet = iconSet;
             }
 
             if (isImplicit != null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/ImplicitTopLevelDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/ImplicitTopLevelDependenciesSnapshotFilter.cs
@@ -61,9 +61,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
                     return resultDependency;
                 }
 
+                DependencyIconSet implicitIconSet = resultDependency.IconSet
+                    .WithIcon(internalProvider.GetImplicitIcon())
+                    .WithExpandedIcon(internalProvider.GetImplicitIcon());
+
                 resultDependency = resultDependency.SetProperties(
-                    icon: internalProvider.GetImplicitIcon(),
-                    expandedIcon: internalProvider.GetImplicitIcon(),
+                    iconSet: implicitIconSet,
                     isImplicit: true);
                 filterAnyChanges = true;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependency.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Immutable;
 
-using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
@@ -30,6 +29,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         /// </summary>
         string Alias { get; }
 
+        DependencyIconSet IconSet { get; }
+
         /// <summary>
         /// IDependency is immutable and sometimes tree view provider or snapshot filters need 
         /// to change some properties of a given dependency. This method creates a new instance 
@@ -41,8 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             ProjectTreeFlags? flags = null,
             string schemaName = null,
             IImmutableList<string> dependencyIDs = null,
-            ImageMoniker icon = default,
-            ImageMoniker expandedIcon = default,
+            DependencyIconSet iconSet = null,
             bool? isImplicit = null);
     }
 }


### PR DESCRIPTION
When we create a `Dependency` from another `Dependency` or a `DependencyModel` we re-use their existing `DependencyIconSet`s. This greatly reduces memory consumption related to `ImageMoniker`s as there are usually only a couple dozen distinct icon sets in use within a solution, even with tens of thousands of dependencies.

However, this doesn't help when we're creating a `Dependency` from an `IDependencyModel` supplied by another component--for example, the NPM/Bower package dependencies added by ASP.NET tooling. In those cases we always create a new `DependencyIconSet`.

This change reduces memory usage for those implementations by adding a cache of `DependencyIconSet`s. Every time a `Dependency` creates a new `DependencyIconSet` it runs it through the cache to see if there is an existing set with the same icons; if so, we use that one instead. So while we don't create any fewer instances of `DependencyIconSet` this way most of them will now be garbage collected quickly and only a few will survive long-term.