### PR TITLE
Rename "IsImplicitlyActiveTask" -> "ImplicitlyActive"

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ConfiguredProjectImplicitActivationTrackingTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ConfiguredProjectImplicitActivationTrackingTests.cs
@@ -26,14 +26,14 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         [Fact]
-        public async Task IsImplicitlyActiveTask_WhenDisposed_ThrowsObjectDisposed()
+        public async Task ImplicitlyActive_WhenDisposed_ThrowsObjectDisposed()
         {
             var service = CreateInstance();
             await service.DisposeAsync();
 
             Assert.Throws<ObjectDisposedException>(() =>
             {
-                var ignored = service.IsImplicitlyActiveTask;
+                var ignored = service.ImplicitlyActive;
             });
         }
 
@@ -48,11 +48,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         [Fact]
-        public void IsImplicitlyActiveTask_WhenActiveConfiguredHasNotFired_ReturnsNonCompletedTask()
+        public void ImplicitlyActive_WhenActiveConfiguredHasNotFired_ReturnsNonCompletedTask()
         {
             var service = CreateInstance();
 
-            var result = service.IsImplicitlyActiveTask;
+            var result = service.ImplicitlyActive;
 
             Assert.False(result.IsCompleted);
         }
@@ -71,14 +71,14 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         [Fact]
-        public void IsImplicitlyActiveTask_WhenProjectHasUnloaded_ReturnsCanceledTask()
+        public void ImplicitlyActive_WhenProjectHasUnloaded_ReturnsCanceledTask()
         {
             var cancellationToken = new CancellationToken(canceled: true);
             var tasksService = IProjectAsynchronousTasksServiceFactory.ImplementUnloadCancellationToken(cancellationToken);
 
             var service = CreateInstance(tasksService);
 
-            var result = service.IsImplicitlyActiveTask;
+            var result = service.ImplicitlyActive;
 
             Assert.True(result.IsCanceled);
         }
@@ -98,7 +98,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         [Fact]
-        public void IsImplicitlyActiveTask_WhenProjectUnloadCancellationTokenSourceHasBeenDisposed_ReturnsNonCompletedTask()
+        public void ImplicitlyActive_WhenProjectUnloadCancellationTokenSourceHasBeenDisposed_ReturnsNonCompletedTask()
         {
             var cancellationTokenSource = new CancellationTokenSource();
             var tasksService = IProjectAsynchronousTasksServiceFactory.ImplementUnloadCancellationToken(cancellationTokenSource.Token);
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             var service = CreateInstance(tasksService);
 
-            var result = service.IsImplicitlyActiveTask;
+            var result = service.ImplicitlyActive;
 
             Assert.False(result.IsCompleted);
         }
@@ -127,7 +127,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         [Fact]
-        public void IsImplicitlyActiveTask_WhenProjectUnloadCancellationTokenSourceHasBeenCanceledAndDisposed_ReturnsCanceledTask()
+        public void ImplicitlyActive_WhenProjectUnloadCancellationTokenSourceHasBeenCanceledAndDisposed_ReturnsCanceledTask()
         {
             var cancellationTokenSource = new CancellationTokenSource();
             var tasksService = IProjectAsynchronousTasksServiceFactory.ImplementUnloadCancellationToken(cancellationTokenSource.Token);
@@ -136,7 +136,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             var service = CreateInstance(tasksService);
 
-            var result = service.IsImplicitlyActiveTask;
+            var result = service.ImplicitlyActive;
 
             Assert.True(result.IsCanceled);
         }
@@ -181,12 +181,12 @@ namespace Microsoft.VisualStudio.ProjectSystem
         [InlineData(new object[] { new[] { "Debug|x86|net46" },                                                      "Debug|x86|net46" })]
         [InlineData(new object[] { new[] { "Debug|x86|net46", "Release|x86|net46" },                                 "Debug|x86|net46" })]
         [InlineData(new object[] { new[] { "Debug|x86|net46", "Release|x86|net46", "Release|AnyCPU|net46" },         "Debug|x86|net46" })]
