### PR TITLE
Simplify integration tests

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/OpenProjectTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/OpenProjectTests.cs
@@ -10,12 +10,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
     [TestClass]
     public class CreateProjectTests : TestBase
     {
-        [ClassInitialize]
-        public static void ClassInitialize(TestContext context)
-        {
-            Initialize(context);
-        }
-
         [TestMethod]
         public void CreateProject_CreateAndBuild()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/OpenProjectTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/OpenProjectTests.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using Microsoft.Test.Apex.VisualStudio.Solution;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
+namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
     [TestClass]
     public class CreateProjectTests : TestBase

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/OpenProjectTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/OpenProjectTests.cs
@@ -41,8 +41,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
                 
                 Assert.IsTrue(success, $"project '{consoleProject.FileName}' failed to build.{Environment.NewLine}errors:{Environment.NewLine}{string.Join(Environment.NewLine, errors)}");
             }
-
-            VisualStudio.Stop();
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/OpenProjectTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/OpenProjectTests.cs
@@ -19,40 +19,36 @@ namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
         [TestMethod]
         public void CreateProject_CreateAndBuild()
         {
-            var VS = GetVS();
-
-            VS.Start();
-
             ProjectTestExtension consoleProject = default;
             using (Scope.Enter("Create Project"))
             {
-                consoleProject = VS.ObjectModel.Solution.CreateProject(ProjectLanguage.CSharp, ProjectTemplate.NetCoreConsoleApp);
+                consoleProject = VisualStudio.ObjectModel.Solution.CreateProject(ProjectLanguage.CSharp, ProjectTemplate.NetCoreConsoleApp);
             }
 
             using (Scope.Enter("Verify Create Project"))
             {
-                VS.ObjectModel.Solution.Verify.HasProject();
+                VisualStudio.ObjectModel.Solution.Verify.HasProject();
             }
 
             using (Scope.Enter("Build Project"))
             {
-                VS.ObjectModel.Solution.Build();
+                VisualStudio.ObjectModel.Solution.Build();
             }
 
             using (Scope.Enter("Verify Build Succeeded"))
             {
-                var success = VS.ObjectModel.Solution.BuildManager.Verify.ProjectBuilt(consoleProject);
+                var success = VisualStudio.ObjectModel.Solution.BuildManager.Verify.ProjectBuilt(consoleProject);
                 string[] errors = new string[] { };
                 if (!success)
                 {
-                    VS.ObjectModel.Shell.ToolWindows.ErrorList.WaitForErrorListItems();
-                    errors = VS.ObjectModel.Shell.ToolWindows.ErrorList.Errors.Select(x => $"Description:'{x.Description}' Project:{x.ProjectName} Line:'{x.LineNumber}'").ToArray();
+                    VisualStudio.ObjectModel.Shell.ToolWindows.ErrorList.WaitForErrorListItems();
+                    errors = VisualStudio.ObjectModel.Shell.ToolWindows.ErrorList.Errors.Select(x => $"Description:'{x.Description}' Project:{x.ProjectName} Line:'{x.LineNumber}'").ToArray();
                 }
                 
                 Assert.IsTrue(success, $"project '{consoleProject.FileName}' failed to build.{Environment.NewLine}errors:{Environment.NewLine}{string.Join(Environment.NewLine, errors)}");
             }
 
-            VS.Stop();
+            VisualStudio.Stop();
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
@@ -36,6 +36,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
             return visualStudioHostConfiguration;
         }
 
+        protected override void DoHostTestCleanup()
+        {
+            base.DoHostTestCleanup();
+
+            TryShutdownVisualStudioInstance();
+        }
 
         [AssemblyInitialize]
         public static void Initialize(TestContext context)

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
@@ -18,26 +18,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
             SetTestInstallationDirectoryIfUnset();
         }
 
-        protected VisualStudioHostConfiguration DefaultHostConfiguration
+        protected override VisualStudioHostConfiguration GetHostConfiguration()
         {
-            get
+            var visualStudioHostConfiguration = new VisualStudioHostConfiguration()
             {
-                var visualStudioHostConfiguration = new VisualStudioHostConfiguration()
-                {
-                    CommandLineArguments = $"/rootSuffix {_hiveName}",
-                    RestoreUserSettings = false,
-                    InheritProcessEnvironment = true,
-                    AutomaticallyDismissMessageBoxes = true,
-                    DelayInitialVsLicenseValidation = true,
-                    ForceFirstLaunch = true,
-                    BootstrapInjection = BootstrapInjectionMethod.DteFromROT,
-                };
+                CommandLineArguments = $"/rootSuffix {_hiveName}",
+                RestoreUserSettings = false,
+                InheritProcessEnvironment = true,
+                AutomaticallyDismissMessageBoxes = true,
+                DelayInitialVsLicenseValidation = true,
+                ForceFirstLaunch = true,
+                BootstrapInjection = BootstrapInjectionMethod.DteFromROT,
+            };
 
-                return visualStudioHostConfiguration;
-            }
+            return visualStudioHostConfiguration;
         }
-
-        protected VisualStudioHost GetVS() => Operations.CreateHost<VisualStudioHost>(DefaultHostConfiguration);
 
         private static string GetVsHiveName(TestContext context)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
@@ -11,6 +11,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
     {
         private static string _hiveName;
 
+        protected TestBase()
+        {
+            // TestCleanup will fire up another instance of Visual Studio to reset 
+            // the AutoloadExternalChanges if it thinks the default changed even if
+            // that was just caused by settings to be sync'd. Just turn this feature off.
+            SuppressReloadPrompt = false;
+        }
+
         protected static void Initialize(TestContext context)
         {
             _hiveName = GetVsHiveName(context);

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
@@ -5,7 +5,7 @@ using System.IO;
 using Microsoft.Test.Apex.VisualStudio;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
+namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
     [TestClass] // AssemblyInitialize won't be found without it
     public abstract class TestBase : VisualStudioHostTest

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
@@ -7,6 +7,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
 {
+    [TestClass] // AssemblyInitialize won't be found without it
     public abstract class TestBase : VisualStudioHostTest
     {
         private static string _hiveName;
@@ -17,13 +18,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
             // the AutoloadExternalChanges if it thinks the default changed even if
             // that was just caused by settings to be sync'd. Just turn this feature off.
             SuppressReloadPrompt = false;
-        }
-
-        protected static void Initialize(TestContext context)
-        {
-            _hiveName = GetVsHiveName(context);
-
-            SetTestInstallationDirectoryIfUnset();
         }
 
         protected override VisualStudioHostConfiguration GetHostConfiguration()
@@ -40,6 +34,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.IntegrationTests
             };
 
             return visualStudioHostConfiguration;
+        }
+
+
+        [AssemblyInitialize]
+        public static void Initialize(TestContext context)
+        {
+            _hiveName = GetVsHiveName(context);
+
+            SetTestInstallationDirectoryIfUnset();
         }
 
         private static string GetVsHiveName(TestContext context)


### PR DESCRIPTION
- Use default VisualStudio host
- Avoid second instance of Visual Studio opening
- Simplify test initialization (just use AssemblyInitialize, instead of ClassInitialize)
- Shutdown Visual Studio automatically after each test rather than making each test do it