### PR TITLE
Avoid crashing when RESX already open in uninitialized tab

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerPanel.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerPanel.vb
@@ -306,7 +306,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
 
                                     'Is this file already opened in the specific editor we want to open it in?  If so, we will not be able to open it
                                     '  as a nested document window.
-                                    Dim hr As Integer = VsUIShellOpenDocument.IsSpecificDocumentViewOpen(VsUIHierarchy, ItemId, MkDocument, (EditorGuid), PhysicalView, 0UI, OpenHierachy, OpenItemId, OpenWindowFrame, fOpen)
+                                    Dim hr As Integer = VsUIShellOpenDocument.IsSpecificDocumentViewOpen(VsUIHierarchy, ItemId, MkDocument, (EditorGuid), PhysicalView, CUInt(__VSIDOFLAGS2.IDO_IncludeUninitializedFrames), OpenHierachy, OpenItemId, OpenWindowFrame, fOpen)
                                     Debug.Assert(VSErrorHandler.Succeeded(hr), "Unexpected failure from VsUIShellOpenDocument.IsSpecificDocumentViewOpen")
                                     If VSErrorHandler.Succeeded(hr) Then
                                         If fOpen <> 0 Then


### PR DESCRIPTION
When you open the Resources page in the AppDesigner and the default RESX is already open in another editor, we display a message that it's already open. If it happens to be uninitialized tab - we crashed because our check skipped it. Avoid that by also asking for uninitialized tabs when we check if the document is open.

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/654708



