### PR TITLE
Fixing Tab and Shift-Tab behavior on Property Pages

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerView.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerView.vb
@@ -1090,7 +1090,8 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                         Dim PropPageView As PropPageDesigner.PropPageDesignerView
                         PropPageView = TryCast(NewCurrentPanel.DocView, PropPageDesigner.PropPageDesignerView)
                         If PropPageView IsNot Nothing Then
-                            PropPageView.ActivatePage(PropPageView.PropPage)
+                            'We are looping in the same page, do not set the undo status to clean
+                            PropPageView.SetControls(PropPageView.PropPage, True)
                         Else
                             'Must have had error loading
                         End If
@@ -1232,11 +1233,21 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         Public Overrides Sub OnItemClick(item As ProjectDesignerTabButton, reactivatePage As Boolean)
             Common.Switches.TracePDFocus(TraceLevel.Warning, "ApplicationDesignerView.OnItemClick")
             MyBase.OnItemClick(item, reactivatePage)
-            ShowTab(SelectedIndex, ForceShow:=True, ForceActivate:=reactivatePage)
+            ShowTab(SelectedIndex, ForceShow:=True)
 
             ' we need set back the tab, if we failed to switch...
             If SelectedIndex <> _activePanelIndex Then
                 SelectedIndex = _activePanelIndex
+            End If
+        End Sub
+
+        Friend Overrides Sub SetControl(firstControl As Boolean)
+            Dim NewCurrentPanel As ApplicationDesignerPanel = _designerPanels(SelectedIndex)
+            Dim PropPageView As PropPageDesigner.PropPageDesignerView
+            PropPageView = TryCast(NewCurrentPanel.DocView, PropPageDesigner.PropPageDesignerView)
+            If PropPageView IsNot Nothing Then
+                'We are looping in the same page, do not set the undo status to clean
+                PropPageView.SetControls(PropPageView.PropPage, firstControl)
             End If
         End Sub
 

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabButton.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabButton.vb
@@ -151,28 +151,43 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                     If parent IsNot Nothing Then
                         parent.OnItemClick(Me, reactivatePage:=True)
                     End If
-                Case Keys.Tab, Keys.Up, Keys.Down
-
-                    If keyCode <> Keys.Tab OrElse (keyData And Keys.Control) <> Keys.Control Then                                   ' Don't process if Ctrl+Tab, but do Process for Ctrl+Up and Ctrl+Down
+                Case Keys.Up
+                    Dim parent As ProjectDesignerTabControl = ParentTabControl
+                    If parent IsNot Nothing Then
+                        Dim nextIndex As Int32 = ButtonIndex - 1
+                        If nextIndex < 0 Then
+                            nextIndex = parent.TabButtonCount - 1
+                        End If
+                        Dim nextButton = parent.GetTabButton(nextIndex)
+                        nextButton.Focus()
+                        nextButton.FocusedFromKeyboardNav = True
+                        Return True
+                    End If
+                Case Keys.Down
+                    Dim parent As ProjectDesignerTabControl = ParentTabControl
+                    If parent IsNot Nothing Then
+                        Dim nextIndex As Int32 = ButtonIndex + 1
+                        If nextIndex >= parent.TabButtonCount Then
+                            nextIndex = 0
+                        End If
+                        Dim nextButton = parent.GetTabButton(nextIndex)
+                        nextButton.Focus()
+                        nextButton.FocusedFromKeyboardNav = True
+                        Return True
+                    End If
+                Case Keys.Left, Keys.Right
+                    ' Don't move focus for left or right
+                    Return True
+                Case Keys.Tab
+                    ' Don't process if Ctrl+Tab, it is reserved for navigation between editor pages
+                    If (keyData And Keys.Control) <> Keys.Control Then
                         Dim parent As ProjectDesignerTabControl = ParentTabControl
                         If parent IsNot Nothing Then
