### PR TITLE
Dependency class optimisations

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependency.cs
@@ -60,24 +60,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         public bool Equals(IDependency other) 
             => other != null && other.Id.Equals(Id, StringComparison.OrdinalIgnoreCase);
 
-        public static bool operator ==(TestDependency left, TestDependency right)
-            => left is null ? right is null : left.Equals(right);
-
-        public static bool operator !=(TestDependency left, TestDependency right)
-            => !(left == right);
-
-        public static bool operator <(TestDependency left, TestDependency right)
-            => left is null ? !(right is null) : left.CompareTo(right) < 0;
-
-        public static bool operator <=(TestDependency left, TestDependency right)
-            => left is null || left.CompareTo(right) <= 0;
-
-        public static bool operator >(TestDependency left, TestDependency right)
-            => !(left is null) && left.CompareTo(right) > 0;
-
-        public static bool operator >=(TestDependency left, TestDependency right)
-            => left is null ? right is null : left.CompareTo(right) >= 0;
-
         public int CompareTo(IDependency other) 
             => other == null ? 1 : StringComparer.OrdinalIgnoreCase.Compare(Id, other.Id);
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependency.cs
@@ -59,8 +59,5 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
         public bool Equals(IDependency other) 
             => other != null && other.Id.Equals(Id, StringComparison.OrdinalIgnoreCase);
-
-        public int CompareTo(IDependency other) 
-            => other == null ? 1 : StringComparer.OrdinalIgnoreCase.Compare(Id, other.Id);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
@@ -487,7 +487,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
                 // We are excluding folder elements until CPS allows empty folders to be part of the order; when they do, we can omit checking the item type for "Folder".
                 // Related changes will also need to happen in TryMoveElementsToTop when CPS allows empty folders in ordering.
                 // Don't choose items that were imported. Most likely won't happen on added elements, but just in case for sanity.
