### PR TITLE
Remove topLevelBuilder from IDependenciesSnapshotFilter

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyFactory.cs
@@ -38,6 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                                             bool? setPropertiesResolved = null,
                                             ProjectTreeFlags? setPropertiesFlags = null,
                                             bool? setPropertiesImplicit = null,
+                                            IDependency setPropertiesReturn = null,
                                             bool? equals = null,
                                             IImmutableList<string> setPropertiesDependencyIDs = null,
                                             string setPropertiesSchemaName = null,
@@ -139,7 +140,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                             setPropertiesDependencyIDs,
                             setPropertiesIconSet,
                             setPropertiesImplicit))
-                    .Returns(mock.Object);
+                    .Returns(setPropertiesReturn ?? mock.Object);
             }
 
             if (equals == true)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyFactory.cs
@@ -142,7 +142,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                     .Returns(mock.Object);
             }
 
-            if (equals.HasValue && equals.Value)
+            if (equals == true)
             {
                 mock.Setup(x => x.Equals(It.IsAny<IDependency>())).Returns(true);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DuplicatedDependenciesSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DuplicatedDependenciesSnapshotFilterTests.cs
@@ -13,15 +13,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     public class DuplicatedDependenciesSnapshotFilterTests
     {
         [Fact]
-        public void WhenThereNoMatchingDependencies_ShouldNotUpdateCaption()
+        public void BeforeAdd_NoDuplicate_ShouldNotUpdateCaption()
         {
+            // Both top level
+            // Same provider type
+            // Different captions
+            //   -> No change
+
+            const string providerType = "myprovider";
+
             var dependency = IDependencyFactory.Implement(
-                providerType: "myprovider",
+                providerType: providerType,
                 id: "mydependency1",
                 caption: "MyCaption");
 
             var otherDependency = IDependencyFactory.Implement(
-                    providerType: "myprovider",
+                    providerType: providerType,
                     id: "mydependency2",
                     caption: "otherCaption");
 
@@ -53,18 +60,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void WhenThereIsMatchingDependencies_ShouldUpdateCaptionForAll()
+        public void BeforeAdd_WhenThereIsMatchingDependencies_ShouldUpdateCaptionForAll()
         {
+            // Both top level
+            // Same provider type
+            // Same captions
+            //   -> Changes caption for both to match alias
+
+            const string providerType = "myprovider";
             const string caption = "MyCaption";
+
             var dependency = IDependencyFactory.Implement(
-                providerType: "myprovider",
+                providerType: providerType,
                 id: "mydependency1",
                 caption: caption,
                 alias: "mydependency1 (mydependency1ItemSpec)",
                 setPropertiesCaption: "mydependency1 (mydependency1ItemSpec)");
 
             var otherDependency = IDependencyFactory.Implement(
-                    providerType: "myprovider",
+                    providerType: providerType,
                     id: "mydependency2",
                     caption: caption,
                     alias: "mydependency2 (mydependency2ItemSpec)",
@@ -99,11 +113,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void WhenThereIsMatchingDependencyWithAliasApplied_ShouldUpdateCaptionForCurrentDependency()
+        public void BeforeAdd_WhenThereIsMatchingDependencyWithAliasApplied_ShouldUpdateCaptionForCurrentDependency()
         {
+            // Both top level
+            // Same provider type
+            // Duplicate caption, though with parenthesized text after one instance
+            //   -> Changes caption of non-parenthesized
+
+            const string providerType = "myprovider";
             const string caption = "MyCaption";
+
             var dependency = IDependencyFactory.Implement(
-                providerType: "myprovider",
+                providerType: providerType,
                 id: "mydependency1",
                 caption: caption,
                 alias: "mydependency1 (mydependency1ItemSpec)",
@@ -111,7 +132,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             var otherDependency = IDependencyFactory.Implement(
                    originalItemSpec: "mydependency2ItemSpec",
-                    providerType: "myprovider",
+                    providerType: providerType,
                     id: "mydependency2",
                     caption: $"{caption} (mydependency2ItemSpec)");
 
@@ -143,16 +164,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
-        public void WhenThereIsMatchingDependency_WithSubstringCaption()
+        public void BeforeAdd_WhenThereIsMatchingDependency_WithSubstringCaption()
         {
+            // Both top level
+            // Same provider type
+            // Duplicate caption, though with parenthesized text after one instance
+            //   -> Changes caption of non-parenthesized
+
+            const string providerType = "myprovider";
             const string caption = "MyCaption";
+
             var dependency = IDependencyFactory.Implement(
-                providerType: "myprovider",
+                providerType: providerType,
                 id: "mydependency1",
                 caption: caption);
 
             var otherDependency = IDependencyFactory.Implement(
-                    providerType: "myprovider",
+                    providerType: providerType,
                     id: "mydependency2",
                     caption: caption + "X");
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/ImplicitTopLevelDependenciesSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/ImplicitTopLevelDependenciesSnapshotFilterTests.cs
@@ -34,7 +34,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 worldBuilder,
                 null,
                 null,
-                null,
                 out bool filterAnyChanges);
 
             Assert.Equal(dependency.Object.Id, resultDependency.Id);
@@ -63,7 +62,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 null,
                 dependency.Object,
                 worldBuilder,
-                null,
                 null,
                 null,
                 out bool filterAnyChanges);
@@ -95,7 +93,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 null,
                 dependency.Object,
                 worldBuilder,
-                null,
                 null,
                 null,
                 out bool filterAnyChanges);
@@ -130,7 +127,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 worldBuilder,
                 null,
                 null,
-                null,
                 out bool filterAnyChanges);
 
             Assert.Equal(dependency.Object.Id, resultDependency.Id);
@@ -162,7 +158,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 null,
                 dependency.Object,
                 worldBuilder,
-                null,
                 null,
                 ImmutableHashSet.Create("myprojectitem"),
                 out bool filterAnyChanges);
@@ -203,7 +198,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 null,
                 dependency.Object,
                 worldBuilder,
-                null,
                 new Dictionary<string, IProjectDependenciesSubTreeProvider>
                 {
                     { subTreeProvider.ProviderType, subTreeProvider }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/SdkAndPackagesDependenciesSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/SdkAndPackagesDependenciesSnapshotFilterTests.cs
@@ -23,10 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 id: "mydependency1",
                 topLevel: false);
 
-            var worldBuilder = new Dictionary<string, IDependency>()
-            {
-                { dependency.Object.Id, dependency.Object },
-            }.ToImmutableDictionary().ToBuilder();
+            var worldBuilder = new [] { dependency.Object }.ToImmutableDictionary(d => d.Id).ToBuilder();
 
             var filter = new SdkAndPackagesDependenciesSnapshotFilter();
 
@@ -46,7 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         [Fact]
         public void WhenSdk_ShouldFindMatchingPackageAndSetProperties()
         {
-            var dependencyIDs = new List<string> { "id1", "id2" }.ToImmutableList();
+            var dependencyIDs = new [] { "id1", "id2" }.ToImmutableList();
 
             var mockTargetFramework = ITargetFrameworkFactory.Implement(moniker: "tfm");
 
@@ -69,11 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     dependencyIDs: dependencyIDs);
 
             var topLevelBuilder = ImmutableHashSet<IDependency>.Empty.Add(sdkDependency.Object).ToBuilder();
-            var worldBuilder = new Dictionary<string, IDependency>()
-            {
-                { sdkDependency.Object.Id, sdkDependency.Object },
-                { otherDependency.Object.Id, otherDependency.Object }
-            }.ToImmutableDictionary().ToBuilder();
+            var worldBuilder = new[] { sdkDependency.Object, otherDependency.Object }.ToImmutableDictionary(d => d.Id).ToBuilder();
 
             var filter = new SdkAndPackagesDependenciesSnapshotFilter();
 
@@ -94,8 +87,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         [Fact]
         public void WhenSdkAndPackageUnresolved_ShouldDoNothing()
         {
-            var dependencyIDs = new List<string> { "id1", "id2" }.ToImmutableList();
-
             var mockTargetFramework = ITargetFrameworkFactory.Implement(moniker: "tfm");
 
             var dependency = IDependencyFactory.Implement(
@@ -133,7 +124,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         [Fact]
         public void WhenPackage_ShouldFindMatchingSdkAndSetProperties()
         {
-            var dependencyIDs = new List<string> { "id1", "id2" }.ToImmutableList();
+            var dependencyIDs = new [] { "id1", "id2" }.ToImmutableList();
 
             var mockTargetFramework = ITargetFrameworkFactory.Implement(moniker: "tfm");
 
@@ -157,11 +148,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     setPropertiesSchemaName: ResolvedSdkReference.SchemaName,
                     equals: true);
 
-            var worldBuilder = new Dictionary<string, IDependency>()
-            {
-                { dependency.Object.Id, dependency.Object },
-                { sdkDependency.Object.Id, sdkDependency.Object }
-            }.ToImmutableDictionary().ToBuilder();
+            var worldBuilder = new[] { dependency.Object, sdkDependency.Object }.ToImmutableDictionary(d => d.Id).ToBuilder();
 
             var topLevelBuilder = ImmutableHashSet<IDependency>.Empty.Add(sdkDependency.Object).ToBuilder();
             var filter = new SdkAndPackagesDependenciesSnapshotFilter();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependency.cs
@@ -48,7 +48,32 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             DependencyIconSet iconSet = null,
             bool? isImplicit = null)
         {
-            return this;
+            return new TestDependency
+            {
+                ProviderType = ProviderType,
+                Name = Name,
+                Caption = caption ?? Caption,
+                OriginalItemSpec = OriginalItemSpec,
+                Path = Path,
+                FullPath = FullPath,
+                SchemaName = schemaName ?? SchemaName,
+                SchemaItemType = SchemaItemType,
+                Version = Version,
+                Resolved = resolved ?? Resolved,
+                TopLevel = TopLevel,
+                Implicit = isImplicit ?? Implicit,
+                Visible = Visible,
+                Priority = Priority,
+                Icon = iconSet?.Icon ?? Icon,
+                ExpandedIcon = iconSet?.ExpandedIcon ?? ExpandedIcon,
+                UnresolvedIcon = iconSet?.UnresolvedIcon ?? UnresolvedIcon,
+                UnresolvedExpandedIcon = iconSet?.UnresolvedExpandedIcon ?? UnresolvedExpandedIcon,
+                Properties = Properties,
+                DependencyIDs = dependencyIDs ?? DependencyIDs,
+                Flags = flags ?? Flags,
+                Id = Id,
+                Alias = Alias
+            };
         }
 
         public override int GetHashCode() 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnresolvedDependenciesSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnresolvedDependenciesSnapshotFilterTests.cs
@@ -36,7 +36,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 worldBuilder,
                 null,
                 null,
-                null,
                 out bool filterAnyChanges);
 
             Assert.Null(resultDependency);
@@ -65,7 +64,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 worldBuilder,
                 null,
                 null,
-                null,
                 out bool filterAnyChanges);
 
             Assert.NotNull(resultDependency);
@@ -87,7 +85,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 null,
                 null,
                 dependency.Object,
-                null,
                 null,
                 null,
                 null,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnsupportedProjectsSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnsupportedProjectsSnapshotFilterTests.cs
@@ -58,7 +58,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 worldBuilder,
                 null,
                 null,
-                null,
                 out bool filterAnyChanges);
 
             resultDependency = filter.BeforeAdd(
@@ -66,7 +65,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 null,
                 topLevelDependency.Object,
                 worldBuilder,
-                null,
                 null,
                 null,
                 out bool filterAnyChanges2);
@@ -78,7 +76,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 worldBuilder,
                 null,
                 null,
-                null,
                 out bool filterAnyChanges3);
 
             resultDependency = filter.BeforeAdd(
@@ -86,7 +83,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 null,
                 topLevelResolvedSharedProjectDependency.Object,
                 worldBuilder,
-                null,
                 null,
                 null,
                 out bool filterAnyChanges4);
