### PR TITLE
BuildUpToDateCheck improvements

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -583,7 +583,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     $"Checking build output file '{sourcePath}':",
                     $"    Source {sourceTime.ToLocalTime()}: '{sourcePath}'.",
                     $"    Destination {destinationTime.ToLocalTime()}: '{destinationPath}'.",
-                    "Build output destination is newer than source, not up to date."
+                    "Source is newer than build output destination, not up to date."
                 },
                 "CopyOutput");
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -580,7 +580,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             await AssertNotUpToDateAsync(
                 new[]
                 {
-                    $"Checking build output file '{sourcePath}':",
+                    $"Checking copied output ({UpToDateCheckBuilt.SchemaName} with {UpToDateCheckBuilt.OriginalProperty} property) file '{sourcePath}':",
                     $"    Source {sourceTime.ToLocalTime()}: '{sourcePath}'.",
                     $"    Destination {destinationTime.ToLocalTime()}: '{destinationPath}'.",
                     "Source is newer than build output destination, not up to date."
@@ -611,7 +611,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             await AssertNotUpToDateAsync(
                 new[]
                 {
-                    $"Checking build output file '{sourcePath}':",
+                    $"Checking copied output ({UpToDateCheckBuilt.SchemaName} with {UpToDateCheckBuilt.OriginalProperty} property) file '{sourcePath}':",
                     $"Source '{sourcePath}' does not exist, not up to date."
                 },
                 "CopyOutput");
@@ -642,7 +642,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             await AssertNotUpToDateAsync(
                 new[]
                 {
-                    $"Checking build output file '{sourcePath}':",
+                    $"Checking copied output ({UpToDateCheckBuilt.SchemaName} with {UpToDateCheckBuilt.OriginalProperty} property) file '{sourcePath}':",
                     $"    Source {sourceTime.ToLocalTime()}: '{sourcePath}'.",
                     $"Destination '{destinationPath}' does not exist, not up to date."
                 },

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -113,7 +113,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 // Run through once so we know things are considered up to date before running further tests.
                 // Most tests will assert that the project is not up to date, so this provides a good baseline.
-                await AssertUpToDateAsync();
+                await AssertUpToDateAsync("No build outputs defined.");
             }
         }
 
@@ -243,7 +243,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             _projectVersion--;
 
-            await AssertUpToDateAsync();
+            await AssertUpToDateAsync("No build outputs defined.");
         }
 
         [Fact]
