### PR TITLE
[WIP] Add project capability DynamicDependentFile

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
@@ -33,6 +33,7 @@ namespace Microsoft.VisualStudio.Packaging
 
 
         public const string DefaultCapabilities = ProjectCapability.AppDesigner + "; " +
+                                                  ProjectCapability.DynamicDependentFile + "; " +
                                                   ProjectCapability.EditAndContinue + "; " +
                                                   ProjectCapability.HandlesOwnReload + "; " +
                                                   ProjectCapability.OpenProjectFile + "; " +

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapability.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapability.cs
@@ -19,6 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public const string AppDesigner = nameof(AppDesigner);
         public const string AppSettings = nameof(AppSettings);
         public const string DependenciesTree = nameof(DependenciesTree);
+        public const string DynamicDependentFile = ProjectCapabilities.DynamicDependentFile;
         public const string EditAndContinue = nameof(EditAndContinue);
         public const string LaunchProfiles = nameof(LaunchProfiles);
         public const string OpenProjectFile = nameof(OpenProjectFile);


### PR DESCRIPTION
Enables CPS support for dependent files.

Note, this PR impacts web projects. They currently provide their own `IDependentFilesProvider`. This change will cause results from the CPS implementation to mix with theirs, giving confusing results.

This PR is marked WIP while we discuss another (internal) PR against CPS that provides a fix for web projects.

/cc @abpiskunov @lifengl 