### PR TITLE
Passing GeneratePathProperty metadata as part of nomination

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
@@ -84,10 +84,10 @@
                     DisplayName="Suppress warnings"
                     Description="Comma-delimited list of warnings that should be suppressed for this package" />
 
-    <StringProperty Name="GeneratePathProperty" 
+    <BoolProperty Name="GeneratePathProperty" 
                     Visible="True"
-                    DisplayName="Generate Path Property"
-                    Description="Generates msbuild property to the path of this reference" />
+                    DisplayName="Generate path property"
+                    Description="Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'." />
 
     <BoolProperty Name="Visible"
                   Visible="False"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
@@ -84,6 +84,11 @@
                     DisplayName="Suppress warnings"
                     Description="Comma-delimited list of warnings that should be suppressed for this package" />
 
+    <StringProperty Name="GeneratePathProperty" 
+                    Visible="True"
+                    DisplayName="Generate Path Property"
+                    Description="Generates msbuild property to the path of this reference" />
+
     <BoolProperty Name="Visible"
                   Visible="False"
                   ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.xaml
@@ -112,11 +112,6 @@
                     Description="Version of reference.">
     </StringProperty>
 
-    <StringProperty Name="GeneratePathProperty" 
-                    Visible="True"
-                    DisplayName="GeneratePathProperty"
-                    Description="Generates msbuild property to the path of this reference" />
-
     <!-- Hidden properties -->
     <BoolProperty Name="LinkLibraryDependencies"
                   Visible="False" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.xaml
@@ -112,6 +112,11 @@
                     Description="Version of reference.">
     </StringProperty>
 
+    <StringProperty Name="GeneratePathProperty" 
+                    Visible="True"
+                    DisplayName="GeneratePathProperty"
+                    Description="Generates msbuild property to the path of this reference" />
+
     <!-- Hidden properties -->
     <BoolProperty Name="LinkLibraryDependencies"
                   Visible="False" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.cs.xlf
@@ -77,6 +77,16 @@
         <target state="translated">Umístění odkazovaného balíčku</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|GeneratePathProperty|DisplayName">
+        <source>Generate Path Property</source>
+        <target state="new">Generate Path Property</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|GeneratePathProperty|Description">
+        <source>Generates msbuild property to the path of this reference</source>
+        <target state="new">Generates msbuild property to the path of this reference</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.cs.xlf
@@ -77,14 +77,14 @@
         <target state="translated">Umístění odkazovaného balíčku</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|GeneratePathProperty|DisplayName">
-        <source>Generate Path Property</source>
-        <target state="new">Generate Path Property</target>
+      <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
+        <source>Generate path property</source>
+        <target state="new">Generate path property</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|GeneratePathProperty|Description">
-        <source>Generates msbuild property to the path of this reference</source>
-        <target state="new">Generates msbuild property to the path of this reference</target>
+      <trans-unit id="BoolProperty|GeneratePathProperty|Description">
+        <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
+        <target state="new">Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.de.xlf
@@ -77,14 +77,14 @@
         <target state="translated">Speicherort des Pakets, auf das verwiesen wird.</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|GeneratePathProperty|DisplayName">
-        <source>Generate Path Property</source>
-        <target state="new">Generate Path Property</target>
+      <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
+        <source>Generate path property</source>
+        <target state="new">Generate path property</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|GeneratePathProperty|Description">
-        <source>Generates msbuild property to the path of this reference</source>
-        <target state="new">Generates msbuild property to the path of this reference</target>
+      <trans-unit id="BoolProperty|GeneratePathProperty|Description">
+        <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
+        <target state="new">Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.de.xlf
@@ -77,6 +77,16 @@
         <target state="translated">Speicherort des Pakets, auf das verwiesen wird.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|GeneratePathProperty|DisplayName">