@@ -467,6 +467,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             await AssertNotUpToDateAsync(
                 new[]
                 {
+                    "No build outputs defined.",
                     $"Latest write timestamp on input marker is {outputTime.AddMinutes(2).ToLocalTime()} on 'Reference1OriginalPath'.",
                     $"Write timestamp on output marker is {outputTime.ToLocalTime()} on 'C:\\Dev\\Solution\\Project\\Marker'.",
                     "Input marker is newer than output marker, not up to date."
@@ -580,6 +581,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             await AssertNotUpToDateAsync(
                 new[]
                 {
+                    "No build outputs defined.",
                     $"Checking copied output ({UpToDateCheckBuilt.SchemaName} with {UpToDateCheckBuilt.OriginalProperty} property) file '{sourcePath}':",
                     $"    Source {sourceTime.ToLocalTime()}: '{sourcePath}'.",
                     $"    Destination {destinationTime.ToLocalTime()}: '{destinationPath}'.",
@@ -611,6 +613,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             await AssertNotUpToDateAsync(
                 new[]
                 {
+                    "No build outputs defined.",
                     $"Checking copied output ({UpToDateCheckBuilt.SchemaName} with {UpToDateCheckBuilt.OriginalProperty} property) file '{sourcePath}':",
                     $"Source '{sourcePath}' does not exist, not up to date."
                 },
@@ -642,6 +645,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             await AssertNotUpToDateAsync(
                 new[]
                 {
+                    "No build outputs defined.",
                     $"Checking copied output ({UpToDateCheckBuilt.SchemaName} with {UpToDateCheckBuilt.OriginalProperty} property) file '{sourcePath}':",
                     $"    Source {sourceTime.ToLocalTime()}: '{sourcePath}'.",
                     $"Destination '{destinationPath}' does not exist, not up to date."
@@ -676,6 +680,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             await AssertNotUpToDateAsync(
                 new[]
                 {
+                    "No build outputs defined.",
                     $"Checking PreserveNewest file '{sourcePath}':",
                     $"    Source {sourceTime.ToLocalTime()}: '{sourcePath}'.",
                     $"    Destination {destinationTime.ToLocalTime()}: '{destinationPath}'.",
@@ -709,6 +714,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             await AssertNotUpToDateAsync(
                 new[]
                 {
+                    "No build outputs defined.",
                     $"Checking PreserveNewest file '{sourcePath}':",
                     $"Source '{sourcePath}' does not exist, not up to date."
                 },
@@ -740,6 +746,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             await AssertNotUpToDateAsync(
                 new[]
                 {
+                    "No build outputs defined.",
                     $"Checking PreserveNewest file '{sourcePath}':",
                     $"    Source {sourceTime.ToLocalTime()}: '{sourcePath}'.",
                     $"Destination '{destinationPath}' does not exist, not up to date."
@@ -776,9 +783,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             writer.Assert();
         }
 
-        private async Task AssertUpToDateAsync()
+        private async Task AssertUpToDateAsync(params string[] logMessages)
         {
-            var writer = new AssertWriter { "Project is up to date." };
+            var writer = new AssertWriter();
+
+            if (logMessages != null)
+            {
+                foreach (var logMessage in logMessages)
+                {
+                    writer.Add(logMessage);
+                }
+            }
+
+            writer.Add("Project is up to date.");
+
             Assert.True(await _buildUpToDateCheck.IsUpToDateAsync(BuildAction.Build, writer));
             AssertTelemetrySuccessEvent();
             writer.Assert();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -432,10 +432,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             return (latest, latestPath);
         }
 
+        /// <summary>
+        /// Returns one of:
+        /// <list type="bullet">
+        ///     <item><c>(time, path)</c> describing the earliest output when all were found</item>
+        ///     <item><c>(null, path)</c> where <c>path</c> is the first output that could not be found</item>
+        ///     <item><c>(null, null)</c> when there were no outputs</item>
+        /// </list>
+        /// </summary>
         private (DateTime? time, string path) GetEarliestOutput(IEnumerable<string> outputs, IDictionary<string, DateTime> timestampCache)
         {
             DateTime? earliest = DateTime.MaxValue;
             string earliestPath = null;
+            bool hasOutput = false;
 
             foreach (string output in outputs)
             {
@@ -451,9 +460,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     earliest = time;
                     earliestPath = output;
                 }
+
+                hasOutput = true;
             }
 
-            return (earliest, earliestPath);
+            return hasOutput
+                ? (earliest, earliestPath)
+                : (null, null);
         }
 
         private bool CheckOutputs(BuildUpToDateCheckLogger logger, IDictionary<string, DateTime> timestampCache)
@@ -485,9 +498,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     }
                 }
             }
-            else
+            else if (outputPath != null)
             {
                 return Fail(logger, "Outputs", "Output '{0}' does not exist, not up to date.", outputPath);
+            }
+            else
+            {
+                logger.Info("No build outputs defined.");
             }
 
             return true;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -542,7 +542,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 return true;
             }
 
-            if (outputMarkerTime <= latestInputMarkerTime)
+            if (outputMarkerTime < latestInputMarkerTime)
             {
                 return Fail(logger, "Marker", "Input marker is newer than output marker, not up to date.");
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -583,7 +583,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                 if (destinationTime < sourceTime)
                 {
-                    return Fail(logger, "CopyOutput", "Build output destination is newer than source, not up to date.");
+                    return Fail(logger, "CopyOutput", "Source is newer than build output destination, not up to date.");
                 }
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -557,7 +557,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 string source = _configuredProject.UnconfiguredProject.MakeRooted(sourceRelative);
                 string destination = _configuredProject.UnconfiguredProject.MakeRooted(destinationRelative);
 
-                logger.Info("Checking build output file '{0}':", source);
+                logger.Info("Checking copied output (" + UpToDateCheckBuilt.SchemaName + " with " + UpToDateCheckBuilt.OriginalProperty + " property) file '{0}':", source);
 
                 DateTime? sourceTime = GetTimestampUtc(source, timestampCache);
 


### PR DESCRIPTION
While looking into #4261, a few improvements to the log output were identified.

---

When _no_ outputs are specified, the log gave a misleading message of form:

> FastUpToDate: Earliest write timestamp on output is 31/12/9999 23:59:59 on ''.

Now we print out:

> No build outputs defined.

This would have sped up the diagnosis of the problem.

---

Copied output files (as opposed to built ones) were logged as:

> Checking build output file '{sourcePath}':

This is better explained as:

> Checking copied output (UpToDateCheckBuilt with Original property) file '{sourcePath}':

---

@davkean noticed this message is backwards:

> Build output destination is newer than source, not up to date.

It should read:

> Source is newer than build output destination, not up to date.

---

Finally a non-logging change. Before if the input and output markers had the _same_ timestamp, they were considered out-of-date. The inquality was changed from `<=` to `<`.