### PR TITLE
Dependency node grooming

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/TestProjectTree.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/TestProjectTree.cs
@@ -23,19 +23,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
         private void GetChildrenTestStats(StringBuilder builder)
         {
-            builder.AppendLine(GetStats(this));
+            builder.AppendLine(GetStats());
             foreach (var child in _children)
             {
                 child.GetChildrenTestStats(builder);
             }
         }
 
-        private string GetStats(IProjectTree node)
+        private string GetStats()
         {
             var stats = $"Caption={Caption}, FilePath={FilePath}, IconHash={Icon.GetHashCode()}, ExpandedIconHash={ExpandedIcon.GetHashCode()}, Rule={BrowseObjectProperties?.Name ?? ""}, IsProjectItem={IsProjectItem}, CustomTag={CustomTag}";
             if (Flags.Contains(ProjectTreeFlags.Common.BubbleUp))
             {
-                stats += $", BubbleUpFlag=True";
+                stats += ", BubbleUpFlag=True";
             }
 
             return stats;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
@@ -169,15 +169,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         {
             lock (_gate)
             {
-                if (_configuredProjectContextsMap.TryGetValue(configuredProject, out targetedProjectContext))
-                {
-                    return true;
-                }
-                else
-                {
-                    targetedProjectContext = null;
-                    return false;
-                }
+                return _configuredProjectContextsMap.TryGetValue(configuredProject, out targetedProjectContext);
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -47,9 +47,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             IProjectThreadingService threadingService,
             UnconfiguredProject project,
             IDependenciesSnapshotProvider dependenciesSnapshotProvider,
-            [Import(DependencySubscriptionsHost.DependencySubscriptionsHostContract)]
-            ICrossTargetSubscriptionsHost dependenciesHost,
-            [Import(ExportContractNames.Scopes.UnconfiguredProject)]IProjectAsynchronousTasksService tasksService,
+            [Import(DependencySubscriptionsHost.DependencySubscriptionsHostContract)] ICrossTargetSubscriptionsHost dependenciesHost,
+            [Import(ExportContractNames.Scopes.UnconfiguredProject)] IProjectAsynchronousTasksService tasksService,
             IDependencyTreeTelemetryService treeTelemetryService)
             : base(threadingService, project)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -395,28 +395,30 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     {
                         if (TasksService.UnloadCancellationToken.IsCancellationRequested)
                         {
-                            return;
+                            return Task.CompletedTask;
                         }
 
-                        await BuildTreeForSnapshotAsync();
+                        BuildTreeForSnapshot();
+
+                        return Task.CompletedTask;
                     }).Task;
                 }
                 else
                 {
                     _treeUpdateQueueTask = _treeUpdateQueueTask.ContinueWith(
-                        t => BuildTreeForSnapshotAsync(), TaskScheduler.Default);
+                        t => BuildTreeForSnapshot(), TaskScheduler.Default);
                 }
             }
 
             return;
 
-            Task BuildTreeForSnapshotAsync()
+            void BuildTreeForSnapshot()
             {
                 Lazy<IDependenciesTreeViewProvider, IOrderPrecedenceMetadataView> viewProvider = ViewProviders.FirstOrDefault();
 
                 if (viewProvider == null)
                 {
-                    return Task.CompletedTask;
+                    return;
                 }
 
                 Task<IProjectVersionedValue<IProjectTreeSnapshot>> nowait = SubmitTreeUpdateAsync(
@@ -434,8 +436,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                         // way of merging, mute them for now and get to it in U1
                         return new TreeUpdateResult(dependenciesNode, false, null);
                     });
