### PR TITLE
UpToDateCheck uses first (newest) MSBuildAllProjects only

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         private string _msBuildProjectDirectory;
         private string _markerFile;
         private string _outputRelativeOrFullPath;
-        private string _msBuildAllProjects;
+        private string _newestImportInput;
 
         private DateTime _lastCheckTimeUtc = DateTime.MinValue;
 
@@ -126,7 +126,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             _msBuildProjectFullPath = e.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildProjectFullPathProperty, _msBuildProjectFullPath);
             _msBuildProjectDirectory = e.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildProjectDirectoryProperty, _msBuildProjectDirectory);
             _outputRelativeOrFullPath = e.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.OutputPathProperty, _outputRelativeOrFullPath);
-            _msBuildAllProjects = e.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildAllProjectsProperty, "");
+            string msBuildAllProjects = e.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildAllProjectsProperty, "");
+            _newestImportInput = new LazyStringSplit(msBuildAllProjects, ';').FirstOrDefault();
 
             if (e.ProjectChanges.TryGetValue(ResolvedAnalyzerReference.SchemaName, out IProjectChangeDescription changes) &&
                 changes.Difference.AnyChanges)
@@ -333,14 +334,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             logger.Verbose("    '{0}'", _msBuildProjectFullPath);
             yield return _msBuildProjectFullPath;
 
-            if (!string.IsNullOrWhiteSpace(_msBuildAllProjects))
+            if (_newestImportInput != null)
             {
-                logger.Verbose("Adding import inputs:");
-                foreach (string input in new LazyStringSplit(_msBuildAllProjects, ';'))
-                {
-                    logger.Verbose("    '{0}'", input);
-                    yield return input;
-                }
+                logger.Verbose("Adding newest import input:");
+                logger.Verbose("    '{0}'", _newestImportInput);
+                yield return _newestImportInput;
             }
 
             foreach ((string itemType, HashSet<(string path, string link, CopyToOutputDirectoryType copyType)> changes) in _items)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -127,6 +127,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             _msBuildProjectDirectory = e.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildProjectDirectoryProperty, _msBuildProjectDirectory);
             _outputRelativeOrFullPath = e.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.OutputPathProperty, _outputRelativeOrFullPath);
             string msBuildAllProjects = e.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildAllProjectsProperty, "");
+
+            // The first item in this semicolon-separated list of project files will always be the one
+            // with the newest timestamp. As we are only interested in timestamps on these files, we can
+            // save memory and time by only considering this first path (dotnet/project-system#4333).
             _newestImportInput = new LazyStringSplit(msBuildAllProjects, ';').FirstOrDefault();
 
             if (e.ProjectChanges.TryGetValue(ResolvedAnalyzerReference.SchemaName, out IProjectChangeDescription changes) &&


### PR DESCRIPTION
Fixes #3744 

//cc: @AndyGerlicher @rainersigwald 