### PR TITLE
[LanguageService] Fix "fixed" capabilities not being set

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapability.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapability.cs
@@ -33,10 +33,10 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public const string PackageReferences = ProjectCapabilities.PackageReferences;
         public const string PreserveFormatting = nameof(PreserveFormatting);
         public const string ProjectConfigurationsDeclaredDimensions = ProjectCapabilities.ProjectConfigurationsDeclaredDimensions;
-        public const string LanguageService = "(LanguageService & !LanguageService2)";
-        public const string LanguageService2 = "(!LanguageService & LanguageService2)";
-        public const string DotNetLanguageService = DotNet + " & " + LanguageService;
-        public const string DotNetLanguageService2 = DotNet + " & " + LanguageService2;
+        public const string LanguageService = nameof(LanguageService);
+        public const string LanguageService2 = nameof(LanguageService2);
+        public const string DotNetLanguageService = DotNet + " & (LanguageService & !LanguageService2)";        // Temporary until we turn new language service hookup
+        public const string DotNetLanguageService2 = DotNet + " & (!LanguageService & LanguageService2)";
         public const string SortByDisplayOrder = ProjectCapabilities.SortByDisplayOrder;
         public const string DotNet = ".NET";
     }


### PR DESCRIPTION
We pass LanguageService as a fixed capability to CPS - but rather as raw capability it was an expression which caused them to ignore the capabilites. Fix it so that we continue to pass raw capability to project factory.