### PR TITLE
Handle more cases when calculating folder names

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/FileItemServicesTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/FileItemServicesTests.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    public class FileItemServicesTests
+    {
+        [Fact]
+        public void GetLogicalFolderNames_NullAsBasePath_ThrowsArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>("basePath", () =>
+            {
+                FileItemServices.GetLogicalFolderNames((string)null, "fullPath", ImmutableDictionary<string, string>.Empty);
+            });
+        }
+
+        [Fact]
+        public void GetLogicalFolderNames_NullAsFullPath_ThrowsArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>("fullPath", () =>
+            {
+                FileItemServices.GetLogicalFolderNames("basePath", (string)null, ImmutableDictionary<string, string>.Empty);
+            });
+        }
+
+        [Fact]
+        public void GetLogicalFolderNames_NullAsMetadata_ThrowsArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>("metadata", () =>
+            {
+                FileItemServices.GetLogicalFolderNames("basePath", "fullPath", (IImmutableDictionary<string, string>)null);
+            });
+        }
+
+        [Fact]
+        public void GetLogicalFolderNames_EmptyAsBasePath_ThrowsArgument()
+        {
+            Assert.Throws<ArgumentException>("basePath", () =>
+            {
+                FileItemServices.GetLogicalFolderNames(string.Empty, "fullPath", ImmutableDictionary<string, string>.Empty);
+            });
+        }
+
+        [Fact]
+        public void GetLogicalFolderNames_EmptyAsFullPath_ThrowsArgument()
+        {
+            Assert.Throws<ArgumentException>("fullPath", () =>
+            {
+                FileItemServices.GetLogicalFolderNames("basePath", string.Empty, ImmutableDictionary<string, string>.Empty);
+            });
+        }
+
+        [Theory] // BasePath                                        FullPath                                 Link                                           Expected
+        [InlineData("C:\\Project",                                  "C:\\Project\\Source.cs",                null,                                          null)]
+        [InlineData("C:\\Project",                                  "C:\\Project\\Source.cs",                "",                                            null)]
+        [InlineData("C:\\Project",                                  "C:\\Project\\Folder\\Source.cs",        "",                                            "Folder")]
+        [InlineData("C:\\Project",                                  "C:\\Project\\Folder\\Source.cs",        " ",                                           "Folder")]
+        [InlineData("C:\\Project",                                  "C:\\Project\\Source.cs",                "Folder\\Source.cs",                           "Folder")]
+        [InlineData("C:\\Project",                                  "C:\\Project\\Source.cs",                "Folder\\SubFolder\\Source.cs",                "Folder", "SubFolder")]
+        [InlineData("C:\\Project",                                  "C:\\Project\\Source.cs",                "Folder\\Source.cs ",                          "Folder")]
+        [InlineData("C:\\Project",                                  "C:\\Project\\Source.cs",                "Folder\\SubFolder\\Source.cs ",               "Folder", "SubFolder")]
+        [InlineData("C:\\Project",                                  "C:\\Source.cs",                         "Folder\\SubFolder\\Source.cs ",               "Folder", "SubFolder")]
+        [InlineData("C:\\Project",                                  "C:\\Source.cs",                         "Folder\\SubFolder\\..\\Source.cs ",           "Folder")]
+        [InlineData("C:\\Project",                                  "C:\\Source.cs",                         "Folder\\SubFolder\\Child\\..\\Source.cs ",    "Folder", "SubFolder")]
+        [InlineData("C:\\Project",                                  "C:\\Source.cs",                         "Folder\\..\\Source.cs ",                       null)]
+        [InlineData("C:\\Folder\\Project" ,                         "C:\\Folder\\Project\\Source.cs",        null,                                           null)]
+        [InlineData("C:\\Folder\\Project",                          "C:\\Folder\\Source.cs",                 null,                                           null)]
+        [InlineData("C:\\Folder\\Project",                          "D:\\Source.cs",                         null,                                           null)]
+        [InlineData("C:\\Folder\\Project",                          "\\Source.cs",                           null,                                           null)]
+        [InlineData("C:\\Folder\\Project",                          "C:\\Folder\\Project\\Source.cs",        "..\\Source.cs",                                null)]
+        [InlineData("C:\\Folder\\Project",                          "C:\\Folder\\Source.cs",                 "..\\Source.cs",                                null)]
+        [InlineData("C:\\Folder\\Project",                          "C:\\Folder\\Project\\Source.cs",        "\\Source.cs",                                  null)]
+        [InlineData("C:\\Folder\\Project",                          "C:\\Folder\\Project\\Source.cs",        "..\\Folder\\Source.cs",                        null)]
+        [InlineData("C:\\Folder\\Project",                          "C:\\Folder\\Source.cs",                 "..\\Folder\\Source.cs",                        null)]
+        [InlineData("C:\\Folder\\Project",                          "C:\\Folder\\Project\\Source.cs",        "\\Folder\\Source.cs",                          null)]
+        [InlineData("C:\\Folder\\Project",                          "C:\\Folder\\Project\\Source.cs",        "Folder\\..\\..\\Source.cs",                    null)]
+        [InlineData("C:\\Folder\\Project",                          "C:\\Folder\\Project\\Source.cs",        "D:\\Folder\\Source.cs",                        null)]
+        [InlineData("C:\\Folder\\Project",                          "C:\\Folder\\Project\\Source.cs",        "C:\\Folder\\Project\\Source.cs",               null)]
+        public void GetLogicalFolderNames_Returns(string basePath, string fullPath, string link, params string[] expected)
+        {
+            var metadata = ImmutableDictionary<string, string>.Empty;
+            if (link != null)
+            {
+                metadata = metadata.SetItem(Compile.LinkProperty, link);
+            }
+
+            var result = FileItemServices.GetLogicalFolderNames(basePath, fullPath, metadata);
+
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/FileItemServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/FileItemServices.cs
@@ -1,15 +1,50 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
+using System.IO;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal static class FileItemServices
     {
-        public static string GetLinkFilePath(IImmutableDictionary<string, string> metadata)
+        /// <summary>
+        ///     Returns the logical folder names of the specified <paramref name="fullPath"/>, starting
+        ///     at <paramref name="basePath"/>, using 'Link' metadata if it represents a linked file.
+        /// </summary>
+        public static string[] GetLogicalFolderNames(string basePath, string fullPath, IImmutableDictionary<string, string> metadata)
         {
+            Requires.NotNullOrEmpty(basePath, nameof(basePath));
+            Requires.NotNullOrEmpty(fullPath, nameof(fullPath));
             Requires.NotNull(metadata, nameof(metadata));
 
+            // Roslyn wants the effective set of folders from the source up to, but not including the project 
+            // root to handle the cases where linked files have a different path in the tree than what its path 
+            // on disk is. It uses these folders for code actions that create files alongside others, such as 
+            // extract interface.
+
+            string linkOrFullPath = GetLinkFilePath(metadata) ?? fullPath;
+
+            // We try to make either the link path or full path relative to the project path
+            string relativePath = PathHelper.MakeRelative(basePath, linkOrFullPath);
+            if (relativePath.Length == 0)
+                return null;
+
+            // Is this outside of base path?
+            if (Path.IsPathRooted(relativePath) || relativePath.StartsWith("..\\", StringComparison.OrdinalIgnoreCase))
+                return null;
+
+            string relativeDirectoryName = Path.GetDirectoryName(relativePath);
+            if (relativeDirectoryName.Length == 0)
+                return null;
+
+            // We now have a folder in the form of `Folder1\Folder2` relative to the
+            // project directory split it up into individual path components
+            return relativeDirectoryName.Split(Delimiter.Path);
+        }
+
+        private static string GetLinkFilePath(IImmutableDictionary<string, string> metadata)
+        {
             // This mimic's CPS's handling of Link metadata
             if (metadata.TryGetValue(Compile.LinkProperty, out string linkFilePath) && !string.IsNullOrWhiteSpace(linkFilePath))
             {
@@ -18,6 +53,5 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             return null;
         }
-
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/FileItemServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/FileItemServices.cs
@@ -1,14 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using System.IO;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal static class FileItemServices
     {
-        public static readonly char[] PathSeparatorCharacters = { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
-
         public static string GetLinkFilePath(IImmutableDictionary<string, string> metadata)
         {
             Requires.NotNull(metadata, nameof(metadata));
@@ -16,10 +13,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
             // This mimic's CPS's handling of Link metadata
             if (metadata.TryGetValue(Compile.LinkProperty, out string linkFilePath) && !string.IsNullOrWhiteSpace(linkFilePath))
             {
-                return linkFilePath.TrimEnd(PathSeparatorCharacters);
+                return linkFilePath.TrimEnd(Delimiter.Path);
             }
 
             return null;
         }
+
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
         protected override void AddToContext(string fullPath, IImmutableDictionary<string, string> metadata, bool isActiveContext, IProjectLogger logger)
         {
-            string[] folderNames = GetFolderNames(fullPath, metadata);
+            string[] folderNames = FileItemServices.GetLogicalFolderNames(Path.GetDirectoryName(_project.FullPath), fullPath, metadata);
 
             logger.WriteLine("Adding source file '{0}'", fullPath);
             Context.AddSourceFile(fullPath, isInCurrentContext: isActiveContext, folderNames: folderNames);
@@ -69,43 +69,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         {
             logger.WriteLine("Removing source file '{0}'", fullPath);
             Context.RemoveSourceFile(fullPath);
-        }
-
-        private string[] GetFolderNames(string fullPath, IImmutableDictionary<string, string> metadata)
-        {
-            // Roslyn wants the effective set of folders from the source up to, but not including the project 
-            // root to handle the cases where linked files have a different path in the tree than what its path 
-            // on disk is. It uses these folders for code actions that create files alongside others, such as 
-            // extract interface.
-
-            // First we check for a linked item, and we use its effective folder in 
-            // the tree, otherwise, we just use the parent folder of the file itself
-            string parentFolder = GetLinkedParentFolder(metadata);
-            if (parentFolder == null)
-                parentFolder = GetParentFolder(fullPath);
-
-            // We now have a folder in the form of `Folder1\Folder2` relative to the
-            // project directory  split it up into individual path components
-            if (parentFolder.Length > 0)
-            {
-                return parentFolder.Split(Delimiter.Path);
-            }
-
-            return null;
-        }
-
-        private static string GetLinkedParentFolder(IImmutableDictionary<string, string> metadata)
-        {
-            string linkFilePath = FileItemServices.GetLinkFilePath(metadata);
-            if (linkFilePath != null)
-                return Path.GetDirectoryName(linkFilePath);
-
-            return null;
-        }
-
-        private string GetParentFolder(string fullPath)
-        {
-            return Path.GetDirectoryName(_project.MakeRelative(fullPath));
         }
 
         private IProjectChangeDiff ConvertToProjectDiff(BuildOptions added, BuildOptions removed)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/SourceItemHandler.cs
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             // project directory  split it up into individual path components
             if (parentFolder.Length > 0)
             {
-                return parentFolder.Split(FileItemServices.PathSeparatorCharacters);
+                return parentFolder.Split(Delimiter.Path);
             }
 
             return null;


### PR DESCRIPTION
Pull out folder name calculation into separate method and handle more cases. This is needed for Razor support.

Note: This doesn't produce anymore allocations than previously, but now shows at least one place where we can reduce allocations (getting the "project directory" to pass to GetLogicalFolderNames).