### PR TITLE
Fix typos in identifiers

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerPanel.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerPanel.vb
@@ -299,14 +299,14 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                                 If EditorGuid.Equals(Guid.Empty) Then
                                     VSErrorHandler.ThrowOnFailure(VsUIShellOpenDocument.OpenDocumentViaProject(MkDocument, (LogicalViewGuid), OleServiceProvider, VsUIHierarchy, ItemId, WindowFrame))
                                 Else
-                                    Dim OpenHierachy As IVsUIHierarchy = Nothing
+                                    Dim OpenHierarchy As IVsUIHierarchy = Nothing
                                     Dim OpenItemId As UInteger
                                     Dim OpenWindowFrame As IVsWindowFrame = Nothing
                                     Dim fOpen As Integer
 
                                     'Is this file already opened in the specific editor we want to open it in?  If so, we will not be able to open it
                                     '  as a nested document window.
-                                    Dim hr As Integer = VsUIShellOpenDocument.IsSpecificDocumentViewOpen(VsUIHierarchy, ItemId, MkDocument, (EditorGuid), PhysicalView, CUInt(__VSIDOFLAGS2.IDO_IncludeUninitializedFrames), OpenHierachy, OpenItemId, OpenWindowFrame, fOpen)
+                                    Dim hr As Integer = VsUIShellOpenDocument.IsSpecificDocumentViewOpen(VsUIHierarchy, ItemId, MkDocument, (EditorGuid), PhysicalView, CUInt(__VSIDOFLAGS2.IDO_IncludeUninitializedFrames), OpenHierarchy, OpenItemId, OpenWindowFrame, fOpen)
                                     Debug.Assert(VSErrorHandler.Succeeded(hr), "Unexpected failure from VsUIShellOpenDocument.IsSpecificDocumentViewOpen")
                                     If VSErrorHandler.Succeeded(hr) Then
                                         If fOpen <> 0 Then

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabControlRenderer.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabControlRenderer.vb
@@ -583,7 +583,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             If IsSelected Then
 
                 ' Create an array of points which describes the path of the triangle