@@ -129,7 +125,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 null,
                 null,
                 null,
-                null,
                 out bool filterAnyChanges);
 
             dependency.VerifyAll();
@@ -154,7 +149,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 null,
                 null,
                 dependency.Object,
-                null,
                 null,
                 null,
                 null,
@@ -194,7 +188,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 null,
                 null,
                 null,
-                null,
                 out bool filterAnyChanges);
 
             dependency.VerifyAll();
@@ -229,7 +222,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 null,
                 null,
                 dependency.Object,
-                null,
                 null,
                 null,
                 null,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DependenciesSnapshotFilterBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DependenciesSnapshotFilterBase.cs
@@ -17,7 +17,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             ITargetFramework targetFramework,
             IDependency dependency,
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
-            ImmutableHashSet<IDependency>.Builder topLevelBuilder,
             IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviderByProviderType,
             IImmutableSet<string> projectItemSpecs,
             out bool filterAnyChanges)
@@ -31,7 +30,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             ITargetFramework targetFramework,
             IDependency dependency,
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
-            ImmutableHashSet<IDependency>.Builder topLevelBuilder,
             out bool filterAnyChanges)
         {
             filterAnyChanges = false;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/IDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/IDependenciesSnapshotFilter.cs
@@ -25,10 +25,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
         /// <param name="targetFramework">Target framework for which dependency was resolved.</param>
         /// <param name="dependency">The dependency to which filter should be applied.</param>
         /// <param name="worldBuilder">Builder for immutable world dictionary of updating snapshot.</param>
-        /// <param name="topLevelBuilder">Top level dependencies list builder of updating snapshot.</param>
         /// <param name="subTreeProviderByProviderType">All dictionary of subtree providers keyed by <see cref="IProjectDependenciesSubTreeProvider.ProviderType"/>.</param>
         /// <param name="projectItemSpecs">List of all items contained in project's xml at given moment, otherwise, <see langword="null"/> if we do not have any data.</param>
-        /// <param name="filterAnyChanges"><see langword="true"/> if the returned dependency differs from <paramref name="dependency"/>, or if <paramref name="worldBuilder"/> or <paramref name="topLevelBuilder"/> changed, otherwise <see langword="false"/>.</param>
+        /// <param name="filterAnyChanges"><see langword="true"/> if the returned dependency differs from <paramref name="dependency"/>, or if <paramref name="worldBuilder"/> changed, otherwise <see langword="false"/>.</param>
         /// <returns>
         /// The dependency to be added, or <see langword="null"/> if the filter prohibits adding the dependency.
         /// Implementations may return a modified dependency to be added to the snapshot.
@@ -38,7 +37,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             ITargetFramework targetFramework,
             IDependency dependency,
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
-            ImmutableHashSet<IDependency>.Builder topLevelBuilder,
             IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviderByProviderType,
             IImmutableSet<string> projectItemSpecs,
             out bool filterAnyChanges);
