### PR TITLE
Reference HostAgnostic.props from VisualStudio.props

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/MultipleValuesStore.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/MultipleValuesStore.vb
@@ -107,7 +107,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
 
         <Conditional("DEBUG")>
         Public Sub DebugTrace(Message As String)
-#If DEBUG Then
             Debug.Assert(ConfigNames.Length = PlatformNames.Length AndAlso PlatformNames.Length = Values.Length)
             Common.Switches.TracePDUndo(Message)
             Trace.Indent()
@@ -115,7 +114,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                 Common.Switches.TracePDUndo("[" & ConfigNames(i) & "|" & PlatformNames(i) & "] Value=" & Common.DebugToString(Values(i)))
             Next
             Trace.Unindent()
-#End If
         End Sub
 
     End Class

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
@@ -1926,8 +1926,8 @@ NextControl:
 
         End Sub
 
+        <Conditional("DEBUG")>
         Private Sub VerifyPropertiesWhichMayReloadProjectAreLast()
-#If DEBUG Then
             Dim APreviousPropertyHadProjectMayBeReloadedDuringPropertySetFlag As Boolean = False
             For Each _controlData As PropertyControlData In ControlData
                 Dim ProjectMayBeReloadedDuringPropertySet As Boolean = (0 <> (_controlData.GetFlags() And ControlDataFlags.ProjectMayBeReloadedDuringPropertySet))
@@ -1941,7 +1941,6 @@ NextControl:
                     Return
                 End If
             Next
-#End If
         End Sub
 
         ''' <summary>

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/SKUMatrix.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/SKUMatrix.vb
@@ -1,7 +1,10 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports VSLangProj80
+Imports System.Diagnostics.CodeAnalysis
+
 Imports Microsoft.VisualStudio.Shell
+
+Imports VSLangProj80
 
 Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
@@ -17,7 +20,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             'Disallow creation
         End Sub
 
-        <CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2233:OperationsShouldNotOverflow", MessageId:="PropertyId-10063")>
+        <SuppressMessage("Microsoft.Usage", "CA2233:OperationsShouldNotOverflow", MessageId:="PropertyId-10063")>
         Public Shared Function IsHidden(PropertyId As Integer) As Boolean
 
             If VSProductSKU.IsExpress Then

--- a/src/VisualStudio.props
+++ b/src/VisualStudio.props
@@ -1,4 +1,6 @@
 <Project>
+  <Import Project="HostAgnostic.props"/>
+
   <ItemGroup>
     <PackageReference Include="VSLangProj" />
     <PackageReference Include="VSLangProj2" />


### PR DESCRIPTION
To reduce conflicts when making package changes, it must easier for each project to redeclare their dependencies on a package than making use of package inheritance. To do that I have all VisualStudio projects (Managed.VS, CSharp.VS, etc) just declare their dependencies on packages in HostAgnostic instead of inheriting from their project reference to these projects.