### PR TITLE
 IWorkspaceProjectContextHost.Loaded -> PublishAsync

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/AbstractMultiLifetimeComponentFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/AbstractMultiLifetimeComponentFactory.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return new MultiLifetimeComponent(joinableTaskContextNode);
         }
 
-        public class MultiLifetimeComponent : AbstractMultiLifetimeComponent
+        public class MultiLifetimeComponent : AbstractMultiLifetimeComponent<IMultiLifetimeInstance>
         {
             public MultiLifetimeComponent(JoinableTaskContextNode joinableTaskContextNode) 
                 : base(joinableTaskContextNode)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/AbstractMultiLifetimeComponentFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/AbstractMultiLifetimeComponentFactory.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Threading;
 
@@ -14,14 +15,14 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return new MultiLifetimeComponent(joinableTaskContextNode);
         }
 
-        public class MultiLifetimeComponent : AbstractMultiLifetimeComponent<IMultiLifetimeInstance>
+        public class MultiLifetimeComponent : AbstractMultiLifetimeComponent<MultiLifetimeComponent.MultiLifetimeInstance>
         {
             public MultiLifetimeComponent(JoinableTaskContextNode joinableTaskContextNode) 
                 : base(joinableTaskContextNode)
             {
             }
 
-            protected override IMultiLifetimeInstance CreateInstance()
+            protected override MultiLifetimeInstance CreateInstance()
             {
                 return new MultiLifetimeInstance();
             }
@@ -29,6 +30,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
             public new bool IsInitialized
             {
                 get { return base.IsInitialized; }
+            }
+
+            public new Task<MultiLifetimeInstance> PublishInstanceAsync(CancellationToken cancellationToken = default)
+            {
+                return base.PublishInstanceAsync(cancellationToken);
             }
 
             public class MultiLifetimeInstance : IMultiLifetimeInstance

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/AbstractMultiLifetimeComponentFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/AbstractMultiLifetimeComponentFactory.cs
@@ -32,9 +32,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 get { return base.IsInitialized; }
             }
 
-            public new Task<MultiLifetimeInstance> PublishInstanceAsync(CancellationToken cancellationToken = default)
+            public new Task<MultiLifetimeInstance> WaitForLoadedAsync(CancellationToken cancellationToken = default)
             {
-                return base.PublishInstanceAsync(cancellationToken);
+                return base.WaitForLoadedAsync(cancellationToken);
             }
 
             public class MultiLifetimeInstance : IMultiLifetimeInstance

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/AbstractMultiLifetimeComponentTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/AbstractMultiLifetimeComponentTests.cs
@@ -9,11 +9,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
     public class AbstractMultiLifetimeComponentTests
     {
         [Fact]
-        public void PublishInstanceAsync_WhenNotUnPublishInstanceAsync_ReturnsNonCompletedTask()
+        public void WaitForLoadedAsync_WhenNotLoadedAsync_ReturnsNonCompletedTask()
         {
             var component = CreateInstance();
 
-            var result = component.PublishInstanceAsync();
+            var result = component.WaitForLoadedAsync();
 
             Assert.False(result.IsCanceled);
             Assert.False(result.IsCompleted);
@@ -21,26 +21,26 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         [Fact]
-        public async Task PublishInstanceAsync_WhenLoaded_ReturnsCompletedTask()
+        public async Task WaitForLoadedAsync_WhenLoaded_ReturnsCompletedTask()
         {
             var component = CreateInstance();
 
             await component.LoadAsync();
 
-            var result = component.PublishInstanceAsync();
+            var result = component.WaitForLoadedAsync();
 
             Assert.True(result.IsCompleted);
         }
 
         [Fact]
-        public async Task PublishInstanceAsync_WhenUnloaded_ReturnsNonCompletedTask()
+        public async Task WaitForLoadedAsync_WhenUnloaded_ReturnsNonCompletedTask()
         {
             var component = CreateInstance();
 
             await component.LoadAsync();
             await component.UnloadAsync();
 
-            var result = component.PublishInstanceAsync();
+            var result = component.WaitForLoadedAsync();
 
             Assert.False(result.IsCanceled);
             Assert.False(result.IsCompleted);
@@ -48,26 +48,26 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         [Fact]
-        public async Task PublishInstanceAsync_DisposedWhenUnloaded_ReturnsCancelledTask()
+        public async Task WaitForLoadedAsync_DisposedWhenUnloaded_ReturnsCancelledTask()
         {
             var component = CreateInstance();
 
             await component.DisposeAsync();
 
-            var result = component.PublishInstanceAsync();
+            var result = component.WaitForLoadedAsync();
 
             Assert.True(result.IsCanceled);
         }
 
         [Fact]
-        public async Task PublishInstanceAsync_DisposedWhenLoaded_ReturnsCancelledTask()
+        public async Task WaitForLoadedAsync_DisposedWhenLoaded_ReturnsCancelledTask()
         {
             var component = CreateInstance();
 
             await component.LoadAsync();
             await component.DisposeAsync();
 
-            var result = component.PublishInstanceAsync();
+            var result = component.WaitForLoadedAsync();
 
             Assert.True(result.IsCanceled);
         }
@@ -89,7 +89,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             await component.LoadAsync();
 
-            var result = await component.PublishInstanceAsync();
+            var result = await component.WaitForLoadedAsync();
 
             Assert.True(result.IsInitialized);
         }
@@ -101,11 +101,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             await component.LoadAsync();
 
-            var instance = await component.PublishInstanceAsync();
+            var instance = await component.WaitForLoadedAsync();
 
             await component.LoadAsync();
 
-            var result = await component.PublishInstanceAsync();
+            var result = await component.WaitForLoadedAsync();
 
             Assert.Same(instance, result);
         }
@@ -117,14 +117,14 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             await component.LoadAsync();
 
-            var instance = await component.PublishInstanceAsync();
+            var instance = await component.WaitForLoadedAsync();
 
             await component.UnloadAsync();
 
             // We should create a new instance here
             await component.LoadAsync();
 
-            var result = await component.PublishInstanceAsync();
+            var result = await component.WaitForLoadedAsync();
 
             Assert.NotSame(instance, result);
         }
