### PR TITLE
Rename ILanguageServiceHost -> IActiveWorkspaceProjectContextHost

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IActiveWorkspaceProjectContextHostFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IActiveWorkspaceProjectContextHostFactory.cs
@@ -6,16 +6,16 @@ using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
-    internal static class ILanguageServiceHostFactory
+    internal static class IActiveWorkspaceProjectContextHostFactory
     {
-        public static ILanguageServiceHost Create()
+        public static IActiveWorkspaceProjectContextHost Create()
         {
-            return Mock.Of<ILanguageServiceHost>();
+            return Mock.Of<IActiveWorkspaceProjectContextHost>();
         }
 
-        public static ILanguageServiceHost ImplementHostSpecificErrorReporter(Func<object> action)
+        public static IActiveWorkspaceProjectContextHost ImplementHostSpecificErrorReporter(Func<object> action)
         {
-            var mock = new Mock<ILanguageServiceHost>();
+            var mock = new Mock<IActiveWorkspaceProjectContextHost>();
             mock.SetupGet(h => h.HostSpecificErrorReporter)
                 .Returns(action);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Build/LanguageServiceErrorListProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Build/LanguageServiceErrorListProviderTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
         {
             int callCount = 0;
             var reporter = IVsLanguageServiceBuildErrorReporter2Factory.ImplementClearErrors(() => { callCount++; return 0; });
-            var host = ILanguageServiceHostFactory.ImplementHostSpecificErrorReporter(() => reporter);
+            var host = IActiveWorkspaceProjectContextHostFactory.ImplementHostSpecificErrorReporter(() => reporter);
             var task = CreateDefaultTask();
             var provider = CreateInstance(host);
 
@@ -121,7 +121,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
                 throw new NotImplementedException();
             });
 
-            var host = ILanguageServiceHostFactory.ImplementHostSpecificErrorReporter(() => reporter);
+            var host = IActiveWorkspaceProjectContextHostFactory.ImplementHostSpecificErrorReporter(() => reporter);
             var provider = CreateInstance(host);
             var task = CreateDefaultTask();
 
@@ -138,7 +138,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
                 throw new Exception();
             });
 
-            var host = ILanguageServiceHostFactory.ImplementHostSpecificErrorReporter(() => reporter);
+            var host = IActiveWorkspaceProjectContextHostFactory.ImplementHostSpecificErrorReporter(() => reporter);
             var provider = CreateInstance(host);
             var task = CreateDefaultTask();
 
@@ -152,7 +152,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
         public async Task AddMessageAsync_ReturnsHandledAndStopProcessing()
         {
             var reporter = IVsLanguageServiceBuildErrorReporter2Factory.ImplementReportError((string bstrErrorMessage, string bstrErrorId, VSTASKPRIORITY nPriority, int iLine, int iColumn, int iEndLine, int iEndColumn, string bstrFileName) => { });
-            var host = ILanguageServiceHostFactory.ImplementHostSpecificErrorReporter(() => reporter);
+            var host = IActiveWorkspaceProjectContextHostFactory.ImplementHostSpecificErrorReporter(() => reporter);
             var provider = CreateInstance(host);
             var task = CreateDefaultTask();
 
@@ -169,7 +169,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
             {
                 result = nPriority;
             });
-            var host = ILanguageServiceHostFactory.ImplementHostSpecificErrorReporter(() => reporter);
+            var host = IActiveWorkspaceProjectContextHostFactory.ImplementHostSpecificErrorReporter(() => reporter);
             var provider = CreateInstance(host);
 
             await provider.AddMessageAsync(new TargetGeneratedError("Test", new BuildWarningEventArgs(null, "Code", "File", 1, 1, 1, 1, "Message", "HelpKeyword", "Sender")));
@@ -185,7 +185,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
             {
                 result = nPriority;
             });
-            var host = ILanguageServiceHostFactory.ImplementHostSpecificErrorReporter(() => reporter);
+            var host = IActiveWorkspaceProjectContextHostFactory.ImplementHostSpecificErrorReporter(() => reporter);
             var provider = CreateInstance(host);
 
             await provider.AddMessageAsync(new TargetGeneratedError("Test", new BuildErrorEventArgs(null, "Code", "File", 1, 1, 1, 1, "Message", "HelpKeyword", "Sender")));
