### PR TITLE
Fix dependencies node regression

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
@@ -128,6 +128,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
                 if (newDependency.TopLevel)
                 {
+                    topLevelBuilder.Remove(newDependency);
                     topLevelBuilder.Add(newDependency);
                 }
             }


### PR DESCRIPTION
Fixes an error I introduced in 77ca8fac8d423fbbfb1a43f5b1d71e0af3cb80f1 that caused many dependency tree nodes to appear with warning icons.

A unit test has been added to ensure this doesn't return.

The misconception in that earlier commit was that the `Add` method replaces items that already present. There is no method on `ImmutableHashSet<>.Builder` that achieves this, so we need the remove/add combo.