-                .Where(x => !previousIncludes.Contains(x.EvaluatedInclude, StringComparer.OrdinalIgnoreCase) && !x.ItemType.Equals("Folder", StringComparison.OrdinalIgnoreCase) && !x.IsImported)
+                .Where(x => !previousIncludes.Contains(x.EvaluatedInclude, StringComparer.OrdinalIgnoreCase) && !x.ItemType.Equals("Folder", StringComparisons.ItemTypes) && !x.IsImported)
                 .Select(x => x.Xml)
                 .ToImmutableArray();
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -221,7 +221,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     ProjectItem unresolvedReferenceItem = project.GetItemsByEvaluatedInclude(nodeItemContext.ItemName)
                         .FirstOrDefault(item => string.Equals(item.ItemType,
                                                               nodeItemContext.ItemType,
-                                                              StringComparison.OrdinalIgnoreCase));
+                                                              StringComparisons.ItemTypes));
 
                     Report.IfNot(unresolvedReferenceItem != null, "Cannot find reference to remove.");
                     if (unresolvedReferenceItem != null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
@@ -267,9 +267,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         public bool Equals(IDependency other) 
             => StringComparer.OrdinalIgnoreCase.Equals(Id, other?.Id);
 
-        public int CompareTo(IDependency other)
-            => StringComparer.OrdinalIgnoreCase.Compare(Id, other?.Id);
-
         public override string ToString()
         {
             // Used for debugging only

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
-using System.Globalization;
 using System.Text;
 
 using Microsoft.VisualStudio.Imaging.Interop;
@@ -243,7 +242,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
                 return string.IsNullOrEmpty(path) || path.Equals(Caption, StringComparison.OrdinalIgnoreCase)
                     ? Caption
-                    : string.Format(CultureInfo.CurrentCulture, "{0} ({1})", Caption, path);
+                    : string.Concat(Caption, " (", path, ")");
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
@@ -267,24 +267,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         public bool Equals(IDependency other) 
             => StringComparer.OrdinalIgnoreCase.Equals(Id, other?.Id);
 
-        public static bool operator ==(Dependency left, Dependency right)
-            => left is null ? right is null : left.Equals(right);
-
-        public static bool operator !=(Dependency left, Dependency right)
-            => !(left == right);
-
-        public static bool operator <(Dependency left, Dependency right)
-            => left is null ? !(right is null) : left.CompareTo(right) < 0;
-
-        public static bool operator <=(Dependency left, Dependency right)
-            => left is null || left.CompareTo(right) <= 0;
-
-        public static bool operator >(Dependency left, Dependency right)
-            => !(left is null) && left.CompareTo(right) > 0;
-
-        public static bool operator >=(Dependency left, Dependency right)
-            => left is null ? right is null : left.CompareTo(right) >= 0;
-
         public int CompareTo(IDependency other)
             => StringComparer.OrdinalIgnoreCase.Compare(Id, other?.Id);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
@@ -106,17 +106,39 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         /// <summary>
         /// Private constructor used to clone Dependency
         /// </summary>
-        private Dependency(Dependency model, string modelId)
-            : this(model, model.TargetFramework, model._containingProjectPath)
+        private Dependency(
+            Dependency dependency,
+            string caption,
+            bool? resolved,
+            ProjectTreeFlags? flags,
+            string schemaName,
+            IImmutableList<string> dependencyIDs,
+            DependencyIconSet iconSet,
+            bool? isImplicit)
         {
-            // since this is a clone make the modelId and dependencyIds match the original model
-            _modelId = modelId;
-            _fullPath = model._fullPath; // Grab the cached value if we've already created it
+            // Copy values as necessary to create a clone with any properties overridden
 
-            if (model.DependencyIDs != null && model.DependencyIDs.Count != 0)
-            {
-                DependencyIDs = model.DependencyIDs;
-            }
+            _modelId = dependency._modelId;
+            _fullPath = dependency._fullPath;
+            TargetFramework = dependency.TargetFramework;
+            _containingProjectPath = dependency._containingProjectPath;
+            ProviderType = dependency.ProviderType;
+            Name = dependency.Name;
+            Version = dependency.Version;
+            OriginalItemSpec = dependency.OriginalItemSpec;
+            Path = dependency.Path;
+            _schemaItemType = dependency.SchemaItemType;
+            TopLevel = dependency.TopLevel;
+            Visible = dependency.Visible;
+            Priority = dependency.Priority;
+            Properties = dependency.Properties;
+            Caption = caption ?? dependency.Caption;
+            Resolved = resolved ?? dependency.Resolved;
+            Flags = flags ?? dependency.Flags;
+            SchemaName = schemaName ?? dependency.SchemaName;
+            DependencyIDs = dependencyIDs ?? dependency.DependencyIDs;
+            IconSet = iconSet != null ? s_iconSetCache.GetOrAddIconSet(iconSet) : dependency.IconSet;
+            Implicit = isImplicit ?? dependency.Implicit;
         }
 
         #region IDependencyModel
@@ -170,7 +192,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             }
         }
 
-        public string SchemaName { get; private set; }
+        public string SchemaName { get; }
 
         private readonly string _schemaItemType;
 
@@ -188,11 +210,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             }
         }
 
-        public string Caption { get; private set; }
+        public string Caption { get; }
         public string Version { get; }
-        public bool Resolved { get; private set; }
+        public bool Resolved { get; }
         public bool TopLevel { get; }
-        public bool Implicit { get; private set; }
+        public bool Implicit { get; }
         public bool Visible { get; }
 
         public ImageMoniker Icon => IconSet.Icon;
@@ -200,14 +222,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         public ImageMoniker UnresolvedIcon => IconSet.UnresolvedIcon;
         public ImageMoniker UnresolvedExpandedIcon => IconSet.UnresolvedExpandedIcon;
 
-        public DependencyIconSet IconSet { get; private set; }
+        public DependencyIconSet IconSet { get; }
 
         public int Priority { get; }
-        public ProjectTreeFlags Flags { get; set; }
+        public ProjectTreeFlags Flags { get; }
 
         public IImmutableDictionary<string, string> Properties { get; }
 
