### PR TITLE
Simplify package reference version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,6 +9,9 @@
   </ItemGroup>
 
   <PropertyGroup>
+    <!-- Workaround for https://github.com/dotnet/sdk/issues/2288 -->
+    <LanguageTargets Condition="'$(MSBuildProjectExtension)' == '.proj'">$(MSBuildToolsPath)\Microsoft.Common.targets</LanguageTargets>
+
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
 
     <RestoreSources>$(RestoreSources);https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json</RestoreSources>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
   <Import Project="build\RepoToolset\RestoreSources.props"/>
 
   <ItemGroup>
-    <PackageReference Include="RoslynTools.RepoToolset" Version="$(RoslynToolsRepoToolsetVersion)" />
+    <PackageReference Include="RoslynTools.RepoToolset" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,4 @@
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project>
+  <Import Project="build\Packages.targets"/>
+</Project>

--- a/build/Codecov.proj
+++ b/build/Codecov.proj
@@ -31,4 +31,6 @@
     <Exec Condition="'$(UseCodecov)' == 'true'"
           Command="&quot;$(_CodecovPath)&quot; @(_CodecovArgs, ' ')" />
   </Target>
+
+  <Import Project="..\Packages.targets" />
 </Project>

--- a/build/Internal/Toolset.csproj
+++ b/build/Internal/Toolset.csproj
@@ -7,6 +7,7 @@
     <RestoreSources/>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.IBCMerge" Version="[$(MicrosoftDotNetIBCMergeVersion)]" />
+    <PackageReference Include="Microsoft.DotNet.IBCMerge" />
   </ItemGroup>
+  <Import Project="..\Packages.targets" />
 </Project>

