### PR TITLE
Update Roslyn dependencies

### DIFF
--- a/build/Default.ruleset
+++ b/build/Default.ruleset
@@ -71,6 +71,7 @@
     <Rule Id="RS1012" Action="None" />
     <Rule Id="RS1013" Action="None" />
     <Rule Id="RS1014" Action="Warning" />
+    <Rule Id="RS1022" Action="None" />  <!-- https://github.com/dotnet/roslyn-analyzers/issues/1861 -->
   </Rules>
   <Rules AnalyzerId="Microsoft.Composition.Analyzers" RuleNamespace="Microsoft.Composition.Analyzers">
     <Rule Id="RS0006" Action="Error" />

--- a/build/Packages.targets
+++ b/build/Packages.targets
@@ -30,25 +30,18 @@
     <!-- VS SDK -->
     <PackageReference Update="Microsoft.VSSDK.BuildTools" Version="15.8.3252" />
     <PackageReference Update="Microsoft.VisualStudio.ComponentModelHost" Version="15.0.26606"/>
-    <PackageReference Update="Microsoft.VisualStudio.Composition" Version="15.8.98"/>
-    <PackageReference Update="Microsoft.VisualStudio.CoreUtility" Version="16.0.177-g0ae5fa46a1" />
+    <PackageReference Update="Microsoft.VisualStudio.Composition" Version="15.8.98"/>    
     <PackageReference Update="Microsoft.VisualStudio.Data.Core" Version="9.0.21022" />
     <PackageReference Update="Microsoft.VisualStudio.DataDesign.Common" Version="15.0.26606-alpha"/>
     <PackageReference Update="Microsoft.VisualStudio.Data.Services" Version="9.0.21022" />
     <PackageReference Update="Microsoft.VisualStudio.DataTools.Interop" Version="15.0.26606-alpha" />
     <PackageReference Update="Microsoft.VisualStudio.Designer.Interfaces" Version="1.1.4322" />
     <PackageReference Update="Microsoft.VisualStudio.Diagnostics.PerformanceProvider" Version="16.0.28226-alpha" />
-    <PackageReference Update="Microsoft.VisualStudio.Editor" Version="15.0.26606" />
     <PackageReference Update="Microsoft.VisualStudio.GraphModel" Version="16.0.28226-alpha" />
     <PackageReference Update="Microsoft.VisualStudio.ImageCatalog" Version="15.0.26606" />
-    <PackageReference Update="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" Version="14.3.25407"/>
+    <PackageReference Update="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" Version="14.3.25408"/>
     <PackageReference Update="Microsoft.VisualStudio.ManagedInterfaces" Version="8.0.50727" />
     <PackageReference Update="Microsoft.VisualStudio.Telemetry" Version="15.3.799-masterDDDBA9E4" />
-    <PackageReference Update="Microsoft.VisualStudio.Text.Data" Version="15.0.26606" />
-    <PackageReference Update="Microsoft.VisualStudio.Text.UI" Version="15.0.26606" />
-    <PackageReference Update="Microsoft.VisualStudio.Text.UI.Wpf" Version="15.0.26606" />
-    <PackageReference Update="Microsoft.VisualStudio.Text.UI.Wpf" Version="15.0.26606" />
-    <PackageReference Update="Microsoft.VisualStudio.Text.Logic" Version="15.0.26606" />
     <PackageReference Update="Microsoft.VisualStudio.TextManager.Interop.9.0" Version="9.0.30729" />
     <PackageReference Update="Microsoft.VisualStudio.TextManager.Interop.10.0" Version="10.0.30319" />
     <PackageReference Update="Microsoft.VisualStudio.TextManager.Interop.12.0" Version="12.0.30110" />
@@ -87,6 +80,14 @@
     <PackageReference Update="EnvDTE80" Version="8.0.1" />
     <PackageReference Update="EnvDTE90" Version="9.0.1" />
 
+    <!-- VS Editor APIs -->
+    <PackageReference Update="Microsoft.VisualStudio.CoreUtility" Version="16.0.177-g0ae5fa46a1" />
+    <PackageReference Update="Microsoft.VisualStudio.Editor" Version="16.0.177-g0ae5fa46a1" />
+    <PackageReference Update="Microsoft.VisualStudio.Text.Data" Version="16.0.177-g0ae5fa46a1" />
+    <PackageReference Update="Microsoft.VisualStudio.Text.UI" Version="16.0.177-g0ae5fa46a1" />
+    <PackageReference Update="Microsoft.VisualStudio.Text.UI.Wpf" Version="16.0.177-g0ae5fa46a1" />
+    <PackageReference Update="Microsoft.VisualStudio.Text.Logic" Version="16.0.177-g0ae5fa46a1" />
+    
     <PackageReference Update="Microsoft.Test.Apex.VisualStudio" Version="15.8.27703" />
     
     <!-- CPS -->
