### PR TITLE
Make fields ReadOnly in VB code

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerPanel.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerPanel.vb
@@ -42,7 +42,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         Private _inOnClose As Boolean
 
         Private _vsWindowFrame As IVsWindowFrame
-        Private _serviceProvider As IServiceProvider
+        Private ReadOnly _serviceProvider As IServiceProvider
 
         'Document related items
         Private _mkDocument As String
@@ -75,7 +75,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         Private _creatingDesigner As Boolean
 
         'The owning project designer
-        Private _view As ApplicationDesignerView
+        Private ReadOnly _view As ApplicationDesignerView
 
 
         ''' <summary>

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/CmdTargetHelper.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/CmdTargetHelper.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         Implements OleInterop.IOleCommandTarget
         Implements IVsWindowFrameNotify3
 
-        Private _windowPane As ApplicationDesignerWindowPane
+        Private ReadOnly _windowPane As ApplicationDesignerWindowPane
 
         Public Sub New(WindowPane As ApplicationDesignerWindowPane)
             Debug.Assert(WindowPane IsNot Nothing)

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DeferrableWindowPaneProviderService.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DeferrableWindowPaneProviderService.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
     Public NotInheritable Class DeferrableWindowPaneProviderService
         Inherits WindowPaneProviderService
 
-        Private _docData As DocData
+        Private ReadOnly _docData As DocData
 
         ' <devdoc>
         '     Creates a new DeferrableWindowPaneProviderService.

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabButton.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabButton.vb
@@ -239,7 +239,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             Inherits ButtonBaseAccessibleObject
 
             ' button which this accessible object belongs to
-            Private _button As ProjectDesignerTabButton
+            Private ReadOnly _button As ProjectDesignerTabButton
 
             Public Sub New(owner As ProjectDesignerTabButton)
                 MyBase.New(owner)

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabControl.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabControl.vb
@@ -12,9 +12,9 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         Inherits ContainerControl
 
         'A list of all buttons currently contained by the control
-        Private _buttonCollection As New List(Of ProjectDesignerTabButton)
+        Private ReadOnly _buttonCollection As New List(Of ProjectDesignerTabButton)
 
-        Private _renderer As ProjectDesignerTabRenderer 'The renderer to use for painting.  May not be Nothing.
+        Private ReadOnly _renderer As ProjectDesignerTabRenderer 'The renderer to use for painting.  May not be Nothing.
         Private _selectedItem As ProjectDesignerTabButton ' Currently-seleted item.  May be Nothing.
         Private _hoverItem As ProjectDesignerTabButton ' Currently-hovered item.  May be Nothing.
         Private _hostingPanel As Panel
@@ -23,8 +23,8 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         Public WithEvents OverflowButton As Button
 
         'The overflow menu that gets displayed when the overflow button is pressed
-        Private _overflowMenu As New ContextMenuStrip
-        Private _overflowTooltip As New ToolTip
+        Private ReadOnly _overflowMenu As New ContextMenuStrip
+        Private ReadOnly _overflowTooltip As New ToolTip
 
         'Backs up the ServiceProvider property
         Private _serviceProvider As IServiceProvider
@@ -697,7 +697,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             Inherits ControlAccessibleObject
 
             ' button which this accessible object belongs to
-            Private _tabControl As ProjectDesignerTabControl
+            Private ReadOnly _tabControl As ProjectDesignerTabControl
 
             Public Sub New(owner As ProjectDesignerTabControl)
                 MyBase.New(owner)

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabControlRenderer.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabControlRenderer.vb
@@ -99,7 +99,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         Private _tabControlRect As Rectangle 'The entire area of the tab control, including the tabs and panel area
 
         'Pointer to the ProjectDesignerTabControl which owns this renderer.  May not be null
-        Private _owner As ProjectDesignerTabControl
+        Private ReadOnly _owner As ProjectDesignerTabControl
 
         'The service provider to use.  May be Nothing
         Private _serviceProvider As IServiceProvider

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/PropertyPageInfo.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/PropertyPageInfo.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         Private _info As OleInterop.PROPPAGEINFO
         Private _site As PropertyPageSite
         Private _loadException As Exception 'The exception that occurred while loading the page, if any
-        Private _parentView As ApplicationDesignerView 'The owning application designer view
+        Private ReadOnly _parentView As ApplicationDesignerView 'The owning application designer view
         Private _loadAlreadyAttempted As Boolean 'Whether or not we've attempted to load this property page
 
         Private Const REGKEY_CachedPageTitles As String = "\ProjectDesigner\CachedPageTitles"

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/SpecialFileCustomViewProvider.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/SpecialFileCustomViewProvider.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         Private _view As Control
         Private ReadOnly _linkText As String
         Private WithEvents _designerView As ApplicationDesignerView
-        Private _designerPanel As ApplicationDesignerPanel
+        Private ReadOnly _designerPanel As ApplicationDesignerPanel
         Private ReadOnly _specialFileId As Integer
 
 
@@ -155,7 +155,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         Inherits CustomDocumentMonikerProvider
 
         Private ReadOnly _specialFileId As Integer
-        Private _designerView As ApplicationDesignerView
+        Private ReadOnly _designerView As ApplicationDesignerView
 
         ''' <summary>
         ''' Constructor.

--- a/src/Microsoft.VisualStudio.AppDesigner/Common/ShellUtil.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/Common/ShellUtil.vb
@@ -248,7 +248,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
 
             'Cookie for use with IVsShell.{Advise,Unadvise}BroadcastMessages
             Private _cookieBroadcastMessages As UInteger
-            Private _serviceProvider As IServiceProvider
+            Private ReadOnly _serviceProvider As IServiceProvider
 
             Public Sub New(sp As IServiceProvider)
                 _serviceProvider = sp
@@ -348,7 +348,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
             Inherits BroadcastMessageEventsHelper
 
             ' Control that we are going to set the font on (if any)
-            Private _control As Control
+            Private ReadOnly _control As Control
 
             Private ReadOnly _serviceProvider As IServiceProvider
 

--- a/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
@@ -632,7 +632,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
             ' in this list. All unknown entries will be reported as &hFF
             '
             ' Add more entries to the end of this list. Do *not* put any new entries in the middle of the list!
-            Private Shared s_sqmOrder() As Guid = {
+            Private Shared ReadOnly s_sqmOrder() As Guid = {
                 KnownPropertyPageGuids.GuidApplicationPage_VB,
                 KnownPropertyPageGuids.GuidApplicationPage_CS,
                 KnownPropertyPageGuids.GuidApplicationPage_JS,

--- a/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/DesignerMenuCommand.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/DesignerMenuCommand.vb
@@ -170,7 +170,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
             _statusValid = True
         End Sub 'UpdateStatus
 
-        Private _rootDesigner As BaseRootDesigner ' Pointer to the RootDesigner allowing refreshing all menu commands.
+        Private ReadOnly _rootDesigner As BaseRootDesigner ' Pointer to the RootDesigner allowing refreshing all menu commands.
         Private ReadOnly _commandEnabledHandler As CheckCommandStatusHandler ' Handler to check if the command should be enabled.
         Private ReadOnly _commandCheckedHandler As CheckCommandStatusHandler ' Handler to check if the command should be checked.
         Private ReadOnly _commandVisibleHandler As CheckCommandStatusHandler ' Handler to check if the command should be hidden.

--- a/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/ErrorControl.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/ErrorControl.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
     Public NotInheritable Class ErrorControl
 
         Private _firstGotFocus As Boolean = True
-        Private _sizingLabel As Label
+        Private ReadOnly _sizingLabel As Label
 
         Public Sub New()
             ' This call is required by the Windows Form Designer.

--- a/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/SourceCodeControlManager.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/SourceCodeControlManager.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         Private ReadOnly _serviceProvider As IServiceProvider
 
         ' A map of file names to manage
-        Private _managedFiles As New Dictionary(Of String, Boolean)(3, StringComparer.OrdinalIgnoreCase)
+        Private ReadOnly _managedFiles As New Dictionary(Of String, Boolean)(3, StringComparer.OrdinalIgnoreCase)
 
 #End Region
 

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/ConfigurationState.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/ConfigurationState.vb
@@ -32,7 +32,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         Private _vsCfgProvider As IVsCfgProvider2
 
         'Pointer to the parent application designer view
-        Private _view As ApplicationDesigner.ApplicationDesignerView
+        Private ReadOnly _view As ApplicationDesigner.ApplicationDesignerView
 
         'The current selections in the configuration/platform comboboxes
         Private _selectedConfigIndex As Integer

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropertyPagePropertyDescriptor.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropertyPagePropertyDescriptor.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         Inherits PropertyDescriptor
 
         'The property descriptor for the Project or Config property we wrap
-        Private _propDesc As PropertyDescriptor
+        Private ReadOnly _propDesc As PropertyDescriptor
         Private ReadOnly _typeConverter As TypeConverter
         Private ReadOnly _displayName As String
         Private ReadOnly _name As String

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/ChildPageSite.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/ChildPageSite.vb
@@ -20,8 +20,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <remarks></remarks>
         Public Const NestingCharacter As String = ":"
 
-        Private _wrappedInternalSite As IPropertyPageSiteInternal 'May *not* be Nothing
-        Private _wrappedUndoSite As IVsProjectDesignerPageSite    'May be Nothing
+        Private ReadOnly _wrappedInternalSite As IPropertyPageSiteInternal 'May *not* be Nothing
+        Private ReadOnly _wrappedUndoSite As IVsProjectDesignerPageSite    'May be Nothing
         Private ReadOnly _nestedPropertyNamePrefix As String               'Prefix string to be placed at the beginning of PropertyName to distinguish properties from the page hosted by this child page site
 
 

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/CpsPropertyDescriptorWrapper.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/CpsPropertyDescriptorWrapper.vb
@@ -12,7 +12,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     Public Class CpsPropertyDescriptorWrapper
         Inherits PropertyDescriptor
 
-        Private _defaultDescriptor As PropertyDescriptor
+        Private ReadOnly _defaultDescriptor As PropertyDescriptor
 
         Public Sub New(defaultDescriptor As PropertyDescriptor)
             MyBase.New(defaultDescriptor.Name, {})

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
@@ -156,8 +156,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
         'Used for caching property change notification until after Apply is done
         Private Class PropertyChange
-            Public DispId As Integer
-            Public Source As PropertyChangeSource
+            Public ReadOnly DispId As Integer
+            Public ReadOnly Source As PropertyChangeSource
 
             Public Sub New(DispId As Integer, Source As PropertyChangeSource)
                 Me.DispId = DispId
@@ -244,10 +244,10 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Private _uiShellService As IVsUIShell
         Private _uiShell2Service As IVsUIShell2
 
-        Private Shared s_runningPropertyPages As New ArrayList
+        Private Shared ReadOnly s_runningPropertyPages As New ArrayList
 
         'Child property pages that have been shown are cached here
-        Private _childPages As New Dictionary(Of Type, PropPageUserControlBase)
+        Private ReadOnly _childPages As New Dictionary(Of Type, PropPageUserControlBase)
 
         Private _pageRequiresScaling As Boolean = True
 
@@ -267,7 +267,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Private _pageEnabledState As Boolean = True
 
         'A list of all connected property listeners
-        Private _propertyListeners As New ArrayList '(Of PropertyListener)
+        Private ReadOnly _propertyListeners As New ArrayList '(Of PropertyListener)
 
         'Whether the page should be enabled based only on the debug state of the application
         Private _pageEnabledPerDebugMode As Boolean = True
@@ -281,7 +281,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
         'Dispids which the page is changing manually, and which are to be ignored while listening for
         '  property changes
-        Private _suspendPropertyChangeListeningDispIds As New List(Of Integer)
+        Private ReadOnly _suspendPropertyChangeListeningDispIds As New List(Of Integer)
 
         'DISPID_UNKNOWN
         Public DISPID_UNKNOWN As Integer = Interop.Win32Constant.DISPID_UNKNOWN

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropertyListener.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropertyListener.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
         Private _cookieActiveCfg As NativeMethods.ConnectionPointCookie 'The connection cookie for IPropertyNotifySink
         Private _cookieInactiveCfg As NativeMethods.ConnectionPointCookie 'The connection cookie for ILangInactiveCfgPropertyNotifySink
-        Private _propPage As PropPageUserControlBase 'The property page to notify when a property changes
+        Private ReadOnly _propPage As PropPageUserControlBase 'The property page to notify when a property changes
 
 #If DEBUG Then
         Private ReadOnly _debugSourceName As String 'For debugging purposes: name of the properties object that is being listened to

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/ValidationException.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/ValidationException.vb
@@ -12,7 +12,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Inherits ApplicationException
 
         Private ReadOnly _validationResult As ValidationResult
-        Private _control As Control
+        Private ReadOnly _control As Control
 
         Public Sub New(result As ValidationResult, message As String, Optional control As Control = Nothing, Optional InnerException As Exception = Nothing)
             MyBase.New(message, InnerException)

--- a/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/AutoAddImportsCollisionDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/AutoAddImportsCollisionDialog.vb
@@ -8,7 +8,7 @@ Namespace Microsoft.VisualStudio.Editors.AddImports
         Private _importMnemonic As Char? = Nothing
         Private _doNotImportMnemonic As Char? = Nothing
         Private _lastFocus As Control
-        Private _helpCallBack As IVBAddImportsDialogHelpCallback
+        Private ReadOnly _helpCallBack As IVBAddImportsDialogHelpCallback
 
         Public Sub New([namespace] As String, identifier As String, minimallyQualifiedName As String, callBack As IVBAddImportsDialogHelpCallback, isp As IServiceProvider)
             MyBase.New(isp)

--- a/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/AutoAddImportsExtensionCollisionDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/AutoAddImportsExtensionCollisionDialog.vb
@@ -6,7 +6,7 @@ Imports System.Windows.Forms
 Namespace Microsoft.VisualStudio.Editors.AddImports
     Friend Class AutoAddImportsExtensionCollisionDialog
         Private _lastFocus As Control
-        Private _helpCallBack As IVBAddImportsDialogHelpCallback
+        Private ReadOnly _helpCallBack As IVBAddImportsDialogHelpCallback
 
         Public Sub New([namespace] As String, identifier As String, minimallyQualifiedName As String, helpCAllback As IVBAddImportsDialogHelpCallback, isp As IServiceProvider)
             MyBase.New(isp)

--- a/src/Microsoft.VisualStudio.Editors/Common/ProjectBatchEdit.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/ProjectBatchEdit.vb
@@ -23,7 +23,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
     Friend Class ProjectBatchEdit
         Implements IDisposable
 
-        Private _projectBuildSystem As IVsProjectBuildSystem
+        Private ReadOnly _projectBuildSystem As IVsProjectBuildSystem
         Private _batchCount As Integer
 
 

--- a/src/Microsoft.VisualStudio.Editors/Common/ShellUtil.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/ShellUtil.vb
@@ -504,7 +504,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
 
             'Cookie for use with IVsShell.{Advise,Unadvise}BroadcastMessages
             Private _cookieBroadcastMessages As UInteger
-            Private _serviceProvider As IServiceProvider
+            Private ReadOnly _serviceProvider As IServiceProvider
 
             Friend Sub New(sp As IServiceProvider)
                 _serviceProvider = sp
@@ -604,7 +604,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
             Inherits BroadcastMessageEventsHelper
 
             ' Control that we are going to set the font on (if any)
-            Private _control As Control
+            Private ReadOnly _control As Control
 
             Private ReadOnly _serviceProvider As IServiceProvider
 

--- a/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
@@ -1428,7 +1428,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
             ' in this list. All unknown entries will be reported as &hFF
             '
             ' Add more entries to the end of this list. Do *not* put any new entries in the middle of the list!
-            Private Shared s_sqmOrder() As Guid = {
+            Private Shared ReadOnly s_sqmOrder() As Guid = {
                 KnownPropertyPageGuids.GuidApplicationPage_VB,
                 KnownPropertyPageGuids.GuidApplicationPage_CS,
                 KnownPropertyPageGuids.GuidApplicationPage_JS,

--- a/src/Microsoft.VisualStudio.Editors/Common/VsStatusBarWrapper.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/VsStatusBarWrapper.vb
@@ -52,7 +52,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
             _vsStatusBar.SetText(text)
         End Sub
 
-        Private _vsStatusBar As IVsStatusbar
+        Private ReadOnly _vsStatusBar As IVsStatusbar
 
         Private _vsStatusBarCookie As UInteger = 0
         Private _total As Integer = 0

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/AccessModifierComboBox.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/AccessModifierComboBox.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
     ''' </summary>
     ''' <remarks></remarks>
     Friend Class AccessModifierConverter
-        Private _converter As TypeConverter
+        Private ReadOnly _converter As TypeConverter
 
         Public Enum Access
             [Public]
@@ -66,12 +66,12 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         Implements IDisposable
 
         Private _isDisposed As Boolean = False
-        Private _rootDesigner As BaseRootDesigner
-        Private _projectItem As EnvDTE.ProjectItem
+        Private ReadOnly _rootDesigner As BaseRootDesigner
+        Private ReadOnly _projectItem As EnvDTE.ProjectItem
         Private ReadOnly _serviceProvider As IServiceProvider
         Private ReadOnly _namespaceToOverrideIfCustomToolIsEmpty As String
-        Private _codeGeneratorEntries As New List(Of CodeGenerator)
-        Private _recognizedCustomToolValues As New List(Of String)
+        Private ReadOnly _codeGeneratorEntries As New List(Of CodeGenerator)
+        Private ReadOnly _recognizedCustomToolValues As New List(Of String)
 
         Private _designerCommandBarComboBoxCommand As DesignerCommandBarComboBox
         Private _commandIdCombobox As CommandID
@@ -133,7 +133,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             Inherits CodeGenerator
 
             Private ReadOnly _accessibility As AccessModifierConverter.Access
-            Private _serviceProvider As IServiceProvider
+            Private ReadOnly _serviceProvider As IServiceProvider
 
             Public Sub New(accessibility As AccessModifierConverter.Access, serviceProvider As IServiceProvider, customToolValue As String)
                 MyBase.New(customToolValue)
@@ -192,7 +192,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ' Map from command ID to LIFO list of command handlers. The item at the head of the list is the item 
             ' that is currently registered with the shell's MenuCommandService
             ' 
-            Private Shared s_packageCommandForwarderLists As New Dictionary(Of CommandID, LinkedList(Of DesignerMenuCommand))
+            Private Shared ReadOnly s_packageCommandForwarderLists As New Dictionary(Of CommandID, LinkedList(Of DesignerMenuCommand))
 
             Public Shared Sub RegisterMenuCommandForwarder(commandID As CommandID, forwarder As DesignerMenuCommand)
                 Dim menuCommandService As IMenuCommandService = VBPackage.Instance.MenuCommandService

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseEditorFactory.vb
@@ -64,7 +64,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
 
         Private _site As Object 'The site that owns this editor factory
         Private _serviceProvider As Shell.ServiceProvider 'The service provider from m_Site
-        Private _designerLoaderType As Type 'The type of designer loader to create.  Typically there is a separate designer loader class per editor factory (and therefore per designer type)
+        Private ReadOnly _designerLoaderType As Type 'The type of designer loader to create.  Typically there is a separate designer loader class per editor factory (and therefore per designer type)
         Private Shared ReadOnly s_defaultPhysicalViewName As String = Nothing 'The default physical view *must* be Nothing
 
 #End Region

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerMenuCommand.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerMenuCommand.vb
@@ -166,7 +166,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             _statusValid = True
         End Sub 'UpdateStatus
 
-        Private _rootDesigner As BaseRootDesigner ' Pointer to the RootDesigner allowing refreshing all menu commands.
+        Private ReadOnly _rootDesigner As BaseRootDesigner ' Pointer to the RootDesigner allowing refreshing all menu commands.
         Private ReadOnly _commandEnabledHandler As CheckCommandStatusHandler ' Handler to check if the command should be enabled.
         Private ReadOnly _commandCheckedHandler As CheckCommandStatusHandler ' Handler to check if the command should be checked.
         Private ReadOnly _commandVisibleHandler As CheckCommandStatusHandler ' Handler to check if the command should be hidden.
@@ -357,7 +357,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
     ''' <remarks></remarks>
     Friend Class LatchedCommandGroup
 