--- a/build/Packages.targets
+++ b/build/Packages.targets
@@ -1,0 +1,128 @@
+<Project>
+
+  <PropertyGroup>
+    <RestoreSources>
+      $(RestoreSources);
+      https://vside.myget.org/F/devcore/api/v3/index.json;
+      https://dotnet.myget.org/F/msbuild/api/v3/index.json;
+      https://dotnet.myget.org/F/nuget-build/api/v3/index.json;
+      https://dotnet.myget.org/F/roslyn/api/v3/index.json;
+      https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json;
+      https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json;
+      https://dotnet.myget.org/F/templating/api/v3/index.json;
+      https://dotnet.myget.org/F/project-system-interop/api/v3/index.json;
+      https://vside.myget.org/F/vs-impl/api/v3/index.json;
+    </RestoreSources>
+  </PropertyGroup>
+
+  <ItemGroup>
+
+    <!-- Toolset -->
+    <PackageReference Update="RoslynTools.RepoToolset" Version="$(RoslynToolsRepoToolsetVersion)" />
+    <PackageReference Update="RoslynTools.VsixExpInstaller" Version="$(RoslynToolsVsixExpInstallerVersion)" />
+    <PackageReference Update="RoslynDependencies.ProjectSystem.OptimizationData" Version="$(RoslynDependenciesProjectSystemOptimizationDataVersion)" />
+    <PackageReference Update="Microsoft.DotNet.IBCMerge" Version="[$(MicrosoftDotNetIBCMergeVersion)]" />
+    <PackageReference Update="Microsoft.DiaSymReader.Pdb2Pdb" Version="$(MicrosoftDiaSymReaderPdb2PdbVersion)" />
+    <PackageReference Update="OpenCover" Version="$(OpenCoverVersion)" />
+    <PackageReference Update="Codecov" Version="$(CodecovVersion)" />
+
+    <!-- VS SDK -->
+    <PackageReference Update="Microsoft.VSSDK.BuildTools" Version="15.8.3252" />
+    <PackageReference Update="Microsoft.VisualStudio.ComponentModelHost" Version="15.0.26606"/>
+    <PackageReference Update="Microsoft.VisualStudio.Composition" Version="15.8.98"/>
+    <PackageReference Update="Microsoft.VisualStudio.CoreUtility" Version="15.0.26606" />
+    <PackageReference Update="Microsoft.VisualStudio.Data.Core" Version="9.0.21022" />
+    <PackageReference Update="Microsoft.VisualStudio.DataDesign.Common" Version="15.0.26606-alpha"/>
+    <PackageReference Update="Microsoft.VisualStudio.Data.Services" Version="9.0.21022" />
+    <PackageReference Update="Microsoft.VisualStudio.DataTools.Interop" Version="15.0.26606-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.Designer.Interfaces" Version="1.1.4322" />
+    <PackageReference Update="Microsoft.VisualStudio.Diagnostics.PerformanceProvider" Version="15.0.26606-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.Editor" Version="15.0.26606" />
+    <PackageReference Update="Microsoft.VisualStudio.GraphModel" Version="15.0.26606-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.ImageCatalog" Version="15.0.26606" />
+    <PackageReference Update="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" Version="14.3.25407"/>
+    <PackageReference Update="Microsoft.VisualStudio.ManagedInterfaces" Version="8.0.50727" />
+    <PackageReference Update="Microsoft.VisualStudio.Telemetry" Version="15.3.799-masterDDDBA9E4" />
+    <PackageReference Update="Microsoft.VisualStudio.Text.Data" Version="15.0.26606" />
+    <PackageReference Update="Microsoft.VisualStudio.Text.UI" Version="15.0.26606" />
+    <PackageReference Update="Microsoft.VisualStudio.Text.UI.Wpf" Version="15.0.26606" />
+    <PackageReference Update="Microsoft.VisualStudio.Text.UI.Wpf" Version="15.0.26606" />
+    <PackageReference Update="Microsoft.VisualStudio.Text.Logic" Version="15.0.26606" />
+    <PackageReference Update="Microsoft.VisualStudio.TextManager.Interop.9.0" Version="9.0.30729" />
+    <PackageReference Update="Microsoft.VisualStudio.TextManager.Interop.10.0" Version="10.0.30319" />
+    <PackageReference Update="Microsoft.VisualStudio.TextManager.Interop.12.0" Version="12.0.30110" />
+    <PackageReference Update="Microsoft.VisualStudio.TextManager.Interop.12.1.DesignTime" Version="12.1.30328" />
+    <PackageReference Update="Microsoft.VisualStudio.Settings.15.0" Version="15.8.28010" />
+    <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.16.30" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.15.0" Version="15.0.26606" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Design" Version="15.0.26606" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Framework" Version="15.0.26606" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.9.0" Version="9.0.30729" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.10.0" Version="10.0.30319" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.11.0" Version="11.0.61030" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.12.1.DesignTime" Version="12.1.30328" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime" Version="14.3.25407" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime" Version="15.0.26201" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime" Version="15.0.26606" />
+    <PackageReference Update="Microsoft.VisualStudio.TemplateWizardInterface" Version="8.0.0-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading" Version="15.8.145" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="15.8.145" />
+    <PackageReference Update="Microsoft.VisualStudio.Utilities" Version="15.0.26607" />
+    <PackageReference Update="Microsoft.VisualStudio.Validation" Version="15.3.58" />
+    <PackageReference Update="Microsoft.VisualStudio.VSHelp" Version="15.0.26606-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.WCFReference.Interop" Version="9.0.30729" />
+    <PackageReference Update="Microsoft.VisualStudio.XmlEditor" Version="15.0.26606-alpha" />
+    <PackageReference Update="Microsoft.VSDesigner" Version="15.0.26606-alpha" />
+    <PackageReference Update="VsWebSite.Interop" Version="8.0.0-alpha"/>
+    <PackageReference Update="VSLangProj" Version="7.0.3300" />
+    <PackageReference Update="VSLangProj2" Version="7.0.5000" />
+    <PackageReference Update="VSLangProj80" Version="8.0.50727" />
+    <PackageReference Update="VSLangProj90" Version="9.0.30729" />
+    <PackageReference Update="VSLangProj100" Version="10.0.30319" />
+    <PackageReference Update="VSLangProj110" Version="11.0.61030" />
+    <PackageReference Update="VSLangProj158" Version="15.8.0" />
+    <PackageReference Update="EnvDTE" Version="8.0.1" />
+    <PackageReference Update="EnvDTE80" Version="8.0.1" />
+    <PackageReference Update="EnvDTE90" Version="9.0.1" />
+
+    <PackageReference Update="Microsoft.Test.Apex.VisualStudio" Version="15.8.27703" />
+    
+    <!-- CPS -->
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK" Version="16.0.201-pre-g7d366164d0" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers" Version="16.0.201-pre-g7d366164d0" />
+    
+    <!-- Roslyn -->
+    <PackageReference Update="Microsoft.VisualStudio.LanguageServices" Version="2.6.0-beta1-62113-02" />
+    <PackageReference Update="Microsoft.VisualStudio.IntegrationTest.Utilities" Version="2.6.0-beta1-62113-02" />
+    <PackageReference Update="Microsoft.Net.RoslynDiagnostics" Version="2.6.1-beta1-62702-01" />
+    
+    <!-- NuGet -->
+    <PackageReference Update="NuGet.SolutionRestoreManager.Interop" Version="4.3.0" />
+    <PackageReference Update="NuGet.VisualStudio" Version="4.3.0" />
+
+    <!-- MSBuild -->
+    <PackageReference Update="Microsoft.Build" Version="15.8.166"/>
+    <PackageReference Update="Microsoft.Build.Utilities.Core" Version="15.8.166"/>
+    <PackageReference Update="Microsoft.Build.Engine" Version="15.8.166"/>
+    <PackageReference Update="Microsoft.Build.Tasks.Core" Version="15.8.166"/>
+    
+    <!-- Libraries -->
+    <PackageReference Update="Newtonsoft.Json" Version="9.0.1"/>
+    
+    <!-- Tests -->
+    <PackageReference Update="Moq" Version="4.9.0"/>
+    <PackageReference Update="xunit" Version="$(XUnitVersion)" />
+    <PackageReference Update="xunit.assert" Version="$(XunitVersion)" />
+    <PackageReference Update="xunit.extensibility.core" Version="$(XunitVersion)" />
+    <PackageReference Update="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioVersion)" />
+    <PackageReference Update="xunit.runner.console" Version="$(XUnitVersion)" />
+    <PackageReference Update="xunit.analyzers" Version="0.10.0"/>
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
+    
+    <PackageReference Update="Microsoft.DotNet.Test.ProjectTemplates.1.x" Version="$(MicrosoftDotNetProjectTemplatesVersion)" />
+    <PackageReference Update="Microsoft.DotNet.Common.ProjectTemplates.1.x" Version="$(MicrosoftDotNetProjectTemplatesVersion)" />
+    
+  </ItemGroup>
+  
+
+</Project>

