### PR TITLE
Allow integration tests to run from VS

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -54,6 +54,7 @@
     <MicrosoftVisualStudioTextManagerInterop12Version>12.0.30110</MicrosoftVisualStudioTextManagerInterop12Version>
     <MicrosoftVisualStudioTextManagerInterop121DesignTimeVersion>12.1.30328</MicrosoftVisualStudioTextManagerInterop121DesignTimeVersion>
     <MicrosoftVisualStudioSetupConfigurationVersion>1.16.30</MicrosoftVisualStudioSetupConfigurationVersion>
+    <MicrosoftVisualStudioSettings15Version>15.8.28010</MicrosoftVisualStudioSettings15Version>
     <MicrosoftVisualStudioShell15Version>15.0.26606</MicrosoftVisualStudioShell15Version>
     <MicrosoftVisualStudioShellDesignVersion>15.0.26606</MicrosoftVisualStudioShellDesignVersion>
     <MicrosoftVisualStudioShellFrameworkVersion>15.0.26606</MicrosoftVisualStudioShellFrameworkVersion>

--- a/src/DeployIntegrationDependencies/DeployIntegrationDependencies.csproj
+++ b/src/DeployIntegrationDependencies/DeployIntegrationDependencies.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Test.Apex.VisualStudio" Version="$(MicrosoftTestApexVisualStudioVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="$(MicrosoftVisualStudioLanguageServicesVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Settings.15.0" Version="$(MicrosoftVisualStudioSettings15Version)" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="$(MicrosoftVisualStudioCompositionVersion)"/>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/OpenProjectTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/OpenProjectTests.cs
@@ -51,6 +51,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
                 
                 Assert.IsTrue(success, $"project '{consoleProject.FileName}' failed to build.{Environment.NewLine}errors:{Environment.NewLine}{string.Join(Environment.NewLine, errors)}");
             }
+
+            VS.Stop();
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/OpenProjectTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/OpenProjectTests.cs
@@ -2,42 +2,19 @@
 
 using System;
 using System.Linq;
-using Microsoft.Test.Apex.VisualStudio;
 using Microsoft.Test.Apex.VisualStudio.Solution;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
 {
     [TestClass]
-    public class CreateProjectTests : VisualStudioHostTest
+    public class CreateProjectTests : TestBase
     {
-        private static string _hiveName;
-
-        [ClassInitialize()]
+        [ClassInitialize]
         public static void ClassInitialize(TestContext context)
         {
-            _hiveName = context.Properties["VsRootSuffix"].ToString();
+            Initialize(context);
         }
-
-        protected VisualStudioHostConfiguration DefaultHostConfiguration
-        {
-            get
-            {
-                var visualStudioHostConfiguration = new VisualStudioHostConfiguration()
-                {
-                    CommandLineArguments = $"/rootSuffix {_hiveName}",
-                    RestoreUserSettings = false,
-                    InheritProcessEnvironment = true,
-                    AutomaticallyDismissMessageBoxes = true,
-                    DelayInitialVsLicenseValidation = true,
-                    ForceFirstLaunch = true,
-                };
-
-                return visualStudioHostConfiguration;
-            }
-        }
-
-        protected VisualStudioHost GetVS() => Operations.CreateHost<VisualStudioHost>(DefaultHostConfiguration);
 
         [TestMethod]
         public void CreateProject_CreateAndBuild()

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using Microsoft.Test.Apex.VisualStudio;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -13,6 +14,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
         protected static void Initialize(TestContext context)
         {
             _hiveName = GetVsHiveName(context);
+
+            SetTestInstallationDirectoryIfUnset();
         }
 
         protected VisualStudioHostConfiguration DefaultHostConfiguration
@@ -42,6 +45,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
                 return rootSuffix;
 
             return Environment.GetEnvironmentVariable("RootSuffix") ?? "Exp";
+        }
+
+        private static void SetTestInstallationDirectoryIfUnset()
+        {
+            string installationUnderTest = "VisualStudio.InstallationUnderTest.Path";
+
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(installationUnderTest)))
+            {
+                string vsDirectory = Environment.GetEnvironmentVariable("VSAPPIDDIR");
+                string devenv = Environment.GetEnvironmentVariable("VSAPPIDNAME");
+                if (!string.IsNullOrEmpty(vsDirectory) && !string.IsNullOrEmpty(devenv))
+                {
+                    Environment.SetEnvironmentVariable(installationUnderTest, Path.Combine(vsDirectory, devenv));
+                }
+            }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
@@ -30,6 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
                     AutomaticallyDismissMessageBoxes = true,
                     DelayInitialVsLicenseValidation = true,
                     ForceFirstLaunch = true,
+                    BootstrapInjection = BootstrapInjectionMethod.DteFromROT,
                 };
 
                 return visualStudioHostConfiguration;

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using Microsoft.Test.Apex.VisualStudio;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -11,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
 
         protected static void Initialize(TestContext context)
         {
-            _hiveName = context.Properties["VsRootSuffix"].ToString();
+            _hiveName = GetVsHiveName(context);
         }
 
         protected VisualStudioHostConfiguration DefaultHostConfiguration
@@ -33,5 +34,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
         }
 
         protected VisualStudioHost GetVS() => Operations.CreateHost<VisualStudioHost>(DefaultHostConfiguration);
+
+        private static string GetVsHiveName(TestContext context)
+        {
+            string rootSuffix = (string)context.Properties["VsRootSuffix"];
+            if (!string.IsNullOrEmpty(rootSuffix))
+                return rootSuffix;
+
+            return Environment.GetEnvironmentVariable("RootSuffix") ?? "Exp";
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.Test.Apex.VisualStudio;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
+{
+    public abstract class TestBase : VisualStudioHostTest
+    {
+        private static string _hiveName;
+
+        protected static void Initialize(TestContext context)
+        {
+            _hiveName = context.Properties["VsRootSuffix"].ToString();
+        }
+
+        protected VisualStudioHostConfiguration DefaultHostConfiguration
+        {
+            get
+            {
+                var visualStudioHostConfiguration = new VisualStudioHostConfiguration()
+                {
+                    CommandLineArguments = $"/rootSuffix {_hiveName}",
+                    RestoreUserSettings = false,
+                    InheritProcessEnvironment = true,
+                    AutomaticallyDismissMessageBoxes = true,
+                    DelayInitialVsLicenseValidation = true,
+                    ForceFirstLaunch = true,
+                };
+
+                return visualStudioHostConfiguration;
+            }
+        }
+
+        protected VisualStudioHost GetVS() => Operations.CreateHost<VisualStudioHost>(DefaultHostConfiguration);
+    }
+}


### PR DESCRIPTION
Integration tests were;

- Expecting that VsRootSuffix was alway passed to it from config settings - it's not. We respect the ROOTSUFFIX environment variable, or default to 'Exp'
- Always running against the last build installed, not the build from which you run the test. We now respect the environment settings set via VS to pick the right version when running in UI. Will not affect outside of VS.
- VS was left running. I have no idea how Apex is supposed to work, but right now we only have a single test - I just close it after it by opting into DTE mode (I can't figure out how to do this outside of that), we'll need to think about how to do this for multiple tests. What is the expectation here?
- Introduced TestBase class, MSTest has a really weird init model and won't let me put ClassInitialize on a base or as instance method. We should just move to xUnit if we don't need MSTest

After these changes, the test "passes" for 15.8, it fails for 16.0 because of missing 16.0.0.0 Apex dlls: https://github.com/dotnet/project-system/issues/3992.

The tests however, are really failing under the covers because of https://github.com/dotnet/project-system/issues/3990. I scoped that out of this change.