### PR TITLE
Remove unused double click capability

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -58,9 +58,4 @@
     <SuppressFromVsix Include="Microsoft.VisualStudio.DataTools.Interop.dll"/>
     <SuppressFromVsix Include="Microsoft.VisualStudio.XmlEditor.dll"/>
   </ItemGroup>
-  
-  <!-- Dogfood double click editing of project files: https://github.com/dotnet/project-system/issues/1224 -->
-  <ItemGroup>
-    <ProjectCapability Include="DoubleClickEditProjectFile"/>
-  </ItemGroup>
 </Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapability.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapability.cs
@@ -22,7 +22,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public const string EditAndContinue = nameof(EditAndContinue);
         public const string LaunchProfiles = nameof(LaunchProfiles);
         public const string OpenProjectFile = nameof(OpenProjectFile);
-        public const string DoubleClickEditProjectFile = nameof(DoubleClickEditProjectFile);
         public const string HandlesOwnReload = ProjectCapabilities.HandlesOwnReload;
         public const string ReferenceManagerAssemblies = nameof(ReferenceManagerAssemblies);
         public const string ReferenceManagerBrowse = nameof(ReferenceManagerBrowse);


### PR DESCRIPTION
More leftovers from #4134. Apologies, these should have been removed in #4135 