--- a/build/Toolset.proj
+++ b/build/Toolset.proj
@@ -9,10 +9,11 @@
     <RestoreSources>https://api.nuget.org/v3/index.json;https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json;https://dotnet.myget.org/F/symreader-converter/api/v3/index.json</RestoreSources>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="RoslynTools.RepoToolset" Version="$(RoslynToolsRepoToolsetVersion)" />
-    <PackageReference Include="RoslynTools.VsixExpInstaller" Version="$(RoslynToolsVsixExpInstallerVersion)" />
-    <PackageReference Include="Codecov" Version="$(CodecovVersion)" />
-    <PackageReference Include="OpenCover" Version="$(OpenCoverVersion)" />
-    <PackageReference Include="Microsoft.DiaSymReader.Pdb2Pdb" Version="$(MicrosoftDiaSymReaderPdb2PdbVersion)" />
+    <PackageReference Include="RoslynTools.RepoToolset" />
+    <PackageReference Include="RoslynTools.VsixExpInstaller" />
+    <PackageReference Include="Codecov" />
+    <PackageReference Include="OpenCover" />
+    <PackageReference Include="Microsoft.DiaSymReader.Pdb2Pdb" />
   </ItemGroup>
+
 </Project>

--- a/build/Versions.props
+++ b/build/Versions.props
@@ -13,12 +13,12 @@
     <!-- Toolset -->
     <RoslynToolsRepoToolsetVersion>1.0.0-beta-62705-01</RoslynToolsRepoToolsetVersion>
     <RoslynToolsVsixExpInstallerVersion>1.0.0-beta-62503-02</RoslynToolsVsixExpInstallerVersion>
+    <RoslynIntegrationVsixVersion>2.6.0.6211302</RoslynIntegrationVsixVersion>
     <RoslynDependenciesProjectSystemOptimizationDataVersion>2.6.0-beta1-62205-02</RoslynDependenciesProjectSystemOptimizationDataVersion>
     <VSWhereVersion>2.3.2</VSWhereVersion>
     <TRXUnitVersion>1.0.0-beta1</TRXUnitVersion>
     <MicrosoftDotNetIBCMergeVersion>4.7.1-alpha-00001</MicrosoftDotNetIBCMergeVersion>
     <MicrosoftNetCompilersVersion>2.9.0</MicrosoftNetCompilersVersion>
-    <MicrosoftVSSDKBuildToolsVersion>15.8.3252</MicrosoftVSSDKBuildToolsVersion>
     <MicrosoftDiaSymReaderPdb2PdbVersion>1.1.0-beta1-62624-01</MicrosoftDiaSymReaderPdb2PdbVersion>
     <OpenCoverVersion>4.6.519</OpenCoverVersion>
     <CodecovVersion>1.1.0</CodecovVersion>
@@ -30,94 +30,10 @@
     -->
     <MicroBuildPluginsSwixBuildVersion>1.0.422</MicroBuildPluginsSwixBuildVersion>
     
