### PR TITLE
Assembly Information Property Page Accessible Name Change

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/AssemblyInfoPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AssemblyInfoPropPage.resx
@@ -919,7 +919,7 @@
     <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="TitleLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="ComVisibleCheckBox" Row="10" RowSpan="1" Column="0" ColumnSpan="2" /&gt;&lt;Control Name="NeutralLanguageLabel" Row="9" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="Title" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="DescriptionLabel" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="Description" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="CompanyLabel" Row="2" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="Company" Row="2" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="ProductLabel" Row="3" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="Product" Row="3" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="CopyrightLabel" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="Copyright" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="TrademarkLabel" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="Trademark" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="AssemblyVersionLabel" Row="6" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="AssemblyVersionLayoutPanel" Row="6" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="FileVersionLabel" Row="7" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="FileVersionLayoutPanel" Row="7" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="GuidTextBox" Row="8" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="NeutralLanguageComboBox" Row="9" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="GuidLabel" Row="8" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="AssemblyVersionMajorTextBox.AccessibleName" xml:space="preserve">
-    <value>Major</value>
+    <value>Assembly Version major</value>
   </data>
   <data name="AssemblyVersionMajorTextBox.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
@@ -933,20 +933,8 @@
   <data name="AssemblyVersionMajorTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;AssemblyVersionMajorTextBox.Name" xml:space="preserve">
-    <value>AssemblyVersionMajorTextBox</value>
-  </data>
-  <data name="&gt;&gt;AssemblyVersionMajorTextBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;AssemblyVersionMajorTextBox.Parent" xml:space="preserve">
-    <value>AssemblyVersionLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;AssemblyVersionMajorTextBox.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="AssemblyVersionMinorTextBox.AccessibleName" xml:space="preserve">
-    <value>Minor</value>
+    <value>Assembly Version minor</value>
   </data>
   <data name="AssemblyVersionMinorTextBox.Location" type="System.Drawing.Point, System.Drawing">
     <value>45, 0</value>
@@ -960,20 +948,8 @@
   <data name="AssemblyVersionMinorTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;AssemblyVersionMinorTextBox.Name" xml:space="preserve">
-    <value>AssemblyVersionMinorTextBox</value>
-  </data>
-  <data name="&gt;&gt;AssemblyVersionMinorTextBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;AssemblyVersionMinorTextBox.Parent" xml:space="preserve">
-    <value>AssemblyVersionLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;AssemblyVersionMinorTextBox.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="AssemblyVersionBuildTextBox.AccessibleName" xml:space="preserve">
-    <value>Build</value>
+    <value>Assembly Version build</value>
   </data>
   <data name="AssemblyVersionBuildTextBox.Location" type="System.Drawing.Point, System.Drawing">
     <value>90, 0</value>
@@ -987,20 +963,8 @@
   <data name="AssemblyVersionBuildTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
-  <data name="&gt;&gt;AssemblyVersionBuildTextBox.Name" xml:space="preserve">
-    <value>AssemblyVersionBuildTextBox</value>
-  </data>
-  <data name="&gt;&gt;AssemblyVersionBuildTextBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;AssemblyVersionBuildTextBox.Parent" xml:space="preserve">
-    <value>AssemblyVersionLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;AssemblyVersionBuildTextBox.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="AssemblyVersionRevisionTextBox.AccessibleName" xml:space="preserve">
-    <value>Revision</value>
+    <value>Assembly Version revision</value>
   </data>
   <data name="AssemblyVersionRevisionTextBox.Location" type="System.Drawing.Point, System.Drawing">
     <value>135, 0</value>
@@ -1014,20 +978,8 @@
   <data name="AssemblyVersionRevisionTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
-  <data name="&gt;&gt;AssemblyVersionRevisionTextBox.Name" xml:space="preserve">
-    <value>AssemblyVersionRevisionTextBox</value>
-  </data>
-  <data name="&gt;&gt;AssemblyVersionRevisionTextBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;AssemblyVersionRevisionTextBox.Parent" xml:space="preserve">
-    <value>AssemblyVersionLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;AssemblyVersionRevisionTextBox.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
   <data name="FileVersionMajorTextBox.AccessibleName" xml:space="preserve">
-    <value>Major</value>
+    <value>File Version major</value>
   </data>
   <data name="FileVersionMajorTextBox.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
@@ -1041,20 +993,8 @@
   <data name="FileVersionMajorTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;FileVersionMajorTextBox.Name" xml:space="preserve">
