### PR TITLE
Fix dependencies node showing unresolved icons

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependenciesChanges.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IDependenciesChanges.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 
@@ -15,13 +16,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     }
 
     [DebuggerDisplay("({" + nameof(ProviderType) + ("}, {" + nameof(DependencyId) + "})"))]
-    public readonly struct RemovedDependencyIdentity
+    public readonly struct RemovedDependencyIdentity : IEquatable<RemovedDependencyIdentity>
     {
         public string ProviderType { get; }
         public string DependencyId { get; }
 
         public RemovedDependencyIdentity(string providerType, string dependencyId) : this()
         {
+            Requires.NotNull(providerType, nameof(providerType));
+            Requires.NotNull(dependencyId, nameof(dependencyId));
+
             ProviderType = providerType;
             DependencyId = dependencyId;
         }
@@ -31,5 +35,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             providerType = ProviderType;
             dependencyId = DependencyId;
         }
+
+        public bool Equals(RemovedDependencyIdentity other)
+        {
+            return string.Equals(ProviderType, other.ProviderType, StringComparisons.DependencyProviderTypes) && 
+                   string.Equals(DependencyId, other.DependencyId, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override bool Equals(object obj) => obj is RemovedDependencyIdentity other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (StringComparer.OrdinalIgnoreCase.GetHashCode(ProviderType) * 397) ^
+                        StringComparer.OrdinalIgnoreCase.GetHashCode(DependencyId);
+            }
+        }
+
+        public static bool operator ==(RemovedDependencyIdentity left, RemovedDependencyIdentity right) => left.Equals(right);
+        public static bool operator !=(RemovedDependencyIdentity left, RemovedDependencyIdentity right) => !left.Equals(right);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
@@ -124,7 +124,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
                 anyChanges = true;
 
-                worldBuilder[newDependency.Id] = newDependency;
+                worldBuilder.Remove(newDependency.Id);
+                worldBuilder.Add(newDependency.Id, newDependency);
 
                 if (newDependency.TopLevel)
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependenciesChanges.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependenciesChanges.cs
@@ -38,15 +38,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
         {
             lock (_added)
             {
+                _added.Remove(model);
                 _added.Add(model);
             }
         }
 
         public void IncludeRemovedChange(string providerType, string dependencyId)
         {
+            var identity = new RemovedDependencyIdentity(providerType, dependencyId);
+
             lock (_removed)
             {
-                _removed.Add(new RemovedDependencyIdentity(providerType, dependencyId));
+                _removed.Remove(identity);
+                _removed.Add(identity);
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Shipped.txt
@@ -479,6 +479,11 @@ Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.RemovedDependencyIdent
 Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.RemovedDependencyIdentity.DependencyId.get -> string
 Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.RemovedDependencyIdentity.ProviderType.get -> string
 Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.RemovedDependencyIdentity.RemovedDependencyIdentity(string providerType, string dependencyId) -> void
+Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.RemovedDependencyIdentity.Equals(Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.RemovedDependencyIdentity other) -> bool
+override Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.RemovedDependencyIdentity.Equals(object obj) -> bool
+override Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.RemovedDependencyIdentity.GetHashCode() -> int
+static Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.RemovedDependencyIdentity.operator !=(Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.RemovedDependencyIdentity left, Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.RemovedDependencyIdentity right) -> bool
+static Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.RemovedDependencyIdentity.operator ==(Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.RemovedDependencyIdentity left, Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.RemovedDependencyIdentity right) -> bool
 Microsoft.VisualStudio.ProjectSystem.VS.Utilities.FocusAttacher
 Microsoft.VisualStudio.ProjectSystem.VS.Utilities.FocusAttacher.FocusAttacher() -> void
 static Microsoft.VisualStudio.ProjectSystem.VS.ManagedImageMonikers.ApplicationPrivate.get -> Microsoft.VisualStudio.Imaging.Interop.ImageMoniker


### PR DESCRIPTION
Some fixes that restore the correct presentation of the dependencies node.

As mentioned in #4269, the change in e8d5becd53e75ac5382772124341912ae1eaac14 should not be necessary. As far as I can tell it only changes the order of items in the dictionary, which shouldn't have a bearing on anything of consequence. I'll follow up on that tomorrow.

Also added `Equals`/`GetHashCode` to the custom struct recently introduced in place of the `ValueTuple`. It's used in a set, and the default `ValueType` implementations are slow and likely to cause collisions (it's my understanding they'd only compute the hash code on the first field, `ProviderType` which is commonly duplicated). This 