### PR TITLE
Refactor blocks

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectItemSchemaServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectItemSchemaServiceFactory.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Threading.Tasks.Dataflow;
-
 using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem
@@ -13,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var projectItemSchemaService = new Mock<IProjectItemSchemaService>();
 
             projectItemSchemaService.SetupGet(o => o.SourceBlock)
-                .Returns(new BroadcastBlock<IProjectVersionedValue<IProjectItemSchema>>(null));
+                .Returns(DataflowBlockSlim.CreateBroadcastBlock<IProjectVersionedValue<IProjectItemSchema>>());
 
             return projectItemSchemaService.Object;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectValueDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectValueDataSource.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
     internal class ProjectValueDataSource<T> : ProjectValueDataSourceBase<T>
         where T : class
     {
-        private BroadcastBlock<IProjectVersionedValue<T>> _broadcastBlock;
+        private IBroadcastBlock<IProjectVersionedValue<T>> _broadcastBlock;
         private int _version;
 
         public ProjectValueDataSource(IProjectCommonServices services)
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             base.Initialize();
 
-            _broadcastBlock = new BroadcastBlock<IProjectVersionedValue<T>>(null);
+            _broadcastBlock = DataflowBlockSlim.CreateBroadcastBlock<IProjectVersionedValue<T>>(null);
         }
 
         public async Task SendAndCompleteAsync(T value, ITargetBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>> targetBlock)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileDebugTargetGenerator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileDebugTargetGenerator.cs
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                     return new ProjectVersionedValue<IReadOnlyList<IEnumValue>>(generatedResult, dataSources);
                 });
 