-                Dim trainglePoints() As PointF =
+                Dim trianglePoints() As PointF =
                 {
                     New PointF(triangleHorizontalStart - 1, triangleVerticalStart),
                     New PointF(button.Width, CSng(triangleVerticalStart) + CSng(TriangleHeight) / 2),
@@ -592,7 +592,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
 
                 Using trianglePath As New GraphicsPath()
 
-                    trianglePath.AddPolygon(trainglePoints)
+                    trianglePath.AddPolygon(trianglePoints)
 
                     ' Draw the rectangle using Fill Rectangle with the default smoothing mode
                     ' If the rectangle is drawn with SmoothingMode.HighQuality / AntiAliased it

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/PropertyPageSite.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/PropertyPageSite.vb
@@ -140,7 +140,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                 Return False
             End If
 
-            Dim successed As Boolean = True
+            Dim success As Boolean = True
 
             Try
                 InsideOnStatusChange = True
@@ -151,7 +151,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                         Try
                             _propPage.Apply()
                         Catch ex As Exception
-                            successed = False
+                            success = False
                             If Not Common.IsCheckoutCanceledException(ex) Then
                                 Debug.Assert(_appDesView IsNot Nothing, "No project designer - can't show error message: " & ex.ToString())
                                 If _appDesView IsNot Nothing Then
@@ -182,7 +182,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                 InsideOnStatusChange = False
             End Try
 
-            Return successed
+            Return success
 
         End Function
 

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropertyPageException.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropertyPageException.vb
@@ -33,9 +33,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Me.HelpLink = helpLink
         End Sub
 
-        Public Sub New(message As String, innerException As Exception, ShowHeaderandFooterInErrorControl As Boolean)
+        Public Sub New(message As String, innerException As Exception, ShowHeaderAndFooterInErrorControl As Boolean)
             MyBase.New(message, innerException)
-            _showHeaderAndFooterInErrorControl = ShowHeaderandFooterInErrorControl
+            _showHeaderAndFooterInErrorControl = ShowHeaderAndFooterInErrorControl
         End Sub
 
         ''' <summary>

--- a/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/AutoAddImportsExtensionCollisionDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/AutoAddImportsExtensionCollisionDialog.vb
@@ -6,13 +6,13 @@ Imports System.Windows.Forms
 Namespace Microsoft.VisualStudio.Editors.AddImports
     Friend Class AutoAddImportsExtensionCollisionDialog
         Private _lastFocus As Control
-        Private ReadOnly _helpCallBack As IVBAddImportsDialogHelpCallback
+        Private ReadOnly _helpCallback As IVBAddImportsDialogHelpCallback
 
-        Public Sub New([namespace] As String, identifier As String, minimallyQualifiedName As String, helpCAllback As IVBAddImportsDialogHelpCallback, isp As IServiceProvider)
+        Public Sub New([namespace] As String, identifier As String, minimallyQualifiedName As String, helpCallback As IVBAddImportsDialogHelpCallback, isp As IServiceProvider)
             MyBase.New(isp)
             SuspendLayout()
             Try
-                _helpCallBack = helpCAllback
+                _helpCallBack = helpCallback
                 InitializeComponent()
                 txtMain_.Text = String.Format(My.Resources.AddImports.AddImportsExtensionMethodsMainFormatString, [namespace], identifier, minimallyQualifiedName)
                 txtMain_.AutoSize = True

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerTypeDiscoveryService.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerTypeDiscoveryService.vb
@@ -112,12 +112,12 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                 activeConfig2 = TryCast(activeConfig(0), IVsProjectCfg2)
 
                 If activeConfig2 IsNot Nothing Then
-                    Dim outputgroup As IVsOutputGroup = Nothing
-                    activeConfig2.OpenOutputGroup(BuildOutputGroup.Built, outputgroup)
-                    Dim outputgroup2 As IVsOutputGroup2 = TryCast(outputgroup, IVsOutputGroup2)
-                    If outputgroup2 IsNot Nothing Then
+                    Dim outputGroup As IVsOutputGroup = Nothing
+                    activeConfig2.OpenOutputGroup(BuildOutputGroup.Built, outputGroup)
+                    Dim outputGroup2 As IVsOutputGroup2 = TryCast(outputGroup, IVsOutputGroup2)
+                    If outputGroup2 IsNot Nothing Then
                         Dim output As IVsOutput2 = Nothing
-                        VSErrorHandler.ThrowOnFailure(outputgroup2.get_KeyOutputObject(output))
+                        VSErrorHandler.ThrowOnFailure(outputGroup2.get_KeyOutputObject(output))
                         If output IsNot Nothing Then
                             Dim url As String = Nothing
                             VSErrorHandler.ThrowOnFailure(output.get_DeploySourceURL(url))

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/WrapCheckBox.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/WrapCheckBox.vb
@@ -32,18 +32,18 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             CacheTextSize()
         End Sub
 
-        Public Overrides Function GetPreferredSize(proposedsize As Size) As Size
-            Dim prefSize As Size = MyBase.GetPreferredSize(proposedsize)
-            If (proposedsize.Width > 1) AndAlso
-                    (prefSize.Width > proposedsize.Width) AndAlso
+        Public Overrides Function GetPreferredSize(proposedSize As Size) As Size
+            Dim prefSize As Size = MyBase.GetPreferredSize(proposedSize)
+            If (proposedSize.Width > 1) AndAlso
+                    (prefSize.Width > proposedSize.Width) AndAlso
                     (Not String.IsNullOrEmpty(Text) AndAlso
-                    Not proposedsize.Width.Equals(Integer.MaxValue) OrElse
-                    Not proposedsize.Height.Equals(Integer.MaxValue)) Then
+                    Not proposedSize.Width.Equals(Integer.MaxValue) OrElse
+                    Not proposedSize.Height.Equals(Integer.MaxValue)) Then
                 ' we have the possibility of wrapping... back out the single line of text
                 Dim bordersAndPadding As Size = prefSize - _cachedSizeOfOneLineOfText
                 ' add back in the text size, subtract baseprefsize.width and 3 from proposed size width 
                 ' so they wrap properly
-                Dim newConstraints As Size = proposedsize - bordersAndPadding - New Size(3, 0)
+                Dim newConstraints As Size = proposedSize - bordersAndPadding - New Size(3, 0)
 
                 ' guarding against errors with newConstraints.
                 If newConstraints.Width < 0 Then

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/AddMyExtensionsDialog.resx
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/AddMyExtensionsDialog.resx
@@ -240,10 +240,10 @@
   <data name="colHeaderExtensionVersion.Width" type="System.Int32, mscorlib">
     <value>80</value>
   </data>
-  <data name="colHeaderExensionDescription.Text" xml:space="preserve">
+  <data name="colHeaderExtensionDescription.Text" xml:space="preserve">
     <value>Description</value>
   </data>
-  <data name="colHeaderExensionDescription.Width" type="System.Int32, mscorlib">
+  <data name="colHeaderExtensionDescription.Width" type="System.Int32, mscorlib">
     <value>250</value>
   </data>
   <data name="listViewExtensions.AccessibleName" xml:space="preserve">
@@ -339,10 +339,10 @@
   <data name="&gt;&gt;colHeaderExtensionVersion.Type" xml:space="preserve">
     <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;colHeaderExensionDescription.Name" xml:space="preserve">
-    <value>colHeaderExensionDescription</value>
+  <data name="&gt;&gt;colHeaderExtensionDescription.Name" xml:space="preserve">
+    <value>colHeaderExtensionDescription</value>
   </data>
-  <data name="&gt;&gt;colHeaderExensionDescription.Type" xml:space="preserve">
+  <data name="&gt;&gt;colHeaderExtensionDescription.Type" xml:space="preserve">
     <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/AddMyExtensionsDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/AddMyExtensionsDialog.vb
@@ -159,7 +159,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         Friend WithEvents buttonOK As Button
         Friend WithEvents tableLayoutOKCancelButtons As TableLayoutPanel
         Friend WithEvents colHeaderExtensionName As ColumnHeader
-        Friend WithEvents colHeaderExensionDescription As ColumnHeader
+        Friend WithEvents colHeaderExtensionDescription As ColumnHeader
         Friend WithEvents colHeaderExtensionVersion As ColumnHeader
         Friend WithEvents tableLayoutOverarching As TableLayoutPanel
 
@@ -172,7 +172,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
             listViewExtensions = New ListView
             colHeaderExtensionName = New ColumnHeader
             colHeaderExtensionVersion = New ColumnHeader
-            colHeaderExensionDescription = New ColumnHeader
+            colHeaderExtensionDescription = New ColumnHeader
             tableLayoutOverarching.SuspendLayout()
             tableLayoutOKCancelButtons.SuspendLayout()
             SuspendLayout()
@@ -206,7 +206,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
             '
             'listViewExtensions
             '
-            listViewExtensions.Columns.AddRange(New ColumnHeader() {colHeaderExtensionName, colHeaderExtensionVersion, colHeaderExensionDescription})
+            listViewExtensions.Columns.AddRange(New ColumnHeader() {colHeaderExtensionName, colHeaderExtensionVersion, colHeaderExtensionDescription})
             resources.ApplyResources(listViewExtensions, "listViewExtensions")
             listViewExtensions.FullRowSelect = True
             listViewExtensions.HideSelection = False
@@ -225,7 +225,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
             '
             'colHeaderExtensionDescription
             '
-            resources.ApplyResources(colHeaderExensionDescription, "colHeaderExensionDescription")
+            resources.ApplyResources(colHeaderExtensionDescription, "colHeaderExtensionDescription")
             '
             'AddMyExtensionsDialog
             '

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AddMyExtensionsDialog.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AddMyExtensionsDialog.cs.xlf
@@ -22,11 +22,6 @@
         <target state="translated">Verze</target>
         <note />
       </trans-unit>
-      <trans-unit id="colHeaderExensionDescription.Text">
-        <source>Description</source>
-        <target state="translated">Popis</target>
-        <note />
-      </trans-unit>
       <trans-unit id="listViewExtensions.AccessibleName">
         <source>Available My Namespace Extensions</source>
         <target state="translated">Dostupná rozšíření rozhraní My Namespace</target>
@@ -35,6 +30,11 @@
       <trans-unit id="$this.Text">
         <source>Add Visual Basic My Namespace Extension</source>
         <target state="translated">Přidat pro Visual Basic rozšíření rozhraní My Namespace</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="colHeaderExtensionDescription.Text">
+        <source>Description</source>
+        <target state="new">Description</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AddMyExtensionsDialog.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AddMyExtensionsDialog.de.xlf
@@ -22,11 +22,6 @@
         <target state="translated">Version</target>
         <note />
       </trans-unit>
-      <trans-unit id="colHeaderExensionDescription.Text">
-        <source>Description</source>
-        <target state="translated">Beschreibung</target>
-        <note />
-      </trans-unit>
       <trans-unit id="listViewExtensions.AccessibleName">
         <source>Available My Namespace Extensions</source>
         <target state="translated">Verfügbare My-Namespaceerweiterungen</target>
@@ -35,6 +30,11 @@
       <trans-unit id="$this.Text">
         <source>Add Visual Basic My Namespace Extension</source>
         <target state="translated">Visual Basic-My-Namespaceerweiterung hinzufügen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="colHeaderExtensionDescription.Text">
+        <source>Description</source>
+        <target state="new">Description</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AddMyExtensionsDialog.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AddMyExtensionsDialog.es.xlf
@@ -22,11 +22,6 @@
         <target state="translated">Versión</target>
         <note />
       </trans-unit>
-      <trans-unit id="colHeaderExensionDescription.Text">
-        <source>Description</source>
-        <target state="translated">Descripción</target>
-        <note />
-      </trans-unit>
       <trans-unit id="listViewExtensions.AccessibleName">
         <source>Available My Namespace Extensions</source>
         <target state="translated">Extensiones del espacio de nombres My disponibles</target>
@@ -35,6 +30,11 @@
       <trans-unit id="$this.Text">
         <source>Add Visual Basic My Namespace Extension</source>
         <target state="translated">Agregar la extensión de espacio de nombres My de Visual Basic</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="colHeaderExtensionDescription.Text">
+        <source>Description</source>
+        <target state="new">Description</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AddMyExtensionsDialog.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AddMyExtensionsDialog.fr.xlf
@@ -22,11 +22,6 @@
         <target state="translated">Version</target>
         <note />
       </trans-unit>
-      <trans-unit id="colHeaderExensionDescription.Text">
-        <source>Description</source>
-        <target state="translated">Description</target>
-        <note />
-      </trans-unit>
       <trans-unit id="listViewExtensions.AccessibleName">
         <source>Available My Namespace Extensions</source>
         <target state="translated">Extensions de l'espace de noms My disponibles</target>
@@ -35,6 +30,11 @@
       <trans-unit id="$this.Text">
         <source>Add Visual Basic My Namespace Extension</source>
         <target state="translated">Ajouter l'extension de l'espace de noms My de Visual Basic</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="colHeaderExtensionDescription.Text">
+        <source>Description</source>
+        <target state="new">Description</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AddMyExtensionsDialog.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AddMyExtensionsDialog.it.xlf
@@ -22,11 +22,6 @@
         <target state="translated">Versione</target>
         <note />
       </trans-unit>
-      <trans-unit id="colHeaderExensionDescription.Text">
-        <source>Description</source>
-        <target state="translated">Descrizione</target>
-        <note />
-      </trans-unit>
       <trans-unit id="listViewExtensions.AccessibleName">
         <source>Available My Namespace Extensions</source>
         <target state="translated">Estensioni dello spazio dei nomi My disponibili</target>
@@ -35,6 +30,11 @@
       <trans-unit id="$this.Text">
         <source>Add Visual Basic My Namespace Extension</source>
         <target state="translated">Aggiungi estensione dello spazio dei nomi My di Visual Basic</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="colHeaderExtensionDescription.Text">
+        <source>Description</source>
+        <target state="new">Description</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AddMyExtensionsDialog.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AddMyExtensionsDialog.ja.xlf
@@ -22,11 +22,6 @@
         <target state="translated">バージョン</target>
         <note />
       </trans-unit>
-      <trans-unit id="colHeaderExensionDescription.Text">
-        <source>Description</source>
-        <target state="translated">説明</target>
-        <note />
-      </trans-unit>
       <trans-unit id="listViewExtensions.AccessibleName">
         <source>Available My Namespace Extensions</source>
         <target state="translated">使用できるマイ名前空間拡張</target>
@@ -35,6 +30,11 @@
       <trans-unit id="$this.Text">
         <source>Add Visual Basic My Namespace Extension</source>
         <target state="translated">Visual Basic のマイ名前空間拡張の追加</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="colHeaderExtensionDescription.Text">
+        <source>Description</source>
+        <target state="new">Description</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AddMyExtensionsDialog.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AddMyExtensionsDialog.ko.xlf
@@ -22,11 +22,6 @@
         <target state="translated">버전</target>
         <note />
       </trans-unit>
-      <trans-unit id="colHeaderExensionDescription.Text">
-        <source>Description</source>
-        <target state="translated">설명</target>
-        <note />
-      </trans-unit>
       <trans-unit id="listViewExtensions.AccessibleName">
         <source>Available My Namespace Extensions</source>
         <target state="translated">사용 가능한 My 네임스페이스 확장</target>
@@ -35,6 +30,11 @@
       <trans-unit id="$this.Text">
         <source>Add Visual Basic My Namespace Extension</source>
         <target state="translated">Visual Basic My 네임스페이스 확장 추가</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="colHeaderExtensionDescription.Text">
+        <source>Description</source>
+        <target state="new">Description</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AddMyExtensionsDialog.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AddMyExtensionsDialog.pl.xlf
@@ -22,11 +22,6 @@
         <target state="translated">Wersja</target>
         <note />
       </trans-unit>
-      <trans-unit id="colHeaderExensionDescription.Text">
-        <source>Description</source>
-        <target state="translated">Opis</target>
-        <note />
-      </trans-unit>
       <trans-unit id="listViewExtensions.AccessibleName">
         <source>Available My Namespace Extensions</source>
         <target state="translated">Dostępne rozszerzenia My Namespace</target>
@@ -35,6 +30,11 @@
       <trans-unit id="$this.Text">
         <source>Add Visual Basic My Namespace Extension</source>
         <target state="translated">Dodaj rozszerzenie My Namespace w Visual Basic</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="colHeaderExtensionDescription.Text">
+        <source>Description</source>
+        <target state="new">Description</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AddMyExtensionsDialog.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AddMyExtensionsDialog.pt-BR.xlf
@@ -22,11 +22,6 @@
         <target state="translated">Versão</target>
         <note />
       </trans-unit>
-      <trans-unit id="colHeaderExensionDescription.Text">
-        <source>Description</source>
-        <target state="translated">Descrição</target>
-        <note />
-      </trans-unit>
       <trans-unit id="listViewExtensions.AccessibleName">
         <source>Available My Namespace Extensions</source>
         <target state="translated">Extensões Disponíveis do Meu Namespace</target>
@@ -35,6 +30,11 @@
       <trans-unit id="$this.Text">
         <source>Add Visual Basic My Namespace Extension</source>
         <target state="translated">Adicionar Extensão do My Namespace do Visual Basic</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="colHeaderExtensionDescription.Text">
+        <source>Description</source>
+        <target state="new">Description</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AddMyExtensionsDialog.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AddMyExtensionsDialog.ru.xlf
@@ -22,11 +22,6 @@
         <target state="translated">Версия</target>
         <note />
       </trans-unit>
-      <trans-unit id="colHeaderExensionDescription.Text">
-        <source>Description</source>
-        <target state="translated">Описание</target>
-        <note />
-      </trans-unit>
       <trans-unit id="listViewExtensions.AccessibleName">
         <source>Available My Namespace Extensions</source>
         <target state="translated">Доступные расширения пространства имен My</target>
@@ -35,6 +30,11 @@
       <trans-unit id="$this.Text">
         <source>Add Visual Basic My Namespace Extension</source>
         <target state="translated">Добавление расширения My Namespace Visual Basic</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="colHeaderExtensionDescription.Text">
+        <source>Description</source>
+        <target state="new">Description</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AddMyExtensionsDialog.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AddMyExtensionsDialog.tr.xlf
@@ -22,11 +22,6 @@
         <target state="translated">Sürüm</target>
         <note />
       </trans-unit>
-      <trans-unit id="colHeaderExensionDescription.Text">
-        <source>Description</source>
-        <target state="translated">Açıklama</target>
-        <note />
-      </trans-unit>
       <trans-unit id="listViewExtensions.AccessibleName">
         <source>Available My Namespace Extensions</source>
         <target state="translated">Kullanılabilir My Namespace Uzantıları</target>
@@ -35,6 +30,11 @@
       <trans-unit id="$this.Text">
         <source>Add Visual Basic My Namespace Extension</source>
         <target state="translated">Visual Basic My Namespace Uzantı Ekleme</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="colHeaderExtensionDescription.Text">
+        <source>Description</source>
+        <target state="new">Description</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AddMyExtensionsDialog.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AddMyExtensionsDialog.zh-Hans.xlf
@@ -22,11 +22,6 @@
         <target state="translated">版本</target>
         <note />
       </trans-unit>
-      <trans-unit id="colHeaderExensionDescription.Text">
-        <source>Description</source>
-        <target state="translated">说明</target>
-        <note />
-      </trans-unit>
       <trans-unit id="listViewExtensions.AccessibleName">
         <source>Available My Namespace Extensions</source>
         <target state="translated">可用的 My 命名空间扩展</target>
@@ -35,6 +30,11 @@
       <trans-unit id="$this.Text">
         <source>Add Visual Basic My Namespace Extension</source>
         <target state="translated">添加 Visual Basic 的 My 命名空间扩展</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="colHeaderExtensionDescription.Text">
+        <source>Description</source>
+        <target state="new">Description</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AddMyExtensionsDialog.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/xlf/AddMyExtensionsDialog.zh-Hant.xlf
@@ -22,11 +22,6 @@
         <target state="translated">版本</target>
         <note />
       </trans-unit>
-      <trans-unit id="colHeaderExensionDescription.Text">
-        <source>Description</source>
-        <target state="translated">說明</target>
-        <note />
-      </trans-unit>
       <trans-unit id="listViewExtensions.AccessibleName">
         <source>Available My Namespace Extensions</source>
         <target state="translated">可用的 My 命名空間延伸模組</target>
@@ -35,6 +30,11 @@
       <trans-unit id="$this.Text">
         <source>Add Visual Basic My Namespace Extension</source>
         <target state="translated">加入 Visual Basic My 命名空間擴充功能</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="colHeaderExtensionDescription.Text">
+        <source>Description</source>
+        <target state="new">Description</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBWinForms.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageVBWinForms.vb
@@ -607,12 +607,12 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Setter for MainForm.  We handle this so that we also get notified when the property
         '''   has changed.
         ''' </summary>
-        ''' <param name="conrol"></param>
+        ''' <param name="control"></param>
         ''' <param name="prop"></param>
         ''' <param name="value"></param>
         ''' <returns></returns>
         ''' <remarks></remarks>
-        Protected Function MainFormNoRootNSSet(conrol As Control, prop As PropertyDescriptor, value As Object) As Boolean
+        Protected Function MainFormNoRootNSSet(control As Control, prop As PropertyDescriptor, value As Object) As Boolean
             If Not PropertyControlData.IsSpecialValue(value) Then
                 MainFormTextboxNoRootNS.Text = DirectCast(value, String)
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworkPropertyControlData.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworkPropertyControlData.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                    TypeOf _comboBox.Items(_comboBox.SelectedIndex) Is InstallOtherFrameworksComboBoxValue
         End Function
 
-        Private Sub NativageToInstallOtherFrameworksFWLink()
+        Private Sub NavigateToInstallOtherFrameworksFWLink()
 
             If Site Is Nothing Then
                 ' Can't do anything without a site
@@ -77,7 +77,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 ' If the user chooses 'Install other frameworks...', move the selection back to the last target
                 ' framework value and navigate to the fwlink
                 _comboBox.SelectedIndex = IndexOfLastCommittedValue
-                NativageToInstallOtherFrameworksFWLink()
+                NavigateToInstallOtherFrameworksFWLink()
 
             ElseIf _comboBox.SelectedIndex <> IndexOfLastCommittedValue Then
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/UnusedReferencePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/UnusedReferencePropPage.vb
@@ -373,13 +373,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                             For Each UnusedRefPath As String In UnusedRefPaths
                                 If UnusedRefPath.Length > 0 Then
 
-                                    Dim formatedPath As String = UnusedRefPath.ToUpper(Globalization.CultureInfo.InvariantCulture)
-                                    Dim refObj As Object = pathHash.Item(formatedPath)
+                                    Dim formattedPath As String = UnusedRefPath.ToUpper(Globalization.CultureInfo.InvariantCulture)
+                                    Dim refObj As Object = pathHash.Item(formattedPath)
 
                                     If refObj IsNot Nothing Then
                                         UnusedRefsList.Add(RefsList(CInt(refObj)))
                                         ' remove the one we matched, so we don't scan it and waste time to GetAssemblyName again...
-                                        pathHash.Remove(formatedPath)
+                                        pathHash.Remove(formattedPath)
                                     ElseIf IO.File.Exists(UnusedRefPath) Then
                                         ' If we haven't matched any path, we need collect the assembly name and use it to do match...
                                         Dim UnusedRefName As String = GetAssemblyName(UnusedRefPath).FullName
@@ -505,7 +505,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="sender">Event args</param>
         ''' <param name="e">Event args</param>
-        Private Sub OnUnusedRerenceListColumnClick(sender As Object, e As ColumnClickEventArgs) Handles UnusedReferenceList.ColumnClick
+        Private Sub OnUnusedReferenceListColumnClick(sender As Object, e As ColumnClickEventArgs) Handles UnusedReferenceList.ColumnClick
             ListViewComparer.HandleColumnClick(UnusedReferenceList, _referenceSorter, e)
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
@@ -1293,23 +1293,23 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
         ''' <param name="list"></param>
         ''' <remarks></remarks>
         Private Sub FindXamlPageFiles(projectItems As ProjectItems, list As List(Of ProjectItem))
-            For Each projectitem As ProjectItem In projectItems
-                If IO.Path.GetExtension(projectitem.FileNames(1)).Equals(".xaml", StringComparison.OrdinalIgnoreCase) Then
+            For Each projectItem As ProjectItem In projectItems
+                If IO.Path.GetExtension(projectItem.FileNames(1)).Equals(".xaml", StringComparison.OrdinalIgnoreCase) Then
                     'We only want .xaml files with BuildAction="Page"
-                    Dim CurrentBuildAction As String = DTEUtils.GetBuildActionAsString(projectitem)
+                    Dim CurrentBuildAction As String = DTEUtils.GetBuildActionAsString(projectItem)
                     If CurrentBuildAction IsNot Nothing AndAlso BUILDACTION_PAGE.Equals(CurrentBuildAction, StringComparison.OrdinalIgnoreCase) Then
                         'Build action is correct.
 
                         'Is the item inside the project folders (instead of, say, a link to an external file)?
-                        If IsFileRelativeToProjectPath(projectitem.FileNames(1)) Then
+                        If IsFileRelativeToProjectPath(projectItem.FileNames(1)) Then
                             'Okay, we want this one
-                            list.Add(projectitem)
+                            list.Add(projectItem)
                         End If
                     End If
                 End If
 
-                If projectitem.ProjectItems IsNot Nothing Then
-                    FindXamlPageFiles(projectitem.ProjectItems, list)
+                If projectItem.ProjectItems IsNot Nothing Then
+                    FindXamlPageFiles(projectItem.ProjectItems, list)
                 End If
             Next
         End Sub

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
@@ -139,7 +139,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Private Const DESIGNER_PADDING_TOP As Integer = 23
 
         ' the separator character to save multiple extensions in one string
-        Private Const SAFE_EXTENSION_SEPERATOR As Char = "|"c
+        Private Const SAFE_EXTENSION_SEPARATOR As Char = "|"c
 
 #End Region
 
@@ -1677,7 +1677,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                                 Resource.SetTypeResolutionContext(Me)
 
                                 ' We should check whether the project can accept the item before adding the external file to the project
-                                If Not IsValidResourseItem(Resource, Message, HelpID) Then
+                                If Not IsValidResourceItem(Resource, Message, HelpID) Then
                                     DsMsgBox(My.Resources.Microsoft_VisualStudio_Editors_Designer.GetString(My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_Err_CantAddUnsupportedResource_1Arg, Resource.Name) & vbCrLf & vbCrLf & Message, MessageBoxButtons.OK, MessageBoxIcon.Error, , HelpID)
                                     Continue For
                                 End If
@@ -1786,7 +1786,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 Dim Message As String = String.Empty
                 Dim HelpID As String = String.Empty
 
-                If Not IsValidResourseItem(NewResource, Message, HelpID) Then
+                If Not IsValidResourceItem(NewResource, Message, HelpID) Then
                     DsMsgBox(My.Resources.Microsoft_VisualStudio_Editors_Designer.GetString(My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_Err_CantAddUnsupportedResource_1Arg, NewResource.Name) & vbCrLf & vbCrLf & Message, MessageBoxButtons.OK, MessageBoxIcon.Error, , HelpID)
                     Return
                 End If
@@ -2187,7 +2187,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Checks to see whether we can add a resource to this file
         ''' </summary>
         ''' <remarks></remarks>
-        Private Function IsValidResourseItem(NewResource As Resource, ByRef Message As String, ByRef HelpID As String) As Boolean
+        Private Function IsValidResourceItem(NewResource As Resource, ByRef Message As String, ByRef HelpID As String) As Boolean
             Return NewResource.ResourceTypeEditor.IsResourceItemValid(NewResource, _resourceFile, Message, HelpID)
         End Function
 
@@ -2388,7 +2388,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <summary>
         ''' The Cancel Edit command is never enabled. 
         ''' </summary>
-        ''' <param name="menucommand">Ignored</param>
+        ''' <param name="menuCommand">Ignored</param>
         ''' <returns>False</returns>
         ''' <remarks>
         ''' We never enable this command because we are currently trying to commit all pending edits in our 
@@ -2397,7 +2397,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' we basically unbind the keyboard shortcut and let the DataGridView do it's built-in thing (which happens to be the 
         ''' right thing :)            
         ''' </remarks>
-        Private Function MenuCancelEditEnableHandler(menucommand As DesignerMenuCommand) As Boolean
+        Private Function MenuCancelEditEnableHandler(menuCommand As DesignerMenuCommand) As Boolean
             Return False
         End Function
 
@@ -3526,7 +3526,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                         ' Check the registry setting, which remembers a list of extensions that the customer told us not to pop up a warning dialog again...
                         Dim extraSafeExtensions As String = SafeExtensions
                         If Not String.IsNullOrEmpty(extraSafeExtensions) Then
-                            Dim extensions As String() = extraSafeExtensions.Split(New Char() {SAFE_EXTENSION_SEPERATOR})
+                            Dim extensions As String() = extraSafeExtensions.Split(New Char() {SAFE_EXTENSION_SEPARATOR})
                             For Each safeExtension As String In extensions
                                 If String.Equals(fileExtension, safeExtension, StringComparison.OrdinalIgnoreCase) Then
                                     isSafe = True
@@ -3547,7 +3547,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                                     If String.IsNullOrEmpty(extraSafeExtensions) Then
                                         extraSafeExtensions = fileExtension
                                     Else
-                                        extraSafeExtensions = extraSafeExtensions & SAFE_EXTENSION_SEPERATOR & fileExtension
+                                        extraSafeExtensions = extraSafeExtensions & SAFE_EXTENSION_SEPARATOR & fileExtension
                                     End If
                                     SafeExtensions = extraSafeExtensions
                                 End If
@@ -3703,7 +3703,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                             Using NewResourceItem As New Resource(_resourceFile, "Test", "", NewResourceValue, Me)
                                 Dim Message As String = String.Empty
                                 Dim HelpID As String = String.Empty
-                                If Not IsValidResourseItem(NewResourceItem, Message, HelpID) Then
+                                If Not IsValidResourceItem(NewResourceItem, Message, HelpID) Then
                                     DsMsgBox(My.Resources.Microsoft_VisualStudio_Editors_Designer.GetString(My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_Err_CantAddUnsupportedResource_1Arg, ResourceToImportTo.Name) & vbCrLf & vbCrLf & Message, MessageBoxButtons.OK, MessageBoxIcon.Error, , HelpID)
                                     Return
                                 End If

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceFile.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceFile.vb
@@ -1681,11 +1681,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     ' We should ignore, if we couldn't find type...
                     ' We also skip the mscorlib.dll
                     If resourceType IsNot Nothing AndAlso resourceType.Assembly IsNot GetType(String).Assembly Then
-                        Dim assmeblyName As String = resourceType.Assembly.GetName().Name
+                        Dim assemblyName As String = resourceType.Assembly.GetName().Name
 
                         ' skip the assembly if we have already processed it
-                        If Not assemblyCollection.Contains(assmeblyName) Then
-                            assemblyCollection.Add(assmeblyName)
+                        If Not assemblyCollection.Contains(assemblyName) Then
+                            assemblyCollection.Add(assemblyName)
 
                             Try
                                 If vsLangProj Is Nothing Then
@@ -1701,9 +1701,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                                     End If
                                 End If
 
-                                If vsLangProj.References.Find(assmeblyName) Is Nothing Then
+                                If vsLangProj.References.Find(assemblyName) Is Nothing Then
                                     ' Let the project system to handle the exactly version...
-                                    vsLangProj.References.Add(assmeblyName)
+                                    vsLangProj.References.Add(assemblyName)
                                 End If
                             Catch ex As CheckoutException
                                 ' Ignore CheckoutException

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceListView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceListView.vb
@@ -811,9 +811,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     ' NOTE: 3 pages cache looks too conservative, for list/detail view, the tiny icon shouldn't cost a lot memory,
                     '  and Thumbnail view doesn't show many in one page
                     Const PagesInCache As Integer = 5
-                    Const PagesInCachDetailView As Integer = 20
+                    Const PagesInCacheDetailView As Integer = 20
                     If Me.View = ResourceView.Details Then
-                        _thumbnailCache.MaximumSuggestedCacheSize = _thumbnailCache.MinimumSizeBeforeRecycling * PagesInCachDetailView
+                        _thumbnailCache.MaximumSuggestedCacheSize = _thumbnailCache.MinimumSizeBeforeRecycling * PagesInCacheDetailView
                     Else
                         _thumbnailCache.MaximumSuggestedCacheSize = _thumbnailCache.MinimumSizeBeforeRecycling * PagesInCache
                     End If

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ThumbnailCache.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ThumbnailCache.vb
@@ -405,8 +405,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="Index">Index in the ImageList.</param>
         ''' <param name="Key">Key to be removed.</param>
