### PR TITLE
Implement build manager

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Automation/VsLangProjectPropertiesTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Automation/VsLangProjectPropertiesTests.cs
@@ -73,11 +73,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             unconfiguredProjectMock.Setup(p => p.Capabilities)
                                    .Returns((IProjectCapabilitiesScope)null);
 
+            var buildManager = new Mock<BuildManager>();
+
             var vsproject = new VSProjectTestImpl(
                                 innerVSProjectMock.Object,
                                 threadingService: Mock.Of<IProjectThreadingService>(),
                                 projectProperties: Mock.Of<ActiveConfiguredProject<ProjectProperties>>(),
-                                project: unconfiguredProjectMock.Object);
+                                project: unconfiguredProjectMock.Object,
+                                buildManager: buildManager.Object);
 
             vsproject.SetImportsImpl(importsImpl);
             vsproject.SetVSProjectEventsImpl(vsProjectEventsImpl);
@@ -199,7 +202,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             var vsproject = CreateInstance(
                 Mock.Of<VSLangProj.VSProject>(),
                 threadingService: Mock.Of<IProjectThreadingService>(),
-                projectProperties: Mock.Of<ActiveConfiguredProject<ProjectProperties>>());
+                projectProperties: Mock.Of<ActiveConfiguredProject<ProjectProperties>>(),
+                buildManager: Mock.Of<BuildManager>());
             Assert.Null(vsproject.ExtenderCATID);
         }
 
@@ -207,14 +211,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             VSLangProj.VSProject vsproject = null,
             IProjectThreadingService threadingService = null,
             ActiveConfiguredProject<ProjectProperties> projectProperties = null,
-            UnconfiguredProject project = null)
+            UnconfiguredProject project = null,
+            BuildManager buildManager = null)
         {
             if (project == null)
             {
                 project = UnconfiguredProjectFactory.Create();
             }
 
-            return new VSProject(vsproject, threadingService, projectProperties, project);
+            return new VSProject(vsproject, threadingService, projectProperties, project, buildManager);
         }
 
         internal class VSProjectTestImpl : VSProject
@@ -223,8 +228,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
                 VSLangProj.VSProject vsProject,
                 IProjectThreadingService threadingService,
                 ActiveConfiguredProject<ProjectProperties> projectProperties,
