### PR TITLE
Prevent ScrollViewer from being focusable

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageControl.xaml
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageControl.xaml
@@ -3,7 +3,7 @@
                          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                          xmlns:r="clr-namespace:My.Resources"
                          xmlns:local="clr-namespace:Microsoft.VisualStudio.Editors.OptionPages">
-    <ScrollViewer VerticalScrollBarVisibility="Auto">
+    <ScrollViewer VerticalScrollBarVisibility="Auto" Focusable="false">
         <StackPanel>
             <GroupBox x:Uid="FastUpToDateGroupBox" Header="{x:Static r:GeneralOptionPageResources.General_FastUpToDateCheck_Title}">
                 <StackPanel Orientation="Vertical">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WpfBasedPropertyPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WpfBasedPropertyPage.cs
@@ -84,7 +84,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             var viewer = new ScrollViewer
             {
                 VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
-                HorizontalScrollBarVisibility = ScrollBarVisibility.Auto
+                HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
+                Focusable = false,
             };
 
             viewer.Content = _control;


### PR DESCRIPTION
ScrollViewer's are focusable by default, which means that you if you click them, they get focus rectangles. Turn this off, and turn them into WinForms-like panels, which still have scrollbars (and can be scrolled by paging through the controls).

Before:
![image](https://user-images.githubusercontent.com/1103906/46991064-f6eaba80-d14f-11e8-8328-a81f62064f8b.png)

After:
![image](https://user-images.githubusercontent.com/1103906/46991073-07029a00-d150-11e8-82dd-3edd05516775.png)
