### PR TITLE
ITargetedProjectContext isn't IDisposable

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContext.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -15,7 +14,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         private readonly ImmutableDictionary<ITargetFramework, ITargetedProjectContext> _configuredProjectContextsByTargetFramework;
         private readonly ImmutableDictionary<string, ConfiguredProject> _configuredProjectsByTargetFramework;
         private readonly ITargetFramework _activeTargetFramework;
-        private readonly HashSet<ITargetedProjectContext> _disposedConfiguredProjectContexts;
 
         public AggregateCrossTargetProjectContext(
             bool isCrossTargeting,
@@ -34,15 +32,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             _configuredProjectContextsByTargetFramework = configuredProjectContextsByTargetFramework;
             _configuredProjectsByTargetFramework = configuredProjectsByTargetFramework;
             _activeTargetFramework = activeTargetFramework;
-            _disposedConfiguredProjectContexts = new HashSet<ITargetedProjectContext>();
             TargetFrameworkProvider = targetFrameworkProvider;
         }
 
         private ITargetFrameworkProvider TargetFrameworkProvider { get; }
 
         public IEnumerable<ITargetedProjectContext> InnerProjectContexts => _configuredProjectContextsByTargetFramework.Values;
-
-        public ImmutableArray<ITargetedProjectContext> DisposedInnerProjectContexts => _disposedConfiguredProjectContexts.ToImmutableArray();
 
         public IEnumerable<ConfiguredProject> InnerConfiguredProjects => _configuredProjectsByTargetFramework.Values;
 
@@ -128,25 +123,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             }
 
             return true;
-        }
-
-        public void Dispose(Func<ITargetedProjectContext, bool> shouldDisposeInnerContext)
-        {
-            // Dispose the inner project contexts.
-            var disposedContexts = new List<ITargetedProjectContext>();
-            foreach (ITargetedProjectContext innerProjectContext in InnerProjectContexts)
-            {
-                if (shouldDisposeInnerContext(innerProjectContext))
-                {
-                    innerProjectContext.Dispose();
-                    disposedContexts.Add(innerProjectContext);
-                }
-            }
-
-            lock (_disposedConfiguredProjectContexts)
-            {
-                _disposedConfiguredProjectContexts.AddRange(disposedContexts);
-            }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             return context;
         }
 
-        public Task ReleaseProjectContextAsync(AggregateCrossTargetProjectContext context)
+        public void ReleaseProjectContext(AggregateCrossTargetProjectContext context)
         {
             Requires.NotNull(context, nameof(context));
 
@@ -73,8 +73,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
                 // We can remove the ones which are only used by the current context being released.
                 RemoveUnusedConfiguredProjectsState_NoLock();
             }
-
-            return Task.CompletedTask;
         }
 
         // Clears saved host objects and project contexts for unused configured projects.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
@@ -60,11 +60,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             return context;
         }
 
-        public async Task ReleaseProjectContextAsync(AggregateCrossTargetProjectContext context)
+        public Task ReleaseProjectContextAsync(AggregateCrossTargetProjectContext context)
         {
             Requires.NotNull(context, nameof(context));
 
-            ImmutableHashSet<ITargetedProjectContext> usedProjectContexts;
             lock (_gate)
             {
                 if (!_contexts.Remove(context))
@@ -73,17 +72,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
                 // Update the maps storing configured project host objects and project contexts which are shared across created contexts.
                 // We can remove the ones which are only used by the current context being released.
                 RemoveUnusedConfiguredProjectsState_NoLock();
-
-                usedProjectContexts = _configuredProjectContextsMap.Values.ToImmutableHashSet();
             }
 
-            // TODO: https://github.com/dotnet/roslyn-project-system/issues/353
-            await _commonServices.ThreadingService.SwitchToUIThread();
-
-            // We don't want to dispose the inner workspace contexts that are still being used by other active aggregate contexts.
-            bool shouldDisposeInnerContext(ITargetedProjectContext c) => !usedProjectContexts.Contains(c);
-
-            context.Dispose(shouldDisposeInnerContext);
+            return Task.CompletedTask;
         }
 
         // Clears saved host objects and project contexts for unused configured projects.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetSubscriptionHostBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/CrossTargetSubscriptionHostBase.cs
