### PR TITLE
Also publish the raw test result log files directory

### DIFF
--- a/.vsts-dnceng.yml
+++ b/.vsts-dnceng.yml
@@ -25,6 +25,13 @@ phases:
         publishLocation: Container
       continueOnError: true
       condition: failed()
+    - task: PublishBuildArtifacts@1
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\$(_configuration)\TestResults'
+        ArtifactName: '$(_configuration) Test Result Logs'
+        publishLocation: Container
+      continueOnError: true
+      condition: failed()
     - task: PublishTestResults@2
       inputs:
         testRunner: 'xUnit'


### PR DESCRIPTION
Against dev16.0.x so that if any other PRs to that run into trouble we'll already have it there.