### PR TITLE
Rename "evaluation" and "design-time" usage in new language service hookup

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IApplyChangesToWorkspaceContextFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IApplyChangesToWorkspaceContextFactory.cs
@@ -22,10 +22,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             return mock.Object;
         }
 
-        public static IApplyChangesToWorkspaceContext ImplementApplyEvaluation(Action<IProjectVersionedValue<IProjectSubscriptionUpdate>, bool, CancellationToken> action)
+        public static IApplyChangesToWorkspaceContext ImplementApplyProjectEvaluation(Action<IProjectVersionedValue<IProjectSubscriptionUpdate>, bool, CancellationToken> action)
         {
             var mock = new Mock<IApplyChangesToWorkspaceContext>();
-            mock.Setup(c => c.ApplyEvaluation(It.IsAny<IProjectVersionedValue<IProjectSubscriptionUpdate>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            mock.Setup(c => c.ApplyProjectEvaluation(It.IsAny<IProjectVersionedValue<IProjectSubscriptionUpdate>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .Callback(action);
 
             return mock.Object;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IApplyChangesToWorkspaceContextFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IApplyChangesToWorkspaceContextFactory.cs
@@ -13,10 +13,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             return Mock.Of<IApplyChangesToWorkspaceContext>();
         }
 
-        public static IApplyChangesToWorkspaceContext ImplementApplyDesignTime(Action<IProjectVersionedValue<IProjectSubscriptionUpdate>, bool, CancellationToken> action)
+        public static IApplyChangesToWorkspaceContext ImplementApplyProjectBuild(Action<IProjectVersionedValue<IProjectSubscriptionUpdate>, bool, CancellationToken> action)
         {
             var mock = new Mock<IApplyChangesToWorkspaceContext>();
-            mock.Setup(c => c.ApplyDesignTime(It.IsAny<IProjectVersionedValue<IProjectSubscriptionUpdate>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            mock.Setup(c => c.ApplyProjectBuild(It.IsAny<IProjectVersionedValue<IProjectSubscriptionUpdate>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .Callback(action);
 
             return mock.Object;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IEvaluationHandlerFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IEvaluationHandlerFactory.cs
@@ -10,21 +10,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
     internal static class IEvaluationHandlerFactory
     {
-        public static IEvaluationHandler ImplementEvaluationRule(string evaluationRule)
+        public static IProjectEvaluationHandler ImplementProjectEvaluationRule(string evaluationRule)
         {
-            var mock = new Mock<IEvaluationHandler>();
+            var mock = new Mock<IProjectEvaluationHandler>();
 
-            mock.SetupGet(h => h.EvaluationRule)
+            mock.SetupGet(h => h.ProjectEvaluationRule)
                 .Returns(evaluationRule);
 
             return mock.Object;
         }
 
-        public static IEvaluationHandler ImplementHandle(string evaluationRule, Action<IComparable, IProjectChangeDescription, bool, IProjectLogger> action)
+        public static IProjectEvaluationHandler ImplementHandle(string evaluationRule, Action<IComparable, IProjectChangeDescription, bool, IProjectLogger> action)
         {
-            var mock = new Mock<IEvaluationHandler>();
+            var mock = new Mock<IProjectEvaluationHandler>();
 
-            mock.SetupGet(h => h.EvaluationRule)
+            mock.SetupGet(h => h.ProjectEvaluationRule)
                 .Returns(evaluationRule);
 
             mock.Setup(h => h.Handle(It.IsAny<IComparable>(), It.IsAny<IProjectChangeDescription>(), It.IsAny<bool>(), It.IsAny<IProjectLogger>()))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContextTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContextTests.cs
@@ -95,13 +95,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
 
         [Fact]
-        public void GetEvaluationRules_WhenNotInitialized_ThrowsInvalidOperation()
+        public void GetProjectEvaluationRules_WhenNotInitialized_ThrowsInvalidOperation()
         {
             var applyChangesToWorkspace = CreateInstance();
 
             Assert.Throws<InvalidOperationException>(() =>
             {
-                applyChangesToWorkspace.GetEvaluationRules();
+                applyChangesToWorkspace.GetProjectEvaluationRules();
             });
         }
 
@@ -117,7 +117,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
 
         [Fact]
-        public void ApplyEvaluation_WhenNotInitialized_ThrowsInvalidOperation()
+        public void ApplyProjectEvaluation_WhenNotInitialized_ThrowsInvalidOperation()
         {
             var applyChangesToWorkspace = CreateInstance();
 
@@ -125,7 +125,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             Assert.Throws<InvalidOperationException>(() =>
             {
-                applyChangesToWorkspace.ApplyEvaluation(update, false, CancellationToken.None);
+                applyChangesToWorkspace.ApplyProjectEvaluation(update, false, CancellationToken.None);
             });
         }
 
@@ -166,7 +166,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var context = IWorkspaceProjectContextMockFactory.Create();
             Assert.Throws<ObjectDisposedException>(() =>
             {
-                applyChangesToWorkspace.GetEvaluationRules();
+                applyChangesToWorkspace.GetProjectEvaluationRules();
             });
         }
 
@@ -185,7 +185,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
 
         [Fact]
-        public async Task ApplyEvaluation_WhenDisposed_ThrowsObjectDisposed()
+        public async Task ApplyProjectEvaluation_WhenDisposed_ThrowsObjectDisposed()
         {
             var applyChangesToWorkspace = CreateInstance();
 
@@ -195,7 +195,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             Assert.Throws<ObjectDisposedException>(() =>
             {
-                applyChangesToWorkspace.ApplyEvaluation(update, true, CancellationToken.None);
+                applyChangesToWorkspace.ApplyProjectEvaluation(update, true, CancellationToken.None);
             });
         }
 
@@ -215,14 +215,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
 
         [Fact]
-        public void GetEvaluationRules_ReturnsAllEvaluationRuleNames()
+        public void GetProjectEvaluationRules_ReturnsAllProjectEvaluationRuleNames()
         {
-            var handler1 = IEvaluationHandlerFactory.ImplementEvaluationRule("Rule1");
-            var handler2 = IEvaluationHandlerFactory.ImplementEvaluationRule("Rule2");
+            var handler1 = IEvaluationHandlerFactory.ImplementProjectEvaluationRule("Rule1");
+            var handler2 = IEvaluationHandlerFactory.ImplementProjectEvaluationRule("Rule2");
 
             var applyChangesToWorkspace = CreateInitializedInstance(handlers: new[] { handler1, handler2 });
 
-            var result = applyChangesToWorkspace.GetEvaluationRules();
+            var result = applyChangesToWorkspace.GetProjectEvaluationRules();
 
             Assert.Equal(new[] { "Rule1", "Rule2" }, result.OrderBy(n => n));
         }
@@ -238,7 +238,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
 
         [Fact]
-        public void ApplyEvaluation_WhenNoRuleChanges_DoesNotCallHandler()
+        public void ApplyProjectEvaluation_WhenNoRuleChanges_DoesNotCallHandler()
         {
             int callCount = 0;
             var handler = IEvaluationHandlerFactory.ImplementHandle("RuleName", (version, description, isActiveContext, logger) => { callCount++; });
@@ -256,7 +256,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     }
 }");
 
-            applyChangesToWorkspace.ApplyEvaluation(update, isActiveContext: false, CancellationToken.None);
+            applyChangesToWorkspace.ApplyProjectEvaluation(update, isActiveContext: false, CancellationToken.None);
 
             Assert.Equal(0, callCount);
         }
@@ -286,7 +286,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
 
         [Fact]
-        public void ApplyEvaluation_CallsHandler()
+        public void ApplyProjectEvaluation_CallsHandler()
         {
             (IComparable version, IProjectChangeDescription description, bool isActiveContext, IProjectLogger logger) result = default;
 
@@ -307,7 +307,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
     }
 }");
-            applyChangesToWorkspace.ApplyEvaluation(update, isActiveContext: true, CancellationToken.None);
+            applyChangesToWorkspace.ApplyProjectEvaluation(update, isActiveContext: true, CancellationToken.None);
 
             Assert.Equal(2, result.version);
             Assert.NotNull(result.description);
@@ -352,7 +352,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
 
         [Fact]
-        public void ApplyEvaluation_WhenCancellationTokenCancelled_StopsProcessingHandlers()
+        public void ApplyProjectEvaluation_WhenCancellationTokenCancelled_StopsProcessingHandlers()
         {
             var cancellationTokenSource = new CancellationTokenSource();
 
@@ -384,7 +384,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
     }
 }");
-            applyChangesToWorkspace.ApplyEvaluation(update, isActiveContext: true, cancellationTokenSource.Token);
+            applyChangesToWorkspace.ApplyProjectEvaluation(update, isActiveContext: true, cancellationTokenSource.Token);
 
             Assert.True(cancellationTokenSource.IsCancellationRequested);
             Assert.Equal(0, callCount);
@@ -426,7 +426,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
 
         [Fact]
-        public void ApplyEvaluation_IgnoresCommandLineHandlers()
+        public void ApplyProjectEvaluation_IgnoresCommandLineHandlers()
         {
             int callCount = 0;
             var handler = ICommandLineHandlerFactory.ImplementHandle((version, added, removed, isActiveContext, logger) => { callCount++; });
@@ -448,7 +448,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
     }
 }");
-            applyChangesToWorkspace.ApplyEvaluation(update, isActiveContext: true, CancellationToken.None);
+            applyChangesToWorkspace.ApplyProjectEvaluation(update, isActiveContext: true, CancellationToken.None);
 
             Assert.Equal(0, callCount);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContextTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContextTests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             Assert.Throws<InvalidOperationException>(() =>
             {
-                applyChangesToWorkspace.GetDesignTimeRules();
+                applyChangesToWorkspace.GetProjectBuildRules();
             });
         }
 
@@ -130,7 +130,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
 
         [Fact]
-        public void ApplyDesignTime_WhenNotInitialized_ThrowsInvalidOperation()
+        public void ApplyProjectBuild_WhenNotInitialized_ThrowsInvalidOperation()
         {
             var applyChangesToWorkspace = CreateInstance();
 
@@ -138,7 +138,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             Assert.Throws<InvalidOperationException>(() =>
             {
-                applyChangesToWorkspace.ApplyDesignTime(update, false, CancellationToken.None);
+                applyChangesToWorkspace.ApplyProjectBuild(update, false, CancellationToken.None);
             });
         }
 
@@ -180,7 +180,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var context = IWorkspaceProjectContextMockFactory.Create();
             Assert.Throws<ObjectDisposedException>(() =>
             {
-                applyChangesToWorkspace.GetDesignTimeRules();
+                applyChangesToWorkspace.GetProjectBuildRules();
             });
         }
 
@@ -200,7 +200,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
 
         [Fact]
-        public async Task ApplyDesignTime_WhenDisposed_ThrowsObjectDisposed()
+        public async Task ApplyProjectBuild_WhenDisposed_ThrowsObjectDisposed()
         {
             var applyChangesToWorkspace = CreateInstance();
 
@@ -210,7 +210,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             Assert.Throws<ObjectDisposedException>(() =>
             {
-                applyChangesToWorkspace.ApplyDesignTime(update, true, CancellationToken.None);
+                applyChangesToWorkspace.ApplyProjectBuild(update, true, CancellationToken.None);
             });
         }
 
@@ -232,7 +232,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         {
             var applyChangesToWorkspace = CreateInitializedInstance();
 
-            var result = applyChangesToWorkspace.GetDesignTimeRules();
+            var result = applyChangesToWorkspace.GetProjectBuildRules();
 
             Assert.Single(result, "CompilerCommandLineArgs");
         }
@@ -262,7 +262,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
 
         [Fact]
-        public void ApplyDesignTime_WhenNoCompilerCommandLineArgsRuleChanges_DoesNotCallHandler()
+        public void ApplyProjectBuild_WhenNoCompilerCommandLineArgsRuleChanges_DoesNotCallHandler()
         {
             int callCount = 0;
             var handler = ICommandLineHandlerFactory.ImplementHandle((version, added, removed, isActiveContext, logger) => { callCount++; });
@@ -280,7 +280,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     }
 }");
 
-            applyChangesToWorkspace.ApplyDesignTime(update, isActiveContext: false, CancellationToken.None);
+            applyChangesToWorkspace.ApplyProjectBuild(update, isActiveContext: false, CancellationToken.None);
 
             Assert.Equal(0, callCount);
         }
@@ -316,7 +316,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
 
         [Fact]
-        public void ApplyDesignTime_ParseCommandLineAndCallsHandler()
+        public void ApplyProjectBuild_ParseCommandLineAndCallsHandler()
         {
             (IComparable version, BuildOptions added, BuildOptions removed, bool isActiveContext, IProjectLogger logger) result = default;
 
@@ -341,7 +341,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
     }
 }");
