### PR TITLE
Remove usage of AbstractProject

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/ProjectFileOrAssemblyInfoPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/ProjectFileOrAssemblyInfoPropertiesProvider.cs
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             {
                 return projectContextHost.OpenContextForWriteAsync(accessor =>
                 {
-                    return Task.FromResult(((AbstractProject)accessor.Context).Id);
+                    return Task.FromResult(accessor.Context.Id);
                 });
             });
         }


### PR DESCRIPTION
We can use the new IWorkspaceProjectContext.Id property.