-
-                return Task.CompletedTask;
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -326,9 +326,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
                         lock (SyncObject)
                         {
+                            Verify.NotDisposed(this);
+
                             DependenciesSnapshotProvider.SnapshotChanged += OnDependenciesSnapshotChanged;
 
-                            Verify.NotDisposed(this);
                             Task<IProjectVersionedValue<IProjectTreeSnapshot>> nowait = SubmitTreeUpdateAsync(
                                 (treeSnapshot, configuredProjectExports, cancellationToken) =>
                                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -328,6 +328,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                         {
                             Verify.NotDisposed(this);
 
+                            // Issue this token before hooking the SnapshotChanged event to prevent a race
+                            // where a snapshot tree is replaced by the initial, empty tree created below.
+                            // The handler will cancel this token before submitting its update.
+                            CancellationToken initialTreeCancellationToken = GetNextTreeUpdateCancellationToken();
+
                             DependenciesSnapshotProvider.SnapshotChanged += OnDependenciesSnapshotChanged;
 
                             Task<IProjectVersionedValue<IProjectTreeSnapshot>> nowait = SubmitTreeUpdateAsync(
@@ -341,7 +346,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
                                     return Task.FromResult(new TreeUpdateResult(dependenciesNode, lazyFill: true));
                                 },
-                                GetNextTreeUpdateCancellationToken());
+                                initialTreeCancellationToken);
                         }
 
                     },

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -65,7 +65,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             TasksService = tasksService;
             _treeTelemetryService = treeTelemetryService;
 
+            // Hook this so we can unregister the snapshot change event when the project unloads
             unconfiguredProject.ProjectUnloading += OnUnconfiguredProjectUnloading;
+
+            Task OnUnconfiguredProjectUnloading(object sender, EventArgs args)
+            {
+                UnconfiguredProject.ProjectUnloading -= OnUnconfiguredProjectUnloading;
+                DependenciesSnapshotProvider.SnapshotChanged -= OnDependenciesSnapshotChanged;
+
+                return Task.CompletedTask;
+            }
         }
 
         /// <summary>
@@ -368,14 +377,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     visible: true,
                     flags: values.Flags);
             }
-        }
-
-        private Task OnUnconfiguredProjectUnloading(object sender, EventArgs args)
-        {
-            UnconfiguredProject.ProjectUnloading -= OnUnconfiguredProjectUnloading;
-            DependenciesSnapshotProvider.SnapshotChanged -= OnDependenciesSnapshotChanged;
-
-            return Task.CompletedTask;
         }
 
         private void OnDependenciesSnapshotChanged(object sender, SnapshotChangedEventArgs e)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -466,43 +466,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             return NamedCatalogs;
         }
 
-        /// <summary>
-        /// Gets the rule(s) that applies to a reference.
-        /// </summary>
-        /// <param name="itemType">The item type on the unresolved reference.</param>
-        /// <param name="resolved">
-        /// A value indicating whether to return rules for resolved or unresolved reference state.
-        /// </param>
-        /// <param name="namedCatalogs">The dictionary of catalogs.</param>
-        /// <returns>The sequence of matching rules.  Hopefully having exactly one element.</returns>
-        private IEnumerable<Rule> GetSchemaForReference(string itemType,
-                                                        bool resolved,
-                                                        IImmutableDictionary<string, IPropertyPagesCatalog> namedCatalogs)
-        {
-            Requires.NotNull(namedCatalogs, nameof(namedCatalogs));
-
-            // Note: usually for default/generic dependencies we have sets of 2 rule schemas:
-            //  - rule for unresolved dependency, they persist in ProjectFile
-            //  - rule for resolved dependency, they persist in ResolvedReference
-            // So to be able to find rule for resolved or unresolved reference we need to be consistent there 
-            // and make sure we do set ResolvedReference persistence for resolved dependencies, since we rely
-            // on that here when pick correct rule schema.
-            // (old code used to check if rule datasource has SourceType=TargetResults, which was true for Resolved,
-            // dependencies. However now we have custom logic for collecting unresolved dependencies too and use 
-            // DesignTime build results there too. That's why we switched to check for persistence).
-            IPropertyPagesCatalog browseObjectCatalog = namedCatalogs[PropertyPageContexts.BrowseObject];
-            IReadOnlyCollection<string> schemas = browseObjectCatalog.GetPropertyPagesSchemas(itemType);
-
-            return from schemaName in browseObjectCatalog.GetPropertyPagesSchemas(itemType)
-                   let schema = browseObjectCatalog.GetSchema(schemaName)
-                   where schema.DataSource != null
-                         && string.Equals(itemType, schema.DataSource.ItemType, StringComparison.OrdinalIgnoreCase)
-                         && (resolved == string.Equals(schema.DataSource.Persistence,
-                                                       RuleDataSourceTypes.PersistenceResolvedReference,
-                                                       StringComparison.OrdinalIgnoreCase))
-                   select schema;
-        }
-
         private void ApplyProjectTreePropertiesCustomization(
                         IProjectTreeCustomizablePropertyContext context,
                         ReferencesProjectTreeCustomizablePropertyValues values)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -325,7 +325,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                             Task<IProjectVersionedValue<IProjectTreeSnapshot>> nowait = SubmitTreeUpdateAsync(
                                 (treeSnapshot, configuredProjectExports, cancellationToken) =>
                                 {
-                                    IProjectTree dependenciesNode = CreateDependenciesFolder(null);
+                                    IProjectTree dependenciesNode = CreateDependenciesFolder();
 
                                     // TODO create providers nodes that can be visible when empty
                                     //dependenciesNode = CreateOrUpdateSubTreeProviderNodes(dependenciesNode, 
@@ -337,6 +337,32 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
                     },
                     registerFaultHandler: true);
