### PR TITLE
Changed Neutral Language ComboBoxStyle to DropDownList

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/AssemblyInfoPropPage.Designer.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AssemblyInfoPropPage.Designer.vb
@@ -256,6 +256,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Me.NeutralLanguageComboBox.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend
             Me.NeutralLanguageComboBox.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems
             resources.ApplyResources(Me.NeutralLanguageComboBox, "NeutralLanguageComboBox")
+            Me.NeutralLanguageComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList
             Me.NeutralLanguageComboBox.FormattingEnabled = True
             Me.NeutralLanguageComboBox.Name = "NeutralLanguageComboBox"
             Me.NeutralLanguageComboBox.Sorted = True


### PR DESCRIPTION
Fixes: [646618](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/646618)

The text that it announces isn't exactly what the "expected result" was, but the bug asked for the combo box to be announced, which it does now.

This also fixes [646590](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/646590/)

Pressing Escape with the Neutral Language ComboBox expanded no longer closes the entire Assembly Information window, instead collapsing the Neutral Language ComboBox.

I feel like there is an added benefit to this change as well:

The Neutral Language ComboBox in the Assembly Information window checks to make sure that you inputted a correct Neutral Language if you try to enter your own. This essentially means that editing it is useless, because the only selections that you can use are already in the drop down list. If you enter something that does not match what is available you get this:
<img width="427" alt="notalanguage" src="https://user-images.githubusercontent.com/36282608/45980936-3bc77980-c008-11e8-8607-48019652d7d2.PNG">

This means that it should be changed to a DropDownList style because it doesn't allow editing. 

Another case in the prop pages that already uses a DropDownList style is under Publish->Description->Publish language - and this is seemingly pulling from the same list of available languages, so the behavior should probably match.