-            var broadcastBlock = new BroadcastBlock<IProjectVersionedValue<IReadOnlyList<IEnumValue>>>(b => b);
+            var broadcastBlock = DataflowBlockSlim.CreateBroadcastBlock<IProjectVersionedValue<IReadOnlyList<IEnumValue>>>();
 
             _launchProfileProviderLink = LaunchSettingProvider.SourceBlock.LinkTo(
                 debugProfilesBlock,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileDebugTargetGenerator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileDebugTargetGenerator.cs
@@ -81,7 +81,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
         protected override void Initialize()
         {
-            var debugProfilesBlock = new TransformBlock<ILaunchSettings, IProjectVersionedValue<IReadOnlyList<IEnumValue>>>(
+            var debugProfilesBlock = DataflowBlockSlim.CreateTransformBlock<ILaunchSettings, IProjectVersionedValue<IReadOnlyList<IEnumValue>>>(
                 update =>
                 {
                     // Compute the new enum values from the profile provider

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/PackageRestoreInitiator.PackageRestoreInitiatorInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/PackageRestoreInitiator.PackageRestoreInitiatorInstance.cs
@@ -104,7 +104,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
                         });
 
                     Action<Tuple<ImmutableList<IProjectValueVersions>, TIdentityDictionary>> action = ProjectPropertyChanged;
-                    var target = new ActionBlock<Tuple<ImmutableList<IProjectValueVersions>, TIdentityDictionary>>(action);
+                    var target = DataflowBlockSlim.CreateActionBlock(action);
 
                     var targetLinkOptions = DataflowOption.PropagateCompletion;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/PackageRestoreInitiator.PackageRestoreInitiatorInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/PackageRestoreInitiator.PackageRestoreInitiatorInstance.cs
@@ -119,7 +119,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
 
             private static IPropagatorBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>, IProjectVersionedValue<IProjectSubscriptionUpdate>> CreateVersionDropperBlock()
             {
-                var transformBlock = new TransformBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>, IProjectVersionedValue<IProjectSubscriptionUpdate>>(data =>
+                var transformBlock = DataflowBlockSlim.CreateTransformBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>, IProjectVersionedValue<IProjectSubscriptionUpdate>>(data =>
                 {
                     return new ProjectVersionedValue<IProjectSubscriptionUpdate>(data.Value, data.DataSourceVersions.RemoveRange(s_keysToDrop));
                 });

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Threading.Tasks.Dataflow;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using Microsoft.VisualStudio.Shell;
@@ -122,7 +121,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
                     StandardRuleDataflowLinkOptions sourceLinkOptions = DataflowOption.WithRuleNames(ConfigurationGeneral.SchemaName);
 
                     ProjectDataSources.SourceBlockAndLink<IProjectVersionedValue<IProjectSubscriptionUpdate>> propertySource = _activeConfiguredProjectSubscriptionService.ProjectRuleSource.SourceBlock.SyncLinkOptions(sourceLinkOptions);
-                    var target = new ActionBlock<IProjectVersionedValue<Tuple<IProjectTreeSnapshot, IProjectSubscriptionUpdate>>>(DataFlow_ChangedAsync);
+                    var target = DataflowBlockSlim.CreateActionBlock<IProjectVersionedValue<Tuple<IProjectTreeSnapshot, IProjectSubscriptionUpdate>>>(DataFlow_ChangedAsync);
 
                     // Join the two sources so that we get synchronized versions of the data.
                     _treeWatcher = ProjectDataSources.SyncLinkTo(treeSource, propertySource, target);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetRuleSubscriberBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetRuleSubscriberBase.cs
@@ -123,7 +123,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
                     linkOptions: DataflowOption.PropagateCompletion));
 
             var actionBlockDesignTimeBuild =
-                new ActionBlock<IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectCatalogSnapshot, IProjectCapabilitiesSnapshot>>>(
+                DataflowBlockSlim.CreateActionBlock<IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectCatalogSnapshot, IProjectCapabilitiesSnapshot>>>(
                     e => OnProjectChangedAsync(e, configuredProject, RuleHandlerType.DesignTimeBuild),
                     new ExecutionDataflowBlockOptions()
                     {
@@ -131,7 +131,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
                     });
 
             var actionBlockEvaluation =
-                new ActionBlock<IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectCatalogSnapshot, IProjectCapabilitiesSnapshot>>>(
+                DataflowBlockSlim.CreateActionBlock<IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectCatalogSnapshot, IProjectCapabilitiesSnapshot>>>(
                      e => OnProjectChangedAsync(e, configuredProject, RuleHandlerType.Evaluation),
                      new ExecutionDataflowBlockOptions()
                      {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
                     linkOptions: DataflowOption.PropagateCompletion));
 
             var actionBlock =
-                new ActionBlock<IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectSharedFoldersSnapshot, IProjectCatalogSnapshot>>>
+                DataflowBlockSlim.CreateActionBlock<IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectSharedFoldersSnapshot, IProjectCatalogSnapshot>>>
                     (e => OnProjectChangedAsync(e),
                     new ExecutionDataflowBlockOptions()
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProviderSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProviderSource.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
         {
             JoinUpstreamDataSources(_orderedItemSource);
 
-            var providerProducerBlock = new TransformBlock<IProjectVersionedValue<IReadOnlyCollection<ProjectItemIdentity>>, IProjectVersionedValue<IProjectTreePropertiesProvider>>(
+            var providerProducerBlock = DataflowBlockSlim.CreateTransformBlock<IProjectVersionedValue<IReadOnlyCollection<ProjectItemIdentity>>, IProjectVersionedValue<IProjectTreePropertiesProvider>>(
                 orderedItems =>
                 {
                     return new ProjectVersionedValue<IProjectTreePropertiesProvider>(new TreeItemOrderPropertyProvider(orderedItems.Value, _project), orderedItems.DataSourceVersions);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         private readonly UnconfiguredProject _project;
         private readonly IActiveConfigurationGroupService _activeConfigurationGroupService;
         private readonly IUnconfiguredProjectTasksService _tasksService;
-        private readonly ActionBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>> _targetBlock;
+        private readonly ITargetBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>> _targetBlock;
         private IDisposable _subscription;
 
         [ImportingConstructor]
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             _project = project;
             _activeConfigurationGroupService = activeConfigurationGroupService;
             _tasksService = tasksService;
-            _targetBlock = new ActionBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>>(OnActiveConfigurationsChanged);
+            _targetBlock = DataflowBlockSlim.CreateActionBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>>(OnActiveConfigurationsChanged);
         }
 
         [ProjectAutoLoad(ProjectLoadCheckpoint.ProjectInitialCapabilitiesEstablished)]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ConfiguredProjectImplicitActivationTracking.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ConfiguredProjectImplicitActivationTracking.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         private readonly ConfiguredProject _project;
         private readonly IProjectAsynchronousTasksService _tasksService;
         private readonly IActiveConfigurationGroupService _activeConfigurationGroupService;
-        private readonly ActionBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>> _targetBlock;
+        private readonly ITargetBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>> _targetBlock;
         private TaskCompletionSource<object> _isImplicitlyActiveSource = new TaskCompletionSource<object>();
         private IDisposable _subscription;
 
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             _project = project;
             _activeConfigurationGroupService = activeConfigurationGroupService;
             _tasksService = tasksService;
-            _targetBlock = new ActionBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>>(OnActiveConfigurationsChanged);
+            _targetBlock = DataflowBlockSlim.CreateActionBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>>(OnActiveConfigurationsChanged);
 
             ImplicitlyActiveServices = new OrderPrecedenceImportCollection<IImplicitlyActiveService>(projectCapabilityCheckProvider: project);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DataFlowUtilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DataFlowUtilities.cs
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             Requires.NotNull(source, nameof(source));
             Requires.NotNull(target, nameof(target));
 
-            return source.LinkTo(new ActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(target),
+            return source.LinkTo(DataflowBlockSlim.CreateActionBlock(target),
                                  DataflowOption.PropagateCompletion,
                                  initialDataAsNew: true,
                                  suppressVersionOnlyUpdates: suppressVersionOnlyUpdates,
@@ -80,7 +80,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             Requires.NotNull(source, nameof(source));
             Requires.NotNull(target, nameof(target));
 
-            return source.LinkTo(new ActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(target),
+            return source.LinkTo(DataflowBlockSlim.CreateActionBlock(target),
                                  DataflowOption.PropagateCompletion,
                                  initialDataAsNew: true,
                                  suppressVersionOnlyUpdates: suppressVersionOnlyUpdates,
@@ -117,7 +117,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             Requires.NotNull(source, nameof(source));
             Requires.NotNull(target, nameof(target));
 
-            return source.LinkTo(new ActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(target),
+            return source.LinkTo(DataflowBlockSlim.CreateActionBlock(target),
                                  DataflowOption.PropagateCompletion,
                                  initialDataAsNew: true,
                                  suppressVersionOnlyUpdates: suppressVersionOnlyUpdates,
@@ -154,7 +154,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             Requires.NotNull(source, nameof(source));
             Requires.NotNull(target, nameof(target));
 
-            return source.LinkTo(new ActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(target),
+            return source.LinkTo(DataflowBlockSlim.CreateActionBlock(target),
                                  DataflowOption.PropagateCompletion,
                                  initialDataAsNew: true,
                                  suppressVersionOnlyUpdates: suppressVersionOnlyUpdates,
@@ -180,7 +180,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             Requires.NotNull(source, nameof(source));
             Requires.NotNull(target, nameof(target));
 
-            return source.LinkTo(new ActionBlock<T>(target), DataflowOption.PropagateCompletion);
+            return source.LinkTo(DataflowBlockSlim.CreateActionBlock(target), DataflowOption.PropagateCompletion);
         }
 
         /// <summary>
@@ -202,7 +202,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             Requires.NotNull(source, nameof(source));
             Requires.NotNull(target, nameof(target));
 
-            return source.LinkTo(new ActionBlock<T>(target), DataflowOption.PropagateCompletion);
+            return source.LinkTo(DataflowBlockSlim.CreateActionBlock(target), DataflowOption.PropagateCompletion);
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -184,7 +184,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 // The use of AsyncLazy with dataflow can allow state stored in the execution context to leak through. The downstream affect is
                 // calls to say, get properties, may fail. To avoid this, we capture the execution context here, and it will be reapplied when
                 // we get new subscription data from the dataflow.
-                var projectChangesBlock = new ActionBlock<IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectCapabilitiesSnapshot>>>(
+                var projectChangesBlock = DataflowBlockSlim.CreateActionBlock(
                             DataflowUtilities.CaptureAndApplyExecutionContext<IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectCapabilitiesSnapshot>>>(ProjectRuleBlock_ChangedAsync));
                 StandardRuleDataflowLinkOptions evaluationLinkOptions = DataflowOption.WithRuleNames(ProjectDebugger.SchemaName);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
         // The source for our dataflow
         private IReceivableSourceBlock<ILaunchSettings> _changedSourceBlock;
-        protected BroadcastBlock<ILaunchSettings> _broadcastBlock;
+        protected IBroadcastBlock<ILaunchSettings> _broadcastBlock;
 
         protected IFileSystem FileManager { get; set; }
 
@@ -173,7 +173,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         protected override void Initialize()
         {
             // Create our broadcast block for subscribers to get new ILaunchProfiles Information
-            _broadcastBlock = new BroadcastBlock<ILaunchSettings>(s => s);
+            _broadcastBlock = DataflowBlockSlim.CreateBroadcastBlock<ILaunchSettings>();
             _changedSourceBlock = _broadcastBlock.SafePublicize();
 
 


### PR DESCRIPTION
There is now a `DataflowBlockSlim` class that exists to reduce memory pressure associated with using dataflow types.  This PR switches to use it instead of creating new dataflow objects.