### PR TITLE
IDependenciesSnapshotFilter.BeforeRemove returns bool

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/ImplicitTopLevelDependenciesSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/ImplicitTopLevelDependenciesSnapshotFilterTests.cs
@@ -164,7 +164,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 worldBuilder,
                 null,
                 null,
-                new HashSet<string>(new[] { "myprojectitem" }),
+                ImmutableHashSet.Create("myprojectitem"),
                 out bool filterAnyChanges);
 
             Assert.Equal(dependency.Object.Id, resultDependency.Id);
@@ -208,7 +208,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 {
                     { subTreeProvider.ProviderType, subTreeProvider }
                 },
-                new HashSet<string>(),
+                ImmutableHashSet<string>.Empty,
                 out bool filterAnyChanges);
 
             Assert.Equal(dependency.Object.Id, resultDependency.Id);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
@@ -669,7 +669,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 ImmutableDictionary<string, IDependency>.Builder worldBuilder,
                 ImmutableHashSet<IDependency>.Builder topLevelBuilder,
                 IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
-                HashSet<string> projectItemSpecs,
+                IImmutableSet<string> projectItemSpecs,
                 out bool filterAnyChanges)
             {
                 filterAnyChanges = _filterAnyChanges;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
@@ -668,7 +668,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 IDependency dependency,
                 ImmutableDictionary<string, IDependency>.Builder worldBuilder,
                 ImmutableHashSet<IDependency>.Builder topLevelBuilder,
-                Dictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
+                IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
                 HashSet<string> projectItemSpecs,
                 out bool filterAnyChanges)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
@@ -696,7 +696,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 return dependency;
             }
 
-            public IDependency BeforeRemove(
+            public bool BeforeRemove(
                 string projectPath,
                 ITargetFramework targetFramework,
                 IDependency dependency,
@@ -710,7 +710,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 {
                     if (info.Item2 == FilterAction.Cancel)
                     {
-                        return null;
+                        return false;
                     }
                     else if (info.Item2 == FilterAction.ShouldBeAdded)
                     {
@@ -724,7 +724,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     }
                 }
 
-                return dependency;
+                return true;
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -102,7 +102,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             IProjectCatalogSnapshot catalogs,
             IEnumerable<IDependenciesSnapshotFilter> snapshotFilters,
             IEnumerable<IProjectDependenciesSubTreeProvider> subTreeProviders,
-            HashSet<string> projectItemSpecs)
+            IImmutableSet<string> projectItemSpecs)
         {
             bool anyChanges = false;
             var builder = _targets.ToBuilder();
@@ -160,7 +160,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             ITargetFramework activeTargetFramework,
             IEnumerable<IDependenciesSnapshotFilter> snapshotFilters,
             IEnumerable<IProjectDependenciesSubTreeProvider> subTreeProviders,
-            HashSet<string> projectItemSpecs,
+            IImmutableSet<string> projectItemSpecs,
             out bool anyChanges)
         {
             var newSnapshot = new DependenciesSnapshot(projectPath, activeTargetFramework, previousSnapshot);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DependenciesSnapshotFilterBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DependenciesSnapshotFilterBase.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             return dependency;
         }
 
-        public virtual IDependency BeforeRemove(
+        public virtual bool BeforeRemove(
             string projectPath,
             ITargetFramework targetFramework,
             IDependency dependency,
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             out bool filterAnyChanges)
         {
             filterAnyChanges = false;
-            return dependency;
+            return true;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DependenciesSnapshotFilterBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DependenciesSnapshotFilterBase.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             IDependency dependency,
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
             ImmutableHashSet<IDependency>.Builder topLevelBuilder,
-            Dictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
+            IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
             HashSet<string> projectItemSpecs,
             out bool filterAnyChanges)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DependenciesSnapshotFilterBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DependenciesSnapshotFilterBase.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
             ImmutableHashSet<IDependency>.Builder topLevelBuilder,
             IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
-            HashSet<string> projectItemSpecs,
+            IImmutableSet<string> projectItemSpecs,
             out bool filterAnyChanges)
         {
             filterAnyChanges = false;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DuplicatedDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DuplicatedDependenciesSnapshotFilter.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             IDependency dependency,
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
             ImmutableHashSet<IDependency>.Builder topLevelBuilder,
-            Dictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
+            IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
             HashSet<string> projectItemSpecs,
             out bool filterAnyChanges)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DuplicatedDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DuplicatedDependenciesSnapshotFilter.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
             ImmutableHashSet<IDependency>.Builder topLevelBuilder,
             IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
-            HashSet<string> projectItemSpecs,
+            IImmutableSet<string> projectItemSpecs,
             out bool filterAnyChanges)
         {
             filterAnyChanges = false;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/IDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/IDependenciesSnapshotFilter.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             IDependency dependency,
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
             ImmutableHashSet<IDependency>.Builder topLevelBuilder,
-            Dictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
+            IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
             HashSet<string> projectItemSpecs,
             out bool filterAnyChanges);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/IDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/IDependenciesSnapshotFilter.cs
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
             ImmutableHashSet<IDependency>.Builder topLevelBuilder,
             IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
