### PR TITLE
Fix Dependencies Node

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetRuleSubscriberBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetRuleSubscriberBase.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
     {
 #pragma warning disable CA2213 // OnceInitializedOnceDisposedAsync are not tracked corretly by the IDisposeable analyzer
         private readonly SemaphoreSlim _gate = new SemaphoreSlim(initialCount: 1);
-        private readonly DisposableBag _subscriptions = new DisposableBag();
+        private DisposableBag _subscriptions;
 #pragma warning restore CA2213
         private readonly IUnconfiguredProjectCommonServices _commonServices;
         private readonly IProjectAsynchronousTasksService _tasksService;
@@ -79,7 +79,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         public void ReleaseSubscriptions()
         {
             _currentProjectContext = null;
-            _subscriptions.Dispose();
+
+            if (_subscriptions != null)
+            {
+                _subscriptions.Dispose();
+                _subscriptions = null;
+            }
         }
 
         private void SubscribeToConfiguredProject(
@@ -101,6 +106,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
                     {
                         NameFormat = "CrossTarget Intermediate Evaluation Input: {1}"
                     });
+
+            if (_subscriptions == null)
+            {
+                _subscriptions = new DisposableBag();
+            }
 
             _subscriptions.AddDisposable(
                 subscriptionService.JointRuleSource.SourceBlock.LinkTo(


### PR DESCRIPTION
Commit b064bdf8 replaced a couple of lists of `IDisposable` items within `CrossTargetRuleSubscriberBase<T>` with a single `DisposableBag`. This broke the Dependencies node--it would still appear in Solution Explorer, but would never have any children.

The lists were holding various dataflow link subscriptions. These links may be added, disposed, and replaced multiple times during the life of the `CrossTargetRuleSubscriberBase<T>`. The issue is that while the original lists could be cleared and reused after disposing of their contents a `DisposableBag` can only be disposed once. After that any attempt to add an item to the bag simply causes it to be disposed immediately. So after the first call to `CrossTargetRuleSubscriberBase<T>.ReleaseSubscriptions` subsequent attempts to create and store new dataflow links would just cause them to be immediately disposed.

The fix here is to dispose and null out the `DisposableBag` when subscriptions are released, and then instantiate a new one as needed.