### PR TITLE
 Avoid crashing when editing settings while debugging

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerLoader.vb
@@ -772,6 +772,14 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             End If
         End Sub
 
+        Friend Function IsDesignerEditable() As Boolean
+
+            ' We are only editable if we're not debugging in any form 
+            ' (break state or running), or we're not building the project
+            Return InDesignMode() AndAlso Not IsReadOnly()
+
+        End Function
+
         Friend Function IsReadOnly() As Boolean
             Return _readOnly
         End Function

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerLoader.vb
@@ -550,7 +550,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 SetReadOnlyMode(False, String.Empty)
                 _readOnly = False
             End If
-            If _modifiedDuringLoad AndAlso InDesignMode() Then
+            If _modifiedDuringLoad AndAlso IsDesignerEditable() Then
                 Try
                     OnModifying()
                     Modified = True
@@ -711,8 +711,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             End Get
         End Property
 
-
-        Friend Function InDesignMode() As Boolean
+        Private Function InDesignMode() As Boolean
             Return _currentDebugMode = DBGMODE.DBGMODE_Design
         End Function
 
@@ -777,16 +776,15 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             End If
         End Sub
 
+        ''' <summary>
+        '''     Returns a value indicating whether the designer is currently editable; that is, 
+        '''     we're not debugging in any form and the solution is not currently building.
+        ''' </summary>
+        ''' <returns></returns>
         Friend Function IsDesignerEditable() As Boolean
 
-            ' We are only editable if we're not debugging in any form 
-            ' (break state or running), or we're not building the project
-            Return InDesignMode() AndAlso Not IsReadOnly()
+            Return InDesignMode() AndAlso Not _readOnly
 
-        End Function
-
-        Friend Function IsReadOnly() As Boolean
-            Return _readOnly
         End Function
 
         ''' <summary>

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerLoader.vb
@@ -655,6 +655,11 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         End Sub
 
         Friend Function EnsureCheckedOut() As Boolean
+
+            If Not IsDesignerEditable() Then
+                Return False
+            End If
+
             Try
                 Dim ProjectReloaded As Boolean
                 ManualCheckOut(ProjectReloaded)

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
@@ -69,7 +69,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                     Return False
                 End If
 
-                Return designerLoader.InDesignMode AndAlso Not designerLoader.IsReadOnly
+                Return designerLoader.IsDesignerEditable()
             End Function
         End Class
 
@@ -1253,7 +1253,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <remarks></remarks>
         Private Sub OnSettingsGridViewCellBeginEdit(sender As Object, e As DataGridViewCellCancelEventArgs) Handles _settingsGridView.CellBeginEdit
             ' Check out , but we can't check out if resource file is readonly
-            If (Not InDesignMode()) OrElse (DesignerLoader.IsReadOnly) OrElse (Not EnsureCheckedOut()) Then
+            If (Not InDesignMode()) OrElse (Not EnsureCheckedOut()) Then
                 e.Cancel = True
             Else
                 Select Case e.ColumnIndex

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
@@ -933,17 +933,13 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             End Try
         End Function
 
-        Private Function InDesignMode() As Boolean
+        Private Function IsDesignerEditable() As Boolean
             If DesignerLoader Is Nothing Then
                 Debug.Fail("Failed to get the IDesignerLoaderService from out settings site (or the IDesignerLoaderService wasn't a SettingsDesignerLoader :(")
                 Return False
             End If
 
-            Try
-                Return DesignerLoader.InDesignMode
-            Catch ex As Exception When ReportWithoutCrash(ex, NameOf(InDesignMode), NameOf(SettingsDesignerView))
-                Throw
-            End Try
+            Return DesignerLoader.IsDesignerEditable
         End Function
 
 #End Region
@@ -1633,9 +1629,8 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <returns></returns>
         ''' <remarks></remarks>
         Private Function MenuRemoveEnableHandler(MenuCommand As DesignerMenuCommand) As Boolean
-            ' If we are not in design mode or we are read-only we shouldn't allow 
-            ' removal of rows...
-            If Not InDesignMode() Or DesignerLoader.IsReadOnly Then
+            ' If we are not editable we shouldn't allow removal of rows...
+            If Not IsDesignerEditable() Then
                 Return False
             End If
 
@@ -1661,7 +1656,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <returns></returns>
         ''' <remarks></remarks>
         Private Function MenuEditCellEnableHandler(MenuCommand As DesignerMenuCommand) As Boolean
-            Return _settingsGridView.CurrentCell IsNot Nothing AndAlso Not _settingsGridView.IsCurrentCellInEditMode AndAlso InDesignMode() AndAlso Not _settingsGridView.CurrentCell.ReadOnly AndAlso Not DesignerLoader.IsReadOnly
+            Return _settingsGridView.CurrentCell IsNot Nothing AndAlso Not _settingsGridView.IsCurrentCellInEditMode AndAlso IsDesignerEditable() AndAlso Not _settingsGridView.CurrentCell.ReadOnly
         End Function
 
         ''' <summary>
@@ -1671,7 +1666,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <remarks></remarks>
         ''' <returns></returns>
         Private Function MenuViewCodeEnableHandler(MenuCommand As DesignerMenuCommand) As Boolean