-    <value>FileVersionMajorTextBox</value>
-  </data>
-  <data name="&gt;&gt;FileVersionMajorTextBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;FileVersionMajorTextBox.Parent" xml:space="preserve">
-    <value>FileVersionLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;FileVersionMajorTextBox.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="FileVersionMinorTextBox.AccessibleName" xml:space="preserve">
-    <value>Minor</value>
+    <value>File Version minor</value>
   </data>
   <data name="FileVersionMinorTextBox.Location" type="System.Drawing.Point, System.Drawing">
     <value>45, 0</value>
@@ -1068,20 +1008,8 @@
   <data name="FileVersionMinorTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;FileVersionMinorTextBox.Name" xml:space="preserve">
-    <value>FileVersionMinorTextBox</value>
-  </data>
-  <data name="&gt;&gt;FileVersionMinorTextBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;FileVersionMinorTextBox.Parent" xml:space="preserve">
-    <value>FileVersionLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;FileVersionMinorTextBox.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="FileVersionBuildTextBox.AccessibleName" xml:space="preserve">
-    <value>Build</value>
+    <value>File Version build</value>
   </data>
   <data name="FileVersionBuildTextBox.Location" type="System.Drawing.Point, System.Drawing">
     <value>90, 0</value>
@@ -1095,20 +1023,8 @@
   <data name="FileVersionBuildTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
-  <data name="&gt;&gt;FileVersionBuildTextBox.Name" xml:space="preserve">
-    <value>FileVersionBuildTextBox</value>
-  </data>
-  <data name="&gt;&gt;FileVersionBuildTextBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;FileVersionBuildTextBox.Parent" xml:space="preserve">
-    <value>FileVersionLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;FileVersionBuildTextBox.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="FileVersionRevisionTextBox.AccessibleName" xml:space="preserve">
-    <value>Revision</value>
+    <value>File Version revision</value>
   </data>
   <data name="FileVersionRevisionTextBox.Location" type="System.Drawing.Point, System.Drawing">
     <value>135, 0</value>
@@ -1122,21 +1038,9 @@
   <data name="FileVersionRevisionTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
-  <data name="&gt;&gt;FileVersionRevisionTextBox.Name" xml:space="preserve">
-    <value>FileVersionRevisionTextBox</value>
-  </data>
-  <data name="&gt;&gt;FileVersionRevisionTextBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;FileVersionRevisionTextBox.Parent" xml:space="preserve">
-    <value>FileVersionLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;FileVersionRevisionTextBox.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <data name="$this.Localizable" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
+  </data>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
   </data>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.resx
@@ -1365,9 +1365,9 @@
   <data name="&gt;&gt;chkDefineDebug.ZOrder" xml:space="preserve">
     <value>23</value>
   </data>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <data name="$this.Localizable" type="System.Boolean, mscorlib">
     <value>True</value>
-  </metadata>
+  </data>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>
   </data>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.cs.xlf
@@ -53,23 +53,23 @@
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMajorTextBox.AccessibleName">
-        <source>Major</source>
-        <target state="translated">Hlavní</target>
+        <source>File Version major</source>
+        <target state="needs-review-translation">Hlavní</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMinorTextBox.AccessibleName">
-        <source>Minor</source>
-        <target state="translated">Vedlejší</target>
+        <source>File Version minor</source>
+        <target state="needs-review-translation">Vedlejší</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionBuildTextBox.AccessibleName">
-        <source>Build</source>
-        <target state="translated">Build</target>
+        <source>File Version build</source>
+        <target state="needs-review-translation">Build</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
-        <source>Revision</source>
-        <target state="translated">Revize</target>
+        <source>File Version revision</source>
+        <target state="needs-review-translation">Revize</target>
         <note />
       </trans-unit>
       <trans-unit id="GuidLabel.Text">
