### PR TITLE
Inherit Font/Colors in WPF property pages

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPage.cs
@@ -111,7 +111,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             // Initialization can cause some events to be fired when we change some values
             // so we use this flag (_ignoreEvents) to notify IsDirty to ignore
             // any changes that happen during initialization
-            Win32Methods.SetParent(Handle, hWndParent);
+
+            Control parent = FromHandle(hWndParent);
+            if (parent != null)
+            {   // We're hosted in WinForms, make sure we 
+                // set Parent so that we inherit Font & Colors
+                Parent = parent;
+            }
+            else
+            {
+                Win32Methods.SetParent(Handle, hWndParent);
+            }
+
             ResumeLayout();
             _isActivated = true;
 


### PR DESCRIPTION
Fixes: #2122 
Fixes: #646 
WPF will automatically inherit Windows Forms fonts https://docs.microsoft.com/en-us/dotnet/framework/wpf/advanced/windows-forms-and-wpf-property-mapping. Make sure we set the Control.Parent if it's available, which sets this up.