### PR TITLE
Minor changes to get language service working

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/LanguageServiceErrorListProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/LanguageServiceErrorListProvider.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
     ///     An implementation of <see cref="IVsErrorListProvider"/> that delegates onto the language
     ///     service so that it de-dup warnings and errors between IntelliSense and build.
     /// </summary>
-    [AppliesTo(ProjectCapability.DotNetLanguageService)]
+    [AppliesTo(ProjectCapability.DotNetLanguageServiceOrLanguageService2)]
     [Export(typeof(IVsErrorListProvider))]
     [Order(Order.Default)]
     internal partial class LanguageServiceErrorListProvider : IVsErrorListProvider

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ProjectContextCodeModelProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ProjectContextCodeModelProvider.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
     /// </summary>
     [Export(typeof(ICodeModelProvider))]
     [Export(typeof(IProjectCodeModelProvider))]
-    [AppliesTo(ProjectCapability.DotNetLanguageService)]
+    [AppliesTo(ProjectCapability.DotNetLanguageServiceOrLanguageService2)]
     internal class ProjectContextCodeModelProvider : ICodeModelProvider, IProjectCodeModelProvider
     {
         private readonly IProjectThreadingService _threadingService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         [ProjectAutoLoad(ProjectLoadCheckpoint.ProjectInitialCapabilitiesEstablished)]
-        [AppliesTo(ProjectCapability.DotNetLanguageService)]
+        [AppliesTo(ProjectCapability.DotNetLanguageServiceOrLanguageService2)]
         public Task InitializeAsync()
         {
             EnsureInitialized();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/ImplicitlyActiveConfiguredProjectReadyToBuild.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/ImplicitlyActiveConfiguredProjectReadyToBuild.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace Microsoft.VisualStudio.ProjectSystem.Build
 {
     [Export(typeof(IConfiguredProjectReadyToBuild))]
-    [AppliesTo(ProjectCapability.DotNetLanguageService)]
+    [AppliesTo(ProjectCapability.DotNetLanguageServiceOrLanguageService2)]
     [Order(Order.Default)]
     internal sealed class ImplicitlyActiveConfiguredProjectReadyToBuild : IConfiguredProjectReadyToBuild, IDisposable
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/TurnOffUseHostCompilerIfAvailableBuildPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/TurnOffUseHostCompilerIfAvailableBuildPropertiesProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Build
     ///     Turns off UseHostCompilerIfAvailable to prevent CoreCompile from always being called during builds, see: https://github.com/dotnet/sdk/issues/708.
     /// </summary>
     [ExportBuildGlobalPropertiesProvider]
-    [AppliesTo(ProjectCapability.DotNetLanguageService)]
+    [AppliesTo(ProjectCapability.DotNetLanguageServiceOrLanguageService2)]
     internal class TurnOffUseHostCompilerIfAvailableBuildPropertiesProvider : StaticGlobalPropertiesProviderBase
     {
         private static readonly Task<IImmutableDictionary<string, string>> s_buildProperties = Task.FromResult<IImmutableDictionary<string, string>>(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -89,8 +89,6 @@
                           DeclaredSourceItems;
                           UserSourceItems;" />
 
-    <ProjectCapability Include="LanguageService" />
-
     <!-- Reference Manager capabilities -->
     <ProjectCapability Include="ReferenceManagerAssemblies" />
     <ProjectCapability Include="ReferenceManagerBrowse" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ILanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ILanguageServiceHost.cs
@@ -48,8 +48,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         /// <summary>
         ///     Initializes the langauge service host.
         /// </summary>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        Task InitializeAsync(CancellationToken cancellationToken = default);
+        Task InitializeAsync();
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -99,9 +99,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             return Task.CompletedTask;
         }
 
-        Task ILanguageServiceHost.InitializeAsync(CancellationToken cancellationToken)
+        public Task InitializeAsync()
         {
-            return InitializeAsync(cancellationToken);
+            return InitializeAsync(CancellationToken.None);
         }
 
         private async Task OnProjectChangedCoreAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> e, RuleHandlerType handlerType)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapability.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapability.cs
@@ -37,6 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public const string LanguageService2 = nameof(LanguageService2);
         public const string DotNetLanguageService = DotNet + " & (LanguageService & !LanguageService2)";        // Temporary until we turn new language service hookup
         public const string DotNetLanguageService2 = DotNet + " & (!LanguageService & LanguageService2)";
+        public const string DotNetLanguageServiceOrLanguageService2 = DotNet + "& (LanguageService | LanguageService2)";
         public const string SortByDisplayOrder = ProjectCapabilities.SortByDisplayOrder;
         public const string DotNet = ".NET";
     }


### PR DESCRIPTION
- Remove unused cancellation token, which simplifies a change I'm making in the future
- Opt components/services into both new and old language service, so when I turn on LanguageService2 they still turn on
- Remove "LanguageService" from dynamic capabilities
  - This capability is always a fixed capability (comes from project factory registration), so this change has zero impact on the product, but prevents me from manually switching from LanguageService -> LanguageService2 while testing.