@@ -78,23 +78,23 @@
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionMajorTextBox.AccessibleName">
-        <source>Major</source>
-        <target state="translated">Hlavní</target>
+        <source>Assembly Version major</source>
+        <target state="needs-review-translation">Hlavní</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionMinorTextBox.AccessibleName">
-        <source>Minor</source>
-        <target state="translated">Vedlejší</target>
+        <source>Assembly Version minor</source>
+        <target state="needs-review-translation">Vedlejší</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionBuildTextBox.AccessibleName">
-        <source>Build</source>
-        <target state="translated">Build</target>
+        <source>Assembly Version build</source>
+        <target state="needs-review-translation">Build</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionRevisionTextBox.AccessibleName">
-        <source>Revision</source>
-        <target state="translated">Revize</target>
+        <source>Assembly Version revision</source>
+        <target state="needs-review-translation">Revize</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.de.xlf
@@ -53,23 +53,23 @@
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMajorTextBox.AccessibleName">
-        <source>Major</source>
-        <target state="translated">Hauptversion</target>
+        <source>File Version major</source>
+        <target state="needs-review-translation">Hauptversion</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMinorTextBox.AccessibleName">
-        <source>Minor</source>
-        <target state="translated">Nebenversion</target>
+        <source>File Version minor</source>
+        <target state="needs-review-translation">Nebenversion</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionBuildTextBox.AccessibleName">
-        <source>Build</source>
-        <target state="translated">Build</target>
+        <source>File Version build</source>
+        <target state="needs-review-translation">Build</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
-        <source>Revision</source>
-        <target state="translated">Revision</target>
+        <source>File Version revision</source>
+        <target state="needs-review-translation">Revision</target>
         <note />
       </trans-unit>
       <trans-unit id="GuidLabel.Text">
@@ -78,23 +78,23 @@
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionMajorTextBox.AccessibleName">
-        <source>Major</source>
-        <target state="translated">Hauptversion</target>
+        <source>Assembly Version major</source>
+        <target state="needs-review-translation">Hauptversion</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionMinorTextBox.AccessibleName">
-        <source>Minor</source>
-        <target state="translated">Nebenversion</target>
+        <source>Assembly Version minor</source>
+        <target state="needs-review-translation">Nebenversion</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionBuildTextBox.AccessibleName">
-        <source>Build</source>
-        <target state="translated">Build</target>
+        <source>Assembly Version build</source>
+        <target state="needs-review-translation">Build</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionRevisionTextBox.AccessibleName">
-        <source>Revision</source>
-        <target state="translated">Revision</target>
+        <source>Assembly Version revision</source>
+        <target state="needs-review-translation">Revision</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.es.xlf
@@ -53,23 +53,23 @@
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMajorTextBox.AccessibleName">
-        <source>Major</source>
-        <target state="translated">Principal</target>
+        <source>File Version major</source>
+        <target state="needs-review-translation">Principal</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMinorTextBox.AccessibleName">
-        <source>Minor</source>
-        <target state="translated">Secundaria</target>
+        <source>File Version minor</source>
+        <target state="needs-review-translation">Secundaria</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionBuildTextBox.AccessibleName">
-        <source>Build</source>
-        <target state="translated">Compilación</target>
+        <source>File Version build</source>
+        <target state="needs-review-translation">Compilación</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
-        <source>Revision</source>
-        <target state="translated">Revisión</target>
+        <source>File Version revision</source>
+        <target state="needs-review-translation">Revisión</target>
         <note />
       </trans-unit>
       <trans-unit id="GuidLabel.Text">
@@ -78,23 +78,23 @@
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionMajorTextBox.AccessibleName">
-        <source>Major</source>
-        <target state="translated">Principal</target>
+        <source>Assembly Version major</source>
+        <target state="needs-review-translation">Principal</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionMinorTextBox.AccessibleName">
-        <source>Minor</source>
-        <target state="translated">Secundaria</target>
+        <source>Assembly Version minor</source>
+        <target state="needs-review-translation">Secundaria</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionBuildTextBox.AccessibleName">
-        <source>Build</source>
-        <target state="translated">Compilación</target>
+        <source>Assembly Version build</source>
+        <target state="needs-review-translation">Compilación</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionRevisionTextBox.AccessibleName">
-        <source>Revision</source>
-        <target state="translated">Revisión</target>
+        <source>Assembly Version revision</source>
+        <target state="needs-review-translation">Revisión</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.fr.xlf
@@ -53,23 +53,23 @@
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMajorTextBox.AccessibleName">
-        <source>Major</source>
-        <target state="translated">Principale</target>
+        <source>File Version major</source>
+        <target state="needs-review-translation">Principale</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMinorTextBox.AccessibleName">
-        <source>Minor</source>
-        <target state="translated">Secondaire</target>
+        <source>File Version minor</source>
+        <target state="needs-review-translation">Secondaire</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionBuildTextBox.AccessibleName">
-        <source>Build</source>
-        <target state="translated">Build</target>
+        <source>File Version build</source>
+        <target state="needs-review-translation">Build</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
-        <source>Revision</source>
-        <target state="translated">Révision</target>
+        <source>File Version revision</source>
+        <target state="needs-review-translation">Révision</target>
         <note />
       </trans-unit>
       <trans-unit id="GuidLabel.Text">