-    <!-- VS SDK -->
-    <MicrosoftVisualStudioComponentModelHostVersion>15.0.26606</MicrosoftVisualStudioComponentModelHostVersion>
-    <MicrosoftVisualStudioCompositionVersion>15.8.98</MicrosoftVisualStudioCompositionVersion>
-    <MicrosoftVisualStudioCoreUtilityVersion>15.0.26606</MicrosoftVisualStudioCoreUtilityVersion>
-    <MicrosoftVisualStudioDataCoreVersion>9.0.21022</MicrosoftVisualStudioDataCoreVersion>
-    <MicrosoftVisualStudioDataDesignCommonVersion>15.0.26606-alpha</MicrosoftVisualStudioDataDesignCommonVersion>
-    <MicrosoftVisualStudioDataServicesVersion>9.0.21022</MicrosoftVisualStudioDataServicesVersion>
-    <MicrosoftVisualStudioDataToolsInteropVersion>15.0.26606-alpha</MicrosoftVisualStudioDataToolsInteropVersion>
-    <MicrosoftVisualStudioDesignerInterfacesVersion>1.1.4322</MicrosoftVisualStudioDesignerInterfacesVersion>
-    <MicrosoftVisualStudioDiagnosticsPerformanceProviderVersion>15.0.26606-alpha</MicrosoftVisualStudioDiagnosticsPerformanceProviderVersion>
-    <MicrosoftVisualStudioEditorVersion>15.0.26606</MicrosoftVisualStudioEditorVersion>
-    <MicrosoftVisualStudioGraphModelVersion>15.0.26606-alpha</MicrosoftVisualStudioGraphModelVersion>
-    <MicrosoftVisualStudioImageCatalogVersion>15.0.26606</MicrosoftVisualStudioImageCatalogVersion>
-    <MicrosoftVisualStudioImagingInterop140DesignTimeVersion>14.3.25407</MicrosoftVisualStudioImagingInterop140DesignTimeVersion>
-    <MicrosoftVisualStudioManagedInterfacesVersion>8.0.50727</MicrosoftVisualStudioManagedInterfacesVersion>
-    <MicrosoftVisualStudioTelemetryVersion>15.3.799-masterDDDBA9E4</MicrosoftVisualStudioTelemetryVersion>
-    <MicrosoftVisualStudioTextDataVersion>15.0.26606</MicrosoftVisualStudioTextDataVersion>
-    <MicrosoftVisualStudioTextUIVersion>15.0.26606</MicrosoftVisualStudioTextUIVersion>
-    <MicrosoftVisualStudioTextUIWpfVersion>15.0.26606</MicrosoftVisualStudioTextUIWpfVersion>
-    <MicrosoftVisualStudioTextLogicVersion>15.0.26606</MicrosoftVisualStudioTextLogicVersion>
-    <MicrosoftVisualStudioTextManagerInterop9Version>9.0.30729</MicrosoftVisualStudioTextManagerInterop9Version>
-    <MicrosoftVisualStudioTextManagerInterop10Version>10.0.30319</MicrosoftVisualStudioTextManagerInterop10Version>
-    <MicrosoftVisualStudioTextManagerInterop12Version>12.0.30110</MicrosoftVisualStudioTextManagerInterop12Version>
-    <MicrosoftVisualStudioTextManagerInterop121DesignTimeVersion>12.1.30328</MicrosoftVisualStudioTextManagerInterop121DesignTimeVersion>
-    <MicrosoftVisualStudioSetupConfigurationVersion>1.16.30</MicrosoftVisualStudioSetupConfigurationVersion>
-    <MicrosoftVisualStudioSettings15Version>15.8.28010</MicrosoftVisualStudioSettings15Version>
-    <MicrosoftVisualStudioShell15Version>15.0.26606</MicrosoftVisualStudioShell15Version>
-    <MicrosoftVisualStudioShellDesignVersion>15.0.26606</MicrosoftVisualStudioShellDesignVersion>
-    <MicrosoftVisualStudioShellFrameworkVersion>15.0.26606</MicrosoftVisualStudioShellFrameworkVersion>
-    <MicrosoftVisualStudioShellInterop9Version>9.0.30729</MicrosoftVisualStudioShellInterop9Version>
-    <MicrosoftVisualStudioShellInterop10Version>10.0.30319</MicrosoftVisualStudioShellInterop10Version>
-    <MicrosoftVisualStudioShellInterop11Version>11.0.61030</MicrosoftVisualStudioShellInterop11Version>
-    <MicrosoftVisualStudioShellInterop121DesignTimeVersion>12.1.30328</MicrosoftVisualStudioShellInterop121DesignTimeVersion>
-    <MicrosoftVisualStudioShellInterop140DesignTimeVersion>14.3.25407</MicrosoftVisualStudioShellInterop140DesignTimeVersion>
-    <MicrosoftVisualStudioShellInterop150DesignTimeVersion>15.0.26201</MicrosoftVisualStudioShellInterop150DesignTimeVersion>
-    <MicrosoftVisualStudioShellInterop153DesignTimeVersion>15.0.26606</MicrosoftVisualStudioShellInterop153DesignTimeVersion>
-    <MicrosoftVisualStudioTemplateWizardInterfaceVersion>8.0.0-alpha</MicrosoftVisualStudioTemplateWizardInterfaceVersion>
-    <MicrosoftVisualStudioThreadingVersion>15.8.145</MicrosoftVisualStudioThreadingVersion>
-    <MicrosoftVisualStudioThreadingAnalyzersVersion>15.8.145</MicrosoftVisualStudioThreadingAnalyzersVersion>
-    <MicrosoftVisualStudioUtilitiesVersion>15.0.26607</MicrosoftVisualStudioUtilitiesVersion>
-    <MicrosoftVisualStudioValidationVersion>15.3.58</MicrosoftVisualStudioValidationVersion>
-    <MicrosoftVisualStudioVsHelpVersion>15.0.26606-alpha</MicrosoftVisualStudioVsHelpVersion>
-    <MicrosoftVisualStudioWCFReferenceInteropVersion>9.0.30729</MicrosoftVisualStudioWCFReferenceInteropVersion>
-    <MicrosoftVisualStudioXmlEditorVersion>15.0.26606-alpha</MicrosoftVisualStudioXmlEditorVersion>
-    <MicrosoftVsDesignerVersion>15.0.26606-alpha</MicrosoftVsDesignerVersion>
-    <VsWebSiteInteropVersion>8.0.0-alpha</VsWebSiteInteropVersion>
-
-    <!-- CPS -->
-    <MicrosoftVisualStudioProjectSystemSDKVersion>16.0.201-pre-g7d366164d0</MicrosoftVisualStudioProjectSystemSDKVersion>
-    <MicrosoftVisualStudioProjectSystemAnalyzersVersion>$(MicrosoftVisualStudioProjectSystemSDKVersion)</MicrosoftVisualStudioProjectSystemAnalyzersVersion>
-    
-    <!-- Roslyn -->
-    <MicrosoftVisualStudioLanguageServicesVersion>2.6.0-beta1-62113-02</MicrosoftVisualStudioLanguageServicesVersion>
-    <MicrosoftTestApexVisualStudioVersion>15.8.27703</MicrosoftTestApexVisualStudioVersion>
-    <RoslynIntegrationVsixVersion>2.6.0.6211302</RoslynIntegrationVsixVersion>
-    <MicrosoftNetRoslynDiagnosticsVersion>2.6.1-beta1-62702-01</MicrosoftNetRoslynDiagnosticsVersion>
-
-    <!-- NuGet -->
-    <NuGetSolutionRestoreManagerInteropVersion>4.3.0</NuGetSolutionRestoreManagerInteropVersion>
-    <NuGetVisualStudioVersion>4.3.0</NuGetVisualStudioVersion>
-
-    <!-- Msbuild -->
-    <MicrosoftBuildVersion>15.8.166</MicrosoftBuildVersion>
-
-    <!-- Libs -->
-    <NewtonsoftJsonVersion>9.0.1</NewtonsoftJsonVersion>
-
     <!-- Microsoft.DotNet.*.ProjectTemplates -->
     <MicrosoftDotNetProjectTemplatesVersion>1.0.0-beta2-20170629-269</MicrosoftDotNetProjectTemplatesVersion>
 
     <!-- Tests -->