+        <source>Generate Path Property</source>
+        <target state="new">Generate Path Property</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|GeneratePathProperty|Description">
+        <source>Generates msbuild property to the path of this reference</source>
+        <target state="new">Generates msbuild property to the path of this reference</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.es.xlf
@@ -77,14 +77,14 @@
         <target state="translated">Ubicación del paquete al que se hace referencia.</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|GeneratePathProperty|DisplayName">
-        <source>Generate Path Property</source>
-        <target state="new">Generate Path Property</target>
+      <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
+        <source>Generate path property</source>
+        <target state="new">Generate path property</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|GeneratePathProperty|Description">
-        <source>Generates msbuild property to the path of this reference</source>
-        <target state="new">Generates msbuild property to the path of this reference</target>
+      <trans-unit id="BoolProperty|GeneratePathProperty|Description">
+        <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
+        <target state="new">Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.es.xlf
@@ -77,6 +77,16 @@
         <target state="translated">Ubicación del paquete al que se hace referencia.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|GeneratePathProperty|DisplayName">
+        <source>Generate Path Property</source>
+        <target state="new">Generate Path Property</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|GeneratePathProperty|Description">
+        <source>Generates msbuild property to the path of this reference</source>
+        <target state="new">Generates msbuild property to the path of this reference</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.fr.xlf
@@ -77,14 +77,14 @@
         <target state="translated">Emplacement du package actuellement référencé.</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|GeneratePathProperty|DisplayName">
-        <source>Generate Path Property</source>
-        <target state="new">Generate Path Property</target>
+      <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
+        <source>Generate path property</source>
+        <target state="new">Generate path property</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|GeneratePathProperty|Description">
-        <source>Generates msbuild property to the path of this reference</source>
-        <target state="new">Generates msbuild property to the path of this reference</target>
+      <trans-unit id="BoolProperty|GeneratePathProperty|Description">
+        <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
+        <target state="new">Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.fr.xlf
@@ -77,6 +77,16 @@
         <target state="translated">Emplacement du package actuellement référencé.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|GeneratePathProperty|DisplayName">
+        <source>Generate Path Property</source>
+        <target state="new">Generate Path Property</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|GeneratePathProperty|Description">
+        <source>Generates msbuild property to the path of this reference</source>
+        <target state="new">Generates msbuild property to the path of this reference</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.it.xlf
@@ -77,14 +77,14 @@
         <target state="translated">Percorso del pacchetto a cui viene fatto riferimento.</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|GeneratePathProperty|DisplayName">
-        <source>Generate Path Property</source>
-        <target state="new">Generate Path Property</target>
+      <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
+        <source>Generate path property</source>
+        <target state="new">Generate path property</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|GeneratePathProperty|Description">
-        <source>Generates msbuild property to the path of this reference</source>
-        <target state="new">Generates msbuild property to the path of this reference</target>
+      <trans-unit id="BoolProperty|GeneratePathProperty|Description">
+        <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
+        <target state="new">Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.it.xlf
@@ -77,6 +77,16 @@
         <target state="translated">Percorso del pacchetto a cui viene fatto riferimento.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|GeneratePathProperty|DisplayName">
+        <source>Generate Path Property</source>
+        <target state="new">Generate Path Property</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|GeneratePathProperty|Description">
+        <source>Generates msbuild property to the path of this reference</source>
+        <target state="new">Generates msbuild property to the path of this reference</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ja.xlf
@@ -77,14 +77,14 @@
         <target state="translated">参照されているパッケージの場所。</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|GeneratePathProperty|DisplayName">
-        <source>Generate Path Property</source>
-        <target state="new">Generate Path Property</target>
+      <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
+        <source>Generate path property</source>
+        <target state="new">Generate path property</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|GeneratePathProperty|Description">
-        <source>Generates msbuild property to the path of this reference</source>
-        <target state="new">Generates msbuild property to the path of this reference</target>
+      <trans-unit id="BoolProperty|GeneratePathProperty|Description">
+        <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
+        <target state="new">Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ja.xlf
@@ -77,6 +77,16 @@
         <target state="translated">参照されているパッケージの場所。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|GeneratePathProperty|DisplayName">