@@ -78,23 +78,23 @@
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionMajorTextBox.AccessibleName">
-        <source>Major</source>
-        <target state="translated">Principale</target>
+        <source>Assembly Version major</source>
+        <target state="needs-review-translation">Principale</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionMinorTextBox.AccessibleName">
-        <source>Minor</source>
-        <target state="translated">Secondaire</target>
+        <source>Assembly Version minor</source>
+        <target state="needs-review-translation">Secondaire</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionBuildTextBox.AccessibleName">
-        <source>Build</source>
-        <target state="translated">Build</target>
+        <source>Assembly Version build</source>
+        <target state="needs-review-translation">Build</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionRevisionTextBox.AccessibleName">
-        <source>Revision</source>
-        <target state="translated">Révision</target>
+        <source>Assembly Version revision</source>
+        <target state="needs-review-translation">Révision</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.it.xlf
@@ -53,23 +53,23 @@
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMajorTextBox.AccessibleName">
-        <source>Major</source>
-        <target state="translated">Principale</target>
+        <source>File Version major</source>
+        <target state="needs-review-translation">Principale</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMinorTextBox.AccessibleName">
-        <source>Minor</source>
-        <target state="translated">Secondaria</target>
+        <source>File Version minor</source>
+        <target state="needs-review-translation">Secondaria</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionBuildTextBox.AccessibleName">
-        <source>Build</source>
-        <target state="translated">Compilazione</target>
+        <source>File Version build</source>
+        <target state="needs-review-translation">Compilazione</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
-        <source>Revision</source>
-        <target state="translated">Revisione</target>
+        <source>File Version revision</source>
+        <target state="needs-review-translation">Revisione</target>
         <note />
       </trans-unit>
       <trans-unit id="GuidLabel.Text">
@@ -78,23 +78,23 @@
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionMajorTextBox.AccessibleName">
-        <source>Major</source>
-        <target state="translated">Principale</target>
+        <source>Assembly Version major</source>
+        <target state="needs-review-translation">Principale</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionMinorTextBox.AccessibleName">
-        <source>Minor</source>
-        <target state="translated">Secondaria</target>
+        <source>Assembly Version minor</source>
+        <target state="needs-review-translation">Secondaria</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionBuildTextBox.AccessibleName">
-        <source>Build</source>
-        <target state="translated">Compilazione</target>
+        <source>Assembly Version build</source>
+        <target state="needs-review-translation">Compilazione</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionRevisionTextBox.AccessibleName">
-        <source>Revision</source>
-        <target state="translated">Revisione</target>
+        <source>Assembly Version revision</source>
+        <target state="needs-review-translation">Revisione</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.ja.xlf
@@ -53,23 +53,23 @@
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMajorTextBox.AccessibleName">
-        <source>Major</source>
-        <target state="translated">メジャー</target>
+        <source>File Version major</source>
+        <target state="needs-review-translation">メジャー</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMinorTextBox.AccessibleName">
-        <source>Minor</source>
-        <target state="translated">マイナー</target>
+        <source>File Version minor</source>
+        <target state="needs-review-translation">マイナー</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionBuildTextBox.AccessibleName">
-        <source>Build</source>
-        <target state="translated">ビルド</target>
+        <source>File Version build</source>
+        <target state="needs-review-translation">ビルド</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
-        <source>Revision</source>
-        <target state="translated">リビジョン</target>
+        <source>File Version revision</source>
+        <target state="needs-review-translation">リビジョン</target>
         <note />
       </trans-unit>
       <trans-unit id="GuidLabel.Text">
