### PR TITLE
Pass cancellation tokens

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Threading/Tasks/TaskDelaySchedulerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Threading/Tasks/TaskDelaySchedulerTests.cs
@@ -100,5 +100,24 @@ namespace Microsoft.VisualStudio.Threading.Tasks
             await task;
             Assert.False(taskRan);
         }
+
+        [Fact]
+        public async Task ScheduleAsyncTask_Noop_OriginalSourceTokenCancelled()
+        {
+            var cts = new CancellationTokenSource();
+            var scheduler = new TaskDelayScheduler(TimeSpan.FromMilliseconds(250), IProjectThreadingServiceFactory.Create(), cts.Token);
+
+            cts.Cancel();
+
+            bool taskRan = false;
+            var task = scheduler.ScheduleAsyncTask(ct =>
+            {
+                taskRan = true;
+                return Task.CompletedTask;
+            });
+
+            await task;
+            Assert.False(taskRan);
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AvoidPersistingProjectGuidStorageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AvoidPersistingProjectGuidStorageProvider.cs
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
                         {
                             property.Value = ProjectCollection.Escape(value.ToString("B").ToUpperInvariant());
 
-                        });
+                        }, cancellationToken);
                     }
                 }
                 else

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SDKVersionTelemetryServiceComponent.SDKVersionTelemetryServiceInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SDKVersionTelemetryServiceComponent.SDKVersionTelemetryServiceInstance.cs
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                 (NETCoreSdkVersionProperty, version)
                             });
                     });
-                });
+                }, cancellationToken);
 
                 return Task.CompletedTask;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/TaskDelayScheduler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/TaskDelayScheduler.cs
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.Threading.Tasks
                 // First we wait the delay time. If another request has been made in the interval, then this task
                 // is cancelled. To avoid unnecessary OperationCanceled exceptions it tests to see if the token has
                 // been canceled
-                await Task.Delay(TaskDelayTime);
+                await Task.Delay(TaskDelayTime, token);
 
                 bool isCanceled = token.IsCancellationRequested;
                 lock (_syncObject)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/TaskDelayScheduler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/TaskDelayScheduler.cs
@@ -25,12 +25,12 @@ namespace Microsoft.VisualStudio.Threading.Tasks
         /// </summary>
         public TimeSpan TaskDelayTime { get; set; }
 
-        // Task completion source for cancelling a pending file update.
+        // Task completion source for cancelling a pending task
         private CancellationTokenSource PendingUpdateTokenSource { get; set; }
 
         private CancellationToken OriginalSourceToken { get; set; }
 
-        // True if there are pending file changes
+        // True if there is a pending task
         public bool HasPendingUpdates { get { return PendingUpdateTokenSource != null; } }
 
         // Holds the latest scheduled task

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/TaskDelayScheduler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/TaskDelayScheduler.cs
@@ -76,9 +76,18 @@ namespace Microsoft.VisualStudio.Threading.Tasks
             try
             {
                 // First we wait the delay time. If another request has been made in the interval, then this task
-                // is cancelled. To avoid unnecessary OperationCanceled exceptions it tests to see if the token has
-                // been canceled
-                await Task.Delay(TaskDelayTime, token);
+                // is cancelled.
+                try
+                {
+                    if (!token.IsCancellationRequested)
+                    {
+                        await Task.Delay(TaskDelayTime, token);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // fall through
+                }
 
                 bool isCanceled = token.IsCancellationRequested;
                 lock (_syncObject)


### PR DESCRIPTION
These are occasions where we have a cancellation token in flight and were calling a method that supports cancellation without passing the token.