-            applyChangesToWorkspace.ApplyDesignTime(update, isActiveContext: true, CancellationToken.None);
+            applyChangesToWorkspace.ApplyProjectBuild(update, isActiveContext: true, CancellationToken.None);
 
             Assert.Equal(2, result.version);
             Assert.True(result.isActiveContext);
@@ -391,7 +391,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
 
         [Fact]
-        public void ApplyDesignTime_WhenCancellationTokenCancelled_StopsProcessingHandlers()
+        public void ApplyProjectBuild_WhenCancellationTokenCancelled_StopsProcessingHandlers()
         {
             var cancellationTokenSource = new CancellationTokenSource();
 
@@ -418,7 +418,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
     }
 }");
-            applyChangesToWorkspace.ApplyDesignTime(update, isActiveContext: true, cancellationTokenSource.Token);
+            applyChangesToWorkspace.ApplyProjectBuild(update, isActiveContext: true, cancellationTokenSource.Token);
 
             Assert.True(cancellationTokenSource.IsCancellationRequested);
             Assert.Equal(0, callCount);
@@ -455,7 +455,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
 
         [Fact]
-        public void ApplyDesignTime_IgnoresEvaluationHandlers()
+        public void ApplyProjectBuild_IgnoresEvaluationHandlers()
         {
             int callCount = 0;
             var handler = IEvaluationHandlerFactory.ImplementHandle("RuleName", (version, description, isActiveContext, logger) => { callCount++; });
@@ -477,14 +477,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
     }
 }");
-            applyChangesToWorkspace.ApplyDesignTime(update, isActiveContext: true, CancellationToken.None);
+            applyChangesToWorkspace.ApplyProjectBuild(update, isActiveContext: true, CancellationToken.None);
 
             Assert.Equal(0, callCount);
         }
 
 
         [Fact]
-        public void ApplyDesignTime_WhenDesignTimeBuildFails_SetsLastDesignTimeBuildSucceededToFalse()
+        public void ApplyProjectBuild_WhenDesignTimeBuildFails_SetsLastDesignTimeBuildSucceededToFalse()
         {
             var applyChangesToWorkspace = CreateInitializedInstance(out var context);
             context.LastDesignTimeBuildSucceeded = true;
@@ -503,13 +503,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     }
 }");
 
-            applyChangesToWorkspace.ApplyDesignTime(update, isActiveContext: false, CancellationToken.None);
+            applyChangesToWorkspace.ApplyProjectBuild(update, isActiveContext: false, CancellationToken.None);
 
             Assert.False(context.LastDesignTimeBuildSucceeded);
         }
 
         [Fact]
-        public void ApplyDesignTime_AfterFailingDesignTimeBuildSucceeds_SetsLastDesignTimeBuildSucceededToTrue()
+        public void ApplyProjectBuild_AfterFailingDesignTimeBuildSucceeds_SetsLastDesignTimeBuildSucceededToTrue()
         {
             var applyChangesToWorkspace = CreateInitializedInstance(out var context);
 
@@ -527,7 +527,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     }
 }");
 
-            applyChangesToWorkspace.ApplyDesignTime(update, isActiveContext: false, CancellationToken.None);
+            applyChangesToWorkspace.ApplyProjectBuild(update, isActiveContext: false, CancellationToken.None);
 
             Assert.True(context.LastDesignTimeBuildSucceeded);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         }
 
         [Fact]
-        public void ApplyDesignTimeChanges_NullAsVersion_ThrowsArgumentNull()
+        public void ApplyProjectBuild_NullAsVersion_ThrowsArgumentNull()
         {
             var handler = CreateInstance();
 
@@ -83,12 +83,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             Assert.Throws<ArgumentNullException>(() =>
             {
-                handler.ApplyDesignTimeChanges((IComparable)null, difference, true, logger);
+                handler.ApplyProjectBuild((IComparable)null, difference, true, logger);
             });
         }
 
         [Fact]
-        public void ApplyDesignTimeChanges_NullAsDifference_ThrowsArgumentNull()
+        public void ApplyProjectBuild_NullAsDifference_ThrowsArgumentNull()
         {
             var handler = CreateInstance();
 
@@ -97,12 +97,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             Assert.Throws<ArgumentNullException>(() =>
             {
-                handler.ApplyDesignTimeChanges(version, (IProjectChangeDiff)null, true, logger);
+                handler.ApplyProjectBuild(version, (IProjectChangeDiff)null, true, logger);
             });
         }
 
         [Fact]
-        public void ApplyDesignTimeChanges_NullAsLogger_ThrowsArgumentNull()
+        public void ApplyProjectBuild_NullAsLogger_ThrowsArgumentNull()
         {
             var handler = CreateInstance();
 
@@ -111,7 +111,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             Assert.Throws<ArgumentNullException>(() =>
             {
-                handler.ApplyDesignTimeChanges(version, difference, true, (IProjectLogger)null);
+                handler.ApplyProjectBuild(version, difference, true, (IProjectLogger)null);
             });
         }
 
@@ -129,14 +129,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         }
 
         [Fact]
-        public void ApplyDesignTimeChanges_WhenNoChanges_DoesNothing()
+        public void ApplyProjectBuild_WhenNoChanges_DoesNothing()
         {
             var handler = CreateInstance();
 
             var version = 1;
             var difference = IProjectChangeDiffFactory.WithNoChanges();
 
-            ApplyDesignTimeChanges(handler, version, difference);
+            ApplyProjectBuild(handler, version, difference);
 
             Assert.Empty(handler.FileNames);
         }
@@ -165,12 +165,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         [InlineData(@"C:\Source.cs",                        @"C:\Source.cs")]
         [InlineData(@"C:\Project\Source.cs",                @"C:\Project\Source.cs")]
         [InlineData(@"D:\Temp\Source.cs",                   @"D:\Temp\Source.cs")]
-        public void ApplyDesignTimeChanges_AddsItemFullPathRelativeToProject(string includePath, string expected)
+        public void ApplyProjectBuild_AddsItemFullPathRelativeToProject(string includePath, string expected)
         {
             var handler = CreateInstance(@"C:\Project\Project.csproj");
             var difference = IProjectChangeDiffFactory.WithAddedItems(includePath);
 
-            ApplyDesignTimeChanges(handler, 1, difference);
+            ApplyProjectBuild(handler, 1, difference);
 
             Assert.Single(handler.FileNames, expected);
         }
@@ -216,14 +216,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         [InlineData("A.cs;B.cs",                       "B.cs",                          @"C:\Project\A.cs;C:\Project\B.cs")]
         [InlineData("A.cs;B.cs",                       "B.cs;C.cs",                     @"C:\Project\A.cs;C:\Project\B.cs;C:\Project\C.cs")]
         [InlineData("A.cs;B.cs;C.cs",                  "D.cs;E.cs;F.cs",                @"C:\Project\A.cs;C:\Project\B.cs;C:\Project\C.cs;C:\Project\D.cs;C:\Project\E.cs;C:\Project\F.cs")]