+            }
+
+            IProjectTree CreateDependenciesFolder()
+            {
+                var values = new ReferencesProjectTreeCustomizablePropertyValues
+                {
+                    Caption = VSResources.DependenciesNodeName,
+                    Icon = ManagedImageMonikers.ReferenceGroup.ToProjectSystemType(),
+                    ExpandedIcon = ManagedImageMonikers.ReferenceGroup.ToProjectSystemType(),
+                    Flags = DependencyTreeFlags.DependenciesRootNodeFlags
+                };
+
+                ApplyProjectTreePropertiesCustomization(null, values);
+
+                // Note that all the parameters are specified so we can force this call to an
+                // overload of NewTree available prior to 15.5 versions of CPS. Once a 15.5 build
+                // is publicly available we can move this to an overload with default values for
+                // most of the parameters, and we'll only need to pass the interesting ones.
+                return NewTree(
+                    caption: values.Caption,
+                    filePath: null,
+                    browseObjectProperties: null,
+                    icon: values.Icon,
+                    expandedIcon: values.ExpandedIcon,
+                    visible: true,
+                    flags: values.Flags);
             }
         }
 
@@ -403,43 +429,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 });
 
             return Task.CompletedTask;
-        }
-
-        /// <summary>
-        /// Creates the loading References folder node.
-        /// </summary>
-        /// <returns>a new "Dependencies" tree node.</returns>
-        private IProjectTree CreateDependenciesFolder(IProjectTree oldNode)
-        {
-            if (oldNode == null)
-            {
-                var values = new ReferencesProjectTreeCustomizablePropertyValues
-                {
-                    Caption = VSResources.DependenciesNodeName,
-                    Icon = ManagedImageMonikers.ReferenceGroup.ToProjectSystemType(),
-                    ExpandedIcon = ManagedImageMonikers.ReferenceGroup.ToProjectSystemType(),
-                    Flags = DependencyTreeFlags.DependenciesRootNodeFlags
-                };
-
-                ApplyProjectTreePropertiesCustomization(null, values);
-
-                // Note that all the parameters are specified so we can force this call to an
-                // overload of NewTree available prior to 15.5 versions of CPS. Once a 15.5 build
-                // is publicly available we can move this to an overload with default values for
-                // most of the parameters, and we'll only need to pass the interesting ones.
-                return NewTree(
-                         caption: values.Caption,
-                         filePath: null,
-                         browseObjectProperties: null,
-                         icon: values.Icon,
-                         expandedIcon: values.ExpandedIcon,
-                         visible: true,
-                         flags: values.Flags);
-            }
-            else
-            {
-                return oldNode;
-            }
         }
 
         private async Task<IImmutableDictionary<string, IPropertyPagesCatalog>> GetNamedCatalogsAsync(IProjectCatalogSnapshot catalogs)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -349,7 +349,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     Flags = DependencyTreeFlags.DependenciesRootNodeFlags
                 };
 