@@ -201,7 +201,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
             {
                 result = nPriority;
             });
-            var host = ILanguageServiceHostFactory.ImplementHostSpecificErrorReporter(() => reporter);
+            var host = IActiveWorkspaceProjectContextHostFactory.ImplementHostSpecificErrorReporter(() => reporter);
             var provider = CreateInstance(host);
 
             await provider.AddMessageAsync(new TargetGeneratedError("Test", new CriticalBuildMessageEventArgs(null, "Code", "File", 1, 1, 1, 1, "Message", "HelpKeyword", "Sender")));
@@ -228,7 +228,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
                 errorIdResult = bstrErrorId;
             });
 
-            var host = ILanguageServiceHostFactory.ImplementHostSpecificErrorReporter(() => reporter);
+            var host = IActiveWorkspaceProjectContextHostFactory.ImplementHostSpecificErrorReporter(() => reporter);
 
             var provider = CreateInstance(host);
             await provider.AddMessageAsync(new TargetGeneratedError("Test", new BuildErrorEventArgs(null, code, "File", 0, 0, 0, 0, errorMessage, "HelpKeyword", "Sender")));
@@ -259,7 +259,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
                 columnResult = iColumn;
             });
 
-            var host = ILanguageServiceHostFactory.ImplementHostSpecificErrorReporter(() => reporter);
+            var host = IActiveWorkspaceProjectContextHostFactory.ImplementHostSpecificErrorReporter(() => reporter);
 
             var provider = CreateInstance(host);
             await provider.AddMessageAsync(new TargetGeneratedError("Test", new BuildErrorEventArgs(null, "Code", "File", lineNumber, columnNumber, 0, 0, "ErrorMessage", "HelpKeyword", "Sender")));
@@ -291,7 +291,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
                 endColumnResult = iEndColumn;
             });
 
-            var host = ILanguageServiceHostFactory.ImplementHostSpecificErrorReporter(() => reporter);
+            var host = IActiveWorkspaceProjectContextHostFactory.ImplementHostSpecificErrorReporter(() => reporter);
 
             var provider = CreateInstance(host);
             await provider.AddMessageAsync(new TargetGeneratedError("Test", new BuildErrorEventArgs(null, "Code", "File", lineNumber, columnNumber, endLineNumber, endColumnNumber, "ErrorMessage", "HelpKeyword", "Sender")));
@@ -325,7 +325,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
                 fileNameResult = bstrFileName;
             });
 
-            var host = ILanguageServiceHostFactory.ImplementHostSpecificErrorReporter(() => reporter);
+            var host = IActiveWorkspaceProjectContextHostFactory.ImplementHostSpecificErrorReporter(() => reporter);
 
             var provider = CreateInstance(host);
 
@@ -348,11 +348,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
             return CreateInstance(null);
         }
 
-        private static LanguageServiceErrorListProvider CreateInstance(ILanguageServiceHost host)
+        private static LanguageServiceErrorListProvider CreateInstance(IActiveWorkspaceProjectContextHost projectContextHost)
         {
-            host = host ?? ILanguageServiceHostFactory.Create();
+            projectContextHost = projectContextHost ?? IActiveWorkspaceProjectContextHostFactory.Create();
 
-            var provider = new LanguageServiceErrorListProvider(UnconfiguredProjectFactory.Create(), host);
+            var provider = new LanguageServiceErrorListProvider(UnconfiguredProjectFactory.Create(), projectContextHost);
 
             return provider;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactoryTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactoryTests.cs
@@ -110,7 +110,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             Assert.Equal((uint)VSConstants.VSITEMID.Nil, itemid);
         }
 
