### PR TITLE
Show project output panel in release builds

### DIFF
--- a/docs/repo/debugging/logging.md
+++ b/docs/repo/debugging/logging.md
@@ -3,16 +3,16 @@
 The project system code logs information to a custom Output Window pane either
 while debugging or when a certain environment variable is set.
 
-## Inspecting Log While Debugging
+## Enabling project system logs
 
-When you build this repository under debug either within Visual Studio or via
-the command-line, an extra output window pane will be created that contains a
-log of project-system related events.
+Setting the `PROJECTSYSTEM_PROJECTOUTPUTPANEENABLED` environment variable to
+`1` enables project system logging.
 
-## Collecting Log for a Release Build
+This environment variable is set automatically when launching the
+`ProjectSystemSetup` project within Visual Studio, via its
+`launchSettings.json` file.
 
-Run VS with the `PROJECTSYSTEM_PROJECTOUTPUTPANEENABLED` set to `1`.  For
-example:
+To enable this logging in other situations you may, for example:
 
 1. Start a Developer Command Prompt
 2. Run: `set PROJECTSYSTEM_PROJECTOUTPUTPANEENABLED=1`

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectSystemOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectSystemOptions.cs
@@ -23,9 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         private readonly IVsUIService<ISettingsManager> _settingsManager;
         private readonly IEnvironmentHelper _environment;
-#if !DEBUG
         private bool? _isProjectOutputPaneEnabled;
-#endif
 
         [ImportingConstructor]
         private ProjectSystemOptions(IEnvironmentHelper environment, IVsUIService<SVsSettingsPersistenceManager, ISettingsManager> settingsManager)
@@ -38,11 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             get
             {
-#if DEBUG
-                return true;
-#else
                 return IsEnabled("PROJECTSYSTEM_PROJECTOUTPUTPANEENABLED", ref _isProjectOutputPaneEnabled);
-#endif
             }
         }
 

--- a/src/ProjectSystemSetup/Properties/launchSettings.json
+++ b/src/ProjectSystemSetup/Properties/launchSettings.json
@@ -7,7 +7,8 @@
       "environmentVariables": {
         "VisualBasicDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.VisualBasic.DesignTime.targets",
         "FSharpDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.FSharp.DesignTime.targets",
-        "CSharpDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.CSharp.DesignTime.targets"
+        "CSharpDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.CSharp.DesignTime.targets",
+        "PROJECTSYSTEM_PROJECTOUTPUTPANEENABLED": "1"
       }
     },
     "Start (with native debugging)": {
@@ -17,7 +18,8 @@
       "environmentVariables": {
         "VisualBasicDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.VisualBasic.DesignTime.targets",
         "FSharpDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.FSharp.DesignTime.targets",
-        "CSharpDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.CSharp.DesignTime.targets"
+        "CSharpDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.CSharp.DesignTime.targets",
+        "PROJECTSYSTEM_PROJECTOUTPUTPANEENABLED": "1"
       },
       "nativeDebugging": true
     },
@@ -29,8 +31,8 @@
         "VisualBasicDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.VisualBasic.DesignTime.targets",
         "FSharpDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.FSharp.DesignTime.targets",
         "CSharpDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.CSharp.DesignTime.targets",
-        "COMPlus_ZapDisable": "1",
-        "PROJECTSYSTEM_PROJECTOUTPUTPANEENABLED": "1"
+        "PROJECTSYSTEM_PROJECTOUTPUTPANEENABLED": "1",
+        "COMPlus_ZapDisable": "1"
       },
       "nativeDebugging": true
     }

--- a/src/ProjectSystemSetup/Properties/launchSettings.json
+++ b/src/ProjectSystemSetup/Properties/launchSettings.json
@@ -29,7 +29,8 @@
         "VisualBasicDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.VisualBasic.DesignTime.targets",
         "FSharpDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.FSharp.DesignTime.targets",
         "CSharpDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.CSharp.DesignTime.targets",
-        "COMPlus_ZapDisable": "1"
+        "COMPlus_ZapDisable": "1",
+        "PROJECTSYSTEM_PROJECTOUTPUTPANEENABLED": "1"
       },
       "nativeDebugging": true
     }


### PR DESCRIPTION
Fixes #4021

- Remove `#if DEBUG`, control via environment variable only
- Configure launch settings for `ProjectSystemSetup` to set this variable
- Update documentation