-                ApplyProjectTreePropertiesCustomization(null, values);
+                // Allow property providers to perform customization
+                foreach (IProjectTreePropertiesProvider provider in ProjectTreePropertiesProviders.ExtensionValues())
+                {
+                    provider.CalculatePropertyValues(null, values);
+                }
 
                 // Note that all the parameters are specified so we can force this call to an
                 // overload of NewTree available prior to 15.5 versions of CPS. Once a 15.5 build
@@ -453,16 +457,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                                          .GetCatalogsAsync(CancellationToken.None);
 
             return NamedCatalogs;
-        }
-
-        private void ApplyProjectTreePropertiesCustomization(
-                        IProjectTreeCustomizablePropertyContext context,
-                        ReferencesProjectTreeCustomizablePropertyValues values)
-        {
-            foreach (IProjectTreePropertiesProvider provider in ProjectTreePropertiesProviders.ExtensionValues())
-            {
-                provider.CalculatePropertyValues(context, values);
-            }
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -338,7 +338,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                     //dependenciesNode = CreateOrUpdateSubTreeProviderNodes(dependenciesNode, 
                                     //                                                      cancellationToken);
 
-                                    return Task.FromResult(new TreeUpdateResult(dependenciesNode, true));
+                                    return Task.FromResult(new TreeUpdateResult(dependenciesNode, lazyFill: true));
                                 },
                                 GetNextTreeUpdateCancellationToken());
                         }
@@ -418,7 +418,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
                         // TODO We still are getting mismatched data sources and need to figure out better 
                         // way of merging, mute them for now and get to it in U1
-                        return new TreeUpdateResult(dependenciesNode, false, null);
+                        return new TreeUpdateResult(dependenciesNode, lazyFill: false);
                     },
                     GetNextTreeUpdateCancellationToken());
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -555,6 +555,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         private CancellationToken GetNextTreeUpdateCancellationToken()
         {
 #pragma warning disable CA2000 // Dispose objects before losing scope
+            // We can suppress this warning because nextSource will be
+            // assigned to a field before the method returns, and will
+            // later be disposed once it becomes priorSource.
             var nextSource = new CancellationTokenSource();
 #pragma warning restore CA2000 // Dispose objects before losing scope
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/SearchGraphActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/SearchGraphActionHandler.cs
@@ -74,10 +74,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
                     continue;
                 }
 
-                searchResultsPerContext[snapshotProvider.ProjectFilePath] = SearchFlat(snapshotProvider.ProjectFilePath,
-                                                                                     searchTerm.ToLowerInvariant(),
-                                                                                     graphContext,
-                                                                                     snapshot);
+                searchResultsPerContext[snapshotProvider.ProjectFilePath] = SearchFlat(
+                    searchTerm.ToLowerInvariant(),
+                    snapshot);
             }
 
             foreach (IDependenciesSnapshotProvider snapshotProvider in snapshotProviders)
@@ -169,11 +168,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
         /// <summary>
         /// Does flat search among dependency world lists to find any dependencies that match search criteria.
         /// </summary>
-        private static HashSet<IDependency> SearchFlat(
-            string projectPath,
-            string searchTerm,
-            IGraphContext graphContext,
-            IDependenciesSnapshot dependenciesSnapshot)
+        private static HashSet<IDependency> SearchFlat(string searchTerm, IDependenciesSnapshot dependenciesSnapshot)
         {
             var matchedDependencies = new HashSet<IDependency>();
             foreach (KeyValuePair<CrossTarget.ITargetFramework, ITargetedDependenciesSnapshot> targetedSnapshot in dependenciesSnapshot.Targets)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/SearchGraphActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/SearchGraphActionHandler.cs
@@ -146,7 +146,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
 
                             graphContext.Graph.Links.GetOrCreate(topLevelNode,
                                                                  matchedDependencyNode,
-                                                                 null /*label*/,
+                                                                 label: null,
                                                                  GraphCommonSchema.Contains);
                         }
 
