### PR TITLE
Change case of display names in PackageReference XAML

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
@@ -29,17 +29,17 @@
 
     <StringProperty Name="IncludeAssets" 
                     Visible="True"
-                    DisplayName="IncludeAssets"
+                    DisplayName="Included assets"
                     Description="Assets to include from this reference" />
 
     <StringProperty Name="ExcludeAssets" 
                     Visible="True"
-                    DisplayName="ExcludeAssets"
+                    DisplayName="Excluded assets"
                     Description="Assets to exclude from this reference" />
 
     <StringProperty Name="PrivateAssets" 
                     Visible="True"
-                    DisplayName="PrivateAssets"
+                    DisplayName="Private assets"
                     Description="Assets that are private in this reference" />
 
     <StringProperty Name="Name" 
@@ -82,7 +82,7 @@
 
     <StringProperty Name="NoWarn" 
                     Visible="True"
-                    DisplayName="NoWarn"
+                    DisplayName="Warnings to suppress"
                     Description="Comma-delimited list of warnings that should be suppressed for this package" />
 
     <BoolProperty Name="Visible"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.cs.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>IncludeAssets</source>
-        <target state="translated">IncludeAssets</target>
+        <source>Included assets</source>
+        <target state="needs-review-translation">IncludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>ExcludeAssets</source>
-        <target state="translated">ExcludeAssets</target>
+        <source>Excluded assets</source>
+        <target state="needs-review-translation">ExcludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>PrivateAssets</source>
-        <target state="translated">PrivateAssets</target>
+        <source>Private assets</source>
+        <target state="needs-review-translation">PrivateAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>NoWarn</source>
-        <target state="translated">NoWarn</target>
+        <source>Warnings to suppress</source>
+        <target state="needs-review-translation">NoWarn</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.de.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>IncludeAssets</source>
-        <target state="translated">IncludeAssets</target>
+        <source>Included assets</source>
+        <target state="needs-review-translation">IncludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>ExcludeAssets</source>
-        <target state="translated">ExcludeAssets</target>
+        <source>Excluded assets</source>
+        <target state="needs-review-translation">ExcludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>PrivateAssets</source>
-        <target state="translated">PrivateAssets</target>
+        <source>Private assets</source>
+        <target state="needs-review-translation">PrivateAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>NoWarn</source>
-        <target state="translated">NoWarn</target>
+        <source>Warnings to suppress</source>
+        <target state="needs-review-translation">NoWarn</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.es.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>IncludeAssets</source>
-        <target state="translated">IncludeAssets</target>
+        <source>Included assets</source>
+        <target state="needs-review-translation">IncludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>ExcludeAssets</source>
-        <target state="translated">ExcludeAssets</target>
+        <source>Excluded assets</source>
+        <target state="needs-review-translation">ExcludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>PrivateAssets</source>
-        <target state="translated">PrivateAssets</target>
+        <source>Private assets</source>
+        <target state="needs-review-translation">PrivateAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>NoWarn</source>
-        <target state="translated">NoWarn</target>
+        <source>Warnings to suppress</source>
+        <target state="needs-review-translation">NoWarn</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.fr.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>IncludeAssets</source>
-        <target state="translated">IncludeAssets</target>
+        <source>Included assets</source>
+        <target state="needs-review-translation">IncludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>ExcludeAssets</source>
-        <target state="translated">ExcludeAssets</target>
+        <source>Excluded assets</source>
+        <target state="needs-review-translation">ExcludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>PrivateAssets</source>
-        <target state="translated">PrivateAssets</target>
+        <source>Private assets</source>
+        <target state="needs-review-translation">PrivateAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>NoWarn</source>
-        <target state="translated">NoWarn</target>
+        <source>Warnings to suppress</source>
+        <target state="needs-review-translation">NoWarn</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.it.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>IncludeAssets</source>
-        <target state="translated">IncludeAssets</target>
+        <source>Included assets</source>
+        <target state="needs-review-translation">IncludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>ExcludeAssets</source>
-        <target state="translated">ExcludeAssets</target>
+        <source>Excluded assets</source>
+        <target state="needs-review-translation">ExcludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>PrivateAssets</source>
-        <target state="translated">PrivateAssets</target>
+        <source>Private assets</source>
+        <target state="needs-review-translation">PrivateAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>NoWarn</source>
-        <target state="translated">NoWarn</target>
+        <source>Warnings to suppress</source>
+        <target state="needs-review-translation">NoWarn</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ja.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>IncludeAssets</source>
-        <target state="translated">IncludeAssets</target>
+        <source>Included assets</source>
+        <target state="needs-review-translation">IncludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>ExcludeAssets</source>
-        <target state="translated">ExcludeAssets</target>
+        <source>Excluded assets</source>
+        <target state="needs-review-translation">ExcludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>PrivateAssets</source>
-        <target state="translated">PrivateAssets</target>
+        <source>Private assets</source>
+        <target state="needs-review-translation">PrivateAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>NoWarn</source>
-        <target state="translated">NoWarn</target>
+        <source>Warnings to suppress</source>
+        <target state="needs-review-translation">NoWarn</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ko.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>IncludeAssets</source>
-        <target state="translated">IncludeAssets</target>
+        <source>Included assets</source>
+        <target state="needs-review-translation">IncludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>ExcludeAssets</source>
-        <target state="translated">ExcludeAssets</target>
+        <source>Excluded assets</source>
+        <target state="needs-review-translation">ExcludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>PrivateAssets</source>
-        <target state="translated">PrivateAssets</target>
+        <source>Private assets</source>
+        <target state="needs-review-translation">PrivateAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>NoWarn</source>
-        <target state="translated">NoWarn</target>
+        <source>Warnings to suppress</source>
+        <target state="needs-review-translation">NoWarn</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.pl.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>IncludeAssets</source>
-        <target state="translated">Uwzględnij zasoby</target>
+        <source>Included assets</source>
+        <target state="needs-review-translation">Uwzględnij zasoby</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>ExcludeAssets</source>
-        <target state="translated">Wyklucz zasoby</target>
+        <source>Excluded assets</source>
+        <target state="needs-review-translation">Wyklucz zasoby</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>PrivateAssets</source>
-        <target state="translated">Prywatne zasoby</target>
+        <source>Private assets</source>
+        <target state="needs-review-translation">Prywatne zasoby</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>NoWarn</source>
-        <target state="translated">NoWarn</target>
+        <source>Warnings to suppress</source>
+        <target state="needs-review-translation">NoWarn</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.pt-BR.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>IncludeAssets</source>
-        <target state="translated">IncludeAssets</target>
+        <source>Included assets</source>
+        <target state="needs-review-translation">IncludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>ExcludeAssets</source>
-        <target state="translated">ExcludeAssets</target>
+        <source>Excluded assets</source>
+        <target state="needs-review-translation">ExcludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>PrivateAssets</source>
-        <target state="translated">PrivateAssets</target>
+        <source>Private assets</source>
+        <target state="needs-review-translation">PrivateAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>NoWarn</source>
-        <target state="translated">NoWarn</target>
+        <source>Warnings to suppress</source>
+        <target state="needs-review-translation">NoWarn</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ru.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>IncludeAssets</source>
-        <target state="translated">IncludeAssets</target>
+        <source>Included assets</source>
+        <target state="needs-review-translation">IncludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>ExcludeAssets</source>
-        <target state="translated">ExcludeAssets</target>
+        <source>Excluded assets</source>
+        <target state="needs-review-translation">ExcludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>PrivateAssets</source>
-        <target state="translated">PrivateAssets</target>
+        <source>Private assets</source>
+        <target state="needs-review-translation">PrivateAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>NoWarn</source>
-        <target state="translated">NoWarn</target>
+        <source>Warnings to suppress</source>
+        <target state="needs-review-translation">NoWarn</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.tr.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>IncludeAssets</source>
-        <target state="translated">IncludeAssets</target>
+        <source>Included assets</source>
+        <target state="needs-review-translation">IncludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>ExcludeAssets</source>
-        <target state="translated">ExcludeAssets</target>
+        <source>Excluded assets</source>
+        <target state="needs-review-translation">ExcludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>PrivateAssets</source>
-        <target state="translated">PrivateAssets</target>
+        <source>Private assets</source>
+        <target state="needs-review-translation">PrivateAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>NoWarn</source>
-        <target state="translated">NoWarn</target>
+        <source>Warnings to suppress</source>
+        <target state="needs-review-translation">NoWarn</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.zh-Hans.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>IncludeAssets</source>
-        <target state="translated">IncludeAssets</target>
+        <source>Included assets</source>
+        <target state="needs-review-translation">IncludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>ExcludeAssets</source>
-        <target state="translated">ExcludeAssets</target>
+        <source>Excluded assets</source>
+        <target state="needs-review-translation">ExcludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>PrivateAssets</source>
-        <target state="translated">PrivateAssets</target>
+        <source>Private assets</source>
+        <target state="needs-review-translation">PrivateAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>NoWarn</source>
-        <target state="translated">NoWarn</target>
+        <source>Warnings to suppress</source>
+        <target state="needs-review-translation">NoWarn</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.zh-Hant.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
-        <source>IncludeAssets</source>
-        <target state="translated">IncludeAssets</target>
+        <source>Included assets</source>
+        <target state="needs-review-translation">IncludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
-        <source>ExcludeAssets</source>
-        <target state="translated">ExcludeAssets</target>
+        <source>Excluded assets</source>
+        <target state="needs-review-translation">ExcludeAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
@@ -53,8 +53,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>PrivateAssets</source>
-        <target state="translated">PrivateAssets</target>
+        <source>Private assets</source>
+        <target state="needs-review-translation">PrivateAssets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
-        <source>NoWarn</source>
-        <target state="translated">NoWarn</target>
+        <source>Warnings to suppress</source>
+        <target state="needs-review-translation">NoWarn</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">


### PR DESCRIPTION
The user-visible display names now use sentence case. Fixes #4231.