-        public void ApplyDesignTimeChanges_WithExistingEvaluationChanges_CanAddItem(string currentFiles, string filesToAdd, string expected)
+        public void ApplyProjectBuild_WithExistingEvaluationChanges_CanAddItem(string currentFiles, string filesToAdd, string expected)
         {
             string[] expectedFiles = expected.Split(';');
 
             var handler = CreateInstanceWithEvaluationItems(@"C:\Project\Project.csproj", currentFiles);
 
             var difference = IProjectChangeDiffFactory.WithAddedItems(filesToAdd);
-            ApplyDesignTimeChanges(handler, 1, difference);
+            ApplyProjectBuild(handler, 1, difference);
 
             Assert.Equal(handler.FileNames.OrderBy(f => f), expectedFiles.OrderBy(f => f));
         }
@@ -254,14 +254,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         [InlineData("A.cs;B.cs",                       "B.cs",                          @"C:\Project\A.cs")]
         [InlineData("A.cs;B.cs",                       "B.cs;C.cs",                     @"C:\Project\A.cs")]
         [InlineData("A.cs;B.cs;C.cs",                  "A.cs;E.cs;F.cs",                @"C:\Project\B.cs;C:\Project\C.cs")]
-        public void ApplyDesignTimeChanges_WithExistingEvaluationChanges_CanRemoveItem(string currentFiles, string filesToRemove, string expected)
+        public void ApplyProjectBuild_WithExistingEvaluationChanges_CanRemoveItem(string currentFiles, string filesToRemove, string expected)
         {
             string[] expectedFiles = expected.Length == 0 ? Array.Empty<string>() : expected.Split(';');
 
             var handler = CreateInstanceWithEvaluationItems(@"C:\Project\Project.csproj", currentFiles);
 
             var difference = IProjectChangeDiffFactory.WithRemovedItems(filesToRemove);
-            ApplyDesignTimeChanges(handler, 1, difference);
+            ApplyProjectBuild(handler, 1, difference);
 
             Assert.Equal(expectedFiles.OrderBy(f => f), handler.FileNames.OrderBy(f => f));
         }
@@ -292,14 +292,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         [InlineData("A.cs;B.cs",                       "B.cs",                          @"C:\Project\A.cs;C:\Project\B.cs")]
         [InlineData("A.cs;B.cs",                       "B.cs;C.cs",                     @"C:\Project\A.cs;C:\Project\B.cs;C:\Project\C.cs")]
         [InlineData("A.cs;B.cs;C.cs",                  "D.cs;E.cs;F.cs",                @"C:\Project\A.cs;C:\Project\B.cs;C:\Project\C.cs;C:\Project\D.cs;C:\Project\E.cs;C:\Project\F.cs")]
-        public void ApplyDesignTimeChanges_WithExistingDesignTimeChanges_CanAddItem(string currentFiles, string filesToAdd, string expected)
+        public void ApplyProjectBuild_WithExistingDesignTimeChanges_CanAddItem(string currentFiles, string filesToAdd, string expected)
         {
             string[] expectedFiles = expected.Split(';');
 
             var handler = CreateInstanceWithDesignTimeItems(@"C:\Project\Project.csproj", currentFiles);
 
             var difference = IProjectChangeDiffFactory.WithAddedItems(filesToAdd);
-            ApplyDesignTimeChanges(handler, 2, difference);
+            ApplyProjectBuild(handler, 2, difference);
 
             Assert.Equal(expectedFiles.OrderBy(f => f), handler.FileNames.OrderBy(f => f));
         }
@@ -330,14 +330,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         [InlineData("A.cs;B.cs",                       "B.cs",                          @"C:\Project\A.cs")]
         [InlineData("A.cs;B.cs",                       "B.cs;C.cs",                     @"C:\Project\A.cs")]
         [InlineData("A.cs;B.cs;C.cs",                  "A.cs;E.cs;F.cs",                @"C:\Project\B.cs;C:\Project\C.cs")]
-        public void ApplyDesignTimeChanges_WithExistingDesignTimeChanges_CanRemoveItem(string currentFiles, string filesToRemove, string expected)
+        public void ApplyProjectBuild_WithExistingDesignTimeChanges_CanRemoveItem(string currentFiles, string filesToRemove, string expected)
         {
             string[] expectedFiles = expected.Length == 0 ? Array.Empty<string>() : expected.Split(';');
 
             var handler = CreateInstanceWithDesignTimeItems(@"C:\Project\Project.csproj", currentFiles);
 
             var difference = IProjectChangeDiffFactory.WithRemovedItems(filesToRemove);
-            ApplyDesignTimeChanges(handler, 2, difference);
+            ApplyProjectBuild(handler, 2, difference);
 
             Assert.Equal(expectedFiles.OrderBy(f => f), handler.FileNames.OrderBy(f => f));
         }
@@ -395,7 +395,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         }
 
         [Fact]
-        public void ApplyDesignTimeChanges_WhenNewerEvaluationChangesWithAddedConflict_EvaluationWinsOut()
+        public void ApplyProjectBuild_WhenNewerEvaluationChangesWithAddedConflict_EvaluationWinsOut()
         {
             var handler = CreateInstance(@"C:\Project\Project.csproj");
 
@@ -406,13 +406,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             int designTimeVersion = 0;
 
-            ApplyDesignTimeChanges(handler, designTimeVersion, IProjectChangeDiffFactory.WithRemovedItems("Source.cs"));
+            ApplyProjectBuild(handler, designTimeVersion, IProjectChangeDiffFactory.WithRemovedItems("Source.cs"));
 
             Assert.Single(handler.FileNames, @"C:\Project\Source.cs");
         }
 
         [Fact]
-        public void ApplyDesignTimeChanges_WhenNewerEvaluationChangesWithRemovedConflict_EvaluationWinsOut()
+        public void ApplyProjectBuild_WhenNewerEvaluationChangesWithRemovedConflict_EvaluationWinsOut()
         {
             var handler = CreateInstance(@"C:\Project\Project.csproj");
 
@@ -423,13 +423,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             int designTimeVersion = 0;
 
-            ApplyDesignTimeChanges(handler, designTimeVersion, IProjectChangeDiffFactory.WithAddedItems("Source.cs"));
+            ApplyProjectBuild(handler, designTimeVersion, IProjectChangeDiffFactory.WithAddedItems("Source.cs"));
 
             Assert.Empty(handler.FileNames);
         }
 
         [Fact]
-        public void ApplyDesignTimeChanges_WhenOlderEvaluationChangesWithRemovedConflict_DesignTimeWinsOut()
+        public void ApplyProjectBuild_WhenOlderEvaluationChangesWithRemovedConflict_DesignTimeWinsOut()
         {
             var handler = CreateInstance(@"C:\Project\Project.csproj");
 
@@ -440,7 +440,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             int designTimeVersion = 1;
 
-            ApplyDesignTimeChanges(handler, designTimeVersion, IProjectChangeDiffFactory.WithAddedItems("Source.cs"));
+            ApplyProjectBuild(handler, designTimeVersion, IProjectChangeDiffFactory.WithAddedItems("Source.cs"));
 
             Assert.Single(handler.FileNames, @"C:\Project\Source.cs");
         }
@@ -454,12 +454,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             handler.ApplyProjectEvaluation(version, difference, metadata, isActiveContext, logger);
         }
 
-        private static void ApplyDesignTimeChanges(AbstractEvaluationCommandLineHandler handler, IComparable version, IProjectChangeDiff difference)
+        private static void ApplyProjectBuild(AbstractEvaluationCommandLineHandler handler, IComparable version, IProjectChangeDiff difference)
         {
             bool isActiveContext = true;
             var logger = IProjectLoggerFactory.Create();
 
-            handler.ApplyDesignTimeChanges(version, difference, isActiveContext, logger);
+            handler.ApplyProjectBuild(version, difference, isActiveContext, logger);
         }
 
         private static EvaluationCommandLineHandler CreateInstanceWithEvaluationItems(string fullPath, string semiColonSeparatedItems)
@@ -477,7 +477,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             var handler = CreateInstance(fullPath);
 
             // Setup the "current state"
-            ApplyDesignTimeChanges(handler, 1, IProjectChangeDiffFactory.WithAddedItems(semiColonSeparatedItems));
+            ApplyProjectBuild(handler, 1, IProjectChangeDiffFactory.WithAddedItems(semiColonSeparatedItems));
 
             return handler;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     public partial class AbstractEvaluationCommandLineHandlerTests
     {
         [Fact]
-        public void ApplyEvaluationChanges_NullAsVersion_ThrowsArgumentNull()
+        public void ApplyProjectEvaluation_NullAsVersion_ThrowsArgumentNull()
         {
             var handler = CreateInstance();
 
@@ -24,12 +24,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             
             Assert.Throws<ArgumentNullException>(() =>
             {
-                handler.ApplyEvaluationChanges((IComparable)null, difference, metadata, true, logger);
+                handler.ApplyProjectEvaluation((IComparable)null, difference, metadata, true, logger);
             });
         }
 
         [Fact]
-        public void ApplyEvaluationChanges_NullAsDifference_ThrowsArgumentNull()
+        public void ApplyProjectEvaluation_NullAsDifference_ThrowsArgumentNull()
         {
             var handler = CreateInstance();
 
@@ -39,12 +39,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             Assert.Throws<ArgumentNullException>(() =>
             {
-                handler.ApplyEvaluationChanges(version, (IProjectChangeDiff)null, metadata, true, logger);
+                handler.ApplyProjectEvaluation(version, (IProjectChangeDiff)null, metadata, true, logger);
             });
         }
 
         [Fact]
-        public void ApplyEvaluationChanges_NullAsMetadata_ThrowsArgumentNull()
+        public void ApplyProjectEvaluation_NullAsMetadata_ThrowsArgumentNull()
         {
             var handler = CreateInstance();
 
@@ -54,12 +54,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             Assert.Throws<ArgumentNullException>(() =>
             {
-                handler.ApplyEvaluationChanges(version, difference, (ImmutableDictionary<string, IImmutableDictionary<string, string>>)null, true, logger);
+                handler.ApplyProjectEvaluation(version, difference, (ImmutableDictionary<string, IImmutableDictionary<string, string>>)null, true, logger);
             });
         }
 
         [Fact]
-        public void ApplyEvaluationChanges_NullAsLogger_ThrowsArgumentNull()
+        public void ApplyProjectEvaluation_NullAsLogger_ThrowsArgumentNull()
         {
             var handler = CreateInstance();
 
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             
             Assert.Throws<ArgumentNullException>(() =>
             {
-                handler.ApplyEvaluationChanges(version, difference, metadata, true, (IProjectLogger)null);
+                handler.ApplyProjectEvaluation(version, difference, metadata, true, (IProjectLogger)null);
             });
         }
 
@@ -116,14 +116,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         }
 
         [Fact]
