### PR TITLE
Dependency snapshot testing

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyModelFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyModelFactory.cs
@@ -127,10 +127,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         private class TestDependencyModel : IDependencyModel
         {
-            public TestDependencyModel()
-            {
-            }
-
             public string ProviderType { get; set; }
             public string Name { get; set; }
             public string Caption { get; set; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IMockDependenciesViewModelFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IMockDependenciesViewModelFactory.cs
@@ -37,9 +37,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 foreach (var d in createRootViewModel)
                 {
                     mock.Setup(x => x.CreateRootViewModel(
-                                        It.Is<string>((t) => string.Equals(t, d.ProviderType, System.StringComparison.OrdinalIgnoreCase)),
-                                        false))
-                        .Returns(((IDependencyModel)d).ToViewModel(false));
+                            It.Is<string>(t => string.Equals(t, d.ProviderType, System.StringComparison.OrdinalIgnoreCase)),
+                            false))
+                        .Returns(d.ToViewModel(false));
                 }
             }
 
@@ -49,14 +49,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 {
                     mock.Setup(x => x.CreateTargetViewModel(
                             It.Is<ITargetedDependenciesSnapshot>(
-                                (t) => string.Equals(t.TargetFramework.FullName, d.Caption, System.StringComparison.OrdinalIgnoreCase))))
-                        .Returns(((IDependencyModel)d).ToViewModel(false));
+                                t => string.Equals(t.TargetFramework.FullName, d.Caption, System.StringComparison.OrdinalIgnoreCase))))
+                        .Returns(d.ToViewModel(false));
                 }
             }
 
             return mock.Object;
         }