@@ -50,15 +48,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
         /// <param name="targetFramework">Target framework for which dependency was resolved.</param>
         /// <param name="dependency">The dependency to which filter should be applied.</param>
         /// <param name="worldBuilder">Builder for immutable world dictionary of updating snapshot.</param>
-        /// <param name="topLevelBuilder">Top level dependencies list builder of updating snapshot.</param>
-        /// <param name="filterAnyChanges"><see langword="true"/> if <paramref name="worldBuilder"/> or <paramref name="topLevelBuilder"/> changed, otherwise <see langword="false"/>.</param>
+        /// <param name="filterAnyChanges"><see langword="true"/> if <paramref name="worldBuilder"/> changed, otherwise <see langword="false"/>.</param>
         /// <returns><see langword="true"/> if removal is approved, or <see langword="false"/> if <paramref name="dependency"/> should not be removed.</returns>
         bool BeforeRemove(
             string projectPath,
             ITargetFramework targetFramework,
             IDependency dependency,
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
-            ImmutableHashSet<IDependency>.Builder topLevelBuilder,
             out bool filterAnyChanges);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/ImplicitTopLevelDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/ImplicitTopLevelDependenciesSnapshotFilter.cs
@@ -26,7 +26,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             ITargetFramework targetFramework,
             IDependency dependency,
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
-            ImmutableHashSet<IDependency>.Builder topLevelBuilder,
             IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviderByProviderType,
             IImmutableSet<string> projectItemSpecs,
             out bool filterAnyChanges)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/SdkAndPackagesDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/SdkAndPackagesDependenciesSnapshotFilter.cs
