### PR TITLE
Add try/catch around setting up the file watcher

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -724,7 +724,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 }
                 catch (Exception ex)  when (ex is IOException || ex is ArgumentException)
                 {
-                    // IF the project folder is no longer available this will throw, which can happen during branch switching
+                    // If the project folder is no longer available this will throw, which can happen during branch switching
                 }
             }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -712,13 +712,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 // Create our scheduler for processing file changes
                 FileChangeScheduler = new TaskDelayScheduler(FileChangeProcessingDelay, CommonProjectServices.ThreadingService,
                     ProjectServices.ProjectAsynchronousTasks.UnloadCancellationToken);
-
-                FileWatcher = new SimpleFileWatcher(Path.GetDirectoryName(CommonProjectServices.Project.FullPath),
+               
+                try
+                {
+                    FileWatcher = new SimpleFileWatcher(Path.GetDirectoryName(CommonProjectServices.Project.FullPath),
                                                     true,
                                                     NotifyFilters.FileName | NotifyFilters.Size | NotifyFilters.LastWrite,
                                                     LaunchSettingsFilename,
                                                     LaunchSettingsFile_Changed,
                                                     LaunchSettingsFile_Changed);
+                }
+                catch (Exception ex)  when (ex is IOException || ex is ArgumentException)
+                {
+                    // IF the project folder is no longer available this will throw, which can happen during branch switching
+                }
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -716,11 +716,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 try
                 {
                     FileWatcher = new SimpleFileWatcher(Path.GetDirectoryName(CommonProjectServices.Project.FullPath),
-                                                    true,
-                                                    NotifyFilters.FileName | NotifyFilters.Size | NotifyFilters.LastWrite,
-                                                    LaunchSettingsFilename,
-                                                    LaunchSettingsFile_Changed,
-                                                    LaunchSettingsFile_Changed);
+                                                        true,
+                                                        NotifyFilters.FileName | NotifyFilters.Size | NotifyFilters.LastWrite,
+                                                        LaunchSettingsFilename,
+                                                        LaunchSettingsFile_Changed,
+                                                        LaunchSettingsFile_Changed);
                 }
                 catch (Exception ex)  when (ex is IOException || ex is ArgumentException)
                 {


### PR DESCRIPTION
This handles the case where the project folder path goes invalid during a branch switch while the project is loading. This addresses the following feedback issue: https://developercommunity.visualstudio.com/content/problem/361196/project-system-encounters-a-fault-after-a-branch-s.html