-        public void ApplyEvaluationChanges_WhenNoChanges_DoesNothing()
+        public void ApplyProjectEvaluation_WhenNoChanges_DoesNothing()
         {
             var handler = CreateInstance();
 
             var version = 1;
             var difference = IProjectChangeDiffFactory.WithNoChanges();
 
-            ApplyEvaluationChanges(handler, version, difference);
+            ApplyProjectEvaluation(handler, version, difference);
 
             Assert.Empty(handler.FileNames);
         }
@@ -148,12 +148,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         [InlineData(@"C:\Source.cs",                        @"C:\Source.cs")]
         [InlineData(@"C:\Project\Source.cs",                @"C:\Project\Source.cs")]
         [InlineData(@"D:\Temp\Source.cs",                   @"D:\Temp\Source.cs")]
-        public void ApplyEvaluationChanges_AddsItemFullPathRelativeToProject(string includePath, string expected)
+        public void ApplyProjectEvaluation_AddsItemFullPathRelativeToProject(string includePath, string expected)
         {
             var handler = CreateInstance(@"C:\Project\Project.csproj");
             var difference = IProjectChangeDiffFactory.WithAddedItems(includePath);
 
-            ApplyEvaluationChanges(handler, 1, difference);
+            ApplyProjectEvaluation(handler, 1, difference);
 
             Assert.Single(handler.FileNames, expected);
         }
@@ -182,14 +182,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         [InlineData("A.cs;B.cs",                       "B.cs",                          @"C:\Project\A.cs;C:\Project\B.cs")]
         [InlineData("A.cs;B.cs",                       "B.cs;C.cs",                     @"C:\Project\A.cs;C:\Project\B.cs;C:\Project\C.cs")]
         [InlineData("A.cs;B.cs;C.cs",                  "D.cs;E.cs;F.cs",                @"C:\Project\A.cs;C:\Project\B.cs;C:\Project\C.cs;C:\Project\D.cs;C:\Project\E.cs;C:\Project\F.cs")]
-        public void ApplyEvaluationChanges_WithExistingEvaluationChanges_CanAddItem(string currentFiles, string filesToAdd, string expected)
+        public void ApplyProjectEvaluation_WithExistingEvaluationChanges_CanAddItem(string currentFiles, string filesToAdd, string expected)
         {
             string[] expectedFiles = expected.Split(';');
 
             var handler = CreateInstanceWithEvaluationItems(@"C:\Project\Project.csproj", currentFiles);
 
             var difference = IProjectChangeDiffFactory.WithAddedItems(filesToAdd);
-            ApplyEvaluationChanges(handler, 2, difference);
+            ApplyProjectEvaluation(handler, 2, difference);
 
             Assert.Equal(expectedFiles.OrderBy(f => f), handler.FileNames.OrderBy(f => f));
         }
@@ -202,7 +202,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             var difference = IProjectChangeDiffFactory.WithAddedItems("A.cs");
             var metadata = MetadataFactory.Create("A.cs", ("Name", "Value"));
 
-            ApplyEvaluationChanges(handler, 1, difference, metadata);
+            ApplyProjectEvaluation(handler, 1, difference, metadata);
 
             var result = handler.Files[@"C:\Project\A.cs"];
 
@@ -235,14 +235,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         [InlineData("A.cs;B.cs",                       "B.cs",                          @"C:\Project\A.cs")]
         [InlineData("A.cs;B.cs",                       "B.cs;C.cs",                     @"C:\Project\A.cs")]
         [InlineData("A.cs;B.cs;C.cs",                  "A.cs;E.cs;F.cs",                @"C:\Project\B.cs;C:\Project\C.cs")]
-        public void ApplyEvaluationChanges_WithExistingEvaluationChanges_CanRemoveItem(string currentFiles, string filesToRemove, string expected)
+        public void ApplyProjectEvaluation_WithExistingEvaluationChanges_CanRemoveItem(string currentFiles, string filesToRemove, string expected)
         {
             string[] expectedFiles = expected.Length == 0 ? Array.Empty<string>() : expected.Split(';');
 
             var handler = CreateInstanceWithEvaluationItems(@"C:\Project\Project.csproj", currentFiles);
 
             var difference = IProjectChangeDiffFactory.WithRemovedItems(filesToRemove);
-            ApplyEvaluationChanges(handler, 2, difference);
+            ApplyProjectEvaluation(handler, 2, difference);
 
             Assert.Equal(expectedFiles.OrderBy(f => f), handler.FileNames.OrderBy(f => f));
         }
@@ -273,14 +273,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         [InlineData("A.cs;B.cs",                       "B.cs",                          @"C:\Project\A.cs;C:\Project\B.cs")]
         [InlineData("A.cs;B.cs",                       "B.cs;C.cs",                     @"C:\Project\A.cs;C:\Project\B.cs;C:\Project\C.cs")]
         [InlineData("A.cs;B.cs;C.cs",                  "D.cs;E.cs;F.cs",                @"C:\Project\A.cs;C:\Project\B.cs;C:\Project\C.cs;C:\Project\D.cs;C:\Project\E.cs;C:\Project\F.cs")]
-        public void ApplyEvaluationChanges_WithExistingDesignTimeChanges_CanAddItem(string currentFiles, string filesToAdd, string expected)
+        public void ApplyProjectEvaluation_WithExistingDesignTimeChanges_CanAddItem(string currentFiles, string filesToAdd, string expected)
         {
             string[] expectedFiles = expected.Split(';');
 
             var handler = CreateInstanceWithDesignTimeItems(@"C:\Project\Project.csproj", currentFiles);
 
             var difference = IProjectChangeDiffFactory.WithAddedItems(filesToAdd);
-            ApplyEvaluationChanges(handler, 2, difference);
+            ApplyProjectEvaluation(handler, 2, difference);
 
             Assert.Equal(expectedFiles.OrderBy(f => f), handler.FileNames.OrderBy(f => f));
         }
@@ -311,14 +311,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         [InlineData("A.cs;B.cs",                       "B.cs",                          @"C:\Project\A.cs")]
         [InlineData("A.cs;B.cs",                       "B.cs;C.cs",                     @"C:\Project\A.cs")]
         [InlineData("A.cs;B.cs;C.cs",                  "A.cs;E.cs;F.cs",                @"C:\Project\B.cs;C:\Project\C.cs")]
-        public void ApplyEvaluationChanges_WithExistingDesignTimeChanges_CanRemoveItem(string currentFiles, string filesToRemove, string expected)
+        public void ApplyProjectEvaluation_WithExistingDesignTimeChanges_CanRemoveItem(string currentFiles, string filesToRemove, string expected)
         {
             string[] expectedFiles = expected.Length == 0 ? Array.Empty<string>() : expected.Split(';');
 
             var handler = CreateInstanceWithDesignTimeItems(@"C:\Project\Project.csproj", currentFiles);
 
             var difference = IProjectChangeDiffFactory.WithRemovedItems(filesToRemove);
-            ApplyEvaluationChanges(handler, 2, difference);
+            ApplyProjectEvaluation(handler, 2, difference);
 
             Assert.Equal(expectedFiles.OrderBy(f => f), handler.FileNames.OrderBy(f => f));
         }
@@ -347,7 +347,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         [InlineData("A.cs;B.cs",                       "B.cs",              "C.cs",                          @"C:\Project\A.cs;C:\Project\C.cs")]
         [InlineData("A.cs;B.cs;C.cs",                  "B.cs;C.cs",         "D.cs;E.cs",                     @"C:\Project\A.cs;C:\Project\D.cs;C:\Project\E.cs")]
         [InlineData("A.cs;B.cs",                       "A.cs;B.cs",         "B.cs;A.cs",                     @"C:\Project\A.cs;C:\Project\B.cs")]
-        public void ApplyEvaluationChanges_WithExistingEvaluationChanges_CanRenameItem(string currentFiles, string originalNames, string newNames, string expected)
+        public void ApplyProjectEvaluation_WithExistingEvaluationChanges_CanRenameItem(string currentFiles, string originalNames, string newNames, string expected)
         {
             string[] expectedFiles = expected.Length == 0 ? Array.Empty<string>() : expected.Split(';');
 
@@ -355,7 +355,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             var difference = IProjectChangeDiffFactory.WithRenamedItems(originalNames, newNames);
 
-            ApplyEvaluationChanges(handler, 2, difference);
+            ApplyProjectEvaluation(handler, 2, difference);
 
             Assert.Equal(expectedFiles.OrderBy(f => f), handler.FileNames.OrderBy(f => f));
         }
