### PR TITLE
Remove laziness of services

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IActiveWorkspaceProjectContextTrackerFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IActiveWorkspaceProjectContextTrackerFactory.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
+{
+    internal static class IActiveWorkspaceProjectContextTrackerFactory
+    {
+        public static IActiveWorkspaceProjectContextTracker Create()
+        {
+            return Mock.Of<IActiveWorkspaceProjectContextTracker>();
+        }
+
+        public static IActiveWorkspaceProjectContextTracker ImplementIsActiveContext(Func<IWorkspaceProjectContext, bool> action)
+        {
+            var mock = new Mock<IActiveWorkspaceProjectContextTracker>();
+            mock.Setup(t => t.IsActiveContext(It.IsAny<IWorkspaceProjectContext>()))
+                .Returns(action);
+
+            return mock.Object;
+        }
+
+        public static IActiveWorkspaceProjectContextTracker ImplementReleaseContext(Action<IWorkspaceProjectContext> action)
+        {
+            var mock = new Mock<IActiveWorkspaceProjectContextTracker>();
+            mock.Setup(t => t.UnregisterContext(It.IsAny<IWorkspaceProjectContext>()))
+                .Callback(action);
+
+            return mock.Object;
+        }
+
+        public static IActiveWorkspaceProjectContextTracker ImplementRegisterContext(Action<IWorkspaceProjectContext, string> action)
+        {
+            var mock = new Mock<IActiveWorkspaceProjectContextTracker>();
+            mock.Setup(t => t.RegisterContext(It.IsAny<IWorkspaceProjectContext>(), It.IsAny<string>()))
+                .Callback(action);
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceContextHostInstanceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceContextHostInstanceTests.cs
@@ -178,7 +178,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                                                     threadingService,
                                                     tasksService,
                                                     projectSubscriptionService,
-                                                    workspaceProjectContextProvider.AsLazy(),
+                                                    workspaceProjectContextProvider,
                                                     activeWorkspaceProjectContextTracker,
                                                     ExportFactoryFactory.ImplementCreateValueWithAutoDispose(() => applyChangesToWorkspaceContext));
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextProviderTests.cs
@@ -189,6 +189,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
 
         [Fact]
+        public async Task CreateProjectContextAsync_RegistersContextWithTracker()
+        {
+            IWorkspaceProjectContext result = null;
+            var activeWorkspaceProjectContextTracker = IActiveWorkspaceProjectContextTrackerFactory.ImplementRegisterContext((c, id) => { result = c; });
+
+            var context = IWorkspaceProjectContextMockFactory.Create();
+            var workspaceProjectContextFactory = IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext((_, __, ___, ____, ______, _______) => context);
+            var provider = CreateInstance(workspaceProjectContextFactory: workspaceProjectContextFactory, activeWorkspaceProjectContextTracker: activeWorkspaceProjectContextTracker);
+
+            var project = ConfiguredProjectFactory.ImplementProjectConfiguration("Debug|AnyCPU");
+
+            await provider.CreateProjectContextAsync(project);
+
+            Assert.NotNull(result);
+        }
+
+        [Fact]
         public async Task ReleaseProjectContextAsync_DisposesContext()
         {
             var provider = CreateInstance();
@@ -202,6 +219,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         }
 
         [Fact]
+        public async Task ReleaseProjectContextAsync_UnregistersContextWithTracker()
+        {
+            IWorkspaceProjectContext result = null;
+            var activeWorkspaceProjectContextTracker = IActiveWorkspaceProjectContextTrackerFactory.ImplementReleaseContext(c => { result = c; });
+
+            var provider = CreateInstance(activeWorkspaceProjectContextTracker: activeWorkspaceProjectContextTracker);
+
+            var projectContext = IWorkspaceProjectContextMockFactory.Create();
+
+            await provider.ReleaseProjectContextAsync(projectContext);
+
+            Assert.Same(projectContext, result);
+        }
+
+        [Fact]
         public async Task ReleaseProjectContextAsync_WhenContextThrows_SwallowsException()
         {
             var provider = CreateInstance();
@@ -211,7 +243,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             await provider.ReleaseProjectContextAsync(projectContext);
         }
 
-        private static WorkspaceProjectContextProvider CreateInstance(UnconfiguredProject project = null, IProjectThreadingService threadingService = null, IWorkspaceProjectContextFactory workspaceProjectContextFactory = null, ISafeProjectGuidService projectGuidService = null, IProjectRuleSnapshot projectRuleSnapshot = null)
+        private static WorkspaceProjectContextProvider CreateInstance(UnconfiguredProject project = null, IProjectThreadingService threadingService = null, IWorkspaceProjectContextFactory workspaceProjectContextFactory = null, IActiveWorkspaceProjectContextTracker activeWorkspaceProjectContextTracker = null, ISafeProjectGuidService projectGuidService = null, IProjectRuleSnapshot projectRuleSnapshot = null)
         {
             projectRuleSnapshot = projectRuleSnapshot ?? IProjectRuleSnapshotFactory.FromJson(
 @"{
@@ -226,9 +258,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             project = project ?? UnconfiguredProjectFactory.Create();
             threadingService = threadingService ?? IProjectThreadingServiceFactory.Create();
             workspaceProjectContextFactory = workspaceProjectContextFactory ?? IWorkspaceProjectContextFactoryFactory.Create();
+            activeWorkspaceProjectContextTracker = activeWorkspaceProjectContextTracker ?? IActiveWorkspaceProjectContextTrackerFactory.Create();
             projectGuidService = projectGuidService ?? ISafeProjectGuidServiceFactory.ImplementGetProjectGuidAsync(Guid.NewGuid());
 
-            var mock = new Mock<WorkspaceProjectContextProvider>(project, threadingService, projectGuidService, telemetryService, workspaceProjectContextFactory.AsLazy());
+            var mock = new Mock<WorkspaceProjectContextProvider>(project, threadingService, projectGuidService, telemetryService, workspaceProjectContextFactory.AsLazy(), activeWorkspaceProjectContextTracker);
             mock.Protected().Setup<Task<IProjectRuleSnapshot>>("GetLatestSnapshotAsync", ItExpr.IsAny<ConfiguredProject>())
                             .ReturnsAsync(projectRuleSnapshot);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceContextHost.WorkspaceContextHostInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceContextHost.WorkspaceContextHostInstance.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.ComponentModel.Composition;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             private readonly IProjectSubscriptionService _projectSubscriptionService;
             private readonly IProjectThreadingService _threadingService;
             private readonly IUnconfiguredProjectTasksService _tasksService;
-            private readonly Lazy<IWorkspaceProjectContextProvider> _workspaceProjectContextProvider;
+            private readonly IWorkspaceProjectContextProvider _workspaceProjectContextProvider;
             private readonly IActiveWorkspaceProjectContextTracker _activeWorkspaceProjectContextTracker;
             private readonly ExportFactory<IApplyChangesToWorkspaceContext> _applyChangesToWorkspaceContextFactory;
 
@@ -34,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                                                 IProjectThreadingService threadingService,
                                                 IUnconfiguredProjectTasksService tasksService,
                                                 IProjectSubscriptionService projectSubscriptionService,
-                                                Lazy<IWorkspaceProjectContextProvider> workspaceProjectContextProvider,
+                                                IWorkspaceProjectContextProvider workspaceProjectContextProvider,
                                                 IActiveWorkspaceProjectContextTracker activeWorkspaceProjectContextTracker,
                                                 ExportFactory<IApplyChangesToWorkspaceContext> applyChangesToWorkspaceContextFactory)
                 : base(threadingService.JoinableTaskContext)
@@ -55,8 +54,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             protected override async Task InitializeCoreAsync(CancellationToken cancellationToken)
             {
-                _context = await _workspaceProjectContextProvider.Value.CreateProjectContextAsync(_project)
-                                                                       .ConfigureAwait(true);
+                _context = await _workspaceProjectContextProvider.CreateProjectContextAsync(_project)
+                                                                  .ConfigureAwait(true);
 
                 if (_context == null)
                     return;
@@ -83,8 +82,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
                     if (_context != null)
                     {
-                        await _workspaceProjectContextProvider.Value.ReleaseProjectContextAsync(_context)
-                                                                    .ConfigureAwait(true);
+                        await _workspaceProjectContextProvider.ReleaseProjectContextAsync(_context)
+                                                              .ConfigureAwait(true);
                     }
                 }
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceContextHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceContextHost.cs
@@ -21,6 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         private readonly IUnconfiguredProjectTasksService _tasksService;
         private readonly IProjectSubscriptionService _projectSubscriptionService;
         private readonly Lazy<IWorkspaceProjectContextProvider> _workspaceProjectContextProvider;
+        private readonly IActiveWorkspaceProjectContextTracker _activeWorkspaceProjectContextTracker;
         private readonly ExportFactory<IApplyChangesToWorkspaceContext> _applyChangesToWorkspaceContextFactory;
 
         [ImportingConstructor]
@@ -29,6 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                                     IUnconfiguredProjectTasksService tasksService,
                                     IProjectSubscriptionService projectSubscriptionService,
                                     Lazy<IWorkspaceProjectContextProvider> workspaceProjectContextProvider,
+                                    IActiveWorkspaceProjectContextTracker activeWorkspaceProjectContextTracker,
                                     ExportFactory<IApplyChangesToWorkspaceContext> applyChangesToWorkspaceContextFactory)
             : base(threadingService.JoinableTaskContext)
         {
@@ -37,6 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             _tasksService = tasksService;
             _projectSubscriptionService = projectSubscriptionService;
             _workspaceProjectContextProvider = workspaceProjectContextProvider;
+            _activeWorkspaceProjectContextTracker = activeWorkspaceProjectContextTracker;
             _applyChangesToWorkspaceContextFactory = applyChangesToWorkspaceContextFactory;
         }
 
@@ -52,7 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         protected override IMultiLifetimeInstance CreateInstance()
         {
-            return new WorkspaceContextHostInstance(_project, _threadingService, _tasksService, _projectSubscriptionService, _workspaceProjectContextProvider, _applyChangesToWorkspaceContextFactory);
+            return new WorkspaceContextHostInstance(_project, _threadingService, _tasksService, _projectSubscriptionService, _workspaceProjectContextProvider, _activeWorkspaceProjectContextTracker, _applyChangesToWorkspaceContextFactory);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceContextHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceContextHost.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
 
@@ -20,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         private readonly IProjectThreadingService _threadingService;
         private readonly IUnconfiguredProjectTasksService _tasksService;
         private readonly IProjectSubscriptionService _projectSubscriptionService;
-        private readonly Lazy<IWorkspaceProjectContextProvider> _workspaceProjectContextProvider;
+        private readonly IWorkspaceProjectContextProvider _workspaceProjectContextProvider;
         private readonly IActiveWorkspaceProjectContextTracker _activeWorkspaceProjectContextTracker;
         private readonly ExportFactory<IApplyChangesToWorkspaceContext> _applyChangesToWorkspaceContextFactory;
 
@@ -29,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                                     IProjectThreadingService threadingService,
                                     IUnconfiguredProjectTasksService tasksService,
                                     IProjectSubscriptionService projectSubscriptionService,
-                                    Lazy<IWorkspaceProjectContextProvider> workspaceProjectContextProvider,
+                                    WorkspaceProjectContextProvider workspaceProjectContextProvider,
                                     IActiveWorkspaceProjectContextTracker activeWorkspaceProjectContextTracker,
                                     ExportFactory<IApplyChangesToWorkspaceContext> applyChangesToWorkspaceContextFactory)
             : base(threadingService.JoinableTaskContext)


### PR DESCRIPTION
Includes https://github.com/dotnet/project-system/pull/4008 so just review: https://github.com/dotnet/project-system/commit/a210f6bbfbdec86342be3f86ce7ae1ac6f54a521.

These paths are only activated when a configuration is made implicitly active - at which point, the language service is always going to be activated and these services always created. CPS has found that Lazy<T> usage over large number of projects adds up, so we should restrict its usage for uncommon paths.