### PR TITLE
Don't ignore default values

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/PackageRuleHandler.cs
@@ -303,7 +303,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 Requires.NotNull(properties, nameof(properties));
                 Properties = properties;
 
-                DependencyType = GetEnumMetadata(ProjectItemMetadata.Type, DependencyType.Unknown);
+                DependencyType = GetEnumMetadata<DependencyType>(ProjectItemMetadata.Type) ?? DependencyType.Unknown;
                 Name = GetStringMetadata(ProjectItemMetadata.Name);
                 if (string.IsNullOrEmpty(Name))
                 {
@@ -312,8 +312,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
                 Version = GetStringMetadata(ProjectItemMetadata.Version);
                 Path = GetStringMetadata(ProjectItemMetadata.Path);
-                Resolved = GetBoolMetadata(ProjectItemMetadata.Resolved, true);
-                IsImplicitlyDefined = GetBoolMetadata(ProjectItemMetadata.IsImplicitlyDefined, false);
+                Resolved = GetBoolMetadata(ProjectItemMetadata.Resolved) ?? true;
+                IsImplicitlyDefined = GetBoolMetadata(ProjectItemMetadata.IsImplicitlyDefined) ?? false;
 
                 var dependenciesHashSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                 if (properties.ContainsKey(ProjectItemMetadata.Dependencies)
@@ -332,7 +332,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
                 if (DependencyType == DependencyType.Diagnostic)
                 {
-                    Severity = GetEnumMetadata(ProjectItemMetadata.Severity, DiagnosticMessageSeverity.Info);
+                    Severity = GetEnumMetadata<DiagnosticMessageSeverity>(ProjectItemMetadata.Severity) ?? DiagnosticMessageSeverity.Info;
                     DiagnosticCode = GetStringMetadata(ProjectItemMetadata.DiagnosticCode);
                 }
             }
@@ -347,22 +347,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 return string.Empty;
             }
 
-            private T GetEnumMetadata<T>(string metadataName, T defaultValue) where T : struct
+            private T? GetEnumMetadata<T>(string metadataName) where T : struct
             {
                 string enumString = GetStringMetadata(metadataName);
-                T enumValue = defaultValue;
-                Enum.TryParse(enumString ?? string.Empty, /*ignoreCase */ true, out enumValue);
-
-                return enumValue;
+                return Enum.TryParse(enumString, ignoreCase: true, out T enumValue) ? enumValue : (T?)null;
             }
 
-            private bool GetBoolMetadata(string metadataName, bool defaultValue)
+            private bool? GetBoolMetadata(string metadataName)
             {
                 string boolString = GetStringMetadata(metadataName);
-                bool boolValue = defaultValue;
-                bool.TryParse(boolString ?? "false", out boolValue);
-
-                return boolValue;
+                return bool.TryParse(boolString, out bool boolValue) ? boolValue : (bool?)null;
             }
 
             public static string GetTargetFromDependencyId(string dependencyId)


### PR DESCRIPTION
Fixes #3915.

`PackageRuleHander` has a couple of helper methods, `GetEnumMetadata` and `GetBoolMetadata`, that look up some metadata on an item and return value as an enum or bool, respectively. They each take a `defaultValue` parameter, which is the value to return if the metadata is not found or can't be parsed properly. The way these methods are written, however, means that `defaultValue` is always ignored--in the case that `Enum.TryParse` or `bool.TryParse` fail we will instead get whatever default value _they_ choose for their `out` params.

This commit updates the methods so they no longer take a default value and instead return a nullable value. Now the call with either succeed with a value, or fail and return a null. The callers have been updated to use the null coalescing operator to sub in the default value if `GetEnumMetadata`/`GetBoolMetadata` fail. With this approach it is easier to verify that the code is correct.

Note this change shouldn't cause any functional changes. The specific metadata we're looking for should always be present, and the default values would only matter in cases where something else has already gone badly wrong.