@@ -28,7 +28,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             ITargetFramework targetFramework,
             IDependency dependency,
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
-            ImmutableHashSet<IDependency>.Builder topLevelBuilder,
             IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviderByProviderType,
             IImmutableSet<string> projectItemSpecs,
             out bool filterAnyChanges)
@@ -80,7 +79,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
                         dependencyIDs: dependency.DependencyIDs);
 
                     worldBuilder[sdk.Id] = sdk;
-                    topLevelBuilder.Add(sdk);
                 }
             }
 
@@ -92,7 +90,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             ITargetFramework targetFramework,
             IDependency dependency,
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
-            ImmutableHashSet<IDependency>.Builder topLevelBuilder,
             out bool filterAnyChanges)
         {
             filterAnyChanges = false;
@@ -114,13 +111,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
                     //
                     // Set to unresolved, and clear dependencies.
 
-                    filterAnyChanges = true;
-                    sdk = sdk.ToUnresolved(
+                    worldBuilder[sdk.Id] = sdk.ToUnresolved(
                         schemaName: SdkReference.SchemaName,
                         dependencyIDs: ImmutableList<string>.Empty);
 
-                    worldBuilder[sdk.Id] = sdk;
-                    topLevelBuilder.Add(sdk);
+                    filterAnyChanges = true;
                 }
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/UnresolvedDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/UnresolvedDependenciesSnapshotFilter.cs
@@ -25,7 +25,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             ITargetFramework targetFramework,
             IDependency dependency,
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
-            ImmutableHashSet<IDependency>.Builder topLevelBuilder,
             IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviderByProviderType,
             IImmutableSet<string> projectItemSpecs,
             out bool filterAnyChanges)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/UnsupportedProjectsSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/UnsupportedProjectsSnapshotFilter.cs