-                UnconfiguredProject project)
-                : base(vsProject, threadingService, projectProperties, project)
+                UnconfiguredProject project,
+                BuildManager buildManager)
+                : base(vsProject, threadingService, projectProperties, project, buildManager)
             {
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsBuildManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsBuildManager.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.ProjectSystem.VS.ConnectionPoint;
+using Microsoft.VisualStudio.ProjectSystem.VS.Interop;
+using Microsoft.VisualStudio.Shell;
+using VSLangProj;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
+{
+    /// <summary>
+    /// Undocumented.
+    /// </summary>
+    [Export(typeof(BuildManager))]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
+    [Order(Order.Default)]
+    internal class VsBuildManager : ConnectionPointContainer,
+                                    IEventSource<_dispBuildManagerEvents>,
+                                    BuildManager,
+                                    BuildManagerEvents
+    {
+        private readonly VSLangProj.VSProject _vsProject;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VsBuildManager"/> class.
+        /// </summary>
+        [ImportingConstructor]
+        internal VsBuildManager(
+            [Import(ExportContractNames.VsTypes.CpsVSProject)] VSLangProj.VSProject vsProject)
+        {
+            AddEventSource(this as IEventSource<_dispBuildManagerEvents>);
+            _vsProject = vsProject;
+        }
+
+        #region _dispBuildManagerEvents_Event Members
+
+        /// <summary>
+        /// Undocumented.
+        /// </summary>
+        public event _dispBuildManagerEvents_DesignTimeOutputDeletedEventHandler DesignTimeOutputDeleted;
+
+        /// <summary>
+        /// Undocumented.
+        /// </summary>
+        public event _dispBuildManagerEvents_DesignTimeOutputDirtyEventHandler DesignTimeOutputDirty;
+
+        #endregion
+
+        /// <summary>
+        /// Undocumented.
+        /// </summary>
+        public virtual EnvDTE.Project ContainingProject
+        {
+            get { return _vsProject.Project; }
+        }
+
+        /// <summary>
+        /// Undocumented.
+        /// </summary>
+        public virtual EnvDTE.DTE DTE
+        {
+            get { return _vsProject.DTE; }
+        }
+
+        /// <summary>
+        /// Undocumented.
+        /// </summary>
+        public virtual object DesignTimeOutputMonikers
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        /// <summary>
+        /// Undocumented.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1065:DoNotRaiseExceptionsInUnexpectedLocations")]
+        public virtual object Parent
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        #region BuildManager Members
+
+        /// <summary>
+        /// Undocumented.
+        /// </summary>
+        public virtual string BuildDesignTimeOutput(string bstrOutputMoniker)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region IEventSource<_dispBuildManagerEvents> Members
+
+        /// <summary>
+        /// Undocumented.
+        /// </summary>
+        void IEventSource<_dispBuildManagerEvents>.OnSinkAdded(_dispBuildManagerEvents sink)
+        {
+            DesignTimeOutputDeleted += new _dispBuildManagerEvents_DesignTimeOutputDeletedEventHandler(sink.DesignTimeOutputDeleted);
+            DesignTimeOutputDirty += new _dispBuildManagerEvents_DesignTimeOutputDirtyEventHandler(sink.DesignTimeOutputDirty);
+        }
+
+        /// <summary>
+        /// Undocumented.
+        /// </summary>
+        void IEventSource<_dispBuildManagerEvents>.OnSinkRemoved(_dispBuildManagerEvents sink)
+        {
+            DesignTimeOutputDeleted -= new _dispBuildManagerEvents_DesignTimeOutputDeletedEventHandler(sink.DesignTimeOutputDeleted);
+            DesignTimeOutputDirty -= new _dispBuildManagerEvents_DesignTimeOutputDirtyEventHandler(sink.DesignTimeOutputDirty);
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Undocumented.
+        /// </summary>
+        protected virtual void OnDesignTimeOutputDeleted(string outputMoniker)
+        {
+            DesignTimeOutputDeleted?.Invoke(outputMoniker);
+        }
+
+        /// <summary>
+        /// Undocumented.
+        /// </summary>
+        protected virtual void OnDesignTimeOutputDirty(string outputMoniker)
+        {
+            DesignTimeOutputDirty?.Invoke(outputMoniker);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsProject.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsProject.cs
@@ -30,18 +30,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
         private readonly VSLangProj.VSProject _vsProject;
         private readonly IProjectThreadingService _threadingService;
         private readonly ActiveConfiguredProject<ProjectProperties> _projectProperties;
+        private readonly BuildManager _buildManager;
 
         [ImportingConstructor]
         internal VSProject(
             [Import(ExportContractNames.VsTypes.CpsVSProject)] VSLangProj.VSProject vsProject,
             IProjectThreadingService threadingService,
             ActiveConfiguredProject<ProjectProperties> projectProperties,
-            UnconfiguredProject project)
+            UnconfiguredProject project,
+            [Import(typeof(BuildManager))]BuildManager buildManager)
         {
             _vsProject = vsProject;
             _threadingService = threadingService;
             _projectProperties = projectProperties;
-
+            _buildManager = buildManager;
             ImportsImpl = new OrderPrecedenceImportCollection<Imports>(projectCapabilityCheckProvider: project);
             VSProjectEventsImpl = new OrderPrecedenceImportCollection<VSProjectEvents>(projectCapabilityCheckProvider: project);
         }
@@ -54,7 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
 
         public VSLangProj.References References => _vsProject.References;
 
-        public BuildManager BuildManager => _vsProject.BuildManager;
+        public BuildManager BuildManager => _buildManager;
 
         public DTE DTE => _vsProject.DTE;
 


### PR DESCRIPTION
This is the first two checklist items in #4163. Thought I'd start PRing early to make sure everything is as expected. The [current CPS BuildManager](https://devdiv.visualstudio.com/DevDiv/_git/CPS?path=%2Fsrc%2FMicrosoft.VisualStudio.ProjectSystem.VS.Implementation%2FPackage%2FAutomation%2FVSProject%2FOAVSBuildManager.cs&version=GBmaster&line=78&lineStyle=plain&lineEnd=79&lineStartColumn=1&lineEndColumn=1) implementation simply throws `NotImplementedException`'s so I don't think there is any harm in merging this even though its incomplete. If that's not a good idea please let me know.