### PR TITLE
Added Accessible Names For Build Prop Page

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.resx
@@ -1365,9 +1365,9 @@
   <data name="&gt;&gt;chkDefineDebug.ZOrder" xml:space="preserve">
     <value>23</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <data name="$this.Localizable" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
+  </data>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
   </data>
@@ -1382,5 +1382,11 @@
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
     <value>Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase, Microsoft.VisualStudio.AppDesigner, Version=42.42.42.42, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="txtSpecificWarnings.AccessibleName" xml:space="preserve">
+    <value>Specific Warnings To Treat As Errors</value>
+  </data>
+  <data name="txtXMLDocumentationFile.AccessibleName" xml:space="preserve">
+    <value>XML Document File Path</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.cs.xlf
@@ -137,6 +137,16 @@
         <target state="translated">Definovat konstantu DEB&amp;UG</target>
         <note />
       </trans-unit>
+      <trans-unit id="txtSpecificWarnings.AccessibleName">
+        <source>Specific Warnings To Treat As Errors</source>
+        <target state="new">Specific Warnings To Treat As Errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="txtXMLDocumentationFile.AccessibleName">
+        <source>XML Document File Path</source>
+        <target state="new">XML Document File Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.de.xlf
@@ -137,6 +137,16 @@
         <target state="translated">DEB&amp;UG-Konstante definieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="txtSpecificWarnings.AccessibleName">
+        <source>Specific Warnings To Treat As Errors</source>
+        <target state="new">Specific Warnings To Treat As Errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="txtXMLDocumentationFile.AccessibleName">
+        <source>XML Document File Path</source>
+        <target state="new">XML Document File Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.es.xlf
@@ -137,6 +137,16 @@
         <target state="translated">Definir constante DEB&amp;UG</target>
         <note />
       </trans-unit>
+      <trans-unit id="txtSpecificWarnings.AccessibleName">
+        <source>Specific Warnings To Treat As Errors</source>
+        <target state="new">Specific Warnings To Treat As Errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="txtXMLDocumentationFile.AccessibleName">
+        <source>XML Document File Path</source>
+        <target state="new">XML Document File Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.fr.xlf
@@ -137,6 +137,16 @@
         <target state="translated">Définir la constante DEB&amp;UG</target>
         <note />
       </trans-unit>
+      <trans-unit id="txtSpecificWarnings.AccessibleName">
+        <source>Specific Warnings To Treat As Errors</source>
+        <target state="new">Specific Warnings To Treat As Errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="txtXMLDocumentationFile.AccessibleName">
+        <source>XML Document File Path</source>
+        <target state="new">XML Document File Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.it.xlf
@@ -137,6 +137,16 @@
         <target state="translated">Definisci costante DEB&amp;UG</target>
         <note />
       </trans-unit>
+      <trans-unit id="txtSpecificWarnings.AccessibleName">
+        <source>Specific Warnings To Treat As Errors</source>
+        <target state="new">Specific Warnings To Treat As Errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="txtXMLDocumentationFile.AccessibleName">
+        <source>XML Document File Path</source>
+        <target state="new">XML Document File Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.ja.xlf
@@ -137,6 +137,16 @@
         <target state="translated">DEBUG 定数の定義(&amp;U)</target>
         <note />
       </trans-unit>
+      <trans-unit id="txtSpecificWarnings.AccessibleName">
+        <source>Specific Warnings To Treat As Errors</source>
+        <target state="new">Specific Warnings To Treat As Errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="txtXMLDocumentationFile.AccessibleName">
+        <source>XML Document File Path</source>
+        <target state="new">XML Document File Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.ko.xlf
@@ -137,6 +137,16 @@
         <target state="translated">DEBUG 상수 정의(&amp;U)</target>
         <note />
       </trans-unit>
+      <trans-unit id="txtSpecificWarnings.AccessibleName">
+        <source>Specific Warnings To Treat As Errors</source>
+        <target state="new">Specific Warnings To Treat As Errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="txtXMLDocumentationFile.AccessibleName">
+        <source>XML Document File Path</source>
+        <target state="new">XML Document File Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.pl.xlf
@@ -137,6 +137,16 @@
         <target state="translated">Zdefiniuj stałą DEB&amp;UG</target>
         <note />
       </trans-unit>
+      <trans-unit id="txtSpecificWarnings.AccessibleName">
+        <source>Specific Warnings To Treat As Errors</source>
+        <target state="new">Specific Warnings To Treat As Errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="txtXMLDocumentationFile.AccessibleName">
+        <source>XML Document File Path</source>
+        <target state="new">XML Document File Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.pt-BR.xlf
@@ -137,6 +137,16 @@
         <target state="translated">Definir constante DEB&amp;UG</target>
         <note />
       </trans-unit>
+      <trans-unit id="txtSpecificWarnings.AccessibleName">
+        <source>Specific Warnings To Treat As Errors</source>
+        <target state="new">Specific Warnings To Treat As Errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="txtXMLDocumentationFile.AccessibleName">
+        <source>XML Document File Path</source>
+        <target state="new">XML Document File Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.ru.xlf
@@ -137,6 +137,16 @@
         <target state="translated">Определить &amp;константу DEBUG</target>
         <note />
       </trans-unit>
+      <trans-unit id="txtSpecificWarnings.AccessibleName">
+        <source>Specific Warnings To Treat As Errors</source>
+        <target state="new">Specific Warnings To Treat As Errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="txtXMLDocumentationFile.AccessibleName">
+        <source>XML Document File Path</source>
+        <target state="new">XML Document File Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.tr.xlf
@@ -137,6 +137,16 @@
         <target state="translated">DEB&amp;UG sabitini tanımla</target>
         <note />
       </trans-unit>
+      <trans-unit id="txtSpecificWarnings.AccessibleName">
+        <source>Specific Warnings To Treat As Errors</source>
+        <target state="new">Specific Warnings To Treat As Errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="txtXMLDocumentationFile.AccessibleName">
+        <source>XML Document File Path</source>
+        <target state="new">XML Document File Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.zh-Hans.xlf
@@ -137,6 +137,16 @@
         <target state="translated">定义 DEBUG 常量(&amp;U)</target>
         <note />
       </trans-unit>
+      <trans-unit id="txtSpecificWarnings.AccessibleName">
+        <source>Specific Warnings To Treat As Errors</source>
+        <target state="new">Specific Warnings To Treat As Errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="txtXMLDocumentationFile.AccessibleName">
+        <source>XML Document File Path</source>
+        <target state="new">XML Document File Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.zh-Hant.xlf
@@ -137,6 +137,16 @@
         <target state="translated">定義 DEBUG 常數(&amp;U)</target>
         <note />
       </trans-unit>
+      <trans-unit id="txtSpecificWarnings.AccessibleName">
+        <source>Specific Warnings To Treat As Errors</source>
+        <target state="new">Specific Warnings To Treat As Errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="txtXMLDocumentationFile.AccessibleName">
+        <source>XML Document File Path</source>
+        <target state="new">XML Document File Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Fixes [646505](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/646505)

I confirmed that Narrator and and Inspect have the correct behavior.

The actual string to add can be changed, I added what I thought was intuitive:

Specific Warnings: "Specific Warnings To Treat As Errors"
XML documentation file: "XML Document File Path"
