### PR TITLE
Reduce verbosity of codecov PR comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -13,4 +13,4 @@ coverage:
     - "build/src/::src/"
 
 comment:
-  layout: "diff, flags, files, footer"
+  layout: "diff"


### PR DESCRIPTION
https://docs.codecov.io/docs/pull-request-comments

The stuff in the red box becomes omitted from the comment. All information is still available via the link to the report.

![image](https://user-images.githubusercontent.com/350947/47498291-b62c2900-d854-11e8-9891-3aaaaf096895.png)