-            HashSet<string> projectItemSpecs,
+            IImmutableSet<string> projectItemSpecs,
             out bool filterAnyChanges);
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/IDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/IDependenciesSnapshotFilter.cs
@@ -8,20 +8,19 @@ using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Filters
 {
     /// <summary>
+    /// Implementations may influence how dependencies are added and removed from snapshots.
+    /// </summary>
+    /// <remarks>
     /// When snapshot being updated with new, changed, removed dependencies it calls
     /// a list of available filters which can changed new/old items depending on particular
     /// filter condition.
     /// Filter can also prevent snapshot from doing update for given dependency when needed.
-    /// </summary>
+    /// </remarks>
     internal interface IDependenciesSnapshotFilter
     {
         /// <summary>
-        /// Is called before adding a given dependency.
+        /// Called before adding a dependency to a snapshot.
         /// </summary>
-        /// <returns>
-        ///     Returns original or modified dependency depending on filter's logic. 
-        ///     If returns null, snapshot does not do any updates for this dependency.
-        /// </returns>
         /// <param name="projectPath">Path to current project.</param>
         /// <param name="targetFramework">Target framework for which dependency was resolved.</param>
         /// <param name="dependency">The dependency to which filter should be applied.</param>
@@ -29,8 +28,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
         /// <param name="topLevelBuilder">Top level dependencies list builder of updating snapshot.</param>
         /// <param name="subTreeProviders">All known subtree providers</param>
         /// <param name="projectItemSpecs">List of all items contained in project's xml at given moment, otherwise, <see langword="null"/> if we do not have any data.</param>
-        /// <param name="filterAnyChanges">True if filter did any changes in the snapshot</param>
-        /// <returns>Dependency to be added if addition is approved, null if dependency should not be added to snapshot</returns>
+        /// <param name="filterAnyChanges"><see langword="true"/> if the returned dependency differs from <paramref name="dependency"/>, or if <paramref name="worldBuilder"/> or <paramref name="topLevelBuilder"/> changed, otherwise <see langword="false"/>.</param>
+        /// <returns>
+        /// The dependency to be added, or <see langword="null"/> if the filter prohibits adding the dependency.
+        /// Implementations may return a modified dependency to be added to the snapshot.
+        /// </returns>
         IDependency BeforeAdd(
             string projectPath,
             ITargetFramework targetFramework,
@@ -42,16 +44,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             out bool filterAnyChanges);
 
         /// <summary>
-        /// Is called before removing a given dependency.
+        /// Called before removing a dependency from a snapshot.
         /// </summary>
         /// <param name="projectPath">Path to current project.</param>
         /// <param name="targetFramework">Target framework for which dependency was resolved.</param>
         /// <param name="dependency">The dependency to which filter should be applied.</param>
         /// <param name="worldBuilder">Builder for immutable world dictionary of updating snapshot.</param>
         /// <param name="topLevelBuilder">Top level dependencies list builder of updating snapshot.</param>
-        /// <param name="filterAnyChanges">True if filter did any changes in the snapshot</param>
-        /// <returns>Dependency itself if removal is approved, null if dependency should not be removed</returns>
-        IDependency BeforeRemove(
+        /// <param name="filterAnyChanges"><see langword="true"/> if <paramref name="worldBuilder"/> or <paramref name="topLevelBuilder"/> changed, otherwise <see langword="false"/>.</param>
+        /// <returns><see langword="true"/> if removal is approved, or <see langword="false"/> if <paramref name="dependency"/> should not be removed.</returns>
+        bool BeforeRemove(
             string projectPath,
             ITargetFramework targetFramework,
             IDependency dependency,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/ImplicitTopLevelDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/ImplicitTopLevelDependenciesSnapshotFilter.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             IDependency dependency,
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
             ImmutableHashSet<IDependency>.Builder topLevelBuilder,
-            Dictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
+            IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
             HashSet<string> projectItemSpecs,
             out bool filterAnyChanges)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/ImplicitTopLevelDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/ImplicitTopLevelDependenciesSnapshotFilter.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
             ImmutableHashSet<IDependency>.Builder topLevelBuilder,
             IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
-            HashSet<string> projectItemSpecs,
+            IImmutableSet<string> projectItemSpecs,
             out bool filterAnyChanges)
         {
             filterAnyChanges = false;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/SdkAndPackagesDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/SdkAndPackagesDependenciesSnapshotFilter.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             IDependency dependency,
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
             ImmutableHashSet<IDependency>.Builder topLevelBuilder,
-            Dictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
+            IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
             HashSet<string> projectItemSpecs,
             out bool filterAnyChanges)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/SdkAndPackagesDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/SdkAndPackagesDependenciesSnapshotFilter.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
             ImmutableHashSet<IDependency>.Builder topLevelBuilder,
             IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
-            HashSet<string> projectItemSpecs,
+            IImmutableSet<string> projectItemSpecs,
             out bool filterAnyChanges)
         {
             filterAnyChanges = false;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/SdkAndPackagesDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/SdkAndPackagesDependenciesSnapshotFilter.cs
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             return resultDependency;
         }
 
-        public override IDependency BeforeRemove(
+        public override bool BeforeRemove(
             string projectPath,
             ITargetFramework targetFramework,
             IDependency dependency,
@@ -87,12 +87,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             out bool filterAnyChanges)
         {
             filterAnyChanges = false;
-            if (!dependency.TopLevel || !dependency.Resolved)
-            {
-                return dependency;
-            }
 
-            if (dependency.Flags.Contains(DependencyTreeFlags.PackageNodeFlags))
+            if (dependency.TopLevel && 
+                dependency.Resolved && 
+                dependency.Flags.Contains(DependencyTreeFlags.PackageNodeFlags))
             {
                 // find sdk with the same name and clean dependencyIDs
                 string sdkModelId = dependency.Name;
@@ -113,7 +111,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
                 }
             }
 
-            return dependency;
+            return true;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/UnresolvedDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/UnresolvedDependenciesSnapshotFilter.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             IDependency dependency,
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
             ImmutableHashSet<IDependency>.Builder topLevelBuilder,
-            Dictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
+            IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
             HashSet<string> projectItemSpecs,
             out bool filterAnyChanges)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/UnresolvedDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/UnresolvedDependenciesSnapshotFilter.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
             ImmutableHashSet<IDependency>.Builder topLevelBuilder,
             IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
-            HashSet<string> projectItemSpecs,
+            IImmutableSet<string> projectItemSpecs,
             out bool filterAnyChanges)
         {
             filterAnyChanges = false;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/UnsupportedProjectsSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/UnsupportedProjectsSnapshotFilter.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             IDependency dependency,
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
             ImmutableHashSet<IDependency>.Builder topLevelBuilder,
-            Dictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
+            IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
             HashSet<string> projectItemSpecs,
             out bool filterAnyChanges)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/UnsupportedProjectsSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/UnsupportedProjectsSnapshotFilter.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
             ImmutableHashSet<IDependency>.Builder topLevelBuilder,
             IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviders,
