### PR TITLE
Remove menus that already exist in CPS

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Menus.vsct
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Menus.vsct
@@ -71,12 +71,6 @@
     </Menus>
 
     <Groups>
-      <Group guid="guidSHLMainMenu" id="IDG_VS_CTXT_PROJECT_EDITFILE" priority="0x0180">
-        <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_PROJNODE"/>
-      </Group>
-      <Group guid="guidSHLMainMenu" id="IDG_VS_CTXT_PROJECT_EDITFILE" priority="0x0180">
-        <Parent guid="guidSHLMainMenu" id="IDM_VS_MENU_PROJECT"/>
-      </Group>
       <!-- Group added to the Debugging Framework Type menu on the debug controller -->
       <Group guid="guidManagedProjectSystemCommandSet" id="DebugTargetMenuDebugFrameworkGroup" priority="0x0100">
         <Parent guid="guidManagedProjectSystemCommandSet" id="DebugTargetMenuDebugFrameworkMenu"/>


### PR DESCRIPTION
These menus are defined in CPS so we don't need them. Verified edit project menu items work in context menu and Project menu after this change.