@@ -37,7 +37,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             ITargetFramework targetFramework,
             IDependency dependency,
             ImmutableDictionary<string, IDependency>.Builder worldBuilder,
-            ImmutableHashSet<IDependency>.Builder topLevelBuilder,
             IReadOnlyDictionary<string, IProjectDependenciesSubTreeProvider> subTreeProviderByProviderType,
             IImmutableSet<string> projectItemSpecs,
             out bool filterAnyChanges)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
@@ -3,8 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
-using System.Linq;
 
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
@@ -22,7 +20,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 projectPath,
                 targetFramework,
                 catalogs,
-                ImmutableHashSet<IDependency>.Empty,
                 ImmutableStringDictionary<IDependency>.EmptyOrdinalIgnoreCase);
         }
 
@@ -48,16 +45,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             Requires.NotNull(subTreeProviderByProviderType, nameof(subTreeProviderByProviderType));
             // projectItemSpecs can be null
 
-#if DEBUG
-            ValidateDependencies(previousSnapshot.TopLevelDependencies, previousSnapshot.DependenciesWorld);
-#endif
-
             bool anyChanges = false;
 
             ITargetFramework targetFramework = previousSnapshot.TargetFramework;
 
             var worldBuilder = previousSnapshot.DependenciesWorld.ToBuilder();