@@ -190,7 +190,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
             return matchedDependencies;
         }
 
-        private HashSet<IDependency> GetMatchingResultsForDependency(
+        private static HashSet<IDependency> GetMatchingResultsForDependency(
             IDependency rootDependency,
             ITargetedDependenciesSnapshot snapshot,
             HashSet<IDependency> flatMatchingDependencies,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GroupedByTargetTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GroupedByTargetTreeViewProvider.cs
@@ -133,7 +133,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 return null;
             }
 
-            IProjectTree dependenciesNode = null;
+            IProjectTree dependenciesNode;
             if (root.Flags.Contains(DependencyTreeFlags.DependenciesRootNodeFlags))
             {
                 dependenciesNode = root;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GroupedByTargetTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GroupedByTargetTreeViewProvider.cs
@@ -416,11 +416,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     caption: viewModel.Caption,
                     itemContext: itemContext,
                     propertySheet: null,
-                    visible: true,
                     browseObjectProperties: rule,
-                    flags: flags,
                     icon: viewModel.Icon.ToProjectSystemType(),
-                    expandedIcon: viewModel.ExpandedIcon.ToProjectSystemType());
+                    expandedIcon: viewModel.ExpandedIcon.ToProjectSystemType(),
+                    visible: true,
+                    flags: flags);
             }
             else
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependenciesTreeServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependenciesTreeServices.cs
@@ -8,12 +8,12 @@ using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
     /// <summary>
-    /// Abstracts tree nodes API and allows to use them outside of ProjectTreeProviderBase.
+    /// Abstracts tree nodes API and allows to use them outside of <see cref="ProjectTreeProviderBase"/>.
     /// </summary>
     internal interface IDependenciesTreeServices
     {
         /// <summary>
-        /// Creates IProjectItemTree - a tree node associated with a project item.
+        /// Creates <see cref="IProjectItemTree"/> - a tree node associated with a project item.
         /// </summary>
         /// <param name="caption"></param>
         /// <param name="itemContext"></param>
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             ProjectTreeFlags? flags = default);
 
         /// <summary>
-        /// Creates IProjectTree - a generic CPS tree node.
+        /// Creates <see cref="IProjectTree"/> - a generic CPS tree node.
         /// </summary>
         /// <param name="caption"></param>
         /// <param name="filePath"></param>
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             ProjectTreeFlags? flags = default);
 
         /// <summary>
