### PR TITLE
Don't disponse HttpClient

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/Web/DefaultHttpClient.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/Web/DefaultHttpClient.cs
@@ -10,6 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
     [Export(typeof(IHttpClient))]
     internal class DefaultHttpClient : IHttpClient
     {
+        private static readonly Lazy<HttpClient> s_client = new Lazy<HttpClient>(CreateClient);
 
         [ImportingConstructor]
         public DefaultHttpClient(IProjectThreadingService threadingService)
@@ -21,10 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
 
         public Task<string> GetStringAsync(Uri uri)
         {
-            using (HttpClient client = CreateClient())
-            {
-                return client.GetStringAsync(uri);
-            }
+            return s_client.Value.GetStringAsync(uri);
         }
 
         private static HttpClient CreateClient()


### PR DESCRIPTION
This is both good practice ([blog post](https://aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/)) but also made the download of the file actually work in my dev environment. Previously I would regularly get task cancellations.