-            var topLevelBuilder = previousSnapshot.TopLevelDependencies.ToBuilder();
 
             foreach ((string providerType, string dependencyId) in changes.RemovedNodes)
             {
@@ -75,7 +67,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                     foreach (IDependenciesSnapshotFilter filter in snapshotFilters)
                     {
                         canRemove = filter.BeforeRemove(
-                            projectPath, targetFramework, dependency, worldBuilder, topLevelBuilder, out bool filterAnyChanges);
+                            projectPath, targetFramework, dependency, worldBuilder, out bool filterAnyChanges);
 
                         anyChanges |= filterAnyChanges;
 
@@ -91,7 +83,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 {
                     anyChanges = true;
                     worldBuilder.Remove(targetedId);
-                    topLevelBuilder.Remove(dependency);
                 }
             }
 
@@ -108,7 +99,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                             targetFramework,
                             newDependency,
                             worldBuilder,
-                            topLevelBuilder,
                             subTreeProviderByProviderType,
                             projectItemSpecs,
                             out bool filterAnyChanges);
@@ -131,12 +121,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
                 worldBuilder.Remove(newDependency.Id);
                 worldBuilder.Add(newDependency.Id, newDependency);
-
-                if (newDependency.TopLevel)
-                {
-                    topLevelBuilder.Remove(newDependency);
-                    topLevelBuilder.Add(newDependency);
-                }
             }
 
             // Also factor in any changes to path/framework/catalogs
@@ -152,7 +136,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                     projectPath,
                     targetFramework,
                     catalogs,
-                    topLevelBuilder.ToImmutable(),
                     worldBuilder.ToImmutable());
             }
 
@@ -164,48 +147,48 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             string projectPath,
             ITargetFramework targetFramework,
             IProjectCatalogSnapshot catalogs,
-            ImmutableHashSet<IDependency> topLevelDependencies,
             ImmutableDictionary<string, IDependency> dependenciesWorld)
         {
             Requires.NotNullOrEmpty(projectPath, nameof(projectPath));
             Requires.NotNull(targetFramework, nameof(targetFramework));
             // catalogs can be null
-            Requires.NotNull(topLevelDependencies, nameof(topLevelDependencies));
             Requires.NotNull(dependenciesWorld, nameof(dependenciesWorld));
 
             ProjectPath = projectPath;
             TargetFramework = targetFramework;
             Catalogs = catalogs;
-            TopLevelDependencies = topLevelDependencies;
             DependenciesWorld = dependenciesWorld;
 
-#if DEBUG
-            ValidateDependencies(topLevelDependencies, dependenciesWorld);
-#endif
+            bool hasUnresolvedDependency = false;
+            ImmutableHashSet<IDependency>.Builder topLevelDependencies = ImmutableHashSet.CreateBuilder<IDependency>();
 
-            foreach (IDependency topLevelDependency in TopLevelDependencies)
+            foreach ((string id, IDependency dependency) in dependenciesWorld)
             {
-                if (!string.IsNullOrEmpty(topLevelDependency.Path))
+                System.Diagnostics.Debug.Assert(
+                    string.Equals(id, dependency.Id),
+                    "dependenciesWorld dictionary entry keys must match their value's ids.");
+
+                if (!dependency.Resolved)
                 {
-                    _topLevelDependenciesByPathMap.Add(
-                        Dependency.GetID(TargetFramework, topLevelDependency.ProviderType, topLevelDependency.Path),
-                        topLevelDependency);
+                    hasUnresolvedDependency = true;
+                }
+
+                if (dependency.TopLevel)
+                {
+                    bool added = topLevelDependencies.Add(dependency);
+                    System.Diagnostics.Debug.Assert(added, "Duplicate top level dependency found.");
+
+                    if (!string.IsNullOrEmpty(dependency.Path))
+                    {
+                        _topLevelDependenciesByPathMap.Add(
+                            Dependency.GetID(TargetFramework, dependency.ProviderType, dependency.Path),
+                            dependency);
+                    }
                 }
             }
-        }
 