@@ -78,23 +78,23 @@
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionMajorTextBox.AccessibleName">
-        <source>Major</source>
-        <target state="translated">メジャー</target>
+        <source>Assembly Version major</source>
+        <target state="needs-review-translation">メジャー</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionMinorTextBox.AccessibleName">
-        <source>Minor</source>
-        <target state="translated">マイナー</target>
+        <source>Assembly Version minor</source>
+        <target state="needs-review-translation">マイナー</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionBuildTextBox.AccessibleName">
-        <source>Build</source>
-        <target state="translated">ビルド</target>
+        <source>Assembly Version build</source>
+        <target state="needs-review-translation">ビルド</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionRevisionTextBox.AccessibleName">
-        <source>Revision</source>
-        <target state="translated">リビジョン</target>
+        <source>Assembly Version revision</source>
+        <target state="needs-review-translation">リビジョン</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.ko.xlf
@@ -53,23 +53,23 @@
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMajorTextBox.AccessibleName">
-        <source>Major</source>
-        <target state="translated">주</target>
+        <source>File Version major</source>
+        <target state="needs-review-translation">주</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMinorTextBox.AccessibleName">
-        <source>Minor</source>
-        <target state="translated">부</target>
+        <source>File Version minor</source>
+        <target state="needs-review-translation">부</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionBuildTextBox.AccessibleName">
-        <source>Build</source>
-        <target state="translated">빌드</target>
+        <source>File Version build</source>
+        <target state="needs-review-translation">빌드</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
-        <source>Revision</source>
-        <target state="translated">수정 버전</target>
+        <source>File Version revision</source>
+        <target state="needs-review-translation">수정 버전</target>
         <note />
       </trans-unit>
       <trans-unit id="GuidLabel.Text">
@@ -78,23 +78,23 @@
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionMajorTextBox.AccessibleName">
-        <source>Major</source>
-        <target state="translated">주</target>
+        <source>Assembly Version major</source>
+        <target state="needs-review-translation">주</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionMinorTextBox.AccessibleName">
-        <source>Minor</source>
-        <target state="translated">부</target>
+        <source>Assembly Version minor</source>
+        <target state="needs-review-translation">부</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionBuildTextBox.AccessibleName">
-        <source>Build</source>
-        <target state="translated">빌드</target>
+        <source>Assembly Version build</source>
+        <target state="needs-review-translation">빌드</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionRevisionTextBox.AccessibleName">
-        <source>Revision</source>
-        <target state="translated">수정 버전</target>
+        <source>Assembly Version revision</source>
+        <target state="needs-review-translation">수정 버전</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.pl.xlf
@@ -53,23 +53,23 @@
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMajorTextBox.AccessibleName">
-        <source>Major</source>
-        <target state="translated">Główna</target>
+        <source>File Version major</source>
+        <target state="needs-review-translation">Główna</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMinorTextBox.AccessibleName">
-        <source>Minor</source>
-        <target state="translated">Pomocnicza</target>
+        <source>File Version minor</source>
+        <target state="needs-review-translation">Pomocnicza</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionBuildTextBox.AccessibleName">
-        <source>Build</source>
-        <target state="translated">Kompilacja</target>
+        <source>File Version build</source>
+        <target state="needs-review-translation">Kompilacja</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
-        <source>Revision</source>
-        <target state="translated">Poprawka</target>
+        <source>File Version revision</source>
+        <target state="needs-review-translation">Poprawka</target>
         <note />
       </trans-unit>
       <trans-unit id="GuidLabel.Text">
@@ -78,23 +78,23 @@
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionMajorTextBox.AccessibleName">
-        <source>Major</source>
-        <target state="translated">Główna</target>
+        <source>Assembly Version major</source>
+        <target state="needs-review-translation">Główna</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionMinorTextBox.AccessibleName">
-        <source>Minor</source>
-        <target state="translated">Pomocnicza</target>
+        <source>Assembly Version minor</source>
+        <target state="needs-review-translation">Pomocnicza</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionBuildTextBox.AccessibleName">
-        <source>Build</source>
-        <target state="translated">Kompilacja</target>
+        <source>Assembly Version build</source>
+        <target state="needs-review-translation">Kompilacja</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionRevisionTextBox.AccessibleName">
-        <source>Revision</source>
-        <target state="translated">Poprawka</target>
+        <source>Assembly Version revision</source>
+        <target state="needs-review-translation">Poprawka</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.pt-BR.xlf
@@ -53,23 +53,23 @@
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMajorTextBox.AccessibleName">
-        <source>Major</source>
-        <target state="translated">Principal</target>
+        <source>File Version major</source>
+        <target state="needs-review-translation">Principal</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMinorTextBox.AccessibleName">
-        <source>Minor</source>
-        <target state="translated">Secundário</target>
+        <source>File Version minor</source>
+        <target state="needs-review-translation">Secundário</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionBuildTextBox.AccessibleName">
-        <source>Build</source>
-        <target state="translated">Build</target>
+        <source>File Version build</source>
+        <target state="needs-review-translation">Build</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
-        <source>Revision</source>
-        <target state="translated">Revisão</target>
+        <source>File Version revision</source>
+        <target state="needs-review-translation">Revisão</target>
         <note />
       </trans-unit>
       <trans-unit id="GuidLabel.Text">
