### PR TITLE
Fix scroll location when property panel is resized and page is selected again

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerView.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerView.vb
@@ -608,6 +608,9 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                     If PropPage IsNot Nothing Then
                         PropPage.GetPageInfo(Info)
                         PropertyPagePanel.AutoScrollMinSize = New Size(Info(0).SIZE.cx + Padding.Right + Padding.Left, Info(0).SIZE.cy + Padding.Top + Padding.Bottom)
+                        PropertyPagePanel.AutoScroll = True
+                        PropertyPagePanel.VerticalScroll.Value = 0
+                        PropertyPagePanel.HorizontalScroll.Value = 0
                     End If
 
                     PropPage.Activate(PropertyPagePanel.Handle, New OleInterop.RECT() {GetPageRect()}, 0)


### PR DESCRIPTION
Fixes: [646587](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/646587)

This fixes an issue across a number of property pages where if the panel is small enough to require scroll bar(s): 
<img width="794" alt="smallpanel" src="https://user-images.githubusercontent.com/36282608/46893026-5e3cfd80-ce24-11e8-82f4-0356e7346280.PNG">

And you tab to the last item and tab back to the property page's tab item:
<img width="794" alt="tabbedback" src="https://user-images.githubusercontent.com/36282608/46893055-7876db80-ce24-11e8-8e3f-1e9722f8607f.PNG">

When you press Enter to go back into the property page, the "Assembly name" box is selected but the window stays at the bottom of the property page, until you tab to the next item.

This fixes this by resetting the scrolls to 0 that all property pages begin at normally.

