### PR TITLE
Fix crash when adding new setting

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DesignTimeSettings.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/DesignTimeSettings.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel
 
@@ -177,7 +177,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <returns></returns>
         ''' <remarks></remarks>
         Friend Shared Function EqualIdentifiers(Id1 As String, Id2 As String) As Boolean
-            Return String.Equals(Id1, Id2, StringComparison.OrdinalIgnoreCase)
+            Return StringComparers.SettingNames.Equals(Id1, Id2)
         End Function
 
         Friend Function CreateUniqueName(Optional Base As String = Nothing) As String
@@ -185,7 +185,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 Base = My.Resources.Microsoft_VisualStudio_Editors_Designer.SD_DefaultSettingName
             End If
 
-            Dim ExistingNames As New Hashtable
+            Dim ExistingNames As New Hashtable(StringComparers.SettingNames)
             For Each Instance As DesignTimeSettingInstance In _settings
                 ExistingNames.Item(Instance.Name) = Nothing
             Next

--- a/src/Microsoft.VisualStudio.Editors/StringComparers.vb
+++ b/src/Microsoft.VisualStudio.Editors/StringComparers.vb
@@ -1,0 +1,18 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Namespace Microsoft.VisualStudio
+
+    Friend NotInheritable Class StringComparers
+
+        Private Sub StringComparers()
+        End Sub
+
+        Public Shared ReadOnly Property SettingNames As StringComparer
+            Get
+                Return StringComparer.OrdinalIgnoreCase
+            End Get
+        End Property
+
+    End Class
+
+End Namespace


### PR DESCRIPTION
Another Watson I was watching with cabs.

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/705752

CreateUniqueName and EqualIdentifiers had different definitions of what a unqiue identifier was, so if you had a setting called 'setting', and clicked the setting dropdown on the next row, we'd watson because we'd attempt to add new setting called by the default "Setting". Treated them as the same, causes the new setting to be called "Setting1" and avoid the watson.