@@ -365,7 +365,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         [InlineData("A.cs;B.cs",                       "B.cs",              "C.cs",                          @"C:\Project\A.cs;C:\Project\C.cs")]
         [InlineData("A.cs;B.cs;C.cs",                  "B.cs;C.cs",         "D.cs;E.cs",                     @"C:\Project\A.cs;C:\Project\D.cs;C:\Project\E.cs")]
         [InlineData("A.cs;B.cs",                       "A.cs;B.cs",         "B.cs;A.cs",                     @"C:\Project\A.cs;C:\Project\B.cs")]
-        public void ApplyEvaluationChanges_WithExistingDesignTimeChanges_CanRenameItem(string currentFiles, string originalNames, string newNames, string expected)
+        public void ApplyProjectEvaluation_WithExistingDesignTimeChanges_CanRenameItem(string currentFiles, string originalNames, string newNames, string expected)
         {
             string[] expectedFiles = expected.Length == 0 ? Array.Empty<string>() : expected.Split(';');
 
@@ -373,13 +373,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             var difference = IProjectChangeDiffFactory.WithRenamedItems(originalNames, newNames);
 
-            ApplyEvaluationChanges(handler, 2, difference);
+            ApplyProjectEvaluation(handler, 2, difference);
 
             Assert.Equal(expectedFiles.OrderBy(f => f), handler.FileNames.OrderBy(f => f));
         }
 
         [Fact]
-        public void ApplyEvaluationCHanges_WithExistingEvaluationChanges_CanAddChangeMetadata()
+        public void ApplyProjectEvaluationCHanges_WithExistingEvaluationChanges_CanAddChangeMetadata()
         {
             var file = "A.cs";
             var handler = CreateInstanceWithEvaluationItems(@"C:\Project\Project.csproj", file);
@@ -387,7 +387,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             var difference = IProjectChangeDiffFactory.WithChangedItems(file);
             var metadata = MetadataFactory.Create(file, ("Name", "Value"));
 
-            ApplyEvaluationChanges(handler, 2, difference, metadata);
+            ApplyProjectEvaluation(handler, 2, difference, metadata);
 
             var result = handler.Files[@"C:\Project\A.cs"];
 
@@ -402,7 +402,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             int evaluationVersion = 1;
 
             // Setup the "current state"
-            ApplyEvaluationChanges(handler, evaluationVersion, IProjectChangeDiffFactory.WithAddedItems("Source.cs"));
+            ApplyProjectEvaluation(handler, evaluationVersion, IProjectChangeDiffFactory.WithAddedItems("Source.cs"));
 
             int designTimeVersion = 0;
 
@@ -419,7 +419,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             int evaluationVersion = 1;
 
             // Setup the "current state"
-            ApplyEvaluationChanges(handler, evaluationVersion, IProjectChangeDiffFactory.WithRemovedItems("Source.cs"));
+            ApplyProjectEvaluation(handler, evaluationVersion, IProjectChangeDiffFactory.WithRemovedItems("Source.cs"));
 
             int designTimeVersion = 0;
 
@@ -436,7 +436,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             int evaluationVersion = 0;
 
             // Setup the "current state"
-            ApplyEvaluationChanges(handler, evaluationVersion, IProjectChangeDiffFactory.WithRemovedItems("Source.cs"));
+            ApplyProjectEvaluation(handler, evaluationVersion, IProjectChangeDiffFactory.WithRemovedItems("Source.cs"));
 
             int designTimeVersion = 1;
 
@@ -445,13 +445,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Assert.Single(handler.FileNames, @"C:\Project\Source.cs");
         }
 
-        private static void ApplyEvaluationChanges(AbstractEvaluationCommandLineHandler handler, IComparable version, IProjectChangeDiff difference, IImmutableDictionary<string, IImmutableDictionary<string, string>> metadata = null)
+        private static void ApplyProjectEvaluation(AbstractEvaluationCommandLineHandler handler, IComparable version, IProjectChangeDiff difference, IImmutableDictionary<string, IImmutableDictionary<string, string>> metadata = null)
         {
             metadata = metadata ?? ImmutableDictionary<string, IImmutableDictionary<string, string>>.Empty;
             bool isActiveContext = true;
             var logger = IProjectLoggerFactory.Create();
 
-            handler.ApplyEvaluationChanges(version, difference, metadata, isActiveContext, logger);
+            handler.ApplyProjectEvaluation(version, difference, metadata, isActiveContext, logger);
         }
 
         private static void ApplyDesignTimeChanges(AbstractEvaluationCommandLineHandler handler, IComparable version, IProjectChangeDiff difference)
@@ -467,7 +467,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             var handler = CreateInstance(fullPath);
 
             // Setup the "current state"
-            ApplyEvaluationChanges(handler, 1, IProjectChangeDiffFactory.WithAddedItems(semiColonSeparatedItems));
+            ApplyProjectEvaluation(handler, 1, IProjectChangeDiffFactory.WithAddedItems(semiColonSeparatedItems));
 
             return handler;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/EvaluationHandlerTestBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/EvaluationHandlerTestBase.cs
@@ -76,11 +76,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             });
         }
 
-        internal static void Handle(IEvaluationHandler handler, IProjectChangeDescription projectChange)
+        internal static void Handle(IProjectEvaluationHandler handler, IProjectChangeDescription projectChange)
         {
             handler.Handle(1, projectChange, false, IProjectLoggerFactory.Create());
         }
 
-        internal abstract IEvaluationHandler CreateInstance();
+        internal abstract IProjectEvaluationHandler CreateInstance();
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/ProjectFilePathAndDisplayNameEvaluationHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/ProjectFilePathAndDisplayNameEvaluationHandlerTests.cs
@@ -117,7 +117,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Assert.Equal(expected, context.DisplayName);
         }
 
-        internal override IEvaluationHandler CreateInstance()
+        internal override IProjectEvaluationHandler CreateInstance()
         {
             return CreateInstance(null, null);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandlerTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             });
         }
 
-        internal override IEvaluationHandler CreateInstance()
+        internal override IProjectEvaluationHandler CreateInstance()
         {
             return CreateInstance(null, null);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemHandler_EvaluationTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemHandler_EvaluationTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             });
         }
 
-        internal override IEvaluationHandler CreateInstance()
+        internal override IProjectEvaluationHandler CreateInstance()
         {
             return CreateInstance(null, null);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceContextHostInstanceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceContextHostInstanceTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 cancellationToken.ThrowIfCancellationRequested();
             }
 
-            var applyChangesToWorkspaceContext = evaluation ? IApplyChangesToWorkspaceContextFactory.ImplementApplyEvaluation(applyChanges) : IApplyChangesToWorkspaceContextFactory.ImplementApplyDesignTime(applyChanges);
+            var applyChangesToWorkspaceContext = evaluation ? IApplyChangesToWorkspaceContextFactory.ImplementApplyProjectEvaluation(applyChanges) : IApplyChangesToWorkspaceContextFactory.ImplementApplyDesignTime(applyChanges);
 
             var instance = await CreateInitializedInstanceAsync(tasksService: tasksService, applyChangesToWorkspaceContext: applyChangesToWorkspaceContext);
 
@@ -96,7 +96,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 cancellationToken.ThrowIfCancellationRequested();
             }
 
-            var applyChangesToWorkspaceContext = evaluation ? IApplyChangesToWorkspaceContextFactory.ImplementApplyEvaluation(applyChanges) : IApplyChangesToWorkspaceContextFactory.ImplementApplyDesignTime(applyChanges);
+            var applyChangesToWorkspaceContext = evaluation ? IApplyChangesToWorkspaceContextFactory.ImplementApplyProjectEvaluation(applyChanges) : IApplyChangesToWorkspaceContextFactory.ImplementApplyDesignTime(applyChanges);
 
             instance = await CreateInitializedInstanceAsync(applyChangesToWorkspaceContext: applyChangesToWorkspaceContext);
 
@@ -121,7 +121,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 isActiveContextResult = iac;
             }
 
-            var applyChangesToWorkspaceContext = evaluation ? IApplyChangesToWorkspaceContextFactory.ImplementApplyEvaluation(applyChanges) : IApplyChangesToWorkspaceContextFactory.ImplementApplyDesignTime(applyChanges);
+            var applyChangesToWorkspaceContext = evaluation ? IApplyChangesToWorkspaceContextFactory.ImplementApplyProjectEvaluation(applyChanges) : IApplyChangesToWorkspaceContextFactory.ImplementApplyDesignTime(applyChanges);
 
             var instance = await CreateInitializedInstanceAsync(applyChangesToWorkspaceContext: applyChangesToWorkspaceContext);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceContextHostInstanceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceContextHostInstanceTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 cancellationToken.ThrowIfCancellationRequested();
             }
 
-            var applyChangesToWorkspaceContext = evaluation ? IApplyChangesToWorkspaceContextFactory.ImplementApplyProjectEvaluation(applyChanges) : IApplyChangesToWorkspaceContextFactory.ImplementApplyDesignTime(applyChanges);
+            var applyChangesToWorkspaceContext = evaluation ? IApplyChangesToWorkspaceContextFactory.ImplementApplyProjectEvaluation(applyChanges) : IApplyChangesToWorkspaceContextFactory.ImplementApplyProjectBuild(applyChanges);
 
             var instance = await CreateInitializedInstanceAsync(tasksService: tasksService, applyChangesToWorkspaceContext: applyChangesToWorkspaceContext);
 
@@ -96,7 +96,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 cancellationToken.ThrowIfCancellationRequested();
             }
 
