### PR TITLE
Don't handle TextView so opening results from find works

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerEditorFactory.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Runtime.InteropServices
 Imports Common = Microsoft.VisualStudio.Editors.AppDesCommon
@@ -216,21 +216,18 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         Public Function MapLogicalView(ByRef rguidLogicalView As Guid, ByRef pbstrPhysicalView As String) As Integer Implements IVsEditorFactory.MapLogicalView
             pbstrPhysicalView = Nothing
 
-            ' Normal logic for MapLogicalView is to return E_NOTIMPL for any rguidLogicalView values
-            '   that this editor does not support. However, the project-designer is a bit different in
-            '   that one of our NYI features is to treat the logical-view passed in as the initial
-            '   property-page to display, and given that the possible set of pages is not known until
-            '   runtime, we can't code something to look for known values. Therefore, we're returning
-            '   S_OK no matter what logical view is being passed in.
-            '
-            ' Note that my comment above isn't fully accurate because while that is the design, we know
-            '   that the VSCore project system currently only passes LOGVIEWID_Primary. We are adding
-            '   this assert so that if that changes on the project-system side, they're aware that it
-            '   won't work yet.
-            '
-            'Debug.Assert(rguidLogicalView.Equals(LOGVIEWID.LOGVIEWID_Primary), "NYI: Project Designer does not yet support choosing the initial property page thru the logical-view passed to our editor factory.")
+            ' The designer nominally supports VSConstants.LOGVIEWID.Designer_guid however it is also called with other GUIDs
+            ' that are for the various sub-tabs of the property pages
+            ' Rather than hard code those here, we simply allow through everything except Primary and TextView, as those are
+            ' used when opening files for text editing, and we want the project file to be editable as XML for those
 
-            Return NativeMethods.S_OK
+            If rguidLogicalView = VSConstants.LOGVIEWID.TextView_guid OrElse rguidLogicalView = VSConstants.LOGVIEWID.Primary_guid Then
+                Return NativeMethods.E_NOTIMPL
+            Else
+                pbstrPhysicalView = ""
+                Return NativeMethods.S_OK
+            End If
+
         End Function
 
         ''' <summary>

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerEditorFactory.vb
@@ -218,16 +218,14 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
 
             ' The designer nominally supports VSConstants.LOGVIEWID.Designer_guid however it is also called with other GUIDs
             ' that are for the various sub-tabs of the property pages
-            ' Rather than hard code those here, we simply allow through everything except Primary and TextView, as those are
-            ' used when opening files for text editing, and we want the project file to be editable as XML for those
+            ' Rather than hard code those here, we simply allow through everything TextView, as that is
+            ' used when opening files for text editing, and we want the project file to be editable as XML in that scenario
 
-            If rguidLogicalView = VSConstants.LOGVIEWID.TextView_guid OrElse rguidLogicalView = VSConstants.LOGVIEWID.Primary_guid Then
+            If rguidLogicalView = VSConstants.LOGVIEWID.TextView_guid Then
                 Return NativeMethods.E_NOTIMPL
             Else
-                pbstrPhysicalView = ""
                 Return NativeMethods.S_OK
             End If
-
         End Function
 
         ''' <summary>

--- a/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.pkgdef
+++ b/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.pkgdef
@@ -130,6 +130,9 @@
 "Package"="{67909B06-91E9-4F3E-AB50-495046BE9A9A}"
 @="Project Designer"
 
+[$RootKey$\Editors\{04b8ab82-a572-4fef-95ce-5222444b6b64}\LogicalViews]
+"{7651a702-06e5-11d1-8ebd-00a0c90f26ea}"="Design"
+
 [$RootKey$\Editors\{6D2695F9-5365-4A78-89ED-F205C045BFE6}]
 "CommonPhysicalViewAttributes"=dword:00000003
 "DisplayName"="#1200"


### PR DESCRIPTION
Our app designer wasn't using the Designer logical view properly which means that when find results were being opened, if the app designer was open, the shell thought it was a valid window to show instead of opening a window with the text view. This fixes that.

~This goes with a CPS pull request (https://devdiv.visualstudio.com/DevDiv/_git/CPS/pullrequest/152382) to open the designer with the write logical view. If these changes are inserted without the CPS changes then the app designer will not open from the Properties context menu. It will still open from the Debug -> Properties menu item, but still worth holding off on merging this PR until CPS is ready.~
Turns out the CPS change wasn't necessary, I was just incorrectly not handling the Primary logical view. Fixing that means everything works just fine, including legacy projects.

Fixes #4070