### PR TITLE
Do not warn about using a pre-release sdk to build

### DIFF
--- a/build/Versions.props
+++ b/build/Versions.props
@@ -5,6 +5,7 @@
     <VersionBase Condition="'$(UseVisualStudioVersion)' == 'true'">$(VisualStudioVersion)</VersionBase>
     <VersionBase Condition="'$(UseVisualStudioVersion)' != 'true'">$(ProjectSystemVersion)</VersionBase>
     <PreReleaseVersionLabel>beta1</PreReleaseVersionLabel>
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
 
     <!-- Opt-in repo features -->
     <UsingToolVSSDK>true</UsingToolVSSDK>


### PR DESCRIPTION
removes noise on the commandline build. 