-            var applyChangesToWorkspaceContext = evaluation ? IApplyChangesToWorkspaceContextFactory.ImplementApplyProjectEvaluation(applyChanges) : IApplyChangesToWorkspaceContextFactory.ImplementApplyDesignTime(applyChanges);
+            var applyChangesToWorkspaceContext = evaluation ? IApplyChangesToWorkspaceContextFactory.ImplementApplyProjectEvaluation(applyChanges) : IApplyChangesToWorkspaceContextFactory.ImplementApplyProjectBuild(applyChanges);
 
             instance = await CreateInitializedInstanceAsync(applyChangesToWorkspaceContext: applyChangesToWorkspaceContext);
 
@@ -121,7 +121,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 isActiveContextResult = iac;
             }
 
-            var applyChangesToWorkspaceContext = evaluation ? IApplyChangesToWorkspaceContextFactory.ImplementApplyProjectEvaluation(applyChanges) : IApplyChangesToWorkspaceContextFactory.ImplementApplyDesignTime(applyChanges);
+            var applyChangesToWorkspaceContext = evaluation ? IApplyChangesToWorkspaceContextFactory.ImplementApplyProjectEvaluation(applyChanges) : IApplyChangesToWorkspaceContextFactory.ImplementApplyProjectBuild(applyChanges);
 
             var instance = await CreateInitializedInstanceAsync(applyChangesToWorkspaceContext: applyChangesToWorkspaceContext);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContext.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     [Export(typeof(IApplyChangesToWorkspaceContext))]
     internal class ApplyChangesToWorkspaceContext : OnceInitializedOnceDisposed, IApplyChangesToWorkspaceContext
     {
-        private const string DesignTimeRuleName = CompilerCommandLineArgs.SchemaName;
+        private const string ProjectBuildRuleName = CompilerCommandLineArgs.SchemaName;
         private readonly ConfiguredProject _project;
         private readonly IProjectLogger _logger;
         private readonly ExportFactory<IWorkspaceContextHandler>[] _workspaceContextHandlerFactories;
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             }
         }
 
-        public void ApplyDesignTime(IProjectVersionedValue<IProjectSubscriptionUpdate> update, bool isActiveContext, CancellationToken cancellationToken)
+        public void ApplyProjectBuild(IProjectVersionedValue<IProjectSubscriptionUpdate> update, bool isActiveContext, CancellationToken cancellationToken)
         {
             Requires.NotNull(update, nameof(update));
             
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             {
                 VerifyInitializedAndNotDisposed();
 
-                IProjectChangeDescription projectChange = update.Value.ProjectChanges[DesignTimeRuleName];
+                IProjectChangeDescription projectChange = update.Value.ProjectChanges[ProjectBuildRuleName];
 
                 if (projectChange.Difference.AnyChanges)
                 {
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
                     ProcessOptions(projectChange.After);
                     ProcessCommandLine(version, projectChange.Difference, isActiveContext, cancellationToken);
-                    ProcessDesignTimeBuildFailure(projectChange.After);
+                    ProcessProjectBuildFailure(projectChange.After);
                 }
             }
         }
@@ -105,13 +105,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             }
         }
 
-        public IEnumerable<string> GetDesignTimeRules()
+        public IEnumerable<string> GetProjectBuildRules()
         {
             lock (SyncObject)
             {
                 VerifyInitializedAndNotDisposed();
 
-                return new string[] { DesignTimeRuleName };
+                return new string[] { ProjectBuildRuleName };
             }
         }
 
@@ -140,7 +140,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             }
         }
 
-        private void ProcessDesignTimeBuildFailure(IProjectRuleSnapshot snapshot)
+        private void ProcessProjectBuildFailure(IProjectRuleSnapshot snapshot)
         {
             // If 'CompileDesignTime' didn't run due to a preceeding failed target, or a failure in itself, IsEvalutionSucceeded returns false.
             //

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContext.cs
@@ -77,7 +77,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             }
         }
 
-        public void ApplyEvaluation(IProjectVersionedValue<IProjectSubscriptionUpdate> update, bool isActiveContext, CancellationToken cancellationToken)
+        public void ApplyProjectEvaluation(IProjectVersionedValue<IProjectSubscriptionUpdate> update, bool isActiveContext, CancellationToken cancellationToken)
         {
             Requires.NotNull(update, nameof(update));
 
@@ -87,19 +87,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
                 IComparable version = GetConfiguredProjectVersion(update);
 
-                ProcessEvaluationHandlers(version, update, isActiveContext, cancellationToken);
+                ProcessProjectEvaluationHandlers(version, update, isActiveContext, cancellationToken);
             }
         }
 
-        public IEnumerable<string> GetEvaluationRules()
+        public IEnumerable<string> GetProjectEvaluationRules()
         {
             lock (SyncObject)
             {
                 VerifyInitializedAndNotDisposed();
 
                 return _handlers.Select(e => e.Value)
-                                .OfType<IEvaluationHandler>()
-                                .Select(e => e.EvaluationRule)
+                                .OfType<IProjectEvaluationHandler>()
+                                .Select(e => e.ProjectEvaluationRule)
                                 .Distinct(StringComparers.RuleNames)
                                 .ToArray();
             }
@@ -185,16 +185,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             }
         }
 
