### PR TITLE
Implement RunCodeAnalysis property to prevent watsons

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AbstractProjectConfigurationProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AbstractProjectConfigurationProperties.cs
@@ -124,6 +124,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
                 });
             }
         }
+        public bool RunCodeAnalysis
+        {
+            get
+            {
+                return _threadingService.ExecuteSynchronously(async () =>
+                {
+                    ConfiguredBrowseObject browseObjectProperties = await _projectProperties.GetConfiguredBrowseObjectPropertiesAsync();
+                    string value = await browseObjectProperties.RunCodeAnalysis.GetEvaluatedValueAtEndAsync();
+                    return string.Equals(value, bool.TrueString, StringComparisons.PropertyValues);
+                });
+            }
+            set
+            {
+                _threadingService.ExecuteSynchronously(async () =>
+                {
+                    ConfiguredBrowseObject browseObjectProperties = await _projectProperties.GetConfiguredBrowseObjectPropertiesAsync();
+                    await browseObjectProperties.RunCodeAnalysis.SetValueAsync(value);
+                });
+            }
+        }
+
         public object ExtenderNames => null;
         public string __id => throw new System.NotImplementedException();
         public bool DebugSymbols { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
@@ -164,7 +185,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         public bool NoStdLib { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
         public string DebugInfo { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
         public string TreatSpecificWarningsAsErrors { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
-        public bool RunCodeAnalysis { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
         public string CodeAnalysisLogFile { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
         public string CodeAnalysisRuleAssemblies { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }
         public string CodeAnalysisInputAssembly { get => throw new System.NotImplementedException(); set => throw new System.NotImplementedException(); }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AbstractProjectConfigurationProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AbstractProjectConfigurationProperties.cs
@@ -131,8 +131,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
                 return _threadingService.ExecuteSynchronously(async () =>
                 {
                     ConfiguredBrowseObject browseObjectProperties = await _projectProperties.GetConfiguredBrowseObjectPropertiesAsync();
-                    string value = await browseObjectProperties.RunCodeAnalysis.GetEvaluatedValueAtEndAsync();
-                    return string.Equals(value, bool.TrueString, StringComparisons.PropertyValues);
+                    var value = await browseObjectProperties.RunCodeAnalysis.GetValueAsync();
+                    return ((bool?)value).GetValueOrDefault();
                 });
             }
             set

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
@@ -33,6 +33,7 @@
     </StringProperty.DataSource>
   </StringProperty>
 
+  <BoolProperty Name="RunCodeAnalysis" Visible="False" />
   <BoolProperty Name="Prefer32Bit" Visible="False"/>
   <BoolProperty Name="AllowUnsafeBlocks"  Default="False"  Visible="False"/>
   <BoolProperty Name="Optimize" Visible="False"/>


### PR DESCRIPTION
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/680205

This at least solves the 99% case of this property always being hit for SDK projects and correctly handles returning false for the empty string default value. In testing even when RunCodeAnalysis is specifically set to true, none of the other CodeAnalysis* properties are hit.