### PR TITLE
Change default wording of the not supported version fallback message

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
@@ -355,7 +355,7 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Projects targeting versions newer than .NET Core {0}.{1} are not supported by this version of Visual Studio..
+        ///   Looks up a localized string similar to Projects targeting .NET Core {0}.{1} or newer are not supported by this version of Visual Studio..
         /// </summary>
         internal static string NotSupportedDotNetCoreProject {
             get {
@@ -427,7 +427,7 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}..
+        ///   Looks up a localized string similar to A newer version of Visual Studio is recommended for projects targeting .NET Core {0}.{1}..
         /// </summary>
         internal static string PartialSupportedDotNetCoreProject {
             get {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
@@ -283,10 +283,10 @@ In order to debug this project, add an executable project to this solution which
     <value>Project</value>
   </data>
   <data name="PartialSupportedDotNetCoreProject" xml:space="preserve">
-    <value>A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}.</value>
+    <value>A newer version of Visual Studio is recommended for projects targeting .NET Core {0}.{1}.</value>
   </data>
   <data name="NotSupportedDotNetCoreProject" xml:space="preserve">
-    <value>Projects targeting versions newer than .NET Core {0}.{1} are not supported by this version of Visual Studio.</value>
+    <value>Projects targeting .NET Core {0}.{1} or newer are not supported by this version of Visual Studio.</value>
   </data>
   <data name="DontShowAgain" xml:space="preserve">
     <value>Don't show again</value>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
@@ -282,13 +282,13 @@ Pokud chcete projekt ladit, přidejte do řešení spustitelný projekt, který 
         <note />
       </trans-unit>
       <trans-unit id="PartialSupportedDotNetCoreProject">
-        <source>A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}.</source>
+        <source>A newer version of Visual Studio is recommended for projects targeting .NET Core {0}.{1}.</source>
         <target state="needs-review-translation">Pro projekty .NET Core {0}.{1} se doporučuje Visual Studio 2017 verze 15.7 nebo novější.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotSupportedDotNetCoreProject">
-        <source>Projects targeting versions newer than .NET Core {0}.{1} are not supported by this version of Visual Studio.</source>
-        <target state="translated">Tato verze sady Visual Studio nepodporuje projekty, které cílí na verze novější než .NET Core {0}.{1}.</target>
+        <source>Projects targeting .NET Core {0}.{1} or newer are not supported by this version of Visual Studio.</source>
+        <target state="needs-review-translation">Tato verze sady Visual Studio nepodporuje projekty, které cílí na verze novější než .NET Core {0}.{1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="DontShowAgain">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
@@ -282,13 +282,13 @@ Um das Projekt zu debuggen, fügen Sie dieser Projektmappe ein ausführbares Pro
         <note />
       </trans-unit>
       <trans-unit id="PartialSupportedDotNetCoreProject">
-        <source>A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}.</source>
+        <source>A newer version of Visual Studio is recommended for projects targeting .NET Core {0}.{1}.</source>
         <target state="needs-review-translation">Für .NET Core {0}.{1}-Projekte wird Visual Studio 2017, Version 15.7 oder höher, empfohlen.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotSupportedDotNetCoreProject">
-        <source>Projects targeting versions newer than .NET Core {0}.{1} are not supported by this version of Visual Studio.</source>
-        <target state="translated">Projekte für höhere Versionen als .NET Core {0}.{1} werden von dieser Version von Visual Studio nicht unterstützt.</target>
+        <source>Projects targeting .NET Core {0}.{1} or newer are not supported by this version of Visual Studio.</source>
+        <target state="needs-review-translation">Projekte für höhere Versionen als .NET Core {0}.{1} werden von dieser Version von Visual Studio nicht unterstützt.</target>
         <note />
       </trans-unit>
       <trans-unit id="DontShowAgain">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
@@ -282,13 +282,13 @@ Para depurar este proyecto, agregue un proyecto ejecutable a esta solución con 
         <note />
       </trans-unit>
       <trans-unit id="PartialSupportedDotNetCoreProject">
-        <source>A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}.</source>
+        <source>A newer version of Visual Studio is recommended for projects targeting .NET Core {0}.{1}.</source>
         <target state="needs-review-translation">Para los proyectos de .NET Core {0}.{1}, se recomienda Visual Studio 2017 versión 15.7 o superior.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotSupportedDotNetCoreProject">
-        <source>Projects targeting versions newer than .NET Core {0}.{1} are not supported by this version of Visual Studio.</source>
-        <target state="translated">Los proyectos destinados a versiones más recientes que .NET Core {0}.{1} no se admiten en esta versión de Visual Studio.</target>
+        <source>Projects targeting .NET Core {0}.{1} or newer are not supported by this version of Visual Studio.</source>
+        <target state="needs-review-translation">Los proyectos destinados a versiones más recientes que .NET Core {0}.{1} no se admiten en esta versión de Visual Studio.</target>
         <note />
       </trans-unit>
       <trans-unit id="DontShowAgain">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
@@ -282,13 +282,13 @@ Pour déboguer ce projet, ajoutez à cette solution un projet exécutable qui fa
         <note />
       </trans-unit>
       <trans-unit id="PartialSupportedDotNetCoreProject">
-        <source>A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}.</source>
+        <source>A newer version of Visual Studio is recommended for projects targeting .NET Core {0}.{1}.</source>
         <target state="needs-review-translation">Visual Studio 2017 version 15.7 ou ultérieur est recommandé pour les projets .NET Core {0}.{1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotSupportedDotNetCoreProject">
-        <source>Projects targeting versions newer than .NET Core {0}.{1} are not supported by this version of Visual Studio.</source>
-        <target state="translated">Les projets ciblant des versions plus récentes que .NET Core {0}.{1} ne sont pas pris en charge par cette version de Visual Studio.</target>
+        <source>Projects targeting .NET Core {0}.{1} or newer are not supported by this version of Visual Studio.</source>
+        <target state="needs-review-translation">Les projets ciblant des versions plus récentes que .NET Core {0}.{1} ne sont pas pris en charge par cette version de Visual Studio.</target>
         <note />
       </trans-unit>
       <trans-unit id="DontShowAgain">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
@@ -282,13 +282,13 @@ Per eseguire il debug del progetto, aggiungere a questa soluzione un progetto es
         <note />
       </trans-unit>
       <trans-unit id="PartialSupportedDotNetCoreProject">
-        <source>A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}.</source>
+        <source>A newer version of Visual Studio is recommended for projects targeting .NET Core {0}.{1}.</source>
         <target state="needs-review-translation">Per i progetti .NET Core {0}.{1} è consigliato Visual Studio 2017 15.7 o versioni successive.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotSupportedDotNetCoreProject">
-        <source>Projects targeting versions newer than .NET Core {0}.{1} are not supported by this version of Visual Studio.</source>
-        <target state="translated">Con questa versione di Visual Studio non sono supportati i progetti destinati a versioni di .NET Core successive alla versione {0}.{1}.</target>
+        <source>Projects targeting .NET Core {0}.{1} or newer are not supported by this version of Visual Studio.</source>
+        <target state="needs-review-translation">Con questa versione di Visual Studio non sono supportati i progetti destinati a versioni di .NET Core successive alla versione {0}.{1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="DontShowAgain">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
@@ -282,13 +282,13 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="PartialSupportedDotNetCoreProject">
-        <source>A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}.</source>
+        <source>A newer version of Visual Studio is recommended for projects targeting .NET Core {0}.{1}.</source>
         <target state="needs-review-translation">.NET Core {0}.{1} プロジェクトでは、Visual Studio 2017 バージョン 15.7 以降が推奨されています。</target>
         <note />
       </trans-unit>
       <trans-unit id="NotSupportedDotNetCoreProject">
-        <source>Projects targeting versions newer than .NET Core {0}.{1} are not supported by this version of Visual Studio.</source>
-        <target state="translated">.NET Core {0}.{1} 以降のバージョンをターゲットとするプロジェクトは、このバージョンの Visual Studio ではサポートされていません。</target>
+        <source>Projects targeting .NET Core {0}.{1} or newer are not supported by this version of Visual Studio.</source>
+        <target state="needs-review-translation">.NET Core {0}.{1} 以降のバージョンをターゲットとするプロジェクトは、このバージョンの Visual Studio ではサポートされていません。</target>
         <note />
       </trans-unit>
       <trans-unit id="DontShowAgain">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