-        private static VsContainedLanguageComponentsFactory CreateInstance(IVsContainedLanguageFactory containedLanguageFactory = null, IVsProject4 project = null, ProjectProperties properties = null, IConfiguredProjectHostObject hostObject = null, ILanguageServiceHost languageServiceHost = null)
+        private static VsContainedLanguageComponentsFactory CreateInstance(IVsContainedLanguageFactory containedLanguageFactory = null, IVsProject4 project = null, ProjectProperties properties = null, IConfiguredProjectHostObject hostObject = null, IActiveWorkspaceProjectContextHost projectContextHost = null)
         {
             var hostProvider = IProjectHostProviderFactory.ImplementActiveIntellisenseProjectHostObject(hostObject);
             var serviceProvider = IOleAsyncServiceProviderFactory.ImplementQueryServiceAsync(containedLanguageFactory, new Guid(LanguageServiceId));
@@ -120,19 +120,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             projectVsServices.ImplementThreadingService(IProjectThreadingServiceFactory.Create());
             projectVsServices.ImplementActiveConfiguredProjectProperties(properties);
 
-            return CreateInstance(serviceProvider, projectVsServices.Object, hostProvider, languageServiceHost);
+            return CreateInstance(serviceProvider, projectVsServices.Object, hostProvider, projectContextHost);
         }
 
-        private static VsContainedLanguageComponentsFactory CreateInstance(IOleAsyncServiceProvider serviceProvider = null, IUnconfiguredProjectVsServices projectVsServices = null, IProjectHostProvider projectHostProvider = null, ILanguageServiceHost languageServiceHost = null)
+        private static VsContainedLanguageComponentsFactory CreateInstance(IOleAsyncServiceProvider serviceProvider = null, IUnconfiguredProjectVsServices projectVsServices = null, IProjectHostProvider projectHostProvider = null, IActiveWorkspaceProjectContextHost projectContextHost = null)
         {
             projectVsServices = projectVsServices ?? IUnconfiguredProjectVsServicesFactory.Create();
             projectHostProvider = projectHostProvider ?? IProjectHostProviderFactory.Create();
-            languageServiceHost = languageServiceHost ?? ILanguageServiceHostFactory.Create();
+            projectContextHost = projectContextHost ?? IActiveWorkspaceProjectContextHostFactory.Create();
 
             return new VsContainedLanguageComponentsFactory(IVsServiceFactory.Create<SAsyncServiceProvider, IOleAsyncServiceProvider>(serviceProvider),
                                                             projectVsServices,
                                                             projectHostProvider,
-                                                            languageServiceHost);
+                                                            projectContextHost);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/LanguageServiceErrorListProvider.ErrorListDetails.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/LanguageServiceErrorListProvider.ErrorListDetails.cs
@@ -32,12 +32,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
                 set;
             }
 
-            public string GetFileFullPath(ILanguageServiceHost languageServiceHost)
+            public string GetFileFullPath(IActiveWorkspaceProjectContextHost projectContextHost)
             {
                 string projectFile = ProjectFile;
                 if (string.IsNullOrEmpty(projectFile))
                 {
-                    projectFile = languageServiceHost.ActiveProjectContext?.ProjectFilePath;
+                    projectFile = projectContextHost.ActiveProjectContext?.ProjectFilePath;
                 }
 
                 if (!string.IsNullOrEmpty(projectFile) && !string.IsNullOrEmpty(File))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/LanguageServiceErrorListProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/LanguageServiceErrorListProvider.cs
@@ -21,13 +21,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
     {
         private static readonly Task<AddMessageResult> s_handledAndStopProcessing = Task.FromResult(AddMessageResult.HandledAndStopProcessing);
         private static readonly Task<AddMessageResult> s_notHandled = Task.FromResult(AddMessageResult.NotHandled);
-        private readonly ILanguageServiceHost _host;
+        private readonly IActiveWorkspaceProjectContextHost _projectContextHost;
         private IVsLanguageServiceBuildErrorReporter2 _languageServiceBuildErrorReporter;
 
         [ImportingConstructor]
-        public LanguageServiceErrorListProvider(UnconfiguredProject project, ILanguageServiceHost host)
+        public LanguageServiceErrorListProvider(UnconfiguredProject project, IActiveWorkspaceProjectContextHost projectContextHost)
         {
-            _host = host;
+            _projectContextHost = projectContextHost;
         }
 
         public void SuspendRefresh()
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
                                                                     details.ColumnNumberForErrorList,
                                                                     details.EndLineNumberForErrorList,
                                                                     details.EndColumnNumberForErrorList,
-                                                                    details.GetFileFullPath(_host));
+                                                                    details.GetFileFullPath(_projectContextHost));
                     handled = true;
                 }
                 catch (NotImplementedException)