-        ''' <param name="BeLastestItem">It should be the last item in the MRU list, otherwise, it will be the first item, and will be recycle soon.</param>
-        Private Sub UpdateMruList(Index As Integer, Key As Object, BeLastestItem As Boolean)
+        ''' <param name="BeLastItem">It should be the last item in the MRU list, otherwise, it will be the first item, and will be recycle soon.</param>
+        Private Sub UpdateMruList(Index As Integer, Key As Object, BeLastItem As Boolean)
             Dim MruIndex As Integer = Index + 1
 
             ' Check whether we need grow the size of the MRU table...
@@ -418,7 +418,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             _mruList(MruIndex).Key = Key
             If IsInMruList(Index) Then
                 ' It is an item in the list...
-                If (BeLastestItem AndAlso _mruList(0).PreviousIndex = MruIndex) OrElse (Not BeLastestItem AndAlso _mruList(0).NextIndex = MruIndex) Then
+                If (BeLastItem AndAlso _mruList(0).PreviousIndex = MruIndex) OrElse (Not BeLastItem AndAlso _mruList(0).NextIndex = MruIndex) Then
                     ' already in the position
                     Return
                 End If
@@ -429,7 +429,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             End If
 
             ' insert it to the right position...
-            If BeLastestItem Then
+            If BeLastItem Then
                 _mruList(MruIndex).NextIndex = 0
                 _mruList(MruIndex).PreviousIndex = _mruList(0).PreviousIndex
                 _mruList(_mruList(0).PreviousIndex).NextIndex = MruIndex

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/AppConfigSerializer.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/AppConfigSerializer.vb
@@ -178,14 +178,14 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' exist.
         ''' </summary>
         ''' <param name="Hierarchy"></param>
