### PR TITLE
Use static classes where possible

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/Workspaces/WorkspaceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/Workspaces/WorkspaceFactory.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.VisualStudio.Workspaces
 {
-    public class WorkspaceFactory
+    public static class WorkspaceFactory
     {
         private static readonly MetadataReference s_corlibReference = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
         private static readonly MetadataReference s_systemReference = MetadataReference.CreateFromFile(typeof(System.Diagnostics.Debug).Assembly.Location);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/AbstractMultiLifetimeComponentFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/AbstractMultiLifetimeComponentFactory.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    internal class AbstractMultiLifetimeComponentFactory
+    internal static class AbstractMultiLifetimeComponentFactory
     {
         public static MultiLifetimeComponent Create()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/AppDesignerFolderSpecialFileProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/AppDesignerFolderSpecialFileProviderFactory.cs
@@ -6,7 +6,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
 {
-    internal class AppDesignerFolderSpecialFileProviderFactory
+    internal static class AppDesignerFolderSpecialFileProviderFactory
     {
         public static AppDesignerFolderSpecialFileProvider ImplementGetFile(string result)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemFactory.cs
@@ -7,7 +7,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.IO
 {
-    internal class IFileSystemFactory
+    internal static class IFileSystemFactory
     {
         public static IFileSystem Create()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFolderManagerFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFolderManagerFactory.cs
@@ -7,7 +7,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    internal class IFolderManagerFactory
+    internal static class IFolderManagerFactory
     {
         public static IFolderManager Create()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IInterceptingPropertyValueProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IInterceptingPropertyValueProviderFactory.cs
@@ -10,7 +10,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    internal class IInterceptingPropertyValueProviderFactory
+    internal static class IInterceptingPropertyValueProviderFactory
     {
         public static IInterceptingPropertyValueProvider Create(
             Func<string, IProjectProperties, string> onGetEvaluatedPropertyValue = null,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IInterceptingPropertyValueProviderMetadataFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IInterceptingPropertyValueProviderMetadataFactory.cs
@@ -6,7 +6,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    internal class IInterceptingPropertyValueProviderMetadataFactory
+    internal static class IInterceptingPropertyValueProviderMetadataFactory
     {
         public static IInterceptingPropertyValueProviderMetadata Create(string propertyName)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IPhysicalProjectTreeStorageFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IPhysicalProjectTreeStorageFactory.cs
@@ -4,7 +4,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    internal class IPhysicalProjectTreeStorageFactory
+    internal static class IPhysicalProjectTreeStorageFactory
     {
         public static IPhysicalProjectTreeStorage Create()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectFaultHandlerServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectFaultHandlerServiceFactory.cs
@@ -4,7 +4,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    internal class IProjectFaultHandlerServiceFactory
+    internal static class IProjectFaultHandlerServiceFactory
     {
         public static IProjectFaultHandlerService Create()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectItemProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectItemProviderFactory.cs
@@ -7,7 +7,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    internal class IProjectItemProviderFactory
+    internal static class IProjectItemProviderFactory
     {
         public static IProjectItemProvider Create()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectPropertiesFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectPropertiesFactory.cs
@@ -10,7 +10,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    internal class IProjectPropertiesFactory
+    internal static class IProjectPropertiesFactory
     {
         public static Mock<IProjectProperties> MockWithProperty(string propertyName)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectPropertiesProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectPropertiesProviderFactory.cs
@@ -6,7 +6,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    internal class IProjectPropertiesProviderFactory
+    internal static class IProjectPropertiesProviderFactory
     {
         public static IProjectPropertiesProvider Create(IProjectProperties props = null, IProjectProperties commonProps = null)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectServiceFactory.cs
@@ -4,7 +4,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    internal class IProjectServiceFactory
+    internal static class IProjectServiceFactory
     {
         public static IProjectService Create(IProjectServices services = null)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectServicesFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectServicesFactory.cs
@@ -4,7 +4,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    internal class IProjectServicesFactory
+    internal static class IProjectServicesFactory
     {
         public static IProjectServices Create(IProjectThreadingService threadingService = null, IProjectFaultHandlerService faultHandlerService = null, IProjectService projectService = null)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectTreeCustomizablePropertyContextFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectTreeCustomizablePropertyContextFactory.cs
@@ -4,7 +4,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    internal class IProjectTreeCustomizablePropertyContextFactory
+    internal static class IProjectTreeCustomizablePropertyContextFactory
     {
         public static IProjectTreeCustomizablePropertyContext Create()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectTreeCustomizablePropertyValuesFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectTreeCustomizablePropertyValuesFactory.cs
@@ -4,7 +4,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    internal class IProjectTreeCustomizablePropertyValuesFactory
+    internal static class IProjectTreeCustomizablePropertyValuesFactory
     {
         public static IProjectTreeCustomizablePropertyValues Create()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectTreeProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectTreeProviderFactory.cs
@@ -9,7 +9,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    internal class IProjectTreeProviderFactory
+    internal static class IProjectTreeProviderFactory
     {
         public static IProjectTreeProvider ImplementGetAddNewItemDirectory(Func<IProjectTree, string> action)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectTreeServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectTreeServiceFactory.cs
@@ -6,7 +6,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    internal class IProjectTreeServiceFactory
+    internal static class IProjectTreeServiceFactory
     {
         public static IProjectTreeService Create(IProjectTree tree)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectTreeServiceStateFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectTreeServiceStateFactory.cs
@@ -6,7 +6,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    internal class IProjectTreeServiceStateFactory
+    internal static class IProjectTreeServiceStateFactory
     {
         public static IProjectTreeServiceState Create()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectTreeSnapshotFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectTreeSnapshotFactory.cs
@@ -4,7 +4,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    internal class IProjectTreeSnapshotFactory
+    internal static class IProjectTreeSnapshotFactory
     {
         public static IProjectTreeSnapshot Create(IProjectTree tree)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ISpecialFilesManagerFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ISpecialFilesManagerFactory.cs
@@ -4,7 +4,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
 {
-    internal class ISpecialFilesManagerFactory
+    internal static class ISpecialFilesManagerFactory
     {
         public static ISpecialFilesManager ImplementGetFile(string result)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IWorkspaceContextHandlerFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IWorkspaceContextHandlerFactory.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
-    internal class IWorkspaceContextHandlerFactory
+    internal static class IWorkspaceContextHandlerFactory
     {
         public static IWorkspaceContextHandler ImplementDispose(Action action)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/JoinableTaskContextNodeFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/JoinableTaskContextNodeFactory.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.VisualStudio.Threading
 {
-    internal class JoinableTaskContextNodeFactory
+    internal static class JoinableTaskContextNodeFactory
     {
         public static JoinableTaskContextNode Create()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IActiveConfiguredProjectSubscriptionServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IActiveConfiguredProjectSubscriptionServiceFactory.cs
@@ -4,7 +4,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    public class IActiveConfiguredProjectSubscriptionServiceFactory
+    public static class IActiveConfiguredProjectSubscriptionServiceFactory
     {
         public static IActiveConfiguredProjectSubscriptionService Create()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IAggregateDependenciesSnapshotProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IAggregateDependenciesSnapshotProviderFactory.cs
@@ -6,7 +6,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
-    internal class IAggregateDependenciesSnapshotProviderFactory
+    internal static class IAggregateDependenciesSnapshotProviderFactory
     {
         public static IAggregateDependenciesSnapshotProvider Create()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDebugLaunchProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDebugLaunchProviderFactory.cs
@@ -6,7 +6,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
-    public class IDebugLaunchProviderFactory
+    public static class IDebugLaunchProviderFactory
     {
         public static IDebugLaunchProvider ImplementCanLaunchAsync(Func<bool> action)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependenciesChangesFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependenciesChangesFactory.cs
@@ -9,7 +9,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
-    internal class IDependenciesChangesFactory
+    internal static class IDependenciesChangesFactory
     {
         public static IDependenciesChanges Create()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependenciesSnapshotFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependenciesSnapshotFactory.cs
@@ -10,7 +10,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
-    internal class IDependenciesSnapshotFactory
+    internal static class IDependenciesSnapshotFactory
     {
         public static IDependenciesSnapshot Create()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependenciesSnapshotProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependenciesSnapshotProviderFactory.cs
@@ -6,7 +6,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
-    internal class IDependenciesSnapshotProviderFactory
+    internal static class IDependenciesSnapshotProviderFactory
     {
         public static IDependenciesSnapshotProvider Create()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyFactory.cs
@@ -14,7 +14,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
-    internal class IDependencyFactory
+    internal static class IDependencyFactory
     {
         public static IDependency Create()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyModelFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyModelFactory.cs
@@ -12,7 +12,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
-    internal class IDependencyModelFactory
+    internal static class IDependencyModelFactory
     {
         public static IDependencyModel Create()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IMockDependenciesViewModelFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IMockDependenciesViewModelFactory.cs
@@ -11,7 +11,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
-    internal class IMockDependenciesViewModelFactory
+    internal static class IMockDependenciesViewModelFactory
     {
         public static IDependenciesViewModelFactory Create()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectDependenciesSubTreeProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectDependenciesSubTreeProviderFactory.cs
@@ -10,7 +10,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
-    internal class IProjectDependenciesSubTreeProviderFactory
+    internal static class IProjectDependenciesSubTreeProviderFactory
     {
         public static IProjectDependenciesSubTreeProvider Create()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectTreeCustomizablePropertyContextFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectTreeCustomizablePropertyContextFactory.cs
@@ -6,7 +6,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
-    internal class IProjectTreeCustomizablePropertyContextFactory
+    internal static class IProjectTreeCustomizablePropertyContextFactory
     {
         public static IProjectTreeCustomizablePropertyContext Create()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectValueDataSourceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectValueDataSourceFactory.cs
@@ -6,7 +6,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    public class IProjectValueDataSourceFactory
+    public static class IProjectValueDataSourceFactory
     {
         public static IProjectValueDataSource<T> CreateInstance<T>()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITargetFrameworkFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITargetFrameworkFactory.cs
@@ -6,7 +6,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
-    internal class ITargetFrameworkFactory
+    internal static class ITargetFrameworkFactory
     {
         public static ITargetFramework Create()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITargetFrameworkProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITargetFrameworkProviderFactory.cs
@@ -8,7 +8,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
-    internal class ITargetFrameworkProviderFactory
+    internal static class ITargetFrameworkProviderFactory
     {
         public static ITargetFrameworkProvider Create()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITargetedDependenciesSnapshotFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITargetedDependenciesSnapshotFactory.cs
@@ -11,7 +11,7 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
-    internal class ITargetedDependenciesSnapshotFactory
+    internal static class ITargetedDependenciesSnapshotFactory
     {
         public static ITargetedDependenciesSnapshot Create()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphSchema.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphSchema.cs
@@ -7,7 +7,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
     /// <summary>
     /// Contains graph node ids and properties for Dependencies nodes
     /// </summary>
-    internal class DependenciesGraphSchema
+    internal static class DependenciesGraphSchema
     {
         public static readonly GraphSchema Schema = new GraphSchema("Microsoft.VisualStudio.ProjectSystem.VS.Tree.DependenciesSchema");
         public static readonly GraphCategory CategoryDependency = Schema.Categories.AddNewCategory(VSResources.GraphNodeCategoryDependency);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Collections/ImmutableStringDictionary.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Collections/ImmutableStringDictionary.cs
@@ -2,7 +2,7 @@
 
 namespace System.Collections.Immutable
 {
-    internal class ImmutableStringDictionary<TValue>
+    internal static class ImmutableStringDictionary<TValue>
     {
         public static readonly ImmutableDictionary<string, TValue> EmptyOrdinal
             = ImmutableDictionary<string, TValue>.Empty;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/TaskResult.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/TaskResult.cs
@@ -7,7 +7,7 @@ namespace Microsoft.VisualStudio.Threading
     /// <summary>
     ///     Provides sentinel Tasks that represent commonly returned values.
     /// </summary>
-    internal class TaskResult
+    internal static class TaskResult
     {
         /// <summary>
         ///     Represents a Task that's completed successfully with the result of <see langword="false"/>.


### PR DESCRIPTION
These classes are not instantiated and only contain static/const members.

They are all test support types except for:

- `DependenciesGraphSchema`
- `ImmutableStringDictionary<TValue>`
- `TaskResult`

These three types are internal.