+        <source>Generate Path Property</source>
+        <target state="new">Generate Path Property</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|GeneratePathProperty|Description">
+        <source>Generates msbuild property to the path of this reference</source>
+        <target state="new">Generates msbuild property to the path of this reference</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ko.xlf
@@ -77,14 +77,14 @@
         <target state="translated">참조되는 패키지의 위치입니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|GeneratePathProperty|DisplayName">
-        <source>Generate Path Property</source>
-        <target state="new">Generate Path Property</target>
+      <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
+        <source>Generate path property</source>
+        <target state="new">Generate path property</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|GeneratePathProperty|Description">
-        <source>Generates msbuild property to the path of this reference</source>
-        <target state="new">Generates msbuild property to the path of this reference</target>
+      <trans-unit id="BoolProperty|GeneratePathProperty|Description">
+        <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
+        <target state="new">Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ko.xlf
@@ -77,6 +77,16 @@
         <target state="translated">참조되는 패키지의 위치입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|GeneratePathProperty|DisplayName">
+        <source>Generate Path Property</source>
+        <target state="new">Generate Path Property</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|GeneratePathProperty|Description">
+        <source>Generates msbuild property to the path of this reference</source>
+        <target state="new">Generates msbuild property to the path of this reference</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.pl.xlf
@@ -77,6 +77,16 @@
         <target state="translated">Lokalizacja pakietu, którego dotyczy odwołanie.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|GeneratePathProperty|DisplayName">
+        <source>Generate Path Property</source>
+        <target state="new">Generate Path Property</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|GeneratePathProperty|Description">
+        <source>Generates msbuild property to the path of this reference</source>
+        <target state="new">Generates msbuild property to the path of this reference</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.pl.xlf
@@ -77,14 +77,14 @@
         <target state="translated">Lokalizacja pakietu, którego dotyczy odwołanie.</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|GeneratePathProperty|DisplayName">
-        <source>Generate Path Property</source>
-        <target state="new">Generate Path Property</target>
+      <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
+        <source>Generate path property</source>
+        <target state="new">Generate path property</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|GeneratePathProperty|Description">
-        <source>Generates msbuild property to the path of this reference</source>
-        <target state="new">Generates msbuild property to the path of this reference</target>
+      <trans-unit id="BoolProperty|GeneratePathProperty|Description">
+        <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
+        <target state="new">Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.pt-BR.xlf
@@ -77,6 +77,16 @@
         <target state="translated">Localização do pacote que está sendo referenciado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|GeneratePathProperty|DisplayName">
+        <source>Generate Path Property</source>
+        <target state="new">Generate Path Property</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|GeneratePathProperty|Description">
+        <source>Generates msbuild property to the path of this reference</source>
+        <target state="new">Generates msbuild property to the path of this reference</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.pt-BR.xlf
@@ -77,14 +77,14 @@
         <target state="translated">Localização do pacote que está sendo referenciado.</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|GeneratePathProperty|DisplayName">
-        <source>Generate Path Property</source>
-        <target state="new">Generate Path Property</target>
+      <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
+        <source>Generate path property</source>
+        <target state="new">Generate path property</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|GeneratePathProperty|Description">
-        <source>Generates msbuild property to the path of this reference</source>
-        <target state="new">Generates msbuild property to the path of this reference</target>
+      <trans-unit id="BoolProperty|GeneratePathProperty|Description">
+        <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
+        <target state="new">Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ru.xlf
@@ -77,6 +77,16 @@
         <target state="translated">Расположение пакета, на который указывает ссылка.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|GeneratePathProperty|DisplayName">
+        <source>Generate Path Property</source>
+        <target state="new">Generate Path Property</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|GeneratePathProperty|Description">
+        <source>Generates msbuild property to the path of this reference</source>
+        <target state="new">Generates msbuild property to the path of this reference</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ru.xlf
@@ -77,14 +77,14 @@
         <target state="translated">Расположение пакета, на который указывает ссылка.</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|GeneratePathProperty|DisplayName">