-        ''' <param name="Writeable">
+        ''' <param name="Writable">
         ''' If the DocData should be write:able, and a DocDataService is provider, all write:able files added to the
         ''' DocDataService will be checked out
         ''' </param>
         ''' <param name="DocDataService">If specified, the DesignerDocDataService to add/get this DocData to/from</param>
         ''' <returns></returns>
         ''' <remarks></remarks>
-        Friend Shared Function GetAppConfigDocData(ServiceProvider As IServiceProvider, Hierarchy As IVsHierarchy, CreateIfNotExists As Boolean, Writeable As Boolean, Optional DocDataService As DesignerDocDataService = Nothing) As DocData
+        Friend Shared Function GetAppConfigDocData(ServiceProvider As IServiceProvider, Hierarchy As IVsHierarchy, CreateIfNotExists As Boolean, Writable As Boolean, Optional DocDataService As DesignerDocDataService = Nothing) As DocData
             Dim ProjSpecialFiles As IVsProjectSpecialFiles = TryCast(Hierarchy, IVsProjectSpecialFiles)
             Dim AppConfigDocData As DocData = Nothing
 
@@ -212,7 +212,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 If AppConfigItemId <> VSITEMID.NIL Then
                     If DocDataService IsNot Nothing Then
                         Dim Access As FileAccess
-                        If Writeable Then
+                        If Writable Then
                             Access = FileAccess.ReadWrite
                         Else
                             Access = FileAccess.Read

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ProjectUtils.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ProjectUtils.vb
@@ -455,7 +455,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
         Friend Class FindPropertyFilter
             Implements IFindFilter
 
-            Private ReadOnly _containtingClass As EnvDTE.CodeElement
+            Private ReadOnly _containingClass As EnvDTE.CodeElement
             Private ReadOnly _propertyName As String
 
             Public Sub New(ContainingClass As EnvDTE.CodeElement, PropertyName As String)
@@ -469,7 +469,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
                     Throw New ArgumentNullException()
                 End If
 
-                _containtingClass = ContainingClass
+                _containingClass = ContainingClass
                 _propertyName = PropertyName
             End Sub
 
@@ -498,7 +498,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
                     Return False
                 End If
 
-                If Prop.Parent.FullName.Equals(_containtingClass.FullName, comparisonType) Then
+                If Prop.Parent.FullName.Equals(_containingClass.FullName, comparisonType) Then
                     Return True
                 Else
                     Return False
@@ -513,7 +513,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
         Friend Class FindFunctionFilter
             Implements IFindFilter
 
-            Private ReadOnly _containtingClass As EnvDTE.CodeElement
+            Private ReadOnly _containingClass As EnvDTE.CodeElement
             Private ReadOnly _functionName As String
 
             Public Sub New(ContainingClass As EnvDTE.CodeElement, FunctionName As String)
@@ -527,7 +527,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
                     Throw New ArgumentNullException()
                 End If
 
-                _containtingClass = ContainingClass
+                _containingClass = ContainingClass
                 _functionName = FunctionName
             End Sub
 
@@ -561,8 +561,8 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
                     Return False
                 End If
 
-                Dim ContaintingClass As EnvDTE.CodeClass = TryCast(Func.Parent, EnvDTE.CodeClass)
-                If ContaintingClass IsNot Nothing AndAlso ContaintingClass.FullName.Equals(_containtingClass.FullName, comparisonType) Then
+                Dim ContainingClass As EnvDTE.CodeClass = TryCast(Func.Parent, EnvDTE.CodeClass)
+                If ContainingClass IsNot Nothing AndAlso ContainingClass.FullName.Equals(_containingClass.FullName, comparisonType) Then
                     Return True
                 Else
                     Return False
@@ -675,20 +675,20 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
             Const SettingsSavingEventHandlerName As String = "SettingsSavingEventHandler"
 
             ' Add constructor
