### PR TITLE
Test and fix MetadataExtensions

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Utilities/MetadataExtensionsTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Utilities/MetadataExtensionsTests.cs
@@ -1,0 +1,148 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
+{
+    public sealed class MetadataExtensionsTests
+    {
+        [Fact]
+        public void GetStringProperty_WhenNotFound()
+        {
+            var dic = ImmutableDictionary<string, string>.Empty;
+            Assert.Null(dic.GetStringProperty("key"));
+        }
+
+        [Fact]
+        public void GetStringProperty_WhenFound()
+        {
+            var dic = ImmutableDictionary<string, string>.Empty.Add("key", "value");
+            Assert.Equal("value", dic.GetStringProperty("key"));
+        }
+
+        [Fact]
+        public void GetStringProperty_WhenEmpty()
+        {
+            var dic = ImmutableDictionary<string, string>.Empty.Add("key", "");
+            Assert.Null(dic.GetStringProperty("key"));
+        }
+
+        [Fact]
+        public void GetStringProperty_WhenWhiteSpace()
+        {
+            var dic = ImmutableDictionary<string, string>.Empty.Add("key", " ");
+            Assert.Equal(" ", dic.GetStringProperty("key"));
+        }
+
+        [Fact]
+        public void TryGetStringProperty_WhenNotFound()
+        {
+            var dic = ImmutableDictionary<string, string>.Empty;
+            Assert.False(dic.TryGetStringProperty("key", out string value));
+            Assert.Null(value);
+        }
+
+        [Fact]
+        public void TryGetStringProperty_WhenFound()
+        {
+            var dic = ImmutableDictionary<string, string>.Empty.Add("key", "value");
+            Assert.True(dic.TryGetStringProperty("key", out string value));
+            Assert.Equal("value", value);
+        }
+
+        [Fact]
+        public void GetBoolProperty_WhenNotFound()
+        {
+            var dic = ImmutableDictionary<string, string>.Empty;
+            Assert.Null(dic.GetBoolProperty("key"));
+        }
+        
+        [Theory]
+        [InlineData("True",   true)]
+        [InlineData("true",   true)]
+        [InlineData("TRUE",   true)]
+        [InlineData("False",  false)]
+        [InlineData("false",  false)]
+        [InlineData("FALSE",  false)]
+        [InlineData("banana", null)]
+        [InlineData("",       null)]
+        [InlineData("    ",   null)]
+        public void GetBoolProperty_WhenFound(string actual, bool? expected)
+        {
+            var dic = ImmutableDictionary<string, string>.Empty.Add("key", actual);
+            Assert.Equal(expected, dic.GetBoolProperty("key"));
+        }
+
+        [Fact]
+        public void TryGetBoolProperty_WhenNotFound()
+        {
+            var dic = ImmutableDictionary<string, string>.Empty;
+            Assert.False(dic.TryGetBoolProperty("key", out bool value));
+            Assert.False(value);
+        }
+
+        [Theory]
+        [InlineData("True",   true,  true)]
+        [InlineData("true",   true,  true)]
+        [InlineData("TRUE",   true,  true)]
+        [InlineData("False",  true,  false)]
+        [InlineData("false",  true,  false)]
+        [InlineData("FALSE",  true,  false)]
+        [InlineData("banana", false, false)]
+        [InlineData("",       false, false)]
+        [InlineData("    ",   false, false)]
+        public void TryGetBoolProperty_WhenFound(string actual, bool returnValue, bool outValue)
+        {
+            var dic = ImmutableDictionary<string, string>.Empty.Add("key", actual);
+            Assert.Equal(returnValue, dic.TryGetBoolProperty("key", out bool value));
+            Assert.Equal(outValue, value);
+        }
+
+        [Fact]
+        public void GetEnumProperty_WhenNotFound()
+        {
+            var dic = ImmutableDictionary<string, string>.Empty;
+            Assert.Null(dic.GetEnumProperty<TestEnum>("key"));
+        }
+
+        [Theory]
+        [InlineData("Member1", TestEnum.Member1)]
+        [InlineData("Member2", TestEnum.Member2)]
+        [InlineData("Member3", TestEnum.Member3)]
+        [InlineData("MEMBER1", TestEnum.Member1)]
+        [InlineData("member1", TestEnum.Member1)]
+        [InlineData("",        null)]
+        [InlineData("    ",    null)]
+        public void GetEnumProperty_WhenFound(string actual, TestEnum? expected)
+        {
+            var dic = ImmutableDictionary<string, string>.Empty.Add("key", actual);
+            Assert.Equal(expected, dic.GetEnumProperty<TestEnum>("key"));
+        }
+
+        [Fact]
+        public void TryGetEnumProperty_WhenNotFound()
+        {
+            var dic = ImmutableDictionary<string, string>.Empty;
+            Assert.False(dic.TryGetEnumProperty("key", out TestEnum value));
+            Assert.Equal(default(TestEnum), value);
+        }
+
+        [Theory]
+        [InlineData("Member1", true,  TestEnum.Member1)]
+        [InlineData("Member2", true,  TestEnum.Member2)]
+        [InlineData("Member3", true,  TestEnum.Member3)]
+        [InlineData("MEMBER1", true,  TestEnum.Member1)]
+        [InlineData("member1", true,  TestEnum.Member1)]
+        [InlineData("",        false, default(TestEnum))]
+        [InlineData("    ",    false, default(TestEnum))]
+        public void TryGetEnumProperty_WhenFound(string actual, bool returnValue, TestEnum outValue)
+        {
+            var dic = ImmutableDictionary<string, string>.Empty.Add("key", actual);
+            Assert.Equal(returnValue, dic.TryGetEnumProperty("key", out TestEnum value));
+            Assert.Equal(outValue, value);
+        }
+
+        public enum TestEnum { Member1, Member2, Member3 }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Utilities/StringExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Utilities/StringExtensions.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.IO;
 using System.Xml;
 
 using Microsoft.Build.Construction;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/MetadataExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/MetadataExtensions.cs
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
         /// <returns>The string value if found and non-empty, otherwise <see langword="null"/>.</returns>
         public static string GetStringProperty(this IImmutableDictionary<string, string> properties, string key)
         {
-            return properties.TryGetStringProperty(key, out string value) ? value : null;
+            return properties.TryGetStringProperty(key, out string value) && !string.IsNullOrEmpty(value) ? value : null;
         }
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
         /// <returns>The boolean value if found and successfully parsed as a boolean, otherwise <see langword="null"/>.</returns>
         public static bool? GetBoolProperty(this IImmutableDictionary<string, string> properties, string key)
         {
-            return properties.TryGetBoolProperty(key, out bool value) ? value : default;
+            return properties.TryGetBoolProperty(key, out bool value) ? value : default(bool?);
         }
 
         /// <summary>
@@ -118,7 +118,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
         /// <typeparam name="T">The enum type.</typeparam>
         public static T? GetEnumProperty<T>(this IImmutableDictionary<string, string> properties, string key) where T : struct, Enum
         {
-            return properties.TryGetEnumProperty(key, out T value) ? value : default;
+            return properties.TryGetEnumProperty(key, out T value) ? value : default(T?);
         }
     }
 }


### PR DESCRIPTION
In the debugging for #4323 I was surprised by the output of one of these helper methods. Digging further uncovered a bug masked within a ternary where one value was `default`. The `default` was resolved as a non-nullable type, meaning the intended `null` value was never produced.

Tests added for all these extensions.