-        public async Task IsImplicitlyActiveTask_WhenActiveConfigurationChangesAndMatches_ReturnsCompletedTask(string[] configurations, string currentConfiguration)
+        public async Task ImplicitlyActive_WhenActiveConfigurationChangesAndMatches_ReturnsCompletedTask(string[] configurations, string currentConfiguration)
         {
             var project = ConfiguredProjectFactory.ImplementProjectConfiguration(currentConfiguration);
             var service = CreateInstance(project, out ProjectValueDataSource<IConfigurationGroup<ProjectConfiguration>> source);
 
-            var result = service.IsImplicitlyActiveTask;
+            var result = service.ImplicitlyActive;
 
             var configurationGroups = IConfigurationGroupFactory.CreateFromConfigurationNames(configurations);
             await source.SendAndCompleteAsync(configurationGroups, service.TargetBlock);
@@ -303,7 +303,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         [Fact]
-        public async Task IsImplicitlyActiveTask_CompletedStateChangesOverLifetime()
+        public async Task ImplicitlyActive_CompletedStateChangesOverLifetime()
         {
             var project = ConfiguredProjectFactory.ImplementProjectConfiguration("Debug|AnyCPU");
             var service = CreateInstance(project, out ProjectValueDataSource<IConfigurationGroup<ProjectConfiguration>> source);
@@ -314,13 +314,13 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var configurationGroups = IConfigurationGroupFactory.CreateFromConfigurationNames("Debug|AnyCPU");
             await source.SendAsync(configurationGroups);
 
-            Assert.True(service.IsImplicitlyActiveTask.Wait(500));
+            Assert.True(service.ImplicitlyActive.Wait(500));
 
             configurationGroups = IConfigurationGroupFactory.CreateFromConfigurationNames("Debug|x86");
             await source.SendAndCompleteAsync(configurationGroups, service.TargetBlock);
 
             // Should now be considered in-active
-            Assert.False(service.IsImplicitlyActiveTask.IsCompleted);
+            Assert.False(service.ImplicitlyActive.IsCompleted);
         }
 
         private static ConfiguredProjectImplicitActivationTracking CreateInstance()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ConfiguredProjectImplicitActivationTracking.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ConfiguredProjectImplicitActivationTracking.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         private readonly IProjectAsynchronousTasksService _tasksService;
         private readonly IActiveConfigurationGroupService _activeConfigurationGroupService;
         private readonly ActionBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>> _targetBlock;
-        private TaskCompletionSource<object> _isImplicitlyActiveSource = new TaskCompletionSource<object>();
+        private TaskCompletionSource<object> _implicitlyActiveSource = new TaskCompletionSource<object>();
         private IDisposable _subscription;
 
         [ImportingConstructor]
@@ -57,17 +57,17 @@ namespace Microsoft.VisualStudio.ProjectSystem
             {
                 EnsureInitialized();
 
-                return _isImplicitlyActiveSource.Task.Status == TaskStatus.RanToCompletion;
+                return _implicitlyActiveSource.Task.Status == TaskStatus.RanToCompletion;
             }
         }
 
-        public Task IsImplicitlyActiveTask
+        public Task ImplicitlyActive
         {
             get
             {
                 EnsureInitialized();
 
-                return _isImplicitlyActiveSource.Task;
+                return _implicitlyActiveSource.Task;
             }
         }
 
@@ -119,7 +119,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         private Task OnImplicitlyActivated()
         {
-            _isImplicitlyActiveSource.TrySetResult(null);
+            _implicitlyActiveSource.TrySetResult(null);
 
             IEnumerable<Task> tasks = ImplicitlyActiveServices.Select(c => c.Value.ActivateAsync());
 
@@ -134,7 +134,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             // move to after we publish the value
             Thread.MemoryBarrier();
 
-            _isImplicitlyActiveSource = source;
+            _implicitlyActiveSource = source;
 
             IEnumerable<Task> tasks = ImplicitlyActiveServices.Select(c => c.Value.DeactivateAsync());
 
@@ -144,7 +144,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         private void OnCanceled()
         {
             // Notify anyone listening that we're never going to be active
-            _isImplicitlyActiveSource.TrySetCanceled();
+            _implicitlyActiveSource.TrySetCanceled();
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IConfiguredProjectImplicitActivationTracking.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IConfiguredProjectImplicitActivationTracking.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         ///     The returned <see cref="Task"/> is canceled when the <see cref="ConfiguredProject"/> 
         ///     is unloaded.
         /// </remarks>
-        Task IsImplicitlyActiveTask
+        Task ImplicitlyActive
         {
             get;
         }


### PR DESCRIPTION
This was originally named to somewhat mimic IConfiguredProjectActivationTracking.ActivationTask, but everywhere else we avoid the "Task" suffix.