-            If DesignerLoader.IsReadOnly Then
+            If Not IsDesignerEditable() Then
                 Return False
             End If
 
@@ -1715,14 +1710,13 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <returns></returns>
         ''' <remarks></remarks>
         Private Function MenuSynchronizeUserConfigEnableHandler(MenuCommand As DesignerMenuCommand) As Boolean
-            If DesignerLoader.IsReadOnly Then
+            If Not IsDesignerEditable() Then
                 Return False
             End If
 
             If _hierarchy IsNot Nothing Then
                 Dim proj As EnvDTE.Project = DTEUtils.EnvDTEProject(_hierarchy)
-                Return InDesignMode() _
-                    AndAlso proj IsNot Nothing _
+                Return proj IsNot Nothing _
                     AndAlso proj.ConfigurationManager IsNot Nothing
             End If
             Return False
@@ -1735,14 +1729,13 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <returns></returns>
         ''' <remarks></remarks>
         Private Function MenuLoadWebSettingsFromAppConfigEnableHandler(MenuCommand As DesignerMenuCommand) As Boolean
-            If DesignerLoader.IsReadOnly Then
+            If Not IsDesignerEditable() Then
                 Return False
             End If
 
             If _hierarchy IsNot Nothing Then
                 Dim proj As EnvDTE.Project = DTEUtils.EnvDTEProject(_hierarchy)
-                If InDesignMode() _
-                    AndAlso proj IsNot Nothing _
+                If proj IsNot Nothing _
                     AndAlso proj.ConfigurationManager IsNot Nothing _
                     AndAlso Settings IsNot Nothing _
                     AndAlso Settings.Site IsNot Nothing Then
@@ -1822,10 +1815,14 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="e"></param>
         ''' <remarks></remarks>
         Private Sub MenuLoadWebSettingsFromAppConfig(sender As Object, e As EventArgs)
+
+            If Not IsDesignerEditable() Then
+                Return
+            End If
+
             If _hierarchy IsNot Nothing Then
                 Dim proj As EnvDTE.Project = DTEUtils.EnvDTEProject(_hierarchy)
-                If InDesignMode() _
-                    AndAlso proj IsNot Nothing _
+                If proj IsNot Nothing _
                     AndAlso proj.ConfigurationManager IsNot Nothing _
                     AndAlso Settings IsNot Nothing _
                     AndAlso Settings.Site IsNot Nothing Then
@@ -1967,7 +1964,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <returns></returns>
         ''' <remarks></remarks>
         Private Function MenuAddSettingEnableHandler(menucommand As DesignerMenuCommand) As Boolean
-            Return InDesignMode() AndAlso Not DesignerLoader.IsReadOnly
+            Return IsDesignerEditable()
         End Function
 
         ''' <summary>

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
@@ -1140,12 +1140,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                     Return
                 End If
 
-                If Not InDesignMode() Then
-                    Return
-                End If
-
                 If Not EnsureCheckedOut() Then
-                    Debug.Fail("We shouldn't have to check out here since that was done when entering edit mode!?")
                     Return
                 End If
 
@@ -1252,8 +1247,8 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="e"></param>
         ''' <remarks></remarks>
         Private Sub OnSettingsGridViewCellBeginEdit(sender As Object, e As DataGridViewCellCancelEventArgs) Handles _settingsGridView.CellBeginEdit
-            ' Check out , but we can't check out if resource file is readonly
-            If (Not InDesignMode()) OrElse (Not EnsureCheckedOut()) Then
+            ' Check out , but we can't check out if settings file is readonly
+            If Not EnsureCheckedOut() Then
                 e.Cancel = True
             Else
                 Select Case e.ColumnIndex
@@ -1994,11 +1989,9 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="e"></param>
         ''' <remarks></remarks>
         Private Sub MenuEditCell(sender As Object, e As EventArgs)
-            If InDesignMode() Then
-                If _settingsGridView.CurrentCell IsNot Nothing AndAlso Not _settingsGridView.IsCurrentCellInEditMode Then
-                    If EnsureCheckedOut() Then
-                        _settingsGridView.BeginEdit(False)
-                    End If
+            If _settingsGridView.CurrentCell IsNot Nothing AndAlso Not _settingsGridView.IsCurrentCellInEditMode Then
+                If EnsureCheckedOut() Then
+                    _settingsGridView.BeginEdit(False)
                 End If
             End If
         End Sub


### PR DESCRIPTION
(This PR is easier to consume if you look at a commit at a time.)

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/706537.

If you edit the settings designer while debugging the project, Visual Studio crashes because checkout throws an ApplicationException when debugging.

There's two case that turn the "setting designer" into read-only mode; building the project (IsReadOnly) and debugging the project (!IsDesignMode). This change centralizes all usage of these cases into a single "IsDesignerEditable" property to avoid cases where we check one of those cases and not the other. Also removes the need to check these when we attempt to check-out the project. 

This crash has about 32 hits over the past month, so putting it in for 15.9 candidate.