@@ -135,7 +135,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var component = CreateInstance();
 
             await component.LoadAsync();
-            var result = await component.PublishInstanceAsync();
+            var result = await component.WaitForLoadedAsync();
 
             await component.UnloadAsync();
 
@@ -175,7 +175,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var component = CreateInstance();
 
             await component.LoadAsync();
-            var instance = await component.PublishInstanceAsync();
+            var instance = await component.WaitForLoadedAsync();
 
             component.Dispose();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/AbstractMultiLifetimeComponentTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/AbstractMultiLifetimeComponentTests.cs
@@ -3,64 +3,73 @@
 using System.Threading.Tasks;
 
 using Xunit;
-using static Microsoft.VisualStudio.ProjectSystem.AbstractMultiLifetimeComponentFactory.MultiLifetimeComponent;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     public class AbstractMultiLifetimeComponentTests
     {
         [Fact]
-        public void Loaded_WhenNotUnloaded_ReturnsNonCompletedTask()
+        public void PublishInstanceAsync_WhenNotUnPublishInstanceAsync_ReturnsNonCompletedTask()
         {
             var component = CreateInstance();
 
-            Assert.False(component.Loaded.IsCanceled);
-            Assert.False(component.Loaded.IsCompleted);
-            Assert.False(component.Loaded.IsFaulted);
+            var result = component.PublishInstanceAsync();
+
+            Assert.False(result.IsCanceled);
+            Assert.False(result.IsCompleted);
+            Assert.False(result.IsFaulted);
         }
 
         [Fact]
-        public async Task Loaded_WhenLoaded_ReturnsCompletedTask()
+        public async Task PublishInstanceAsync_WhenLoaded_ReturnsCompletedTask()
         {
             var component = CreateInstance();
 
             await component.LoadAsync();
 
-            Assert.True(component.Loaded.IsCompleted);
+            var result = component.PublishInstanceAsync();
+
+            Assert.True(result.IsCompleted);
         }
 
         [Fact]
-        public async Task Loaded_WhenUnloaded_ReturnsNonCompletedTask()
+        public async Task PublishInstanceAsync_WhenUnloaded_ReturnsNonCompletedTask()
         {
             var component = CreateInstance();
 
             await component.LoadAsync();
             await component.UnloadAsync();
 
-            Assert.False(component.Loaded.IsCanceled);
-            Assert.False(component.Loaded.IsCompleted);
-            Assert.False(component.Loaded.IsFaulted);
+            var result = component.PublishInstanceAsync();
+
+            Assert.False(result.IsCanceled);
+            Assert.False(result.IsCompleted);
+            Assert.False(result.IsFaulted);
         }
 
         [Fact]
-        public async Task Loaded_DisposedWhenUnloaded_ReturnsCancelledTask()
+        public async Task PublishInstanceAsync_DisposedWhenUnloaded_ReturnsCancelledTask()
         {
             var component = CreateInstance();
 
             await component.DisposeAsync();
 
-            Assert.True(component.Loaded.IsCanceled);
+            var result = component.PublishInstanceAsync();
+
+            Assert.True(result.IsCanceled);
         }
 
         [Fact]
-        public async Task Loaded_DisposedWhenLoaded_ReturnsCancelledTask()
+        public async Task PublishInstanceAsync_DisposedWhenLoaded_ReturnsCancelledTask()
         {
             var component = CreateInstance();
 
             await component.LoadAsync();
             await component.DisposeAsync();
 
-            Assert.True(component.Loaded.IsCanceled);
+            var result = component.PublishInstanceAsync();
+
+            Assert.True(result.IsCanceled);
         }
 
         [Fact]
@@ -80,7 +89,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             await component.LoadAsync();
 
-            var result = (MultiLifetimeInstance)component.Instance;
+            var result = await component.PublishInstanceAsync();
 
             Assert.True(result.IsInitialized);
         }