-        [Conditional("DEBUG")]
-        public static void ValidateDependencies(ImmutableHashSet<IDependency> topLevelDependencies, ImmutableDictionary<string, IDependency> dependenciesWorld)
-        {
-            System.Diagnostics.Debug.Assert(
-                topLevelDependencies.IsSubsetOf(dependenciesWorld.Values),
-                "Received topLevelDependencies is not a subset of dependenciesWorld");
-            System.Diagnostics.Debug.Assert(
-                topLevelDependencies.SetEquals(dependenciesWorld.Values.Where(d => d.TopLevel)),
-                "Received topLevelDependencies do not match dependenciesWorld having TopLevel==true");
-            System.Diagnostics.Debug.Assert(
-                dependenciesWorld.All(pair => string.Equals(pair.Key, pair.Value.Id, StringComparison.OrdinalIgnoreCase)),
-                "dependenciesWorld dictionary has entries whose keys don't match the value's ID");
+            HasUnresolvedDependency = hasUnresolvedDependency;
+            TopLevelDependencies = topLevelDependencies.ToImmutable();
         }
 
         #endregion
@@ -232,23 +215,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         /// <summary>Re-use an existing, private, object reference for locking, rather than allocating a dedicated object.</summary>
         private object SyncLock => _dependenciesChildrenMap;
 
-        private bool? _hasUnresolvedDependency;
-
         /// <inheritdoc />
-        public bool HasUnresolvedDependency
-        {
-            get
-            {
-                if (_hasUnresolvedDependency == null)
-                {
-                    _hasUnresolvedDependency = 
-                        TopLevelDependencies.Any(x => !x.Resolved) || 
-                        DependenciesWorld.Values.Any(x => !x.Resolved);
-                }
-
-                return _hasUnresolvedDependency.Value;
-            }
-        }
+        public bool HasUnresolvedDependency { get; }
 
         /// <inheritdoc />
         public bool CheckForUnresolvedDependencies(IDependency dependency)


### PR DESCRIPTION
`IDependenciesSnapshotFilter` implementations are the source of a lot of presentation logic for the dependencies node. Keeping this code correct, tested and having good performance is important to the stability and scale of the feature.

`IDependenciesSnapshotFilter` has a moderately complex and implicit contract that's not enforced by the design, though I believe it could be. This PR is a first step towards a design where implementations may not violate the contract.

The 'top-level' dependencies collection is the subset of 'world' dependencies where `TopLevel` is `true`.

Rather than require all filter implementations to correctly manage the top-level collection separately as a `HashSet<IDependency>`, it's possible to just compute that subset when needed directly from the world dependencies.

Benchmarking shows this is faster overall, and allocates less memory. The iteration/test is fast, and the in-memory representation becomes an dense array rather than a scattered persistent hash set. 

| Method |      Mean | Allocated |
|------- |----------:|----------:|
| Update | 124.80 us |    3216 B |
|Rebuild |  91.32 us |     757 B |

The improvement is nice, but these numbers are small&mdash;I only benchmarked to validate this wasn't a perf regression. The main benefit of this PR is the guarantee of correctness. It's impossible for the top-level and world dependency collections to contradict one another.

The computation of `HasUnresolvedDependency` is now performed during that same single scan, rather than lazily after the fact. The previous check for this would scan both the top-level and world dependencies, so this ends up being less work overall seeing as we're scanning the world dependencies anyway.
