### PR TITLE
Add LanguageVersion for C# 8.0 (beta)

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/CSharpLanguageVersion.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CSharpLanguageVersion.vb
@@ -29,6 +29,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Private Const LanguageVersion_DisplayNameFor7_2 As String = "C# 7.2"
         Private Const LanguageVersion_7_3 As String = "7.3"
         Private Const LanguageVersion_DisplayNameFor7_3 As String = "C# 7.3"
+        Private Const LanguageVersion_8_0 As String = "8.0"
+        Private Const LanguageVersion_DisplayNameFor8_0 As String = "C# 8.0 (beta)"
 
         ''' <summary>
         ''' Stores the property value corresponding to the language version
@@ -182,6 +184,16 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Public Shared ReadOnly Property Version7_3() As CSharpLanguageVersion
             Get
                 Static value As New CSharpLanguageVersion(LanguageVersion_7_3, LanguageVersion_DisplayNameFor7_3)
+                Return value
+            End Get
+        End Property
+
+        ''' <summary>
+        ''' Return the C# 8.0 language version object
+        ''' </summary>
+        Public Shared ReadOnly Property Version8_0() As CSharpLanguageVersion
+            Get
+                Static value As New CSharpLanguageVersion(LanguageVersion_8_0, LanguageVersion_DisplayNameFor8_0)
                 Return value
             End Get
         End Property

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CSharpLanguageVersionUtilities.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CSharpLanguageVersionUtilities.vb
@@ -26,7 +26,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 CSharpLanguageVersion.Version7,
                 CSharpLanguageVersion.Version7_1,
                 CSharpLanguageVersion.Version7_2,
-                CSharpLanguageVersion.Version7_3}
+                CSharpLanguageVersion.Version7_3,
+                CSharpLanguageVersion.Version8_0}
 
         End Function
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12466233/46556077-5f0ce700-c89a-11e8-960c-23c1fa935f0e.png)

![image](https://user-images.githubusercontent.com/12466233/46556452-87491580-c89b-11e8-8bdf-df1e015d645e.png)

Notes:
- I intend this change to go into dev16 preview1. Let me know if this is not the appropriate branch to achieve that.
- I did not make the "beta" label localizable. I don't think that's needed. Let me know if you think otherwise.
- dev16 RTM will ship with C# 8.0 marked as beta. The "beta" label will be removed in a later version.

Fixes https://github.com/dotnet/project-system/issues/3569