### PR TITLE
Remove redundant check

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependenciesSnapshotFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependenciesSnapshotFactory.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 mock.Setup(x => x.Targets).Returns(targets.ToImmutableDictionary());
             }
 
-            if (hasUnresolvedDependency != null && hasUnresolvedDependency.HasValue)
+            if (hasUnresolvedDependency.HasValue)
             {
                 mock.Setup(x => x.HasUnresolvedDependency).Returns(hasUnresolvedDependency.Value);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyFactory.cs
@@ -94,22 +94,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 mock.Setup(x => x.DependencyIDs).Returns(ImmutableList<string>.Empty.AddRange(dependencyIDs));
             }
 
-            if (resolved != null && resolved.HasValue)
+            if (resolved.HasValue)
             {
                 mock.Setup(x => x.Resolved).Returns(resolved.Value);
             }
 
-            if (topLevel != null && topLevel.HasValue)
+            if (topLevel.HasValue)
             {
                 mock.Setup(x => x.TopLevel).Returns(topLevel.Value);
             }
 
-            if (isImplicit != null && isImplicit.HasValue)
+            if (isImplicit.HasValue)
             {
                 mock.Setup(x => x.Implicit).Returns(isImplicit.Value);
             }
 
-            if (flags != null && flags.HasValue)
+            if (flags.HasValue)
             {
                 mock.Setup(x => x.Flags).Returns(flags.Value);
             }
@@ -142,7 +142,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                     .Returns(mock.Object);
             }
 
-            if (equals != null && equals.HasValue && equals.Value)
+            if (equals.HasValue && equals.Value)
             {
                 mock.Setup(x => x.Equals(It.IsAny<IDependency>())).Returns(true);
             }
@@ -169,27 +169,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             var json = JObject.Parse(jsonString);
             var data = json.ToObject<TestDependency>();
 
-            if (flags != null && flags.HasValue)
+            if (flags.HasValue)
             {
                 data.Flags = data.Flags.Union(flags.Value);
             }
 
-            if (icon != null && icon.HasValue)
+            if (icon.HasValue)
             {
                 data.Icon = icon.Value;
             }
 
-            if (expandedIcon != null && expandedIcon.HasValue)
+            if (expandedIcon.HasValue)
             {
                 data.ExpandedIcon = expandedIcon.Value;
             }
 
-            if (unresolvedIcon != null && unresolvedIcon.HasValue)
+            if (unresolvedIcon.HasValue)
             {
                 data.UnresolvedIcon = unresolvedIcon.Value;
             }
 
-            if (unresolvedExpandedIcon != null && unresolvedExpandedIcon.HasValue)
+            if (unresolvedExpandedIcon.HasValue)
             {
                 data.UnresolvedExpandedIcon = unresolvedExpandedIcon.Value;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyModelFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyModelFactory.cs
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 mock.Setup(x => x.DependencyIDs).Returns(ImmutableList<string>.Empty.AddRange(dependencyIDs));
             }
 
-            if (resolved != null && resolved.HasValue)
+            if (resolved.HasValue)
             {
                 mock.Setup(x => x.Resolved).Returns(resolved.Value);
             }
@@ -87,27 +87,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             var json = JObject.Parse(jsonString);
             var data = json.ToObject<TestDependencyModel>();
 
-            if (flags != null && flags.HasValue)
+            if (flags.HasValue)
             {
                 data.Flags = data.Flags.Union(flags.Value);
             }
 
-            if (icon != null && icon.HasValue)
+            if (icon.HasValue)
             {
                 data.Icon = icon.Value;
             }
 
-            if (expandedIcon != null && expandedIcon.HasValue)
+            if (expandedIcon.HasValue)
             {
                 data.ExpandedIcon = expandedIcon.Value;
             }
 
-            if (unresolvedIcon != null && unresolvedIcon.HasValue)
+            if (unresolvedIcon.HasValue)
             {
                 data.UnresolvedIcon = unresolvedIcon.Value;
             }
 
-            if (unresolvedExpandedIcon != null && unresolvedExpandedIcon.HasValue)
+            if (unresolvedExpandedIcon.HasValue)
             {
                 data.UnresolvedExpandedIcon = unresolvedExpandedIcon.Value;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IMockDependenciesViewModelFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IMockDependenciesViewModelFactory.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             var behavior = mockBehavior ?? MockBehavior.Strict;
             var mock = new Mock<IDependenciesViewModelFactory>(behavior);
 
-            if (getDependenciesRootIcon != null && getDependenciesRootIcon.HasValue)
+            if (getDependenciesRootIcon.HasValue)
             {
                 mock.Setup(x => x.GetDependenciesRootIcon(It.IsAny<bool>())).Returns(getDependenciesRootIcon.Value);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITargetedDependenciesSnapshotFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITargetedDependenciesSnapshotFactory.cs
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                     .Returns(ImmutableStringDictionary<IDependency>.EmptyOrdinalIgnoreCase.AddRange(dependenciesWorld));
             }
 
-            if (hasUnresolvedDependency != null && hasUnresolvedDependency.HasValue)
+            if (hasUnresolvedDependency.HasValue)
             {
                 mock.Setup(x => x.HasUnresolvedDependency).Returns(hasUnresolvedDependency.Value);
             }
@@ -81,7 +81,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 mock.Setup(x => x.TopLevelDependencies).Returns(dependencies);
             }
 
-            if (checkForUnresolvedDependencies != null && checkForUnresolvedDependencies.HasValue)
+            if (checkForUnresolvedDependencies.HasValue)
             {
                 mock.Setup(x => x.CheckForUnresolvedDependencies(It.IsAny<string>())).Returns(checkForUnresolvedDependencies.Value);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GroupedByTargetTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GroupedByTargetTreeViewProvider.cs
@@ -458,12 +458,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             ProjectTreeFlags? additionalFlags,
             ProjectTreeFlags? excludedFlags)
         {
-            if (additionalFlags != null && additionalFlags.HasValue)
+            if (additionalFlags.HasValue)
             {
                 flags = flags.Union(additionalFlags.Value);
             }
 
-            if (excludedFlags != null && excludedFlags.HasValue)
+            if (excludedFlags.HasValue)
             {
                 flags = flags.Except(excludedFlags.Value);
             }


### PR DESCRIPTION
There are a number of places where we have a nullable value type and we're performing a null check like so:

``` C#
struct Foo { ... }
Foo? f = ...
if (f != null && h.HasValue) { ... }
```

Unless the `Foo` type has an operator that takes a `Foo?` as a parameter this check is redundant; we don't need both the null check and the call to `HasValue`.

This commit removes the null check in these cases.