-                            Dim nextIndex As Integer = ButtonIndex
-                            If (keyCode = Keys.Tab AndAlso (keyData And Keys.Shift) = Keys.Shift) OrElse keyCode = Keys.Up Then     ' Process if Shift+Tab or Up
-                                nextIndex -= 1
-                                If nextIndex < 0 Then
-                                    nextIndex = parent.TabButtonCount - 1
-                                End If
-                            Else
-                                nextIndex += 1
-                                If nextIndex >= parent.TabButtonCount Then
-                                    nextIndex = 0
-                                End If
-                            End If
-                            Dim nextButton = parent.GetTabButton(nextIndex)
-                            nextButton.Focus()
-                            nextButton.FocusedFromKeyboardNav = True
-                            Return True
+                            ' Return focus back to the active property page
+                            parent.OnItemClick(parent.SelectedItem, reactivatePage:=True)
+
                         End If
+                        Return True
                     End If
             End Select
             Return MyBase.ProcessDialogKey(keyData)

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabButton.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabButton.vb
@@ -182,10 +182,12 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                     ' Don't process if Ctrl+Tab, it is reserved for navigation between editor pages
                     If (keyData And Keys.Control) <> Keys.Control Then
                         Dim parent As ProjectDesignerTabControl = ParentTabControl
+                        Dim regularTab As Boolean = (keyData And Keys.Shift) <> Keys.Shift
+
                         If parent IsNot Nothing Then
                             ' Return focus back to the active property page
                             parent.OnItemClick(parent.SelectedItem, reactivatePage:=True)
-
+                            parent.SetControl(regularTab)
                         End If
                         Return True
                     End If

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabControl.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/DesignerTabControl.vb
@@ -470,6 +470,9 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
             SelectedItem = item
         End Sub
 
+        Friend Overridable Sub SetControl(firstControl As Boolean)
+
+        End Sub
 
         ''' <summary>
         ''' Occurs when the mouse enters a button's area

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerView.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerView.vb
@@ -561,6 +561,24 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             End Select
         End Sub
 
