### PR TITLE
Update to codecov.exe that supports gzip

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -17,7 +17,7 @@
     <MicrosoftNetCompilersVersion>2.6.1</MicrosoftNetCompilersVersion>
     <MicrosoftDiaSymReaderPdb2PdbVersion>1.1.0-beta1-62624-01</MicrosoftDiaSymReaderPdb2PdbVersion>
     <OpenCoverVersion>4.6.519</OpenCoverVersion>
-    <CodecovVersion>1.0.3</CodecovVersion>
+    <CodecovVersion>1.1.0</CodecovVersion>
    
     <!--
       TODO:


### PR DESCRIPTION
Cherry-pick of https://github.com/dotnet/project-system/pull/3942 to fix code coverage for 15.9.