@@ -92,11 +101,13 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             await component.LoadAsync();
 
-            var instance = component.Instance;
+            var instance = await component.PublishInstanceAsync();
 
             await component.LoadAsync();
 
-            Assert.Same(instance, component.Instance);
+            var result = await component.PublishInstanceAsync();
+
+            Assert.Same(instance, result);
         }
 
         [Fact]
@@ -106,14 +117,16 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             await component.LoadAsync();
 
-            var instance = component.Instance;
+            var instance = await component.PublishInstanceAsync();
 
             await component.UnloadAsync();
 
             // We should create a new instance here
             await component.LoadAsync();
 
-            Assert.NotSame(instance, component.Instance);
+            var result = await component.PublishInstanceAsync();
+
+            Assert.NotSame(instance, result);
         }
 
         [Fact]
@@ -122,12 +135,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var component = CreateInstance();
 
             await component.LoadAsync();
-            var instance = component.Instance;
+            var result = await component.PublishInstanceAsync();
 
             await component.UnloadAsync();
 
-            Assert.Null(component.Instance);
-            Assert.True(((MultiLifetimeInstance)instance).IsDisposed);
+            Assert.True(result.IsDisposed);
         }
 
         [Fact]
@@ -136,8 +148,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var component = CreateInstance();
 
             await component.UnloadAsync();
-
-            Assert.Null(component.Instance);
         }
 
         [Fact]
@@ -165,11 +175,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var component = CreateInstance();
 
             await component.LoadAsync();
-            var instance = component.Instance;
+            var instance = await component.PublishInstanceAsync();
 
             component.Dispose();
 
-            Assert.True(((MultiLifetimeInstance)instance).IsDisposed);
+            Assert.True(instance.IsDisposed);
         }
 
         private static AbstractMultiLifetimeComponentFactory.MultiLifetimeComponent CreateInstance()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceContextHostTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceContextHostTests.cs
@@ -11,57 +11,67 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     public class WorkspaceContextHostTests
     {
         [Fact]
-        public void Loaded_WhenNotActivated_ReturnsNonCompletedTask()
+        public void PublishAsync_WhenNotActivated_ReturnsNonCompletedTask()
         {
             var component = CreateInstance();
 
-            Assert.False(component.Loaded.IsCanceled);
-            Assert.False(component.Loaded.IsCompleted);
-            Assert.False(component.Loaded.IsFaulted);
+            var result = component.PublishAsync();
+
+            Assert.False(result.IsCanceled);
+            Assert.False(result.IsCompleted);
+            Assert.False(result.IsFaulted);
         }
 
         [Fact]
-        public async Task Loaded_WhenActivated_ReturnsCompletedTask()
+        public async Task PublishAsync_WhenActivated_ReturnsCompletedTask()
         {
             var component = CreateInstance();
 
             await component.ActivateAsync();
 
-            Assert.True(component.Loaded.IsCompleted);
+            var result = component.PublishAsync();
+
+            Assert.True(result.IsCompleted);
         }
 
         [Fact]
-        public async Task Loaded_WhenDeactivated_ReturnsNonCompletedTask()
+        public async Task PublishAsync_WhenDeactivated_ReturnsNonCompletedTask()
         {
             var component = CreateInstance();
 
             await component.ActivateAsync();
             await component.UnloadAsync();
 
-            Assert.False(component.Loaded.IsCanceled);
-            Assert.False(component.Loaded.IsCompleted);
-            Assert.False(component.Loaded.IsFaulted);
+            var result = component.PublishAsync();
+
+            Assert.False(result.IsCanceled);
+            Assert.False(result.IsCompleted);
+            Assert.False(result.IsFaulted);
         }
 
         [Fact]
-        public async Task Loaded_DisposedWhenNotActivated_ReturnsCancelledTask()
+        public async Task PublishAsync_DisposedWhenNotActivated_ReturnsCancelledTask()
         {
             var component = CreateInstance();
 
             await component.DisposeAsync();
 
-            Assert.True(component.Loaded.IsCanceled);
+            var result = component.PublishAsync();
+
+            Assert.True(result.IsCanceled);
         }
 
         [Fact]
-        public async Task Loaded_DisposedWhenActivated_ReturnsCancelledTask()
+        public async Task PublishAsync_DisposedWhenActivated_ReturnsCancelledTask()
         {
             var component = CreateInstance();
 
             await component.ActivateAsync();
             await component.DisposeAsync();
 
-            Assert.True(component.Loaded.IsCanceled);
+            var result = component.PublishAsync();
+
+            Assert.True(result.IsCanceled);
         }
 
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IActiveWorkspaceProjectContextHostFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IActiveWorkspaceProjectContextHostFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 
@@ -29,9 +30,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 _accessor = accessor;
             }
 
