### PR TITLE
Use custom properties for project tree node

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GroupedByTargetTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GroupedByTargetTreeViewProvider.cs
@@ -399,7 +399,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     caption: updatedValues.Caption,
                     browseObjectProperties: rule,
                     icon: updatedValues.Icon,
-                    expandedIcon: updatedValues.ExpandedIcon);
+                    expandedIcon: updatedValues.ExpandedIcon,
+                    flags: updatedValues.Flags);
         }
 
         private static ProjectTreeFlags FilterFlags(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GroupedByTargetTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GroupedByTargetTreeViewProvider.cs
@@ -396,10 +396,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             ApplyProjectTreePropertiesCustomization(updatedNodeParentContext, updatedValues);
 
             return node.SetProperties(
-                    caption: viewModel.Caption,
+                    caption: updatedValues.Caption,
                     browseObjectProperties: rule,
-                    icon: viewModel.Icon.ToProjectSystemType(),
-                    expandedIcon: viewModel.ExpandedIcon.ToProjectSystemType());
+                    icon: updatedValues.Icon,
+                    expandedIcon: updatedValues.ExpandedIcon);
         }
 
         private static ProjectTreeFlags FilterFlags(


### PR DESCRIPTION
In `GroupedByTargetTreeViewProvider` we call `ApplyProjectTreePropertiesCustomization` which enumerates `IProjectTreePropertiesProvider` instances, calling `CalculatePropertyValues`, allowing them to update an instance of `ReferencesProjectTreeCustomizablePropertyValues`.

However we don't then apply any customisations back to the `IProjectTreeNode`.

//cc: @abpiskunov -- do you know whether this was intentional? In testing I didn't find any providers that actually modified values.

Providers can also specify `Flags`. Should we applying them too too?

If there is a valid reason to not be applying these customised properties let me know and I'll document the fact in the code. I suspect this is an oversight that's been harmless so far.