### PR TITLE
Use readonly fields where possible

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests/ProjectSystem/LanguageServices/CSharpSyntaxFactsServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests/ProjectSystem/LanguageServices/CSharpSyntaxFactsServiceTests.cs
@@ -7,7 +7,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     [Trait("UnitTest", "ProjectSystem")]
     public class CSharpSyntaxFactsServiceTests
     {
-        private static ISyntaxFactsService s_service = new CSharpSyntaxFactsService(null);
+        private static readonly ISyntaxFactsService s_service = new CSharpSyntaxFactsService(null);
 
         [Fact]
         public void TestIsValidIdentifier()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IActiveConfiguredProjectsProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IActiveConfiguredProjectsProviderFactory.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
     internal class IActiveConfiguredProjectsProviderFactory
     {
-        private Mock<IActiveConfiguredProjectsProvider> _mock;
+        private readonly Mock<IActiveConfiguredProjectsProvider> _mock;
         public IActiveConfiguredProjectsProviderFactory(MockBehavior mockBehavior = MockBehavior.Strict)
         {
             _mock = new Mock<IActiveConfiguredProjectsProvider>(mockBehavior);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
@@ -24,8 +24,8 @@ namespace Microsoft.VisualStudio.IO
             public Encoding FileEncoding = Encoding.Default;
         };
 
-        private Dictionary<string, FileData> _files = new Dictionary<string, FileData>(StringComparer.OrdinalIgnoreCase);
-        private HashSet<string> _folders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, FileData> _files = new Dictionary<string, FileData>(StringComparer.OrdinalIgnoreCase);
+        private readonly HashSet<string> _folders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         private string _currentDirectory;
 
         public Dictionary<string, FileData> Files { get => _files; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/DebugTokenReplacerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/DebugTokenReplacerTests.cs
@@ -17,12 +17,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     [Trait("UnitTest", "ProjectSystem")]
     public class DebugTokenReplacerTests
     {
-        private Dictionary<string, string> _envVars = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
+        private readonly Dictionary<string, string> _envVars = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
             { "%env1%","envVariable1" },
             { "%env2%","envVariable2" },
             { "%env3%","$(msbuildProperty6)" }
         };
-        private Mock<IEnvironmentHelper> _envHelper = new Mock<IEnvironmentHelper>();
+        private readonly Mock<IEnvironmentHelper> _envHelper = new Mock<IEnvironmentHelper>();
         public DebugTokenReplacerTests()
         {
             _envHelper.Setup(x => x.ExpandEnvironmentVariables(It.IsAny<string>())).Returns<string>((str) =>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsOutputWindow2Factory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsOutputWindow2Factory.cs
@@ -14,8 +14,8 @@ namespace Microsoft.VisualStudio.Shell.Interop
 
         private class VsOutputWindowMock : IVsOutputWindow, IVsOutputWindow2
         {
-            private Guid _activePaneGuid = Guid.NewGuid();
-            private Dictionary<Guid, IVsOutputWindowPane> _panes = new Dictionary<Guid, IVsOutputWindowPane>();
+            private readonly Guid _activePaneGuid = Guid.NewGuid();
+            private readonly Dictionary<Guid, IVsOutputWindowPane> _panes = new Dictionary<Guid, IVsOutputWindowPane>();
 
             public VsOutputWindowMock(IVsOutputWindowPane activePane)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsOutputWindowFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsOutputWindowFactory.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
 
         private class VsOutputWindowMock : IVsOutputWindow
         {
-            private Dictionary<Guid, IVsOutputWindowPane> _panes = new Dictionary<Guid, IVsOutputWindowPane>();
+            private readonly Dictionary<Guid, IVsOutputWindowPane> _panes = new Dictionary<Guid, IVsOutputWindowPane>();
 
             public int GetPane(ref Guid rguidPane, out IVsOutputWindowPane ppPane)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
@@ -23,9 +23,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
     {
         private readonly string _ProjectFile = @"c:\test\project\project.csproj";
         private readonly string _Path = @"c:\program files\dotnet;c:\program files\SomeDirectory";
-        private Mock<IEnvironmentHelper> _mockEnvironment = new Mock<IEnvironmentHelper>();
-        private IFileSystemMock _mockFS = new IFileSystemMock();
-        private Mock<IDebugTokenReplacer> _mockTokenReplace = new Mock<IDebugTokenReplacer>();
+        private readonly Mock<IEnvironmentHelper> _mockEnvironment = new Mock<IEnvironmentHelper>();
+        private readonly IFileSystemMock _mockFS = new IFileSystemMock();
+        private readonly Mock<IDebugTokenReplacer> _mockTokenReplace = new Mock<IDebugTokenReplacer>();
 
         private ConsoleDebugTargetsProvider GetDebugTargetsProvider(string outputType = "exe", Dictionary<string, string> properties = null)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/DebugProfileEnumValuesGeneratorTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/DebugProfileEnumValuesGeneratorTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
     [Trait("UnitTest", "ProjectSystem")]
     public class DebugProfileEnumValuesGenerator_Tests
     {
-        private List<ILaunchProfile> _profiles = new List<ILaunchProfile>() {
+        private readonly List<ILaunchProfile> _profiles = new List<ILaunchProfile>() {
             {new LaunchProfile() { Name="Profile1", LaunchBrowser=true}},
             {new LaunchProfile() { Name = "MyCommand"} },
             {new LaunchProfile() { Name = "Foo"} },

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectDebuggerProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectDebuggerProviderTests.cs
@@ -15,16 +15,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
     [Trait("UnitTest", "ProjectSystem")]
     public class ProjectDebuggerProviderTests
     {
-        private Mock<IDebugProfileLaunchTargetsProvider> _mockWebProvider = new Mock<IDebugProfileLaunchTargetsProvider>();
-        private Mock<IDebugProfileLaunchTargetsProvider> _mockDockerProvider = new Mock<IDebugProfileLaunchTargetsProvider>();
-        private Mock<IDebugProfileLaunchTargetsProvider> _mockExeProvider = new Mock<IDebugProfileLaunchTargetsProvider>();
-        private OrderPrecedenceImportCollection<IDebugProfileLaunchTargetsProvider> _launchProviders =
+        private readonly Mock<IDebugProfileLaunchTargetsProvider> _mockWebProvider = new Mock<IDebugProfileLaunchTargetsProvider>();
+        private readonly Mock<IDebugProfileLaunchTargetsProvider> _mockDockerProvider = new Mock<IDebugProfileLaunchTargetsProvider>();
+        private readonly Mock<IDebugProfileLaunchTargetsProvider> _mockExeProvider = new Mock<IDebugProfileLaunchTargetsProvider>();
+        private readonly OrderPrecedenceImportCollection<IDebugProfileLaunchTargetsProvider> _launchProviders =
             new OrderPrecedenceImportCollection<IDebugProfileLaunchTargetsProvider>(ImportOrderPrecedenceComparer.PreferenceOrder.PreferredComesFirst);
-        private Mock<ConfiguredProject> _configuredProjectMoq = new Mock<ConfiguredProject>();
-        private Mock<ILaunchSettingsProvider> _LaunchSettingsProviderMoq = new Mock<ILaunchSettingsProvider>();
-        private List<IDebugLaunchSettings> _webProviderSettings = new List<IDebugLaunchSettings>();
-        private List<IDebugLaunchSettings> _dockerProviderSettings = new List<IDebugLaunchSettings>();
-        private List<IDebugLaunchSettings> _exeProviderSettings = new List<IDebugLaunchSettings>();
+        private readonly Mock<ConfiguredProject> _configuredProjectMoq = new Mock<ConfiguredProject>();
+        private readonly Mock<ILaunchSettingsProvider> _LaunchSettingsProviderMoq = new Mock<ILaunchSettingsProvider>();
+        private readonly List<IDebugLaunchSettings> _webProviderSettings = new List<IDebugLaunchSettings>();
+        private readonly List<IDebugLaunchSettings> _dockerProviderSettings = new List<IDebugLaunchSettings>();
+        private readonly List<IDebugLaunchSettings> _exeProviderSettings = new List<IDebugLaunchSettings>();
 
         // Set this to have ILaunchSettingsProvider return this profile (null by default)
         private ILaunchProfile _activeProfile;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
     [Trait("UnitTest", "ProjectSystem")]
     public class PostBuildEventValueProviderTests
     {
-        private static PostBuildEventValueProvider.PostBuildEventHelper systemUnderTest =
+        private static readonly PostBuildEventValueProvider.PostBuildEventHelper systemUnderTest =
             new PostBuildEventValueProvider.PostBuildEventHelper();
 
         private static readonly IProjectProperties emptyProjectProperties =

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
     [Trait("UnitTest", "ProjectSystem")]
     public class PreBuildEventValueProviderTests
     {
-        private static PreBuildEventValueProvider.PreBuildEventHelper systemUnderTest =
+        private static readonly PreBuildEventValueProvider.PreBuildEventHelper systemUnderTest =
             new PreBuildEventValueProvider.PreBuildEventHelper();
 
         private static readonly IProjectProperties emptyProjectProperties =

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
@@ -650,7 +650,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 return this;
             }
 
-            private Dictionary<string, Tuple<IDependency, FilterAction>> _beforeAdd
+            private readonly Dictionary<string, Tuple<IDependency, FilterAction>> _beforeAdd
                 = new Dictionary<string, Tuple<IDependency, FilterAction>>(StringComparer.OrdinalIgnoreCase);
 
             public TestDependenciesSnapshotFilter ImplementBeforeRemoveResult(FilterAction action, string id, IDependency dependency)
@@ -660,7 +660,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 return this;
             }
 
-            private Dictionary<string, Tuple<IDependency, FilterAction>> _beforeRemove
+            private readonly Dictionary<string, Tuple<IDependency, FilterAction>> _beforeRemove
                 = new Dictionary<string, Tuple<IDependency, FilterAction>>(StringComparer.OrdinalIgnoreCase);
 
             public IDependency BeforeAdd(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/TestProjectTree.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/TestProjectTree.cs
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         public ProjectImageMoniker Icon { get; set; }
         public string FilePath { get; set; }
         public string Caption { get; set; }
-        private List<TestProjectTree> _children = new List<TestProjectTree>();
+        private readonly List<TestProjectTree> _children = new List<TestProjectTree>();
         public IReadOnlyList<IProjectTree> Children { get { return _children.ToList(); } }
         public IProjectTree Root { get; }
         public IProjectTree Parent { get; set; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProviderTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
     [Trait("UnitTest", "ProjectSystem")]
     public class TreeItemOrderPropertyProviderTests
     {
-        private List<(string type, string include)> _simpleOrderFile = new List<(string type, string include)>
+        private readonly List<(string type, string include)> _simpleOrderFile = new List<(string type, string include)>
         {
             ("Compile", "Order.fs"),
             ("Compile", "Customer.fs"),
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
             Assert.Equal(expectedOrder, values.DisplayOrder);
         }
 
-        private List<(string type, string include)> _simpleOrderFileDuplicate = new List<(string type, string include)>
+        private readonly List<(string type, string include)> _simpleOrderFileDuplicate = new List<(string type, string include)>
         {
             ("Compile", "Order.fs"),
             ("Compile", "Customer.fs"),
@@ -184,7 +184,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
             }
         }
 
-        private List<(string type, string include)> _orderedWithDups = new List<(string type, string include)>
+        private readonly List<(string type, string include)> _orderedWithDups = new List<(string type, string include)>
         {
             ("Compile", "Common.fs"),
             ("Compile", "Tables\\Order.fs"),
@@ -219,7 +219,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
             Assert.Equal(expectedOrder, values.DisplayOrder);
         }
 
-        private List<(string type, string include, string linkPath)> _orderedWithLinkPaths = new List<(string type, string include, string linkPath)>
+        private readonly List<(string type, string include, string linkPath)> _orderedWithLinkPaths = new List<(string type, string include, string linkPath)>
         {
             ("Compile", "Common.fs", "Tables/Test.fs"),
             ("Compile", "Tables\\Order.fs", null),

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ErrorProfileDebugTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ErrorProfileDebugTargetsProvider.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             _configuredProject = configuredProject;
         }
 
-        private ConfiguredProject _configuredProject;
+        private readonly ConfiguredProject _configuredProject;
 
         /// <summary>
         /// This provider handles the NoAction profile

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         private IDisposable _debugProfileProviderLink;
 
         // Unit Tests only
-        private TaskCompletionSource<bool> _firstSnapshotCompleteSource = null;
+        private readonly TaskCompletionSource<bool> _firstSnapshotCompleteSource = null;
 
         private IProjectThreadingService _projectThreadingService;
         private IProjectThreadingService ProjectThreadingService

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPage.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
     {
         private IPropertyPageSite _site = null;
         private bool _isDirty = false;
-        private bool _ignoreEvents = false;
+        private readonly bool _ignoreEvents = false;
         private bool _useJoinableTaskFactory = true;
         private IVsDebugger _debugger;
         private uint _debuggerCookie;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContext.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         private readonly ImmutableDictionary<ITargetFramework, ITargetedProjectContext> _configuredProjectContextsByTargetFramework;
         private readonly ImmutableDictionary<string, ConfiguredProject> _configuredProjectsByTargetFramework;
         private readonly ITargetFramework _activeTargetFramework;
-        private HashSet<ITargetedProjectContext> _disposedConfiguredProjectContexts;
+        private readonly HashSet<ITargetedProjectContext> _disposedConfiguredProjectContexts;
 
         public AggregateCrossTargetProjectContext(
             bool isCrossTargeting,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetFramework.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetFramework.cs
@@ -7,12 +7,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 {
     internal class TargetFramework : ITargetFramework
     {
-        public static ITargetFramework Empty = new TargetFramework(string.Empty);
+        public static readonly ITargetFramework Empty = new TargetFramework(string.Empty);
 
         /// <summary>
         /// Any represents all TFMs, no need to be localized, used only in internal data.
         /// </summary>
-        public static ITargetFramework Any = new TargetFramework("any");
+        public static readonly ITargetFramework Any = new TargetFramework("any");
 
         public TargetFramework(FrameworkName frameworkName, string shortName = null)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -149,7 +149,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// </summary>
         internal class TelemetryState
         {
-            private ConcurrentDictionary<string, bool> _observedRules = new ConcurrentDictionary<string, bool>(StringComparers.RuleNames);
+            private readonly ConcurrentDictionary<string, bool> _observedRules = new ConcurrentDictionary<string, bool>(StringComparers.RuleNames);
 
             internal bool InitializeRule(string rule) =>
                 _observedRules.TryAdd(rule, false);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
@@ -63,7 +63,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
         private OrderPrecedenceImportCollection<IDependenciesGraphActionHandler> GraphActionHandlers { get; }
 
         private readonly object _changedContextsQueueLock = new object();
-        private Dictionary<string, SnapshotChangedEventArgs> _changedContextsQueue =
+        private readonly Dictionary<string, SnapshotChangedEventArgs> _changedContextsQueue =
             new Dictionary<string, SnapshotChangedEventArgs>(StringComparer.OrdinalIgnoreCase);
         private Task _trackChangesTask;
         private IVsImageService2 _imageService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageFrameworkAssembliesViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageFrameworkAssembliesViewModel.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
     internal class PackageFrameworkAssembliesViewModel : DependencyViewModel
     {
-        public static ImageMoniker RegularIcon = KnownMonikers.Library;
+        public static readonly ImageMoniker RegularIcon = KnownMonikers.Library;
 
         public PackageFrameworkAssembliesViewModel()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
     [DebuggerDisplay("{" + nameof(Id) + ",nq}")]
     internal class Dependency : IDependency
     {
-        private static ConcurrentBag<StringBuilder> s_builderPool = new ConcurrentBag<StringBuilder>();
+        private static readonly ConcurrentBag<StringBuilder> s_builderPool = new ConcurrentBag<StringBuilder>();
 
         // These priorities are for graph nodes only and are used to group graph nodes 
         // appropriately in order groups predefined order instead of alphabetically.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
@@ -60,13 +60,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
         private readonly object _snapshotLock = new object();
 
-        private Dictionary<string, IDependency> _topLevelDependenciesByPathMap
+        private readonly Dictionary<string, IDependency> _topLevelDependenciesByPathMap
             = new Dictionary<string, IDependency>(StringComparer.OrdinalIgnoreCase);
 
-        private Dictionary<string, IList<IDependency>> _dependenciesChildrenMap
+        private readonly Dictionary<string, IList<IDependency>> _dependenciesChildrenMap
             = new Dictionary<string, IList<IDependency>>(StringComparer.OrdinalIgnoreCase);
 
-        private Dictionary<string, bool> _unresolvedDescendantsMap
+        private readonly Dictionary<string, bool> _unresolvedDescendantsMap
             = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
 
         private bool? _hasUresolvedDependency;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/DontShowAgainMessageBox.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/DontShowAgainMessageBox.xaml.cs
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UI
             }
         }
 
-        private IUserNotificationServices _userNotificationServices;
+        private readonly IUserNotificationServices _userNotificationServices;
 
         //Strictly used for databinding, no notifications
         public string MessageText { get; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Collections/ImmutableStringHashSet.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Collections/ImmutableStringHashSet.cs
@@ -4,10 +4,10 @@ namespace System.Collections.Immutable
 {
     internal static class ImmutableStringHashSet
     {
-        public static ImmutableHashSet<string> EmptyOrdinal
+        public static readonly ImmutableHashSet<string> EmptyOrdinal
             = ImmutableHashSet<string>.Empty;
 
-        public static ImmutableHashSet<string> EmptyOrdinalIgnoreCase
+        public static readonly ImmutableHashSet<string> EmptyOrdinalIgnoreCase
             = ImmutableHashSet<string>.Empty.WithComparer(StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         private readonly UnconfiguredProject _project;
         private readonly IActiveConfigurationGroupService _activeConfigurationGroupService;
         private readonly IUnconfiguredProjectTasksService _tasksService;
-        private ActionBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>> _targetBlock;
+        private readonly ActionBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>> _targetBlock;
         private IDisposable _subscription;
 
         [ImportingConstructor]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugTokenReplacer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugTokenReplacer.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         private IProjectAccessor ProjectAccessor { get; }
 
         // Regular expression string to extract $(sometoken) elements from a string
-        private static Regex s_matchTokenRegex = new Regex(@"(\$\((?<token>[^\)]+)\))", RegexOptions.IgnoreCase);
+        private static readonly Regex s_matchTokenRegex = new Regex(@"(\$\((?<token>[^\)]+)\))", RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Walks the profile and returns a new one where all the tokens have been replaced. Tokens can consist of 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
         protected int WaitForFirstSnapshotDelay = 5000; // 5 seconds
 
-        private TaskCompletionSource<bool> _firstSnapshotCompletionSource = new TaskCompletionSource<bool>();
+        private readonly TaskCompletionSource<bool> _firstSnapshotCompletionSource = new TaskCompletionSource<bool>();
 
         protected IDisposable ProjectRuleSubscriptionLink { get; set; }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/AggregateWorkspaceProjectContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/AggregateWorkspaceProjectContext.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         private readonly ImmutableDictionary<string, ConfiguredProject> _configuredProjectsByTargetFramework;
         private readonly string _activeTargetFramework;
         private readonly IUnconfiguredProjectHostObject _unconfiguredProjectHostObject;
-        private HashSet<IWorkspaceProjectContext> _disposedConfiguredProjectContexts;
+        private readonly HashSet<IWorkspaceProjectContext> _disposedConfiguredProjectContexts;
 
         public AggregateWorkspaceProjectContext(
             ImmutableDictionary<string, IWorkspaceProjectContext> configuredProjectContextsByTargetFramework,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/SequencialTaskExecutor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/SequencialTaskExecutor.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.Threading.Tasks
         private Task _taskAdded = Task.CompletedTask;
         private readonly object _syncObject = new object();
 #pragma warning disable CA2213 // Tests fail is this is disposed
-        private CancellationTokenSource _disposedCancelTokenSource = new CancellationTokenSource();
+        private readonly CancellationTokenSource _disposedCancelTokenSource = new CancellationTokenSource();
 #pragma warning restore CA2213 
 
         /// <summary>
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.Threading.Tasks
         /// it will be backed up behind the first one completing. The AysncLocal is used to detect when a task is being executed, and if a downstream one gets
         /// added, it will be executed directly, rather than get queued
         /// </summary>
-        private System.Threading.AsyncLocal<bool> _executingTask = new System.Threading.AsyncLocal<bool>();
+        private readonly System.Threading.AsyncLocal<bool> _executingTask = new System.Threading.AsyncLocal<bool>();
 
         /// <summary>
         /// Adds a new task to the continuation chain and returns it so that it can be awaited.

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests/ProjectSystem/LanguageServices/VisualBasicSyntaxFactsServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests/ProjectSystem/LanguageServices/VisualBasicSyntaxFactsServiceTests.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     [Trait("UnitTest", "ProjectSystem")]
     public class VisualBasicSyntaxFactsServiceTests
     {
-        private static ISyntaxFactsService s_service = new VisualBasicSyntaxFactsService(null);
+        private static readonly ISyntaxFactsService s_service = new VisualBasicSyntaxFactsService(null);
 
         [Fact]
         public void TestIsValidIdentifier()


### PR DESCRIPTION
All changed fields are private except for `TargetFramework.Empty`, `TargetFramework.Any`, `PackageFrameworkAssembliesViewModel.RegularIcon` and `ImmutableStringHashSet.*` which public fields on on internal types.

---

We could also add:

```
[*.{cs,vb}]
dotnet_style_readonly_field = true:warning
```

Right now VS shows them as suggestions.