### PR TITLE
Add command-line handler for F#

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp/Microsoft.VisualStudio.ProjectSystem.FSharp.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp/Microsoft.VisualStudio.ProjectSystem.FSharp.csproj
@@ -1,6 +1,6 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\HostAgnostic.props"/>
+  <Import Project="..\HostAgnostic.props" />
   <PropertyGroup>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
     <!-- The value of RuleInjectionClassName of XamlPropertyRule items defined by this project -->
@@ -10,7 +10,7 @@
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.FSharp.VS" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.FSharp.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests" />
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)"/>
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineNotificationHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineNotificationHandler.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+
+using Microsoft.VisualStudio.ProjectSystem.Logging;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
+{
+    /// <summary>
+    ///     An indirection that sends design-time build results in the form of command-line arguments to the F# language-service.
+    /// </summary>
+    /// <remarks>
+    ///     This indirection is needed because Microsoft.VisualStudio.ProjectSystem.FSharp does not have InternalsVisibleTo access to Roslyn.
+    /// </remarks>
+    [Export(typeof(IWorkspaceContextHandler))]
+    internal class CommandLineNotificationHandler : AbstractWorkspaceContextHandler, ICommandLineHandler
+    {
+        [ImportingConstructor]
+        public CommandLineNotificationHandler(ConfiguredProject project)
+        {
+            CommandLineNotifications = new OrderPrecedenceImportCollection<Action<string, BuildOptions, BuildOptions>>(projectCapabilityCheckProvider: project);
+        }
+
+        [ImportMany]
+        public OrderPrecedenceImportCollection<Action<string, BuildOptions, BuildOptions>> CommandLineNotifications
+        {
+            get;
+        }
+
+        public void Handle(IComparable version, BuildOptions added, BuildOptions removed, bool isActiveContext, IProjectLogger logger)
+        {
+            Requires.NotNull(version, nameof(version));
+            Requires.NotNull(added, nameof(added));
+            Requires.NotNull(removed, nameof(removed));
+            Requires.NotNull(logger, nameof(logger));
+
+            VerifyInitialized();
+
+            foreach (Lazy<Action<string, BuildOptions, BuildOptions>, IOrderPrecedenceMetadataView> value in CommandLineNotifications)
+            {
+                value.Value(Context.BinOutputPath, added, removed);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add a command-line handler that notifies FSharpCommandLineParserService.HandleCommandLineNotifications of the new command-line arguments.

This is the replacement for this logic in the now-defunct class: https://github.com/dotnet/project-system/blob/master/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHandlerManager.cs#L213.