### PR TITLE
Correctly locate MSBuild on Dev16

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -138,6 +138,19 @@ function LocateVisualStudio {
   return $vsInstallDir
 }
 
+function LocateMSBuild {
+
+  # Dev15
+  $msbuildExe = Join-Path $vsInstallDir "MSBuild\15.0\Bin\msbuild.exe"
+  
+  if (Test-Path $msbuildExe) {
+     return $msbuildExe
+  }
+
+  # Dev16
+  return Join-Path $vsInstallDir "MSBuild\Current\Bin\msbuild.exe"
+}
+
 function Get-VisualStudioId(){
   $vsWhereExe = GetVsWhereExe
   $vsinstanceId = & $vsWhereExe -all -latest -prerelease -property instanceId -requires Microsoft.Component.MSBuild -requires Microsoft.VisualStudio.Component.VSSDK -requires Microsoft.Net.Component.4.6.TargetingPack -requires Microsoft.VisualStudio.Component.Roslyn.Compiler
@@ -343,7 +356,7 @@ try {
   $ToolsetBuildProj = Join-Path $NuGetPackageRoot "RoslynTools.RepoToolset\$ToolsetVersion\tools\Build.proj"
 
   $vsInstallDir = LocateVisualStudio
-  $MsbuildExe = Join-Path $vsInstallDir "MSBuild\15.0\Bin\msbuild.exe"
+  $MsbuildExe = LocateMSBuild
 
   if ($ci) {
     Create-Directory $TempDir

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -125,7 +125,7 @@ function InstallVSIX([string] $vsixExpInstalleExe, [string] $rootsuffix, [string
 
 function LocateVisualStudio {
   if ($InVSEnvironment) {
-    return Join-Path $env:VS150COMNTOOLS "..\.."
+    return $env:VSINSTALLDIR
   }
 
   $vsWhereExe = GetVsWhereExe
@@ -319,7 +319,7 @@ function RunIntegrationTests {
 }
 
 try {
-  $InVSEnvironment = !($env:VS150COMNTOOLS -eq $null) -and (Test-Path $env:VS150COMNTOOLS)
+  $InVSEnvironment = !($env:VSINSTALLDIR -eq $null) -and (Test-Path $env:VSINSTALLDIR)
   $RepoRoot = Join-Path $PSScriptRoot "..\"
   $ToolsRoot = Join-Path $RepoRoot ".tools"
   $ToolsetRestoreProj = Join-Path $PSScriptRoot "Toolset.proj"
@@ -354,8 +354,6 @@ try {
   }
 
   if (!$InVSEnvironment) {
-    $env:VS150COMNTOOLS = Join-Path $vsInstallDir "Common7\Tools\"
-    $env:VSSDK150Install = Join-Path $vsInstallDir "VSSDK\"
     $env:VSSDKInstall = Join-Path $vsInstallDir "VSSDK\"
   }
 


### PR DESCRIPTION
This is an alternative to https://github.com/dotnet/project-system/pull/4176, this handles both Dev15/Dev16. It does not, however, make uninstalling of the integration tests work - we'll need a follow up for that.