@@ -78,23 +78,23 @@
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionMajorTextBox.AccessibleName">
-        <source>Major</source>
-        <target state="translated">Principal</target>
+        <source>Assembly Version major</source>
+        <target state="needs-review-translation">Principal</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionMinorTextBox.AccessibleName">
-        <source>Minor</source>
-        <target state="translated">Secundário</target>
+        <source>Assembly Version minor</source>
+        <target state="needs-review-translation">Secundário</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionBuildTextBox.AccessibleName">
-        <source>Build</source>
-        <target state="translated">Build</target>
+        <source>Assembly Version build</source>
+        <target state="needs-review-translation">Build</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionRevisionTextBox.AccessibleName">
-        <source>Revision</source>
-        <target state="translated">Revisão</target>
+        <source>Assembly Version revision</source>
+        <target state="needs-review-translation">Revisão</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.ru.xlf
@@ -53,23 +53,23 @@
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMajorTextBox.AccessibleName">
-        <source>Major</source>
-        <target state="translated">Основной номер</target>
+        <source>File Version major</source>
+        <target state="needs-review-translation">Основной номер</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMinorTextBox.AccessibleName">
-        <source>Minor</source>
-        <target state="translated">Дополнительный номер</target>
+        <source>File Version minor</source>
+        <target state="needs-review-translation">Дополнительный номер</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionBuildTextBox.AccessibleName">
-        <source>Build</source>
-        <target state="translated">Сборка</target>
+        <source>File Version build</source>
+        <target state="needs-review-translation">Сборка</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
-        <source>Revision</source>
-        <target state="translated">Редакция</target>
+        <source>File Version revision</source>
+        <target state="needs-review-translation">Редакция</target>
         <note />
       </trans-unit>
       <trans-unit id="GuidLabel.Text">
@@ -78,23 +78,23 @@
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionMajorTextBox.AccessibleName">
-        <source>Major</source>
-        <target state="translated">Основной номер</target>
+        <source>Assembly Version major</source>
+        <target state="needs-review-translation">Основной номер</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionMinorTextBox.AccessibleName">
-        <source>Minor</source>
-        <target state="translated">Дополнительный номер</target>
+        <source>Assembly Version minor</source>
+        <target state="needs-review-translation">Дополнительный номер</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionBuildTextBox.AccessibleName">
-        <source>Build</source>
-        <target state="translated">Сборка</target>
+        <source>Assembly Version build</source>
+        <target state="needs-review-translation">Сборка</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionRevisionTextBox.AccessibleName">
-        <source>Revision</source>
-        <target state="translated">Редакция</target>
+        <source>Assembly Version revision</source>
+        <target state="needs-review-translation">Редакция</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.tr.xlf
@@ -53,23 +53,23 @@
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMajorTextBox.AccessibleName">
-        <source>Major</source>
-        <target state="translated">Önemli</target>
+        <source>File Version major</source>
+        <target state="needs-review-translation">Önemli</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMinorTextBox.AccessibleName">
-        <source>Minor</source>
-        <target state="translated">Önemsiz</target>
+        <source>File Version minor</source>
+        <target state="needs-review-translation">Önemsiz</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionBuildTextBox.AccessibleName">
-        <source>Build</source>
-        <target state="translated">Derleme</target>
+        <source>File Version build</source>
+        <target state="needs-review-translation">Derleme</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
-        <source>Revision</source>
-        <target state="translated">Düzeltme</target>
+        <source>File Version revision</source>
+        <target state="needs-review-translation">Düzeltme</target>
         <note />
       </trans-unit>
       <trans-unit id="GuidLabel.Text">
