### PR TITLE
Immutable interlocked optimisations

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyIconSetCacheTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/DependencyIconSetCacheTests.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Imaging.Interop;
+
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
+{
+    public sealed class DependencyIconSetCacheTests
+    {
+        [Fact]
+        public void GetOrAddIconSet()
+        {
+            var cache = new DependencyIconSetCache();
+
+            ImageMoniker icon1 = KnownMonikers.AboutBox;
+            ImageMoniker icon2 = KnownMonikers.ZoomToggle;
+
+            var iconSet1a = new DependencyIconSet(icon1, icon1, icon1, icon1);
+            var iconSet1b = new DependencyIconSet(icon1, icon1, icon1, icon1);
+
+            Assert.Equal(iconSet1a, iconSet1b);
+            Assert.NotSame(iconSet1a, iconSet1b);
+
+            Assert.Same(iconSet1a, cache.GetOrAddIconSet(iconSet1a));
+            Assert.Same(iconSet1a, cache.GetOrAddIconSet(iconSet1b));
+            Assert.Same(iconSet1a, cache.GetOrAddIconSet(icon1, icon1, icon1, icon1));
+
+            var iconSet2 = new DependencyIconSet(icon2, icon2, icon2, icon2);
+
+            Assert.NotEqual(iconSet1a, iconSet2);
+
+            Assert.Same(iconSet2, cache.GetOrAddIconSet(iconSet2));
+            Assert.Same(iconSet2, cache.GetOrAddIconSet(icon2, icon2, icon2, icon2));
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyIconSetCache.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyIconSetCache.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Immutable;
 using Microsoft.VisualStudio.Imaging.Interop;
-using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
@@ -18,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
         public DependencyIconSet GetOrAddIconSet(DependencyIconSet iconSet)
         {
-            if (ThreadingTools.ApplyChangeOptimistically(ref _iconSets, iconSets => iconSets.Add(iconSet)))
+            if (ImmutableInterlocked.Update(ref _iconSets, (iconSets, arg) => iconSets.Add(arg), iconSet))
             {
                 // The cache did not already contain an equivalent icon set; use the one passed in.
                 return iconSet;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyIconSetCache.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependencyIconSetCache.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Threading;
+
 using Microsoft.VisualStudio.Imaging.Interop;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
@@ -17,22 +19,40 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
         public DependencyIconSet GetOrAddIconSet(DependencyIconSet iconSet)
         {
-            if (ImmutableInterlocked.Update(ref _iconSets, (iconSets, arg) => iconSets.Add(arg), iconSet))
-            {
-                // The cache did not already contain an equivalent icon set; use the one passed in.
-                return iconSet;
-            }
-            else
-            {
-                // The cache already has an equivalent icon set; retrieve and return that one.
-                _iconSets.TryGetValue(iconSet, out DependencyIconSet existingIconSet);
-                return existingIconSet;
-            }
+            return GetOrAdd(ref _iconSets, iconSet);
         }
 
         public DependencyIconSet GetOrAddIconSet(ImageMoniker icon, ImageMoniker expandedIcon, ImageMoniker unresolvedIcon, ImageMoniker unresolvedExpandedIcon)
         {
             return GetOrAddIconSet(new DependencyIconSet(icon, expandedIcon, unresolvedIcon, unresolvedExpandedIcon));
+        }
+
+        private static T GetOrAdd<T>(ref ImmutableHashSet<T> location, T value)
+        {
+            ImmutableHashSet<T> prior = Volatile.Read(ref location);
+
+            while (true)
+            {
+                if (prior.TryGetValue(value, out T existingValue))
+                {
+                    // The value already exists in the set. Return it.
+                    return existingValue;
+                }
+
+                // Add a value to the set. This will succeed as we've just seen that value is not in prior.
+                ImmutableHashSet<T> updated = prior.Add(value);
+
+                // Attempt to update the field optimistically.
+                ImmutableHashSet<T> original = Interlocked.CompareExchange(ref location, updated, prior);
+
+                if (ReferenceEquals(original, prior))
+                {
+                    // The update was successful; return the added icon set.
+                    return value;
+                }
+
+                // Optimistic update failed, so loop around and try again.
+            }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
@@ -224,7 +224,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
 
             foreach (ImageMoniker icon in icons)
             {
-                if (ThreadingTools.ApplyChangeOptimistically(ref _knownIcons, knownIcons => knownIcons.Add(icon)))
+                if (ImmutableInterlocked.Update(ref _knownIcons, (knownIcons, arg) => knownIcons.Add(arg), icon))
                 {
                     _imageService.TryAssociateNameWithMoniker(GetIconStringName(icon), icon);
                 }


### PR DESCRIPTION
Optimisations to interlocked operations on immutable collections (while waiting for a clone from TFS).

I didn't change usages in the language service.

The `GetOrAdd` method is a candidate for [ImmutableInterlocked in corefx](https://github.com/dotnet/corefx/blob/master/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableInterlocked.cs).