### PR TITLE
Add ActiveWorkspaceProjectContextTracker

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/ActiveWorkspaceProjectContextTrackerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/ActiveWorkspaceProjectContextTrackerTests.cs
@@ -1,0 +1,195 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.Shell;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
+{
+    public class ActiveWorkspaceProjectContextTrackerTests
+    {
+        [Fact]
+        public void IsActiveContext_NullAsContext_ThrowsArgumentNull()
+        {
+            var instance = CreateInstance();
+
+            Assert.Throws<ArgumentNullException>("context", () =>
+            {
+                instance.IsActiveContext((IWorkspaceProjectContext)null);
+            });
+        }
+
+        [Fact]
+        public void RegisterContext_NullAsContext_ThrowsArgumentNull()
+        {
+            var instance = CreateInstance();
+
+            Assert.Throws<ArgumentNullException>("context", () =>
+            {
+                instance.RegisterContext((IWorkspaceProjectContext)null, "ContextId");
+            });
+        }
+
+        [Fact]
+        public void RegisterContext_NullAsContextId_ThrowsArgumentNull()
+        {
+            var instance = CreateInstance();
+
+            var context = IWorkspaceProjectContextMockFactory.Create();
+
+            Assert.Throws<ArgumentNullException>("contextId", () =>
+            {
+                instance.RegisterContext(context, (string)null);
+            });
+        }
+
+        [Fact]
+        public void RegisterContext_EmptyAsContextId_ThrowsArgument()
+        {
+            var instance = CreateInstance();
+
+            var context = IWorkspaceProjectContextMockFactory.Create();
+
+            Assert.Throws<ArgumentException>("contextId", () =>
+            {
+                instance.RegisterContext(context, string.Empty);
+            });
+        }
+
+        [Fact]
+        public void UnregisterContext_NullAsContext_ThrowsArgumentNull()
+        {
+            var instance = CreateInstance();
+
+            Assert.Throws<ArgumentNullException>("context", () =>
+            {
+                instance.UnregisterContext((IWorkspaceProjectContext)null);
+            });
+        }
+
+        [Theory]
+        [InlineData(VSConstants.VSITEMID_NIL)]
+        [InlineData(VSConstants.VSITEMID_SELECTION)]
+        [InlineData(0)]
+        public void GetProjectName_InvalidIdAsItemId_ReturnsInvalidArg(uint itemid)
+        {
+            var instance = CreateInstance();
+
+            int result = instance.GetProjectName(itemid, out string projectNameResult);
+
+            Assert.Equal(VSConstants.E_INVALIDARG, result);
+            Assert.Null(projectNameResult);
+        }
+
+        [Fact]
+        public void IsActiveContext_UnregisteredContextAsContext_ThrowsInvalidOperation()
+        {
+            var instance = CreateInstance();
+
+            var context = IWorkspaceProjectContextMockFactory.Create();
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                instance.IsActiveContext(context);
+            });
+        }
+
+        [Fact]
+        public void RegisteredContext_AlreadyRegisteredContextAsContext_ThrowsInvalidOperation()
+        {
+            var instance = CreateInstance();
+
+            var context = IWorkspaceProjectContextMockFactory.Create();
+
+            instance.RegisterContext(context, "ContextId");
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                instance.RegisterContext(context, "ContextId");
+            });
+        }
+
+        [Fact]
+        public void UnregisteredContext_UnregisteredContextAsContext_ThrowsInvalidOperation()
+        {
+            var instance = CreateInstance();
+
+            var context = IWorkspaceProjectContextMockFactory.Create();
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                instance.UnregisterContext(context);
+            });
+        }
+
+        [Fact]
+        public void UnregisterContext_RegisteredContextAsContext_CanUnregister()
+        {
+            var instance = CreateInstance();
+
+            var context = IWorkspaceProjectContextMockFactory.Create();
+
+            instance.RegisterContext(context, "ContextId");
+
+            instance.UnregisterContext(context);
+
+            // Should be unregistered
+            Assert.Throws<InvalidOperationException>(() => instance.IsActiveContext(context));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("AnotherContextId")]
+        [InlineData("contextId")]           // Case-sensitive
+        public void IsActiveContext_WhenActiveIntellisenseProjectContextDoesNotMatch_ReturnsFalse(string activeIntellisenseProjectContext)
+        {
+            var instance = CreateInstance();
+
+            var context = IWorkspaceProjectContextMockFactory.Create();
+            instance.RegisterContext(context, "ContextId");
+
+            instance.ActiveIntellisenseProjectContext = activeIntellisenseProjectContext;
+
+            var result = instance.IsActiveContext(context);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void IsActiveContext_WhenActiveIntellisenseProjectContextMatches_ReturnsTrue()
+        {
+            var instance = CreateInstance();
+
+            var context = IWorkspaceProjectContextMockFactory.Create();
+            instance.RegisterContext(context, "ContextId");
+
+            instance.ActiveIntellisenseProjectContext = "ContextId";
+
+            var result = instance.IsActiveContext(context);
+
+            Assert.True(result);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("ContextId")]
+        public void GetProjectName_ReturnsActiveIntellisenseProjectContext(string activeIntellisenseProjectContext)
+        {
+            var instance = CreateInstance();
+
+            instance.ActiveIntellisenseProjectContext = activeIntellisenseProjectContext;
+
+            instance.GetProjectName(HierarchyId.Root, out string result);
+
+            Assert.Equal(activeIntellisenseProjectContext, result);
+        }
+
+        private static ActiveWorkspaceProjectContextTracker CreateInstance()
+        {
+            return new ActiveWorkspaceProjectContextTracker(UnconfiguredProjectFactory.Create());
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ActiveWorkspaceProjectContextTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ActiveWorkspaceProjectContextTracker.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.TextManager.Interop;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
+{
+    /// <summary>
+    ///     Provides an implementation of <see cref="IActiveWorkspaceProjectContextTracker"/> that tracks the 
+    ///     "active" context by handling the VSHPROPID_ActiveIntellisenseProjectContext IVsHierarchy property.
+    /// </summary>
+    [Export(typeof(IActiveIntellisenseProjectProvider))]
+    [ExportProjectNodeComService(typeof(IVsContainedLanguageProjectNameProvider))]
+    [AppliesTo(ProjectCapability.DotNetLanguageService2)]
+    internal class ActiveWorkspaceProjectContextTracker : IActiveIntellisenseProjectProvider, IVsContainedLanguageProjectNameProvider, IActiveWorkspaceProjectContextTracker
+    {
+        private ImmutableDictionary<IWorkspaceProjectContext, string> _contexts = ImmutableDictionary<IWorkspaceProjectContext, string>.Empty;
+
+        [ImportingConstructor]
+        public ActiveWorkspaceProjectContextTracker(UnconfiguredProject project) // For scoping
+        {
+        }
+
+        public string ActiveIntellisenseProjectContext
+        {
+            get;
+            set;
+        }
+
+        public int GetProjectName(uint itemid, out string pbstrProjectName)
+        {
+            if (itemid == HierarchyId.Nil || itemid == HierarchyId.Selection || itemid == HierarchyId.Empty)
+            {
+                pbstrProjectName = null;
+                return HResult.InvalidArg;
+            }
+
+            pbstrProjectName = ActiveIntellisenseProjectContext;
+
+            return HResult.OK;
+        }
+
+        public bool IsActiveContext(IWorkspaceProjectContext context)
+        {
+            Requires.NotNull(context, nameof(context));
+
+            if (_contexts.TryGetValue(context, out string projectContextId))
+            {
+                return StringComparers.WorkspaceProjectContextIds.Equals(ActiveIntellisenseProjectContext, projectContextId);
+            }
+
+            throw new InvalidOperationException("'context' has not been registered or has already been unregistered");
+        }
+
+        public void RegisterContext(IWorkspaceProjectContext context, string contextId)
+        {
+            Requires.NotNull(context, nameof(context));
+            Requires.NotNullOrEmpty(contextId, nameof(contextId));
+            
+            bool changed = ThreadingTools.ApplyChangeOptimistically(ref _contexts,
+                                                                    projectContexts => projectContexts.SetItem(context, contextId));
+
+            if (!changed)
+                throw new InvalidOperationException("'context' has already been registered.");
+        }
+
+        public void UnregisterContext(IWorkspaceProjectContext context)
+        {
+            Requires.NotNull(context, nameof(context));
+
+            bool changed = ThreadingTools.ApplyChangeOptimistically(ref _contexts,
+                                                                    projectContexts => projectContexts.Remove(context));
+
+            if (!changed)
+                throw new InvalidOperationException("'context' has not been registered or has already been unregistered");
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IActiveWorkspaceProjectContextTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IActiveWorkspaceProjectContextTracker.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
+{
+    /// <summary>
+    ///     Tracks the "active" <see cref="IWorkspaceProjectContext"/> for an <see cref="UnconfiguredProject"/>.
+    /// </summary>
+    /// <remarks>
+    ///     The "active" <see cref="IWorkspaceProjectContext"/> is the one that Roslyn uses to drive IntelliSense, refactoring
+    ///     and code fixes. This is typically controlled by the user via the project drop down in the top-left of the editor, but
+    ///     can be changed in reaction to other factors.
+    /// </remarks>
+    internal interface IActiveWorkspaceProjectContextTracker
+    {
+        /// <summary>
+        ///     Returns a value indicating whether the specified <see cref="IWorkspaceProjectContext"/> is the active one.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="context"/> is <see langword="null" />
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///     <paramref name="context"/> has not been registered or has already been unregistered.
+        /// </exception>
+        bool IsActiveContext(IWorkspaceProjectContext context);
+
+        /// <summary>
+        ///     Registers the <see cref="IWorkspaceProjectContext"/> with the tracker.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="context"/> is <see langword="null" />.
+        ///     <para>
+        ///         -or-
+        ///     </para>
+        ///     <paramref name="contextId"/> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="contextId"/> is an empty string ("").
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///     <paramref name="context"/> has already been been registered.
+        /// </exception>
+        void RegisterContext(IWorkspaceProjectContext context, string contextId);
+
+        /// <summary>
+        ///     Unregisters the <see cref="IWorkspaceProjectContext"/> with the tracker.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="context"/> is <see langword="null" />
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///     <paramref name="context"/> has not been registered or has already been unregistered.
+        /// </exception>
+        void UnregisterContext(IWorkspaceProjectContext context);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/StringComparers.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/StringComparers.cs
@@ -10,6 +10,11 @@ namespace Microsoft.VisualStudio
     /// </summary>
     internal static class StringComparers
     {
+        public static IEqualityComparer<string> WorkspaceProjectContextIds
+        {
+            get { return StringComparer.Ordinal; }
+        }
+
         public static IEqualityComparer<string> Paths
         {
             get { return StringComparer.OrdinalIgnoreCase; }


### PR DESCRIPTION
This tracks Roslyn's active context by handling VSHPROPID_ActiveIntellisenseProjectContext - consumption in a future PR.