-    <MoqVersion>4.9.0</MoqVersion>
     <XUnitVersion>2.4.0</XUnitVersion>
-    <XUnitAnalyzersVersion>0.10.0</XUnitAnalyzersVersion>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <RestoreSources>
-      $(RestoreSources);
-      https://vside.myget.org/F/devcore/api/v3/index.json;
-      https://dotnet.myget.org/F/msbuild/api/v3/index.json;
-      https://dotnet.myget.org/F/nuget-build/api/v3/index.json;
-      https://dotnet.myget.org/F/roslyn/api/v3/index.json;
-      https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json;
-      https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json;
-      https://dotnet.myget.org/F/templating/api/v3/index.json;
-      https://dotnet.myget.org/F/project-system-interop/api/v3/index.json;
-      https://vside.myget.org/F/vs-impl/api/v3/index.json;
-    </RestoreSources>
   </PropertyGroup>
 </Project>

--- a/setup/Directory.Build.targets
+++ b/setup/Directory.Build.targets
@@ -1,5 +1,6 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project>
+  <Import Project="..\Directory.Build.targets"/>
   <Import Project="$(RepoToolsetDir)Imports.targets" Condition="'$(RepoToolsetDir)' != ''" />
   
   <Target Name="Build" DependsOnTargets="ResolveProjectReferences">

--- a/setup/Microsoft.VisualStudio.NetCore.ProjectTemplates.1.x/Microsoft.VisualStudio.NetCore.ProjectTemplates.1.x.csproj
+++ b/setup/Microsoft.VisualStudio.NetCore.ProjectTemplates.1.x/Microsoft.VisualStudio.NetCore.ProjectTemplates.1.x.csproj
@@ -5,8 +5,8 @@
     <VisualStudioInsertionComponent>$(MSBuildProjectName)</VisualStudioInsertionComponent>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Common.ProjectTemplates.1.x" Version="$(MicrosoftDotNetProjectTemplatesVersion)" />
