### PR TITLE
Prevent ArgumentNullException when FrameworkName is null

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/ITargetFramework.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/ITargetFramework.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
                                           IEquatable<string>
     {
         /// <summary>
-        /// Basic target framework info
+        /// Basic target framework info. Can be <see langword="null" /> if the framework is unknown.
         /// </summary>
         FrameworkName FrameworkName { get; }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetFramework.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetFramework.cs
@@ -38,21 +38,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             FriendlyName = moniker;
         }
 
+        /// <inheritdoc />
         public FrameworkName FrameworkName { get; }
 
-        /// <summary>
-        /// Gets the full name of the target framework.
-        /// </summary>
+        /// <inheritdoc />
         public string FullName { get; }
 
-        /// <summary>
-        /// Gets the short name.
-        /// </summary>
+        /// <inheritdoc />
         public string ShortName { get; }
 
-        /// <summary>
-        /// Gets the display name.
-        /// </summary>
+        /// <inheritdoc />
         public string FriendlyName { get; }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetFrameworkProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetFrameworkProvider.cs
@@ -71,20 +71,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         public ITargetFramework GetNearestFramework(ITargetFramework targetFramework,
                                                     IEnumerable<ITargetFramework> otherFrameworks)
         {
-            if (targetFramework == null || otherFrameworks == null || !otherFrameworks.Any())
+            if (targetFramework == null || otherFrameworks == null)
+            {
+                return null;
+            }
+
+            var others = otherFrameworks.ToList();
+
+            if (others.Count == 0)
             {
                 return null;
             }
 
             FrameworkName nearestFrameworkName = _nuGetComparer.GetNearest(
-                targetFramework.FrameworkName, otherFrameworks.Select(x => x.FrameworkName));
+                targetFramework.FrameworkName, others.Select(x => x.FrameworkName));
 
             if (nearestFrameworkName == null)
             {
                 return null;
             }
 
-            return otherFrameworks.FirstOrDefault(x => nearestFrameworkName.Equals(x.FrameworkName));
+            return others.FirstOrDefault(x => nearestFrameworkName.Equals(x.FrameworkName));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetFrameworkProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetFrameworkProvider.cs
@@ -71,12 +71,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         public ITargetFramework GetNearestFramework(ITargetFramework targetFramework,
                                                     IEnumerable<ITargetFramework> otherFrameworks)
         {
-            if (targetFramework == null || otherFrameworks == null)
+            if (targetFramework?.FrameworkName == null || otherFrameworks == null)
             {
                 return null;
             }
 
-            var others = otherFrameworks.ToList();
+            var others = otherFrameworks.Where(other => other.FrameworkName != null).ToList();
 
             if (others.Count == 0)
             {


### PR DESCRIPTION
`IVsFrameworkCompatibility.GetNearest` throws `ArgumentNullException` when we pass it `null`.

These changes should avoid exceptions seen as part of [this ticket](https://developercommunity.visualstudio.com/content/problem/366616/high-cpu-when-idle.html) ([internal issue](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/714441)).

(Really looking forward to nullable reference types!)