### PR TITLE
Revert https://github.com/dotnet/project-system/pull/4003

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Menus.vsct
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Menus.vsct
@@ -67,10 +67,16 @@
         <Strings>
           <ButtonText>&amp;Add Below</ButtonText>
         </Strings>
-      </Menu>  
+      </Menu>
     </Menus>
 
     <Groups>
+      <Group guid="guidSHLMainMenu" id="IDG_VS_CTXT_PROJECT_EDITFILE" priority="0x0180">
+        <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_PROJNODE"/>
+      </Group>
+      <Group guid="guidSHLMainMenu" id="IDG_VS_CTXT_PROJECT_EDITFILE" priority="0x0180">
+        <Parent guid="guidSHLMainMenu" id="IDM_VS_MENU_PROJECT"/>
+      </Group>
       <!-- Group added to the Debugging Framework Type menu on the debug controller -->
       <Group guid="guidManagedProjectSystemCommandSet" id="DebugTargetMenuDebugFrameworkGroup" priority="0x0100">
         <Parent guid="guidManagedProjectSystemCommandSet" id="DebugTargetMenuDebugFrameworkMenu"/>


### PR DESCRIPTION
Seems we do need to define these, but getting .vsct changes to appear in the experimental instance is very temperamental so my testing of the above PR was testing old bits.