### PR TITLE
PackageRuleHandler ignores unresolved changes

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/AnalyzerDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/AnalyzerDependencyModel.cs
@@ -41,14 +41,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             IImmutableDictionary<string, string> properties)
             : base(path, originalItemSpec, flags, resolved, isImplicit, properties)
         {
-            if (Resolved)
-            {
-                Caption = System.IO.Path.GetFileNameWithoutExtension(Name);
-            }
-            else
-            {
-                Caption = Path;
-            }
+            Caption = resolved 
+                ? System.IO.Path.GetFileNameWithoutExtension(path) 
+                : path;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/AssemblyDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/AssemblyDependencyModel.cs
@@ -42,16 +42,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             IImmutableDictionary<string, string> properties)
             : base(path, originalItemSpec, flags, resolved, isImplicit, properties)
         {
-            if (Resolved)
+            if (resolved)
             {
                 string fusionName = null;
                 Properties?.TryGetValue(ResolvedAssemblyReference.FusionNameProperty, out fusionName);
 
-                Caption = string.IsNullOrEmpty(fusionName) ? Name : new AssemblyName(fusionName).Name;
+                Caption = string.IsNullOrEmpty(fusionName) ? path : new AssemblyName(fusionName).Name;
             }
             else
             {
-                Caption = Name;
+                Caption = path;
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/ComDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/ComDependencyModel.cs
@@ -40,14 +40,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             IImmutableDictionary<string, string> properties)
             : base(path, originalItemSpec, flags, resolved, isImplicit, properties)
         {
-            if (Resolved)
-            {
-                Caption = System.IO.Path.GetFileNameWithoutExtension(Name);
-            }
-            else
-            {
-                Caption = Name;
-            }
+            Caption = resolved 
+                ? System.IO.Path.GetFileNameWithoutExtension(path) 
+                : path;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DependencyModel.cs
@@ -37,6 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 
             if (isImplicit)
             {
+                // Cannot remove implicit dependencies
                 Flags = Flags.Except(DependencyTreeFlags.SupportsRemove);
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DependencyModel.cs
@@ -9,44 +9,63 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
     internal abstract class DependencyModel : IDependencyModel
     {
+        [Flags]
+        private enum DependencyFlags
+        {
+            Resolved = 1 << 0,
+            TopLevel = 1 << 1,
+            Implicit = 1 << 2,
+            Visible  = 1 << 3
+        }
+
         protected DependencyModel(
             string path,
             string originalItemSpec,
             ProjectTreeFlags flags,
-            bool resolved,
+            bool isResolved,
             bool isImplicit,
-            IImmutableDictionary<string, string> properties)
+            IImmutableDictionary<string, string> properties,
+            bool isTopLevel = true,
+            bool isVisible = true)
         {
             Requires.NotNullOrEmpty(path, nameof(path));
 
             Path = path;
             OriginalItemSpec = originalItemSpec ?? path;
-            Resolved = resolved;
-            Implicit = isImplicit;
             Properties = properties ?? ImmutableStringDictionary<string>.EmptyOrdinal;
             Caption = path;
 
-            if (resolved)
-            {
-                Flags = flags.Union(DependencyTreeFlags.GenericResolvedDependencyFlags);
-            }
-            else
-            {
-                Flags = flags.Union(DependencyTreeFlags.GenericUnresolvedDependencyFlags);
-            }
+            flags += isResolved 
+                ? DependencyTreeFlags.GenericResolvedDependencyFlags 
+                : DependencyTreeFlags.GenericUnresolvedDependencyFlags;
 
             if (isImplicit)
             {
                 // Cannot remove implicit dependencies
-                Flags = Flags.Except(DependencyTreeFlags.SupportsRemove);
+                flags -= DependencyTreeFlags.SupportsRemove;
             }
 
-            if (Properties.TryGetValue("Visible", out string visibleMetadata)
-                && bool.TryParse(visibleMetadata, out bool visible))
+            Flags = flags;
+
+            if (Properties.TryGetValue("Visible", out string visibleString)
+                && bool.TryParse(visibleString, out bool visibleBool))
             {
-                Visible = visible;
+                isVisible = visibleBool;
             }
+
+            DependencyFlags depFlags = 0;
+            if (isResolved)
+                depFlags |= DependencyFlags.Resolved;
+            if (isVisible)
+                depFlags |= DependencyFlags.Visible;
+            if (isImplicit)
+                depFlags |= DependencyFlags.Implicit;
+            if (isTopLevel)
+                depFlags |= DependencyFlags.TopLevel;
+            _flags = depFlags;
         }
+
+        private readonly DependencyFlags _flags;
 
         public abstract string ProviderType { get; }
 
@@ -57,10 +76,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
         public virtual string SchemaName => null;
         public virtual string SchemaItemType => null;
         public virtual string Version => null;
-        public bool Resolved { get; } = false;
-        public bool TopLevel { get; protected set; } = true;
-        public bool Implicit { get; } = false;
-        public bool Visible { get; protected set; } = true;
+        public bool Resolved => (_flags & DependencyFlags.Resolved) != 0;
+        public bool TopLevel => (_flags & DependencyFlags.TopLevel) != 0;
+        public bool Implicit => (_flags & DependencyFlags.Implicit) != 0;
+        public bool Visible  => (_flags & DependencyFlags.Visible ) != 0;
         public virtual int Priority => 0;
         public ImageMoniker Icon => IconSet.Icon;
         public ImageMoniker ExpandedIcon => IconSet.ExpandedIcon;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DependencyModel.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Immutable;
 
 using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
@@ -47,10 +48,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 
             Flags = flags;
 
-            if (Properties.TryGetValue("Visible", out string visibleString)
-                && bool.TryParse(visibleString, out bool visibleBool))
+            if (Properties.TryGetBoolProperty("Visible", out bool visibleProperty))
             {
-                isVisible = visibleBool;
+                isVisible = visibleProperty;
             }
 
             DependencyFlags depFlags = 0;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DiagnosticDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DiagnosticDependencyModel.cs
@@ -57,9 +57,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 
             _severity = severity;
 
-            code = code ?? string.Empty;
             Name = message;
-            Caption = $"{code.ToUpperInvariant()} {message}".TrimStart();
+            Caption = string.IsNullOrWhiteSpace(code) ? message : string.Concat(code.ToUpperInvariant(), " ", message);
             TopLevel = false;
             Visible = isVisible;
             Flags = Flags.Union(DependencyTreeFlags.DiagnosticNodeFlags);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DiagnosticDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DiagnosticDependencyModel.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             ProjectTreeFlags flags,
             bool isVisible,
             IImmutableDictionary<string, string> properties)
-            : base(originalItemSpec, originalItemSpec, flags, resolved: false, isImplicit: false, properties: properties)
+            : base(originalItemSpec, originalItemSpec, flags, isResolved: false, isImplicit: false, properties: properties, isTopLevel: false, isVisible: isVisible)
         {
             Requires.NotNullOrEmpty(originalItemSpec, nameof(originalItemSpec));
             Requires.NotNullOrEmpty(message, nameof(message));
@@ -59,8 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 
             Name = message;
             Caption = string.IsNullOrWhiteSpace(code) ? message : string.Concat(code.ToUpperInvariant(), " ", message);
-            TopLevel = false;
-            Visible = isVisible;
+
             Flags = Flags.Union(DependencyTreeFlags.DiagnosticNodeFlags);
 
             if (severity == DiagnosticMessageSeverity.Error)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageAnalyzerAssemblyDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageAnalyzerAssemblyDependencyModel.cs
@@ -35,13 +35,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             bool resolved,
             IImmutableDictionary<string, string> properties,
             IEnumerable<string> dependenciesIDs)
-            : base(path, originalItemSpec, flags, resolved, isImplicit: false, properties: properties)
+            : base(path, originalItemSpec, flags, resolved, isImplicit: false, properties: properties, isTopLevel: false)
         {
             Requires.NotNullOrEmpty(name, nameof(name));
 
             Name = name;
             Caption = name;
-            TopLevel = false;
 
             if (dependenciesIDs != null)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageAssemblyDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageAssemblyDependencyModel.cs
@@ -35,13 +35,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             bool resolved,
             IImmutableDictionary<string, string> properties,
             IEnumerable<string> dependenciesIDs)
-            : base(path, originalItemSpec, flags, resolved, isImplicit: false, properties: properties)
+            : base(path, originalItemSpec, flags, resolved, isImplicit: false, properties: properties, isTopLevel: false)
         {
             Requires.NotNullOrEmpty(name, nameof(name));
 
             Name = name;
             Caption = name;
-            TopLevel = false;
 
             if (dependenciesIDs != null)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageDependencyModel.cs
@@ -50,15 +50,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             bool isVisible,
             IImmutableDictionary<string, string> properties,
             IEnumerable<string> dependenciesIDs)
-            : base(path, originalItemSpec, flags, resolved, isImplicit, properties)
+            : base(path, originalItemSpec, flags, resolved, isImplicit, properties, isTopLevel, isVisible)
         {
             Requires.NotNullOrEmpty(name, nameof(name));
 
             Name = name;
             Version = version;
             Caption = string.IsNullOrEmpty(version) ? name : $"{name} ({version})";
-            TopLevel = isTopLevel;
-            Visible = isVisible;
 
             if (dependenciesIDs != null)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageUnknownDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageUnknownDependencyModel.cs
@@ -35,13 +35,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             bool resolved,
             IImmutableDictionary<string, string> properties,
             IEnumerable<string> dependenciesIDs)
-            : base(path, originalItemSpec, flags, resolved, isImplicit: false, properties: properties)
+            : base(path, originalItemSpec, flags, resolved, isImplicit: false, properties: properties, isTopLevel: false)
         {
             Requires.NotNullOrEmpty(name, nameof(name));
 
             Name = name;
             Caption = name;
-            TopLevel = false;
 
             if (dependenciesIDs != null)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/ProjectDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/ProjectDependencyModel.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             : base(path, originalItemSpec, flags, resolved, isImplicit, properties)
         {
             Flags = Flags.Union(DependencyTreeFlags.SupportsHierarchy);
-            Caption = System.IO.Path.GetFileNameWithoutExtension(Name);
+            Caption = System.IO.Path.GetFileNameWithoutExtension(path);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/SdkDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/SdkDependencyModel.cs
@@ -45,8 +45,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             : base(path, originalItemSpec, flags, resolved, isImplicit, properties)
         {
             Flags = Flags.Union(DependencyTreeFlags.SupportsHierarchy);
-            Version = properties != null && properties.ContainsKey(ProjectItemMetadata.Version)
-                ? properties[ProjectItemMetadata.Version] 
+            Version = properties != null && properties.TryGetValue(ProjectItemMetadata.Version, out string version)
+                ? version
                 : string.Empty;
             string baseCaption = Path.Split(Delimiter.Comma, StringSplitOptions.RemoveEmptyEntries)
                 .FirstOrDefault();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/SharedProjectDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/SharedProjectDependencyModel.cs
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
         {
             Flags = Flags.Union(DependencyTreeFlags.SharedProjectFlags)
                          .Except(DependencyTreeFlags.SupportsRuleProperties);
-            Caption = System.IO.Path.GetFileNameWithoutExtension(Name);
+            Caption = System.IO.Path.GetFileNameWithoutExtension(path);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
@@ -164,6 +164,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 }
 
                 return _fullPath;
+
+                string GetFullPath(string originalItemSpec, string containingProjectPath)
+                {
+                    if (string.IsNullOrEmpty(originalItemSpec) || ManagedPathHelper.IsRooted(originalItemSpec))
+                        return originalItemSpec ?? string.Empty;
+
+                    return ManagedPathHelper.TryMakeRooted(containingProjectPath, originalItemSpec);
+                }
             }
         }
 
@@ -191,7 +199,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         public bool TopLevel { get; }
         public bool Implicit { get; private set; }
         public bool Visible { get; }
-
 
         public ImageMoniker Icon => IconSet.Icon;
         public ImageMoniker ExpandedIcon => IconSet.ExpandedIcon;
@@ -405,14 +412,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                     s_builderPool.Add(sb);
                 }
             }
-        }
-
-        private static string GetFullPath(string originalItemSpec, string containingProjectPath)
-        {
-            if (string.IsNullOrEmpty(originalItemSpec) || ManagedPathHelper.IsRooted(originalItemSpec))
-                return originalItemSpec ?? string.Empty;
-
-            return ManagedPathHelper.TryMakeRooted(containingProjectPath, originalItemSpec);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependency.cs
@@ -19,13 +19,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         ITargetFramework TargetFramework { get; }
 
         /// <summary>
-        /// Get the full path of the dependency, if relevant, otherwise, <see langword="string.Empty"/>.
+        /// Get the full path of the dependency, if relevant, otherwise, <see cref="string.Empty"/>.
         /// </summary>
         string FullPath { get; }
 
         /// <summary>
         /// Alias is used to de-dupe tree nodes in the CPS tree. If there are several nodes in the same
-        /// folder with the same name, we replace them all with: Alias = "Caption (OriginalItemSpec)".
+        /// folder with the same name, we replace them all with: <c>Alias = "Caption (OriginalItemSpec)"</c>.
         /// </summary>
         string Alias { get; }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/AnalyzerRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/AnalyzerRuleHandler.cs
@@ -24,6 +24,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             unresolvedIcon: ManagedImageMonikers.CodeInformationWarning,
             unresolvedExpandedIcon: ManagedImageMonikers.CodeInformationWarning);
 