-            Dim constr As New CodeConstructor With {
+            Dim constructor As New CodeConstructor With {
                 .Attributes = MemberAttributes.Public
             }
 
             ' Generate a series of statements to add to the constructor
             Dim thisExpr As New CodeThisReferenceExpression()
-            Dim stmts As New CodeStatementCollection From {
+            Dim statements As New CodeStatementCollection From {
                 New CodeCommentStatement(My.Resources.Microsoft_VisualStudio_Editors_Designer.SD_CODEGENCMT_HOWTO_ATTACHEVTS),
                 New CodeAttachEventStatement(thisExpr, SettingChangingEventName, New CodeMethodReferenceExpression(thisExpr, SettingChangingEventHandlerName)),
                 New CodeAttachEventStatement(thisExpr, SettingsSavingEventName, New CodeMethodReferenceExpression(thisExpr, SettingsSavingEventHandlerName))
             }
 
-            For Each stmt As CodeStatement In stmts
-                constr.Statements.Add(CommentStatement(stmt, generator, True))
+            For Each stmt As CodeStatement In statements
+                constructor.Statements.Add(CommentStatement(stmt, generator, True))
             Next
 
             ' Add stubs for settingschanging/settingssaving event handlers
@@ -709,7 +709,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
             savingStub.Parameters.Add(New CodeParameterDeclarationExpression(GetType(ComponentModel.CancelEventArgs), "e"))
             savingStub.Statements.Add(New CodeCommentStatement(My.Resources.Microsoft_VisualStudio_Editors_Designer.SD_CODEGENCMT_HANDLE_SAVING))
 
-            ct.Members.Add(constr)
+            ct.Members.Add(constructor)
             ct.Members.Add(changingStub)
             ct.Members.Add(savingStub)
         End Sub

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
@@ -1495,12 +1495,12 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                             vsProjectItem.RunCustomTool()
                         End If
                     End If
-                    Dim FullyQualifedClassName As String = SettingsDesigner.FullyQualifiedGeneratedTypedSettingsClassName(Hierarchy, VSITEMID.NIL, Settings, ProjectItem)
+                    Dim FullyQualifiedClassName As String = SettingsDesigner.FullyQualifiedGeneratedTypedSettingsClassName(Hierarchy, VSITEMID.NIL, Settings, ProjectItem)
                     Dim suggestedFileName As String = ""
                     If Settings.UseSpecialClassName AndAlso IsVbProject(Hierarchy) AndAlso SettingsDesigner.IsDefaultSettingsFile(Hierarchy, DesignerLoader.ProjectItemid) Then
                         suggestedFileName = "Settings"
                     End If
-                    ProjectUtils.OpenAndMaybeAddExtendingFile(FullyQualifedClassName, suggestedFileName, Settings.Site, Hierarchy, ProjectItem, CType(VSMDCodeDomProvider.CodeDomProvider, CodeDom.Compiler.CodeDomProvider), Me)
+                    ProjectUtils.OpenAndMaybeAddExtendingFile(FullyQualifiedClassName, suggestedFileName, Settings.Site, Hierarchy, ProjectItem, CType(VSMDCodeDomProvider.CodeDomProvider, CodeDom.Compiler.CodeDomProvider), Me)
                 Catch ex As Exception When ReportWithoutCrash(ex, NameOf(ViewCode), NameOf(SettingsDesignerView))
                     If Settings IsNot Nothing AndAlso Settings.Site IsNot Nothing Then
                         ' We better tell the user that something went wrong (if we still have a settings/settings.site that is)

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
@@ -536,7 +536,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
             ' Add SettingsManageabilityAttribute if this setting is roaming (but only if this is a USER scoped setting...
             If Instance.Roaming AndAlso Instance.Scope = DesignTimeSettingInstance.SettingScope.User Then
-                AddManagebilityAttribue(CodeProperty, Configuration.SettingsManageability.Roaming)
+                AddManageabilityAttribute(CodeProperty, Configuration.SettingsManageability.Roaming)
             End If
 
             Return CodeProperty
@@ -549,7 +549,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             CodeProperty.CustomAttributes.Add(DefaultValueAttribute)
         End Sub
 
-        Private Shared Sub AddManagebilityAttribue(CodeProperty As CodeMemberProperty, Value As Configuration.SettingsManageability)
+        Private Shared Sub AddManageabilityAttribute(CodeProperty As CodeMemberProperty, Value As Configuration.SettingsManageability)
             Dim SettingsManageability As New CodeTypeReferenceExpression(CreateGlobalCodeTypeReference(GetType(Configuration.SettingsManageability)))
             Dim FieldExp As New CodeFieldReferenceExpression(SettingsManageability, Value.ToString)
             Dim Parameters() As CodeAttributeArgument = {New CodeAttributeArgument(FieldExp)}
@@ -599,9 +599,9 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             Dim Parameters() As CodeExpression = {New CodePrimitiveExpression(Instance.Name)}
             Dim IndexerStatement As New CodeIndexerExpression(New CodeThisReferenceExpression(), Parameters)
             ' Make sure we case this value to the correct type
-            Dim AssignmentStatment As New CodeAssignStatement(IndexerStatement, New CodePropertySetValueReferenceExpression)
+            Dim AssignmentStatement As New CodeAssignStatement(IndexerStatement, New CodePropertySetValueReferenceExpression)
 
-            Statements.Add(AssignmentStatment)
+            Statements.Add(AssignmentStatement)
             Return Statements
         End Function
 

--- a/src/Microsoft.VisualStudio.Editors/SettingsGlobalObject/SettingsGlobalObjectProvider.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsGlobalObject/SettingsGlobalObjectProvider.vb
@@ -1619,12 +1619,12 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
 
                         If AppConfigDocData IsNot Nothing Then
                             Dim cfgHelper As New ConfigurationHelperService
-                            Dim FullyQualifedClassName As String = ProjectUtils.FullyQualifiedClassName(ProjectUtils.GeneratedSettingsClassNamespace(_hierarchy, _itemid, True), _className)
+                            Dim FullyQualifiedClassName As String = ProjectUtils.FullyQualifiedClassName(ProjectUtils.GeneratedSettingsClassNamespace(_hierarchy, _itemid, True), _className)
                             Try
                                 AppConfigSerializer.Deserialize(dtSettings,
                                                                     _typeCache,
                                                                     _valueCache,
-                                                                    cfgHelper.GetSectionName(FullyQualifedClassName, String.Empty),
+                                                                    cfgHelper.GetSectionName(FullyQualifiedClassName, String.Empty),
                                                                     AppConfigDocData,
                                                                     AppConfigSerializer.MergeValueMode.UseAppConfigFileValue)
                             Catch ex As ConfigurationErrorsException

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/LanguageServices/CSharpLanguageFeaturesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/LanguageServices/CSharpLanguageFeaturesProviderTests.cs
@@ -132,7 +132,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         [InlineData(new[] { "Microsoft.VisualStudio", "ProjectSystem"},                                 "Microsoft.VisualStudio.ProjectSystem")]
         [InlineData(new[] { "", "Microsoft", "VisualStudio", "ProjectSystem"},                          "Microsoft.VisualStudio.ProjectSystem")]
         [InlineData(new[] { "Microsoft", "", "ProjectSystem"},                                          "Microsoft.ProjectSystem")]
-        public void ConcatNamespaces_ValuesAsNamespacesName_ReturnsConcatedNamespaces(string[] namespaceNames, string expected)
+        public void ConcatNamespaces_ValuesAsNamespacesName_ReturnsConcatenatedNamespaces(string[] namespaceNames, string expected)
         {
             var provider = CreateInstance();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Properties/CSharpProjectDesignerPageProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Properties/CSharpProjectDesignerPageProviderTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
-        public async Task GetPagesAsync_WhenAllCapabiltiesPresent_ReturnsPagesInOrder()
+        public async Task GetPagesAsync_WhenAllCapabilitiesPresent_ReturnsPagesInOrder()
         {
             var provider = CreateInstance(ProjectCapability.LaunchProfiles, ProjectCapability.Pack);
             var result = await provider.GetPagesAsync();

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Properties/CSharpProjectTypeGuidProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Properties/CSharpProjectTypeGuidProviderTests.cs
@@ -20,9 +20,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
         private static CSharpProjectTypeGuidProvider CreateInstance()
         {
-            var unconfiguedProject = UnconfiguredProjectFactory.Create();
+            var unconfiguredProject = UnconfiguredProjectFactory.Create();
 
-            return new CSharpProjectTypeGuidProvider(unconfiguedProject);
+            return new CSharpProjectTypeGuidProvider(unconfiguredProject);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Rename/CSharpSimpleRenamerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Rename/CSharpSimpleRenamerTests.cs
@@ -25,12 +25,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
         [InlineData("struct Foo { decimal price; string title; string author;}", "Foo.cs", "Bar.cs")]
         [InlineData("enum Foo { None, enum1, enum2, enum3, enum4 };", "Foo.cs", "Bar.cs")]
         [InlineData("namespace n1 {class Foo{}} namespace n2 {class Foo{}}", "Foo.cs", "Bar.cs")]
-        public async Task Rename_Symbol_Should_TriggerUserConfirmationAsync(string soureCode, string oldFilePath, string newFilePath)
+        public async Task Rename_Symbol_Should_TriggerUserConfirmationAsync(string sourceCode, string oldFilePath, string newFilePath)
         {
             var userNotificationServices = IUserNotificationServicesFactory.Create();
             var roslynServices = IRoslynServicesFactory.Implement(new CSharpSyntaxFactsService(null));
 
-            await RenameAsync(soureCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, LanguageNames.CSharp);
+            await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, LanguageNames.CSharp);
 
             Mock.Get(userNotificationServices).Verify(h => h.Confirm(It.IsAny<string>()), Times.Once);
             Mock.Get(roslynServices).Verify(h => h.RenameSymbolAsync(It.IsAny<Solution>(), It.IsAny<ISymbol>(), It.IsAny<string>()), Times.Never);
@@ -48,24 +48,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
         [InlineData("class Foo{}", "Bar.cs", "Foo@.cs")]
         [InlineData("class Foo{}", "Foo.cs", "Foo.cs")]
         [InlineData("class Foo{}", "Foo.cs", "Folder1\\Foo.cs")]
-        public async Task Rename_Symbol_Should_Not_HappenAsync(string soureCode, string oldFilePath, string newFilePath)
+        public async Task Rename_Symbol_Should_Not_HappenAsync(string sourceCode, string oldFilePath, string newFilePath)
         {
             var userNotificationServices = IUserNotificationServicesFactory.Create();
             var roslynServices = IRoslynServicesFactory.Implement(new CSharpSyntaxFactsService(null));
 
-            await RenameAsync(soureCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, LanguageNames.CSharp).TimeoutAfter(TimeSpan.FromSeconds(1));
+            await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, LanguageNames.CSharp).TimeoutAfter(TimeSpan.FromSeconds(1));
 
             Mock.Get(userNotificationServices).Verify(h => h.Confirm(It.IsAny<string>()), Times.Never);
             Mock.Get(roslynServices).Verify(h => h.RenameSymbolAsync(It.IsAny<Solution>(), It.IsAny<ISymbol>(), It.IsAny<string>()), Times.Never);
             Mock.Get(roslynServices).Verify(h => h.ApplyChangesToSolution(It.IsAny<Workspace>(), It.IsAny<Solution>()), Times.Never);
         }
 
-        internal async Task RenameAsync(string soureCode, string oldFilePath, string newFilePath, IUserNotificationServices userNotificationServices, IRoslynServices roslynServices, string language)
+        internal async Task RenameAsync(string sourceCode, string oldFilePath, string newFilePath, IUserNotificationServices userNotificationServices, IRoslynServices roslynServices, string language)
         {
             using (var ws = new AdhocWorkspace())
             {
                 var projectId = ProjectId.CreateNewId();
-                Solution solution = ws.AddSolution(InitializeWorkspace(projectId, newFilePath, soureCode, language));
+                Solution solution = ws.AddSolution(InitializeWorkspace(projectId, newFilePath, sourceCode, language));
                 Project project = (from d in solution.Projects where d.Id == projectId select d).FirstOrDefault();
 
                 var environmentOptionsFactory = IEnvironmentOptionsFactory.Implement((string category, string page, string property, bool defaultValue) => { return true; });

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/GlobalJsonRemoverTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/GlobalJsonRemoverTests.cs
@@ -149,7 +149,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         }
 
         [Fact]
-        public void GlobaJsonSetup_NoExistingRemover_RegistersForAdvise()
+        public void GlobalJsonSetup_NoExistingRemover_RegistersForAdvise()
         {
             UnitTestHelper.IsRunningUnitTests = true;
             GlobalJsonRemover.Remover = null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
@@ -153,7 +153,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
 
 
         [Fact]
-        public void NonExistantProjectJson_DoesNotBackUp()
+        public void NonExistentProjectJson_DoesNotBackUp()
         {
             var procRunner = ProcessRunnerFactory.CreateRunner();
             var migrator = CreateInstance(procRunner, CreateFileSystem(false));

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests/ProjectSystem/VS/Properties/FSharpProjectDesignerPageProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests/ProjectSystem/VS/Properties/FSharpProjectDesignerPageProviderTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
-        public async Task GetPagesAsync_WhenAllCapabiltiesPresent_ReturnsPagesInOrder()
+        public async Task GetPagesAsync_WhenAllCapabilitiesPresent_ReturnsPagesInOrder()
         {
             var provider = CreateInstance(ProjectCapability.LaunchProfiles, ProjectCapability.Pack);
             var result = await provider.GetPagesAsync();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/AppDesignerFolderProjectTreePropertiesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/AppDesignerFolderProjectTreePropertiesProviderTests.cs
@@ -35,13 +35,13 @@ namespace Microsoft.VisualStudio.ProjectSystem
         [Fact]
         public void UpdateProjectTreeSettings_NullAsProjectTreeSettings_ThrowsArgumentNull()
         {
-            var ruleSnapsnots = IProjectRuleSnapshotsFactory.Create();
+            var ruleSnapshots = IProjectRuleSnapshotsFactory.Create();
             var propertiesProvider = CreateInstance();
             IImmutableDictionary<string, string> projectTreeSettings = null;
 
             Assert.Throws<ArgumentNullException>("projectTreeSettings", () =>
             {
-                propertiesProvider.UpdateProjectTreeSettings(ruleSnapsnots, ref projectTreeSettings);
+                propertiesProvider.UpdateProjectTreeSettings(ruleSnapshots, ref projectTreeSettings);
             });
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ConfigurationProjectConfigurationDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ConfigurationProjectConfigurationDimensionProviderTests.cs
@@ -247,7 +247,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         [InlineData("$(Foo);Dbg;Retail",        "Dbg")]
         [InlineData("$(Foo); Dbg ;Retail",      "Dbg")]
         [InlineData("Dbg_$(Foo); Dbg ;Retail",  "Dbg")]
-        public async Task GetBestGuessDefaultValuesForDimensionsAsync_ReturnsFirstParsableValue(string configurations, string expected)
+        public async Task GetBestGuessDefaultValuesForDimensionsAsync_ReturnsFirstParseableValue(string configurations, string expected)
         {
             string projectXml =
 $@"<Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/PlatformProjectConfigurationDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/PlatformProjectConfigurationDimensionProviderTests.cs
@@ -170,7 +170,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         [InlineData("$(Foo);ARM;x64",       "ARM")]
         [InlineData("$(Foo); ARM ;x64",     "ARM")]
         [InlineData("x64_$(Foo); ARM ;x64", "ARM")]
-        public async Task GetBestGuessDefaultValuesForDimensionsAsync_ReturnsFirstParsableValue(string platforms, string expected)
+        public async Task GetBestGuessDefaultValuesForDimensionsAsync_ReturnsFirstParseableValue(string platforms, string expected)
         {
             string projectXml =
 $@"<Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/TargetFrameworkProjectConfigurationDimensionProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/TargetFrameworkProjectConfigurationDimensionProviderTests.cs
@@ -135,7 +135,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         [InlineData("$(Foo);net45;net46",         "net45")]
         [InlineData("$(Foo); net45 ;net46",       "net45")]
         [InlineData("net45_$(Foo); net45 ;net46", "net45")]
-        public async Task GetBestGuessDefaultValuesForDimensionsAsync_ReturnsFirstParsableValue(string frameworks, string expected)
+        public async Task GetBestGuessDefaultValuesForDimensionsAsync_ReturnsFirstParseableValue(string frameworks, string expected)
         {
             string projectXml =
 $@"<Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/ActiveDebugFrameworkServicesTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/ActiveDebugFrameworkServicesTests.cs
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Input.Commands
         [InlineData("netcoreapp1.0", "netcoreapp1.0")]
         [InlineData("net461", "net461")]
         [InlineData("", "net462")]
-        [InlineData("someframwork", "net462")]
+        [InlineData("someframework", "net462")]
         public async Task GetConfiguredProjectForActiveFrameworkAsync_ReturnsCorrectProject(string framework, string selectedConfigFramework)
         {
             var project = UnconfiguredProjectFactory.Create();
@@ -120,12 +120,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Input.Commands
                                                                                     .Add("TargetFramework", "net462"))));
 
             var projectProperties = ProjectPropertiesFactory.Create(project, data, data2);
-            var projectConfgProvider = new IActiveConfiguredProjectsProviderFactory(MockBehavior.Strict)
+            var projectConfigProvider = new IActiveConfiguredProjectsProviderFactory(MockBehavior.Strict)
                                        .ImplementGetActiveConfiguredProjectsMapAsync(projects);
 
             var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(projectProperties: projectProperties);
 
-            var debugFrameworkSvcs = new ActiveDebugFrameworkServices(projectConfgProvider.Object, commonServices);
+            var debugFrameworkSvcs = new ActiveDebugFrameworkServices(projectConfigProvider.Object, commonServices);
             var activeConfiguredProject = await debugFrameworkSvcs.GetConfiguredProjectForActiveFrameworkAsync();
             Assert.Equal(selectedConfigFramework, activeConfiguredProject.ProjectConfiguration.Dimensions.GetValueOrDefault("TargetFramework"));
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -183,7 +183,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public async Task UpdateProfiles_MergeInMemroyProfiles()
+        public async Task UpdateProfiles_MergeInMemoryProfiles()
         {
             var moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
@@ -210,7 +210,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public async Task UpdateProfiles_MergeInMemroyProfiles_AddProfileAtAend()
+        public async Task UpdateProfiles_MergeInMemoryProfiles_AddProfileAtEnd()
         {
             var moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);
@@ -239,7 +239,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         [Fact]
-        public async Task UpdateProfiles_MergeInMemroyGlobalSettings()
+        public async Task UpdateProfiles_MergeInMemoryGlobalSettings()
         {
             var moqFS = new IFileSystemMock();
             var provider = GetLaunchSettingsProvider(moqFS);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
@@ -194,7 +194,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         }
 
         [Fact]
-        public void AddEvalautionChanges_CanAddItemWithMetadata()
+        public void AddEvaluationChanges_CanAddItemWithMetadata()
         {
             var handler = CreateInstance(@"C:\Project\Project.csproj");
 
@@ -378,7 +378,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         }
 
         [Fact]
-        public void ApplyProjectEvaluationCHanges_WithExistingEvaluationChanges_CanAddChangeMetadata()
+        public void ApplyProjectEvaluationChanges_WithExistingEvaluationChanges_CanAddChangeMetadata()
         {
             var file = "A.cs";
             var handler = CreateInstanceWithEvaluationItems(@"C:\Project\Project.csproj", file);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextProviderTests.cs
@@ -161,7 +161,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
 
         [Fact]
-        public async Task CreateProjectContextAsync_ReturnsContextWithLastDesignTimeBuildSuceeededSetToFalse()
+        public async Task CreateProjectContextAsync_ReturnsContextWithLastDesignTimeBuildSucceededSetToFalse()
         {
             var context = IWorkspaceProjectContextMockFactory.Create();
             var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((_, __, ___, ____, ______, _______) => context);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/OnceInitializedOnceDisposedUnderLockAsyncTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/OnceInitializedOnceDisposedUnderLockAsyncTests.cs
@@ -154,7 +154,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         [Fact]
-        public async Task ExecuteUnderLockAsync_WhenDisposed_ThrowsOperationCancellated()
+        public async Task ExecuteUnderLockAsync_WhenDisposed_ThrowsOperationCanceled()
         {
             var instance = CreateInstance();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeStorageTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeStorageTests.cs
@@ -77,7 +77,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         [Fact]
-        public async Task CreateFolderAsync_IncludesFolderInProjectNonRecusively()
+        public async Task CreateFolderAsync_IncludesFolderInProjectNonRecursively()
         {
             bool? result = null;
             var project = UnconfiguredProjectFactory.Create(filePath: @"C:\Root.csproj");

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/AssemblyInfoPropertiesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/AssemblyInfoPropertiesProviderTests.cs
@@ -136,7 +136,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [InlineData(@"[assembly: System.Reflection.AssemblyDescriptionAttribute(""MyDescription"")]", "Company", null)]
         [InlineData(@"[assembly: System.Runtime.InteropServices.AssemblyDescriptionAttribute(true)]", "Description", null)]
         [InlineData(@"[assembly: System.Runtime.AssemblyDescriptionAttribute(""MyDescription"")]", "Description", null)]
-        public async Task SourceFileProperties_GetEvalutedPropertyAsync(string code, string propertyName, string expectedValue)
+        public async Task SourceFileProperties_GetEvaluatedPropertyAsync(string code, string propertyName, string expectedValue)
         {
             var provider = CreateProviderForSourceFileValidation(code, propertyName, out Workspace workspace);
             var projectFilePath = workspace.CurrentSolution.Projects.First().FilePath;
@@ -158,7 +158,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [InlineData(@"[assembly: System.Reflection.AssemblyDescriptionAttribute(true)]", "Description", "MyDescription", "MyDescription")]
         [InlineData(@"[assembly: System.Reflection.AssemblyDescriptionAttribute(""MyDescription""]", "Description", "", "")]
         [InlineData(@"[assembly: System.Reflection.AssemblyDescriptionAttribute(""MyDescription""]", "Description", null, null)]
-        public async Task ProjectFileProperties_GetEvalutedPropertyAsync(string code, string propertyName, string propertyValueInProjectFile, string expectedValue)
+        public async Task ProjectFileProperties_GetEvaluatedPropertyAsync(string code, string propertyName, string propertyValueInProjectFile, string expectedValue)
         {
             var provider = CreateProviderForProjectFileValidation(code, propertyName, propertyValueInProjectFile, out Workspace workspace);
             var projectFilePath = workspace.CurrentSolution.Projects.First().FilePath;
@@ -229,7 +229,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         [Theory]
         [InlineData(@"[assembly: System.Reflection.AssemblyDescriptionAttribute(""MyDescription"")]", "Description", "MyDescription")]
-        public async Task SourceFileProperties_GetUnevalutedPropertyAsync(string code, string propertyName, string expectedValue)
+        public async Task SourceFileProperties_GetUnevaluatedPropertyAsync(string code, string propertyName, string expectedValue)
         {
             var provider = CreateProviderForSourceFileValidation(code, propertyName, out Workspace workspace);
             var projectFilePath = workspace.CurrentSolution.Projects.First().FilePath;
@@ -243,7 +243,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [Theory]
         [InlineData(@"[assembly: System.Reflection.AssemblyDescriptionAttribute(""MyDescription"")]", "Description", "MyDescription2", "MyDescription2")]
         [InlineData("", "Description", "MyDescription", "MyDescription")]
-        public async Task ProjectFileProperties_GetUnevalutedPropertyAsync(string code, string propertyName, string propertyValueInProjectFile, string expectedValue)
+        public async Task ProjectFileProperties_GetUnevaluatedPropertyAsync(string code, string propertyName, string propertyValueInProjectFile, string expectedValue)
         {
             var provider = CreateProviderForProjectFileValidation(code, propertyName, propertyValueInProjectFile, out Workspace workspace);
             var projectFilePath = workspace.CurrentSolution.Projects.First().FilePath;
@@ -279,7 +279,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [InlineData(@"[assembly: System.Reflection.AssemblyInformationalVersionAttribute(""2.0.0"")]", "Version", "2.0.0", null)]
         [InlineData(@"[assembly: System.Reflection.AssemblyInformationalVersionAttribute(""2.0.1-beta1"")]", "Version", "2.0.1-beta1", null)]
         [InlineData(@"[assembly: System.Reflection.AssemblyInformationalVersionAttribute(""2016.2"")]", "Version", "2016.2", null)]
-        internal async Task SourceFileProperties_DefaultValues_GetEvalutedPropertyAsync(string code, string propertyName, string expectedValue, Type interceptingProviderType)
+        internal async Task SourceFileProperties_DefaultValues_GetEvaluatedPropertyAsync(string code, string propertyName, string expectedValue, Type interceptingProviderType)
         {
             var interceptingProvider = interceptingProviderType != null ?
                 new Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>(
@@ -308,7 +308,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [InlineData("MyApp", "Product", null, null)]
         [InlineData("MyApp", "Product", "", "")]
         [InlineData("MyApp", "Product", "ExistingValue", "ExistingValue")]
-        internal async Task ProjectFileProperties_DefaultValues_GetEvalutedPropertyAsync(string assemblyName, string propertyName, string existingPropertyValue, string expectedValue)
+        internal async Task ProjectFileProperties_DefaultValues_GetEvaluatedPropertyAsync(string assemblyName, string propertyName, string existingPropertyValue, string expectedValue)
         {
             var additionalProps = new Dictionary<string, string>() { { "AssemblyName", assemblyName } };
 
@@ -351,7 +351,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [InlineData("Version", "1.1.1", "1.0.0.0", "1.0.0.0", null)]
         [InlineData("Version", "1.0.0", "1.0.0.0", "1.0.0.0", null)]
         [InlineData("Version", null, "2016.2", "2016.2", null)]
-        internal async Task ProjectFileProperties_WithInterception_SetEvalutedPropertyAsync(string propertyName, string existingPropertyValue, string propertyValueToSet, string expectedValue, Type interceptingProviderType)
+        internal async Task ProjectFileProperties_WithInterception_SetEvaluatedPropertyAsync(string propertyName, string existingPropertyValue, string propertyValueToSet, string expectedValue, Type interceptingProviderType)
         {
             var interceptingProvider = interceptingProviderType != null ?
                 new Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/References/AlwaysAllowValidProjectReferenceCheckerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/References/AlwaysAllowValidProjectReferenceCheckerTests.cs
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.References
         [InlineData(3)]
         [InlineData(5)]
         [InlineData(10)]
-        public async Task CanAddProjectReferencesAsync_ReturnsAsManyIndivualResultsAsProjects(int count)
+        public async Task CanAddProjectReferencesAsync_ReturnsAsManyIndividualResultsAsProjects(int count)
         {
             var checker = CreateInstance();
             var referencedProjects = CreateSet(count);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Threading/Tasks/SequentialTaskExecutorTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Threading/Tasks/SequentialTaskExecutorTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.Threading.Tasks
         }
 
         [Fact]
-        public async Task EnsureNestedCallsAreExcecutedDirectly()
+        public async Task EnsureNestedCallsAreExecutedDirectly()
         {
             const int NumberOfTasks = 10;
             var sequencer = new SequentialTaskExecutor();
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.Threading.Tasks
         }
 
         [Fact]
-        public void CalltoDisposedObjectShouldThrow()
+        public void CallToDisposedObjectShouldThrow()
         {
             var sequencer = new SequentialTaskExecutor();
             sequencer.Dispose();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Threading/Tasks/TaskExtensionsTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Threading/Tasks/TaskExtensionsTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.Threading.Tasks
     public class TaskExtensionsTests
     {
         [Fact]
-        public async Task TaskExtensiosns_TryWaitForCompleteOrTimeoutTests()
+        public async Task TaskExtensions_TryWaitForCompleteOrTimeoutTests()
         {
             var t1 = TaskResult.True;
             Assert.True(await t1.TryWaitForCompleteOrTimeout(1000));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyTests.cs
@@ -126,7 +126,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         [InlineData(@"../../somepath", @"tfm1\xxx\__\__\somepath")]
         [InlineData(@"__\somepath..\", @"tfm1\xxx\__\somepath__")]
         [InlineData(@"somepath", @"tfm1\xxx\somepath")]
-        public void Dependency_Id_NoSnapsotTargetFramework(string modelId, string expectedId)
+        public void Dependency_Id_NoSnapshotTargetFramework(string modelId, string expectedId)
         {
             var mockModel = IDependencyModelFactory.Implement(providerType: "xxx", id: modelId);
             var mockSnapshot = ITargetedDependenciesSnapshotFactory.Create();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnsupportedProjectsSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnsupportedProjectsSnapshotFilterTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         public void UnsupportedProjectsSnapshotFilter_WhenDependencyNotRecognized_ShouldDoNothing()
         {
             var aggregateSnapshotProvider = IAggregateDependenciesSnapshotProviderFactory.Create();
-            var targetFRameworkProvider = ITargetFrameworkProviderFactory.Create();
+            var targetFrameworkProvider = ITargetFrameworkProviderFactory.Create();
 
             var dependency = IDependencyFactory.Implement(
                 id: "mydependency1",
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             }.ToImmutableDictionary().ToBuilder();
 
-            var filter = new UnsupportedProjectsSnapshotFilter(aggregateSnapshotProvider, targetFRameworkProvider);
+            var filter = new UnsupportedProjectsSnapshotFilter(aggregateSnapshotProvider, targetFrameworkProvider);
 
             var resultDependency = filter.BeforeAdd(
                 null,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/GroupedByTargetTreeViewProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/GroupedByTargetTreeViewProviderTests.cs
@@ -167,7 +167,7 @@ Caption=Dependency1, FilePath=tfm1\Xxx\dependencyXxxpath, IconHash=325249260, Ex
         }
 
         [Fact]
-        public async Task WhenOneTargetSnapshotAndDependencySupportsHierarchyAndIsResolved_ShouldReadd()
+        public async Task WhenOneTargetSnapshotAndDependencySupportsHierarchyAndIsResolved_ShouldRead()
         {
             var tfm1 = ITargetFrameworkFactory.Implement(moniker: "tfm1");
             var dependencyRootYyy = IDependencyFactory.FromJson(@"
@@ -250,7 +250,7 @@ Caption=DependencyExisting, FilePath=tfm1\Yyy\dependencyExistingpath, IconHash=3
         }
 
         [Fact]
-        public async Task WhenOneTargetSnapshotAndDependencySupportsHierarchyAndIsUnresolved_ShouldReadd()
+        public async Task WhenOneTargetSnapshotAndDependencySupportsHierarchyAndIsUnresolved_ShouldRead()
         {
             var dependencyRootYyy = IDependencyFactory.FromJson(@"
 {
@@ -723,7 +723,7 @@ Caption=Dependency1, FilePath=tfm1\Xxx\dependencyxxxpath, IconHash=325249260, Ex
         }
 
         [Fact]
-        public void WhenFindByPathAndNoolNode_ShouldDoNothing()
+        public void WhenFindByPathAndNullNode_ShouldDoNothing()
         {
             // Arrange
             const string projectPath = @"c:\myfolder\mysubfolder\myproject.csproj";

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/UnconfiguredProjectVsServicesTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/UnconfiguredProjectVsServicesTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     public class UnconfiguredProjectVsServicesTests
     {
         [Fact]
-        public void Constructor_ValueAsUnconfiguedProject_SetsVsHierarchyToHostObject()
+        public void Constructor_ValueAsUnconfiguredProject_SetsVsHierarchyToHostObject()
         {
             var hierarchy = IVsHierarchyFactory.Create();
             var project = UnconfiguredProjectFactory.Create(hostObject: hierarchy);
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         }
 
         [Fact]
-        public void Constructor_ValueAsUnconfiguedProject_SetsVsProjectToHostObject()
+        public void Constructor_ValueAsUnconfiguredProject_SetsVsProjectToHostObject()
         {
             var hierarchy = IVsHierarchyFactory.Create();
             var project = UnconfiguredProjectFactory.Create(hostObject: hierarchy);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Telemetry/SDKVersionTelemetryTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Telemetry/SDKVersionTelemetryTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.Telemetry
         private static SDKVersionTelemetryServiceComponent CreateComponent(Guid guid, Action<TelemetryParameters> onTelemetryLogged, string version, SemaphoreSlim semaphore)
         {
             var projectVsServices = CreateProjectServices(version);
-            var projectGuidSevice = CreateISafeProjectGuidService(guid);
+            var projectGuidService = CreateISafeProjectGuidService(guid);
             var telemetryService = CreateITelemetryService(onTelemetryLogged);
             var unconfiguredProjectTasksService = IUnconfiguredProjectTasksServiceFactory.ImplementLoadedProjectAsync(async t =>
             {
@@ -93,7 +93,7 @@ namespace Microsoft.VisualStudio.Telemetry
             });
             return new SDKVersionTelemetryServiceComponent(
                 projectVsServices,
-                projectGuidSevice,
+                projectGuidService,
                 telemetryService,
                 unconfiguredProjectTasksService);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DotNetCoreProjectCompatibilityDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DotNetCoreProjectCompatibilityDetector.cs
@@ -133,7 +133,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                         // Run on the background
                         await TaskScheduler.Default;
 
-                        VersionCompatibilityData compatData = GetVersionCmpatibilityData();
+                        VersionCompatibilityData compatData = GetVersionCompatibilityData();
 
                         // We need to check if this project has been newly created. Our projects will implement IProjectCreationState -we can 
                         // skip any that don't
@@ -173,7 +173,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 // Run on the background
                 await TaskScheduler.Default;
 
-                VersionCompatibilityData compatDataToUse = GetVersionCmpatibilityData();
+                VersionCompatibilityData compatDataToUse = GetVersionCompatibilityData();
 
                 CompatibilityLevel finalCompatLevel = CompatibilityLevel.Recommended;
                 IProjectService projectService = _projectServiceAccessor.Value.GetProjectService();
@@ -347,7 +347,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         /// less than 24 hours old, it uses that data. Otherwise it downloads from the server. If the download fails it will use the previously cached
         ///  file, or if that file doesn't not exist, it uses the data baked into this class
         /// </summary>
-        private VersionCompatibilityData GetVersionCmpatibilityData()
+        private VersionCompatibilityData GetVersionCompatibilityData()
         {
             // Do we need to update our cached data? Note that since the download could take a long time like tens of seconds we don't really want to
             // start showing messages to the user well after their project is opened and they are interacting with it. Thus we start a task to update the 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
@@ -606,7 +606,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             IWritableLaunchSettings newSettings = profiles.ToWritableLaunchSettings();
 
             // Since this get's reentered if the user saves or the user switches active profiles.
-            if (CurrentLaunchSettings != null && !CurrentLaunchSettings.SetttingsDiffer(newSettings))
+            if (CurrentLaunchSettings != null && !CurrentLaunchSettings.SettingsDiffer(newSettings))
             {
                 return;
             }
@@ -759,12 +759,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         }
 
 
-        private ICommand _addEnironmentVariableRowCommand;
+        private ICommand _addEnvironmentVariableRowCommand;
         public ICommand AddEnvironmentVariableRowCommand
         {
             get
             {
-                return LazyInitializer.EnsureInitialized(ref _addEnironmentVariableRowCommand, () =>
+                return LazyInitializer.EnsureInitialized(ref _addEnvironmentVariableRowCommand, () =>
                     new DelegateCommand((state) =>
                     {
                         var newRow = new NameValuePair(PropertyPageResources.EnvVariableNameWatermark, PropertyPageResources.EnvVariableValueWatermark, EnvironmentVariables);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WatermarkStyle.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WatermarkStyle.xaml
@@ -7,7 +7,7 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ui:WatermarkTextBox}">
-                    <Border x:Name="WarterMarkTextBoxBorder"
+                    <Border x:Name="WaterMarkTextBoxBorder"
                             Background="{TemplateBinding Background}"
                             BorderBrush="{TemplateBinding BorderBrush}"
                             BorderThickness="{TemplateBinding BorderThickness}"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/GetChildrenGraphActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/GetChildrenGraphActionHandler.cs
@@ -25,8 +25,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
 
         [ImportingConstructor]
         public GetChildrenGraphActionHandler(IDependenciesGraphBuilder builder,
-                                             IAggregateDependenciesSnapshotProvider aggregateSnpahostProvider)
-            : base(builder, aggregateSnpahostProvider)
+                                             IAggregateDependenciesSnapshotProvider aggregateSnapshotProvider)
+            : base(builder, aggregateSnapshotProvider)
         {
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GroupedByTargetTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GroupedByTargetTreeViewProvider.cs
@@ -174,7 +174,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Func<IProjectTree, IEnumerable<IProjectTree>, IProjectTree> syncFunc)
         {
             var currentNodes = new List<IProjectTree>();
-            var grouppedByProviderType = new Dictionary<string, List<IDependency>>(StringComparer.OrdinalIgnoreCase);
+            var groupedByProviderType = new Dictionary<string, List<IDependency>>(StringComparer.OrdinalIgnoreCase);
             foreach (IDependency dependency in targetedSnapshot.TopLevelDependencies)
             {
                 if (!dependency.Visible)
@@ -183,23 +183,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     {
                         // if provider sends special invisible node with flag ShowEmptyProviderRootNode, we 
                         // need to show provider node even if it does not have any dependencies.
-                        grouppedByProviderType.Add(dependency.ProviderType, new List<IDependency>());
+                        groupedByProviderType.Add(dependency.ProviderType, new List<IDependency>());
                     }
 
                     continue;
                 }
 
-                if (!grouppedByProviderType.TryGetValue(dependency.ProviderType, out List<IDependency> dependencies))
+                if (!groupedByProviderType.TryGetValue(dependency.ProviderType, out List<IDependency> dependencies))
                 {
                     dependencies = new List<IDependency>();
-                    grouppedByProviderType.Add(dependency.ProviderType, dependencies);
+                    groupedByProviderType.Add(dependency.ProviderType, dependencies);
                 }
 
                 dependencies.Add(dependency);
             }
 
             bool isActiveTarget = targetedSnapshot.TargetFramework.Equals(activeTarget);
-            foreach (KeyValuePair<string, List<IDependency>> dependencyGroup in grouppedByProviderType)
+            foreach (KeyValuePair<string, List<IDependency>> dependencyGroup in groupedByProviderType)
             {
                 IDependencyViewModel subTreeViewModel = ViewModelFactory.CreateRootViewModel(
                     dependencyGroup.Key, targetedSnapshot.CheckForUnresolvedDependencies(dependencyGroup.Key));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SDKVersionTelemetryServiceComponent.SDKVersionTelemetryServiceInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SDKVersionTelemetryServiceComponent.SDKVersionTelemetryServiceInstance.cs
@@ -19,20 +19,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             private const string NETCoreSdkVersionProperty = "NETCoreSdkVersion";
 
             private readonly IUnconfiguredProjectVsServices _projectVsServices;
-            private readonly ISafeProjectGuidService _projectGuidSevice;
+            private readonly ISafeProjectGuidService _projectGuidService;
             private readonly ITelemetryService _telemetryService;
             private readonly IUnconfiguredProjectTasksService _unconfiguredProjectTasksService;
 
             [ImportingConstructor]
             public SDKVersionTelemetryServiceInstance(
                 IUnconfiguredProjectVsServices projectVsServices,
-                ISafeProjectGuidService projectGuidSevice,
+                ISafeProjectGuidService projectGuidService,
                 ITelemetryService telemetryService,
                 IUnconfiguredProjectTasksService unconfiguredProjectTasksService)
                 : base(projectVsServices.ThreadingService.JoinableTaskContext)
             {
                 _projectVsServices = projectVsServices;
-                _projectGuidSevice = projectGuidSevice;
+                _projectGuidService = projectGuidService;
                 _telemetryService = telemetryService;
                 _unconfiguredProjectTasksService = unconfiguredProjectTasksService;
             }
@@ -74,7 +74,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             private async Task<string> GetProjectIdAsync()
             {
-                Guid projectGuid = await _projectGuidSevice.GetProjectGuidAsync();
+                Guid projectGuid = await _projectGuidService.GetProjectGuidAsync();
                 return projectGuid == Guid.Empty ? null : projectGuid.ToString();
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SDKVersionTelemetryServiceComponent.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SDKVersionTelemetryServiceComponent.cs
@@ -15,19 +15,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     {
         private readonly IUnconfiguredProjectVsServices _projectVsServices;
         private readonly ITelemetryService _telemetryService;
-        private readonly ISafeProjectGuidService _projectGuidSevice;
+        private readonly ISafeProjectGuidService _projectGuidService;
         private readonly IUnconfiguredProjectTasksService _unconfiguredProjectTasksService;
 
         [ImportingConstructor]
         public SDKVersionTelemetryServiceComponent(
             IUnconfiguredProjectVsServices projectVsServices,
-            ISafeProjectGuidService projectGuidSevice,
+            ISafeProjectGuidService projectGuidService,
             ITelemetryService telemetryService,
             IUnconfiguredProjectTasksService unconfiguredProjectTasksService)
             : base(projectVsServices.ThreadingService.JoinableTaskContext)
         {
             _projectVsServices = projectVsServices;
-            _projectGuidSevice = projectGuidSevice;
+            _projectGuidService = projectGuidService;
             _telemetryService = telemetryService;
             _unconfiguredProjectTasksService = unconfiguredProjectTasksService;
         }
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         protected override IMultiLifetimeInstance CreateInstance()
             => new SDKVersionTelemetryServiceInstance(
                 _projectVsServices,
-                _projectGuidSevice,
+                _projectGuidService,
                 _telemetryService,
                 _unconfiguredProjectTasksService);
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
@@ -69,21 +69,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         private readonly Dictionary<string, bool> _unresolvedDescendantsMap
             = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
 
-        private bool? _hasUresolvedDependency;
+        private bool? _hasUnresolvedDependency;
         public bool HasUnresolvedDependency
         {
             get
             {
-                if (_hasUresolvedDependency == null)
+                if (_hasUnresolvedDependency == null)
                 {
-                    _hasUresolvedDependency = TopLevelDependencies.Any(x => !x.Resolved);
-                    if (!_hasUresolvedDependency.Value)
+                    _hasUnresolvedDependency = TopLevelDependencies.Any(x => !x.Resolved);
+                    if (!_hasUnresolvedDependency.Value)
                     {
-                        _hasUresolvedDependency = DependenciesWorld.Values.Any(x => !x.Resolved);
+                        _hasUnresolvedDependency = DependenciesWorld.Values.Any(x => !x.Resolved);
                     }
                 }
 
-                return _hasUresolvedDependency.Value;
+                return _hasUnresolvedDependency.Value;
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
@@ -125,8 +125,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         private async Task HandleAsync(
             IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectSharedFoldersSnapshot, IProjectCatalogSnapshot>> e)
         {
-            AggregateCrossTargetProjectContext currentAggregaceContext = await _host.GetCurrentAggregateProjectContext();
-            if (currentAggregaceContext == null)
+            AggregateCrossTargetProjectContext currentAggregateContext = await _host.GetCurrentAggregateProjectContext();
+            if (currentAggregateContext == null)
             {
                 return;
             }
@@ -141,7 +141,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             using (await _gate.DisposableWaitAsync())
             {
                 // Get the inner workspace project context to update for this change.
-                ITargetedProjectContext projectContextToUpdate = currentAggregaceContext
+                ITargetedProjectContext projectContextToUpdate = currentAggregateContext
                     .GetInnerProjectContext(projectUpdate.ProjectConfiguration, out bool isActiveContext);
                 if (projectContextToUpdate == null)
                 {
@@ -149,7 +149,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
                 }
 
                 var dependencyChangeContext = new DependenciesRuleChangeContext(
-                        currentAggregaceContext.ActiveProjectContext.TargetFramework, catalogs);
+                        currentAggregateContext.ActiveProjectContext.TargetFramework, catalogs);
 
                 ProcessSharedProjectsUpdates(sharedProjectsUpdate, projectContextToUpdate, dependencyChangeContext);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugTokenReplacer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugTokenReplacer.cs
@@ -19,10 +19,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     {
 
         [ImportingConstructor]
-        public DebugTokenReplacer(IUnconfiguredProjectCommonServices unconnfiguredServices, IEnvironmentHelper environmentHelper,
+        public DebugTokenReplacer(IUnconfiguredProjectCommonServices unconfiguredServices, IEnvironmentHelper environmentHelper,
                                   IActiveDebugFrameworkServices activeDebugFrameworkService, IProjectAccessor projectAccessor)
         {
-            UnconfiguredServices = unconnfiguredServices;
+            UnconfiguredServices = unconfiguredServices;
             EnvironmentHelper = environmentHelper;
             ActiveDebugFrameworkService = activeDebugFrameworkService;
             ProjectAccessor = projectAccessor;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettings.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettings.cs
@@ -53,9 +53,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             GlobalSettings = ImmutableStringDictionary<object>.EmptyOrdinal;
             foreach (KeyValuePair<string, object> kvp in settings.GlobalSettings)
             {
-                if (kvp.Value is ICloneable clonableObject)
+                if (kvp.Value is ICloneable cloneableObject)
                 {
-                    GlobalSettings = GlobalSettings.Add(kvp.Key, clonableObject.Clone());
+                    GlobalSettings = GlobalSettings.Add(kvp.Key, cloneableObject.Clone());
                 }
                 else
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/WritableLaunchSettings.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/WritableLaunchSettings.cs
@@ -33,9 +33,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             {
                 foreach (KeyValuePair<string, object> kvp in settings.GlobalSettings)
                 {
-                    if (kvp.Value is ICloneable clonableObject)
+                    if (kvp.Value is ICloneable cloneableObject)
                     {
-                        GlobalSettings.Add(kvp.Key, clonableObject.Clone());
+                        GlobalSettings.Add(kvp.Key, cloneableObject.Clone());
                     }
                     else
                     {
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
     internal static class WritableLaunchSettingsExtension
     {
-        public static bool SetttingsDiffer(this IWritableLaunchSettings launchSettings, IWritableLaunchSettings settingsToCompare)
+        public static bool SettingsDiffer(this IWritableLaunchSettings launchSettings, IWritableLaunchSettings settingsToCompare)
         {
             if (launchSettings.Profiles.Count != settingsToCompare.Profiles.Count)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/ITaskDelayScheduler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/ITaskDelayScheduler.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.Threading.Tasks
         /// the cancellation of the current scheduled task, the caller will not know
         /// and need to use that latest return task instead.
         /// </summary>
-        JoinableTask ScheduleAsyncTask(Func<CancellationToken, Task> asyncFnctionToCall);
+        JoinableTask ScheduleAsyncTask(Func<CancellationToken, Task> asyncFunctionToCall);
 
         /// <summary>
         /// Returns true if updates are pending

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/TaskDelayScheduler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/TaskDelayScheduler.cs
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.Threading.Tasks
         /// the cancellation of the current scheduled task, the caller will not know
         /// and need to use that latest returned task instead.
         /// </summary>
-        public JoinableTask ScheduleAsyncTask(Func<CancellationToken, Task> asyncFnctionToCall)
+        public JoinableTask ScheduleAsyncTask(Func<CancellationToken, Task> asyncFunctionToCall)
         {
             lock (_syncObject)
             {
@@ -66,12 +66,12 @@ namespace Microsoft.VisualStudio.Threading.Tasks
                 CancellationToken token = PendingUpdateTokenSource.Token;
 
                 // We want to return a joinable task so wrap the function
-                LatestScheduledTask = _threadingService.JoinableTaskFactory.RunAsync(() => ThrottleAsync(asyncFnctionToCall, token));
+                LatestScheduledTask = _threadingService.JoinableTaskFactory.RunAsync(() => ThrottleAsync(asyncFunctionToCall, token));
                 return LatestScheduledTask;
             }
         }
 
-        private async Task ThrottleAsync(Func<CancellationToken, Task> asyncFnctionToCall, CancellationToken token)
+        private async Task ThrottleAsync(Func<CancellationToken, Task> asyncFunctionToCall, CancellationToken token)
         {
             try
             {
@@ -104,7 +104,7 @@ namespace Microsoft.VisualStudio.Threading.Tasks
             }
 
             // Execute the code
-            await asyncFnctionToCall(token);
+            await asyncFunctionToCall(token);
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/LanguageServices/VisualBasicCodeDomProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/LanguageServices/VisualBasicCodeDomProviderTests.cs
@@ -15,12 +15,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         [Fact]
         public void UnconfiguredProject_CanGetSet()
         {
-            var unconfiguedProject = UnconfiguredProjectFactory.Create();
+            var unconfiguredProject = UnconfiguredProjectFactory.Create();
             var provider = CreateInstance();
 
-            provider.Project = unconfiguedProject;
+            provider.Project = unconfiguredProject;
 
-            Assert.Same(unconfiguedProject, provider.Project);
+            Assert.Same(unconfiguredProject, provider.Project);
         }
 
         private static VisualBasicCodeDomProvider CreateInstance()

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Properties/VisualBasicProjectDesignerPageProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Properties/VisualBasicProjectDesignerPageProviderTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
-        public async Task GetPagesAsync_WhenAllCapabiltiesPresent_ReturnsPagesInOrder()
+        public async Task GetPagesAsync_WhenAllCapabilitiesPresent_ReturnsPagesInOrder()
         {
             var provider = CreateInstance(ProjectCapability.LaunchProfiles, ProjectCapability.Pack);
             var result = await provider.GetPagesAsync();

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Rename/VisualBasicSimpleRenameTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Rename/VisualBasicSimpleRenameTests.cs
@@ -65,13 +65,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
         [InlineData("Foo.vb", "Folder1\\foo.vb",
                     @"Class Foo
                       End Class")]
-        public async Task Rename_Symbol_Should_Not_HappenAsync(string oldFilePath, string newFilePath, string soureCode)
+        public async Task Rename_Symbol_Should_Not_HappenAsync(string oldFilePath, string newFilePath, string sourceCode)
         {
 
             var userNotificationServices = IUserNotificationServicesFactory.Create();
             var roslynServices = IRoslynServicesFactory.Implement(new VisualBasicSyntaxFactsService(null));
 
-            await RenameAsync(soureCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, LanguageNames.VisualBasic);
+            await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, LanguageNames.VisualBasic);
 
             Mock.Get(userNotificationServices).Verify(h => h.Confirm(It.IsAny<string>()), Times.Never);
             Mock.Get(roslynServices).Verify(h => h.RenameSymbolAsync(It.IsAny<Solution>(), It.IsAny<ISymbol>(), It.IsAny<string>()), Times.Never);
@@ -112,23 +112,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
                 Class Foo
                 End Class
             End Namespace")]
-        public async Task Rename_Symbol_Should_TriggerUserConfirmationAsync(string oldFilePath, string newFilePath, string soureCode)
+        public async Task Rename_Symbol_Should_TriggerUserConfirmationAsync(string oldFilePath, string newFilePath, string sourceCode)
         {
             var userNotificationServices = IUserNotificationServicesFactory.Create();
             var roslynServices = IRoslynServicesFactory.Implement(new VisualBasicSyntaxFactsService(null));
 
-            await RenameAsync(soureCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, LanguageNames.VisualBasic);
+            await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, LanguageNames.VisualBasic);
 
             Mock.Get(userNotificationServices).Verify(h => h.Confirm(It.IsAny<string>()), Times.Once);
             Mock.Get(roslynServices).Verify(h => h.RenameSymbolAsync(It.IsAny<Solution>(), It.IsAny<ISymbol>(), It.IsAny<string>()), Times.Never);
         }
 
-        internal async Task RenameAsync(string soureCode, string oldFilePath, string newFilePath, IUserNotificationServices userNotificationServices, IRoslynServices roslynServices, string language)
+        internal async Task RenameAsync(string sourceCode, string oldFilePath, string newFilePath, IUserNotificationServices userNotificationServices, IRoslynServices roslynServices, string language)
         {
             using (var ws = new AdhocWorkspace())
             {
                 var projectId = ProjectId.CreateNewId();
-                Solution solution = ws.AddSolution(InitializeWorkspace(projectId, newFilePath, soureCode, language));
+                Solution solution = ws.AddSolution(InitializeWorkspace(projectId, newFilePath, sourceCode, language));
                 Project project = (from d in solution.Projects where d.Id == projectId select d).FirstOrDefault();
 
                 var environmentOptionsFactory = IEnvironmentOptionsFactory.Implement((string category, string page, string property, bool defaultValue) => { return true; });

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/VisualBasicProjectTypeGuidProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/VisualBasicProjectTypeGuidProviderTests.cs
@@ -20,9 +20,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         private static VisualBasicProjectTypeGuidProvider CreateInstance()
         {
-            var unconfiguedProject = UnconfiguredProjectFactory.Create();
+            var unconfiguredProject = UnconfiguredProjectFactory.Create();
 
-            return new VisualBasicProjectTypeGuidProvider(unconfiguedProject);
+            return new VisualBasicProjectTypeGuidProvider(unconfiguredProject);
         }
     }
 }


### PR DESCRIPTION
Another pass at typos, this time in identifiers (riskier than in comments/docs) and this time watching brownbags.

I believe all changed identifiers are either local, private, internal or test names, and therefore that there are no breaking API changes here.