-        /// Gets an IRule to attach to a project item, which would be used to 
+        /// Gets an <see cref="IRule"/> to attach to a project item, which would be used to 
         /// display browse object properties page.
         /// </summary>
         /// <param name="dependency"></param>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependenciesTreeViewProvider.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     internal interface IDependenciesTreeViewProvider
     {
         /// <summary>
-        /// Builds Dependency node contents (target frameworks, groups and top level dependencies)
+        /// Builds Dependency node contents (target frameworks, groups and top level dependencies) for a given snapshot.
         /// </summary>
         /// <param name="dependenciesTree">Old dependencies node</param>
         /// <param name="snapshot">Current dependencies snapshot</param>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -144,12 +144,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
         public bool Equals(IDependenciesSnapshot other)
         {
-            if (other != null && other.ProjectPath.Equals(ProjectPath, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            return false;
+            return other != null && other.ProjectPath.Equals(ProjectPath, StringComparison.OrdinalIgnoreCase);
         }
 
         public static DependenciesSnapshot CreateEmpty(string projectPath)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
@@ -266,30 +266,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             return clone;
         }
 
-        public override int GetHashCode()
-        {
-            return StringComparer.OrdinalIgnoreCase.GetHashCode(Id);
-        }
+        public override int GetHashCode() 
+            => StringComparer.OrdinalIgnoreCase.GetHashCode(Id);
 
-        public override bool Equals(object obj)
-        {
-            if (obj is IDependency other)
-            {
-                return Equals(other);
-            }
+        public override bool Equals(object obj) 
+            => obj is IDependency other && Equals(other);
 
-            return false;
-        }
-
-        public bool Equals(IDependency other)
-        {
-            if (other != null && other.Id.Equals(Id, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-
-            return false;
-        }
+        public bool Equals(IDependency other) 
+            => other != null && other.Id.Equals(Id, StringComparison.OrdinalIgnoreCase);
 
         public static bool operator ==(Dependency left, Dependency right)
             => left is null ? right is null : left.Equals(right);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependenciesSnapshot.cs
@@ -8,7 +8,7 @@ using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 {
     /// <summary>
-    /// Immutable snapshot containing all dependencies for all project's target frameworks.
+    /// Immutable snapshot containing all dependencies for all of a project's target frameworks.
     /// </summary>
     internal interface IDependenciesSnapshot : IEquatable<IDependenciesSnapshot>
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/TreeViewProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/TreeViewProviderBase.cs
@@ -69,21 +69,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             public bool ExistsOnDisk { get; set; }
 
-            public bool IsFolder
-            {
-                get
-                {
-                    return false;
-                }
-            }
+            public bool IsFolder => false;
 
-            public bool IsNonFileSystemProjectItem
-            {
-                get
-                {
-                    return true;
-                }
-            }
+            public bool IsNonFileSystemProjectItem => true;
 
             public IImmutableDictionary<string, string> ProjectTreeSettings { get; set; }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProvider.cs
@@ -13,8 +13,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
     internal class TreeItemOrderPropertyProvider : IProjectTreePropertiesProvider
     {
         private const string FullPathProperty = "FullPath";
-        private readonly Dictionary<string, int> _orderedMap = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
+        private readonly Dictionary<string, int> _orderedMap;
 
         public TreeItemOrderPropertyProvider(IReadOnlyCollection<ProjectItemIdentity> orderedItems, UnconfiguredProject project)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProvider.cs
@@ -15,11 +15,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
         private const string FullPathProperty = "FullPath";
         private readonly Dictionary<string, int> _orderedMap = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
-        private readonly UnconfiguredProject _project;
 
         public TreeItemOrderPropertyProvider(IReadOnlyCollection<ProjectItemIdentity> orderedItems, UnconfiguredProject project)
         {
-            _project = project;
             _orderedMap = CreateOrderedMap(project, orderedItems);
         }
 


### PR DESCRIPTION
Fixes #4140.

More changes made while reading through dependency node code. Easier to review commit-by-commit.

Starts out with removing unused code, tweaking documentation and some formatting.

I focussed on `DependenciesProjectTreeProvider`. It converts dependency snapshots into tree updates for CPS, among other things.

Some private methods were converted to local functions (as discussed over breakfast in Redmond with @davkean and @davidwengier). I generally find that if a private method is only used in one other member, it's a great candidate for conversion to a local function, and doing so often helps identify further opportunities. Unfortunately these transformations wreak havoc on the overall diff, hence being pulled out to separate commits: 7a46b4d6e5556d427656ee149e2dab92c9f8d3ce, 28fa3538b7b6fe36e5a8854f18a27d49c99d92bd, 4983dd77509b560ed169ed89c9774d9a3996b9d4, 4229d747b8f45ab7953d3d3a349e05042def5b4c. 

This lead to the observations discussed in #4140 and the following meatier changes:

- ea1d2e42080aba2fce3406aba35b1d8803178dfe, in which `BuildTreeForSnapshotAsync` is stripped of its false async-ness
- 13c190108056a07c9239d3b0fcd88ab52b93383b, in which the lock, sequencing of tasks and calls through JTF are removed as the code becomes synchronous (it was anyway, in reality, with some tail yielding via schedulers)
- 45ad3fd5c3662d2e37694a4a4fe2c53425b018c3 in which calls to CPS's `SubmitTreeUpdateAsync` are provided a `CancellationToken` that is cancelled as soon as the next update is created

This ends up using CPS's facility for cancellation of async updates, rather than something in the `DependenciesProjectTreeProvider` class itself.