### PR TITLE
Use computed flags

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GroupedByTargetTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GroupedByTargetTreeViewProvider.cs
@@ -418,7 +418,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     propertySheet: null,
                     visible: true,
                     browseObjectProperties: rule,
-                    flags: viewModel.Flags,
+                    flags: flags,
                     icon: viewModel.Icon.ToProjectSystemType(),
                     expandedIcon: viewModel.ExpandedIcon.ToProjectSystemType());
             }


### PR DESCRIPTION
Fixes #3996.

The `GroupedByTargetTreeViewProvider.CreateOrUpdateProjectItemTreeNode` takes `additionalFlags` and `excludedFlags` parameters and uses them to update `viewModel.Flags`. However, the updated flags are not currently used.

This commit updates the method to make use of the flags. This will not change the current behavior as we do not actually pass in any relevant values for `additionalFlags` and `excludedFlags` but we want to avoid any surprises if/when we start to do so.