+        Friend Sub SetControls(propPage As OleInterop.IPropertyPage, firstControl As Boolean)
+            If firstControl Then
+                If _isNativeHostedPropertyPage Then
+                    'Try to set initial focus to the property page, not the configuration panel
+                    FocusFirstOrLastPropertyPageControl(True)
+                Else
+                    ' Select the configuration panel to ensure it gains focus. For configuration pages, this
+                    ' ensures that the configuration panel receives focus and allows a screen reader to give
+                    ' the page context before reading the values of any properties themselves. For other pages
+                    ' this ensures that the first control of the page receives focus, which allows tab navigation
+                    ' to work in a reliable and predicable manner for users who can only use the keyboard.
+                    SelectNextControl(ConfigurationPanel, forward:=True, tabStopOnly:=True, nested:=True, wrap:=True)
+                End If
+            Else
+                FocusFirstOrLastPropertyPageControl(False)
+            End If
+        End Sub
+
         ''' <summary>
         ''' Show the property page 
         ''' </summary>
@@ -584,7 +602,6 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                 End If
 
                 Try
-
                     ' Check the minimum size for the control and make sure that we show scrollbars
                     ' if the PropertyPagePanel becomes smaller...
                     Dim Info As OleInterop.PROPPAGEINFO() = New OleInterop.PROPPAGEINFO(0) {}
@@ -609,8 +626,8 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                     If PropertyPagePanel.Controls.Count > 0 Then
                         Dim controlSize As Size = PropertyPagePanel.Controls(0).Size
                         PropertyPagePanel.AutoScrollMinSize = New Size(
-                                Math.Min(controlSize.Width + Padding.Right + Padding.Left, PropertyPagePanel.AutoScrollMinSize.Width),
-                                Math.Min(controlSize.Height + Padding.Top + Padding.Bottom, PropertyPagePanel.AutoScrollMinSize.Height))
+                            Math.Min(controlSize.Width + Padding.Right + Padding.Left, PropertyPagePanel.AutoScrollMinSize.Width),
+                            Math.Min(controlSize.Height + Padding.Top + Padding.Bottom, PropertyPagePanel.AutoScrollMinSize.Height))
                     End If
 
                     _isPageActivated = True
@@ -635,8 +652,8 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                         SelectNextControl(ConfigurationPanel, forward:=True, tabStopOnly:=True, nested:=True, wrap:=True)
                     End If
 
+                    ''Only set the undo redo state if we are loading a new page
                     SetUndoRedoCleanState()
-
                 Catch ex As Exception When ReportWithoutCrash(ex, NameOf(ActivatePage), NameOf(PropPageDesignerView))
                     'There was a problem displaying the property page.  Show the error control.
                     DisplayErrorControl(ex)


### PR DESCRIPTION
This is a fix for: [646608](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/646608/) and [646587](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/646587/)

In the WinForm property pages, tabbing at the last item in a page will take you to the page's title tab item. For example, tabbing at the "Advanced..." button on the Build property page (the last control on the page) would take you to the "Build" tab. But, If you tabbed again, it would not take you back into the property page as expected, but go down to the next title tab item. There was no way to tab back into the property page, and tabbing kept you in the property page named tabs.

The base for this PR is https://github.com/dotnet/project-system/pull/2666. It is contained in the first commit.

To make the previous comments easier to read, I put them in a table:
<details><summary>Organized Comments from last PR</summary>
<p>

| Dave Kean's Issue     | Tanner's Response  | My Notes
| -                     | -                  | -     
| If I am in the Assembly name textbox on the Application page and I navigate backwards onto the Application tab, my computer beeps | I'm not sure what's causing 1 for you. I am not able to get it to repro currently. | Not a regression. I can repro this. Interestingly, the opposite happens on the Package Property page - shift-tab onto the Package tab does not make a beep, but tabbing all the way around to the tab will beep|
| The currently Focused tab isn't remembered when I tab from the tabs -> page and back, instead it always takes me the current selected tab | Not a regression. The previous implementation did not remember the currently focused tab and also did not provide a way to navigate onto the last control of the page. | Not a regression. I can repro this. |
| Navigating backwards once on the titles - doesn't navigate backwards and take me onto the last control, but rather navigates me forward onto the first control | Not a regression. The previous implementation did not remember the currently focused tab and also did not provide a way to navigate onto the last control of the page. | Not a regression. I can repro this. |
| Starting in the Build events textbox, tabing backwards and then back into the text box enters a TAB character into the box | This is occurring on Shift+Tab, and only on Shift+Tab (when navigating from the first dialog to the build events button). It is likely because the message is continuing to be processed by the text box. | Not a regression. I can repro this. This seems like a WinForms bug - the AcceptTab property is false (and why you can tab and shift-tab in the first place) so it shouldn't even be possible for you to input a tab into the textbox at all. |
| Dirty state of the Tab titles is changed as I tab around the pages: 1. Open Application page, make a change to AssemblyName, SHIFT-TAB to Application title, notice it has * 2. TAB forward onto the page, the * disappears | Something about reactivating the page seems to be causing us to lose the save state. | **This is a new issue.** The dirty marker on the Application tab does go away when tabbed into the page, but the change is still there, pending a save. |
| I can't set focus to the overflow button nor drop it via the keyboard | Doesn't look like we ever handled this, because it is not part of the list of buttons and is instead a standalone control. | Not a regression. This behavior is not handled. |
| I can't navigate from the WPF Debug or Package page onto the page titles | I'm seeing this for WPF Debug but not for the Package page. Probably something was missed since it is hosted WPF rather than WinForms. | This will have to be handled separately in those pages. |
| If you navigate from the Resources (and probably Settings) page onto Page titles, the focus rectangle disappears | Seems the pages in general don't display focus rectangles as well. | Not sure about this one, I can see the focus rectangles, but the shift-tabbing does not work on the the elements in the Resources property page. Either way, it is not a regression. |
| If **underline keyboard shortcuts and access keys** is on, setting focus via the mouse on mouse down on the button and dragging the mouse off the titles does not draw focus rectangles. Also if that setting is off, we give zero indication that button currently has focus at that time. | From David Poeschl: repro on the existing property pages, so not regressions | If you have that setting on, it does not show the focus boxes, but this is not a regression. |
</p>
</details>

<p> </p>

There were some concerns about regressions when it was created, but only one was a new issue - the dirty state of the tab titles was being reset if you shift-tabbed to the title and tabbed back into the property page.

The second commit fixes the issue where shift-tabbing out of property page and tabbing back into would reset the dirty status of the title tab.

The second commit also fixed an issue with the original PR where shift-tab would not behave as expected on the title tab.

This PR is also related to [646614](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/646614/), but that is concerning the WPF property pages. 