+        private static readonly SubTreeRootDependencyModel s_rootModel = new SubTreeRootDependencyModel(
+            ProviderTypeString,
+            VSResources.AnalyzersNodeName,
+            s_iconSet,
+            DependencyTreeFlags.AnalyzerSubTreeRootNodeFlags);
+
         public AnalyzerRuleHandler()
             : base(AnalyzerReference.SchemaName, ResolvedAnalyzerReference.SchemaName)
         {
@@ -31,14 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
         public override string ProviderType => ProviderTypeString;
 
-        public override IDependencyModel CreateRootDependencyNode()
-        {
-            return new SubTreeRootDependencyModel(
-                ProviderTypeString,
-                VSResources.AnalyzersNodeName,
-                s_iconSet,
-                DependencyTreeFlags.AnalyzerSubTreeRootNodeFlags);
-        }
+        public override IDependencyModel CreateRootDependencyNode() => s_rootModel;
 
         protected override IDependencyModel CreateDependencyModel(
             string path,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/AssemblyRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/AssemblyRuleHandler.cs
@@ -24,6 +24,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             unresolvedIcon: KnownMonikers.ReferenceWarning,
             unresolvedExpandedIcon: KnownMonikers.ReferenceWarning);
 
+        private static readonly SubTreeRootDependencyModel s_rootModel = new SubTreeRootDependencyModel(
+            ProviderTypeString,
+            VSResources.AssembliesNodeName,
+            s_iconSet,
+            DependencyTreeFlags.AssemblySubTreeRootNodeFlags);
+
         public AssemblyRuleHandler()
             : base(AssemblyReference.SchemaName, ResolvedAssemblyReference.SchemaName)
         {
@@ -31,14 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
         public override string ProviderType => ProviderTypeString;
 
-        public override IDependencyModel CreateRootDependencyNode()
-        {
-            return new SubTreeRootDependencyModel(
-                ProviderTypeString,
-                VSResources.AssembliesNodeName,
-                s_iconSet,
-                DependencyTreeFlags.AssemblySubTreeRootNodeFlags);
-        }
+        public override IDependencyModel CreateRootDependencyNode() => s_rootModel;
 
         protected override IDependencyModel CreateDependencyModel(
             string path,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ComRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ComRuleHandler.cs
@@ -23,6 +23,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             unresolvedIcon: ManagedImageMonikers.ComponentWarning,
             unresolvedExpandedIcon: ManagedImageMonikers.ComponentWarning);
 
+        private static readonly SubTreeRootDependencyModel s_rootModel = new SubTreeRootDependencyModel(
+            ProviderTypeString,
+            VSResources.ComNodeName,
+            s_iconSet,
+            DependencyTreeFlags.ComSubTreeRootNodeFlags);
+
         public ComRuleHandler()
             : base(ComReference.SchemaName, ResolvedCOMReference.SchemaName)
         {
@@ -30,14 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
         public override string ProviderType => ProviderTypeString;
 
-        public override IDependencyModel CreateRootDependencyNode()
-        {
-            return new SubTreeRootDependencyModel(
-                ProviderTypeString,
-                VSResources.ComNodeName,
-                s_iconSet,
-                DependencyTreeFlags.ComSubTreeRootNodeFlags);
-        }
+        public override IDependencyModel CreateRootDependencyNode() => s_rootModel;
 
         protected override IDependencyModel CreateDependencyModel(
             string path,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependenciesRuleHandlerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependenciesRuleHandlerBase.cs
@@ -7,6 +7,7 @@ using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
+using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions
 {
@@ -135,20 +136,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             bool resolved,
             IProjectRuleSnapshot projectRuleSnapshot)
         {
-            IImmutableDictionary<string, string> properties = GetProjectItemProperties(projectRuleSnapshot, itemSpec);
-            string originalItemSpec = itemSpec;
-            if (resolved)
-            {
-                originalItemSpec = GetOriginalItemSpec(properties);
-            }
+            IImmutableDictionary<string, string> properties = projectRuleSnapshot.GetProjectItemProperties(itemSpec);
 
-            bool isImplicit = false;
-            if (properties != null
-                && properties.TryGetValue(ProjectItemMetadata.IsImplicitlyDefined, out string isImplicitlyDefinedString)
-                && bool.TryParse(isImplicitlyDefinedString, out bool isImplicitlyDefined))
-            {
-                isImplicit = isImplicitlyDefined;
-            }
+            string originalItemSpec = resolved
+                ? properties.GetStringProperty(OriginalItemSpecPropertyName)
+                : itemSpec;
+
+            bool isImplicit = properties.GetBoolProperty(ProjectItemMetadata.IsImplicitlyDefined) ?? false;
 
             return CreateDependencyModel(
                 itemSpec,
@@ -184,34 +178,5 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
         }
 
         #endregion
-
-        protected virtual string GetOriginalItemSpec(IImmutableDictionary<string, string> properties)
-        {
-            if (properties != null && properties.TryGetValue(OriginalItemSpecPropertyName, out string originalItemSpec)
-                && !string.IsNullOrEmpty(originalItemSpec))
-            {
-                return originalItemSpec;
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Finds the resolved reference item for a given unresolved reference.
-        /// </summary>
-        /// <param name="projectRuleSnapshot">Resolved reference project items snapshot to search.</param>
-        /// <param name="itemSpec">The unresolved reference item name.</param>
-        /// <returns>The key is item name and the value is the metadata dictionary.</returns>
-        protected static IImmutableDictionary<string, string> GetProjectItemProperties(
-            IProjectRuleSnapshot projectRuleSnapshot,
-            string itemSpec)
-        {
-            Requires.NotNull(projectRuleSnapshot, nameof(projectRuleSnapshot));
-            Requires.NotNullOrEmpty(itemSpec, nameof(itemSpec));
-
-            projectRuleSnapshot.Items.TryGetValue(itemSpec, out IImmutableDictionary<string, string> properties);
-
-            return properties;
-        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/PackageRuleHandler.cs
@@ -8,6 +8,7 @@ using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models;
+using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions
 {
@@ -93,7 +94,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
             foreach (string removedItem in projectChange.Difference.RemovedItems)
             {
-                IImmutableDictionary<string, string> properties = GetProjectItemProperties(projectChange.Before, removedItem);
+                IImmutableDictionary<string, string> properties = projectChange.Before.GetProjectItemProperties(removedItem);
                 IDependencyModel model = GetDependencyModel(removedItem, resolved,
                                             properties, unresolvedChanges, targetFramework);
                 if (model == null)
@@ -106,7 +107,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
             foreach (string changedItem in projectChange.Difference.ChangedItems)
             {
-                IImmutableDictionary<string, string> properties = GetProjectItemProperties(projectChange.After, changedItem);
+                IImmutableDictionary<string, string> properties = projectChange.After.GetProjectItemProperties(changedItem);
                 IDependencyModel model = GetDependencyModel(changedItem, resolved,
                                             properties, unresolvedChanges, targetFramework);
                 if (model == null)
@@ -120,7 +121,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
             foreach (string addedItem in projectChange.Difference.AddedItems)
             {
-                IImmutableDictionary<string, string> properties = GetProjectItemProperties(projectChange.After, addedItem);
+                IImmutableDictionary<string, string> properties = projectChange.After.GetProjectItemProperties(addedItem);
                 IDependencyModel model = GetDependencyModel(addedItem, resolved,
                                             properties, unresolvedChanges, targetFramework);
                 if (model == null)
@@ -281,17 +282,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 Requires.NotNull(properties, nameof(properties));
                 Properties = properties;
 
-                DependencyType = GetEnumMetadata<DependencyType>(ProjectItemMetadata.Type) ?? DependencyType.Unknown;
-                Name = GetStringMetadata(ProjectItemMetadata.Name);
-                if (string.IsNullOrEmpty(Name))
-                {
-                    Name = ItemSpec;
-                }
-
-                Version = GetStringMetadata(ProjectItemMetadata.Version);
-                Path = GetStringMetadata(ProjectItemMetadata.Path);
-                Resolved = GetBoolMetadata(ProjectItemMetadata.Resolved) ?? true;
-                IsImplicitlyDefined = GetBoolMetadata(ProjectItemMetadata.IsImplicitlyDefined) ?? false;
+                DependencyType = properties.GetEnumProperty<DependencyType>(ProjectItemMetadata.Type) ?? DependencyType.Unknown;
+                Name = properties.GetStringProperty(ProjectItemMetadata.Name) ?? ItemSpec;
+                Version = properties.GetStringProperty(ProjectItemMetadata.Version) ?? string.Empty;
+                Path = properties.GetStringProperty(ProjectItemMetadata.Path) ?? string.Empty;
+                Resolved = properties.GetBoolProperty(ProjectItemMetadata.Resolved) ?? true;
+                IsImplicitlyDefined = properties.GetBoolProperty(ProjectItemMetadata.IsImplicitlyDefined) ?? false;
 
                 var dependenciesHashSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                 if (properties.TryGetValue(ProjectItemMetadata.Dependencies, out string dependencies) && dependencies != null)
@@ -309,32 +305,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
                 if (DependencyType == DependencyType.Diagnostic)
                 {
-                    Severity = GetEnumMetadata<DiagnosticMessageSeverity>(ProjectItemMetadata.Severity) ?? DiagnosticMessageSeverity.Info;
-                    DiagnosticCode = GetStringMetadata(ProjectItemMetadata.DiagnosticCode);
+                    Severity = properties.GetEnumProperty<DiagnosticMessageSeverity>(ProjectItemMetadata.Severity) ?? DiagnosticMessageSeverity.Info;
+                    DiagnosticCode = properties.GetStringProperty(ProjectItemMetadata.DiagnosticCode) ?? string.Empty;
                 }
             }
 
-            private string GetStringMetadata(string metadataName)
-            {
-                if (Properties.TryGetValue(metadataName, out string value))
-                {
-                    return value;
-                }
-
-                return string.Empty;
-            }
-
-            private T? GetEnumMetadata<T>(string metadataName) where T : struct
-            {
-                string enumString = GetStringMetadata(metadataName);
-                return Enum.TryParse(enumString, ignoreCase: true, out T enumValue) ? enumValue : (T?)null;
-            }
-
-            private bool? GetBoolMetadata(string metadataName)
-            {
-                string boolString = GetStringMetadata(metadataName);
-                return bool.TryParse(boolString, out bool boolValue) ? boolValue : (bool?)null;
-            }
 
             public static string GetTargetFromDependencyId(string dependencyId)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/PackageRuleHandler.cs
@@ -295,11 +295,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 IsImplicitlyDefined = GetBoolMetadata(ProjectItemMetadata.IsImplicitlyDefined) ?? false;
 
                 var dependenciesHashSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                if (properties.ContainsKey(ProjectItemMetadata.Dependencies)
-                    && properties[ProjectItemMetadata.Dependencies] != null)
+                if (properties.TryGetValue(ProjectItemMetadata.Dependencies, out string dependencies) && dependencies != null)
                 {
-                    string[] dependencyIds = properties[ProjectItemMetadata.Dependencies]
-                        .Split(Delimiter.Semicolon, StringSplitOptions.RemoveEmptyEntries);
+                    string[] dependencyIds = dependencies.Split(Delimiter.Semicolon, StringSplitOptions.RemoveEmptyEntries);
+
                     // store only unique dependency IDs
                     foreach (string dependencyId in dependencyIds)
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/PackageRuleHandler.cs
@@ -25,6 +25,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             unresolvedIcon: ManagedImageMonikers.NuGetGreyWarning,
             unresolvedExpandedIcon: ManagedImageMonikers.NuGetGreyWarning);
 
+        private static readonly SubTreeRootDependencyModel s_rootModel = new SubTreeRootDependencyModel(
+            ProviderTypeString,
+            VSResources.NuGetPackagesNodeName,
+            s_iconSet,
+            DependencyTreeFlags.NuGetSubTreeRootNodeFlags);
+
         [ImportingConstructor]
         public PackageRuleHandler(ITargetFrameworkProvider targetFrameworkProvider)
             : base(PackageReference.SchemaName, ResolvedPackageReference.SchemaName)
@@ -221,14 +227,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             }
         }
 
-        public override IDependencyModel CreateRootDependencyNode()
-        {
-            return new SubTreeRootDependencyModel(
-                ProviderType,
-                VSResources.NuGetPackagesNodeName,
-                s_iconSet,
-                DependencyTreeFlags.NuGetSubTreeRootNodeFlags);
-        }
+        public override IDependencyModel CreateRootDependencyNode() => s_rootModel;
 
         private static PackageDependencyMetadata CreateUnresolvedMetadata(
             string itemSpec,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ProjectRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/ProjectRuleHandler.cs
@@ -29,6 +29,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             unresolvedIcon: ManagedImageMonikers.ApplicationWarning,
             unresolvedExpandedIcon: ManagedImageMonikers.ApplicationWarning);
 
+        private static readonly SubTreeRootDependencyModel s_rootModel = new SubTreeRootDependencyModel(
+            ProviderTypeString,
+            VSResources.ProjectsNodeName,
+            s_iconSet,
+            DependencyTreeFlags.ProjectSubTreeRootNodeFlags);
+
         public override string ProviderType => ProviderTypeString;
 
         [ImportingConstructor]
@@ -66,14 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             }
         }
 
-        public override IDependencyModel CreateRootDependencyNode()
-        {
-            return new SubTreeRootDependencyModel(
-                ProviderTypeString,
-                VSResources.ProjectsNodeName,
-                s_iconSet,
-                DependencyTreeFlags.ProjectSubTreeRootNodeFlags);
-        }
+        public override IDependencyModel CreateRootDependencyNode() => s_rootModel;
 
         protected override IDependencyModel CreateDependencyModel(
             string path,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/SdkRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/SdkRuleHandler.cs
@@ -23,6 +23,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             unresolvedIcon: ManagedImageMonikers.SdkWarning,
             unresolvedExpandedIcon: ManagedImageMonikers.SdkWarning);
 
+        private static readonly SubTreeRootDependencyModel s_rootModel = new SubTreeRootDependencyModel(
+            ProviderTypeString,
+            VSResources.SdkNodeName,
+            s_iconSet,
+            DependencyTreeFlags.SdkSubTreeRootNodeFlags);
+
         public SdkRuleHandler()
             : base(SdkReference.SchemaName, ResolvedSdkReference.SchemaName)
         {
@@ -30,14 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
         public override string ProviderType => ProviderTypeString;
 
-        public override IDependencyModel CreateRootDependencyNode()
-        {
-            return new SubTreeRootDependencyModel(
-                ProviderTypeString,
-                VSResources.SdkNodeName,
-                s_iconSet,
-                DependencyTreeFlags.SdkSubTreeRootNodeFlags);
-        }
+        public override IDependencyModel CreateRootDependencyNode() => s_rootModel;
 
         protected override IDependencyModel CreateDependencyModel(
             string path,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/MetadataExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/MetadataExtensions.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
+{
+    internal static class MetadataExtensions
+    {
+        /// <summary>
+        /// Finds the resolved reference item for a given unresolved reference.
+        /// </summary>
+        /// <param name="projectRuleSnapshot">Resolved reference project items snapshot to search.</param>
+        /// <param name="itemSpec">The unresolved reference item name.</param>
+        /// <returns>The key is item name and the value is the metadata dictionary.</returns>
+        public static IImmutableDictionary<string, string> GetProjectItemProperties(this IProjectRuleSnapshot projectRuleSnapshot, string itemSpec)
+        {
+            Requires.NotNull(projectRuleSnapshot, nameof(projectRuleSnapshot));
+            Requires.NotNullOrEmpty(itemSpec, nameof(itemSpec));
+
+            projectRuleSnapshot.Items.TryGetValue(itemSpec, out IImmutableDictionary<string, string> properties);
+
+            return properties;
+        }
+
+        public static bool TryGetStringProperty(this IImmutableDictionary<string, string> properties, string key, out string stringValue)
+        {
+            if (properties != null &&
+                properties.TryGetValue(key, out stringValue) &&
+                !string.IsNullOrEmpty(stringValue))
+            {
+                return true;
+            }
+
+            stringValue = default;
+            return false;
+        }
+
+        public static string GetStringProperty(this IImmutableDictionary<string, string> properties, string key)
+        {
+            return properties.TryGetStringProperty(key, out string value) ? value : null;
+        }
+
+        public static bool TryGetBoolProperty(this IImmutableDictionary<string, string> properties, string key, out bool boolValue)
+        {
+            if (properties.TryGetStringProperty(key, out string valueString) &&
+                bool.TryParse(valueString, out boolValue))
+            {
+                return true;
+            }
+
+            boolValue = default;
+            return false;
+        }
+
+        public static bool? GetBoolProperty(this IImmutableDictionary<string, string> properties, string key)
+        {
+            return properties.TryGetBoolProperty(key, out bool value) ? value : default;
+        }
+
+        public static bool TryGetEnumProperty<T>(this IImmutableDictionary<string, string> properties, string key, out T enumValue) where T : struct
+        {
+            if (properties.TryGetStringProperty(key, out string valueString) &&
+                Enum.TryParse(valueString, ignoreCase: true, out enumValue))
+            {
+                return true;
+            }
+
+            enumValue = default;
+            return false;
+        }
+
+        public static T? GetEnumProperty<T>(this IImmutableDictionary<string, string> properties, string key) where T : struct
+        {
+            return properties.TryGetEnumProperty(key, out T value) ? value : default;
+        }
+    }
+}


### PR DESCRIPTION
(**NOTE** Includes #4242 so only review 99f193fc222f2251b4b8b6a49ca8852553efc111)

Previously, if `resolved` was `false`, `PackageRuleHandler.GetDependencyModel` would set `isTarget` to `false`, do a bunch of work/allocation that didn't change the value, then later test `isTarget` and return `null`. Its callers would, in turn, then `continue` their loops without observable side-effects.

This change avoids that work/allocation in the case that `resolved` would be `false`.

@abpiskunov could you review 99f193fc222f2251b4b8b6a49ca8852553efc111 please? Is the fact that unresolved packages aren't added intended, or is it a bug that requires a different fix?