@@ -98,7 +98,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
             // We defer grabbing error reporter the until the first build event, because the language service is initialized asynchronously
             if (_languageServiceBuildErrorReporter == null)
             {
-                _languageServiceBuildErrorReporter = (IVsLanguageServiceBuildErrorReporter2)_host.HostSpecificErrorReporter;
+                _languageServiceBuildErrorReporter = (IVsLanguageServiceBuildErrorReporter2)_projectContextHost.HostSpecificErrorReporter;
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/EditAndContinue/EditAndContinueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/EditAndContinue/EditAndContinueProvider.cs
@@ -19,13 +19,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.EditAndContinue
     [AppliesTo(ProjectCapability.EditAndContinue)]
     internal class EditAndContinueProvider : IVsENCRebuildableProjectCfg, IVsENCRebuildableProjectCfg2, IVsENCRebuildableProjectCfg4, IDisposable
     {
-        private ILanguageServiceHost _host;
+        private IActiveWorkspaceProjectContextHost _projectContextHost;
         private IProjectThreadingService _threadingService;
 
         [ImportingConstructor]
-        public EditAndContinueProvider(ILanguageServiceHost host, IProjectThreadingService threadingService)
+        public EditAndContinueProvider(IActiveWorkspaceProjectContextHost projectContextHost, IProjectThreadingService threadingService)
         {
-            _host = host;
+            _projectContextHost = projectContextHost;
             _threadingService = threadingService;
         }
 
@@ -120,7 +120,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.EditAndContinue
             {
                 await _threadingService.SwitchToUIThread();
 
-                var encProvider = (IVsENCRebuildableProjectCfg2)_host?.HostSpecificEditAndContinueService;
+                var encProvider = (IVsENCRebuildableProjectCfg2)_projectContextHost?.HostSpecificEditAndContinueService;
                 if (encProvider != null)
                 {
                     return action(encProvider);
@@ -134,7 +134,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.EditAndContinue
         {
             // Important for ProjectNodeComServices to null out fields to reduce the amount 
             // of data we leak when extensions incorrectly holds onto the IVsHierarchy.
-            _host = null;
+            _projectContextHost = null;
             _threadingService = null;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ProjectContextCodeModelProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ProjectContextCodeModelProvider.cs
@@ -20,21 +20,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
     {
         private readonly IProjectThreadingService _threadingService;
         private readonly ICodeModelFactory _codeModelFactory;
-        private readonly ILanguageServiceHost _languageServiceHost;
+        private readonly IActiveWorkspaceProjectContextHost _projectContextHost;
 
         [ImportingConstructor]
-        public ProjectContextCodeModelProvider(IProjectThreadingService threadingService, ICodeModelFactory codeModelFactory, ILanguageServiceHost languageServiceHost)
+        public ProjectContextCodeModelProvider(IProjectThreadingService threadingService, ICodeModelFactory codeModelFactory, IActiveWorkspaceProjectContextHost projectContextHost)
         {
             _threadingService = threadingService;
             _codeModelFactory = codeModelFactory;
-            _languageServiceHost = languageServiceHost;
+            _projectContextHost = projectContextHost;
         }
 
         public CodeModel GetCodeModel(Project project)
         {
             Requires.NotNull(project, nameof(project));
 
-            IWorkspaceProjectContext projectContext = _languageServiceHost.ActiveProjectContext;
+            IWorkspaceProjectContext projectContext = _projectContextHost.ActiveProjectContext;
             if (projectContext == null)
                 return null;
 
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         {
             Requires.NotNull(fileItem, nameof(fileItem));
 
-            IWorkspaceProjectContext projectContext = _languageServiceHost.ActiveProjectContext;
+            IWorkspaceProjectContext projectContext = _projectContextHost.ActiveProjectContext;
             if (projectContext == null)
                 return null;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
@@ -22,19 +22,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         private readonly IVsService<SAsyncServiceProvider, IOleAsyncServiceProvider> _serviceProvider;
         private readonly IUnconfiguredProjectVsServices _projectVsServices;
         private readonly IProjectHostProvider _projectHostProvider;
-        private readonly ILanguageServiceHost _languageServiceHost;
+        private readonly IActiveWorkspaceProjectContextHost _projectContextHost;
         private readonly AsyncLazy<IVsContainedLanguageFactory> _containedLanguageFactory;
 
         [ImportingConstructor]
         public VsContainedLanguageComponentsFactory(IVsService<SAsyncServiceProvider, IOleAsyncServiceProvider> serviceProvider,
                                                     IUnconfiguredProjectVsServices projectVsServices,
                                                     IProjectHostProvider projectHostProvider,
-                                                    ILanguageServiceHost languageServiceHost)
+                                                    IActiveWorkspaceProjectContextHost projectContextHost)
         {
             _serviceProvider = serviceProvider;
             _projectVsServices = projectVsServices;
             _projectHostProvider = projectHostProvider;
-            _languageServiceHost = languageServiceHost;
+            _projectContextHost = projectContextHost;
 
             _containedLanguageFactory = new AsyncLazy<IVsContainedLanguageFactory>(GetContainedLanguageFactoryAsync, projectVsServices.ThreadingService.JoinableTaskFactory);
         }
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
 
         private async Task<(HierarchyId itemid, IVsHierarchy hierarchy, IVsContainedLanguageFactory containedLanguageFactory)> GetContainedLanguageFactoryForFileAsync(string filePath)
         {
-            await _languageServiceHost.InitializeAsync()
+            await _projectContextHost.InitializeAsync()
                                       .ConfigureAwait(true);
 
             await _projectVsServices.ThreadingService.SwitchToUIThread();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/ProjectFileOrAssemblyInfoPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/ProjectFileOrAssemblyInfoPropertiesProvider.cs
@@ -27,11 +27,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             [Import(ContractNames.ProjectPropertyProviders.ProjectFile)] IProjectInstancePropertiesProvider instanceProvider,
             [ImportMany(ContractNames.ProjectPropertyProviders.ProjectFile)]IEnumerable<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>> interceptingValueProviders,
             UnconfiguredProject project,
-            ILanguageServiceHost languageServiceHost,
+            IActiveWorkspaceProjectContextHost projectContextHost,
             VisualStudioWorkspace workspace,
             IProjectThreadingService threadingService)
             : base(delegatedProvider, instanceProvider, interceptingValueProviders, project,
-                  getActiveProjectId: () => ((AbstractProject)languageServiceHost.ActiveProjectContext)?.Id,
+                  getActiveProjectId: () => ((AbstractProject)projectContextHost.ActiveProjectContext)?.Id,
                   workspace: workspace,
                   threadingService: threadingService)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IActiveWorkspaceProjectContextHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IActiveWorkspaceProjectContextHost.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     /// <summary>
     ///     Hosts a <see cref="IWorkspaceProjectContext"/> and handles the interaction between the project system and the language service.
     /// </summary>
-    internal interface ILanguageServiceHost
+    internal interface IActiveWorkspaceProjectContextHost
     {
         /// <summary>
         ///     Gets an object that represents a host-specific error reporter.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -16,9 +16,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     /// <summary>
     ///     Hosts a <see cref="IWorkspaceProjectContext"/> and handles the interaction between the project system and the language service.
     /// </summary>
-    [Export(typeof(ILanguageServiceHost))]
+    [Export(typeof(IActiveWorkspaceProjectContextHost))]
     [AppliesTo(ProjectCapability.DotNetLanguageService)]
-    internal partial class LanguageServiceHost : OnceInitializedOnceDisposedAsync, ILanguageServiceHost
+    internal partial class LanguageServiceHost : OnceInitializedOnceDisposedAsync, IActiveWorkspaceProjectContextHost
     {
 #pragma warning disable CA2213 // OnceInitializedOnceDisposedAsync are not tracked correctly by the IDisposeable analyzer
         private readonly SemaphoreSlim _gate = new SemaphoreSlim(initialCount: 1);


### PR DESCRIPTION
This interface will represent the "host" that matches the current configuration, and will eventually let me swap old integration with new integration.