-        Private _commands As New Dictionary(Of Integer, MenuCommand)
+        Private ReadOnly _commands As New Dictionary(Of Integer, MenuCommand)
 
         ''' <summary>
         ''' Add a command to the group

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerTypeDiscoveryService.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerTypeDiscoveryService.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
     Friend Class DesignerTypeDiscoveryService
         Implements ComponentModel.Design.ITypeDiscoveryService
 
-        Private _serviceProvider As IServiceProvider
+        Private ReadOnly _serviceProvider As IServiceProvider
         Private ReadOnly _hierarchy As IVsHierarchy
 
         ''' <summary>

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/ErrorControl.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/ErrorControl.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
     Friend NotInheritable Class ErrorControl
 
         Private _firstGotFocus As Boolean = True
-        Private _sizingLabel As Label
+        Private ReadOnly _sizingLabel As Label
 
         Friend Sub New()
             ' This call is required by the Windows Form Designer.

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/GenericComponentSerializationStore.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/GenericComponentSerializationStore.vb
@@ -456,7 +456,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             'Backing for public properties
             Private ReadOnly _objectName As String
             Private ReadOnly _propertyName As String
-            Private _serializedValue As Byte()
+            Private ReadOnly _serializedValue As Byte()
 
             ''' <summary>
             ''' Constructor

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/SourceCodeControlManager.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/SourceCodeControlManager.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         Private ReadOnly _serviceProvider As IServiceProvider
 
         ' A map of file names to manage
-        Private _managedFiles As New Dictionary(Of String, Boolean)(3, StringComparer.OrdinalIgnoreCase)
+        Private ReadOnly _managedFiles As New Dictionary(Of String, Boolean)(3, StringComparer.OrdinalIgnoreCase)
 
 #End Region
 

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/WrapCheckBox.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/WrapCheckBox.vb
@@ -77,7 +77,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         End Sub
 
         Private _cachedSizeOfOneLineOfText As Size = Size.Empty
-        Private _preferredSizeHash As New Dictionary(Of Size, Size)()
+        Private ReadOnly _preferredSizeHash As New Dictionary(Of Size, Size)()
 
     End Class
 End Namespace

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationProperties.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationProperties.vb
@@ -138,7 +138,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
 
         'WeakReference list of MyApplicationProperties objects, one for each
         '  IVsHierarchy that we've been initialized against
-        Private Shared s_myPropertyInstances As New Hashtable
+        Private Shared ReadOnly s_myPropertyInstances As New Hashtable
 
 
         ''' <summary>

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/AddMyExtensionsDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/AddMyExtensionsDialog.vb
@@ -150,7 +150,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
 
         Private ReadOnly _extensionTemplates As List(Of MyExtensionTemplate)
         Private _extensionTemplatesToAdd As List(Of MyExtensionTemplate)
