### PR TITLE
Reduce size of dependency view models

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DependencyViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DependencyViewModel.cs
@@ -7,17 +7,33 @@ using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
-    internal class DependencyViewModel : IDependencyViewModel
+    internal sealed class DependencyViewModel : IDependencyViewModel
     {
-        public string Caption { get; set; }
-        public string FilePath { get; set; }
-        public string SchemaName { get; set; }
-        public string SchemaItemType { get; set; }
-        public int Priority { get; set; }
-        public ImageMoniker Icon { get; set; }
-        public ImageMoniker ExpandedIcon { get; set; }
-        public IImmutableDictionary<string, string> Properties { get; set; }
-        public ProjectTreeFlags Flags { get; set; }
-        public IDependency OriginalModel { get; set; }
+        private readonly IDependencyModel _model;
+        private readonly bool _hasUnresolvedDependency;
+
+        public DependencyViewModel(IDependency dependency, bool hasUnresolvedDependency)
+            : this((IDependencyModel)dependency, hasUnresolvedDependency)
+        {
+            OriginalModel = dependency;
+        }
+
+        public DependencyViewModel(IDependencyModel model, bool hasUnresolvedDependency)
+        {
+            _model = model;
+            _hasUnresolvedDependency = hasUnresolvedDependency;
+        }
+
+        public IDependency OriginalModel { get; }
+
+        public string Caption => _model.Caption;
+        public string FilePath => _model.Id;
+        public string SchemaName => _model.SchemaName;
+        public string SchemaItemType => _model.SchemaItemType;
+        public int Priority => _model.Priority;
+        public ImageMoniker Icon => _hasUnresolvedDependency ? _model.UnresolvedIcon : _model.Icon;
+        public ImageMoniker ExpandedIcon => _hasUnresolvedDependency ? _model.UnresolvedExpandedIcon : _model.ExpandedIcon;
+        public IImmutableDictionary<string, string> Properties => _model.Properties;
+        public ProjectTreeFlags Flags => _model.Flags;
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/IDependencyModelExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/IDependencyModelExtensions.cs
@@ -6,18 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
     {
         public static IDependencyViewModel ToViewModel(this IDependencyModel self, bool hasUnresolvedDependency)
         {
-            return new DependencyViewModel
-            {
-                Caption = self.Caption,
-                FilePath = self.Id,
-                SchemaName = self.SchemaName,
-                SchemaItemType = self.SchemaItemType,
-                Priority = self.Priority,
-                Icon = hasUnresolvedDependency ? self.UnresolvedIcon : self.Icon,
-                ExpandedIcon = hasUnresolvedDependency ? self.UnresolvedExpandedIcon : self.ExpandedIcon,
-                Properties = self.Properties,
-                Flags = self.Flags
-            };
+            return new DependencyViewModel(self, hasUnresolvedDependency);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageFrameworkAssembliesViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageFrameworkAssembliesViewModel.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Immutable;
+
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models;
@@ -7,17 +9,19 @@ using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    internal class PackageFrameworkAssembliesViewModel : DependencyViewModel
+    internal sealed class PackageFrameworkAssembliesViewModel : IDependencyViewModel
     {
         public static readonly ImageMoniker RegularIcon = KnownMonikers.Library;
 
-        public PackageFrameworkAssembliesViewModel()
-        {
-            Caption = VSResources.FrameworkAssembliesNodeName;
-            Icon = RegularIcon;
-            ExpandedIcon = Icon;
-            Priority = Dependency.FrameworkAssemblyNodePriority;
-            Flags = DependencyTreeFlags.FrameworkAssembliesNodeFlags;
-        }
+        public string Caption => VSResources.FrameworkAssembliesNodeName;
+        public string FilePath => null;
+        public string SchemaName => null;
+        public string SchemaItemType => null;
+        public int Priority => Dependency.FrameworkAssemblyNodePriority;
+        public ImageMoniker Icon => RegularIcon;
+        public ImageMoniker ExpandedIcon => RegularIcon;
+        public IImmutableDictionary<string, string> Properties => null;
+        public ProjectTreeFlags Flags => DependencyTreeFlags.FrameworkAssembliesNodeFlags;
+        public IDependency OriginalModel => null;
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/TargetDependencyViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/TargetDependencyViewModel.cs
@@ -1,18 +1,33 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Immutable;
+
 using Microsoft.VisualStudio.Imaging;
+using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
-    internal class TargetDependencyViewModel : DependencyViewModel
+    internal sealed class TargetDependencyViewModel : IDependencyViewModel
     {
+        private readonly bool _hasUnresolvedDependency;
+
         public TargetDependencyViewModel(ITargetedDependenciesSnapshot snapshot)
         {
             Caption = snapshot.TargetFramework.FriendlyName;
-            Icon = snapshot.HasUnresolvedDependency ? ManagedImageMonikers.LibraryWarning : KnownMonikers.Library;
-            ExpandedIcon = Icon;
             Flags = DependencyTreeFlags.TargetNodeFlags.Add($"$TFM:{snapshot.TargetFramework.FullName}");
+            _hasUnresolvedDependency = snapshot.HasUnresolvedDependency;
         }
+
+        public string Caption { get; }
+        public string FilePath => null;
+        public string SchemaName => null;
+        public string SchemaItemType => null;
+        public int Priority => Dependency.FrameworkAssemblyNodePriority;
+        public ImageMoniker Icon => _hasUnresolvedDependency ? ManagedImageMonikers.LibraryWarning : KnownMonikers.Library;
+        public ImageMoniker ExpandedIcon => _hasUnresolvedDependency ? ManagedImageMonikers.LibraryWarning : KnownMonikers.Library;
+        public IImmutableDictionary<string, string> Properties => null;
+        public ProjectTreeFlags Flags { get; }
+        public IDependency OriginalModel => null;
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
@@ -34,21 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         /// </summary>
         public static IDependencyViewModel ToViewModel(this IDependency self, ITargetedDependenciesSnapshot snapshot)
         {
-            bool showAsResolved = self.Resolved && !snapshot.CheckForUnresolvedDependencies(self);
-
-            return new DependencyViewModel
-            {
-                Caption = self.Caption,
-                FilePath = self.Id,
-                SchemaName = self.SchemaName,
-                SchemaItemType = self.SchemaItemType,
-                Priority = self.Priority,
-                Icon = showAsResolved ? self.Icon : self.UnresolvedIcon,
-                ExpandedIcon = showAsResolved ? self.ExpandedIcon : self.UnresolvedExpandedIcon,
-                Properties = self.Properties,
-                Flags = self.Flags,
-                OriginalModel = self
-            };
+            return new DependencyViewModel(self, hasUnresolvedDependency: self.IsOrHasUnresolvedDependency(snapshot));
         }
 
         /// <summary>


### PR DESCRIPTION
Implementations of `IDependencyViewModel` properties generally have fixed values or can delegate to a source object. They're faster to construct and take less memory.

A consequence of this is that `DependencyViewModel` now has a reference to `IDependencyModel`. However these view model objects are very short-lived, being constructed to pass directly to `IDependenciesTreeViewProvider` and `IDependenciesGraphBuilder` which query them on the stack, but don't retain references.