-        public IImmutableList<string> DependencyIDs { get; private set; }
+        public IImmutableList<string> DependencyIDs { get; }
 
         #endregion
 
@@ -224,44 +246,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             DependencyIconSet iconSet = null,
             bool? isImplicit = null)
         {
-            var clone = new Dependency(this, _modelId);
-
-            if (caption != null)
-            {
-                clone.Caption = caption;
-            }
-
-            if (resolved != null)
-            {
-                clone.Resolved = resolved.Value;
-            }
-
-            if (flags != null)
-            {
-                clone.Flags = flags.Value;
-            }
-
-            if (schemaName != null)
-            {
-                clone.SchemaName = schemaName;
-            }
-
-            if (dependencyIDs != null)
-            {
-                clone.DependencyIDs = dependencyIDs;
-            }
-
-            if (iconSet != null)
-            {
-                clone.IconSet = s_iconSetCache.GetOrAddIconSet(iconSet);
-            }
-
-            if (isImplicit != null)
-            {
-                clone.Implicit = isImplicit.Value;
-            }
-
-            return clone;
+            return new Dependency(this, caption, resolved, flags, schemaName, dependencyIDs, iconSet, isImplicit);
         }
 
         public override int GetHashCode() 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
@@ -132,7 +132,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             Visible = dependency.Visible;
             Priority = dependency.Priority;
             Properties = dependency.Properties;
-            Caption = caption ?? dependency.Caption;
+            Caption = caption ?? dependency.Caption; // TODO if Properties contains "Folder.IdentityProperty" should we update it? (see public ctor)
             Resolved = resolved ?? dependency.Resolved;
             Flags = flags ?? dependency.Flags;
             SchemaName = schemaName ?? dependency.SchemaName;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
@@ -235,7 +235,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
         public ITargetFramework TargetFramework { get; }
 
-        public string Alias => GetAlias(this);
+        public string Alias
+        {
+            get
+            {
+                string path = OriginalItemSpec ?? Path;
+
+                return string.IsNullOrEmpty(path) || path.Equals(Caption, StringComparison.OrdinalIgnoreCase)
+                    ? Caption
+                    : string.Format(CultureInfo.CurrentCulture, "{0} ({1})", Caption, path);
+            }
+        }
 
         public IDependency SetProperties(
             string caption = null,
@@ -293,19 +303,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             if (Visible)  sb.Append(" Visible");
 
             return sb.ToString();
-        }
-
-        private static string GetAlias(IDependency dependency)
-        {
-            string path = dependency.OriginalItemSpec ?? dependency.Path;
-            if (string.IsNullOrEmpty(path) || path.Equals(dependency.Caption, StringComparison.OrdinalIgnoreCase))
-            {
-                return dependency.Caption;
-            }
-            else
-            {
-                return string.Format(CultureInfo.CurrentCulture, "{0} ({1})", dependency.Caption, path);
-            }
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
@@ -89,7 +89,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                      .Add(Folder.IdentityProperty, Caption)
                      .Add(Folder.FullPathProperty, Path);
 
-            if (dependencyModel.DependencyIDs == null)
+            if (dependencyModel.DependencyIDs == null || dependencyModel.DependencyIDs.Count == 0)
             {
                 DependencyIDs = ImmutableList<string>.Empty;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependency.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
     /// Represents internal immutable dependency entity that is stored in immutable 
     /// snapshot <see cref="ITargetedDependenciesSnapshot"/>.
     /// </summary>
-    internal interface IDependency : IEquatable<IDependency>, IComparable<IDependency>, IDependencyModel
+    internal interface IDependency : IEquatable<IDependency>, IDependencyModel
     {
         /// <summary>
         /// Target framework of the snapshot dependency belongs to


### PR DESCRIPTION
For the `Dependency` class:

- Remove the chained constructors to avoid duplicate work when cloning via `SetProperties`
- Make all properties get-only
- Remove unused operator overloads
- Avoid creating an immutable array builder when we know it would end up empty