-        private void ProcessEvaluationHandlers(IComparable version, IProjectVersionedValue<IProjectSubscriptionUpdate> update, bool isActiveContext, CancellationToken cancellationToken)
+        private void ProcessProjectEvaluationHandlers(IComparable version, IProjectVersionedValue<IProjectSubscriptionUpdate> update, bool isActiveContext, CancellationToken cancellationToken)
         {
             foreach (ExportLifetimeContext<IWorkspaceContextHandler> handler in _handlers)
             {
                 if (cancellationToken.IsCancellationRequested)
                     break;
 
-                if (handler.Value is IEvaluationHandler evaluationHandler)
+                if (handler.Value is IProjectEvaluationHandler evaluationHandler)
                 {
-                    IProjectChangeDescription projectChange = update.Value.ProjectChanges[evaluationHandler.EvaluationRule];
+                    IProjectChangeDescription projectChange = update.Value.ProjectChanges[evaluationHandler.ProjectEvaluationRule];
                     if (!projectChange.Difference.AnyChanges)
                         continue;
                     

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ContextHandlerProvider.Handlers.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ContextHandlerProvider.Handlers.cs
@@ -8,10 +8,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     {
         private class Handlers
         {
-            public readonly ImmutableArray<(IEvaluationHandler handler, string evaluationRuleName)> EvaluationHandlers;
+            public readonly ImmutableArray<(IProjectEvaluationHandler handler, string evaluationRuleName)> EvaluationHandlers;
             public readonly ImmutableArray<ICommandLineHandler> CommandLineHandlers;
 
-            public Handlers(ImmutableArray<(IEvaluationHandler handler, string evaluationRuleName)> evaluationHandlers, ImmutableArray<ICommandLineHandler> commandLineHandlers)
+            public Handlers(ImmutableArray<(IProjectEvaluationHandler handler, string evaluationRuleName)> evaluationHandlers, ImmutableArray<ICommandLineHandler> commandLineHandlers)
             {
                 EvaluationHandlers = evaluationHandlers;
                 CommandLineHandlers = commandLineHandlers;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ContextHandlerProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ContextHandlerProvider.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             get { return s_allEvaluationRuleNames; }
         }
 
-        public ImmutableArray<(IEvaluationHandler handler, string evaluationRuleName)> GetEvaluationHandlers(IWorkspaceProjectContext context)
+        public ImmutableArray<(IProjectEvaluationHandler handler, string evaluationRuleName)> GetEvaluationHandlers(IWorkspaceProjectContext context)
         {
             Requires.NotNull(context, nameof(context));
 
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         private Handlers CreateHandlers(IWorkspaceProjectContext context)
         {
-            ImmutableArray<(IEvaluationHandler handler, string evaluationRuleName)>.Builder evaluationHandlers = ImmutableArray.CreateBuilder<(IEvaluationHandler handler, string evaluationRuleName)>(s_handlerFactories.Length);
+            ImmutableArray<(IProjectEvaluationHandler handler, string evaluationRuleName)>.Builder evaluationHandlers = ImmutableArray.CreateBuilder<(IProjectEvaluationHandler handler, string evaluationRuleName)>(s_handlerFactories.Length);
             ImmutableArray<ICommandLineHandler>.Builder commandLineHandlers = ImmutableArray.CreateBuilder<ICommandLineHandler>(s_handlerFactories.Length);
 
             foreach ((HandlerFactory factory, string evaluationRuleName) factory in s_handlerFactories)
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 handler.Initialize(context);
 
                 // NOTE: Handlers can be both IEvaluationHandler and ICommandLineHandler
-                if (handler is IEvaluationHandler evaluationHandler)
+                if (handler is IProjectEvaluationHandler evaluationHandler)
                 {
                     evaluationHandlers.Add((evaluationHandler, factory.evaluationRuleName));
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         }
 
         /// <summary>
-        ///     Applys the specified version of evaluation <see cref="IProjectChangeDiff"/> and metadata to the underlying 
+        ///     Applies the specified version of evaluation <see cref="IProjectChangeDiff"/> and metadata to the underlying 
         ///     <see cref="IWorkspaceProjectContext"/>, indicating if the context is the currently active one.
         /// </summary>
         /// <exception cref="ArgumentNullException">
@@ -120,7 +120,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         }
 
         /// <summary>
-        ///     Applys the specified version of design-time build <see cref="IProjectChangeDiff"/> to the underlying
+        ///     Applies the specified version of design-time build <see cref="IProjectChangeDiff"/> to the underlying
         ///     <see cref="IWorkspaceProjectContext"/>, indicating if the context is the currently active one.
         /// </summary>
         /// <exception cref="ArgumentNullException">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     /// </summary>
     internal abstract partial class AbstractEvaluationCommandLineHandler : AbstractWorkspaceContextHandler
     {
-        // This class is not thread-safe, and the assumption is that the caller will make sure that evaluations and design-time builds 
+        // This class is not thread-safe, and the assumption is that the caller will make sure that project evaluations and design-time builds 
         // do not overlap inside the class at the same time.
         //
         // In the ideal world, we would simply wait for a design-time build to get the command-line arguments that would have been passed
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         // metadata.
         //
         private readonly HashSet<string> _paths = new HashSet<string>(StringComparers.Paths);
-        private readonly Queue<VersionedProjectChangeDiff> _evaluations = new Queue<VersionedProjectChangeDiff>();
+        private readonly Queue<VersionedProjectChangeDiff> _projectEvaluations = new Queue<VersionedProjectChangeDiff>();
         private readonly UnconfiguredProject _project;
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         }
 
         /// <summary>
-        ///     Applies the specified version of evaluation <see cref="IProjectChangeDiff"/> and metadata to the underlying 
+        ///     Applies the specified version of the project evaluation <see cref="IProjectChangeDiff"/> and metadata to the underlying 
         ///     <see cref="IWorkspaceProjectContext"/>, indicating if the context is the currently active one.
         /// </summary>
         /// <exception cref="ArgumentNullException">
@@ -103,7 +103,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         ///     </para>
         ///     <paramref name="logger" /> is <see langword="null"/>.
         /// </exception>
-        public void ApplyEvaluationChanges(IComparable version, IProjectChangeDiff difference, IImmutableDictionary<string, IImmutableDictionary<string, string>> metadata, bool isActiveContext, IProjectLogger logger)
+        public void ApplyProjectEvaluation(IComparable version, IProjectChangeDiff difference, IImmutableDictionary<string, IImmutableDictionary<string, string>> metadata, bool isActiveContext, IProjectLogger logger)
         {
             Requires.NotNull(version, nameof(version));
             Requires.NotNull(difference, nameof(difference));
@@ -114,7 +114,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
                 return;
 
             difference = NormalizeDifferences(difference);
-            EnqueueEvaluation(version, difference);
+            EnqueueProjectEvaluation(version, difference);
 
             ApplyChangesToContext(version, difference, metadata, isActiveContext, logger);
         }
@@ -207,10 +207,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
         private IProjectChangeDiff ResolveDesignTimeConflicts(IComparable designTimeVersion, IProjectChangeDiff designTimeDifference)
         {
-            DiscardOutOfDateEvaluations(designTimeVersion);
+            DiscardOutOfDateProjectEvaluations(designTimeVersion);
 
             // Walk all evaluations (if any) that occurred since we launched and resolve the conflicts
-            foreach (VersionedProjectChangeDiff evaluation in _evaluations)
+            foreach (VersionedProjectChangeDiff evaluation in _projectEvaluations)
             {
                 Assumes.True(evaluation.Version.IsLaterThan(designTimeVersion), "Attempted to resolve a conflict between a design-time build and an earlier evaluation.");
 
@@ -231,27 +231,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             return new ProjectChangeDiff(added, removed, designTimeDifferences.ChangedItems);
         }
 
-        private void DiscardOutOfDateEvaluations(IComparable version)
+        private void DiscardOutOfDateProjectEvaluations(IComparable version)
         {
             // Throw away evaluations that are the same version or earlier than the design-time build
             // version as it has more up-to-date information on the the current state of the project
 
             // Note, evaluations could be empty if previous evaluations resulted in no new changes
-            while (_evaluations.Count > 0)
+            while (_projectEvaluations.Count > 0)
             {
-                VersionedProjectChangeDiff evaluation = _evaluations.Peek();
-                if (!evaluation.Version.IsEarlierThanOrEqualTo(version))
+                VersionedProjectChangeDiff projectEvaluation = _projectEvaluations.Peek();
+                if (!projectEvaluation.Version.IsEarlierThanOrEqualTo(version))
                     break;
 
-                _evaluations.Dequeue();
+                _projectEvaluations.Dequeue();
             }
         }
 
-        private void EnqueueEvaluation(IComparable version, IProjectChangeDiff evaluationDifference)
+        private void EnqueueProjectEvaluation(IComparable version, IProjectChangeDiff evaluationDifference)
         {
-            Assumes.False(_evaluations.Count > 0 && version.IsEarlierThanOrEqualTo(_evaluations.Peek().Version), "Attempted to push an evaluation that regressed in version.");
+            Assumes.False(_projectEvaluations.Count > 0 && version.IsEarlierThanOrEqualTo(_projectEvaluations.Peek().Version), "Attempted to push an evaluation that regressed in version.");
 
-            _evaluations.Enqueue(new VersionedProjectChangeDiff(version, evaluationDifference));
+            _projectEvaluations.Enqueue(new VersionedProjectChangeDiff(version, evaluationDifference));
         }
 
         private static IProjectChangeDiff NormalizeDifferences(IProjectChangeDiff difference)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectFilePathAndDisplayNameEvaluationHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectFilePathAndDisplayNameEvaluationHandler.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     ///     and <see cref="IWorkspaceProjectContext.DisplayName"/>.
     /// </summary>
     [Export(typeof(IWorkspaceContextHandler))]
-    internal class ProjectFilePathAndDisplayNameEvaluationHandler : AbstractWorkspaceContextHandler, IEvaluationHandler
+    internal class ProjectFilePathAndDisplayNameEvaluationHandler : AbstractWorkspaceContextHandler, IProjectEvaluationHandler
     {
         private readonly ConfiguredProject _project;
         private readonly IImplicitlyActiveDimensionProvider _implicitlyActiveDimensionProvider;
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             _implicitlyActiveDimensionProvider = implicitlyActiveDimensionProvider;
         }
 
-        public string EvaluationRule
+        public string ProjectEvaluationRule
         {
             get { return ConfigurationGeneral.SchemaName; }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     ///     Handles changes to the project and makes sure the language service is aware of them.
     /// </summary>
     [Export(typeof(IWorkspaceContextHandler))]
-    internal class ProjectPropertiesItemHandler : AbstractWorkspaceContextHandler, IEvaluationHandler
+    internal class ProjectPropertiesItemHandler : AbstractWorkspaceContextHandler, IProjectEvaluationHandler
     {
         [ImportingConstructor]
         public ProjectPropertiesItemHandler(UnconfiguredProject project)
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Requires.NotNull(project, nameof(project));
         }
 
-        public string EvaluationRule
+        public string ProjectEvaluationRule
         {
             get { return ConfigurationGeneral.SchemaName; }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             IProjectChangeDiff difference = ConvertToProjectDiff(added, removed);
 
-            ApplyDesignTimeChanges(version, difference, isActiveContext, logger);
+            ApplyProjectBuild(version, difference, isActiveContext, logger);
         }
 
         protected override void AddToContext(string fullPath, IImmutableDictionary<string, string> metadata, bool isActiveContext, IProjectLogger logger)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     ///     to the compiler during design-time builds.
     /// </summary>
     [Export(typeof(IWorkspaceContextHandler))]
-    internal partial class SourceItemHandler : AbstractEvaluationCommandLineHandler, IEvaluationHandler, ICommandLineHandler
+    internal partial class SourceItemHandler : AbstractEvaluationCommandLineHandler, IProjectEvaluationHandler, ICommandLineHandler
     {
         private readonly UnconfiguredProject _project;
 
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             _project = project;
         }
 
-        public string EvaluationRule
+        public string ProjectEvaluationRule
         {
             get { return Compile.SchemaName; }
         }
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             VerifyInitialized();
 
-            ApplyEvaluationChanges(version, projectChange.Difference, projectChange.After.Items, isActiveContext, logger);
+            ApplyProjectEvaluation(version, projectChange.Difference, projectChange.After.Items, isActiveContext, logger);
         }
 
         public void Handle(IComparable version, BuildOptions added, BuildOptions removed, bool isActiveContext, IProjectLogger logger)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IApplyChangesToWorkspaceContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IApplyChangesToWorkspaceContext.cs
@@ -18,10 +18,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         IEnumerable<string> GetProjectEvaluationRules();
 
         /// <summary>
-        ///     Returns an enumerable of design-time rules that should passed to
-        ///     <see cref="ApplyDesignTime(IProjectVersionedValue{IProjectSubscriptionUpdate}, bool)"/>.
+        ///     Returns an enumerable of project build rules that should passed to
+        ///     <see cref="ApplyProjectBuild(IProjectVersionedValue{IProjectSubscriptionUpdate}, bool)"/>.
         /// </summary>
-        IEnumerable<string> GetDesignTimeRules();
+        IEnumerable<string> GetProjectBuildRules();
 
         /// <summary>
         ///     Initializes the service with the specified <see cref="IWorkspaceProjectContext"/>.
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         void ApplyProjectEvaluation(IProjectVersionedValue<IProjectSubscriptionUpdate> update, bool isActiveContext, CancellationToken cancellationToken);
 
         /// <summary>
-        ///     Applies evaluation changes to the underlying <see cref="IWorkspaceProjectContext"/>.
+        ///     Applies project build changes to the underlying <see cref="IWorkspaceProjectContext"/>.
         /// </summary>
         /// <exception cref="ArgumentNullException">
         ///     <paramref name="update"/> is <see langword="null"/>.
@@ -72,6 +72,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ///     to the project snapshot state. The cancellation token should only be cancelled with the
         ///     intention that the <see cref="IWorkspaceProjectContext"/> will be immediately disposed.
         /// </remarks>
-        void ApplyDesignTime(IProjectVersionedValue<IProjectSubscriptionUpdate> update, bool isActiveContext, CancellationToken cancellationToken);
+        void ApplyProjectBuild(IProjectVersionedValue<IProjectSubscriptionUpdate> update, bool isActiveContext, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IApplyChangesToWorkspaceContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IApplyChangesToWorkspaceContext.cs
@@ -12,10 +12,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     internal interface IApplyChangesToWorkspaceContext
     {
         /// <summary>
-        ///     Returns an enumerable of evaluation rules that should passed to
-        ///     <see cref="ApplyEvaluation(IProjectVersionedValue{IProjectSubscriptionUpdate}, bool, CancellationToken)"/>.
+        ///     Returns an enumerable of project evaluation rules that should passed to
+        ///     <see cref="ApplyProjectEvaluation(IProjectVersionedValue{IProjectSubscriptionUpdate}, bool, CancellationToken)"/>.
         /// </summary>
-        IEnumerable<string> GetEvaluationRules();
+        IEnumerable<string> GetProjectEvaluationRules();
 
         /// <summary>
         ///     Returns an enumerable of design-time rules that should passed to
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         void Initialize(IWorkspaceProjectContext context);
 
         /// <summary>
-        ///     Applies evaluation changes to the underlying <see cref="IWorkspaceProjectContext"/>.
+        ///     Applies project evaluation changes to the underlying <see cref="IWorkspaceProjectContext"/>.
         /// </summary>
         /// <exception cref="ArgumentNullException">
         ///     <paramref name="update"/> is <see langword="null"/>.
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ///     to the project snapshot state. The cancellation token should only be cancelled with the
         ///     intention that the <see cref="IWorkspaceProjectContext"/> will be immediately disposed.
         /// </remarks>
-        void ApplyEvaluation(IProjectVersionedValue<IProjectSubscriptionUpdate> update, bool isActiveContext, CancellationToken cancellationToken);
+        void ApplyProjectEvaluation(IProjectVersionedValue<IProjectSubscriptionUpdate> update, bool isActiveContext, CancellationToken cancellationToken);
 
         /// <summary>
         ///     Applies evaluation changes to the underlying <see cref="IWorkspaceProjectContext"/>.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IApplyChangesToWorkspaceContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IApplyChangesToWorkspaceContext.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         void Initialize(IWorkspaceProjectContext context);
 
         /// <summary>
-        ///     Applys evaluation changes to the underlying <see cref="IWorkspaceProjectContext"/>.
+        ///     Applies evaluation changes to the underlying <see cref="IWorkspaceProjectContext"/>.
         /// </summary>
         /// <exception cref="ArgumentNullException">
         ///     <paramref name="update"/> is <see langword="null"/>.
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         void ApplyEvaluation(IProjectVersionedValue<IProjectSubscriptionUpdate> update, bool isActiveContext, CancellationToken cancellationToken);
 
         /// <summary>
-        ///     Applys evaluation changes to the underlying <see cref="IWorkspaceProjectContext"/>.
+        ///     Applies evaluation changes to the underlying <see cref="IWorkspaceProjectContext"/>.
         /// </summary>
         /// <exception cref="ArgumentNullException">
         ///     <paramref name="update"/> is <see langword="null"/>.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IContextHandlerProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IContextHandlerProvider.cs
@@ -5,13 +5,13 @@ using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
     /// <summary>
-    ///     Provides <see cref="ICommandLineHandler"/> and <see cref="IEvaluationHandler"/> instances for 
+    ///     Provides <see cref="ICommandLineHandler"/> and <see cref="IProjectEvaluationHandler"/> instances for 
     ///     <see cref="IWorkspaceProjectContext"/> instances.
     /// </summary>
     internal interface IContextHandlerProvider
     {
         /// <summary>
-        ///     Gets the evaluation rules for all <see cref="IEvaluationHandler"/> instances.
+        ///     Gets the evaluation rules for all <see cref="IProjectEvaluationHandler"/> instances.
         /// </summary>
         ImmutableArray<string> EvaluationRuleNames { get; }
 
@@ -24,13 +24,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ImmutableArray<ICommandLineHandler> GetCommandLineHandlers(IWorkspaceProjectContext context);
 
         /// <summary>
-        ///     Returns the array of <see cref="IEvaluationHandler"/> instances and their evaluation rule names
+        ///     Returns the array of <see cref="IProjectEvaluationHandler"/> instances and their evaluation rule names
         ///     for the specified <see cref="IWorkspaceProjectContext"/>.
         /// </summary>
         /// <exception cref="ArgumentNullException">
         ///     <paramref name="context"/> is <see langword="null"/>.
         /// </exception>
-        ImmutableArray<(IEvaluationHandler handler, string evaluationRuleName)> GetEvaluationHandlers(IWorkspaceProjectContext context);
+        ImmutableArray<(IProjectEvaluationHandler handler, string evaluationRuleName)> GetEvaluationHandlers(IWorkspaceProjectContext context);
 
         /// <summary>
         ///     Releases the handlers for the specified <see cref="IWorkspaceProjectContext"/>.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IProjectEvaluationHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IProjectEvaluationHandler.cs
@@ -7,21 +7,21 @@ using Microsoft.VisualStudio.ProjectSystem.Logging;
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
     /// <summary>
-    ///     Handles changes to a language service rule, and applies them to a
+    ///     Handles changes to project evaluation rule and applies them to a
     ///     <see cref="IWorkspaceProjectContext"/> instance.
     /// </summary>
-    internal interface IEvaluationHandler : IWorkspaceContextHandler
+    internal interface IProjectEvaluationHandler : IWorkspaceContextHandler
     {
         /// <summary>
-        ///     Gets the evaluation rule that the <see cref="IEvaluationHandler"/> handles.
+        ///     Gets the project evaluation rule that the <see cref="IProjectEvaluationHandler"/> handles.
         /// </summary>
-        string EvaluationRule
+        string ProjectEvaluationRule
         {
             get;
         }
 
         /// <summary>
-        ///     Handles the specified set of changes to a rule, and applies them
+        ///     Handles the specified set of changes to the project evaluation rule, and applies them
         ///     to the underlying <see cref="IWorkspaceProjectContext"/>.
         /// </summary>
         /// <param name="version">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHandlerManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHandlerManager.cs
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         private void HandleEvaluation(IProjectVersionedValue<IProjectSubscriptionUpdate> update, IWorkspaceProjectContext context, bool isActiveContext)
         {
-            ImmutableArray<(IEvaluationHandler handler, string evaluationRuleName)> handlers = _handlerProvider.GetEvaluationHandlers(context);
+            ImmutableArray<(IProjectEvaluationHandler handler, string evaluationRuleName)> handlers = _handlerProvider.GetEvaluationHandlers(context);
 
             IComparable version = update.DataSourceVersions[ProjectDataSources.ConfiguredProjectVersion];
 
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             {
                 WriteHeader(logger, update, version, RuleHandlerType.Evaluation, isActiveContext);
 
-                foreach ((IEvaluationHandler handler, string evaluationRuleName) handler in handlers)
+                foreach ((IProjectEvaluationHandler handler, string evaluationRuleName) handler in handlers)
                 {
                     string ruleName = handler.evaluationRuleName;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/RuleHandlerType.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/RuleHandlerType.cs
@@ -6,13 +6,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     internal enum RuleHandlerType
     {
         /// <summary>
-        ///     The <see cref="IEvaluationHandler"/> handles changes 
+        ///     The <see cref="IProjectEvaluationHandler"/> handles changes 
         ///     to evaluation rules.
         /// </summary>
         Evaluation,
 
         /// <summary>
-        ///     The <see cref="IEvaluationHandler"/> handles changes 
+        ///     The <see cref="IProjectEvaluationHandler"/> handles changes 
         ///     to design-time build rules.
         /// </summary>
         DesignTimeBuild,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceContextHost.WorkspaceContextHostInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceContextHost.WorkspaceContextHostInstance.cs
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
                 _subscriptions.AddDisposable(_projectSubscriptionService.ProjectBuildRuleSource.SourceBlock.LinkToAsyncAction(
                         target: e => OnProjectChangedAsync(e, evaluation: false),
-                        ruleNames: _applyChangesToWorkspaceContext.Value.GetDesignTimeRules()));
+                        ruleNames: _applyChangesToWorkspaceContext.Value.GetProjectBuildRules()));
             }
 
             protected override async Task DisposeCoreUnderLockAsync(bool initialized)
@@ -99,7 +99,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                     }
                     else
                     {
-                        _applyChangesToWorkspaceContext.Value.ApplyDesignTime(update, isActiveContext: true, cancellationToken);
+                        _applyChangesToWorkspaceContext.Value.ApplyProjectBuild(update, isActiveContext: true, cancellationToken);
                     }
 
                     return Task.CompletedTask;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceContextHost.WorkspaceContextHostInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceContextHost.WorkspaceContextHostInstance.cs
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 _subscriptions = new DisposableBag(CancellationToken.None);
                 _subscriptions.AddDisposable(_projectSubscriptionService.ProjectRuleSource.SourceBlock.LinkToAsyncAction(
                         target: e => OnProjectChangedAsync(e, evaluation: true),
-                        ruleNames: _applyChangesToWorkspaceContext.Value.GetEvaluationRules()));
+                        ruleNames: _applyChangesToWorkspaceContext.Value.GetProjectEvaluationRules()));
 
                 _subscriptions.AddDisposable(_projectSubscriptionService.ProjectBuildRuleSource.SourceBlock.LinkToAsyncAction(
                         target: e => OnProjectChangedAsync(e, evaluation: false),
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 {
                     if (evaluation)
                     {
-                        _applyChangesToWorkspaceContext.Value.ApplyEvaluation(update, isActiveContext: true, cancellationToken);
+                        _applyChangesToWorkspaceContext.Value.ApplyProjectEvaluation(update, isActiveContext: true, cancellationToken);
                     }
                     else
                     {


### PR DESCRIPTION
As a part of https://github.com/dotnet/project-system/issues/3425, I need to create public API with build/design-time & evaluation terminology. For better or worse, CPS refers to "design-time builds" as "project build" and as "evaluation" as "project evaluation" or just "project" so to try be consistent with it, I've gone and applied these terms across the new language service hookup. I avoided touching the old code - as it will be deleted when we turn the new one on.