@@ -282,13 +282,13 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="PartialSupportedDotNetCoreProject">
-        <source>A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}.</source>
+        <source>A newer version of Visual Studio is recommended for projects targeting .NET Core {0}.{1}.</source>
         <target state="needs-review-translation">.NET Core {0}.{1} 프로젝트에는 Visual Studio 2017 버전 15.7 이상이 권장됩니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotSupportedDotNetCoreProject">
-        <source>Projects targeting versions newer than .NET Core {0}.{1} are not supported by this version of Visual Studio.</source>
-        <target state="translated">.NET Core {0}.{1} 이상의 버전을 대상으로 하는 프로젝트는 이 버전의 Visual Studio에서 지원되지 않습니다.</target>
+        <source>Projects targeting .NET Core {0}.{1} or newer are not supported by this version of Visual Studio.</source>
+        <target state="needs-review-translation">.NET Core {0}.{1} 이상의 버전을 대상으로 하는 프로젝트는 이 버전의 Visual Studio에서 지원되지 않습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="DontShowAgain">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
@@ -282,13 +282,13 @@ Aby debugować ten projekt, dodaj projekt wykonywalny do tego rozwiązania, któ
         <note />
       </trans-unit>
       <trans-unit id="PartialSupportedDotNetCoreProject">
-        <source>A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}.</source>
+        <source>A newer version of Visual Studio is recommended for projects targeting .NET Core {0}.{1}.</source>
         <target state="needs-review-translation">Dla projektów platformy .NET Core {0}.{1} zalecany jest program Visual Studio 2017 w wersji 15.7 lub nowszej.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotSupportedDotNetCoreProject">
-        <source>Projects targeting versions newer than .NET Core {0}.{1} are not supported by this version of Visual Studio.</source>
-        <target state="translated">Projekty przeznaczone dla wersji nowszych niż platforma .NET Core {0}.{1} nie są obsługiwane przez tę wersję programu Visual Studio.</target>
+        <source>Projects targeting .NET Core {0}.{1} or newer are not supported by this version of Visual Studio.</source>
+        <target state="needs-review-translation">Projekty przeznaczone dla wersji nowszych niż platforma .NET Core {0}.{1} nie są obsługiwane przez tę wersję programu Visual Studio.</target>
         <note />
       </trans-unit>
       <trans-unit id="DontShowAgain">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
@@ -282,13 +282,13 @@ Para depurar esse projeto, adicione um projeto executável a essa solução que 
         <note />
       </trans-unit>
       <trans-unit id="PartialSupportedDotNetCoreProject">
-        <source>A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}.</source>
+        <source>A newer version of Visual Studio is recommended for projects targeting .NET Core {0}.{1}.</source>
         <target state="needs-review-translation">O Visual Studio 2017 versão 15.7 ou mais recente é recomendado para o .NET Core {0}. Projetos {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotSupportedDotNetCoreProject">
-        <source>Projects targeting versions newer than .NET Core {0}.{1} are not supported by this version of Visual Studio.</source>
-        <target state="translated">Projetos que destinam versões mais recentes que o .NET Core {0}. {1} não são compatíveis com esta versão do Visual Studio.</target>
+        <source>Projects targeting .NET Core {0}.{1} or newer are not supported by this version of Visual Studio.</source>
+        <target state="needs-review-translation">Projetos que destinam versões mais recentes que o .NET Core {0}. {1} não são compatíveis com esta versão do Visual Studio.</target>
         <note />
       </trans-unit>
       <trans-unit id="DontShowAgain">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
@@ -282,13 +282,13 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="PartialSupportedDotNetCoreProject">
-        <source>A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}.</source>
+        <source>A newer version of Visual Studio is recommended for projects targeting .NET Core {0}.{1}.</source>
         <target state="needs-review-translation">Для проектов .NET Core {0}.{1} рекомендуем использовать Visual Studio 2017 версии 15.7 или более новую версию.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotSupportedDotNetCoreProject">
-        <source>Projects targeting versions newer than .NET Core {0}.{1} are not supported by this version of Visual Studio.</source>
-        <target state="translated">Эта версия Visual Studio не поддерживает проекты, нацеленные на версии новее .NET Core {0}.{1}.</target>
+        <source>Projects targeting .NET Core {0}.{1} or newer are not supported by this version of Visual Studio.</source>
+        <target state="needs-review-translation">Эта версия Visual Studio не поддерживает проекты, нацеленные на версии новее .NET Core {0}.{1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="DontShowAgain">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
@@ -282,13 +282,13 @@ Bu projede hata ayıklamak için bu çözüme, kitaplık projesine başvuran bir
         <note />
       </trans-unit>
       <trans-unit id="PartialSupportedDotNetCoreProject">
-        <source>A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}.</source>
+        <source>A newer version of Visual Studio is recommended for projects targeting .NET Core {0}.{1}.</source>
         <target state="needs-review-translation">.NET Core {0}.{1} projeleri için Visual Studio 2017 sürüm 15.7 veya daha yeni bir sürüm önerilir.</target>
         <note />
       </trans-unit>
       <trans-unit id="NotSupportedDotNetCoreProject">
-        <source>Projects targeting versions newer than .NET Core {0}.{1} are not supported by this version of Visual Studio.</source>
-        <target state="translated">.NET Core {0}.{1} sürümünden daha yeni sürümleri hedefleyen projeler bu Visual Studio sürümünde desteklenmez.</target>
+        <source>Projects targeting .NET Core {0}.{1} or newer are not supported by this version of Visual Studio.</source>
+        <target state="needs-review-translation">.NET Core {0}.{1} sürümünden daha yeni sürümleri hedefleyen projeler bu Visual Studio sürümünde desteklenmez.</target>
         <note />
       </trans-unit>
       <trans-unit id="DontShowAgain">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
@@ -282,13 +282,13 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="PartialSupportedDotNetCoreProject">
-        <source>A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}.</source>
+        <source>A newer version of Visual Studio is recommended for projects targeting .NET Core {0}.{1}.</source>
         <target state="needs-review-translation">.NET Core {0}.{1} 项目建议使用 Visual Studio 2017 版本 15.7 或更新版本。</target>
         <note />
       </trans-unit>
       <trans-unit id="NotSupportedDotNetCoreProject">
-        <source>Projects targeting versions newer than .NET Core {0}.{1} are not supported by this version of Visual Studio.</source>
-        <target state="translated">此版 Visual Studio 不支持面向版本新于 .NET Core {0}.{1} 的项目。</target>
+        <source>Projects targeting .NET Core {0}.{1} or newer are not supported by this version of Visual Studio.</source>
+        <target state="needs-review-translation">此版 Visual Studio 不支持面向版本新于 .NET Core {0}.{1} 的项目。</target>
         <note />
       </trans-unit>
       <trans-unit id="DontShowAgain">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
@@ -282,13 +282,13 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="PartialSupportedDotNetCoreProject">
-        <source>A newer version of Visual Studio is recommended for projects targetting .NET Core {0}.{1}.</source>
+        <source>A newer version of Visual Studio is recommended for projects targeting .NET Core {0}.{1}.</source>
         <target state="needs-review-translation">建議在 .NET Core {0}.{1} 專案使用 Visual Studio 2017 15.7 以上的版本。</target>
         <note />
       </trans-unit>
       <trans-unit id="NotSupportedDotNetCoreProject">
-        <source>Projects targeting versions newer than .NET Core {0}.{1} are not supported by this version of Visual Studio.</source>
-        <target state="translated">這一版本的 Visual Studio 不支援以 .NET Core {0}.{1} 以上版本為目標的專案。</target>
+        <source>Projects targeting .NET Core {0}.{1} or newer are not supported by this version of Visual Studio.</source>
+        <target state="needs-review-translation">這一版本的 Visual Studio 不支援以 .NET Core {0}.{1} 以上版本為目標的專案。</target>
         <note />
       </trans-unit>
       <trans-unit id="DontShowAgain">


### PR DESCRIPTION
Previous message looks like it was written assuming compat information was updated early, but these days bits are available _very_ early.

Reported(?) on Twitter: https://twitter.com/ben_a_adams/status/1049847644745584641
Possibly the compat file should be updated to look further ahead than 3.0? Looks like @AngelosP owns that.