### PR TITLE
Plumb through IsActiveContext

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IActiveWorkspaceProjectContextTrackerFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IActiveWorkspaceProjectContextTrackerFactory.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
+{
+    internal static class IActiveWorkspaceProjectContextTrackerFactory
+    {
+        public static IActiveWorkspaceProjectContextTracker Create()
+        {
+            return Mock.Of<IActiveWorkspaceProjectContextTracker>();
+        }
+
+        public static IActiveWorkspaceProjectContextTracker ImplementIsActiveContext(Func<IWorkspaceProjectContext, bool> action)
+        {
+            var mock = new Mock<IActiveWorkspaceProjectContextTracker>();
+            mock.Setup(t => t.IsActiveContext(It.IsAny<IWorkspaceProjectContext>()))
+                .Returns(action);
+
+            return mock.Object;
+        }
+
+        public static IActiveWorkspaceProjectContextTracker ImplementReleaseContext(Action<IWorkspaceProjectContext> action)
+        {
+            var mock = new Mock<IActiveWorkspaceProjectContextTracker>();
+            mock.Setup(t => t.UnregisterContext(It.IsAny<IWorkspaceProjectContext>()))
+                .Callback(action);
+
+            return mock.Object;
+        }
+
+        public static IActiveWorkspaceProjectContextTracker ImplementRegisterContext(Action<IWorkspaceProjectContext, string> action)
+        {
+            var mock = new Mock<IActiveWorkspaceProjectContextTracker>();
+            mock.Setup(t => t.RegisterContext(It.IsAny<IWorkspaceProjectContext>(), It.IsAny<string>()))
+                .Callback(action);
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextProviderTests.cs
@@ -189,6 +189,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
 
         [Fact]
+        public async Task CreateProjectContextAsync_RegistersContextWithTracker()
+        {
+            IWorkspaceProjectContext result = null;
+            var activeWorkspaceProjectContextTracker = IActiveWorkspaceProjectContextTrackerFactory.ImplementRegisterContext((c, id) => { result = c; });
+
+            var context = IWorkspaceProjectContextMockFactory.Create();
+            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((_, __, ___, ____, ______, _______) => context);
+            var provider = CreateInstance(workspaceProjectContextFactory: workspaceProjectContextFactory, activeWorkspaceProjectContextTracker: activeWorkspaceProjectContextTracker);
+
+            var project = ConfiguredProjectFactory.ImplementProjectConfiguration("Debug|AnyCPU");
+
+            await provider.CreateProjectContextAsync(project);
+
+            Assert.NotNull(result);
+        }
+
+        [Fact]
         public async Task ReleaseProjectContextAsync_DisposesContext()
         {
             var provider = CreateInstance();
@@ -202,6 +219,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
 
         [Fact]
+        public async Task ReleaseProjectContextAsync_UnregistersContextWithTracker()
+        {
+            IWorkspaceProjectContext result = null;
+            var activeWorkspaceProjectContextTracker = IActiveWorkspaceProjectContextTrackerFactory.ImplementReleaseContext(c => { result = c; });
+
+            var provider = CreateInstance(activeWorkspaceProjectContextTracker: activeWorkspaceProjectContextTracker);
+
+            var projectContext = IWorkspaceProjectContextMockFactory.Create();
+
+            await provider.ReleaseProjectContextAsync(projectContext);
+
+            Assert.Same(projectContext, result);
+        }
+
+        [Fact]
         public async Task ReleaseProjectContextAsync_WhenContextThrows_SwallowsException()
         {
             var provider = CreateInstance();
@@ -211,7 +243,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             await provider.ReleaseProjectContextAsync(projectContext);
         }
 
-        private static WorkspaceProjectContextProvider CreateInstance(UnconfiguredProject project = null, IProjectThreadingService threadingService = null, IWorkspaceProjectContextFactory workspaceProjectContextFactory = null, ISafeProjectGuidService projectGuidService = null, IProjectRuleSnapshot projectRuleSnapshot = null)
+        private static WorkspaceProjectContextProvider CreateInstance(UnconfiguredProject project = null, IProjectThreadingService threadingService = null, IWorkspaceProjectContextFactory workspaceProjectContextFactory = null, IActiveWorkspaceProjectContextTracker activeWorkspaceProjectContextTracker = null, ISafeProjectGuidService projectGuidService = null, IProjectRuleSnapshot projectRuleSnapshot = null)
         {
             projectRuleSnapshot = projectRuleSnapshot ?? IProjectRuleSnapshotFactory.FromJson(
 @"{
@@ -226,9 +258,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             project = project ?? UnconfiguredProjectFactory.Create();
             threadingService = threadingService ?? IProjectThreadingServiceFactory.Create();
             workspaceProjectContextFactory = workspaceProjectContextFactory ?? IWorkspaceProjectContextFactoryFactory.Create();
+            activeWorkspaceProjectContextTracker = activeWorkspaceProjectContextTracker ?? IActiveWorkspaceProjectContextTrackerFactory.Create();
             projectGuidService = projectGuidService ?? ISafeProjectGuidServiceFactory.ImplementGetProjectGuidAsync(Guid.NewGuid());
 
-            var mock = new Mock<WorkspaceProjectContextProvider>(project, threadingService, projectGuidService, telemetryService, workspaceProjectContextFactory.AsLazy());
+            var mock = new Mock<WorkspaceProjectContextProvider>(project, threadingService, projectGuidService, telemetryService, workspaceProjectContextFactory.AsLazy(), activeWorkspaceProjectContextTracker);
             mock.Protected().Setup<Task<IProjectRuleSnapshot>>("GetLatestSnapshotAsync", ItExpr.IsAny<ConfiguredProject>())
                             .ReturnsAsync(projectRuleSnapshot);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceContextHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceContextHost.cs
@@ -21,6 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         private readonly IUnconfiguredProjectTasksService _tasksService;
         private readonly IProjectSubscriptionService _projectSubscriptionService;
         private readonly Lazy<IWorkspaceProjectContextProvider> _workspaceProjectContextProvider;
+        private readonly IActiveWorkspaceProjectContextTracker _activeWorkspaceProjectContextTracker;
         private readonly ExportFactory<IApplyChangesToWorkspaceContext> _applyChangesToWorkspaceContextFactory;
 
         [ImportingConstructor]
@@ -29,6 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                                     IUnconfiguredProjectTasksService tasksService,
                                     IProjectSubscriptionService projectSubscriptionService,
                                     Lazy<IWorkspaceProjectContextProvider> workspaceProjectContextProvider,
+                                    IActiveWorkspaceProjectContextTracker activeWorkspaceProjectContextTracker,
                                     ExportFactory<IApplyChangesToWorkspaceContext> applyChangesToWorkspaceContextFactory)
             : base(threadingService.JoinableTaskContext)
         {
@@ -37,6 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             _tasksService = tasksService;
             _projectSubscriptionService = projectSubscriptionService;
             _workspaceProjectContextProvider = workspaceProjectContextProvider;
+            _activeWorkspaceProjectContextTracker = activeWorkspaceProjectContextTracker;
             _applyChangesToWorkspaceContextFactory = applyChangesToWorkspaceContextFactory;
         }
 
@@ -52,7 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         protected override IMultiLifetimeInstance CreateInstance()
         {
-            return new WorkspaceContextHostInstance(_project, _threadingService, _tasksService, _projectSubscriptionService, _workspaceProjectContextProvider, _applyChangesToWorkspaceContextFactory);
+            return new WorkspaceContextHostInstance(_project, _threadingService, _tasksService, _projectSubscriptionService, _workspaceProjectContextProvider, _activeWorkspaceProjectContextTracker, _applyChangesToWorkspaceContextFactory);
         }
     }
 }


### PR DESCRIPTION
Register/Unregister the context when it is created so that the host can now query if the context is hosting is the active one.