@@ -78,23 +78,23 @@
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionMajorTextBox.AccessibleName">
-        <source>Major</source>
-        <target state="translated">Önemli</target>
+        <source>Assembly Version major</source>
+        <target state="needs-review-translation">Önemli</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionMinorTextBox.AccessibleName">
-        <source>Minor</source>
-        <target state="translated">Önemsiz</target>
+        <source>Assembly Version minor</source>
+        <target state="needs-review-translation">Önemsiz</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionBuildTextBox.AccessibleName">
-        <source>Build</source>
-        <target state="translated">Derleme</target>
+        <source>Assembly Version build</source>
+        <target state="needs-review-translation">Derleme</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionRevisionTextBox.AccessibleName">
-        <source>Revision</source>
-        <target state="translated">Düzeltme</target>
+        <source>Assembly Version revision</source>
+        <target state="needs-review-translation">Düzeltme</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.zh-Hans.xlf
@@ -53,23 +53,23 @@
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMajorTextBox.AccessibleName">
-        <source>Major</source>
-        <target state="translated">主要</target>
+        <source>File Version major</source>
+        <target state="needs-review-translation">主要</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMinorTextBox.AccessibleName">
-        <source>Minor</source>
-        <target state="translated">次要</target>
+        <source>File Version minor</source>
+        <target state="needs-review-translation">次要</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionBuildTextBox.AccessibleName">
-        <source>Build</source>
-        <target state="translated">生成</target>
+        <source>File Version build</source>
+        <target state="needs-review-translation">生成</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
-        <source>Revision</source>
-        <target state="translated">修订</target>
+        <source>File Version revision</source>
+        <target state="needs-review-translation">修订</target>
         <note />
       </trans-unit>
       <trans-unit id="GuidLabel.Text">
@@ -78,23 +78,23 @@
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionMajorTextBox.AccessibleName">
-        <source>Major</source>
-        <target state="translated">主要</target>
+        <source>Assembly Version major</source>
+        <target state="needs-review-translation">主要</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionMinorTextBox.AccessibleName">
-        <source>Minor</source>
-        <target state="translated">次要</target>
+        <source>Assembly Version minor</source>
+        <target state="needs-review-translation">次要</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionBuildTextBox.AccessibleName">
-        <source>Build</source>
-        <target state="translated">生成</target>
+        <source>Assembly Version build</source>
+        <target state="needs-review-translation">生成</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionRevisionTextBox.AccessibleName">
-        <source>Revision</source>
-        <target state="translated">修订</target>
+        <source>Assembly Version revision</source>
+        <target state="needs-review-translation">修订</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/AssemblyInfoPropPage.zh-Hant.xlf
@@ -53,23 +53,23 @@
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMajorTextBox.AccessibleName">
-        <source>Major</source>
-        <target state="translated">主要</target>
+        <source>File Version major</source>
+        <target state="needs-review-translation">主要</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMinorTextBox.AccessibleName">
-        <source>Minor</source>
-        <target state="translated">次要</target>
+        <source>File Version minor</source>
+        <target state="needs-review-translation">次要</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionBuildTextBox.AccessibleName">
-        <source>Build</source>
-        <target state="translated">組建</target>
+        <source>File Version build</source>
+        <target state="needs-review-translation">組建</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
-        <source>Revision</source>
-        <target state="translated">修訂</target>
+        <source>File Version revision</source>
+        <target state="needs-review-translation">修訂</target>
         <note />
       </trans-unit>
       <trans-unit id="GuidLabel.Text">
@@ -78,23 +78,23 @@
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionMajorTextBox.AccessibleName">
-        <source>Major</source>
-        <target state="translated">主要</target>
+        <source>Assembly Version major</source>
+        <target state="needs-review-translation">主要</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionMinorTextBox.AccessibleName">
-        <source>Minor</source>
-        <target state="translated">次要</target>
+        <source>Assembly Version minor</source>
+        <target state="needs-review-translation">次要</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionBuildTextBox.AccessibleName">
-        <source>Build</source>
-        <target state="translated">組建</target>
+        <source>Assembly Version build</source>
+        <target state="needs-review-translation">組建</target>
         <note />
       </trans-unit>
       <trans-unit id="AssemblyVersionRevisionTextBox.AccessibleName">
-        <source>Revision</source>
-        <target state="translated">修訂</target>
+        <source>Assembly Version revision</source>
+        <target state="needs-review-translation">修訂</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
Fix for: [646509](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/646509)

Changed the .AccessibleName to the recommended names for the Assembly Version and File Version. Before, the narrator would only read "Major, Minor, Build, Revision" instead of saying whether it was Assembly or File Version.

Now, Narrator will announce which one you are changing. 

I confirmed that Narrator and and Inspect have the correct behavior.