-            public Task Loaded
+            public Task PublishAsync(CancellationToken cancellationToken = default)
             {
-                get { return Task.CompletedTask; }
+                return Task.CompletedTask;
             }
 
             public Task OpenContextForWriteAsync(Func<IWorkspaceProjectContextAccessor, Task> action)
@@ -43,6 +44,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             {
                 return action(_accessor);
             }
+
+
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
 
         private async Task<(HierarchyId itemid, IVsHierarchy hierarchy, IVsContainedLanguageFactory containedLanguageFactory)> GetContainedLanguageFactoryForFileAsync(string filePath)
         {
-            await _projectContextHost.Loaded;
+            await _projectContextHost.PublishAsync();
 
             await _projectVsServices.ThreadingService.SwitchToUIThread();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/PackageRestoreInitiator.PackageRestoreInitiatorInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/PackageRestoreInitiator.PackageRestoreInitiatorInstance.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
 
     internal partial class PackageRestoreInitiator
     {
-        private class PackageRestoreInitiatorInstance : OnceInitializedOnceDisposedAsync, IMultiLifetimeInstance
+        internal class PackageRestoreInitiatorInstance : OnceInitializedOnceDisposedAsync, IMultiLifetimeInstance
         {
             private readonly IUnconfiguredProjectVsServices _projectVsServices;
             private readonly IVsSolutionRestoreService _solutionRestoreService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/PackageRestoreInitiator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/PackageRestoreInitiator.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
     /// </summary>
     [Export(ExportContractNames.Scopes.UnconfiguredProject, typeof(IProjectDynamicLoadComponent))]
     [AppliesTo(ProjectCapability.PackageReferences)]
-    internal partial class PackageRestoreInitiator : AbstractMultiLifetimeComponent, IProjectDynamicLoadComponent
+    internal partial class PackageRestoreInitiator : AbstractMultiLifetimeComponent<PackageRestoreInitiator.PackageRestoreInitiatorInstance>, IProjectDynamicLoadComponent
     {
         private readonly IUnconfiguredProjectVsServices _projectVsServices;
         private readonly IVsSolutionRestoreService _solutionRestoreService;
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             _logger = logger;
         }
 
-        protected override IMultiLifetimeInstance CreateInstance()
+        protected override PackageRestoreInitiatorInstance CreateInstance()
         {
             return new PackageRestoreInitiatorInstance(_projectVsServices, _solutionRestoreService, _activeConfigurationGroupService, _logger);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SDKVersionTelemetryServiceComponent.SDKVersionTelemetryServiceInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SDKVersionTelemetryServiceComponent.SDKVersionTelemetryServiceInstance.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
     internal partial class SDKVersionTelemetryServiceComponent
     {
-        protected class SDKVersionTelemetryServiceInstance : OnceInitializedOnceDisposedAsync, IMultiLifetimeInstance
+        internal class SDKVersionTelemetryServiceInstance : OnceInitializedOnceDisposedAsync, IMultiLifetimeInstance
         {
             private readonly IUnconfiguredProjectVsServices _projectVsServices;
             private readonly ISafeProjectGuidService _projectGuidService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SDKVersionTelemetryServiceComponent.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/SDKVersionTelemetryServiceComponent.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     /// </summary>
     [Export(ExportContractNames.Scopes.UnconfiguredProject, typeof(IProjectDynamicLoadComponent))]
     [AppliesTo(ProjectCapability.DotNet)]
-    internal partial class SDKVersionTelemetryServiceComponent : AbstractMultiLifetimeComponent, IProjectDynamicLoadComponent
+    internal partial class SDKVersionTelemetryServiceComponent : AbstractMultiLifetimeComponent<SDKVersionTelemetryServiceComponent.SDKVersionTelemetryServiceInstance>, IProjectDynamicLoadComponent
     {
         private readonly IUnconfiguredProjectVsServices _projectVsServices;
         private readonly ITelemetryService _telemetryService;
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             _unconfiguredProjectTasksService = unconfiguredProjectTasksService;
         }
 
-        protected override IMultiLifetimeInstance CreateInstance()
+        protected override SDKVersionTelemetryServiceInstance CreateInstance()
             => new SDKVersionTelemetryServiceInstance(
                 _projectVsServices,
                 _projectGuidService,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractMultiLifetimeComponent.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractMultiLifetimeComponent.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         ///     This method does not initiate loading of the <see cref="AbstractMultiLifetimeComponent{T}"/>, however,
         ///     it will join the load when it starts.
         /// </remarks>
-        protected async Task<T> PublishInstanceAsync(CancellationToken cancellationToken = default)
+        protected async Task<T> WaitForLoadedAsync(CancellationToken cancellationToken = default)
         {
             // Wait until LoadAsync has been called, force switching to thread-pool in case
             // there's already someone waiting for us on the UI thread.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractMultiLifetimeComponent.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractMultiLifetimeComponent.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         where T : class, IMultiLifetimeInstance
     {
         private readonly object _lock = new object();
-        private TaskCompletionSource<(T instance, JoinableTask initializeAsyncTask)> _instanceTaskSource = new TaskCompletionSource<(T instance, JoinableTask initializeAsyncTask)>();
+        private TaskCompletionSource<(T instance, JoinableTask initializeAsyncTask)> _instanceTaskSource = new TaskCompletionSource<(T instance, JoinableTask initializeAsyncTask)>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         protected AbstractMultiLifetimeComponent(JoinableTaskContextNode joinableTaskContextNode)
              : base(joinableTaskContextNode)
@@ -89,7 +89,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 {
                     // Should throw TaskCancellatedException if already cancelled in Dispose
                     (instance, _) = _instanceTaskSource.Task.GetAwaiter().GetResult();
-                    _instanceTaskSource = new TaskCompletionSource<(T instance, JoinableTask initializeAsyncTask)>();
+                    _instanceTaskSource = new TaskCompletionSource<(T instance, JoinableTask initializeAsyncTask)>(TaskCreationOptions.RunContinuationsAsynchronously);
                 }
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractMultiLifetimeComponent.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractMultiLifetimeComponent.cs
@@ -11,28 +11,29 @@ namespace Microsoft.VisualStudio.ProjectSystem
     ///     An <see langword="abstract"/> base class that simplifies the lifetime of 
     ///     a component that is loaded and unloaded multiple times.
     /// </summary>
-    internal abstract class AbstractMultiLifetimeComponent : OnceInitializedOnceDisposedAsync
+    internal abstract class AbstractMultiLifetimeComponent<T> : OnceInitializedOnceDisposedAsync
+        where T : IMultiLifetimeInstance
     {
         private readonly object _lock = new object();
         private TaskCompletionSource<object> _loadedSource = new TaskCompletionSource<object>();
-        private IMultiLifetimeInstance _instance;
+        private T _instance;
 
         protected AbstractMultiLifetimeComponent(JoinableTaskContextNode joinableTaskContextNode)
             : base(joinableTaskContextNode)
         {
         }
 
-        public IMultiLifetimeInstance Instance
+        public T Instance
         {
             get { return _instance; }
         }
 
         /// <summary>
-        ///     Gets a task that is completed when current <see cref="AbstractMultiLifetimeComponent"/> has 
+        ///     Gets a task that is completed when current <see cref="AbstractMultiLifetimeComponent{T}"/> has 
         ///     completed loading.
         /// </summary>
         /// <remarks>
-        ///     The returned <see cref="Task"/> is canceled when the <see cref="AbstractMultiLifetimeComponent"/> 
+        ///     The returned <see cref="Task"/> is canceled when the <see cref="AbstractMultiLifetimeComponent{T}"/> 
         ///     is disposed.
         /// </remarks>
         public Task Loaded
@@ -77,7 +78,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 if (_instance != null)
                 {
                     instance = _instance;
-                    _instance = null;
+                    _instance = default;
                     _loadedSource = new TaskCompletionSource<object>();
                 }
             }
@@ -105,6 +106,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// <summary>
         ///     Creates a new instance of the underlying <see cref="IMultiLifetimeInstance"/>.
         /// </summary>
-        protected abstract IMultiLifetimeInstance CreateInstance();
+        protected abstract T CreateInstance();
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractMultiLifetimeComponent.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractMultiLifetimeComponent.cs
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
                 Assumes.True(_instanceTaskSource.Task.IsCompleted);
 
-                // Should throw TaskCancellatedException if already cancelled in Dispose
+                // Should throw TaskCanceledException if already cancelled in Dispose
                 (_, initializeAsyncTask) = _instanceTaskSource.Task.GetAwaiter().GetResult();
             }
 
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             {
                 if (_instanceTaskSource.Task.IsCompleted)
                 {
-                    // Should throw TaskCancellatedException if already cancelled in Dispose
+                    // Should throw TaskCanceledException if already cancelled in Dispose
                     (instance, _) = _instanceTaskSource.Task.GetAwaiter().GetResult();
                     _instanceTaskSource = new TaskCompletionSource<(T instance, JoinableTask initializeAsyncTask)>(TaskCreationOptions.RunContinuationsAsynchronously);
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractMultiLifetimeComponent.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractMultiLifetimeComponent.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -12,33 +13,43 @@ namespace Microsoft.VisualStudio.ProjectSystem
     ///     a component that is loaded and unloaded multiple times.
     /// </summary>
     internal abstract class AbstractMultiLifetimeComponent<T> : OnceInitializedOnceDisposedAsync
-        where T : IMultiLifetimeInstance
+        where T : class, IMultiLifetimeInstance
     {
         private readonly object _lock = new object();
-        private TaskCompletionSource<object> _loadedSource = new TaskCompletionSource<object>();
-        private T _instance;
+        private TaskCompletionSource<(T instance, JoinableTask initializeAsyncTask)> _instanceTaskSource = new TaskCompletionSource<(T instance, JoinableTask initializeAsyncTask)>();
 
         protected AbstractMultiLifetimeComponent(JoinableTaskContextNode joinableTaskContextNode)
-            : base(joinableTaskContextNode)
+             : base(joinableTaskContextNode)
         {
-        }
-
-        public T Instance
-        {
-            get { return _instance; }
         }
 
         /// <summary>
-        ///     Gets a task that is completed when current <see cref="AbstractMultiLifetimeComponent{T}"/> has 
-        ///     completed loading.
+        ///     Returns a task that will complete when current <see cref="AbstractMultiLifetimeComponent{T}"/> has completed
+        ///     loading and has published its instance.
         /// </summary>
+        /// <exception cref="OperationCanceledException">
+        ///     The result is awaited and the <see cref="ConfiguredProject"/> is unloaded.
+        ///     <para>
+        ///         -or
+        ///     </para>
+        ///     The result is awaited and <paramref name="cancellationToken"/> is cancelled.
+        /// </exception>
         /// <remarks>
-        ///     The returned <see cref="Task"/> is canceled when the <see cref="AbstractMultiLifetimeComponent{T}"/> 
-        ///     is disposed.
+        ///     This method does not initiate loading of the <see cref="AbstractMultiLifetimeComponent{T}"/>, however,
+        ///     it will join the load when it starts.
         /// </remarks>
-        public Task Loaded
+        protected async Task<T> PublishInstanceAsync(CancellationToken cancellationToken = default)
         {
-            get { return _loadedSource.Task; }
+            // Wait until LoadAsync has been called, force switching to thread-pool in case
+            // there's already someone waiting for us on the UI thread.
+            (T instance, JoinableTask initializeAsyncTask) = await _instanceTaskSource.Task.WithCancellation(cancellationToken)
+                                                                                           .ConfigureAwait(false);
+
+            // Now join Instance.InitializeAsync so that if someone is waiting on the UI thread for us, 
+            // the instance is allowed to switch to that thread to complete if needed.
+            await initializeAsyncTask.JoinAsync(cancellationToken);
+
+            return instance;
         }
 
         public async Task LoadAsync()
@@ -48,38 +59,37 @@ namespace Microsoft.VisualStudio.ProjectSystem
             await LoadCoreAsync();
         }
 
-        private async Task LoadCoreAsync()
+        public async Task LoadCoreAsync()
         {
-            TaskCompletionSource<object> loadedSource = null;
-            IMultiLifetimeInstance instance;
+            JoinableTask initializeAsyncTask;
+
             lock (_lock)
             {
-                if (_instance == null)
+                if (!_instanceTaskSource.Task.IsCompleted)
                 {
-                    _instance = CreateInstance();
-                    loadedSource = _loadedSource;
+                    (T instance, JoinableTask initializeAsyncTask) result = CreateInitializedInstanceAsync();
+                    _instanceTaskSource.SetResult(result);
                 }
 
-                instance = _instance;
+                Assumes.True(_instanceTaskSource.Task.IsCompleted);
+
+                // Should throw TaskCancellatedException if already cancelled in Dispose
+                (_, initializeAsyncTask) = _instanceTaskSource.Task.GetAwaiter().GetResult();
             }
 
-            // While all callers should wait on InitializeAsync, 
-            // only one should complete the completion source
-            await instance.InitializeAsync();
-            loadedSource?.SetResult(null);
+            await initializeAsyncTask;
         }
 
         public Task UnloadAsync()
         {
-            IMultiLifetimeInstance instance = null;
-
+            T instance = null;
             lock (_lock)
             {
-                if (_instance != null)
+                if (_instanceTaskSource.Task.IsCompleted)
                 {
-                    instance = _instance;
-                    _instance = default;
-                    _loadedSource = new TaskCompletionSource<object>();
+                    // Should throw TaskCancellatedException if already cancelled in Dispose
+                    (instance, _) = _instanceTaskSource.Task.GetAwaiter().GetResult();
+                    _instanceTaskSource = new TaskCompletionSource<(T instance, JoinableTask initializeAsyncTask)>();
                 }
             }
 
@@ -95,7 +105,10 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             await UnloadAsync();
 
-            _loadedSource.TrySetCanceled();
+            lock (_lock)
+            {
+                _instanceTaskSource.TrySetCanceled();
+            }
         }
 
         protected override Task InitializeCoreAsync(CancellationToken cancellationToken)
@@ -107,5 +120,14 @@ namespace Microsoft.VisualStudio.ProjectSystem
         ///     Creates a new instance of the underlying <see cref="IMultiLifetimeInstance"/>.
         /// </summary>
         protected abstract T CreateInstance();
+
+        private (T instance, JoinableTask initializeAsyncTask) CreateInitializedInstanceAsync()
+        {
+            T instance = CreateInstance();
+
+            JoinableTask initializeAsyncTask = JoinableFactory.RunAsync(instance.InitializeAsync);
+
+            return (instance, initializeAsyncTask);
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IMultiLifetimeInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IMultiLifetimeInstance.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     /// <summary>
-    ///     Represents an instance that is automatically initialized when its parent <see cref="AbstractMultiLifetimeComponent{Task}"/>
+    ///     Represents an instance that is automatically initialized when its parent <see cref="AbstractMultiLifetimeComponent{T}"/>
     ///     is loaded, or disposed when it is unloaded.
     /// </summary>
     internal interface IMultiLifetimeInstance

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IMultiLifetimeInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IMultiLifetimeInstance.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     /// <summary>
-    ///     Represents an instance that is automatically initialized when its parent <see cref="AbstractMultiLifetimeComponent"/>
+    ///     Represents an instance that is automatically initialized when its parent <see cref="AbstractMultiLifetimeComponent{Task}"/>
     ///     is loaded, or disposed when it is unloaded.
     /// </summary>
     internal interface IMultiLifetimeInstance

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IWorkspaceProjectContextHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IWorkspaceProjectContextHost.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
@@ -13,17 +14,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     internal interface IWorkspaceProjectContextHost
     {
         /// <summary>
-        ///     Gets a task that is completed when current <see cref="IWorkspaceProjectContextHost"/> has 
-        ///     completed loading.
+        ///     Returns a task that will complete when current <see cref="IWorkspaceProjectContextHost"/> has completed
+        ///     loading.
         /// </summary>
         /// <exception cref="OperationCanceledException">
         ///     The result is awaited and the <see cref="ConfiguredProject"/> is unloaded.
+        ///     <para>
+        ///         -or
+        ///     </para>
+        ///     The result is awaited and <paramref name="cancellationToken"/> is cancelled.
         /// </exception>
-        Task Loaded
-        {
-            get;
-        }
-
+        /// <remarks>
+        ///     This method does not initiate loading of the <see cref="IWorkspaceProjectContextHost"/>, however,
+        ///     it will join the load when it starts.
+        /// </remarks>
+        Task PublishAsync(CancellationToken cancellationToken = default);
+               
         /// <summary>
         ///     Opens the <see cref="IWorkspaceProjectContext"/>, passing it to the specified action for writing.
         /// </summary>
@@ -37,7 +43,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ///     The result is awaited and the <see cref="ConfiguredProject"/> is unloaded.
         /// </exception>
         Task OpenContextForWriteAsync(Func<IWorkspaceProjectContextAccessor, Task> action);
-
 
         /// <summary>
         ///     Opens the <see cref="IWorkspaceProjectContext"/>, passing it to the specified action for writing.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -80,7 +80,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         [AppliesTo(ProjectCapability.DotNetLanguageService)]
         public Task OnProjectFactoryCompletedAsync()
         {
-            return Loaded;
+            return PublishAsync();
         }
 
         protected override Task InitializeCoreAsync(CancellationToken cancellationToken)
@@ -96,21 +96,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             return Task.CompletedTask;
         }
 
-        public Task Loaded
+        public Task PublishAsync(CancellationToken cancellationToken = default)
         {
-            get { return InitializeAsync(CancellationToken.None); }
+            return InitializeAsync(cancellationToken);
         }
 
         public async Task OpenContextForWriteAsync(Func<IWorkspaceProjectContextAccessor, Task> action)
         {
-            await Loaded;
+            await PublishAsync();
 
             await action(new WorkspaceProjectContextAccessor(ActiveProjectContext));
         }
 
         public async Task<T> OpenContextForWriteAsync<T>(Func<IWorkspaceProjectContextAccessor, Task<T>> action)
         {
-            await Loaded;
+            await PublishAsync();
 
             return await action(new WorkspaceProjectContextAccessor(ActiveProjectContext));
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceContextHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceContextHost.cs
@@ -56,14 +56,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         public Task PublishAsync(CancellationToken cancellationToken = default)
         {
-            return PublishInstanceAsync(cancellationToken);
+            return WaitForLoadedAsync(cancellationToken);
         }
 
         public async Task OpenContextForWriteAsync(Func<IWorkspaceProjectContextAccessor, Task> action)
         {
             Requires.NotNull(action, nameof(action));
 
-            WorkspaceContextHostInstance instance = await PublishInstanceAsync();
+            WorkspaceContextHostInstance instance = await WaitForLoadedAsync();
 
             // Throws OperationCanceledException if 'instance' is Disposed
             await instance.OpenContextForWriteAsync(action);
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         {
             Requires.NotNull(action, nameof(action));
 
-            WorkspaceContextHostInstance instance = await PublishInstanceAsync();
+            WorkspaceContextHostInstance instance = await WaitForLoadedAsync();
 
             // Throws OperationCanceledException if 'instance' is Disposed
             return await instance.OpenContextForWriteAsync(action);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceContextHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceContextHost.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     /// </summary>
     [Export(typeof(IImplicitlyActiveService))]
     [AppliesTo(ProjectCapability.DotNetLanguageService2)]
-    internal partial class WorkspaceContextHost : AbstractMultiLifetimeComponent, IImplicitlyActiveService, IWorkspaceProjectContextHost
+    internal partial class WorkspaceContextHost : AbstractMultiLifetimeComponent<WorkspaceContextHost.WorkspaceContextHostInstance>, IImplicitlyActiveService, IWorkspaceProjectContextHost
     {
         private readonly ConfiguredProject _project;
         private readonly IProjectThreadingService _threadingService;
@@ -77,14 +77,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         {
             await Loaded;
 
-            var instance = (WorkspaceContextHostInstance)Instance;
+            WorkspaceContextHostInstance instance = Instance;
             if (instance == null)   // Unloaded between being Loaded and here
                 throw new OperationCanceledException();
 
             return instance;
         }
 
-        protected override IMultiLifetimeInstance CreateInstance()
+        protected override WorkspaceContextHostInstance CreateInstance()
         {
             return new WorkspaceContextHostInstance(_project, _threadingService, _tasksService, _projectSubscriptionService, _workspaceProjectContextProvider, _activeWorkspaceProjectContextTracker, _applyChangesToWorkspaceContextFactory);
         }


### PR DESCRIPTION
This fixes a deadlock when the UI thread is blocked on Loaded, such as during PrioritizedProjectLoad. This occurred because MultiLifetimeComponent.Loaded was backed by a TaskCompletionSource that did not have a JoinableTask relationship to the code that completed it (MultiLifetimeComponent.LoadAsync).

I sat down with Andrew Arnott came up with a design that creates the relationship. I've used the name Publish (mimicking ITreeService, etc) as this method is basically the precursor to #3425.