### PR TITLE
Mark test traits at assembly level

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests/ProjectSystem/LanguageServices/CSharpSyntaxFactsServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests/ProjectSystem/LanguageServices/CSharpSyntaxFactsServiceTests.cs
@@ -4,7 +4,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class CSharpSyntaxFactsServiceTests
     {
         private static readonly ISyntaxFactsService s_service = new CSharpSyntaxFactsService(null);

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Xunit;
+
+[assembly: AssemblyTrait("", "UnitTest")]

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Packaging/CSharpProjectSystemPackageTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Packaging/CSharpProjectSystemPackageTests.cs
@@ -4,7 +4,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.Packaging
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class CSharpProjectSystemPackageTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Automation/CSharpExtenderCATIDProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Automation/CSharpExtenderCATIDProviderTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class CSharpExtenderCATIDProviderTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/CSharpProjectCompatibilityProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/CSharpProjectCompatibilityProviderTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class CSharpProjectCompatibilityProviderTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Imaging/CSharpProjectImageProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Imaging/CSharpProjectImageProviderTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Imaging
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class CSharpProjectImageProviderTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/LanguageServices/CSharpCodeDomProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/LanguageServices/CSharpCodeDomProviderTests.cs
@@ -4,7 +4,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class CSharpCodeDomProviderTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/LanguageServices/CSharpLanguageFeaturesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/LanguageServices/CSharpLanguageFeaturesProviderTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class CSharpLanguageFeaturesProviderTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Properties/CSharpProjectConfigurationPropertiesTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Properties/CSharpProjectConfigurationPropertiesTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class CSharpProjectConfigurationPropertiesTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Properties/CSharpProjectDesignerPageProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Properties/CSharpProjectDesignerPageProviderTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class CSharpProjectDesignerPageProviderTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Properties/CSharpProjectTypeGuidProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Properties/CSharpProjectTypeGuidProviderTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class CSharpProjectTypeGuidProviderTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Rename/CSharpSimpleRenamerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Rename/CSharpSimpleRenamerTests.cs
@@ -13,7 +13,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class CSharpSimpleRenamerTests : SimpleRenamerTestsBase
     {
         protected override string ProjectFileExtension => "csproj";

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/GlobalJsonRemoverTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/GlobalJsonRemoverTests.cs
@@ -17,7 +17,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class GlobalJsonRemoverTests
     {
         private const string Directory = @"C:\Temp";

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
@@ -20,7 +20,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class MigrateXprojProjectFactoryTests
     {
         private const string SlnLocation = @"C:\Temp";

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Xunit;
+
+[assembly: AssemblyTrait("", "UnitTest")]

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.UnitTests/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Xunit;
+
+[assembly: AssemblyTrait("", "UnitTest")]

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests/Packaging/FSharpProjectSystemPackageTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests/Packaging/FSharpProjectSystemPackageTests.cs
@@ -4,7 +4,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.Packaging
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class FSharpProjectSystemPackageTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests/ProjectSystem/VS/FSharpProjectSelectorTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests/ProjectSystem/VS/FSharpProjectSelectorTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class FSharpProjectSelectorTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests/ProjectSystem/VS/Imaging/FSharpProjectImageProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests/ProjectSystem/VS/Imaging/FSharpProjectImageProviderTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Imaging
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class FSharpProjectImageProviderTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests/ProjectSystem/VS/Properties/FSharpProjectDesignerPageProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests/ProjectSystem/VS/Properties/FSharpProjectDesignerPageProviderTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class FSharpProjectDesignerPageProviderTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Xunit;
+
+[assembly: AssemblyTrait("", "UnitTest")]

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[assembly: TestCategory("Integration")]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/ProjectSystem/ProjectTreeParserTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/ProjectSystem/ProjectTreeParserTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class ProjectTreeParserTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Xunit;
+
+[assembly: AssemblyTrait("", "UnitTest")]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Build/BuildUtilitiesTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Build/BuildUtilitiesTests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.Build
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class BuildUtilitiesTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/AbstractMultiLifetimeComponentTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/AbstractMultiLifetimeComponentTests.cs
@@ -7,7 +7,6 @@ using static Microsoft.VisualStudio.ProjectSystem.AbstractMultiLifetimeComponent
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class AbstractMultiLifetimeComponentTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsLoaderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsLoaderTests.cs
@@ -7,7 +7,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class ActiveConfiguredProjectsLoaderTests
     {
         [Theory]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsProviderTests.cs
@@ -11,7 +11,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class ActiveConfiguredProjectsProviderTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/AppDesignerFolderProjectTreePropertiesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/AppDesignerFolderProjectTreePropertiesProviderTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class AppDesignerFolderProjectTreePropertiesProviderTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Build/PublishableProjectConfigProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Build/PublishableProjectConfigProviderTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Build
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class PublishableProjectConfigProviderTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Build/TargetFrameworkGlobalBuildPropertyProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Build/TargetFrameworkGlobalBuildPropertyProviderTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Properties
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class TargetFrameworkGlobalBuildPropertyProviderTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ConfigurationProjectConfigurationDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ConfigurationProjectConfigurationDimensionProviderTests.cs
@@ -11,7 +11,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Configuration
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class ConfigurationProjectConfigurationDimensionProviderTests
     {
         private const string Configurations = nameof(Configurations);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/PlatformProjectConfigurationDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/PlatformProjectConfigurationDimensionProviderTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Configuration
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class PlatformProjectConfigurationDimensionProviderTests
     {
         private const string Platforms = nameof(Platforms);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/TargetFrameworkProjectConfigurationDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/TargetFrameworkProjectConfigurationDimensionProviderTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Configuration
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class TargetFrameworkProjectConfigurationDimensionProviderTests
     {
         private const string ProjectXmlTFM =

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ConfiguredProjectImplicitActivationTrackingTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ConfiguredProjectImplicitActivationTrackingTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class ConfiguredProjectImplicitActivationTrackingTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/ActiveDebugFrameworkServicesTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/ActiveDebugFrameworkServicesTests.cs
@@ -11,7 +11,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Input.Commands
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class ActiveDebugFrameworkServicesTests
     {
         [Theory]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/DebugTokenReplacerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/DebugTokenReplacerTests.cs
@@ -14,7 +14,6 @@ using Xunit;
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
 
-    [Trait("UnitTest", "ProjectSystem")]
     public class DebugTokenReplacerTests
     {
         private readonly Dictionary<string, string> _envVars = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfileDataTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfileDataTests.cs
@@ -14,7 +14,6 @@ using Xunit;
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
 
-    [Trait("UnitTest", "ProjectSystem")]
     public class LaunchProfileDataTests
     {
         [Theory]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfileExtensionsTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfileExtensionsTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class LaunchProfileExtensionsTests
     {
         [Theory]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfileTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfileTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class LaunchProfileTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -24,7 +24,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class LaunchSettingsProviderTests
     {
         internal LaunchSettingsUnderTest GetLaunchSettingsProvider(IFileSystem fileSystem, string appDesignerFolder = @"c:\test\Project1\Properties", string activeProfile = "")

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class LaunchSettingsTests
     {
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Imaging/ProjectImageProviderAggregatorTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Imaging/ProjectImageProviderAggregatorTests.cs
@@ -5,7 +5,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Imaging
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class ProjectImageProviderAggregatorTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public partial class AbstractEvaluationCommandLineHandlerTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandlerTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class AdditionalFilesItemHandlerTests : CommandLineHandlerTestBase
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandlerTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class AnalyzerItemHandlerTests : CommandLineHandlerTestBase
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandlerTests.cs
@@ -12,7 +12,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class MetadataReferenceItemHandlerTests : CommandLineHandlerTestBase
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/ProjectFilePathAndDisplayNameEvaluationHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/ProjectFilePathAndDisplayNameEvaluationHandlerTests.cs
@@ -7,7 +7,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class ProjectFilePathAndDisplayNameEvaluationHandlerTests : EvaluationHandlerTestBase
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandlerTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class ProjectPropertiesItemHandlerTests : EvaluationHandlerTestBase
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemHandler_CommandLineTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemHandler_CommandLineTests.cs
@@ -11,7 +11,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class SourceItemHandler_CommandTests : CommandLineHandlerTestBase
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemHandler_EvaluationTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemHandler_EvaluationTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class SourceItemHandler_EvaluationTests : EvaluationHandlerTestBase
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Logging/ProjectLoggingExtensionsTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Logging/ProjectLoggingExtensionsTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Logging
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class ProjectLoggingExtensionsTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeStorageTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeStorageTests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class PhysicalProjectTreeStorageTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class PhysicalProjectTreeTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ProjectRootImageProjectTreeModifierTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ProjectRootImageProjectTreeModifierTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class ProjectRootImageProjectTreeModifierTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/AssemblyInfoPropertiesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/AssemblyInfoPropertiesProviderTests.cs
@@ -58,7 +58,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         }
     }
 
-    [Trait("UnitTest", "ProjectSystem")]
     public class AssemblyInfoPropertiesProviderTests
     {
         private TestProjectFileOrAssemblyInfoPropertiesProvider CreateProviderForSourceFileValidation(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationManifestValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationManifestValueProviderTests.cs
@@ -7,7 +7,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Properties
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class ApplicationManifestValueProviderTests
     {
         [Theory]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/AssemblyOriginatorKeyFileValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/AssemblyOriginatorKeyFileValueProviderTests.cs
@@ -11,7 +11,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.ProjectPropertiesProviders
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class AssemblyOriginatorKeyFileValueProviderTests
     {
         private const string AssemblyOriginatorKeyFilePropertyName = "AssemblyOriginatorKeyFile";

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectPropertiesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectPropertiesProviderTests.cs
@@ -5,7 +5,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Properties
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class InterceptedProjectPropertiesProviderTests
     {
         private const string MockPropertyName = "MockProperty";

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/TargetFrameworkValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/TargetFrameworkValueProviderTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.ProjectPropertiesProviders
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class TargetFrameworkValueProviderTests
     {
         private const string TargetFrameworkPropertyName = "TargetFramework";

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/SupportedTargetFrameworksEnumProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/SupportedTargetFrameworksEnumProviderTests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Properties
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class SupportedTargetFrameworksEnumProviderTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/References/AlwaysAllowValidProjectReferenceCheckerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/References/AlwaysAllowValidProjectReferenceCheckerTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.References
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class AlwaysAllowValidProjectReferenceCheckerTests
     {
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Reload/ProjectReloadInterceptorTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Reload/ProjectReloadInterceptorTests.cs
@@ -11,7 +11,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class ProjectReloadInterceptorTests
     {
         [Theory]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviderTests.cs
@@ -11,7 +11,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class SpecialFileProviderTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProviderTests.cs
@@ -7,7 +7,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class AppDesignerFolderSpecialFileProviderTests
     {
         [Theory]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UnconfiguredProjectCommonServicesTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UnconfiguredProjectCommonServicesTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class UnconfiguredProjectCommonServicesTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UnconfiguredProjectTasksServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UnconfiguredProjectTasksServiceTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class UnconfiguredProjectTasksServiceTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Xunit;
+
+[assembly: AssemblyTrait("", "UnitTest")]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Threading/Tasks/SequentialTaskExecutorTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Threading/Tasks/SequentialTaskExecutorTests.cs
@@ -9,8 +9,6 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.Threading.Tasks
 {
-
-    [Trait("UnitTest", "ProjectSystem")]
     public class SequentialTaskExecutorTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Threading/Tasks/TaskDelaySchedulerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Threading/Tasks/TaskDelaySchedulerTests.cs
@@ -12,7 +12,6 @@ using Task = System.Threading.Tasks.Task;
 namespace Microsoft.VisualStudio.Threading.Tasks
 {
 
-    [Trait("UnitTest", "ProjectSystem")]
     public class TaskDelaySchedulerTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Threading/Tasks/TaskExtensionsTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Threading/Tasks/TaskExtensionsTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.Threading.Tasks
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class TaskExtensionsTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Automation/VsLangProjectPropertiesTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Automation/VsLangProjectPropertiesTests.cs
@@ -14,7 +14,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class VSProject_VSLangProjectPropertiesTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Build/LanguageServiceErrorListProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Build/LanguageServiceErrorListProviderTests.cs
@@ -11,7 +11,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class LanguageServiceErrorListProviderTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/CreateFileFromTemplateServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/CreateFileFromTemplateServiceTests.cs
@@ -11,7 +11,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class CreateFileFromTemplateServiceTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ConsoleDebugLaunchProviderTests.cs
@@ -18,7 +18,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class ConsoleDebugLaunchProviderTest
     {
         private readonly string _ProjectFile = @"c:\test\project\project.csproj";

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/DebugProfileEnumValuesGeneratorTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/DebugProfileEnumValuesGeneratorTests.cs
@@ -13,7 +13,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class DebugProfileEnumValuesGenerator_Tests
     {
         private readonly List<ILaunchProfile> _profiles = new List<ILaunchProfile>() {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/LaunchProfilesDebugPageGuidProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/LaunchProfilesDebugPageGuidProviderTests.cs
@@ -7,7 +7,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class LaunchProfilesDebugPageGuidProviderTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectDebuggerProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectDebuggerProviderTests.cs
@@ -12,7 +12,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class ProjectDebuggerProviderTests
     {
         private readonly Mock<IDebugProfileLaunchTargetsProvider> _mockWebProvider = new Mock<IDebugProfileLaunchTargetsProvider>();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/DebugTests/StartupProjectRegistrarTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/DebugTests/StartupProjectRegistrarTests.cs
@@ -10,7 +10,6 @@ using static Microsoft.VisualStudio.ProjectSystem.VS.Debug.StartupProjectRegistr
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class StartupProjectRegistrarTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractAddClassProjectCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractAddClassProjectCommandTests.cs
@@ -11,7 +11,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public abstract class AbstractAddClassProjectCommandTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommandTests.cs
@@ -11,7 +11,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public abstract class AbstractGenerateNuGetPackageCommandTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractOpenProjectDesignerCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractOpenProjectDesignerCommandTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public abstract class AbstractOpenProjectDesignerCommandTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AddClassProjectCSharpCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AddClassProjectCSharpCommandTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class AddClassProjectCSharpCommandTests : AbstractAddClassProjectCommandTests
     {
         internal override string DirName { get; } = "Visual C# Items";

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AddClassProjectVBCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AddClassProjectVBCommandTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class AddClassProjectVBCommandTests : AbstractAddClassProjectCommandTests
     {
         internal override string DirName { get; } = "Common Items";

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksDynamicMenuCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksDynamicMenuCommandTests.cs
@@ -12,7 +12,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class DebugFrameworksDynamicMenuCommandTests
     {
         [Theory]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksMenuTextUpdaterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksMenuTextUpdaterTests.cs
@@ -12,7 +12,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class DebugFrameworkMenuTextUpdaterTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageProjectContextMenuCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageProjectContextMenuCommandTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class GenerateNuGetPackageProjectContextMenuCommandTests : AbstractGenerateNuGetPackageCommandTests
     {
         internal override long GetCommandId() => ManagedProjectSystemCommandId.GenerateNuGetPackageProjectContextMenu;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageTopLevelBuildMenuCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageTopLevelBuildMenuCommandTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class GenerateNuGetPackageTopLevelBuildMenuCommandTests : AbstractGenerateNuGetPackageCommandTests
     {
         internal override long GetCommandId() => ManagedProjectSystemCommandId.GenerateNuGetPackageTopLevelBuild;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/OpenProjectDesignerCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/OpenProjectDesignerCommandTests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class OpenProjectDesignerCommandTests : AbstractOpenProjectDesignerCommandTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/OpenProjectDesignerOnDefaultActionCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/OpenProjectDesignerOnDefaultActionCommandTests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class OpenProjectDesignerOnDefaultActionCommandTests : AbstractOpenProjectDesignerCommandTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/AbstractMoveCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/AbstractMoveCommandTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public abstract class AbstractMoveCommandTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/MoveDownCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/MoveDownCommandTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class MoveDownCommandTests : AbstractMoveCommandTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/MoveUpCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/MoveUpCommandTests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class MoveUpCommandTests : AbstractMoveCommandTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelperTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelperTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class OrderingHelperTests
     {
         private static void AssertEqualProject(string expected, Project project)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Logging/ProjectOutputWindowPaneProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Logging/ProjectOutputWindowPaneProviderTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class ProjectOutputWindowPaneProviderTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Logging/ProjectOutputWindowProjectLoggerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Logging/ProjectOutputWindowProjectLoggerTests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class ProjectOutputWindowProjectLoggerTests
     {
         [Theory]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/NuGet/ProjectAssetFileWatcherTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/NuGet/ProjectAssetFileWatcherTests.cs
@@ -11,7 +11,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class ProjectAssetFileWatcherTests
     {
         private const string ProjectCurrentStateJson = @"{

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/NuGet/ProjectRestoreInfoBuilderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/NuGet/ProjectRestoreInfoBuilderTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class ProjectRestoreInfoBuilderTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/AvoidPersistingProjectGuidStorageProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/AvoidPersistingProjectGuidStorageProviderTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class AvoidPersistingProjectGuidStorageProviderTests
     {
         [Theory]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/OutputTypeExValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/OutputTypeExValueProviderTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class OutputTypeExValueProviderTests
     {
         [Theory]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/OutputTypeValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/OutputTypeValueProviderTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class OutputTypeValueProviderTests
     {
         [Theory]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class PostBuildEventValueProviderTests
     {
         private static readonly PostBuildEventValueProvider.PostBuildEventHelper systemUnderTest =

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class PreBuildEventValueProviderTests
     {
         private static readonly PreBuildEventValueProvider.PreBuildEventHelper systemUnderTest =

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/ProjectDesignerPageMetadataTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/ProjectDesignerPageMetadataTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class ProjectDesignerPageMetadataTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/ProjectDesignerServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/ProjectDesignerServiceTests.cs
@@ -13,7 +13,6 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class ProjectDesignerServiceTests
     {
         [Theory]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/BuildMacroInfoTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/BuildMacroInfoTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class BuildMacroInfoTests
     {
         [Theory]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/DebugPageViewModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/DebugPageViewModelTests.cs
@@ -15,7 +15,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class DebugPageViewModelTests
     {
         private class ViewModelData

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/PropertyPageControlTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/PropertyPageControlTests.cs
@@ -11,7 +11,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class PropertyPageControlTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/PropertyPageTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/PropertyPageTests.cs
@@ -11,7 +11,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class PropertyPageTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/References/DesignTimeAssemblyResolutionTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/References/DesignTimeAssemblyResolutionTests.cs
@@ -14,7 +14,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.References
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class DesignTimeAssemblyResolutionTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/References/ReferenceContextProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/References/ReferenceContextProviderTests.cs
@@ -4,7 +4,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.References
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class ReferenceContextProviderTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/SpecialFileProviders/VsProjectSpecialFilesManagerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/SpecialFileProviders/VsProjectSpecialFilesManagerTests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.SpecialFilesProviders
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class VsProjectSpecialFilesManagerTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyIconSetTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyIconSetTests.cs
@@ -5,7 +5,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class DependencyIconSetTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/AnalyzerDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/AnalyzerDependencyModelTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class AnalyzerDependencyModelTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/AssemblyDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/AssemblyDependencyModelTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class AssemblyDependencyModelTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/ComDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/ComDependencyModelTests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class ComDependencyModelTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DependenciesViewModelFactoryTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DependenciesViewModelFactoryTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class DependenciesViewModelFactoryTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DependencyModelTests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class DependencyModelTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DiagnosticDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DiagnosticDependencyModelTests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class DiagnosticDependencyModelTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageAnalyzerAssemblyDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageAnalyzerAssemblyDependencyModelTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class PackageAnalyzerAssemblyDependencyModelTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageAssemblyDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageAssemblyDependencyModelTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class PackageAssemblyDependencyModelTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageDependencyModelTests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class PackageDependencyModelTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageFrameworkAssembliesViewModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageFrameworkAssembliesViewModelTests.cs
@@ -7,7 +7,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class PackageFrameworkAssembliesViewModelTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageUnknownDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageUnknownDependencyModelTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class PackageUnknownDependencyModelTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/ProjectDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/ProjectDependencyModelTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class ProjectDependencyModelTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SdkDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SdkDependencyModelTests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class SdkDependencyModelTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SharedProjectDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SharedProjectDependencyModelTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class SharedSharedProjectDependencyModelTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SubTreeRootDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SubTreeRootDependencyModelTests.cs
@@ -7,7 +7,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class SubTreeRootDependencyModelTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyExtensionsTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyExtensionsTests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class DependencyExtensionsTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyTests.cs
@@ -11,7 +11,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class DependencyTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DuplicatedDependenciesSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DuplicatedDependenciesSnapshotFilterTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class DuplicatedDependenciesSnapshotFilterTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/ImplicitTopLevelDependenciesSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/ImplicitTopLevelDependenciesSnapshotFilterTests.cs
@@ -11,7 +11,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class ImplicitTopLevelDependenciesSnapshotFilterTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/SdkAndPackagesDependenciesSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/SdkAndPackagesDependenciesSnapshotFilterTests.cs
@@ -12,7 +12,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class SdkAndPackagesDependenciesSnapshotFilterTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
@@ -14,7 +14,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class TargetedDependenciesSnapshotTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnresolvedDependenciesSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnresolvedDependenciesSnapshotFilterTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class UnresolvedDependenciesSnapshotFilterTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnsupportedProjectsSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnsupportedProjectsSnapshotFilterTests.cs
@@ -11,7 +11,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class UnsupportedProjectsSnapshotFilterTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/GroupedByTargetTreeViewProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/GroupedByTargetTreeViewProviderTests.cs
@@ -13,7 +13,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class GroupedByTargetTreeViewProviderTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProviderTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class TreeItemOrderPropertyProviderTests
     {
         private readonly List<(string type, string include)> _simpleOrderFile = new List<(string type, string include)>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/UI/MultiChoiceMsgBoxViewModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/UI/MultiChoiceMsgBoxViewModelTests.cs
@@ -5,7 +5,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.UI
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class MultiChoiceMsgBoxViewModelTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/UnconfiguredProjectVsServicesTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/UnconfiguredProjectVsServicesTests.cs
@@ -7,7 +7,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class UnconfiguredProjectVsServicesTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Utilities/EnumMatchToBooleanConverterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Utilities/EnumMatchToBooleanConverterTests.cs
@@ -7,7 +7,6 @@ using Xunit;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
 {
 
-    [Trait("UnitTest", "ProjectSystem")]
     public class EnumMatchToBooleanConverterTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/VsSafeProjectGuidServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/VsSafeProjectGuidServiceTests.cs
@@ -7,7 +7,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class VsSafeProjectGuidServiceTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/VsServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/VsServiceTests.cs
@@ -8,7 +8,6 @@ using IAsyncServiceProvider = Microsoft.VisualStudio.Shell.IAsyncServiceProvider
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class VsServiceTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/VsUIServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/VsUIServiceTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class VsUIServiceTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Xunit;
+
+[assembly: AssemblyTrait("", "UnitTest")]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Shell/HierarchyIdTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Shell/HierarchyIdTests.cs
@@ -4,7 +4,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.Shell
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class HierarchyIdTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Telemetry/SDKVersionTelemetryTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Telemetry/SDKVersionTelemetryTests.cs
@@ -14,7 +14,6 @@ using static Microsoft.VisualStudio.Telemetry.ITelemetryServiceFactory;
 
 namespace Microsoft.VisualStudio.Telemetry
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class SDKVersionTelemetryTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Telemetry/VsTelemetryServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Telemetry/VsTelemetryServiceTests.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.Telemetry
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class VsTelemetryServiceTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests/ProjectSystem/LanguageServices/VisualBasicSyntaxFactsServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests/ProjectSystem/LanguageServices/VisualBasicSyntaxFactsServiceTests.cs
@@ -5,7 +5,6 @@ using Xunit;
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
 
-    [Trait("UnitTest", "ProjectSystem")]
     public class VisualBasicSyntaxFactsServiceTests
     {
         private static readonly ISyntaxFactsService s_service = new VisualBasicSyntaxFactsService(null);

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Xunit;
+
+[assembly: AssemblyTrait("", "UnitTest")]

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/Packaging/VisualBasicProjectSystemPackageTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/Packaging/VisualBasicProjectSystemPackageTests.cs
@@ -4,7 +4,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.Packaging
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class VisualBasicProjectSystemPackageTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Automation/VisualBasicExtenderCATIDProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Automation/VisualBasicExtenderCATIDProviderTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class VisualBasicExtenderCATIDProviderTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Automation/VisualBasicNamespaceImportsListTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Automation/VisualBasicNamespaceImportsListTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class VisualBasicNamespaceImportsListTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Automation/VsImportsTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Automation/VsImportsTests.cs
@@ -11,7 +11,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class VsImportsTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Automation/VsProjectEventsTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Automation/VsProjectEventsTests.cs
@@ -10,7 +10,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class VsProjectEventsTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Imaging/VisualBasicProjectImageProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Imaging/VisualBasicProjectImageProviderTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Imaging
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class VisualBasicProjectImageProviderTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/LanguageServices/VisualBasicCodeDomProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/LanguageServices/VisualBasicCodeDomProviderTests.cs
@@ -4,7 +4,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class VisualBasicCodeDomProviderTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Properties/MapDynamicEnumValuesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Properties/MapDynamicEnumValuesProviderTests.cs
@@ -12,7 +12,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class MapDynamicEnumValuesProviderTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Properties/VisualBasicProjectConfigurationPropertiesTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Properties/VisualBasicProjectConfigurationPropertiesTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class VisualBasicProjectConfigurationPropertiesTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Properties/VisualBasicProjectDesignerPageProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Properties/VisualBasicProjectDesignerPageProviderTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class VisualBasicProjectDesignerPageProviderTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Rename/VisualBasicSimpleRenameTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Rename/VisualBasicSimpleRenameTests.cs
@@ -11,7 +11,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class VisualBasicSimpleRenameTests : SimpleRenamerTestsBase
     {
         protected override string ProjectFileExtension => "vbproj";

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/VisualBasicProjectCompatibilityProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/VisualBasicProjectCompatibilityProviderTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class VisualBasicProjectCompatibilityProviderTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/VisualBasicProjectTypeGuidProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/VisualBasicProjectTypeGuidProviderTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
-    [Trait("UnitTest", "ProjectSystem")]
     public class VisualBasicProjectTypeGuidProviderTests
     {
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Xunit;
+
+[assembly: AssemblyTrait("", "UnitTest")]


### PR DESCRIPTION
Avoids needing to mark each individual class with a trait.

If you sort by trait you will see the following which lets you just run the unit tests if you want:

![image](https://user-images.githubusercontent.com/1103906/45423012-53803300-b6d5-11e8-87fd-c368d617766a.png)

