### PR TITLE
Fix copy/paste bug in test code

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyExtensionsTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyExtensionsTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             mockSnapshot = ITargetedDependenciesSnapshotFactory.ImplementHasUnresolvedDependency("tfm1\\yyy\\dependencyExisting", true);
 
-            Assert.True(dependency1.IsOrHasUnresolvedDependency(mockSnapshot));
+            Assert.True(dependency2.IsOrHasUnresolvedDependency(mockSnapshot));
 
             var dependency3 = IDependencyFactory.FromJson(@"
 {


### PR DESCRIPTION
The `dependency2` var was unused. I believe it was intended to be used in this assertion. The test passes either way however.