### PR TITLE
Avoid checking out project when assets file changed

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectAccessorFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectAccessorFactory.cs
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 return Task.CompletedTask;
             }
 
-            public Task OpenProjectForWriteAsync(ConfiguredProject project, Action<Project> action, CancellationToken cancellationToken = default)
+            public Task OpenProjectForWriteAsync(ConfiguredProject project, Action<Project> action, ProjectCheckoutOption option, CancellationToken cancellationToken = default)
             {
                 action(_evaluationProject);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
@@ -280,7 +280,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
                                     project.MarkDirty();
                                     configuredProject.NotifyProjectChange();
 
-                                }, cancellationToken); // Stay on same thread that took lock
+                                }, ProjectCheckoutOption.DoNotCheckout, cancellationToken); // Stay on same thread that took lock
                             }
                         }, cancellationToken); // Stay on same thread that took lock
                     });

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectAccessor.cs
@@ -154,8 +154,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// <param name="action">
         ///     The <see cref="Action{T}"/> to run while holding the lock.
         /// </param>
+        /// <param name="option">
+        ///     Indicates whether to checkout the project from source control. The default is <see cref="ProjectCheckoutOption.Checkout"/>.
+        /// </param>
         /// <param name="cancellationToken">
-        ///     A token whose cancellation signals lost interest in the result.
+        ///     A token whose cancellation signals lost interest in the result. The default is <see cref="CancellationToken.None"/>.
         /// </param>
         /// <returns>
         ///     The result of executing <paramref name="action"/> over the <see cref="Project"/>.
@@ -170,6 +173,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// <remarks>
         ///     NOTE: To avoid deadlocks, do not call arbitrary services or asynchronous code within <paramref name="action"/>.
         /// </remarks>
-        Task OpenProjectForWriteAsync(ConfiguredProject project, Action<Project> action, CancellationToken cancellationToken = default);
+        Task OpenProjectForWriteAsync(ConfiguredProject project, Action<Project> action, ProjectCheckoutOption option = ProjectCheckoutOption.Checkout, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectAccessor.cs
@@ -107,14 +107,17 @@ namespace Microsoft.VisualStudio.ProjectSystem
             }
         }
 
-        public async Task OpenProjectForWriteAsync(ConfiguredProject project, Action<Project> action, CancellationToken cancellationToken = default)
+        public async Task OpenProjectForWriteAsync(ConfiguredProject project, Action<Project> action, ProjectCheckoutOption option = ProjectCheckoutOption.Checkout, CancellationToken cancellationToken = default)
         {
             Requires.NotNull(project, nameof(project));
             Requires.NotNull(project, nameof(action));
 
             using (ProjectWriteLockReleaser access = await _projectLockService.WriteLockAsync(cancellationToken))
             {
-                await access.CheckoutAsync(project.UnconfiguredProject.FullPath);
+                if (option == ProjectCheckoutOption.Checkout)
+                {
+                    await access.CheckoutAsync(project.UnconfiguredProject.FullPath);
+                }
 
                 Project evaluatedProject = await access.GetProjectAsync(project, cancellationToken);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCheckoutOption.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCheckoutOption.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal enum ProjectCheckoutOption
+    {
+        /// <summary>
+        ///     Do not checkout the project from source control.
+        /// </summary>
+        DoNotCheckout,
+
+        /// <summary>
+        ///     Checkout the project from source control.
+        /// </summary>
+        Checkout,
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/dotnet/project-system/issues/4200.

This was regressed in https://github.com/dotnet/project-system/commit/c7fac9f3723f0ef23cd7fb07acd477d33114d313#diff-286141d8d6dce9c17a55788e87581b6d. To trigger reevaluation, we mark the MSBuild project as dirty, and call ConfiguredProject.NotifyProjectChange. Previously this did not checkout the project, but did so when we moved it to use ProjectAccessor. Avoid checking out the project on this path.