@@ -224,7 +224,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
                 // Dispose the old project context, if one exists.
                 if (previousContextToDispose != null)
                 {
-                    await DisposeAggregateProjectContextAsync(previousContextToDispose);
+                    DisposeAggregateProjectContext(previousContextToDispose);
                 }
 
                 // Create new project context.
@@ -236,9 +236,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             });
         }
 
-        private async Task DisposeAggregateProjectContextAsync(AggregateCrossTargetProjectContext projectContext)
+        private void DisposeAggregateProjectContext(AggregateCrossTargetProjectContext projectContext)
         {
-            await _contextProvider.Value.ReleaseProjectContextAsync(projectContext);
+            _contextProvider.Value.ReleaseProjectContext(projectContext);
         }
 
         private async Task AddSubscriptionsAsync(AggregateCrossTargetProjectContext newProjectContext)
@@ -291,11 +291,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             {
                 DisposeAndClearSubscriptions();
 
-                await ExecuteWithinLockAsync(async () =>
+                await ExecuteWithinLockAsync(() =>
                 {
                     if (_currentAggregateProjectContext != null)
                     {
-                        await _contextProvider.Value.ReleaseProjectContextAsync(_currentAggregateProjectContext);
+                        _contextProvider.Value.ReleaseProjectContext(_currentAggregateProjectContext);
                     }
                 });
             }
@@ -324,9 +324,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             return _gate.ExecuteWithinLockAsync(JoinableCollection, JoinableFactory, task);
         }
 
-        private Task ExecuteWithinLockAsync(Func<Task> task)
+        private Task ExecuteWithinLockAsync(Action action)
         {
-            return _gate.ExecuteWithinLockAsync(JoinableCollection, JoinableFactory, task);
+            return _gate.ExecuteWithinLockAsync(JoinableCollection, JoinableFactory, action);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/IAggregateCrossTargetProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/IAggregateCrossTargetProjectContextProvider.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         /// </returns>
         /// <remarks>
         ///     When finished with the return <see cref="AggregateCrossTargetProjectContext"/>, callers must call 
-        ///     <see cref="ReleaseProjectContextAsync(AggregateCrossTargetProjectContext)"/>.
+        ///     <see cref="ReleaseProjectContext"/>.
         /// </remarks>
         Task<AggregateCrossTargetProjectContext> CreateProjectContextAsync();
 
@@ -37,6 +37,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         ///     <paramref name="context"/> was not created via <see cref="CreateProjectContextAsync"/> or 
         ///     has already been unregistered.
         /// </exception>
-        Task ReleaseProjectContextAsync(AggregateCrossTargetProjectContext context);
+        void ReleaseProjectContext(AggregateCrossTargetProjectContext context);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/ITargetedProjectContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/ITargetedProjectContext.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 {
-    internal interface ITargetedProjectContext : IDisposable
+    internal interface ITargetedProjectContext
     {
         string DisplayName { get; set; }
         string ProjectFilePath { get; set; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetedProjectContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetedProjectContext.cs
@@ -21,9 +21,5 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         public ITargetFramework TargetFramework { get; }
         public string TargetPath { get; }
         public bool LastDesignTimeBuildSucceeded { get; set; }
-
-        public void Dispose()
-        {
-        }
     }
 }


### PR DESCRIPTION
Fixes #4162 

- f92766180468a67f2b4cb992099b5ffcd2aea3b4 removes `IDisposable` from the interface and all code related to that
- 5a7a2b7a47033ff55221f8004cbe6d1e05f6541d makes `IAggregateCrossTargetProjectContextProvider.ReleaseProjectContextAsync` non-async