-        Private _comparer As ListViewComparer
+        Private ReadOnly _comparer As ListViewComparer
 
 #Region "Windows Forms Designer generated code"
 

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityProjectService.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityProjectService.vb
@@ -517,12 +517,12 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
 
         ' Service provider, current project, project hierarchy and solution.
         Private ReadOnly _vbPackage As VBPackage
-        Private _project As Project
-        Private _projectHierarchy As IVsHierarchy
+        Private ReadOnly _project As Project
+        Private ReadOnly _projectHierarchy As IVsHierarchy
         Private _projectTypeID As String
 
         ' Extension templates information.
-        Private _extensibilitySettings As MyExtensibilitySettings
+        Private ReadOnly _extensibilitySettings As MyExtensibilitySettings
         ' Managing extension code files in current project.
         Private WithEvents _projectSettings As MyExtensibilityProjectSettings
 
@@ -592,8 +592,8 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
                 Return MyBase.Equals(obj)
             End Function
 
-            Private _assemblyName As String
-            Private _changeType As AddRemoveAction
+            Private ReadOnly _assemblyName As String
+            Private ReadOnly _changeType As AddRemoveAction
             Private _extensionTemplates As List(Of MyExtensionTemplate)
             Private _extensionProjectFiles As List(Of MyExtensionProjectItemGroup)
         End Class ' Private Class AssemblyChange

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityProjectSettings.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilityProjectSettings.vb
@@ -677,12 +677,12 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         End Sub
 #End Region
 
