### PR TITLE
Fix launchSettings.json modified on IDE load and branch switch

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         protected OrderPrecedenceImportCollection<ILaunchSettingsSerializationProvider, IJsonSection> JsonSerializationProviders { get; set; }
 
         [ImportMany]
-        private OrderPrecedenceImportCollection<ISourceCodeControlIntegration> SourceControlIntegrations { get; set; }
+        protected OrderPrecedenceImportCollection<ISourceCodeControlIntegration> SourceControlIntegrations { get; set; }
 
         // The source for our dataflow
         private IReceivableSourceBlock<ILaunchSettings> _changedSourceBlock;
@@ -786,9 +786,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// made, the file will be checked out and saved. Note it ignores the value of the active profile
         /// as this setting is controlled by a user property.
         /// </summary>
-        private async Task UpdateAndSaveSettingsInternalAsync(ILaunchSettings newSettings, bool persistToDisk = true)
+        protected async Task UpdateAndSaveSettingsInternalAsync(ILaunchSettings newSettings, bool persistToDisk = true)
         {
-            await CheckoutSettingsFileAsync();
+            if (persistToDisk)
+            {
+                await CheckoutSettingsFileAsync();
+            }
 
             // Make sure the profiles are copied. We don't want them to mutate.
             string activeProfileName = ActiveProfile?.Name;


### PR DESCRIPTION
This addresses the following customer feedback item https://developercommunity.visualstudio.com/content/problem/255121/launchsettingsjson-modified-on-ide-load-and-branch.html

The only code change was in UpdateAndSaveSettingsInternalAsync which was calling to check out the file even when dontPersist is set to true.

Rest of the change was updating unit tests to verify the correct behavior