-
-
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IMockDependenciesViewModelFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IMockDependenciesViewModelFactory.cs
@@ -20,8 +20,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         public static IDependenciesViewModelFactory Implement(
             ImageMoniker? getDependenciesRootIcon = null,
-            IEnumerable<IDependency> createRootViewModel = null,
-            IEnumerable<IDependency> createTargetViewModel = null,
+            IEnumerable<IDependencyModel> createRootViewModel = null,
+            IEnumerable<IDependencyModel> createTargetViewModel = null,
             MockBehavior? mockBehavior = null)
         {
             var behavior = mockBehavior ?? MockBehavior.Strict;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITargetedDependenciesSnapshotFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITargetedDependenciesSnapshotFactory.cs
@@ -3,12 +3,15 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 
 using Moq;
+
+using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
@@ -81,13 +84,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             if (topLevelDependencies != null)
             {
-                var dependencies = ImmutableHashSet<IDependency>.Empty;
-                foreach (var d in topLevelDependencies)
-                {
-                    dependencies = dependencies.Add(d);
-                }
+                Assert.True(topLevelDependencies.All(d => d.TopLevel));
 
-                mock.Setup(x => x.TopLevelDependencies).Returns(dependencies);
+                mock.Setup(x => x.TopLevelDependencies)
+                    .Returns(ImmutableHashSet.CreateRange(topLevelDependencies));
             }
 
             if (checkForUnresolvedDependencies.HasValue)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITargetedDependenciesSnapshotFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITargetedDependenciesSnapshotFactory.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 
@@ -21,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         public static ITargetedDependenciesSnapshot Implement(
             string projectPath = null,
             ITargetFramework targetFramework = null,
-            Dictionary<string, IDependency> dependenciesWorld = null,
+            IEnumerable<IDependency> dependenciesWorld = null,
             bool? hasUnresolvedDependency = null,
             IProjectCatalogSnapshot catalogs = null,
             IEnumerable<IDependency> topLevelDependencies = null,
@@ -42,7 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         public static Mock<ITargetedDependenciesSnapshot> ImplementMock(
             string projectPath = null,
             ITargetFramework targetFramework = null,
-            Dictionary<string, IDependency> dependenciesWorld = null,
+            IEnumerable<IDependency> dependenciesWorld = null,
             bool? hasUnresolvedDependency = null,
             IProjectCatalogSnapshot catalogs = null,
             IEnumerable<IDependency> topLevelDependencies = null,
@@ -65,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             if (dependenciesWorld != null)
             {
                 mock.Setup(x => x.DependenciesWorld)
-                    .Returns(ImmutableStringDictionary<IDependency>.EmptyOrdinalIgnoreCase.AddRange(dependenciesWorld));
+                    .Returns(dependenciesWorld.ToImmutableDictionary(d => d.Id, StringComparer.OrdinalIgnoreCase));
             }
 
             if (hasUnresolvedDependency.HasValue)
@@ -106,7 +107,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             var behavior = mockBehavior ?? MockBehavior.Default;
             var mock = new Mock<ITargetedDependenciesSnapshot>(behavior);
 
-            mock.Setup(x => x.CheckForUnresolvedDependencies(It.Is<IDependency>(y => y.Id.Equals(id, System.StringComparison.OrdinalIgnoreCase))))
+            mock.Setup(x => x.CheckForUnresolvedDependencies(It.Is<IDependency>(y => y.Id.Equals(id, StringComparison.OrdinalIgnoreCase))))
                 .Returns(hasUnresolvedDependency);
 
             return mock.Object;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyTests.cs
@@ -50,12 +50,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         [Fact]
         public void Dependency_Constructor_WhenOptionalValuesNotProvided_ShouldSetDefaults()
         {
-            const string jsonModel = @"
-{
-    ""ProviderType"": ""xxx"",
-    ""Id"": ""mymodel""
-}";
-            var mockModel = IDependencyModelFactory.FromJson(jsonModel);
+            var mockModel = IDependencyModelFactory.FromJson(@"
+            {
+                ""ProviderType"": ""xxx"",
+                ""Id"": ""mymodel""
+            }");
 
             var dependency = new Dependency(mockModel, ITargetFrameworkFactory.Implement("tfm1"), @"C:\Foo\Project.csproj");
 
@@ -76,26 +75,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         [Fact]
         public void Dependency_Constructor_WhenValidModelProvided_ShouldSetAllProperties()
         {
-            const string jsonModel = @"
-{
-    ""ProviderType"": ""xxx"",
-    ""Id"": ""mymodelid"",
-    ""Name"": ""mymodelname"",
-    ""Version"": ""2.0.0-1"",
-    ""Caption"": ""mymodel"",
-    ""OriginalItemSpec"": ""mymodeloriginal"",
-    ""Path"": ""mymodelpath"",
-    ""SchemaName"": ""MySchema"",
-    ""SchemaItemType"": ""MySchemaItemType"",
-    ""Resolved"": ""true"",
-    ""TopLevel"": ""true"",
-    ""Implicit"": ""true"",
-    ""Visible"": ""true"",
-    ""Priority"": ""3""
-}";
-
-            var mockModel = IDependencyModelFactory.FromJson(
-                jsonModel,
+            var mockModel = IDependencyModelFactory.FromJson(@"
+                {
+                    ""ProviderType"": ""xxx"",
+                    ""Id"": ""mymodelid"",
+                    ""Name"": ""mymodelname"",
+                    ""Version"": ""2.0.0-1"",
+                    ""Caption"": ""mymodel"",
+                    ""OriginalItemSpec"": ""mymodeloriginal"",
+                    ""Path"": ""mymodelpath"",
+                    ""SchemaName"": ""MySchema"",
+                    ""SchemaItemType"": ""MySchemaItemType"",
+                    ""Resolved"": ""true"",
+                    ""TopLevel"": ""true"",
+                    ""Implicit"": ""true"",
+                    ""Visible"": ""true"",
+                    ""Priority"": ""3""
+                }",
                 flags: DependencyTreeFlags.DependencyFlags.Union(DependencyTreeFlags.GenericDependencyFlags),
                 icon: KnownMonikers.Path,
                 expandedIcon: KnownMonikers.PathIcon,
@@ -198,6 +194,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             Assert.Equal(dependency1, dependency2);
             Assert.NotEqual(dependency1, dependency3);
+            Assert.False(dependency1.Equals(other: null));
             Assert.Equal(dependency1.GetHashCode(), dependency2.GetHashCode());
             Assert.NotEqual(dependency1.GetHashCode(), dependency3.GetHashCode());
         }
@@ -335,27 +332,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         [Fact]
         public void WhenCreatingUnrelatedDependenciesWithSameIcons_BothUseSameIconSet()
         {
-            const string jsonModel1 = @"
-{
-    ""ProviderType"": ""alpha"",
-    ""Id"": ""modelOne"",
-}";
-
-            const string jsonModel2 = @"
-{
-    ""ProviderType"": ""beta"",
-    ""Id"": ""modelTwo"",
-}";
-
-            var model1 = IDependencyModelFactory.FromJson(
-                jsonModel1,
+            var model1 = IDependencyModelFactory.FromJson(@"
+                {
+                    ""ProviderType"": ""alpha"",
+                    ""Id"": ""modelOne"",
+                }",
                 icon: KnownMonikers.Path,
                 expandedIcon: KnownMonikers.PathIcon,
                 unresolvedIcon: KnownMonikers.PathListBox,
                 unresolvedExpandedIcon: KnownMonikers.PathListBoxItem);
 
-            var model2 = IDependencyModelFactory.FromJson(
-                jsonModel2,
+            var model2 = IDependencyModelFactory.FromJson(@"
+                {
+                    ""ProviderType"": ""beta"",
+                    ""Id"": ""modelTwo"",
+                }",
                 icon: KnownMonikers.Path,
                 expandedIcon: KnownMonikers.PathIcon,
                 unresolvedIcon: KnownMonikers.PathListBox,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyTests.cs
@@ -39,6 +39,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 var mockModel = IDependencyModelFactory.Implement(providerType: "someprovider", id: "id");
                 new Dependency(mockModel, null, null);
             });
+
+            Assert.Throws<ArgumentNullException>("containingProjectPath", () =>
+            {
+                var mockModel = IDependencyModelFactory.Implement(providerType: "someprovider", id: "id", originalItemSpec: "originalItemSpec");
+                new Dependency(mockModel, targetFramework: new TargetFramework("tfm"), containingProjectPath: null);
+            });
         }
 
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DuplicatedDependenciesSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DuplicatedDependenciesSnapshotFilterTests.cs
@@ -15,11 +15,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         [Fact]
         public void WhenThereNoMatchingDependencies_ShouldNotUpdateCaption()
         {
-            const string caption = "MyCaption";
             var dependency = IDependencyFactory.Implement(
                 providerType: "myprovider",
                 id: "mydependency1",
-                caption: caption);
+                caption: "MyCaption");
 
             var otherDependency = IDependencyFactory.Implement(
                     providerType: "myprovider",

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
@@ -77,7 +77,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var targetFramework = ITargetFrameworkFactory.Implement("tfm1");
 
-            var dependencyModelTop1 = IDependencyFactory.FromJson(@"
+            var dependencyTop1 = IDependencyFactory.FromJson(@"
 {
     ""ProviderType"": ""Xxx"",
     ""Id"": ""tfm1\\xxx\\topdependency1"",
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     ""Resolved"":""true""
 }", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
 
-            var dependencyModelChild1 = IDependencyFactory.FromJson(@"
+            var dependencyChild1 = IDependencyFactory.FromJson(@"
 {
     ""ProviderType"": ""Xxx"",
     ""Id"": ""tfm1\\xxx\\childdependency1"",
@@ -104,10 +104,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 catalogs: catalogs,
                 dependenciesWorld: new Dictionary<string, IDependency>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { dependencyModelTop1.Id, dependencyModelTop1 },
-                    { dependencyModelChild1.Id, dependencyModelChild1 },
+                    { dependencyTop1.Id, dependencyTop1 },
+                    { dependencyChild1.Id, dependencyChild1 },
                 },
-                topLevelDependencies: new [] { dependencyModelTop1 });
+                topLevelDependencies: new [] { dependencyTop1 });
 
             var changes = IDependenciesChangesFactory.Implement(
                 addedNodes: Array.Empty<IDependencyModel>(), 
@@ -131,7 +131,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var targetFramework = ITargetFrameworkFactory.Implement("tfm1");
 
-            var dependencyModelTop1 = IDependencyFactory.FromJson(@"
+            var dependencyTop1 = IDependencyFactory.FromJson(@"
 {
     ""ProviderType"": ""Xxx"",
     ""Id"": ""tfm1\\xxx\\topdependency1"",
@@ -141,7 +141,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     ""Resolved"":""true""
 }", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
 
-            var dependencyModelChild1 = IDependencyFactory.FromJson(@"
+            var dependencyChild1 = IDependencyFactory.FromJson(@"
 {
     ""ProviderType"": ""Xxx"",
     ""Id"": ""tfm1\\xxx\\childdependency1"",
@@ -158,14 +158,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 catalogs: catalogs,
                 dependenciesWorld: new Dictionary<string, IDependency>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { dependencyModelTop1.Id, dependencyModelTop1 },
-                    { dependencyModelChild1.Id, dependencyModelChild1 },
+                    { dependencyTop1.Id, dependencyTop1 },
+                    { dependencyChild1.Id, dependencyChild1 },
                 },
-                topLevelDependencies: new [] { dependencyModelTop1 });
+                topLevelDependencies: new [] { dependencyTop1 });
 
             var changes = IDependenciesChangesFactory.Implement(
                 addedNodes: Array.Empty<IDependencyModel>(), 
-                removedNodes: new [] { new RemovedDependencyIdentity(dependencyModelTop1.ProviderType, dependencyModelTop1.Id ) });
+                removedNodes: new [] { new RemovedDependencyIdentity(dependencyTop1.ProviderType, dependencyTop1.Id ) });
 
             var snapshotFilter = new TestDependenciesSnapshotFilter()
                     .ImplementBeforeRemoveResult(FilterAction.Cancel, @"tfm1\xxx\newdependency1", null);
@@ -188,7 +188,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var targetFramework = ITargetFrameworkFactory.Implement("tfm1");
 
-            var dependencyModelTop1 = IDependencyFactory.FromJson(@"
+            var dependencyTop1 = IDependencyFactory.FromJson(@"
 {
     ""ProviderType"": ""Xxx"",
     ""Id"": ""tfm1\\xxx\\topdependency1"",
@@ -198,22 +198,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     ""Resolved"":""true""
 }", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
 
-            var dependencyModelChild1 = IDependencyFactory.FromJson(@"
+            var dependencyChild1 = IDependencyFactory.FromJson(@"
 {
     ""ProviderType"": ""Xxx"",
     ""Id"": ""tfm1\\xxx\\childdependency1"",
     ""Name"":""ChildDependency1"",
     ""Caption"":""ChildDependency1"",
-    ""SchemaItemType"":""Xxx"",
-    ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
-
-            var dependencyModelTop1Removed = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Xxx"",
-    ""Id"": ""topdependency1"",
-    ""Name"":""TopDependency1"",
-    ""Caption"":""TopDependency1"",
     ""SchemaItemType"":""Xxx"",
     ""Resolved"":""true""
 }", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
@@ -225,14 +215,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 catalogs: catalogs,
                 dependenciesWorld: new Dictionary<string, IDependency>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { dependencyModelTop1.Id, dependencyModelTop1 },
-                    { dependencyModelChild1.Id, dependencyModelChild1 },
+                    { dependencyTop1.Id, dependencyTop1 },
+                    { dependencyChild1.Id, dependencyChild1 },
                 },
-                topLevelDependencies: new [] { dependencyModelTop1 });
+                topLevelDependencies: new [] { dependencyTop1 });
 
             var changes = IDependenciesChangesFactory.Implement(
                 addedNodes: Array.Empty<IDependencyModel>(), 
-                removedNodes: new [] { new RemovedDependencyIdentity(dependencyModelTop1Removed.ProviderType, dependencyModelTop1Removed.Id ) });
+                removedNodes: new [] { new RemovedDependencyIdentity("Xxx", "topdependency1") });
 
             var snapshotFilter = new TestDependenciesSnapshotFilter()
                     .ImplementBeforeRemoveResult(FilterAction.Cancel, @"tfm1\xxx\topdependency1", null)
@@ -262,7 +252,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var targetFramework = ITargetFrameworkFactory.Implement("tfm1");
 
-            var dependencyModelTop1 = IDependencyFactory.FromJson(@"
+            var dependencyTop1 = IDependencyFactory.FromJson(@"
 {
     ""ProviderType"": ""Xxx"",
     ""Id"": ""tfm1\\xxx\\topdependency1"",
@@ -272,7 +262,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     ""Resolved"":""true""
 }", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
 
-            var dependencyModelChild1 = IDependencyFactory.FromJson(@"
+            var dependencyChild1 = IDependencyFactory.FromJson(@"
 {
     ""ProviderType"": ""Xxx"",
     ""Id"": ""tfm1\\xxx\\childdependency1"",
@@ -282,7 +272,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     ""Resolved"":""true""
 }", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
 
-            var dependencyModelNew1 = IDependencyFactory.FromJson(@"
+            var dependencyModelNew1 = IDependencyModelFactory.FromJson(@"
 {
     ""ProviderType"": ""Xxx"",
     ""Id"": ""newdependency1"",
@@ -298,10 +288,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 catalogs: catalogs,
                 dependenciesWorld: new Dictionary<string, IDependency>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { dependencyModelTop1.Id, dependencyModelTop1 },
-                    { dependencyModelChild1.Id, dependencyModelChild1 },
+                    { dependencyTop1.Id, dependencyTop1 },
+                    { dependencyChild1.Id, dependencyChild1 },
                 },
-                topLevelDependencies: new [] { dependencyModelTop1 });
+                topLevelDependencies: new [] { dependencyTop1 });
 
             var changes = IDependenciesChangesFactory.Implement(
                 addedNodes: new [] { dependencyModelNew1 }, 
@@ -328,7 +318,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var targetFramework = ITargetFrameworkFactory.Implement("tfm1");
 
-            var dependencyModelTop1 = IDependencyFactory.FromJson(@"
+            var dependencyTop1 = IDependencyFactory.FromJson(@"
 {
     ""ProviderType"": ""Xxx"",
     ""Id"": ""tfm1\\xxx\\topdependency1"",
@@ -338,7 +328,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     ""Resolved"":""true""
 }", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
 
-            var dependencyModelChild1 = IDependencyFactory.FromJson(@"
+            var dependencyChild1 = IDependencyFactory.FromJson(@"
 {
     ""ProviderType"": ""Xxx"",
     ""Id"": ""tfm1\\xxx\\childdependency1"",
@@ -348,7 +338,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     ""Resolved"":""true""
 }", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
 
-            var dependencyModelNew1 = IDependencyFactory.FromJson(@"
+            var dependencyModelNew1 = IDependencyModelFactory.FromJson(@"
 {
     ""ProviderType"": ""Xxx"",
     ""Id"": ""newdependency1"",
@@ -365,10 +355,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 catalogs: catalogs,
                 dependenciesWorld: new Dictionary<string, IDependency>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { dependencyModelTop1.Id, dependencyModelTop1 },
-                    { dependencyModelChild1.Id, dependencyModelChild1 },
+                    { dependencyTop1.Id, dependencyTop1 },
+                    { dependencyChild1.Id, dependencyChild1 },
                 },
-                topLevelDependencies: new [] { dependencyModelTop1 });
+                topLevelDependencies: new [] { dependencyTop1 });
 
             var changes = IDependenciesChangesFactory.Implement(
                 addedNodes: new [] { dependencyModelNew1 }, 
@@ -402,7 +392,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var targetFramework = ITargetFrameworkFactory.Implement("tfm1");
 
-            var dependencyModelTop1 = IDependencyFactory.FromJson(@"
+            var dependencyTop1 = IDependencyFactory.FromJson(@"
 {
     ""ProviderType"": ""Xxx"",
     ""Id"": ""topdependency1"",
@@ -412,7 +402,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     ""Resolved"":""true""
 }", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
 
-            var dependencyModelChild1 = IDependencyFactory.FromJson(@"
+            var dependencyChild1 = IDependencyFactory.FromJson(@"
 {
     ""ProviderType"": ""Xxx"",
     ""Id"": ""childdependency1"",
@@ -422,7 +412,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     ""Resolved"":""true""
 }", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
 
-            var dependencyModelAdded1 = IDependencyFactory.FromJson(@"
+            var dependencyModelAdded1 = IDependencyModelFactory.FromJson(@"
 {
     ""ProviderType"": ""Xxx"",
     ""Id"": ""addeddependency1"",
@@ -432,7 +422,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     ""Resolved"":""true""
 }", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
 
-            var dependencyModelAdded2 = IDependencyFactory.FromJson(@"
+            var dependencyModelAdded2 = IDependencyModelFactory.FromJson(@"
 {
     ""ProviderType"": ""Xxx"",
     ""Id"": ""addeddependency2"",
@@ -442,7 +432,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     ""Resolved"":""true""
 }", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
 
-            var dependencyModelAdded3 = IDependencyFactory.FromJson(@"
+            var dependencyModelAdded3 = IDependencyModelFactory.FromJson(@"
 {
     ""ProviderType"": ""Xxx"",
     ""Id"": ""addeddependency3"",
@@ -473,16 +463,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     ""Resolved"":""true""
 }", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
 
-            var dependencyModelRemoved1 = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Xxx"",
-    ""Id"": ""Removeddependency1"",
-    ""Name"":""RemovedDependency1"",
-    ""Caption"":""RemovedDependency1"",
-    ""SchemaItemType"":""Xxx"",
-    ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
-
             var dependencyInsteadRemoved1 = IDependencyFactory.FromJson(@"
 {
     ""ProviderType"": ""Xxx"",
@@ -500,15 +480,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 catalogs: catalogs,
                 dependenciesWorld: new Dictionary<string, IDependency>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { @"tfm1\xxx\topdependency1", dependencyModelTop1 },
-                    { @"tfm1\xxx\childdependency1", dependencyModelChild1 },
+                    { @"tfm1\xxx\topdependency1", dependencyTop1 },
+                    { @"tfm1\xxx\childdependency1", dependencyChild1 },
                     { @"tfm1\xxx\Removeddependency1", dependencyRemoved1 },
                 },
-                topLevelDependencies: new [] { dependencyModelTop1 });
+                topLevelDependencies: new [] { dependencyTop1 });
 
             var changes = IDependenciesChangesFactory.Implement(
                 addedNodes: new [] { dependencyModelAdded1, dependencyModelAdded2, dependencyModelAdded3 },
-                removedNodes: new[] { new RemovedDependencyIdentity(dependencyModelRemoved1.ProviderType, dependencyModelRemoved1.Id) });
+                removedNodes: new[] { new RemovedDependencyIdentity("Xxx", "Removeddependency1") });
 
             var snapshotFilter = new TestDependenciesSnapshotFilter()
                 .ImplementBeforeAddResult(FilterAction.Cancel, @"tfm1\xxx\addeddependency1", null)
@@ -546,7 +526,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var targetFramework = ITargetFrameworkFactory.Implement("tfm1");
 
-            var dependencyModelTopPrevious = IDependencyFactory.FromJson(@"
+            var dependencyTopPrevious = IDependencyFactory.FromJson(@"
             {
                 ""ProviderType"": ""Xxx"",
                 ""Id"": ""tfm1\\xxx\\topdependency1"",
@@ -556,7 +536,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 ""Resolved"": ""true""
             }", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
 
-            var dependencyModelTopAdded = IDependencyFactory.FromJson(@"
+            var dependencyModelTopAdded = IDependencyModelFactory.FromJson(@"
             {
                 ""ProviderType"": ""Xxx"",
                 ""Id"": ""topdependency1"",
@@ -566,7 +546,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 ""Resolved"": ""true""
             }", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
 
-            var dependencyModelTopUpdated = IDependencyFactory.FromJson(@"
+            var dependencyTopUpdated = IDependencyFactory.FromJson(@"
             {
                 ""ProviderType"": ""Xxx"",
                 ""Id"": ""tfm1\\xxx\\topdependency1"",
@@ -582,14 +562,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 targetFramework: targetFramework,
                 catalogs: catalogs,
                 dependenciesWorld: new Dictionary<string, IDependency>(StringComparer.OrdinalIgnoreCase),
-                topLevelDependencies: new[] { dependencyModelTopPrevious });
+                topLevelDependencies: new[] { dependencyTopPrevious });
 
             var changes = IDependenciesChangesFactory.Implement(
                 addedNodes: new[] { dependencyModelTopAdded },
                 removedNodes: Array.Empty<RemovedDependencyIdentity>());
 
             var snapshotFilter = new TestDependenciesSnapshotFilter()
-                    .ImplementBeforeAddResult(FilterAction.ShouldBeAdded, @"tfm1\xxx\topdependency1", dependencyModelTopUpdated);
+                    .ImplementBeforeAddResult(FilterAction.ShouldBeAdded, @"tfm1\xxx\topdependency1", dependencyTopUpdated);
 
             var snapshot = TargetedDependenciesSnapshot.FromChanges(
                 projectPath,
@@ -601,7 +581,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 null);
 
             Assert.NotSame(previousSnapshot, snapshot);
-            Assert.Same(dependencyModelTopUpdated, snapshot.TopLevelDependencies.Single());
+            Assert.Same(dependencyTopUpdated, snapshot.TopLevelDependencies.Single());
         }
 
         /// <summary>
@@ -611,7 +591,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         [Fact]
         public void TCheckForUnresolvedDependencies_CircularDependency_DoesNotRecurseInfinitely()
         {
-            var dependencyModelTop1 = IDependencyFactory.FromJson(@"
+            var dependencyTop1 = IDependencyFactory.FromJson(@"
             {
                 ""ProviderType"": ""Xxx"",
                 ""Id"": ""tfm1\\xxx\\topdependency1"",
@@ -622,7 +602,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 ""DependencyIDs"": [ ""tfm1\\xxx\\topdependency2"" ]
             }", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
 
-            var dependencyModelTop2 = IDependencyFactory.FromJson(@"
+            var dependencyTop2 = IDependencyFactory.FromJson(@"
             {
                 ""ProviderType"": ""Xxx"",
                 ""Id"": ""tfm1\\xxx\\topdependency2"",
@@ -639,13 +619,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 catalogs: null,
                 dependenciesWorld: new Dictionary<string, IDependency>()
                 {
-                    { dependencyModelTop1.Id, dependencyModelTop1 },
-                    { dependencyModelTop2.Id, dependencyModelTop2 },
+                    { dependencyTop1.Id, dependencyTop1 },
+                    { dependencyTop2.Id, dependencyTop2 },
                 }.ToImmutableDictionary(),
-                topLevelDependencies: new List<IDependency>() { dependencyModelTop1 }.ToImmutableHashSet());
+                topLevelDependencies: new List<IDependency>() { dependencyTop1 }.ToImmutableHashSet());
 
             // verify it doesn't stack overflow
-            previousSnapshot.CheckForUnresolvedDependencies(dependencyModelTop1);   
+            previousSnapshot.CheckForUnresolvedDependencies(dependencyTop1);   
         }
 
         internal enum FilterAction

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
@@ -424,7 +424,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     ""Name"":""TopDependency1"",
                     ""Caption"":""TopDependency1"",
                     ""SchemaItemType"":""Xxx"",
-                    ""Resolved"":""true""
+                    ""Resolved"":""true"",
+                    ""TopLevel"":""true""
                 }",
                 icon: KnownMonikers.Uninstall,
                 expandedIcon: KnownMonikers.Uninstall);
@@ -436,7 +437,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     ""Name"":""ChildDependency1"",
                     ""Caption"":""ChildDependency1"",
                     ""SchemaItemType"":""Xxx"",
-                    ""Resolved"":""true""
+                    ""Resolved"":""true"",
+                    ""TopLevel"":""false""
                 }",
                 icon: KnownMonikers.Uninstall,
                 expandedIcon: KnownMonikers.Uninstall);
@@ -448,7 +450,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     ""Name"":""AddedDependency1"",
                     ""Caption"":""AddedDependency1"",
                     ""SchemaItemType"":""Xxx"",
-                    ""Resolved"":""true""
+                    ""Resolved"":""true"",
+                    ""TopLevel"":""false""
                 }",
                 icon: KnownMonikers.Uninstall,
                 expandedIcon: KnownMonikers.Uninstall);
@@ -460,7 +463,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     ""Name"":""AddedDependency2"",
                     ""Caption"":""AddedDependency2"",
                     ""SchemaItemType"":""Xxx"",
-                    ""Resolved"":""true""
+                    ""Resolved"":""true"",
+                    ""TopLevel"":""false""
                 }",
                 icon: KnownMonikers.Uninstall,
                 expandedIcon: KnownMonikers.Uninstall);
@@ -485,7 +489,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     ""Name"":""AddedDependency2Changed"",
                     ""Caption"":""AddedDependency2Changed"",
                     ""SchemaItemType"":""Xxx"",
-                    ""Resolved"":""true""
+                    ""Resolved"":""true"",
+                    ""TopLevel"":""true""
                 }",
                 icon: KnownMonikers.Uninstall,
                 expandedIcon: KnownMonikers.Uninstall);
@@ -497,7 +502,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     ""Name"":""RemovedDependency1"",
                     ""Caption"":""RemovedDependency1"",
                     ""SchemaItemType"":""Xxx"",
-                    ""Resolved"":""true""
+                    ""Resolved"":""true"",
+                    ""TopLevel"":""false""
                 }",
                 icon: KnownMonikers.Uninstall,
                 expandedIcon: KnownMonikers.Uninstall);
@@ -509,10 +515,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     ""Name"":""InsteadRemovedDependency1"",
                     ""Caption"":""InsteadRemovedDependency1"",
                     ""SchemaItemType"":""Xxx"",
-                    ""Resolved"":""true""
+                    ""Resolved"":""true"",
+                    ""TopLevel"":""false""
                 }",
                 icon: KnownMonikers.Uninstall,
                 expandedIcon: KnownMonikers.Uninstall);
+
+            Assert.True(dependencyTop1.TopLevel);
+            Assert.False(dependencyChild1.TopLevel);
+            Assert.False(dependencyRemoved1.TopLevel);
 
             var catalogs = IProjectCatalogSnapshotFactory.Create();
             var previousSnapshot = ITargetedDependenciesSnapshotFactory.Implement(
@@ -521,9 +532,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 catalogs: catalogs,
                 dependenciesWorld: new Dictionary<string, IDependency>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { @"tfm1\xxx\topdependency1", dependencyTop1 },
-                    { @"tfm1\xxx\childdependency1", dependencyChild1 },
-                    { @"tfm1\xxx\Removeddependency1", dependencyRemoved1 },
+                    { dependencyTop1.Id, dependencyTop1 },
+                    { dependencyChild1.Id, dependencyChild1 },
+                    { dependencyRemoved1.Id, dependencyRemoved1 },
                 },
                 topLevelDependencies: new [] { dependencyTop1 });
 
@@ -646,6 +657,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     ""Caption"":""TopDependency1"",
                     ""SchemaItemType"":""Xxx"",
                     ""Resolved"":""true"",
+                    ""TopLevel"":""true"",
                     ""DependencyIDs"": [ ""tfm1\\xxx\\topdependency2"" ]
                 }",
                 icon: KnownMonikers.Uninstall,
@@ -659,6 +671,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     ""Caption"":""TopDependency2"",
                     ""SchemaItemType"":""Xxx"",
                     ""Resolved"":""true"",
+                    ""TopLevel"":""false"",
                     ""DependencyIDs"": [ ""tfm1\\xxx\\topdependency1"" ]
                 }",
                 icon: KnownMonikers.Uninstall,
@@ -738,6 +751,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     {
                         worldBuilder.Remove(info.Item1.Id);
                         worldBuilder.Add(info.Item1.Id, info.Item1);
+
+                        if (info.Item1.TopLevel)
+                        {
+                            topLevelBuilder.Remove(info.Item1);
+                            topLevelBuilder.Add(info.Item1);
+                        }
+
                         return info.Item1;
                     }
                     else

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
@@ -78,24 +78,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var targetFramework = ITargetFrameworkFactory.Implement("tfm1");
 
             var dependencyTop1 = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Xxx"",
-    ""Id"": ""tfm1\\xxx\\topdependency1"",
-    ""Name"":""TopDependency1"",
-    ""Caption"":""TopDependency1"",
-    ""SchemaItemType"":""Xxx"",
-    ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+                {
+                    ""ProviderType"": ""Xxx"",
+                    ""Id"": ""tfm1\\xxx\\topdependency1"",
+                    ""Name"":""TopDependency1"",
+                    ""Caption"":""TopDependency1"",
+                    ""SchemaItemType"":""Xxx"",
+                    ""Resolved"":""true""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall);
 
             var dependencyChild1 = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Xxx"",
-    ""Id"": ""tfm1\\xxx\\childdependency1"",
-    ""Name"":""ChildDependency1"",
-    ""Caption"":""ChildDependency1"",
-    ""SchemaItemType"":""Xxx"",
-    ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+                {
+                    ""ProviderType"": ""Xxx"",
+                    ""Id"": ""tfm1\\xxx\\childdependency1"",
+                    ""Name"":""ChildDependency1"",
+                    ""Caption"":""ChildDependency1"",
+                    ""SchemaItemType"":""Xxx"",
+                    ""Resolved"":""true""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall);
 
             var catalogs = IProjectCatalogSnapshotFactory.Create();
             var previousSnapshot = ITargetedDependenciesSnapshotFactory.Implement(
@@ -132,24 +136,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var targetFramework = ITargetFrameworkFactory.Implement("tfm1");
 
             var dependencyTop1 = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Xxx"",
-    ""Id"": ""tfm1\\xxx\\topdependency1"",
-    ""Name"":""TopDependency1"",
-    ""Caption"":""TopDependency1"",
-    ""SchemaItemType"":""Xxx"",
-    ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+                {
+                    ""ProviderType"": ""Xxx"",
+                    ""Id"": ""tfm1\\xxx\\topdependency1"",
+                    ""Name"":""TopDependency1"",
+                    ""Caption"":""TopDependency1"",
+                    ""SchemaItemType"":""Xxx"",
+                    ""Resolved"":""true""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall);
 
             var dependencyChild1 = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Xxx"",
-    ""Id"": ""tfm1\\xxx\\childdependency1"",
-    ""Name"":""ChildDependency1"",
-    ""Caption"":""ChildDependency1"",
-    ""SchemaItemType"":""Xxx"",
-    ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+                {
+                    ""ProviderType"": ""Xxx"",
+                    ""Id"": ""tfm1\\xxx\\childdependency1"",
+                    ""Name"":""ChildDependency1"",
+                    ""Caption"":""ChildDependency1"",
+                    ""SchemaItemType"":""Xxx"",
+                    ""Resolved"":""true""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall);
 
             var catalogs = IProjectCatalogSnapshotFactory.Create();
             var previousSnapshot = ITargetedDependenciesSnapshotFactory.Implement(
@@ -189,24 +197,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var targetFramework = ITargetFrameworkFactory.Implement("tfm1");
 
             var dependencyTop1 = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Xxx"",
-    ""Id"": ""tfm1\\xxx\\topdependency1"",
-    ""Name"":""TopDependency1"",
-    ""Caption"":""TopDependency1"",
-    ""SchemaItemType"":""Xxx"",
-    ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+                {
+                    ""ProviderType"": ""Xxx"",
+                    ""Id"": ""tfm1\\xxx\\topdependency1"",
+                    ""Name"":""TopDependency1"",
+                    ""Caption"":""TopDependency1"",
+                    ""SchemaItemType"":""Xxx"",
+                    ""Resolved"":""true""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall);
 
             var dependencyChild1 = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Xxx"",
-    ""Id"": ""tfm1\\xxx\\childdependency1"",
-    ""Name"":""ChildDependency1"",
-    ""Caption"":""ChildDependency1"",
-    ""SchemaItemType"":""Xxx"",
-    ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+                {
+                    ""ProviderType"": ""Xxx"",
+                    ""Id"": ""tfm1\\xxx\\childdependency1"",
+                    ""Name"":""ChildDependency1"",
+                    ""Caption"":""ChildDependency1"",
+                    ""SchemaItemType"":""Xxx"",
+                    ""Resolved"":""true""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall);
 
             var catalogs = IProjectCatalogSnapshotFactory.Create();
             var previousSnapshot = ITargetedDependenciesSnapshotFactory.Implement(
@@ -253,34 +265,41 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var targetFramework = ITargetFrameworkFactory.Implement("tfm1");
 
             var dependencyTop1 = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Xxx"",
-    ""Id"": ""tfm1\\xxx\\topdependency1"",
-    ""Name"":""TopDependency1"",
-    ""Caption"":""TopDependency1"",
-    ""SchemaItemType"":""Xxx"",
-    ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+                {
+                    ""ProviderType"": ""Xxx"",
+                    ""Id"": ""tfm1\\xxx\\topdependency1"",
+                    ""Name"":""TopDependency1"",
+                    ""Caption"":""TopDependency1"",
+                    ""SchemaItemType"":""Xxx"",
+                    ""Resolved"":""true""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall);
 
             var dependencyChild1 = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Xxx"",
-    ""Id"": ""tfm1\\xxx\\childdependency1"",
-    ""Name"":""ChildDependency1"",
-    ""Caption"":""ChildDependency1"",
-    ""SchemaItemType"":""Xxx"",
-    ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+                {
+                    ""ProviderType"": ""Xxx"",
+                    ""Id"": ""tfm1\\xxx\\childdependency1"",
+                    ""Name"":""ChildDependency1"",
+                    ""Caption"":""ChildDependency1"",
+                    ""SchemaItemType"":""Xxx"",
+                    ""Resolved"":""true""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall);
 
             var dependencyModelNew1 = IDependencyModelFactory.FromJson(@"
-{
-    ""ProviderType"": ""Xxx"",
-    ""Id"": ""newdependency1"",
-    ""Name"":""NewDependency1"",
-    ""Caption"":""NewDependency1"",
-    ""SchemaItemType"":""Xxx"",
-    ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+                {
+                    ""ProviderType"": ""Xxx"",
+                    ""Id"": ""newdependency1"",
+                    ""Name"":""NewDependency1"",
+                    ""Caption"":""NewDependency1"",
+                    ""SchemaItemType"":""Xxx"",
+                    ""Resolved"":""true""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall);
+
             var catalogs = IProjectCatalogSnapshotFactory.Create();
             var previousSnapshot = ITargetedDependenciesSnapshotFactory.Implement(
                 projectPath: projectPath,
@@ -319,34 +338,40 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var targetFramework = ITargetFrameworkFactory.Implement("tfm1");
 
             var dependencyTop1 = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Xxx"",
-    ""Id"": ""tfm1\\xxx\\topdependency1"",
-    ""Name"":""TopDependency1"",
-    ""Caption"":""TopDependency1"",
-    ""SchemaItemType"":""Xxx"",
-    ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+                {
+                    ""ProviderType"": ""Xxx"",
+                    ""Id"": ""tfm1\\xxx\\topdependency1"",
+                    ""Name"":""TopDependency1"",
+                    ""Caption"":""TopDependency1"",
+                    ""SchemaItemType"":""Xxx"",
+                    ""Resolved"":""true""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall);
 
             var dependencyChild1 = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Xxx"",
-    ""Id"": ""tfm1\\xxx\\childdependency1"",
-    ""Name"":""ChildDependency1"",
-    ""Caption"":""ChildDependency1"",
-    ""SchemaItemType"":""Xxx"",
-    ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+                {
+                    ""ProviderType"": ""Xxx"",
+                    ""Id"": ""tfm1\\xxx\\childdependency1"",
+                    ""Name"":""ChildDependency1"",
+                    ""Caption"":""ChildDependency1"",
+                    ""SchemaItemType"":""Xxx"",
+                    ""Resolved"":""true""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall);
 
             var dependencyModelNew1 = IDependencyModelFactory.FromJson(@"
-{
-    ""ProviderType"": ""Xxx"",
-    ""Id"": ""newdependency1"",
-    ""Name"":""NewDependency1"",
-    ""Caption"":""NewDependency1"",
-    ""SchemaItemType"":""Xxx"",
-    ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+                {
+                    ""ProviderType"": ""Xxx"",
+                    ""Id"": ""newdependency1"",
+                    ""Name"":""NewDependency1"",
+                    ""Caption"":""NewDependency1"",
+                    ""SchemaItemType"":""Xxx"",
+                    ""Resolved"":""true""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall);
 
             var catalogs = IProjectCatalogSnapshotFactory.Create();
             var previousSnapshot = ITargetedDependenciesSnapshotFactory.Implement(
@@ -393,85 +418,101 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var targetFramework = ITargetFrameworkFactory.Implement("tfm1");
 
             var dependencyTop1 = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Xxx"",
-    ""Id"": ""topdependency1"",
-    ""Name"":""TopDependency1"",
-    ""Caption"":""TopDependency1"",
-    ""SchemaItemType"":""Xxx"",
-    ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+                {
+                    ""ProviderType"": ""Xxx"",
+                    ""Id"": ""topdependency1"",
+                    ""Name"":""TopDependency1"",
+                    ""Caption"":""TopDependency1"",
+                    ""SchemaItemType"":""Xxx"",
+                    ""Resolved"":""true""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall);
 
             var dependencyChild1 = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Xxx"",
-    ""Id"": ""childdependency1"",
-    ""Name"":""ChildDependency1"",
-    ""Caption"":""ChildDependency1"",
-    ""SchemaItemType"":""Xxx"",
-    ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+                {
+                    ""ProviderType"": ""Xxx"",
+                    ""Id"": ""childdependency1"",
+                    ""Name"":""ChildDependency1"",
+                    ""Caption"":""ChildDependency1"",
+                    ""SchemaItemType"":""Xxx"",
+                    ""Resolved"":""true""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall);
 
             var dependencyModelAdded1 = IDependencyModelFactory.FromJson(@"
-{
-    ""ProviderType"": ""Xxx"",
-    ""Id"": ""addeddependency1"",
-    ""Name"":""AddedDependency1"",
-    ""Caption"":""AddedDependency1"",
-    ""SchemaItemType"":""Xxx"",
-    ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+                {
+                    ""ProviderType"": ""Xxx"",
+                    ""Id"": ""addeddependency1"",
+                    ""Name"":""AddedDependency1"",
+                    ""Caption"":""AddedDependency1"",
+                    ""SchemaItemType"":""Xxx"",
+                    ""Resolved"":""true""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall);
 
             var dependencyModelAdded2 = IDependencyModelFactory.FromJson(@"
-{
-    ""ProviderType"": ""Xxx"",
-    ""Id"": ""addeddependency2"",
-    ""Name"":""AddedDependency2"",
-    ""Caption"":""AddedDependency2"",
-    ""SchemaItemType"":""Xxx"",
-    ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+                {
+                    ""ProviderType"": ""Xxx"",
+                    ""Id"": ""addeddependency2"",
+                    ""Name"":""AddedDependency2"",
+                    ""Caption"":""AddedDependency2"",
+                    ""SchemaItemType"":""Xxx"",
+                    ""Resolved"":""true""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall);
 
             var dependencyModelAdded3 = IDependencyModelFactory.FromJson(@"
-{
-    ""ProviderType"": ""Xxx"",
-    ""Id"": ""addeddependency3"",
-    ""Name"":""AddedDependency3"",
-    ""Caption"":""AddedDependency3"",
-    ""SchemaItemType"":""Xxx"",
-    ""Resolved"":""true"",
-    ""TopLevel"":""false""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+                {
+                    ""ProviderType"": ""Xxx"",
+                    ""Id"": ""addeddependency3"",
+                    ""Name"":""AddedDependency3"",
+                    ""Caption"":""AddedDependency3"",
+                    ""SchemaItemType"":""Xxx"",
+                    ""Resolved"":""true"",
+                    ""TopLevel"":""false""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall);
 
             var dependencyAdded2Changed = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Xxx"",
-    ""Id"": ""tfm1\\xxx\\addeddependency2"",
-    ""Name"":""AddedDependency2Changed"",
-    ""Caption"":""AddedDependency2Changed"",
-    ""SchemaItemType"":""Xxx"",
-    ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+                {
+                    ""ProviderType"": ""Xxx"",
+                    ""Id"": ""tfm1\\xxx\\addeddependency2"",
+                    ""Name"":""AddedDependency2Changed"",
+                    ""Caption"":""AddedDependency2Changed"",
+                    ""SchemaItemType"":""Xxx"",
+                    ""Resolved"":""true""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall);
 
             var dependencyRemoved1 = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Xxx"",
-    ""Id"": ""tfm1\\xxx\\Removeddependency1"",
-    ""Name"":""RemovedDependency1"",
-    ""Caption"":""RemovedDependency1"",
-    ""SchemaItemType"":""Xxx"",
-    ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+                {
+                    ""ProviderType"": ""Xxx"",
+                    ""Id"": ""tfm1\\xxx\\Removeddependency1"",
+                    ""Name"":""RemovedDependency1"",
+                    ""Caption"":""RemovedDependency1"",
+                    ""SchemaItemType"":""Xxx"",
+                    ""Resolved"":""true""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall);
 
             var dependencyInsteadRemoved1 = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Xxx"",
-    ""Id"": ""tfm1\\xxx\\InsteadRemoveddependency1"",
-    ""Name"":""InsteadRemovedDependency1"",
-    ""Caption"":""InsteadRemovedDependency1"",
-    ""SchemaItemType"":""Xxx"",
-    ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+                {
+                    ""ProviderType"": ""Xxx"",
+                    ""Id"": ""tfm1\\xxx\\InsteadRemoveddependency1"",
+                    ""Name"":""InsteadRemovedDependency1"",
+                    ""Caption"":""InsteadRemovedDependency1"",
+                    ""SchemaItemType"":""Xxx"",
+                    ""Resolved"":""true""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall);
 
             var catalogs = IProjectCatalogSnapshotFactory.Create();
             var previousSnapshot = ITargetedDependenciesSnapshotFactory.Implement(
@@ -527,34 +568,40 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var targetFramework = ITargetFrameworkFactory.Implement("tfm1");
 
             var dependencyTopPrevious = IDependencyFactory.FromJson(@"
-            {
-                ""ProviderType"": ""Xxx"",
-                ""Id"": ""tfm1\\xxx\\topdependency1"",
-                ""Name"": ""TopDependency1"",
-                ""Caption"": ""TopDependency1"",
-                ""SchemaItemType"": ""Xxx"",
-                ""Resolved"": ""true""
-            }", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+                {
+                    ""ProviderType"": ""Xxx"",
+                    ""Id"": ""tfm1\\xxx\\topdependency1"",
+                    ""Name"": ""TopDependency1"",
+                    ""Caption"": ""TopDependency1"",
+                    ""SchemaItemType"": ""Xxx"",
+                    ""Resolved"": ""true""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall);
 
             var dependencyModelTopAdded = IDependencyModelFactory.FromJson(@"
-            {
-                ""ProviderType"": ""Xxx"",
-                ""Id"": ""topdependency1"",
-                ""Name"": ""TopDependency1"",
-                ""Caption"": ""TopDependency1"",
-                ""SchemaItemType"": ""Xxx"",
-                ""Resolved"": ""true""
-            }", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+                {
+                    ""ProviderType"": ""Xxx"",
+                    ""Id"": ""topdependency1"",
+                    ""Name"": ""TopDependency1"",
+                    ""Caption"": ""TopDependency1"",
+                    ""SchemaItemType"": ""Xxx"",
+                    ""Resolved"": ""true""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall);
 
             var dependencyTopUpdated = IDependencyFactory.FromJson(@"
-            {
-                ""ProviderType"": ""Xxx"",
-                ""Id"": ""tfm1\\xxx\\topdependency1"",
-                ""Name"": ""TopDependency1"",
-                ""Caption"": ""TopDependency1"",
-                ""SchemaItemType"": ""Xxx"",
-                ""Resolved"": ""true""
-            }", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+                {
+                    ""ProviderType"": ""Xxx"",
+                    ""Id"": ""tfm1\\xxx\\topdependency1"",
+                    ""Name"": ""TopDependency1"",
+                    ""Caption"": ""TopDependency1"",
+                    ""SchemaItemType"": ""Xxx"",
+                    ""Resolved"": ""true""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall);
 
             var catalogs = IProjectCatalogSnapshotFactory.Create();
             var previousSnapshot = ITargetedDependenciesSnapshotFactory.Implement(
@@ -592,26 +639,30 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         public void TCheckForUnresolvedDependencies_CircularDependency_DoesNotRecurseInfinitely()
         {
             var dependencyTop1 = IDependencyFactory.FromJson(@"
-            {
-                ""ProviderType"": ""Xxx"",
-                ""Id"": ""tfm1\\xxx\\topdependency1"",
-                ""Name"":""TopDependency1"",
-                ""Caption"":""TopDependency1"",
-                ""SchemaItemType"":""Xxx"",
-                ""Resolved"":""true"",
-                ""DependencyIDs"": [ ""tfm1\\xxx\\topdependency2"" ]
-            }", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+                {
+                    ""ProviderType"": ""Xxx"",
+                    ""Id"": ""tfm1\\xxx\\topdependency1"",
+                    ""Name"":""TopDependency1"",
+                    ""Caption"":""TopDependency1"",
+                    ""SchemaItemType"":""Xxx"",
+                    ""Resolved"":""true"",
+                    ""DependencyIDs"": [ ""tfm1\\xxx\\topdependency2"" ]
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall);
 
             var dependencyTop2 = IDependencyFactory.FromJson(@"
-            {
-                ""ProviderType"": ""Xxx"",
-                ""Id"": ""tfm1\\xxx\\topdependency2"",
-                ""Name"":""TopDependency2"",
-                ""Caption"":""TopDependency2"",
-                ""SchemaItemType"":""Xxx"",
-                ""Resolved"":""true"",
-                ""DependencyIDs"": [ ""tfm1\\xxx\\topdependency1"" ]
-            }", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+                {
+                    ""ProviderType"": ""Xxx"",
+                    ""Id"": ""tfm1\\xxx\\topdependency2"",
+                    ""Name"":""TopDependency2"",
+                    ""Caption"":""TopDependency2"",
+                    ""SchemaItemType"":""Xxx"",
+                    ""Resolved"":""true"",
+                    ""DependencyIDs"": [ ""tfm1\\xxx\\topdependency1"" ]
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall);
 
             var previousSnapshot = new TargetedDependenciesSnapshot(
                 "ProjectPath",

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
@@ -84,7 +84,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     ""Name"":""TopDependency1"",
                     ""Caption"":""TopDependency1"",
                     ""SchemaItemType"":""Xxx"",
-                    ""Resolved"":""true""
+                    ""Resolved"":""true"",
+                    ""TopLevel"":""true""
                 }",
                 icon: KnownMonikers.Uninstall,
                 expandedIcon: KnownMonikers.Uninstall);
@@ -96,7 +97,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     ""Name"":""ChildDependency1"",
                     ""Caption"":""ChildDependency1"",
                     ""SchemaItemType"":""Xxx"",
-                    ""Resolved"":""true""
+                    ""Resolved"":""true"",
+                    ""TopLevel"":""false""
                 }",
                 icon: KnownMonikers.Uninstall,
                 expandedIcon: KnownMonikers.Uninstall);
@@ -138,7 +140,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     ""Name"":""TopDependency1"",
                     ""Caption"":""TopDependency1"",
                     ""SchemaItemType"":""Xxx"",
-                    ""Resolved"":""true""
+                    ""Resolved"":""true"",
+                    ""TopLevel"":""true""
                 }",
                 icon: KnownMonikers.Uninstall,
                 expandedIcon: KnownMonikers.Uninstall);
@@ -150,7 +153,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     ""Name"":""ChildDependency1"",
                     ""Caption"":""ChildDependency1"",
                     ""SchemaItemType"":""Xxx"",
-                    ""Resolved"":""true""
+                    ""Resolved"":""true"",
+                    ""TopLevel"":""false""
                 }",
                 icon: KnownMonikers.Uninstall,
                 expandedIcon: KnownMonikers.Uninstall);
@@ -195,7 +199,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     ""Name"":""TopDependency1"",
                     ""Caption"":""TopDependency1"",
                     ""SchemaItemType"":""Xxx"",
-                    ""Resolved"":""true""
+                    ""Resolved"":""true"",
+                    ""TopLevel"":""true""
                 }",
                 icon: KnownMonikers.Uninstall,
                 expandedIcon: KnownMonikers.Uninstall);
@@ -207,7 +212,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     ""Name"":""ChildDependency1"",
                     ""Caption"":""ChildDependency1"",
                     ""SchemaItemType"":""Xxx"",
-                    ""Resolved"":""true""
+                    ""Resolved"":""true"",
+                    ""TopLevel"":""false""
                 }",
                 icon: KnownMonikers.Uninstall,
                 expandedIcon: KnownMonikers.Uninstall);
@@ -259,7 +265,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     ""Name"":""TopDependency1"",
                     ""Caption"":""TopDependency1"",
                     ""SchemaItemType"":""Xxx"",
-                    ""Resolved"":""true""
+                    ""Resolved"":""true"",
+                    ""TopLevel"":""true""
                 }",
                 icon: KnownMonikers.Uninstall,
                 expandedIcon: KnownMonikers.Uninstall);
@@ -271,7 +278,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     ""Name"":""ChildDependency1"",
                     ""Caption"":""ChildDependency1"",
                     ""SchemaItemType"":""Xxx"",
-                    ""Resolved"":""true""
+                    ""Resolved"":""true"",
+                    ""TopLevel"":""false""
                 }",
                 icon: KnownMonikers.Uninstall,
                 expandedIcon: KnownMonikers.Uninstall);
@@ -328,7 +336,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     ""Name"":""TopDependency1"",
                     ""Caption"":""TopDependency1"",
                     ""SchemaItemType"":""Xxx"",
-                    ""Resolved"":""true""
+                    ""Resolved"":""true"",
+                    ""TopLevel"":""true""
                 }",
                 icon: KnownMonikers.Uninstall,
                 expandedIcon: KnownMonikers.Uninstall);
@@ -340,7 +349,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     ""Name"":""ChildDependency1"",
                     ""Caption"":""ChildDependency1"",
                     ""SchemaItemType"":""Xxx"",
-                    ""Resolved"":""true""
+                    ""Resolved"":""true"",
+                    ""TopLevel"":""false""
                 }",
                 icon: KnownMonikers.Uninstall,
                 expandedIcon: KnownMonikers.Uninstall);
@@ -400,7 +410,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var dependencyTop1 = IDependencyFactory.FromJson(@"
                 {
                     ""ProviderType"": ""Xxx"",
-                    ""Id"": ""topdependency1"",
+                    ""Id"": ""tfm1\\xxx\\topdependency1"",
                     ""Name"":""TopDependency1"",
                     ""Caption"":""TopDependency1"",
                     ""SchemaItemType"":""Xxx"",
@@ -413,7 +423,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var dependencyChild1 = IDependencyFactory.FromJson(@"
                 {
                     ""ProviderType"": ""Xxx"",
-                    ""Id"": ""childdependency1"",
+                    ""Id"": ""tfm1\\xxx\\childdependency1"",
                     ""Name"":""ChildDependency1"",
                     ""Caption"":""ChildDependency1"",
                     ""SchemaItemType"":""Xxx"",
@@ -537,7 +547,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Same(projectPath, snapshot.ProjectPath);
             Assert.Same(catalogs, snapshot.Catalogs);
             AssertEx.CollectionLength(snapshot.TopLevelDependencies, 2);
-            Assert.Contains(snapshot.TopLevelDependencies, x => x.Id.Equals(@"topdependency1"));
+            Assert.Contains(snapshot.TopLevelDependencies, x => x.Id.Equals(@"tfm1\xxx\topdependency1"));
             Assert.Contains(snapshot.TopLevelDependencies, x => x.Id.Equals(@"tfm1\xxx\addeddependency2") && x.Caption.Equals("AddedDependency2Changed"));
             AssertEx.CollectionLength(snapshot.DependenciesWorld, 5);
             Assert.True(snapshot.DependenciesWorld.ContainsKey(@"tfm1\xxx\topdependency1"));
@@ -594,7 +604,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 projectPath: projectPath,
                 targetFramework: targetFramework,
                 catalogs: catalogs,
-                dependenciesWorld: new Dictionary<string, IDependency>(StringComparer.OrdinalIgnoreCase),
+                dependenciesWorld: new[] { dependencyTopPrevious },
                 topLevelDependencies: new[] { dependencyTopPrevious });
 
             var changes = IDependenciesChangesFactory.Implement(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
@@ -357,6 +357,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     ""SchemaItemType"":""Xxx"",
     ""Resolved"":""true""
 }", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall);
+
             var catalogs = IProjectCatalogSnapshotFactory.Create();
             var previousSnapshot = ITargetedDependenciesSnapshotFactory.Implement(
                 projectPath: projectPath,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
@@ -106,11 +106,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 projectPath: projectPath,
                 targetFramework: targetFramework,
                 catalogs: catalogs,
-                dependenciesWorld: new Dictionary<string, IDependency>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { dependencyTop1.Id, dependencyTop1 },
-                    { dependencyChild1.Id, dependencyChild1 },
-                },
+                dependenciesWorld: new [] { dependencyTop1, dependencyChild1 },
                 topLevelDependencies: new [] { dependencyTop1 });
 
             var changes = IDependenciesChangesFactory.Implement(
@@ -164,11 +160,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 projectPath: projectPath,
                 targetFramework: targetFramework,
                 catalogs: catalogs,
-                dependenciesWorld: new Dictionary<string, IDependency>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { dependencyTop1.Id, dependencyTop1 },
-                    { dependencyChild1.Id, dependencyChild1 },
-                },
+                dependenciesWorld: new [] { dependencyTop1, dependencyChild1 },
                 topLevelDependencies: new [] { dependencyTop1 });
 
             var changes = IDependenciesChangesFactory.Implement(
@@ -225,11 +217,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 projectPath: projectPath,
                 targetFramework: targetFramework,
                 catalogs: catalogs,
-                dependenciesWorld: new Dictionary<string, IDependency>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { dependencyTop1.Id, dependencyTop1 },
-                    { dependencyChild1.Id, dependencyChild1 },
-                },
+                dependenciesWorld: new [] { dependencyTop1, dependencyChild1 },
                 topLevelDependencies: new [] { dependencyTop1 });
 
             var changes = IDependenciesChangesFactory.Implement(
@@ -305,11 +293,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 projectPath: projectPath,
                 targetFramework: targetFramework,
                 catalogs: catalogs,
-                dependenciesWorld: new Dictionary<string, IDependency>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { dependencyTop1.Id, dependencyTop1 },
-                    { dependencyChild1.Id, dependencyChild1 },
-                },
+                dependenciesWorld: new [] { dependencyTop1, dependencyChild1 },
                 topLevelDependencies: new [] { dependencyTop1 });
 
             var changes = IDependenciesChangesFactory.Implement(
@@ -378,11 +362,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 projectPath: projectPath,
                 targetFramework: targetFramework,
                 catalogs: catalogs,
-                dependenciesWorld: new Dictionary<string, IDependency>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { dependencyTop1.Id, dependencyTop1 },
-                    { dependencyChild1.Id, dependencyChild1 },
-                },
+                dependenciesWorld: new [] { dependencyTop1, dependencyChild1 },
                 topLevelDependencies: new [] { dependencyTop1 });
 
             var changes = IDependenciesChangesFactory.Implement(
@@ -530,12 +510,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 projectPath: projectPath,
                 targetFramework: targetFramework,
                 catalogs: catalogs,
-                dependenciesWorld: new Dictionary<string, IDependency>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { dependencyTop1.Id, dependencyTop1 },
-                    { dependencyChild1.Id, dependencyChild1 },
-                    { dependencyRemoved1.Id, dependencyRemoved1 },
-                },
+                dependenciesWorld: new [] { dependencyTop1, dependencyChild1, dependencyRemoved1 },
                 topLevelDependencies: new [] { dependencyTop1 });
 
             var changes = IDependenciesChangesFactory.Implement(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/GroupedByTargetTreeViewProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/GroupedByTargetTreeViewProviderTests.cs
@@ -49,13 +49,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         public async Task WhenOneTargetSnapshotWithExistingDependencies_ShouldApplyChanges()
         {
             var tfm1 = ITargetFrameworkFactory.Implement(moniker: "tfm1");
-            var dependencyRootXxx = IDependencyFactory.FromJson(@"
+            var dependencyModelRootXxx = IDependencyModelFactory.FromJson(@"
 {
     ""ProviderType"": ""Xxx"",
     ""Id"": ""XxxDependencyRoot"",
     ""Name"":""XxxDependencyRoot"",
     ""Caption"":""XxxDependencyRoot"",
     ""Resolved"":""true""
+}");
+
+            var dependencyModelRootYyy = IDependencyModelFactory.FromJson(@"
+{
+    ""ProviderType"": ""Yyy"",
+    ""Id"": ""YyyDependencyRoot"",
+    ""Name"":""YyyDependencyRoot"",
+    ""Caption"":""YyyDependencyRoot""
 }");
 
             var dependencyXxx1 = IDependencyFactory.FromJson(@"
@@ -68,14 +76,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     ""SchemaItemType"":""Xxx"",
     ""Resolved"":""true""
 }", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall, targetFramework: tfm1);
-
-            var dependencyRootYyy = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Yyy"",
-    ""Id"": ""YyyDependencyRoot"",
-    ""Name"":""YyyDependencyRoot"",
-    ""Caption"":""YyyDependencyRoot""
-}");
 
             var dependencyYyy1 = IDependencyFactory.FromJson(@"
 {
@@ -136,7 +136,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             var treeViewModelFactory = IMockDependenciesViewModelFactory.Implement(
                 getDependenciesRootIcon: KnownMonikers.AboutBox,
-                createRootViewModel: new[] { dependencyRootXxx, dependencyRootYyy });
+                createRootViewModel: new[] { dependencyModelRootXxx, dependencyModelRootYyy });
 
             var testData = new Dictionary<ITargetFramework, List<IDependency>>
             {
@@ -481,7 +481,7 @@ Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconH
         [Fact]
         public async Task WheEmptySnapshotAndVisibilityMarkerNotProvided_ShouldHideSubTreeRoot()
         {
-            var dependencyRootYyy = IDependencyFactory.FromJson(@"
+            var dependencyModelRootYyy = IDependencyModelFactory.FromJson(@"
 {
     ""ProviderType"": ""Yyy"",
     ""Id"": ""YyyDependencyRoot"",
@@ -520,7 +520,7 @@ Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconH
 
             var treeViewModelFactory = IMockDependenciesViewModelFactory.Implement(
                 getDependenciesRootIcon: KnownMonikers.AboutBox,
-                createRootViewModel: new[] { dependencyRootYyy });
+                createRootViewModel: new[] { dependencyModelRootYyy });
 
             var testData = new Dictionary<ITargetFramework, List<IDependency>>
             {
@@ -552,7 +552,7 @@ Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconH
             var tfm2 = ITargetFrameworkFactory.Implement(moniker: "tfm2");
             var tfmAny = ITargetFrameworkFactory.Implement(moniker: "any");
 
-            var dependencyRootXxx = IDependencyFactory.FromJson(@"
+            var dependencyModelRootXxx = IDependencyModelFactory.FromJson(@"
 {
     ""ProviderType"": ""Xxx"",
     ""Id"": ""XxxDependencyRoot"",
@@ -572,7 +572,7 @@ Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconH
     ""Resolved"":""true""
 }", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall, targetFramework: tfm1);
 
-            var dependencyRootYyy = IDependencyFactory.FromJson(@"
+            var dependencyModelRootYyy = IDependencyModelFactory.FromJson(@"
 {
     ""ProviderType"": ""Yyy"",
     ""Id"": ""YyyDependencyRoot"",
@@ -602,7 +602,7 @@ Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconH
     ""Resolved"":""true""
 }", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall, targetFramework: tfm1);
 
-            var dependencyRootZzz = IDependencyFactory.FromJson(@"
+            var dependencyModelRootZzz = IDependencyModelFactory.FromJson(@"
 {
     ""ProviderType"": ""Zzz"",
     ""Id"": ""ZzzDependencyRoot"",
@@ -659,13 +659,13 @@ Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconH
             dependenciesRoot.Add(oldRootChildToBeRemoved);
             dependenciesRoot.Add(dependencyRootYyyTree);
 
-            var target1 = IDependencyFactory.FromJson(@"
+            var targetModel1 = IDependencyModelFactory.FromJson(@"
 {
     ""Id"": ""tfm1"",
     ""Name"":""tfm1"",
     ""Caption"":""tfm1""
 }");
-            var target2 = IDependencyFactory.FromJson(@"
+            var targetModel2 = IDependencyModelFactory.FromJson(@"
 {
     ""Id"": ""tfm2"",
     ""Name"":""tfm2"",
@@ -674,8 +674,8 @@ Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconH
 
             var treeViewModelFactory = IMockDependenciesViewModelFactory.Implement(
                 getDependenciesRootIcon: KnownMonikers.AboutBox,
-                createRootViewModel: new[] { dependencyRootXxx, dependencyRootYyy, dependencyRootZzz },
-                createTargetViewModel: new[] { target1, target2 });
+                createRootViewModel: new[] { dependencyModelRootXxx, dependencyModelRootYyy, dependencyModelRootZzz },
+                createTargetViewModel: new[] { targetModel1, targetModel2 });
 
             var testData = new Dictionary<ITargetFramework, List<IDependency>>
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/GroupedByTargetTreeViewProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/GroupedByTargetTreeViewProviderTests.cs
@@ -701,7 +701,7 @@ Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconH
             // Act
             var resultTree = await provider.BuildTreeAsync(dependenciesRoot, GetSnapshot(testData));
 
-            // Assert            
+            // Assert
             var expectedFlatHierarchy =
 @"Caption=MyDependencies, FilePath=, IconHash=325248080, ExpandedIconHash=325248080, Rule=, IsProjectItem=False, CustomTag=
 Caption=ZzzDependencyRoot, FilePath=ZzzDependencyRoot, IconHash=0, ExpandedIconHash=0, Rule=, IsProjectItem=False, CustomTag=
@@ -1021,20 +1021,22 @@ Caption=Dependency1, FilePath=tfm1\Xxx\dependencyxxxpath, IconHash=325249260, Ex
             Assert.Null(result);
         }
 
-        private IDependenciesSnapshot GetSnapshot(Dictionary<ITargetFramework, List<IDependency>> testData)
+        private static IDependenciesSnapshot GetSnapshot(Dictionary<ITargetFramework, List<IDependency>> testData)
         {
             var catalogs = IProjectCatalogSnapshotFactory.Create();
             var targets = new Dictionary<ITargetFramework, ITargetedDependenciesSnapshot>();
-            foreach (var kvp in testData)
+
+            foreach ((ITargetFramework targetFramework, List<IDependency> dependencies) in testData)
             {
                 var targetedSnapshot = ITargetedDependenciesSnapshotFactory.Implement(
                     catalogs: catalogs,
-                    topLevelDependencies: kvp.Value,
+                    topLevelDependencies: dependencies,
                     checkForUnresolvedDependencies: false,
-                    targetFramework: kvp.Key);
+                    targetFramework: targetFramework);
 
-                targets.Add(kvp.Key, targetedSnapshot);
+                targets.Add(targetFramework, targetedSnapshot);
             }
+
             return IDependenciesSnapshotFactory.Implement(
                 targets: targets,
                 hasUnresolvedDependency: false,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/GroupedByTargetTreeViewProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/GroupedByTargetTreeViewProviderTests.cs
@@ -50,54 +50,63 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         {
             var tfm1 = ITargetFrameworkFactory.Implement(moniker: "tfm1");
             var dependencyModelRootXxx = IDependencyModelFactory.FromJson(@"
-{
-    ""ProviderType"": ""Xxx"",
-    ""Id"": ""XxxDependencyRoot"",
-    ""Name"":""XxxDependencyRoot"",
-    ""Caption"":""XxxDependencyRoot"",
-    ""Resolved"":""true""
-}");
+                {
+                    ""ProviderType"": ""Xxx"",
+                    ""Id"": ""XxxDependencyRoot"",
+                    ""Name"":""XxxDependencyRoot"",
+                    ""Caption"":""XxxDependencyRoot"",
+                    ""Resolved"":""true""
+                }");
 
             var dependencyModelRootYyy = IDependencyModelFactory.FromJson(@"
-{
-    ""ProviderType"": ""Yyy"",
-    ""Id"": ""YyyDependencyRoot"",
-    ""Name"":""YyyDependencyRoot"",
-    ""Caption"":""YyyDependencyRoot""
-}");
+                {
+                    ""ProviderType"": ""Yyy"",
+                    ""Id"": ""YyyDependencyRoot"",
+                    ""Name"":""YyyDependencyRoot"",
+                    ""Caption"":""YyyDependencyRoot""
+                }");
 
             var dependencyXxx1 = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Xxx"",
-    ""Id"": ""tfm1\\xxx\\dependency1"",
-    ""Name"":""dependency1"",
-    ""Path"":""dependencyXxxpath"",
-    ""Caption"":""Dependency1"",
-    ""SchemaItemType"":""Xxx"",
-    ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall, targetFramework: tfm1);
+                {
+                    ""ProviderType"": ""Xxx"",
+                    ""Id"": ""tfm1\\xxx\\dependency1"",
+                    ""Name"":""dependency1"",
+                    ""Path"":""dependencyXxxpath"",
+                    ""Caption"":""Dependency1"",
+                    ""SchemaItemType"":""Xxx"",
+                    ""Resolved"":""true""
+                }", 
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall,
+                targetFramework: tfm1);
 
             var dependencyYyy1 = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Yyy"",
-    ""Id"": ""tfm1\\yyy\\dependency1"",
-    ""Name"":""dependency1"",
-    ""Path"":""dependencyYyypath"",
-    ""Caption"":""Dependency1"",
-    ""SchemaItemType"":""Yyy"",
-    ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall, targetFramework: tfm1);
+                {
+                    ""ProviderType"": ""Yyy"",
+                    ""Id"": ""tfm1\\yyy\\dependency1"",
+                    ""Name"":""dependency1"",
+                    ""Path"":""dependencyYyypath"",
+                    ""Caption"":""Dependency1"",
+                    ""SchemaItemType"":""Yyy"",
+                    ""Resolved"":""true""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall,
+                targetFramework: tfm1);
 
             var dependencyYyyExisting = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Yyy"",
-    ""Id"": ""tfm1\\yyy\\dependencyExisting"",
-    ""Name"":""dependencyExisting"",
-    ""Path"":""dependencyExistingPath"",
-    ""Caption"":""DependencyExisting"",
-    ""SchemaItemType"":""Yyy"",
-    ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall, targetFramework: tfm1);
+                {
+                    ""ProviderType"": ""Yyy"",
+                    ""Id"": ""tfm1\\yyy\\dependencyExisting"",
+                    ""Name"":""dependencyExisting"",
+                    ""Path"":""dependencyExistingPath"",
+                    ""Caption"":""DependencyExisting"",
+                    ""SchemaItemType"":""Yyy"",
+                    ""Resolved"":""true""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall,
+                targetFramework: tfm1);
 
             var dependencies = new List<IDependency>
             {
@@ -171,26 +180,28 @@ Caption=Dependency1, FilePath=tfm1\Xxx\dependencyXxxpath, IconHash=325249260, Ex
         {
             var tfm1 = ITargetFrameworkFactory.Implement(moniker: "tfm1");
             var dependencyRootYyy = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Yyy"",
-    ""Id"": ""YyyDependencyRoot"",
-    ""Name"":""YyyDependencyRoot"",
-    ""Caption"":""YyyDependencyRoot"",
-    ""Resolved"":""true""
-}");
+                {
+                    ""ProviderType"": ""Yyy"",
+                    ""Id"": ""YyyDependencyRoot"",
+                    ""Name"":""YyyDependencyRoot"",
+                    ""Caption"":""YyyDependencyRoot"",
+                    ""Resolved"":""true""
+                }");
+
             var dependencyYyyExisting = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Yyy"",
-    ""Id"": ""tfm1\\yyy\\dependencyExisting"",
-    ""Name"":""dependencyExisting"",
-    ""Path"":""dependencyExistingpath"",
-    ""Caption"":""DependencyExisting"",
-    ""SchemaItemType"":""Yyy"",
-    ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall,
-    expandedIcon: KnownMonikers.Uninstall,
-    flags: DependencyTreeFlags.SupportsHierarchy,
-    targetFramework: tfm1);
+                {
+                    ""ProviderType"": ""Yyy"",
+                    ""Id"": ""tfm1\\yyy\\dependencyExisting"",
+                    ""Name"":""dependencyExisting"",
+                    ""Path"":""dependencyExistingpath"",
+                    ""Caption"":""DependencyExisting"",
+                    ""SchemaItemType"":""Yyy"",
+                    ""Resolved"":""true""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall,
+                flags: DependencyTreeFlags.SupportsHierarchy,
+                targetFramework: tfm1);
 
             var dependencies = new List<IDependency>
             {
@@ -253,26 +264,27 @@ Caption=DependencyExisting, FilePath=tfm1\Yyy\dependencyExistingpath, IconHash=3
         public async Task WhenOneTargetSnapshotAndDependencySupportsHierarchyAndIsUnresolved_ShouldRead()
         {
             var dependencyRootYyy = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Yyy"",
-    ""Id"": ""YyyDependencyRoot"",
-    ""Name"":""YyyDependencyRoot"",
-    ""Caption"":""YyyDependencyRoot"",
-    ""Resolved"":""true""
-}");
+                {
+                    ""ProviderType"": ""Yyy"",
+                    ""Id"": ""YyyDependencyRoot"",
+                    ""Name"":""YyyDependencyRoot"",
+                    ""Caption"":""YyyDependencyRoot"",
+                    ""Resolved"":""true""
+                }");
             var dependencyYyyExisting = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Yyy"",
-    ""Id"": ""tfm1\\yyy\\dependencyExisting"",
-    ""Name"":""dependencyExisting"",
-    ""Caption"":""DependencyExisting"",
-    ""SchemaItemType"":""Yyy"",
-    ""Resolved"":""false""
-}", icon: KnownMonikers.Uninstall,
-    expandedIcon: KnownMonikers.Uninstall,
-    unresolvedIcon: KnownMonikers.Uninstall,
-    unresolvedExpandedIcon: KnownMonikers.Uninstall,
-    flags: DependencyTreeFlags.SupportsHierarchy);
+                {
+                    ""ProviderType"": ""Yyy"",
+                    ""Id"": ""tfm1\\yyy\\dependencyExisting"",
+                    ""Name"":""dependencyExisting"",
+                    ""Caption"":""DependencyExisting"",
+                    ""SchemaItemType"":""Yyy"",
+                    ""Resolved"":""false""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall,
+                unresolvedIcon: KnownMonikers.Uninstall,
+                unresolvedExpandedIcon: KnownMonikers.Uninstall,
+                flags: DependencyTreeFlags.SupportsHierarchy);
 
             var dependencies = new List<IDependency>
             {
@@ -335,24 +347,25 @@ Caption=DependencyExisting, FilePath=tfm1\yyy\dependencyExisting, IconHash=32524
         public async Task WhenOneTargetSnapshotAndDependencySupportsRule_ShouldCreateRule()
         {
             var dependencyRootYyy = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Yyy"",
-    ""Id"": ""YyyDependencyRoot"",
-    ""Name"":""YyyDependencyRoot"",
-    ""Caption"":""YyyDependencyRoot"",
-    ""Resolved"":""true""
-}");
+                {
+                    ""ProviderType"": ""Yyy"",
+                    ""Id"": ""YyyDependencyRoot"",
+                    ""Name"":""YyyDependencyRoot"",
+                    ""Caption"":""YyyDependencyRoot"",
+                    ""Resolved"":""true""
+                }");
             var dependencyYyyExisting = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Yyy"",
-    ""Id"": ""tfm1\\yyy\\dependencyExisting"",
-    ""Name"":""dependencyExisting"",
-    ""Caption"":""DependencyExisting"",
-    ""SchemaItemType"":""Yyy"",
-    ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall,
-    expandedIcon: KnownMonikers.Uninstall,
-    flags: DependencyTreeFlags.SupportsRuleProperties);
+                {
+                    ""ProviderType"": ""Yyy"",
+                    ""Id"": ""tfm1\\yyy\\dependencyExisting"",
+                    ""Name"":""dependencyExisting"",
+                    ""Caption"":""DependencyExisting"",
+                    ""SchemaItemType"":""Yyy"",
+                    ""Resolved"":""true""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall,
+                flags: DependencyTreeFlags.SupportsRuleProperties);
 
             var dependencies = new List<IDependency>
             {
@@ -414,22 +427,23 @@ Caption=DependencyExisting, FilePath=tfm1\yyy\dependencyExisting, IconHash=32524
         public async Task WheEmptySnapshotAndVisibilityMarkerProvided_ShouldDisplaySubTreeRoot()
         {
             var dependencyRootYyy = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Yyy"",
-    ""Id"": ""YyyDependencyRoot"",
-    ""Name"":""YyyDependencyRoot"",
-    ""Caption"":""YyyDependencyRoot"",
-    ""Resolved"":""true""
-}");
+                {
+                    ""ProviderType"": ""Yyy"",
+                    ""Id"": ""YyyDependencyRoot"",
+                    ""Name"":""YyyDependencyRoot"",
+                    ""Caption"":""YyyDependencyRoot"",
+                    ""Resolved"":""true""
+                }");
             var dependencyVisibilityMarker = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Yyy"",
-    ""Id"": ""someid"",
-    ""Name"":""someid"",
-    ""Caption"":""someid"",
-    ""Resolved"":""false"",
-    ""Visible"":""false""
-}", flags: DependencyTreeFlags.ShowEmptyProviderRootNode);
+                {
+                    ""ProviderType"": ""Yyy"",
+                    ""Id"": ""someid"",
+                    ""Name"":""someid"",
+                    ""Caption"":""someid"",
+                    ""Resolved"":""false"",
+                    ""Visible"":""false""
+                }",
+                flags: DependencyTreeFlags.ShowEmptyProviderRootNode);
 
             var dependencies = new List<IDependency>
             {
@@ -482,22 +496,22 @@ Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconH
         public async Task WheEmptySnapshotAndVisibilityMarkerNotProvided_ShouldHideSubTreeRoot()
         {
             var dependencyModelRootYyy = IDependencyModelFactory.FromJson(@"
-{
-    ""ProviderType"": ""Yyy"",
-    ""Id"": ""YyyDependencyRoot"",
-    ""Name"":""YyyDependencyRoot"",
-    ""Caption"":""YyyDependencyRoot"",
-    ""Resolved"":""true""
-}");
+                {
+                    ""ProviderType"": ""Yyy"",
+                    ""Id"": ""YyyDependencyRoot"",
+                    ""Name"":""YyyDependencyRoot"",
+                    ""Caption"":""YyyDependencyRoot"",
+                    ""Resolved"":""true""
+                }");
             var dependencyVisibilityMarker = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Yyy"",
-    ""Id"": ""someid"",
-    ""Name"":""someid"",
-    ""Caption"":""someid"",
-    ""Resolved"":""false"",
-    ""Visible"":""false""
-}");
+                {
+                    ""ProviderType"": ""Yyy"",
+                    ""Id"": ""someid"",
+                    ""Name"":""someid"",
+                    ""Caption"":""someid"",
+                    ""Resolved"":""false"",
+                    ""Visible"":""false""
+                }");
 
             var dependencies = new List<IDependency>
             {
@@ -553,71 +567,82 @@ Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconH
             var tfmAny = ITargetFrameworkFactory.Implement(moniker: "any");
 
             var dependencyModelRootXxx = IDependencyModelFactory.FromJson(@"
-{
-    ""ProviderType"": ""Xxx"",
-    ""Id"": ""XxxDependencyRoot"",
-    ""Name"":""XxxDependencyRoot"",
-    ""Caption"":""XxxDependencyRoot"",
-    ""Resolved"":""true""
-}");
+                {
+                    ""ProviderType"": ""Xxx"",
+                    ""Id"": ""XxxDependencyRoot"",
+                    ""Name"":""XxxDependencyRoot"",
+                    ""Caption"":""XxxDependencyRoot"",
+                    ""Resolved"":""true""
+                }");
 
             var dependencyXxx1 = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Xxx"",
-    ""Id"": ""xxx\\dependency1"",
-    ""Path"": ""dependencyxxxpath"",
-    ""Name"":""dependency1"",
-    ""Caption"":""Dependency1"",
-    ""SchemaItemType"":""Xxx"",
-    ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall, targetFramework: tfm1);
+                {
+                    ""ProviderType"": ""Xxx"",
+                    ""Id"": ""xxx\\dependency1"",
+                    ""Path"": ""dependencyxxxpath"",
+                    ""Name"":""dependency1"",
+                    ""Caption"":""Dependency1"",
+                    ""SchemaItemType"":""Xxx"",
+                    ""Resolved"":""true""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall,
+                targetFramework: tfm1);
 
             var dependencyModelRootYyy = IDependencyModelFactory.FromJson(@"
-{
-    ""ProviderType"": ""Yyy"",
-    ""Id"": ""YyyDependencyRoot"",
-    ""Name"":""YyyDependencyRoot"",
-    ""Caption"":""YyyDependencyRoot""
-}");
+                {
+                    ""ProviderType"": ""Yyy"",
+                    ""Id"": ""YyyDependencyRoot"",
+                    ""Name"":""YyyDependencyRoot"",
+                    ""Caption"":""YyyDependencyRoot""
+                }");
 
             var dependencyYyy1 = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Yyy"",
-    ""Id"": ""yyy\\dependency1"",
-    ""Path"": ""dependencyyyypath"",
-    ""Name"":""dependency1"",
-    ""Caption"":""Dependency1"",
-    ""SchemaItemType"":""Yyy"",
-    ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall, targetFramework: tfm1);
+                {
+                    ""ProviderType"": ""Yyy"",
+                    ""Id"": ""yyy\\dependency1"",
+                    ""Path"": ""dependencyyyypath"",
+                    ""Name"":""dependency1"",
+                    ""Caption"":""Dependency1"",
+                    ""SchemaItemType"":""Yyy"",
+                    ""Resolved"":""true""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall,
+                targetFramework: tfm1);
 
             var dependencyYyyExisting = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Yyy"",
-    ""Id"": ""yyy\\dependencyExisting"",
-    ""Path"": ""dependencyyyyExistingpath"",
-    ""Name"":""dependencyExisting"",
-    ""Caption"":""DependencyExisting"",
-    ""SchemaItemType"":""Yyy"",
-    ""Resolved"":""true""
-}", icon: KnownMonikers.Uninstall, expandedIcon: KnownMonikers.Uninstall, targetFramework: tfm1);
+                {
+                    ""ProviderType"": ""Yyy"",
+                    ""Id"": ""yyy\\dependencyExisting"",
+                    ""Path"": ""dependencyyyyExistingpath"",
+                    ""Name"":""dependencyExisting"",
+                    ""Caption"":""DependencyExisting"",
+                    ""SchemaItemType"":""Yyy"",
+                    ""Resolved"":""true""
+                }",
+                icon: KnownMonikers.Uninstall,
+                expandedIcon: KnownMonikers.Uninstall,
+                targetFramework: tfm1);
 
             var dependencyModelRootZzz = IDependencyModelFactory.FromJson(@"
-{
-    ""ProviderType"": ""Zzz"",
-    ""Id"": ""ZzzDependencyRoot"",
-    ""Name"":""ZzzDependencyRoot"",
-    ""Caption"":""ZzzDependencyRoot"",
-    ""Resolved"":""true""
-}", flags: ProjectTreeFlags.Create(ProjectTreeFlags.Common.BubbleUp));
+                {
+                    ""ProviderType"": ""Zzz"",
+                    ""Id"": ""ZzzDependencyRoot"",
+                    ""Name"":""ZzzDependencyRoot"",
+                    ""Caption"":""ZzzDependencyRoot"",
+                    ""Resolved"":""true""
+                }",
+                flags: ProjectTreeFlags.Create(ProjectTreeFlags.Common.BubbleUp));
             var dependencyAny1 = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Zzz"",
-    ""Id"": ""ZzzDependencyAny1"",
-    ""Path"": ""ZzzDependencyAny1path"",
-    ""Name"":""ZzzDependencyAny1"",
-    ""Caption"":""ZzzDependencyAny1""
-}", targetFramework: tfmAny);
+                {
+                    ""ProviderType"": ""Zzz"",
+                    ""Id"": ""ZzzDependencyAny1"",
+                    ""Path"": ""ZzzDependencyAny1path"",
+                    ""Name"":""ZzzDependencyAny1"",
+                    ""Caption"":""ZzzDependencyAny1""
+                }",
+                targetFramework: tfmAny);
 
             var dependencies = new List<IDependency>
             {
@@ -660,17 +685,17 @@ Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconH
             dependenciesRoot.Add(dependencyRootYyyTree);
 
             var targetModel1 = IDependencyModelFactory.FromJson(@"
-{
-    ""Id"": ""tfm1"",
-    ""Name"":""tfm1"",
-    ""Caption"":""tfm1""
-}");
+                {
+                    ""Id"": ""tfm1"",
+                    ""Name"":""tfm1"",
+                    ""Caption"":""tfm1""
+                }");
             var targetModel2 = IDependencyModelFactory.FromJson(@"
-{
-    ""Id"": ""tfm2"",
-    ""Name"":""tfm2"",
-    ""Caption"":""tfm2""
-}");
+                {
+                    ""Id"": ""tfm2"",
+                    ""Name"":""tfm2"",
+                    ""Caption"":""tfm2""
+                }");
 
             var treeViewModelFactory = IMockDependenciesViewModelFactory.Implement(
                 getDependenciesRootIcon: KnownMonikers.AboutBox,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/GroupedByTargetTreeViewProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/GroupedByTargetTreeViewProviderTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 { tfm1, dependencies }
             };
 
-            var project = UnconfiguredProjectFactory.Create(filePath: @"c:\somefodler\someproject.csproj");
+            var project = UnconfiguredProjectFactory.Create(filePath: @"c:\somefolder\someproject.csproj");
             var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(project: project);
 
             var provider = new GroupedByTargetTreeViewProvider(
@@ -229,7 +229,7 @@ Caption=Dependency1, FilePath=tfm1\Xxx\dependencyXxxpath, IconHash=325249260, Ex
                 { tfm1, dependencies }
             };
 
-            var project = UnconfiguredProjectFactory.Create(filePath: @"c:\somefodler\someproject.csproj");
+            var project = UnconfiguredProjectFactory.Create(filePath: @"c:\somefolder\someproject.csproj");
             var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(project: project);
 
             var provider = new GroupedByTargetTreeViewProvider(
@@ -311,7 +311,7 @@ Caption=DependencyExisting, FilePath=tfm1\Yyy\dependencyExistingpath, IconHash=3
                 { ITargetFrameworkFactory.Implement(moniker: "tfm1"), dependencies }
             };
 
-            var project = UnconfiguredProjectFactory.Create(filePath: @"c:\somefodler\someproject.csproj");
+            var project = UnconfiguredProjectFactory.Create(filePath: @"c:\somefolder\someproject.csproj");
             var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(project: project);
 
             var provider = new GroupedByTargetTreeViewProvider(
@@ -390,7 +390,7 @@ Caption=DependencyExisting, FilePath=tfm1\yyy\dependencyExisting, IconHash=32524
                 { ITargetFrameworkFactory.Implement(moniker: "tfm1"), dependencies }
             };
 
-            var project = UnconfiguredProjectFactory.Create(filePath: @"c:\somefodler\someproject.csproj");
+            var project = UnconfiguredProjectFactory.Create(filePath: @"c:\somefolder\someproject.csproj");
             var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(project: project);
 
             var provider = new GroupedByTargetTreeViewProvider(
@@ -459,7 +459,7 @@ Caption=DependencyExisting, FilePath=tfm1\yyy\dependencyExisting, IconHash=32524
                 { ITargetFrameworkFactory.Implement(moniker: "tfm1"), dependencies }
             };
 
-            var project = UnconfiguredProjectFactory.Create(filePath: @"c:\somefodler\someproject.csproj");
+            var project = UnconfiguredProjectFactory.Create(filePath: @"c:\somefolder\someproject.csproj");
             var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(project: project);
 
             var provider = new GroupedByTargetTreeViewProvider(
@@ -527,7 +527,7 @@ Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconH
                 { ITargetFrameworkFactory.Implement(moniker: "tfm1"), dependencies }
             };
 
-            var project = UnconfiguredProjectFactory.Create(filePath: @"c:\somefodler\someproject.csproj");
+            var project = UnconfiguredProjectFactory.Create(filePath: @"c:\somefolder\someproject.csproj");
             var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(project: project);
 
             var provider = new GroupedByTargetTreeViewProvider(
@@ -684,7 +684,7 @@ Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconH
                 { tfmAny, dependenciesAny }
             };
 
-            var project = UnconfiguredProjectFactory.Create(filePath: @"c:\somefodler\someproject.csproj");
+            var project = UnconfiguredProjectFactory.Create(filePath: @"c:\somefolder\someproject.csproj");
             var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(project: project);
 
             var provider = new GroupedByTargetTreeViewProvider(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/GroupedByTargetTreeViewProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/GroupedByTargetTreeViewProviderTests.cs
@@ -671,12 +671,6 @@ Caption=YyyDependencyRoot, FilePath=YyyDependencyRoot, IconHash=0, ExpandedIconH
     ""Name"":""tfm2"",
     ""Caption"":""tfm2""
 }");
-            var targetAny = IDependencyFactory.FromJson(@"
-{
-    ""Id"": ""any"",
-    ""Name"":""any"",
-    ""Caption"":""any""
-}");
 
             var treeViewModelFactory = IMockDependenciesViewModelFactory.Implement(
                 getDependenciesRootIcon: KnownMonikers.AboutBox,
@@ -734,13 +728,6 @@ Caption=Dependency1, FilePath=tfm1\Xxx\dependencyxxxpath, IconHash=325249260, Ex
             var project = UnconfiguredProjectFactory.Create();
             var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(project: project);
 
-            var dependenciesRoot = new TestProjectTree
-            {
-                Caption = "MyDependencies",
-                FilePath = "",
-                Flags = ProjectTreeFlags.Empty
-            };
-
             // Act
             var provider = new GroupedByTargetTreeViewProvider(treeServices, treeViewModelFactory, commonServices);
             var resultTree = provider.FindByPath(null, Path.Combine(projectFolder, @"somenode"));
@@ -780,9 +767,6 @@ Caption=Dependency1, FilePath=tfm1\Xxx\dependencyxxxpath, IconHash=325249260, Ex
         public void WhenFindByPathAndAbsoluteNodePath_ShouldFind()
         {
             // Arrange
-            const string projectPath = @"c:\myfolder\mysubfolder\myproject.csproj";
-            var projectFolder = Path.GetDirectoryName(projectPath);
-
             var treeServices = new MockIDependenciesTreeServices();
             var treeViewModelFactory = IMockDependenciesViewModelFactory.Implement();
             var project = UnconfiguredProjectFactory.Create();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                     previousTargetedSnapshot = TargetedDependenciesSnapshot.CreateEmpty(projectPath, targetFramework, catalogs);
                 }
 
-                var newTargetedSnapshot = TargetedDependenciesSnapshot.FromChanges(
+                ITargetedDependenciesSnapshot newTargetedSnapshot = TargetedDependenciesSnapshot.FromChanges(
                     projectPath,
                     previousTargetedSnapshot,
                     dependenciesChanges,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
@@ -65,14 +65,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             // This is needed for tree update logic to track if tree node changing state from unresolved 
             // to resolved or vice-versa (it helps to decide if we need to remove it or update in-place
             // in the tree to avoid flicks).
-            if (Resolved)
-            {
-                Flags = Flags.Union(DependencyTreeFlags.ResolvedFlags);
-            }
-            else
-            {
-                Flags = Flags.Union(DependencyTreeFlags.UnresolvedFlags);
-            }
+            Flags += Resolved
+                ? DependencyTreeFlags.ResolvedFlags
+                : DependencyTreeFlags.UnresolvedFlags;
 
             // If this is one of our implementations of IDependencyModel then we can just reuse the icon
             // set rather than creating a new one.


### PR DESCRIPTION
This PR contains preliminary work ahead of a change I'd like to follow up with.

The change that's coming is to `ITargetedDependenciesSnapshot` and how its `TopLevelDependencies` and `DependenciesWorld` collections are constructed, primarily to simplify the API such that components are unable to produce invalid state _by design_. This will simplify testing and will also reduce allocations.

That work is based on the following rules:

- `TopLevelDependencies` is the subset of `DependenciesWorld` where `TopLevel == true`
- All `DependenciesWorld` dictionary entries have keys that match their (dependency) value's `Id`

In 29cbdf95741f348588a0734c7ffe904f2ad0ea33 these rules are codified as assertions.

This PR:

- Fixes unit tests that violated the above rules by correcting test data
- Makes a clear distinction between `IDependency` and `IDependencyModel` in tests (this can be confusing because `IDependency` derives from `IDependencyModel`&mdash'I'm considering breaking this inheritance in the near future as they're not really fungible)
- Other test code simplifications, formatting, removal of unused code