-        Private _projectService As MyExtensibilityProjectService
+        Private ReadOnly _projectService As MyExtensibilityProjectService
         Private ReadOnly _serviceProvider As IServiceProvider ' Usually VBPackage.
-        Private _project As Project ' The associated project.
+        Private ReadOnly _project As Project ' The associated project.
         Private ReadOnly _projectHierarchy As IVsHierarchy ' The associated project hierarchy.
 
-        Private _vsBuildPropertyStorage As IVsBuildPropertyStorage ' Used to set the item extension attributes.
+        Private ReadOnly _vsBuildPropertyStorage As IVsBuildPropertyStorage ' Used to set the item extension attributes.
 
         Private _extensionFolderProjectItem As ProjectItem ' "My Extensions" folder.
 

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilitySettings.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilitySettings.vb
@@ -465,14 +465,14 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         ' - value is an AssemblyDictionary of object. AssemblyDictionary contains extension templates
         '   + key is an assembly full name.
         '   + enabling getting extension templates associated with an assembly with / without version.
-        Private _extensionInfos As New Dictionary(Of String, AssemblyDictionary(Of MyExtensionTemplate))
+        Private ReadOnly _extensionInfos As New Dictionary(Of String, AssemblyDictionary(Of MyExtensionTemplate))
         ' The auto options dictionary:
         ' - key is assembly full name without culture / public key - case insensitive.
         ' - value is AssemblyAutoOption.
-        Private _autoOptions As New Dictionary(Of String, AssemblyAutoOption)(StringComparer.OrdinalIgnoreCase)
+        Private ReadOnly _autoOptions As New Dictionary(Of String, AssemblyAutoOption)(StringComparer.OrdinalIgnoreCase)
 
         ' Assembly settings file path
-        Private _settingsFilePath As String
+        Private ReadOnly _settingsFilePath As String
         ' Cached and lazy-init TypeConverter for AssemblyOption enumeration.
         Private Shared s_assemblyOptionConverter As TypeConverter
 

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilitySolutionService.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensibilitySolutionService.vb
@@ -344,9 +344,9 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         End Sub
 #End Region
 
-        Private _vbPackage As VBPackage
+        Private ReadOnly _vbPackage As VBPackage
         ' Collection of MyExtensibilityProjectServices for each known project.
-        Private _projectServices As New Dictionary(Of Project, MyExtensibilityProjectService)()
+        Private ReadOnly _projectServices As New Dictionary(Of Project, MyExtensibilityProjectService)()
         ' My Extensibility settings of the current VS. Lazy init.
         Private _extensibilitySettings As MyExtensibilitySettings
         ' Handle solution closing and project removal events.

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensionListView.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensionListView.vb
@@ -72,7 +72,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         Private ReadOnly _menuCommandAddExtension As New MenuCommand(
             New EventHandler(AddressOf AddExtension_Click),
             Constants.MenuConstants.CommandIDMyEXTENSIONAddExtension)
