### PR TITLE
SDKVersion was pushing telemetry under wrong name

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Telemetry/SDKVersionTelemetryTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Telemetry/SDKVersionTelemetryTests.cs
@@ -23,16 +23,16 @@ namespace Microsoft.VisualStudio.Telemetry
             var version = "42.42.42.42";
             var (success, result) = await CreateComponentAndGetResult(guid, version);
             Assert.True(success);
-            Assert.Equal("SDKVersion", result.EventName);
+            Assert.Equal("vs/projectsystem/managed/sdkversion", result.EventName);
             Assert.Collection(result.Properties,
                 args =>
                 {
-                    Assert.Equal("Project", args.propertyName);
+                    Assert.Equal("vs.projectsystem.managed.sdkversion.project", args.propertyName);
                     Assert.Equal(guid.ToString(), args.propertyValue as string);
                 },
                 args =>
                 {
-                    Assert.Equal("NETCoreSdkVersion", args.propertyName);
+                    Assert.Equal("vs.projectsystem.managed.sdkversion.netcoresdkversion", args.propertyName);
                     Assert.Equal(version, args.propertyValue);
                 });
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SDKVersionTelemetryServiceComponent.SDKVersionTelemetryServiceInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SDKVersionTelemetryServiceComponent.SDKVersionTelemetryServiceInstance.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,11 +12,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     {
         protected class SDKVersionTelemetryServiceInstance : OnceInitializedOnceDisposedAsync, IMultiLifetimeInstance
         {
-            private const string TelemetryEventName = "SDKVersion";
-            private const string ProjectProperty = "Project";
-            private const string NameProperty = "Name";
-            private const string NETCoreSdkVersionProperty = "NETCoreSdkVersion";
-
             private readonly IUnconfiguredProjectVsServices _projectVsServices;
             private readonly ISafeProjectGuidService _projectGuidService;
             private readonly ITelemetryService _telemetryService;
@@ -57,13 +51,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                             return;
                         }
 
-                        _telemetryService.PostProperties(
-                            TelemetryEventName,
-                            new List<(string, object)>
-                            {
-                                (ProjectProperty, projectId),
-                                (NETCoreSdkVersionProperty, version)
-                            });
+                        _telemetryService.PostProperties(TelemetryEventName.SDKVersion, new []
+                        {
+                            (TelemetryPropertyName.SDKVersionProject, (object)projectId),
+                            (TelemetryPropertyName.SDKVersionNETCoreSdkVersion, version)
+                        });
                     });
                 }, cancellationToken);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryEventName.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryEventName.cs
@@ -44,6 +44,11 @@ namespace Microsoft.VisualStudio.Telemetry
         /// </summary>
         public static readonly string LanguageServiceInitFault = BuildEventName("LanguageServiceInit/Fault");
 
+        /// <summary>
+        ///     Indicates that .NET Core SDK version.
+        /// </summary>
+        public static readonly string SDKVersion = BuildEventName("SDKVersion");
+
         private static string BuildEventName(string eventName)
         {
             return Prefix + "/" + eventName.ToLowerInvariant();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryPropertyName.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryPropertyName.cs
@@ -47,6 +47,16 @@ namespace Microsoft.VisualStudio.Telemetry
         /// </summary>
         public static readonly string DesignTimeBuildCompleteTargets = BuildPropertyName(TelemetryEventName.DesignTimeBuildComplete, "Targets");
 
+        /// <summary>
+        ///     Indicates the project that contains the SDK version.
+        /// </summary>
+        public static readonly string SDKVersionProject = BuildPropertyName(TelemetryEventName.SDKVersion, "Project");
+
+        /// <summary>
+        ///     Indicates the actual underlying version of .NET Core SDK.
+        /// </summary>
+        public static readonly string SDKVersionNETCoreSdkVersion = BuildPropertyName(TelemetryEventName.SDKVersion, "NETCoreSdkVersion");
+
         private static string BuildPropertyName(string eventName, string propertyName)
         {
             // Property names use the event names, but with slashes replaced by periods.


### PR DESCRIPTION
This broke when d897cd2d merged into master, this code path changed to no longer automatically add the event prefix. Change this code to use the same pattern everywhere else.

This was only broken in Dev16.