@@ -94,7 +95,8 @@
     <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers" Version="16.0.201-pre-g7d366164d0" />
     
     <!-- Roslyn -->
-    <PackageReference Update="Microsoft.VisualStudio.LanguageServices" Version="2.6.0-beta1-62113-02" />
+    <PackageReference Update="Microsoft.VisualStudio.LanguageServices" Version="2.11.0-beta1-63430-03" />
+    <PackageReference Update="Microsoft.CodeAnalysis" Version="2.11.0-beta1-63430-03" />
     <PackageReference Update="Microsoft.VisualStudio.IntegrationTest.Utilities" Version="2.6.0-beta1-62113-02" />
     <PackageReference Update="Microsoft.Net.RoslynDiagnostics" Version="2.6.1-beta1-62702-01" />
     

--- a/src/DeployIntegrationDependencies/DeployIntegrationDependencies.csproj
+++ b/src/DeployIntegrationDependencies/DeployIntegrationDependencies.csproj
@@ -1,5 +1,6 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\VisualStudio.props"/>
   <PropertyGroup>
     <PlatformTarget>x86</PlatformTarget>
     <TargetFramework>net461</TargetFramework>
@@ -9,10 +10,6 @@
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices\Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.csproj" />
 
     <PackageReference Include="Microsoft.Test.Apex.VisualStudio" />
-    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" />
-    <PackageReference Include="Microsoft.VisualStudio.Settings.15.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" />
-    <PackageReference Include="Microsoft.VisualStudio.Composition" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
   </ItemGroup>
 </Project>

--- a/src/HostAgnostic.props
+++ b/src/HostAgnostic.props
@@ -17,6 +17,8 @@
     <!-- Roslyn -->
     <PackageReference Include="Microsoft.Net.RoslynDiagnostics" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices" />
+    <PackageReference Include="Microsoft.CodeAnalysis" />
+    
 
     <!-- MSBuild -->
     <PackageReference Include="Microsoft.Build" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.DebuggerTraceListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.DebuggerTraceListener.cs
@@ -8,6 +8,8 @@ using System.Reflection;
 
 using Microsoft.VisualStudio.ProjectSystem;
 
+using DiagDebugger = System.Diagnostics.Debugger;
+
 namespace Microsoft.VisualStudio.Packaging
 {
     internal partial class ManagedProjectSystemPackage
@@ -20,9 +22,9 @@ namespace Microsoft.VisualStudio.Packaging
 
             public override void Write(string message)
             {
-                if (Debugger.IsLogging())
+                if (DiagDebugger.IsLogging())
                 {
-                    Debugger.Log(0, null, message);
+                    DiagDebugger.Log(0, null, message);
                 }
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextProvider.ForegroundWorkspaceProjectContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextProvider.ForegroundWorkspaceProjectContext.cs
@@ -67,6 +67,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 set { UnderlyingContext.BinOutputPath = value; }
             }
 
+            public ProjectId Id
+            {
+                get { return UnderlyingContext.Id; }
+            }
+
             public void AddAdditionalFile(string filePath, bool isInCurrentContext = true)
             {
                 UnderlyingContext.AddAdditionalFile(filePath, isInCurrentContext);
@@ -75,6 +80,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             public void AddAnalyzerReference(string referencePath)
             {
                 UnderlyingContext.AddAnalyzerReference(referencePath);
+            }
+
+            public void AddDynamicFile(string filePath, IEnumerable<string> folderNames = null)
+            {
+                UnderlyingContext.AddDynamicFile(filePath, folderNames);
             }
 
             public void AddMetadataReference(string referencePath, MetadataReferenceProperties properties)
@@ -97,6 +107,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 UnderlyingContext.Dispose();
             }
 
+            public void EndBatch()
+            {
+                UnderlyingContext.EndBatch();
+            }
+
             public void RemoveAdditionalFile(string filePath)
             {
                 UnderlyingContext.RemoveAdditionalFile(filePath);
@@ -105,6 +120,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             public void RemoveAnalyzerReference(string referencePath)
             {
                 UnderlyingContext.RemoveAnalyzerReference(referencePath);
+            }
+
+            public void RemoveDynamicFile(string fullPath)
+            {
+                UnderlyingContext.RemoveDynamicFile(fullPath);
             }
 
             public void RemoveMetadataReference(string referencePath)
@@ -130,6 +150,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             public void SetRuleSetFile(string filePath)
             {
                 UnderlyingContext.SetRuleSetFile(filePath);
+            }
+
+            public void StartBatch()
+            {
+                UnderlyingContext.StartBatch();
             }
         }
     }


### PR DESCRIPTION
Update Roslyn to the version currently in Preview 1 so that we can consume the new APIs for Razor.