-            HashSet<string> projectItemSpecs,
+            IImmutableSet<string> projectItemSpecs,
             out bool filterAnyChanges)
         {
             filterAnyChanges = false;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
@@ -178,7 +178,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             IDependenciesChanges changes,
             IEnumerable<IDependenciesSnapshotFilter> snapshotFilters,
             IEnumerable<IProjectDependenciesSubTreeProvider> subTreeProviders,
-            HashSet<string> projectItemSpecs)
+            IImmutableSet<string> projectItemSpecs)
         {
             var worldBuilder = DependenciesWorld.ToBuilder();
             var topLevelBuilder = TopLevelDependencies.ToBuilder();
@@ -295,7 +295,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             IProjectCatalogSnapshot catalogs,
             IEnumerable<IDependenciesSnapshotFilter> snapshotFilters,
             IEnumerable<IProjectDependenciesSubTreeProvider> subTreeProviders,
-            HashSet<string> projectItemSpecs,
+            IImmutableSet<string> projectItemSpecs,
             out bool anyChanges)
         {
             var newSnapshot = new TargetedDependenciesSnapshot(projectPath, targetFramework, previousSnapshot, catalogs);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySubscriptionsHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySubscriptionsHost.cs
@@ -270,7 +270,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
         {
             bool anyChanges;
 
-            HashSet<string> projectItemSpecs = GetProjectItemSpecsFromSnapshot(catalogs);
+            IImmutableSet<string> projectItemSpecs = GetProjectItemSpecsFromSnapshot(catalogs);
 
             // Note: we are updating existing snapshot, not receiving a complete new one. Thus we must
             // ensure incremental updates are done in the correct order. This lock ensures that here.
@@ -295,14 +295,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             }
         }
 
-        private static HashSet<string> GetProjectItemSpecsFromSnapshot(IProjectCatalogSnapshot catalogs)
+        private static IImmutableSet<string> GetProjectItemSpecsFromSnapshot(IProjectCatalogSnapshot catalogs)
         {
             // We don't have catalog snapshot, we're likely updating because one of our project 
             // dependencies changed. Just return 'no data'
             if (catalogs == null)
                 return null;
 
-            var projectItemSpecs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            ImmutableHashSet<string>.Builder projectItemSpecs = ImmutableHashSet.CreateBuilder(StringComparer.OrdinalIgnoreCase);
 
             foreach (ProjectItemInstance item in catalogs.Project.ProjectInstance.Items)
             {
@@ -315,7 +315,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                     projectItemSpecs.Add(itemSpec);
             }
 
-            return projectItemSpecs;
+            return projectItemSpecs.ToImmutable();
         }
 
         private void ScheduleDependenciesUpdate()


### PR DESCRIPTION
Unlike `IDependenciesSnapshotFilter.BeforeAdd`, it doesn't make sense for `IDependenciesSnapshotFilter.BeforeRemove` to modify the dependency. It either removes the dependency or does not.

Updated documentation to hopefully make the meaning of return and `out` vars clearer.