### PR TITLE
Avoid crash when StartProgram has invalid characters

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.vb
@@ -340,7 +340,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                         If Trim(StartProgram.Text).Length = 0 Then
                             message = My.Resources.Microsoft_VisualStudio_Editors_Designer.PropPage_NeedExternalProgram
                             Return ValidationResult.Warning
-                        ElseIf Not Path.GetExtension(StartProgram.Text).Equals(".exe", StringComparison.OrdinalIgnoreCase) Then
+                        ElseIf Not StartProgram.Text.EndsWith(".exe", StringComparison.OrdinalIgnoreCase) Then
                             message = My.Resources.Microsoft_VisualStudio_Editors_Designer.PropPage_NotAnExeError
                             Return ValidationResult.Warning
                         End If


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/705763

When StartProgram has invalid characters and remote debugging is enabled, there are certain cases where the property page crashes during validation. When remote debugging is disabled, the validation check was being done in File.Exists which will always return false for invalid characters and would never hit this case.

~Merging into 15.9~, because this is our highest watson, with about ~100 hits in the past month.