### PR TITLE
Fix thread affinity of IWorkspaceProjectContext

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceContextHost.WorkspaceContextHostInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceContextHost.WorkspaceContextHostInstance.cs
@@ -20,7 +20,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         {
             private readonly ConfiguredProject _project;
             private readonly IProjectSubscriptionService _projectSubscriptionService;
-            private readonly IProjectThreadingService _threadingService;
             private readonly IUnconfiguredProjectTasksService _tasksService;
             private readonly IWorkspaceProjectContextProvider _workspaceProjectContextProvider;
             private readonly IActiveWorkspaceProjectContextTracker _activeWorkspaceProjectContextTracker;
@@ -41,7 +40,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             {
                 _project = project;
                 _projectSubscriptionService = projectSubscriptionService;
-                _threadingService = threadingService;
                 _tasksService = tasksService;
                 _workspaceProjectContextProvider = workspaceProjectContextProvider;
                 _applyChangesToWorkspaceContextFactory = applyChangesToWorkspaceContextFactory;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextProvider.WorkspaceProjectContextAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextProvider.WorkspaceProjectContextAccessor.cs
@@ -9,14 +9,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         private class WorkspaceProjectContextAccessor : IWorkspaceProjectContextAccessor
         {
             private readonly IWorkspaceProjectContext _context;
-            private readonly IProjectThreadingService _threadingService;
             private readonly string _contextId;
 
-            public WorkspaceProjectContextAccessor(string contextId, IWorkspaceProjectContext context, IProjectThreadingService threadingService)
+            public WorkspaceProjectContextAccessor(string contextId, IWorkspaceProjectContext context)
             {
                 _contextId = contextId;
                 _context = context;
-                _threadingService = threadingService;
             }
 
             public string ContextId
@@ -26,22 +24,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             public IWorkspaceProjectContext Context
             {
-                get
-                {
-                    _threadingService.VerifyOnUIThread();
-
-                    return _context;
-                }
+                get { return _context; }
             }
 
             public object HostSpecificEditAndContinueService
             {
-                get { return Context; }
+                get { return _context; }
             }
 
             public object HostSpecificErrorReporter
             {
-                get { return Context; }
+                get { return _context; }
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextProvider.cs
@@ -55,9 +55,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             return new WorkspaceProjectContextAccessor(data.WorkspaceProjectContextId, context, _threadingService);
         }
 
-        public Task ReleaseProjectContextAsync(IWorkspaceProjectContextAccessor accessor)
+        public async Task ReleaseProjectContextAsync(IWorkspaceProjectContextAccessor accessor)
         {
             Requires.NotNull(accessor, nameof(accessor));
+
+            // TODO: https://github.com/dotnet/project-system/issues/353.
+            await _threadingService.SwitchToUIThread();
 
             try
             {
@@ -66,8 +69,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             catch (Exception ex) when(_telemetryService.PostFault(TelemetryEventName.LanguageServiceInitFault, ex))
             {
             }
-
-            return Task.CompletedTask;
         }
 
         private async Task<IWorkspaceProjectContext> CreateProjectContextHandlingFaultAsync(ProjectContextInitData data, object hostObject)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextProvider.cs
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             if (context == null)
                 return null;
 
-            return new WorkspaceProjectContextAccessor(data.WorkspaceProjectContextId, context, _threadingService);
+            return new WorkspaceProjectContextAccessor(data.WorkspaceProjectContextId, context);
         }
 
         public async Task ReleaseProjectContextAsync(IWorkspaceProjectContextAccessor accessor)


### PR DESCRIPTION
- Release context on UI-thread
  - I was lead to believe that Dispose was free-threaded, but it enforces UI thread and I missed it because of Watson handling.

- Avoid UI-thread check through accessor
  - Missed a call through the accessor which hit error reporter, which I missed because it faulted the block.