-    <PackageReference Include="Microsoft.DotNet.Test.ProjectTemplates.1.x" Version="$(MicrosoftDotNetProjectTemplatesVersion)" />
+    <PackageReference Include="Microsoft.DotNet.Common.ProjectTemplates.1.x" />
+    <PackageReference Include="Microsoft.DotNet.Test.ProjectTemplates.1.x" />
   </ItemGroup>
   <ItemGroup>
     <SwrProperty Include="Version=$(VsixVersion)" />

--- a/src/DeployIntegrationDependencies/DeployIntegrationDependencies.csproj
+++ b/src/DeployIntegrationDependencies/DeployIntegrationDependencies.csproj
@@ -6,12 +6,13 @@
     <PublishOutputToSymStore>false</PublishOutputToSymStore>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Test.Apex.VisualStudio" Version="$(MicrosoftTestApexVisualStudioVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="$(MicrosoftVisualStudioLanguageServicesVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Settings.15.0" Version="$(MicrosoftVisualStudioSettings15Version)" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Composition" Version="$(MicrosoftVisualStudioCompositionVersion)"/>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
+
+    <PackageReference Include="Microsoft.Test.Apex.VisualStudio" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" />
+    <PackageReference Include="Microsoft.VisualStudio.Settings.15.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" />
+    <PackageReference Include="Microsoft.VisualStudio.Composition" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
   </ItemGroup>
 </Project>

--- a/src/DeployTestDependencies/DeployTestDependencies.csproj
+++ b/src/DeployTestDependencies/DeployTestDependencies.csproj
@@ -18,10 +18,10 @@
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.VisualBasic\Microsoft.VisualStudio.ProjectSystem.VisualBasic.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
-    <PackageReference Include="xunit" Version="$(XUnitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioVersion)" />
-    <PackageReference Include="xunit.runner.console" Version="$(XUnitVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="xunit.runner.console" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Readme.txt" />

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,5 +1,6 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project>
+  <Import Project="..\Directory.Build.targets" />
   <Import Project="$(RepoToolsetDir)Imports.targets" Condition="'$(RepoToolsetDir)' != ''" />
   <Import Project="..\build\VisualStudio.XamlRules.targets"/>
   

--- a/src/HostAgnostic.props
+++ b/src/HostAgnostic.props
@@ -10,28 +10,28 @@
     <Reference Include="PresentationFramework" />
 
     <!-- CPS and Roslyn -->
-    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" Version="$(MicrosoftVisualStudioProjectSystemSDKVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="$(MicrosoftVisualStudioLanguageServicesVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Validation" Version="$(MicrosoftVisualStudioValidationVersion)" />    
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" />
-    <PackageReference Include="Microsoft.Net.RoslynDiagnostics" Version="$(MicrosoftNetRoslynDiagnosticsVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Analyzers" Version="$(MicrosoftVisualStudioProjectSystemAnalyzersVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" />
+    <PackageReference Include="Microsoft.VisualStudio.Validation" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" />
+    <PackageReference Include="Microsoft.Net.RoslynDiagnostics" />
+    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Analyzers" />
 
     <!-- Msbuild -->
-    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Build.Engine" Version="$(MicrosoftBuildVersion)" />
+    <PackageReference Include="Microsoft.Build" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" />
+    <PackageReference Include="Microsoft.Build.Engine" />
 
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' == 'true'" >
-    <PackageReference Include="Moq" Version="$(MoqVersion)"/>
-    <PackageReference Include="xunit.analyzers" Version="$(XUnitAnalyzersVersion)"/>
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit.analyzers" />
 
     <!-- TODO: Some tests need this. Seems wrong. -->
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell15Version)" />
-    <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="$(MicrosoftVisualStudioTextUIVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.UI" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
+++ b/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
@@ -13,9 +13,9 @@
     <PackageTags>Roslyn Project AppDesigner VisualStudio</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.DataDesign.Common" Version="$(MicrosoftVisualStudioDataDesignCommonVersion)"/>
-    <PackageReference Include="VsWebSite.Interop" Version="$(VsWebSiteInteropVersion)"/>
-    <PackageReference Include="Microsoft.VisualStudio.TemplateWizardInterface" Version="$(MicrosoftVisualStudioTemplateWizardInterfaceVersion)"/>
+    <PackageReference Include="Microsoft.VisualStudio.DataDesign.Common" />
+    <PackageReference Include="VsWebSite.Interop" />
+    <PackageReference Include="Microsoft.VisualStudio.TemplateWizardInterface" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Common\ManagedCodeMarkers.vb">

--- a/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
+++ b/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
@@ -15,9 +15,9 @@
     <PackageTags>Roslyn Project Property Page Editors VisualStudio</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="$(MicrosoftVisualStudioLanguageServicesVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="$(MicrosoftVisualStudioSetupConfigurationVersion)" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" />
+    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.AppDesigner\Microsoft.VisualStudio.AppDesigner.vbproj" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Need VSSDK to generate pkgdef -->
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="$(MicrosoftVSSDKBuildToolsVersion)" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.CSharp\Microsoft.VisualStudio.ProjectSystem.CSharp.csproj" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/Microsoft.VisualStudio.ProjectSystem.FSharp.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/Microsoft.VisualStudio.ProjectSystem.FSharp.VS.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Need VSSDK to generate pkgdef -->
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="$(MicrosoftVSSDKBuildToolsVersion)" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.FSharp\Microsoft.VisualStudio.ProjectSystem.FSharp.csproj" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\DeployIntegrationDependencies\DeployIntegrationDependencies.csproj" ReferenceOutputAssembly="false" />
-    <PackageReference Include="Microsoft.Test.Apex.VisualStudio" Version="$(MicrosoftTestApexVisualStudioVersion)" />
+    <PackageReference Include="Microsoft.Test.Apex.VisualStudio" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Configuration" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj
@@ -5,9 +5,9 @@
     <PublishOutputToSymStore>false</PublishOutputToSymStore>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Moq" Version="$(MoqVersion)" />
-    <PackageReference Include="xunit.assert" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.extensibility.core" Version="$(XunitVersion)" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit.assert" />
+    <PackageReference Include="xunit.extensibility.core" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -16,10 +16,9 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Need VSSDK to generate pkgdef -->
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="$(MicrosoftVSSDKBuildToolsVersion)" />
-    
-    <PackageReference Include="NuGet.SolutionRestoreManager.Interop" Version="$(NuGetSolutionRestoreManagerInteropVersion)" />
-    <PackageReference Include="NuGet.VisualStudio" Version="$(NuGetVisualStudioVersion)" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" />
+    <PackageReference Include="NuGet.SolutionRestoreManager.Interop" />
+    <PackageReference Include="NuGet.VisualStudio" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Need VSSDK to generate pkgdef -->
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="$(MicrosoftVSSDKBuildToolsVersion)" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.VS\Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj" />

--- a/src/ProjectSystemSetup/ProjectSystemSetup.csproj
+++ b/src/ProjectSystemSetup/ProjectSystemSetup.csproj
@@ -15,7 +15,7 @@
     <VisualStudioInsertionComponent>Microsoft.VisualStudio.ProjectSystem.Managed</VisualStudioInsertionComponent>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="RoslynDependencies.ProjectSystem.OptimizationData" Version="$(RoslynDependenciesProjectSystemOptimizationDataVersion)" />
+    <PackageReference Include="RoslynDependencies.ProjectSystem.OptimizationData" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.CSharp.VS\Microsoft.VisualStudio.ProjectSystem.CSharp.VS.csproj">

--- a/src/VisualStudio.props
+++ b/src/VisualStudio.props
@@ -1,61 +1,61 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="VSLangProj" Version="7.0.3300" />
-    <PackageReference Include="VSLangProj2" Version="7.0.5000" />
-    <PackageReference Include="VSLangProj80" Version="8.0.50727" />
-    <PackageReference Include="VSLangProj90" Version="9.0.30729" />
-    <PackageReference Include="VSLangProj100" Version="10.0.30319" />
-    <PackageReference Include="VSLangProj110" Version="11.0.61030" />
-    <PackageReference Include="VSLangProj158" Version="15.8.0" />
-    
-    <PackageReference Include="EnvDTE" Version="8.0.1" />
-    <PackageReference Include="EnvDTE80" Version="8.0.1" />
-    <PackageReference Include="EnvDTE90" Version="9.0.1" />
-    <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="$(MicrosoftVisualStudioComponentModelHostVersion)"/>
-    <PackageReference Include="Microsoft.VisualStudio.CoreUtility" Version="$(MicrosoftVisualStudioCoreUtilityVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Data.Core" Version="$(MicrosoftVisualStudioDataCoreVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Data.Services" Version="$(MicrosoftVisualStudioDataServicesVersion)" />
+    <PackageReference Include="VSLangProj" />
+    <PackageReference Include="VSLangProj2" />
+    <PackageReference Include="VSLangProj80" />
+    <PackageReference Include="VSLangProj90" />
+    <PackageReference Include="VSLangProj100" />
+    <PackageReference Include="VSLangProj110" />
+    <PackageReference Include="VSLangProj158" />
+
+    <PackageReference Include="EnvDTE" />
+    <PackageReference Include="EnvDTE80" />
+    <PackageReference Include="EnvDTE90" />
+    <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" />
+    <PackageReference Include="Microsoft.VisualStudio.CoreUtility" />
+    <PackageReference Include="Microsoft.VisualStudio.Data.Core" />
+    <PackageReference Include="Microsoft.VisualStudio.Data.Services" />
 
     <!--
        Microsoft.VisualStudio.Diagnostics.PerformanceProvider.dll is needed by GraphProvider unit tests.
        if it is not provided here, tests fail to load this assembly at runtime.
     -->
-    <PackageReference Include="Microsoft.VisualStudio.DataTools.Interop" Version="$(MicrosoftVisualStudioDataToolsInteropVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Diagnostics.PerformanceProvider" Version="$(MicrosoftVisualStudioDiagnosticsPerformanceProviderVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Designer.Interfaces" Version="$(MicrosoftVisualStudioDesignerInterfacesVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.GraphModel" Version="$(MicrosoftVisualStudioGraphModelVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Editor" Version="$(MicrosoftVisualStudioEditorVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" Version="$(MicrosoftVisualStudioImageCatalogVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" Version="$(MicrosoftVisualStudioImagingInterop140DesignTimeVersion)"/>
-    <PackageReference Include="Microsoft.VisualStudio.ManagedInterfaces" Version="$(MicrosoftVisualStudioManagedInterfacesVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="$(MicrosoftVisualStudioTextDataVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Text.Logic" Version="$(MicrosoftVisualStudioTextLogicVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Text.UI" Version="$(MicrosoftVisualStudioTextUIVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" Version="$(MicrosoftVisualStudioTextUIWpfVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.10.0" Version="$(MicrosoftVisualStudioTextManagerInterop10Version)" />
-    <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.12.0" Version="$(MicrosoftVisualStudioTextManagerInterop12Version)" />
-    <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.12.1.DesignTime" Version="$(MicrosoftVisualStudioTextManagerInterop121DesignTimeVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="$(MicrosoftVisualStudioThreadingAnalyzersVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.9.0" Version="$(MicrosoftVisualStudioShellInterop9Version)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.10.0" Version="$(MicrosoftVisualStudioShellInterop10Version)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.11.0" Version="$(MicrosoftVisualStudioShellInterop11Version)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.12.1.DesignTime" Version="$(MicrosoftVisualStudioShellInterop121DesignTimeVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime" Version="$(MicrosoftVisualStudioShellInterop140DesignTimeVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime" Version="$(MicrosoftVisualStudioShellInterop150DesignTimeVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime" Version="$(MicrosoftVisualStudioShellInterop153DesignTimeVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Design" Version="$(MicrosoftVisualStudioShellDesignVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell15Version)" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" Version="$(MicrosoftVisualStudioShellFrameworkVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Telemetry" Version="$(MicrosoftVisualStudioTelemetryVersion)" ExcludeAssets="Build" />
-    <PackageReference Include="Microsoft.VisualStudio.Utilities" Version="$(MicrosoftVisualStudioUtilitiesVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.Validation" Version="$(MicrosoftVisualStudioValidationVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.VSHelp" Version="$(MicrosoftVisualStudioVsHelpVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.XmlEditor" Version="$(MicrosoftVisualStudioXmlEditorVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.WCFReference.Interop" Version="$(MicrosoftVisualStudioWCFReferenceInteropVersion)" />
-    <PackageReference Include="Microsoft.VSDesigner" Version="$(MicrosoftVsDesignerVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.DataTools.Interop" />
+    <PackageReference Include="Microsoft.VisualStudio.Diagnostics.PerformanceProvider" />
+    <PackageReference Include="Microsoft.VisualStudio.Designer.Interfaces" />
+    <PackageReference Include="Microsoft.VisualStudio.GraphModel" />
+    <PackageReference Include="Microsoft.VisualStudio.Editor" />
+    <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" />
+    <PackageReference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" />
+    <PackageReference Include="Microsoft.VisualStudio.ManagedInterfaces" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.Data" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.Logic" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.UI" />
+    <PackageReference Include="Microsoft.VisualStudio.Text.UI.Wpf" />
+    <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.10.0" />
+    <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.12.0" />
+    <PackageReference Include="Microsoft.VisualStudio.TextManager.Interop.12.1.DesignTime" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.9.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.10.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.11.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.12.1.DesignTime"/>
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime"/>
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime"/>
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime"/>
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Design" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" />
+    <PackageReference Include="Microsoft.VisualStudio.Telemetry" />
+    <PackageReference Include="Microsoft.VisualStudio.Utilities" />
+    <PackageReference Include="Microsoft.VisualStudio.Validation" />
+    <PackageReference Include="Microsoft.VisualStudio.VSHelp" />
+    <PackageReference Include="Microsoft.VisualStudio.XmlEditor" />
+    <PackageReference Include="Microsoft.VisualStudio.WCFReference.Interop" />
+    <PackageReference Include="Microsoft.VSDesigner" />
 
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
This is an updated attempt at simplifying the package reference versioning. This will make the move to Dev16 a lot simpler as we won't need to copy around the XXXVersion pattern.