-        Private _menuCommandRemoveExtension As New MenuCommand(
+        Private ReadOnly _menuCommandRemoveExtension As New MenuCommand(
             New EventHandler(AddressOf RemoveExtension_Click),
             Constants.MenuConstants.CommandIDMyEXTENSIONRemoveExtension)
         Private ReadOnly _menuCommands() As MenuCommand =

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensionTemplate.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/MyExtensionTemplate.vb
@@ -163,7 +163,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
 
         Private ReadOnly _id As String ' Extension ID
         Private ReadOnly _version As Version ' Extension version
-        Private _template As Template ' VSCore Template file.
+        Private ReadOnly _template As Template ' VSCore Template file.
         Private ReadOnly _assemblyFullName As String ' Full name of the triggering assembly.
 
         ' Element and attribute names for extension template information in template's custom data.

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/TrackProjectDocumentsEventsHelper.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/TrackProjectDocumentsEventsHelper.vb
@@ -118,7 +118,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
 
 #End Region
 
-        Private _serviceProvider As IServiceProvider
+        Private ReadOnly _serviceProvider As IServiceProvider
         Private _vsTrackProjectDocuments As IVsTrackProjectDocuments2
         Private _vsTrackProjectDocumentsEventsCookie As UInteger
     End Class

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageControl.xaml.vb
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageControl.xaml.vb
@@ -7,7 +7,7 @@ Namespace Microsoft.VisualStudio.Editors.OptionPages
     Partial Friend NotInheritable Class GeneralOptionPageControl
         Inherits OptionPageControl
 
-        Private _generalOptions As GeneralOptions
+        Private ReadOnly _generalOptions As GeneralOptions
 
         Public Shared ReadOnly FastUpToDateLogLevelItemSource As String() = {
             My.Resources.GeneralOptionPageResources.General_FastUpToDateCheck_LogLevel_None,

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.vb
@@ -27,7 +27,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Protected Const INDEX_COMMANDLINEAPP As Integer = 1
         Protected Const INDEX_WINDOWSCLASSLIB As Integer = 2
         Private _rootNamespace As String
-        Private _outputTypeDefaultValues As OutputTypeComboBoxValue()
+        Private ReadOnly _outputTypeDefaultValues As OutputTypeComboBoxValue()
         Private _controlGroup As Control()()
 
         Public Sub New()

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBBase.vb
@@ -442,7 +442,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 Public Delegate Function CompareFun(SemicolonSeparatedNames As String, Item As ApplicationTypeInfo) As Boolean
 
                 ' Non-localized name to match
-                Private _names As New Dictionary(Of String, Boolean)
+                Private ReadOnly _names As New Dictionary(Of String, Boolean)
                 Private ReadOnly _mustBeSupportedInExpressSKUs As Boolean
 
                 ''' <summary>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBWinForms.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBWinForms.vb
@@ -30,12 +30,12 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Protected Const Const_MyApplication As String = "MyApplication"
 
 
-        Private _shutdownModeStringValues As String()
-        Private _authenticationModeStringValues As String()
-        Private _noneText As String
+        Private ReadOnly _shutdownModeStringValues As String()
+        Private ReadOnly _authenticationModeStringValues As String()
+        Private ReadOnly _noneText As String
         Private _myType As String
-        Private _startupObjectLabelText As String 'This one is in the form's resx when initialized
-        Private _startupFormLabelText As String 'This one we pull from resources
+        Private ReadOnly _startupObjectLabelText As String 'This one is in the form's resx when initialized
+        Private ReadOnly _startupFormLabelText As String 'This one we pull from resources
 
         'This is the (cached) MyApplication.MyApplicationProperties object returned by the project system
         Private _myApplicationPropertiesCache As IMyApplicationPropertiesInternal
@@ -66,7 +66,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Protected Const Const_SaveMySettingsOnExit As String = "SaveMySettingsOnExit"
 
         ' Shared list of all known application types and their properties...
-        Private Shared s_applicationTypes As New List(Of ApplicationTypeInfo)
+        Private Shared ReadOnly s_applicationTypes As New List(Of ApplicationTypeInfo)
 
         Private _settingApplicationType As Boolean
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/AssemblyInfoPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AssemblyInfoPropPage.vb
@@ -9,8 +9,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     Friend Class AssemblyInfoPropPage
         Inherits PropPageUserControlBase
 
-        Private _fileVersionTextBoxes As TextBox()
-        Private _assemblyVersionTextBoxes As TextBox()
+        Private ReadOnly _fileVersionTextBoxes As TextBox()
+        Private ReadOnly _assemblyVersionTextBoxes As TextBox()
 
         'After 65535, the project system doesn't complain, and in theory any value is allowed as
         '  the string version of this, but after this value the numeric version of the file version

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CompilePropPage2.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CompilePropPage2.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Private _settingGenerateXmlDocumentation As Boolean
         Private _generateXmlDocumentation As Object
         ' The list of warning ids that are affected by option strict on/off
-        Private _optionStrictIDs() As Integer
+        Private ReadOnly _optionStrictIDs() As Integer
 
         ' List of warnings to ignore
         Private _noWarn() As Integer
@@ -30,9 +30,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Private _comVisible As Object
 
         'Localized error/warning strings for notify column
-        Private _notifyError As String
-        Private _notifyNone As String
-        Private _notifyWarning As String
+        Private ReadOnly _notifyError As String
+        Private ReadOnly _notifyNone As String
+        Private ReadOnly _notifyWarning As String
         Private Const ConditionColumnIndex As Integer = 0
         Private Const NotifyColumnIndex As Integer = 1
         Private Const ConditionColumnWidthPercentage As Integer = 35 'non-resizable column
@@ -638,7 +638,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End Sub
         End Class
 
-        Private _errorInfos As ErrorInfo() = {
+        Private ReadOnly _errorInfos As ErrorInfo() = {
             New ErrorInfo(My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_Compile_42016, "42016,41999", ErrorNotification.None, True, New Integer() {42016, 41999}),
             New ErrorInfo(My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_Compile_42017_42018_42019, "42017,42018,42019,42032,42036", ErrorNotification.None, True, New Integer() {42017, 42018, 42019, 42032, 42036}),
             New ErrorInfo(My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_Compile_42020, "42020,42021,42022", ErrorNotification.None, True, New Integer() {42020, 42021, 42022}),
@@ -1500,7 +1500,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End Class
 
             ' Shared cache of raw & extended configuration objects
-            Private _configurationObjectCache As ConfigurationObjectCache
+            Private ReadOnly _configurationObjectCache As ConfigurationObjectCache
 
             ' Create a new instance
             Public Sub New(ConfigurationObjectCache As ConfigurationObjectCache, id As Integer, name As String, control As Control, setter As SetDelegate, getter As GetDelegate, flags As ControlDataFlags, AssocControls As Control())

--- a/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.vb
@@ -8,8 +8,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     Friend Class PackagePropPage
         Inherits PropPageUserControlBase
 
-        Private _fileVersionTextBoxes As TextBox()
-        Private _assemblyVersionTextBoxes As TextBox()
+        Private ReadOnly _fileVersionTextBoxes As TextBox()
+        Private ReadOnly _assemblyVersionTextBoxes As TextBox()
 
         'After 65535, the project system doesn't complain, and in theory any value is allowed as
         '  the string version of this, but after this value the numeric version of the file version

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePathsPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePathsPropPage.vb
@@ -14,13 +14,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Inherits PropPageUserControlBase
 
         ' We map colors for all bitmap buttons on the page, because the default one is too dark in high-contrast mode, and it is difficult to know whether it is disabled
-        Private _moveUpImageOriginal As Image
+        Private ReadOnly _moveUpImageOriginal As Image
         Private _moveUpImage As Image
         Private _moveUpGreyImage As Image
-        Private _moveDownImageOriginal As Image
+        Private ReadOnly _moveDownImageOriginal As Image
         Private _moveDownImage As Image
         Private _moveDownGreyImage As Image
-        Private _removeFolderImageOriginal As Image
+        Private ReadOnly _removeFolderImageOriginal As Image
         Private _removeFolderImage As Image
         Private _removeFolderGreyImage As Image
         Private _inContrastMode As Boolean   ' whether we are in ContrastMode

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePropPage.vb
@@ -62,7 +62,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Private _hidingImportListSelectedItem As Boolean
 
         ' helper object to sort the reference list
-        Private _referenceSorter As ListViewComparer
+        Private ReadOnly _referenceSorter As ListViewComparer
 
         Private _referenceGroupManager As IVsWCFReferenceManager
 
@@ -2273,12 +2273,12 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Private Const AliasGroup As String = "(?<" & AliasGroupName & ">[^=""'\s]+)"
 
         ' Regular expression for parsing XML imports statement (<xmlns[:Alias]='url'>).
-        Private Shared s_xmlImportRegex As New Regex(
+        Private Shared ReadOnly s_xmlImportRegex As New Regex(
             "^\s*\<\s*[xX][mM][lL][nN][sS]\s*(:\s*" & AliasGroup & ")?\s*=\s*(""[^""]*""|'[^']*')\s*\>\s*$",
             RegexOptions.Compiled)
 
         ' Regular expression for parsing VB alias imports statement (Alias=Namespace).
-        Private Shared s_vbImportRegex As New Regex(
+        Private Shared ReadOnly s_vbImportRegex As New Regex(
             "^\s*" & AliasGroup & "\s*=\s*.*$",
             RegexOptions.Compiled)
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ServiceReferenceComponent.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ServiceReferenceComponent.vb
@@ -14,8 +14,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Inherits Component
         Implements ICustomTypeDescriptor, IReferenceComponent, IUpdatableReferenceComponent
 
-        Private _collection As IVsWCFReferenceGroupCollection
-        Private _referenceGroup As IVsWCFReferenceGroup
+        Private ReadOnly _collection As IVsWCFReferenceGroupCollection
+        Private ReadOnly _referenceGroup As IVsWCFReferenceGroup
 
         Public Sub New(collection As IVsWCFReferenceGroupCollection, referenceGroup As IVsWCFReferenceGroup)
             _collection = collection

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ServicesAuthenticationForm.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ServicesAuthenticationForm.vb
@@ -7,8 +7,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     Partial Friend Class ServicesAuthenticationForm
         Inherits Form
 
-        Private _serviceProvider As IServiceProvider
-        Private _authenticationUrl As String
+        Private ReadOnly _serviceProvider As IServiceProvider
+        Private ReadOnly _authenticationUrl As String
 
         <SuppressMessage("Microsoft.Design", "CA1054:UriParametersShouldNotBeStrings")>
         Public Sub New(authenticationUrl As String, authenticationHost As String, serviceProvider As IServiceProvider)

--- a/src/Microsoft.VisualStudio.Editors/PropPages/SingleConfigPropertyControlData.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/SingleConfigPropertyControlData.vb
@@ -38,7 +38,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Release
         End Enum
 
-        Private _specificConfigName As String
+        Private ReadOnly _specificConfigName As String
 
 
         ' Constructor.  Same as PropertyControlData, except for Config.

--- a/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworkPropertyControlData.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworkPropertyControlData.vb
@@ -12,7 +12,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
     Friend Class TargetFrameworkPropertyControlData
         Inherits PropertyControlData
 
-        Private _comboBox As ComboBox
+        Private ReadOnly _comboBox As ComboBox
 
         Public Sub New(id As Integer, name As String, comboBox As ComboBox, setter As SetDelegate, getter As GetDelegate, flags As ControlDataFlags, AssocControls As Control())
             MyBase.New(id, name, comboBox, setter, getter, flags, AssocControls)

--- a/src/Microsoft.VisualStudio.Editors/PropPages/UnusedReferencePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/UnusedReferencePropPage.vb
@@ -30,7 +30,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Private WithEvents _hostDialog As PropPageHostDialog
 
         ' helper object to sort the reference list
-        Private _referenceSorter As ListViewComparer
+        Private ReadOnly _referenceSorter As ListViewComparer
 
         ' keep the last status of the last call to GetUnusedReferences...
         ' we only update UI when the status was changed...

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/AppDotXamlDocument.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/AppDotXamlDocument.vb
@@ -112,7 +112,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
 
             Private _isDisposed As Boolean
             Private _buffer As IVsTextLines
-            Private _debugLockCheck As IDebugLockCheck 'Used by the document to verify BufferLock is used when it's needed
+            Private ReadOnly _debugLockCheck As IDebugLockCheck 'Used by the document to verify BufferLock is used when it's needed
 
             Public Sub New(buffer As IVsTextLines, debugLockCheck As IDebugLockCheck)
                 If buffer Is Nothing Then

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
@@ -26,9 +26,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         'Holds the DocData for the Application.xaml file
         Private WithEvents _applicationXamlDocData As DocData
 
-        Private Shared s_noneText As String '(None)" in the startup object combobox
-        Private Shared s_startupObjectLabelText As String 'The label text to use for a startup object
-        Private Shared s_startupUriLabelText As String 'The label text to use for a startup Uri
+        Private Shared ReadOnly s_noneText As String '(None)" in the startup object combobox
+        Private Shared ReadOnly s_startupObjectLabelText As String 'The label text to use for a startup object
+        Private Shared ReadOnly s_startupUriLabelText As String 'The label text to use for a startup Uri
         Private _errorControl As AppDotXamlErrorControl
 
         Protected Const STARTUPOBJECT_SubMain As String = "Sub Main"
@@ -376,7 +376,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
 #Region "Application type"
 
         ' Shared list of all known application types and their properties...
-        Private Shared s_applicationTypes As New List(Of ApplicationTypeInfo)
+        Private Shared ReadOnly s_applicationTypes As New List(Of ApplicationTypeInfo)
 
         ''' <summary>
         ''' Initialize the application types applicable to this page (logic is in the base class)
@@ -1392,7 +1392,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
 
 #End Region
 
-        Private Shared s_shutdownModes As New List(Of ShutdownMode)
+        Private Shared ReadOnly s_shutdownModes As New List(Of ShutdownMode)
         Private Shared s_defaultShutdownMode As ShutdownMode
 
         Private Shared Sub InitializeShutdownModeValues()

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WebReferenceComponent.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WebReferenceComponent.vb
@@ -12,8 +12,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Inherits Component
         Implements ICustomTypeDescriptor, IReferenceComponent, IUpdatableReferenceComponent
 
-        Private _page As ReferencePropPage
-        Private _projectItem As EnvDTE.ProjectItem
+        Private ReadOnly _page As ReferencePropPage
+        Private ReadOnly _projectItem As EnvDTE.ProjectItem
 
         Public Sub New(page As ReferencePropPage, projectItem As EnvDTE.ProjectItem)
             _page = page

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/CategoryCollection.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/CategoryCollection.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
 
         'A hashtable list of resources by name.
-        Private _innerHashByName As New Hashtable 'Of String (case-sensitive)
+        Private ReadOnly _innerHashByName As New Hashtable 'Of String (case-sensitive)
 
 
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/FileWatcher.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/FileWatcher.vb
@@ -37,11 +37,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   is based on directories, and allocates system resources per directory.
         ''' </summary>
         ''' <remarks></remarks>
-        Private _directoryWatchers As New Hashtable 'Key = Directory Path (upper-cased, with the backslash)
+        Private ReadOnly _directoryWatchers As New Hashtable 'Key = Directory Path (upper-cased, with the backslash)
 
         'Any Windows Forms control on the primary thread.  This is used for invoking 
         '  the system filewatch events (called on a secondary thread) back to the main thread.
-        Private _controlForSynchronizingThreads As Control
+        Private ReadOnly _controlForSynchronizingThreads As Control
 
 
 
@@ -233,7 +233,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Private WithEvents _fileSystemWatcher As FileSystemWatcher
 
             'The parent FileWatcher class
-            Private _parentFileWatcher As FileWatcher
+            Private ReadOnly _parentFileWatcher As FileWatcher
 
 
             Public Sub New(DirectoryPath As String, ParentFileWatcher As FileWatcher)
@@ -484,7 +484,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Private ReadOnly _fileNameOnly As String
 
             'The parent DirectoryWatcher for this file.
-            Private _directoryWatcher As DirectoryWatcher
+            Private ReadOnly _directoryWatcher As DirectoryWatcher
 
             'A Windows Forms timer used to delay processing of the file changed
             '  event until it's likely that no more changes to the file are
@@ -497,7 +497,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             '  in multiples.
             Private Const DelayInMilliseconds As Integer = 400
 
-            Private _listeners As New ArrayList 'Of IFileWatchListener
+            Private ReadOnly _listeners As New ArrayList 'Of IFileWatchListener
 
 #If DEBUG Then
             'Hashcode of the last thread we fired notifications on.  Used to verify

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/FindReplace.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/FindReplace.vb
@@ -29,7 +29,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
 
         'Pointer to the root designer
-        Private _rootDesigner As ResourceEditorRootDesigner
+        Private ReadOnly _rootDesigner As ResourceEditorRootDesigner
 
         'The find state object. Find state is an opaque object we hold on behalf of the find engine.
         '  Setting this object to Nothing will reset the find / replace loop.

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
@@ -262,7 +262,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '  Resource.  The set of properties shown is based solely on the value type of the
         '  resource and the type of ResourceTypeEditor that it uses.  Therefore we only need to 
         '  create a unique properties collection for each distinct pairing of these values.
-        Private Shared s_propertyDescriptorCollectionHash As New Hashtable '(Of PropertyDescriptorCollection), key = fully-qualified type names of resource value + resource type editor
+        Private Shared ReadOnly s_propertyDescriptorCollectionHash As New Hashtable '(Of PropertyDescriptorCollection), key = fully-qualified type names of resource value + resource type editor
 
         'A list of names which are not recommended for use by the end user (because they cause
         '  compiler errors or other problems).

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceComparerForFind.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceComparerForFind.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Implements IComparer
 
         'A hashtable that maps a Category to its sort order
-        Private _categoryToCategoryOrderHash As New Hashtable
+        Private ReadOnly _categoryToCategoryOrderHash As New Hashtable
 
         'All categories included in the search
         Private ReadOnly _categories As CategoryCollection

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRootDesigner.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRootDesigner.vb
@@ -39,7 +39,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Private WithEvents _designerHost As IDesignerHost = Nothing
 
         ' Contains information about the current state of Find/Replace
-        Private _findReplace As New FindReplace(Me)
+        Private ReadOnly _findReplace As New FindReplace(Me)
 
         ' Indicates whether or not we are trying to register our view helper on a delayed basis
         Private _delayRegisteringViewHelper As Boolean

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
@@ -58,7 +58,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Private _uiInitialized As Boolean
 
         'The set of categories handled by this instance of the resource editor.
-        Private _categories As New CategoryCollection
+        Private ReadOnly _categories As New CategoryCollection
 
         'The root designer associated with this resource editor instance
         Private _rootDesigner As ResourceEditorRootDesigner
@@ -71,10 +71,10 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Private _currentCategory As Category
 
         'Temporary files which can be cleaned up on the next clipboard flush.
-        Private _deleteFilesOnClipboardFlush As New ArrayList
+        Private ReadOnly _deleteFilesOnClipboardFlush As New ArrayList
 
         'Temporary files which can be cleaned up when the editor exists.
-        Private _deleteFoldersOnEditorExit As New ArrayList
+        Private ReadOnly _deleteFoldersOnEditorExit As New ArrayList
 
         'The set of internal resources that we cache for this instance of the resource editor
         Private _cachedResources As CachedResourcesForView
@@ -154,7 +154,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '  the assemblies of any types handled by these type editors.
         '
         'System, mscorlib, System.Drawing, System.Windows.Forms, System.Data
-        Private Shared s_defaultAssemblyReferences() As AssemblyName =
+        Private Shared ReadOnly s_defaultAssemblyReferences() As AssemblyName =
             {
                 GetType(CodeDom.MemberAttributes).Assembly.GetName(),
                 GetType(Integer).Assembly.GetName(),

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView_EditorState.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView_EditorState.vb
@@ -37,10 +37,10 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Private _stringTableCurrentCellAddress As Point
 
             'Current listview view (thumbnail, icons, etc.) for each category, hashed by category name (whether or not these categories are showing)
-            Private _resourceViewHash As New ListDictionary
+            Private ReadOnly _resourceViewHash As New ListDictionary
 
             'Current sorter for each category, hashed by category name (whether or not these categories are showing)
-            Private _categorySorter As New ListDictionary
+            Private ReadOnly _categorySorter As New ListDictionary
 
             'Widths of the columns in the listview's details view (whether or not the listview is currently showing)
             Private _listViewColumnWidths() As Integer

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceFile.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceFile.vb
@@ -37,10 +37,10 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Private WithEvents _componentChangeService As IComponentChangeService
 
         'Our set of resources (keyed by Name normalized to uppercase so our look-up is case-insensitive)
-        Private _resourcesHash As Hashtable = Nothing
+        Private ReadOnly _resourcesHash As Hashtable = Nothing
 
         'an arrayList to keep all meta data, we shouldn't lose them when we save the resource file back...
-        Private _metadataList As ArrayList
+        Private ReadOnly _metadataList As ArrayList
 
         'The root component for the resource editor.  Cannot be Nothing.
         Private ReadOnly _rootComponent As ResourceEditorRootComponent
@@ -54,11 +54,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
         'Holds a set of tasks for each Resource that has any task list entries.
         'Hashes key=Resource to ResourceTaskSet.
-        Private _resourceErrorsHash As New Hashtable 'Of Resource To ResourceTaskSet
+        Private ReadOnly _resourceErrorsHash As New Hashtable 'Of Resource To ResourceTaskSet
 
         'A list of resources that need to be checked for errors during idle-time
         '  processing.
-        Private _resourcesToDelayCheckForErrors As New ArrayList
+        Private ReadOnly _resourcesToDelayCheckForErrors As New ArrayList
 
         ' Indicate whether we should suspend delay checking temporary...
         Private _delayCheckSuspended As Boolean
@@ -74,7 +74,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
         ' We get ResourceWrite from this environment service
         '  the reason is some projects (device project) need write the resource file in v1.x format, but other projects write in 2.0 format.
-        Private _resxService As IResXResourceService
+        Private ReadOnly _resxService As IResXResourceService
 
         'True if the original file bases on alphabetized order, we will keep this style...
         Private _alphabetizedOrder As Boolean = True
@@ -93,7 +93,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ' If it is true, we are adding a collection of resources to the file
         Private _inBatchAdding As Boolean
 
-        Private _multiTargetService As MultiTargetService
+        Private ReadOnly _multiTargetService As MultiTargetService
 
         Private ReadOnly _allowMOTW As Boolean = False
 #End Region
@@ -1109,7 +1109,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <remarks></remarks>
         Private NotInheritable Class ResourceTaskSet
             'The number of error types that we have.  Calculated from the ResourceTaskType enum.
-            Private Shared s_errorTypeCount As Integer
+            Private Shared ReadOnly s_errorTypeCount As Integer
 
             'Backs Tasks property
             '  (could just have well been a hashtable as an array, but an array is more lightweight)

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceListView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceListView.vb
@@ -24,7 +24,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '  Since we're using the listview in virtual mode (in order to accomplish
         '  delay-load of the images from disk), we keep track of the data ourselves.
         '  The base listview notifies us when it needs data to display.
-        Private _virtualResourceList As New ArrayList 'Of Resource
+        Private ReadOnly _virtualResourceList As New ArrayList 'Of Resource
 
         'A cache of thumbnails for the listview items that we are displaying.  This has
         '  knowledge of our imagelist, and manages it for us.
@@ -1279,18 +1279,18 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Private Structure LVITEM
 #Disable Warning IDE1006 ' Naming Styles
             Public mask As Integer
-            Public iItem As Integer
-            Public iSubItem As Integer
+            Public ReadOnly iItem As Integer
+            Public ReadOnly iSubItem As Integer
             Public state As Integer
             Public stateMask As Integer
-            Public pszText As String
-            Public cchTextMax As Integer
-            Public iImage As Integer
-            Public lParam As IntPtr
-            Public iIndent As Integer
-            Public iGroupId As Integer
-            Public cColumns As Integer
-            Public puColumns As IntPtr
+            Public ReadOnly pszText As String
+            Public ReadOnly cchTextMax As Integer
+            Public ReadOnly iImage As Integer
+            Public ReadOnly lParam As IntPtr
+            Public ReadOnly iIndent As Integer
+            Public ReadOnly iGroupId As Integer
+            Public ReadOnly cColumns As Integer
+            Public ReadOnly puColumns As IntPtr
 #Enable Warning IDE1006 ' Naming Styles
         End Structure
 
@@ -1508,8 +1508,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         Private Class ImageCacheRequirement
             ' We should cache images from StartIndex to EndIndex (included)
-            Public StartIndex As Integer
-            Public EndIndex As Integer
+            Public ReadOnly StartIndex As Integer
+            Public ReadOnly EndIndex As Integer
 
             ''' <summary>
             ''' Constructor.

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
         'A list of all Resource entries that are displayed in this string table (with the exception
         '  of the uncommitted resource, if any)
-        Private _virtualResourceList As New ArrayList
+        Private ReadOnly _virtualResourceList As New ArrayList
 
         'The row that is currently being removed, if any.
         Private _removingRow As DataGridViewRow

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeDescriptor.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeDescriptor.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
 
         ' The instance of the Resource that we're providing type description information for.
-        Private _instance As Resource = Nothing
+        Private ReadOnly _instance As Resource = Nothing
 
 
         '======================================================================

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourcesFolderService.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourcesFolderService.vb
@@ -122,7 +122,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 #End Region
 
         'Trace switch for this class.
-        Private Shared s_resourcesFolderServiceSwitch As New TraceSwitch("ResourcesFolderService", "Traces the behavior of the Resources Folder Service")
+        Private Shared ReadOnly s_resourcesFolderServiceSwitch As New TraceSwitch("ResourcesFolderService", "Traces the behavior of the Resources Folder Service")
 
 
 #Region "Tracing"

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ThumbnailCache.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ThumbnailCache.vb
@@ -29,7 +29,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
     Friend NotInheritable Class ThumbnailCache
 
         'The ImageList which contains the thumbnail images
-        Private _imageList As ImageList
+        Private ReadOnly _imageList As ImageList
 
         'The number of reserved images at the bottom of the list of images, set by the user.
         '   These could be used for overlays, common images, etc.  They will never
@@ -49,7 +49,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '  replace an old image in the ImageList (without shifting other indices) does not allow you 
         '  to simultaneously change the key.  When we replace an image in the imagelist, we're also
         '  using a different key.
-        Private _keys As New Hashtable
+        Private ReadOnly _keys As New Hashtable
 
         'An Mru List we maintained to release the most less used item in the ImageList when we need load a new image.
         ' For performance reason, we implement the list table inside an array of structures. Each item contains a point (index)

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DataGridViewUITypeEditorEditingControl.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DataGridViewUITypeEditorEditingControl.vb
@@ -325,7 +325,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         Private Class EditContext
             Implements System.ComponentModel.ITypeDescriptorContext
 
-            Private _instance As DesignTimeSettingInstance
+            Private ReadOnly _instance As DesignTimeSettingInstance
 
             Public Sub New(instance As DesignTimeSettingInstance)
                 _instance = instance

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DesignTimeSettings.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DesignTimeSettings.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <remarks></remarks>
         Private _useSpecialClassName As Boolean
 
-        Private _settings As New List(Of DesignTimeSettingInstance)(16)
+        Private ReadOnly _settings As New List(Of DesignTimeSettingInstance)(16)
 
         Private Function IEnumerableOfDesignTimeSettingInstance_GetEnumerator() As IEnumerator(Of DesignTimeSettingInstance) Implements IEnumerable(Of DesignTimeSettingInstance).GetEnumerator
             Return _settings.GetEnumerator()

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/FakeCollectionEditor.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/FakeCollectionEditor.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
     Friend Class StringArrayEditorForStringCollections
         Inherits UITypeEditor
 
-        Private _parent As UITypeEditor
+        Private ReadOnly _parent As UITypeEditor
 
         ''' <summary>
         ''' Create a new StringArrayEditorForStringCollections

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ProjectUtils.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ProjectUtils.vb
@@ -383,7 +383,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
         Friend Class KnownClassName
             Implements IFindFilter
 
-            Private _className As String
+            Private ReadOnly _className As String
             Private ReadOnly _classOrModule As ClassOrModule
 
             Friend Sub New(ClassName As String, Optional ClassOrModule As ClassOrModule = ClassOrModule.ClassOnly)
@@ -424,7 +424,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
             ''' The class to expand
             ''' </summary>
             ''' <remarks></remarks>
-            Private _classToExpand As EnvDTE80.CodeClass2
+            Private ReadOnly _classToExpand As EnvDTE80.CodeClass2
 
             Friend Sub New(ClassToExpand As EnvDTE80.CodeClass2)
                 If ClassToExpand Is Nothing Then
@@ -455,7 +455,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
         Friend Class FindPropertyFilter
             Implements IFindFilter
 
-            Private _containtingClass As EnvDTE.CodeElement
+            Private ReadOnly _containtingClass As EnvDTE.CodeElement
             Private ReadOnly _propertyName As String
 
             Public Sub New(ContainingClass As EnvDTE.CodeElement, PropertyName As String)
@@ -513,7 +513,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
         Friend Class FindFunctionFilter
             Implements IFindFilter
 
-            Private _containtingClass As EnvDTE.CodeElement
+            Private ReadOnly _containtingClass As EnvDTE.CodeElement
             Private ReadOnly _functionName As String
 
             Public Sub New(ContainingClass As EnvDTE.CodeElement, FunctionName As String)

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingTypeNameResolutionService.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingTypeNameResolutionService.vb
@@ -25,10 +25,10 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 #Region "Private fields"
 
         ' Map from language specific names to the corresponding .NET FX type name
-        Private _languageSpecificToFxTypeName As Dictionary(Of String, String)
+        Private ReadOnly _languageSpecificToFxTypeName As Dictionary(Of String, String)
 
         ' Map from .NET FX type names to language specific type names
-        Private _fxTypeNameToLanguageSpecific As Dictionary(Of String, String)
+        Private ReadOnly _fxTypeNameToLanguageSpecific As Dictionary(Of String, String)
 
         ' Is the current language case-sensitive?
         Private ReadOnly _caseSensitive As Boolean

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
@@ -112,7 +112,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         Private WithEvents _settingsTableLayoutPanel As TableLayoutPanel
         Private _isReportingError As Boolean
         Private _isShowingTypePicker As Boolean
-        Private _toolbarPanel As DesignerToolbarPanel
+        Private ReadOnly _toolbarPanel As DesignerToolbarPanel
 
         ' Does the current language support partial classes? If yes, enable the ViewCode button...
         Private _viewCodeEnabled As Boolean

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsValueCache.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsValueCache.vb
@@ -9,7 +9,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
         ' We cache the values in a hashtable of hashtables:
         ' Type -> Serialized value -> Deserialized value
-        Private _cachedSettingValues As New Dictionary(Of Type, Dictionary(Of String, Object))
+        Private ReadOnly _cachedSettingValues As New Dictionary(Of Type, Dictionary(Of String, Object))
 
         Private ReadOnly _culture As Globalization.CultureInfo
 

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypePickerDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypePickerDialog.vb
@@ -177,7 +177,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
 #End Region
 
-        Private _typeTreeView As TypeTV
+        Private ReadOnly _typeTreeView As TypeTV
 
         Private Sub TypeTreeViewAfterSelectHandler(sender As Object, e As TreeViewEventArgs)
             If e.Node IsNot Nothing Then

--- a/src/Microsoft.VisualStudio.Editors/SettingsGlobalObject/SettingsGlobalObjectProvider.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsGlobalObject/SettingsGlobalObjectProvider.vb
@@ -1174,19 +1174,19 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         Inherits GlobalObject
         Implements VSDesignerPackage.IRefreshSettingsObject
 
-        Private _provider As SettingsGlobalObjectProvider
+        Private ReadOnly _provider As SettingsGlobalObjectProvider
         Private ReadOnly _item As ProjectItem
         Private ReadOnly _hierarchy As IVsHierarchy
         Private _itemid As UInteger
-        Private _typeResolver As ITypeResolutionService
+        Private ReadOnly _typeResolver As ITypeResolutionService
         Private _docData As DocData
         Private _virtualType As Type
         Private _dtSettings As DesignTimeSettings
         Private _namespace As String
-        Private _className As String
+        Private ReadOnly _className As String
         Private _ignoreDocLock As Boolean
         Private ReadOnly _fileName As String
-        Private _valueCache As SettingsValueCache
+        Private ReadOnly _valueCache As SettingsValueCache
         Private _typeCache As SettingsTypeCache
 
         ''' <summary>
@@ -2112,7 +2112,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         Private NotInheritable Class SettingsFileTypeImplementor
             Inherits VirtualTypeImplementor
 
-            Private _globalObject As SettingsFileGlobalObject
+            Private ReadOnly _globalObject As SettingsFileGlobalObject
 
             ''' <summary>
             ''' constructor for this implementor
@@ -2389,7 +2389,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         Private Class GlobalSettingsPropertyCollection
             Inherits SettingsPropertyCollection
 
-            Private _globalObject As SettingsFileGlobalObject
+            Private ReadOnly _globalObject As SettingsFileGlobalObject
 
             ''' <summary>
             ''' 

--- a/src/Microsoft.VisualStudio.Editors/XmlIntellisense/XmlIntellisense.vb
+++ b/src/Microsoft.VisualStudio.Editors/XmlIntellisense/XmlIntellisense.vb
@@ -114,7 +114,7 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
         ' Number of calls into AsyncCompile prior to terminating inital compilation loop
         Private Const CompilationLevel As Integer = 2
 
-        Private _data As XmlIntellisenseSchemasData
+        Private ReadOnly _data As XmlIntellisenseSchemasData
         '--------------------------------------------------------------------------
         ' New:
         '   Initialize the class.
@@ -497,13 +497,13 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
     Friend Class XmlIntellisenseMember
         Implements IXmlIntellisenseMember
 
-        Private _name As XmlQualifiedName
+        Private ReadOnly _name As XmlQualifiedName
         Private _children As XmlIntellisenseMember
         Private _nextMember As XmlIntellisenseMember
         Private _flags As Flags
         Private ReadOnly _element As XmlSchemaElement
 
-        Private Shared s_any As XmlIntellisenseMember
+        Private Shared ReadOnly s_any As XmlIntellisenseMember
 
         Private Enum Flags
             None = 0
@@ -621,9 +621,9 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
     '--------------------------------------------------------------------------
     <ClassInterface(ClassInterfaceType.None)>
     Friend Class IndexedMembers
-        Private _targetNamespaces As Dictionary(Of String, String)
-        Private _indexedByNamespace As Dictionary(Of String, List(Of XmlIntellisenseMember))
-        Private _indexedByName As Dictionary(Of XmlQualifiedName, Object)
+        Private ReadOnly _targetNamespaces As Dictionary(Of String, String)
+        Private ReadOnly _indexedByNamespace As Dictionary(Of String, List(Of XmlIntellisenseMember))
+        Private ReadOnly _indexedByName As Dictionary(Of XmlQualifiedName, Object)
         Private ReadOnly _all As XmlIntellisenseMemberList
         Private ReadOnly _document As XmlIntellisenseMemberList
         Private ReadOnly _roots As XmlIntellisenseMemberList
@@ -900,10 +900,10 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
     Friend Class XmlIntellisenseMemberList
         Implements IXmlIntellisenseMemberList, IEnumerable(Of XmlIntellisenseMember)
 
-        Private _allMembers As IndexedMembers
-        Private _previousStep As XmlIntellisenseMemberList
+        Private ReadOnly _allMembers As IndexedMembers
+        Private ReadOnly _previousStep As XmlIntellisenseMemberList
         Private ReadOnly _axis As Axis
-        Private _name As XmlQualifiedName
+        Private ReadOnly _name As XmlQualifiedName
         Private _members As IEnumerable(Of XmlIntellisenseMember)
 
         Private Enum Axis
@@ -1289,7 +1289,7 @@ Namespace Microsoft.VisualStudio.Editors.XmlIntellisense
     Friend Class XmlIntellisenseMemberEnumerator
         Implements IXmlIntellisenseMemberEnumerator
 
-        Private _enumerator As IEnumerator(Of XmlIntellisenseMember)
+        Private ReadOnly _enumerator As IEnumerator(Of XmlIntellisenseMember)
 
         Public Sub New(Enumerator As IEnumerator(Of XmlIntellisenseMember))
             _enumerator = Enumerator

--- a/src/Microsoft.VisualStudio.Editors/package/VBPackage.vb
+++ b/src/Microsoft.VisualStudio.Editors/package/VBPackage.vb
@@ -369,10 +369,10 @@ Namespace Microsoft.VisualStudio.Editors
             Private _cookie As UInteger
 
             ' A handle to the IVsSolution service providing the events
-            Private _solution As IVsSolution
+            Private ReadOnly _solution As IVsSolution
 
             ' List of files to clean up when a ZIP project is discarded
-            Private _filesToCleanUp As New List(Of String)
+            Private ReadOnly _filesToCleanUp As New List(Of String)
 
             ''' <summary>
             ''' Create a new instance of this class


### PR DESCRIPTION
Makes fields `ReadOnly` where possible in VB code.

Follows #3970 which did the same for C# code.