### PR TITLE
Add workaround for VS 2019 not building editors project

### DIFF
--- a/build/Packages.targets
+++ b/build/Packages.targets
@@ -53,7 +53,7 @@
     <PackageReference Update="Microsoft.VisualStudio.TextManager.Interop.12.0" Version="12.0.30110" />
     <PackageReference Update="Microsoft.VisualStudio.TextManager.Interop.12.1.DesignTime" Version="12.1.30328" />
     <PackageReference Update="Microsoft.VisualStudio.Settings.15.0" Version="15.8.28010" />
-    <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.16.30" />
+    <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="$(MicrosoftVisualStudioSetupConfigurationInteropVersion)" />
     <PackageReference Update="Microsoft.VisualStudio.Shell.15.0" Version="15.0.26606" />
     <PackageReference Update="Microsoft.VisualStudio.Shell.Design" Version="15.0.26606" />
     <PackageReference Update="Microsoft.VisualStudio.Shell.Framework" Version="15.0.26606" />

--- a/build/Versions.props
+++ b/build/Versions.props
@@ -33,6 +33,8 @@
     <!-- Microsoft.DotNet.*.ProjectTemplates -->
     <MicrosoftDotNetProjectTemplatesVersion>1.0.0-beta2-20170629-269</MicrosoftDotNetProjectTemplatesVersion>
 
+    <MicrosoftVisualStudioSetupConfigurationInteropVersion>1.16.30</MicrosoftVisualStudioSetupConfigurationInteropVersion>
+
     <!-- Tests -->
     <XUnitVersion>2.4.0</XUnitVersion>
   </PropertyGroup>

--- a/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
+++ b/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
@@ -18,6 +18,9 @@
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices" />
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" />
+    
+    <!-- Workaround https://github.com/NuGet/Home/issues/7446 -->
+    <Reference Include="$(NuGetPackageRoot)Microsoft.VisualStudio.Setup.Configuration.Interop\$(MicrosoftVisualStudioSetupConfigurationInteropVersion)\lib\net35\Microsoft.VisualStudio.Setup.Configuration.Interop.dll" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.AppDesigner\Microsoft.VisualStudio.AppDesigner.vbproj" />


### PR DESCRIPTION
Compile assets are being thrown away for this one package, add a workaround until the real fix has been made.