### PR TITLE
Wrap context usage in a batch

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceContextHost.WorkspaceContextHostInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceContextHost.WorkspaceContextHostInstance.cs
@@ -95,9 +95,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             {
                 await WaitUntilInitializedCompletedAsync();
 
-                // TODO: https://github.com/dotnet/project-system/issues/353
-                await _threadingService.SwitchToUIThread(_tasksService.UnloadCancellationToken);
-
                 await ExecuteUnderLockAsync(_ => action(_contextAccessor), _tasksService.UnloadCancellationToken);
             }
 
@@ -105,18 +102,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             {
                 await WaitUntilInitializedCompletedAsync();
 
-                // TODO: https://github.com/dotnet/project-system/issues/353
-                await _threadingService.SwitchToUIThread(_tasksService.UnloadCancellationToken);
-
                 return await ExecuteUnderLockAsync(_ => action(_contextAccessor), _tasksService.UnloadCancellationToken);
             }
 
             internal async Task OnProjectChangedAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update, bool evaluation)
             {
                 CancellationToken cancellationToken = _tasksService.UnloadCancellationToken;
-
-                // TODO: https://github.com/dotnet/project-system/issues/353
-                await _threadingService.SwitchToUIThread(cancellationToken);
 
                 await ExecuteUnderLockAsync(ct =>
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextProvider.cs
@@ -55,12 +55,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             return new WorkspaceProjectContextAccessor(data.WorkspaceProjectContextId, context, _threadingService);
         }
 
-        public async Task ReleaseProjectContextAsync(IWorkspaceProjectContextAccessor accessor)
+        public Task ReleaseProjectContextAsync(IWorkspaceProjectContextAccessor accessor)
         {
             Requires.NotNull(accessor, nameof(accessor));
-
-            // TODO: https://github.com/dotnet/project-system/issues/353.
-            await _threadingService.SwitchToUIThread();
 
             try
             {
@@ -69,6 +66,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             catch (Exception ex) when(_telemetryService.PostFault(TelemetryEventName.LanguageServiceInitFault, ex))
             {
             }
+
+            return Task.CompletedTask;
         }
 
         private async Task<IWorkspaceProjectContext> CreateProjectContextHandlingFaultAsync(ProjectContextInitData data, object hostObject)


### PR DESCRIPTION
Roslyn will avoid updating VisualStudioWorkspace until after a batch has finished.