### PR TITLE
Use tuple deconstruction with foreach

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
@@ -303,9 +303,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             // Apply environment variables.
             if (resolvedProfile.EnvironmentVariables != null && resolvedProfile.EnvironmentVariables.Count > 0)
             {
-                foreach (KeyValuePair<string, string> kvp in resolvedProfile.EnvironmentVariables)
+                foreach ((string key, string value) in resolvedProfile.EnvironmentVariables)
                 {
-                    settings.Environment[kvp.Key] = kvp.Value;
+                    settings.Environment[key] = value;
                 }
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectDebuggerProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectDebuggerProvider.cs
@@ -308,11 +308,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
             // Collect all the variables as a null delimited list of key=value pairs.
             var result = new StringBuilder();
-            foreach (KeyValuePair<string, string> pair in environment)
+            foreach ((string key, string value) in environment)
             {
-                result.Append(pair.Key);
+                result.Append(key);
                 result.Append('=');
-                result.Append(pair.Value);
+                result.Append(value);
                 result.Append('\0');
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/UnconfiguredProjectHostObject.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/UnconfiguredProjectHostObject.cs
@@ -96,9 +96,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
                 return;
             }
 
-            foreach (KeyValuePair<uint, IVsHierarchyEvents> eventSinkKvp in _hierEventSinks)
+            foreach (IVsHierarchyEvents eventSink in _hierEventSinks.Values)
             {
-                eventSinkKvp.Value.OnPropertyChanged(itemid, propid, flags);
+                eventSink.OnPropertyChanged(itemid, propid, flags);
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContext.cs
@@ -53,11 +53,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         public void SetProjectFilePathAndDisplayName(string projectFilePath, string displayName)
         {
             // Update the project file path and display name for all the inner project contexts.
-            foreach (KeyValuePair<ITargetFramework, ITargetedProjectContext> innerProjectContextKvp in _configuredProjectContextsByTargetFramework)
+            foreach ((ITargetFramework targetFramework, ITargetedProjectContext innerProjectContext) in _configuredProjectContextsByTargetFramework)
             {
-                ITargetFramework targetFramework = innerProjectContextKvp.Key;
-                ITargetedProjectContext innerProjectContext = innerProjectContextKvp.Value;
-
                 // For cross targeting projects, we ensure that the display name is unique per every target framework.
                 innerProjectContext.DisplayName = IsCrossTargeting ? $"{displayName}({targetFramework})" : displayName;
                 innerProjectContext.ProjectFilePath = projectFilePath;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
@@ -201,12 +201,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             ImmutableDictionary<ITargetFramework, ITargetedProjectContext>.Builder innerProjectContextsBuilder = ImmutableDictionary.CreateBuilder<ITargetFramework, ITargetedProjectContext>();
             ITargetFramework activeTargetFramework = TargetFramework.Empty;
 
-            foreach (KeyValuePair<string, ConfiguredProject> kvp in configuredProjectsMap)
+            foreach ((string tfm, ConfiguredProject configuredProject) in configuredProjectsMap)
             {
-                ConfiguredProject configuredProject = kvp.Value;
                 ProjectProperties projectProperties = configuredProject.Services.ExportProvider.GetExportedValue<ProjectProperties>();
                 ConfigurationGeneral configurationGeneralProperties = await projectProperties.GetConfigurationGeneralPropertiesAsync();
-                ITargetFramework targetFramework = await GetTargetFrameworkAsync(kvp.Key, configurationGeneralProperties);
+                ITargetFramework targetFramework = await GetTargetFrameworkAsync(tfm, configurationGeneralProperties);
 
                 if (!TryGetConfiguredProjectState(configuredProject, out ITargetedProjectContext targetedProjectContext))
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/SearchGraphActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/SearchGraphActionHandler.cs
@@ -176,13 +176,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
             IDependenciesSnapshot dependenciesSnapshot)
         {
             var matchedDependencies = new HashSet<IDependency>();
-            foreach (KeyValuePair<CrossTarget.ITargetFramework, ITargetedDependenciesSnapshot> targetedSnapshot in dependenciesSnapshot.Targets)
+            foreach (ITargetedDependenciesSnapshot targetedSnapshot in dependenciesSnapshot.Targets.Values)
             {
-                foreach (KeyValuePair<string, IDependency> dependency in targetedSnapshot.Value.DependenciesWorld)
+                foreach (IDependency dependency in targetedSnapshot.DependenciesWorld.Values)
                 {
-                    if (dependency.Value.Visible && dependency.Value.Caption.ToLowerInvariant().Contains(searchTerm))
+                    if (dependency.Visible && dependency.Caption.ToLowerInvariant().Contains(searchTerm))
                     {
-                        matchedDependencies.Add(dependency.Value);
+                        matchedDependencies.Add(dependency);
                     }
                 }
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ProjectRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ProjectRuleHandler.cs
@@ -117,9 +117,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             string otherProjectPath = otherProjectSnapshot.ProjectPath;
 
             var dependencyThatNeedChange = new List<IDependency>();
-            foreach (KeyValuePair<ITargetFramework, ITargetedDependenciesSnapshot> target in projectSnapshot.Targets)
+            foreach (ITargetedDependenciesSnapshot targetedDependencies in projectSnapshot.Targets.Values)
             {
-                foreach (IDependency dependency in target.Value.TopLevelDependencies)
+                foreach (IDependency dependency in targetedDependencies.TopLevelDependencies)
                 {
                     // We're only interested in project dependencies
                     if (!StringComparers.DependencyProviderTypes.Equals(dependency.ProviderType, ProviderTypeString))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
@@ -150,13 +150,13 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         private static bool IsActiveConfigurationCandidate(ProjectConfiguration activeSolutionConfiguration, ProjectConfiguration configuration, IImmutableSet<string> ignoredDimensionNames)
         {
-            foreach (KeyValuePair<string, string> dimension in activeSolutionConfiguration.Dimensions)
+            foreach ((string dimensionName, string dimensionValue) in activeSolutionConfiguration.Dimensions)
             {
-                if (ignoredDimensionNames.Contains(dimension.Key))
+                if (ignoredDimensionNames.Contains(dimensionName))
                     continue;
 
-                if (!configuration.Dimensions.TryGetValue(dimension.Key, out string otherDimensionValue) ||
-                    !string.Equals(dimension.Value, otherDimensionValue, StringComparison.Ordinal))
+                if (!configuration.Dimensions.TryGetValue(dimensionName, out string otherDimensionValue) ||
+                    !string.Equals(dimensionValue, otherDimensionValue, StringComparison.Ordinal))
                 {
                     return false;
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugTokenReplacer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugTokenReplacer.cs
@@ -67,19 +67,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             // Since Env variables are an immutable dictionary they are a little messy to update.
             if (resolvedProfile.EnvironmentVariables != null)
             {
-                foreach (KeyValuePair<string, string> kvp in resolvedProfile.EnvironmentVariables)
+                foreach ((string key, string value) in resolvedProfile.EnvironmentVariables)
                 {
-                    resolvedProfile.EnvironmentVariables = resolvedProfile.EnvironmentVariables.SetItem(kvp.Key, await ReplaceTokensInStringAsync(kvp.Value, true));
+                    resolvedProfile.EnvironmentVariables = resolvedProfile.EnvironmentVariables.SetItem(key, await ReplaceTokensInStringAsync(value, true));
                 }
             }
 
             if (resolvedProfile.OtherSettings != null)
             {
-                foreach (KeyValuePair<string, object> kvp in resolvedProfile.OtherSettings)
+                foreach ((string key, object value) in resolvedProfile.OtherSettings)
                 {
-                    if (kvp.Value is string s)
+                    if (value is string s)
                     {
-                        resolvedProfile.OtherSettings = resolvedProfile.OtherSettings.SetItem(kvp.Key, await ReplaceTokensInStringAsync(s, true));
+                        resolvedProfile.OtherSettings = resolvedProfile.OtherSettings.SetItem(key, await ReplaceTokensInStringAsync(s, true));
                     }
 
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileData.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileData.cs
@@ -83,15 +83,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             }
 
             // We walk the profilesObject and serialize each subobject component as either a string, or a dictionary<string,string>
-            foreach (KeyValuePair<string, JToken> profile in profilesObject)
+            foreach ((string key, JToken jToken) in profilesObject)
             {
                 // Name of profile is the key, value is it's contents. We have specific serializing of the data based on the 
                 // JToken type
-                LaunchProfileData profileData = JsonConvert.DeserializeObject<LaunchProfileData>(profile.Value.ToString());
+                LaunchProfileData profileData = JsonConvert.DeserializeObject<LaunchProfileData>(jToken.ToString());
 
                 // Now pick up any custom properties. Handle string, int, boolean
                 var customSettings = new Dictionary<string, object>(StringComparer.Ordinal);
-                foreach (JToken data in profile.Value.Children())
+                foreach (JToken data in jToken.Children())
                 {
                     if (!(data is JProperty dataProperty))
                     {
@@ -146,7 +146,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                     profileData.OtherSettings = customSettings;
                 }
 
-                profiles.Add(profile.Key, profileData);
+                profiles.Add(key, profileData);
             }
 
             return profiles;
@@ -198,9 +198,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             if (profile.OtherSettings != null)
             {
-                foreach (KeyValuePair<string, object> kvp in profile.OtherSettings)
+                foreach ((string key, object value) in profile.OtherSettings)
                 {
-                    data.Add(kvp.Key, kvp.Value);
+                    data.Add(key, value);
                 }
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettings.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettings.cs
@@ -48,20 +48,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 Profiles = Profiles.Add(new LaunchProfile(profile));
             }
 
+            var jsonSerializerSettings = new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore };
+
             // For global settings we want to make new copies of each entry so that the snapshot remains immutable. If the object implements 
             // ICloneable that is used, otherwise, it is serialized back to json, and a new object rehydrated from that
             GlobalSettings = ImmutableStringDictionary<object>.EmptyOrdinal;
-            foreach (KeyValuePair<string, object> kvp in settings.GlobalSettings)
+            foreach ((string key, object value) in settings.GlobalSettings)
             {
-                if (kvp.Value is ICloneable cloneableObject)
+                if (value is ICloneable cloneableObject)
                 {
-                    GlobalSettings = GlobalSettings.Add(kvp.Key, cloneableObject.Clone());
+                    GlobalSettings = GlobalSettings.Add(key, cloneableObject.Clone());
                 }
                 else
                 {
-                    string jsonString = JsonConvert.SerializeObject(kvp.Value, Formatting.Indented, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore });
-                    object clonedObject = JsonConvert.DeserializeObject(jsonString, kvp.Value.GetType());
-                    GlobalSettings = GlobalSettings.Add(kvp.Key, clonedObject);
+                    string jsonString = JsonConvert.SerializeObject(value, Formatting.Indented, jsonSerializerSettings);
+                    object clonedObject = JsonConvert.DeserializeObject(jsonString, value.GetType());
+                    GlobalSettings = GlobalSettings.Add(key, clonedObject);
                 }
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/WritableLaunchSettings.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/WritableLaunchSettings.cs
@@ -31,17 +31,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             // ICloneable that is used, otherwise, it is serialized back to json, and a new object rehydrated from that
             if (settings.GlobalSettings != null)
             {
-                foreach (KeyValuePair<string, object> kvp in settings.GlobalSettings)
+                var jsonSerializerSettings = new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore };
+
+                foreach ((string key, object value) in settings.GlobalSettings)
                 {
-                    if (kvp.Value is ICloneable cloneableObject)
+                    if (value is ICloneable cloneableObject)
                     {
-                        GlobalSettings.Add(kvp.Key, cloneableObject.Clone());
+                        GlobalSettings.Add(key, cloneableObject.Clone());
                     }
                     else
                     {
-                        string jsonString = JsonConvert.SerializeObject(kvp.Value, Formatting.Indented, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore });
-                        object clonedObject = JsonConvert.DeserializeObject(jsonString, kvp.Value.GetType());
-                        GlobalSettings.Add(kvp.Key, clonedObject);
+                        string jsonString = JsonConvert.SerializeObject(value, Formatting.Indented, jsonSerializerSettings);
+                        object clonedObject = JsonConvert.DeserializeObject(jsonString, value.GetType());
+                        GlobalSettings.Add(key, clonedObject);
                     }
                 }
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/AggregateWorkspaceProjectContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/AggregateWorkspaceProjectContext.cs
@@ -57,11 +57,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         public void SetProjectFilePathAndDisplayName(string projectFilePath, string displayName)
         {
             // Update the project file path and display name for all the inner project contexts.
-            foreach (KeyValuePair<string, IWorkspaceProjectContext> innerProjectContextKvp in _configuredProjectContextsByTargetFramework)
+            foreach ((string targetFramework, IWorkspaceProjectContext innerProjectContext) in _configuredProjectContextsByTargetFramework)
             {
-                string targetFramework = innerProjectContextKvp.Key;
-                IWorkspaceProjectContext innerProjectContext = innerProjectContextKvp.Value;
-
                 // For cross targeting projects, we ensure that the display name is unique per every target framework.
                 innerProjectContext.DisplayName = IsCrossTargeting ? $"{displayName}({targetFramework})" : displayName;
                 innerProjectContext.ProjectFilePath = projectFilePath;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/UnconfiguredProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/UnconfiguredProjectContextProvider.cs
@@ -228,10 +228,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             string activeTargetFramework = string.Empty;
             IConfiguredProjectHostObject activeIntellisenseProjectHostObject = null;
 
-            foreach (KeyValuePair<string, ConfiguredProject> kvp in configuredProjectsMap)
+            foreach ((string targetFramework, ConfiguredProject configuredProject) in configuredProjectsMap)
             {
-                string targetFramework = kvp.Key;
-                ConfiguredProject configuredProject = kvp.Value;
                 if (!TryGetConfiguredProjectState(configuredProject, out IWorkspaceProjectContext workspaceProjectContext, out IConfiguredProjectHostObject configuredProjectHostObject))
                 {
                     // Get the target path for the configured project.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectConfigurationExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectConfigurationExtensions.cs
@@ -36,11 +36,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 return projectConfiguration1.Equals(projectConfiguration2);
             }
 
-            foreach (KeyValuePair<string, string> dimensionKvp in projectConfiguration1.Dimensions)
+            foreach ((string dimensionName, string dimensionValue) in projectConfiguration1.Dimensions)
             {
-                string dimensionName = dimensionKvp.Key;
-                string dimensionValue = dimensionKvp.Value;
-
                 // Ignore the TargetFramework.
                 if (StringComparers.ConfigurationDimensionNames.Equals(dimensionName, ConfigurationGeneral.TargetFrameworkProperty))
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/AssemblyInfoProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/AssemblyInfoProperties.cs
@@ -45,10 +45,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             IProjectThreadingService threadingService)
         {
             ImmutableDictionary<string, SourceAssemblyAttributePropertyValueProvider>.Builder builder = ImmutableDictionary.CreateBuilder<string, SourceAssemblyAttributePropertyValueProvider>();
-            foreach (KeyValuePair<string, (string attributeName, string generatePropertyInProjectFileName)> kvp in AssemblyPropertyInfoMap)
+            foreach ((string key, (string attributeName, _)) in AssemblyPropertyInfoMap)
             {
-                var provider = new SourceAssemblyAttributePropertyValueProvider(kvp.Value.attributeName, getActiveProjectId, workspace, threadingService);
-                builder.Add(kvp.Key, provider);
+                var provider = new SourceAssemblyAttributePropertyValueProvider(attributeName, getActiveProjectId, workspace, threadingService);
+                builder.Add(key, provider);
             }
 
             return builder.ToImmutable();


### PR DESCRIPTION
This is a style thing mostly. I find it clearer, but it's newish syntax.

Some cases of this conversion highlighted that only the value was needed. Such cases were changed to enumerate `Values` instead. This potentially changes the order of enumeration, though dictionaries are not generally considered ordered. Note in review that there's a mix of mutable and immutable dictionaries here.