### PR TITLE
Cache ImageMoniker strings, reducing GC heap by 0.5%

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
@@ -341,6 +342,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
                 GraphNodeId.GetPartial(CodeGraphNodeIdName.File, filePath));
         }
 
-        private static string GetIconStringName(ImageMoniker icon) => $"{icon.Guid:D};{icon.Id}";
+        private static readonly ConcurrentDictionary<(int id, Guid guid), string> s_iconNameCache = new ConcurrentDictionary<(int id, Guid guid), string>();
+
+        private static string GetIconStringName(ImageMoniker icon)
+        {
+            return s_iconNameCache.GetOrAdd((icon.Id, icon.Guid), i => $"{i.guid:D};{i.id}");
+        }
     }
 }


### PR DESCRIPTION
VS `GraphNode`s specify their icons as `string`. This string is created from an `ImageMoniker`'s Guid and integer ID.

There are many more graph nodes than distinct icons, hence creating a new string for each node results in a large number of duplicate string objects on the heap. This change results in strings being reused.

Loading `Roslyn.sln` and performing a search in the solution explorer produced the following counts:

|Icon String|Count|Wasted Bytes|
|----|----:|-----------:|
|`ae27a6b0-e345-4288-96df-5eaf394ee369;3644`|12,210|1,172,064|
|`259567c1-aa6b-46bf-811c-c145dd9f3b48;3`|11,491|1,057,080|
|`259567c1-aa6b-46bf-811c-c145dd9f3b48;11`|5,617|516,672|
|`259567c1-aa6b-46bf-811c-c145dd9f3b48;9`|1,423|130,824|
|`259567c1-aa6b-46bf-811c-c145dd9f3b48;1`|1,368|125,764|
|`259567c1-aa6b-46bf-811c-c145dd9f3b48;0`|91|8,280|
|**Total**|**32,200**|**3,010,684**|

Caching these strings reduced the managed heap by 0.5% in the above run.