### PR TITLE
Fix Tab Order on Build Event Command Line Prop Page

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventCommandLineDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventCommandLineDialog.vb
@@ -166,6 +166,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             overarchingTableLayoutPanel.RowStyles.Item(1).SizeType = SizeType.AutoSize
             Height = Height - MacrosPanel.Height
 
+            ShowMacrosButton.Focus()
+
             '// Disable and hide the Insert button
             SetInsertButtonState(False)
 
@@ -179,6 +181,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             MacrosPanel.Visible = True
             overarchingTableLayoutPanel.RowStyles.Item(1).SizeType = SizeType.Percent
             Height = Height + MacrosPanel.Height
+
+            HideMacrosButton.Focus()
 
             '// Show the Insert button
             SetInsertButtonState(True)


### PR DESCRIPTION
Fixes: [646597](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/646597) and [646592](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/646592)

Previously, after expanding or collapsing the macro list, the tab order would move down to the OK button instead of staying on the Macro button. This PR fixes that behavior.

After clicking on Macros >> before fix:
<img width="401" alt="taborderbeforefix" src="https://user-images.githubusercontent.com/36282608/46887960-fda5c480-ce13-11e8-93ae-36c21d3309a9.PNG">
It moves to the OK button.

After clicking on Macros >> After fix:
<img width="401" alt="taborderafterfix" src="https://user-images.githubusercontent.com/36282608/46887986-0b5b4a00-ce14-11e8-9f3f-09a024c1731b.PNG">
It stays on the (now visible)  << Macros Button.

It also fixes it in the reverse case.