-        <source>Generate Path Property</source>
-        <target state="new">Generate Path Property</target>
+      <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
+        <source>Generate path property</source>
+        <target state="new">Generate path property</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|GeneratePathProperty|Description">
-        <source>Generates msbuild property to the path of this reference</source>
-        <target state="new">Generates msbuild property to the path of this reference</target>
+      <trans-unit id="BoolProperty|GeneratePathProperty|Description">
+        <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
+        <target state="new">Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.tr.xlf
@@ -77,14 +77,14 @@
         <target state="translated">Başvurulan paketin konumu.</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|GeneratePathProperty|DisplayName">
-        <source>Generate Path Property</source>
-        <target state="new">Generate Path Property</target>
+      <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
+        <source>Generate path property</source>
+        <target state="new">Generate path property</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|GeneratePathProperty|Description">
-        <source>Generates msbuild property to the path of this reference</source>
-        <target state="new">Generates msbuild property to the path of this reference</target>
+      <trans-unit id="BoolProperty|GeneratePathProperty|Description">
+        <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
+        <target state="new">Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.tr.xlf
@@ -77,6 +77,16 @@
         <target state="translated">Başvurulan paketin konumu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|GeneratePathProperty|DisplayName">
+        <source>Generate Path Property</source>
+        <target state="new">Generate Path Property</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|GeneratePathProperty|Description">
+        <source>Generates msbuild property to the path of this reference</source>
+        <target state="new">Generates msbuild property to the path of this reference</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.zh-Hans.xlf
@@ -77,6 +77,16 @@
         <target state="translated">所引用的包的位置。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|GeneratePathProperty|DisplayName">
+        <source>Generate Path Property</source>
+        <target state="new">Generate Path Property</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|GeneratePathProperty|Description">
+        <source>Generates msbuild property to the path of this reference</source>
+        <target state="new">Generates msbuild property to the path of this reference</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.zh-Hans.xlf
@@ -77,14 +77,14 @@
         <target state="translated">所引用的包的位置。</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|GeneratePathProperty|DisplayName">
-        <source>Generate Path Property</source>
-        <target state="new">Generate Path Property</target>
+      <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
+        <source>Generate path property</source>
+        <target state="new">Generate path property</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|GeneratePathProperty|Description">
-        <source>Generates msbuild property to the path of this reference</source>
-        <target state="new">Generates msbuild property to the path of this reference</target>
+      <trans-unit id="BoolProperty|GeneratePathProperty|Description">
+        <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
+        <target state="new">Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.zh-Hant.xlf
@@ -77,6 +77,16 @@
         <target state="translated">目前參考的套件位置。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|GeneratePathProperty|DisplayName">
+        <source>Generate Path Property</source>
+        <target state="new">Generate Path Property</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|GeneratePathProperty|Description">
+        <source>Generates msbuild property to the path of this reference</source>
+        <target state="new">Generates msbuild property to the path of this reference</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.zh-Hant.xlf
@@ -77,14 +77,14 @@
         <target state="translated">目前參考的套件位置。</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|GeneratePathProperty|DisplayName">
-        <source>Generate Path Property</source>
-        <target state="new">Generate Path Property</target>
+      <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
+        <source>Generate path property</source>
+        <target state="new">Generate path property</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|GeneratePathProperty|Description">
-        <source>Generates msbuild property to the path of this reference</source>
-        <target state="new">Generates msbuild property to the path of this reference</target>
+      <trans-unit id="BoolProperty|GeneratePathProperty|Description">
+        <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
+        <target state="new">Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
AS part of https://github.com/NuGet/NuGet.Client/pull/2271 We added a new feature to generate msbuild property to nuget package path if someone set `GeneratePathProperty` on a `PackageReference`. But Project system wasn't updated to pass this new metadata to NuGet as part of nomination.

This PR is to pass that and pass this new metadata to NuGet.