### PR TITLE
Use object pool

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Properties/CSharpProjectDesignerPageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Properties/CSharpProjectDesignerPageProvider.cs
@@ -3,7 +3,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
+using Microsoft.VisualStudio.Buffers.PooledObjects;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Properties/CSharpProjectDesignerPageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Properties/CSharpProjectDesignerPageProvider.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 {
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
         public Task<IReadOnlyCollection<IPageMetadata>> GetPagesAsync()
         {
-            ImmutableArray<IPageMetadata>.Builder builder = ImmutableArray.CreateBuilder<IPageMetadata>();
+            var builder = PooledArray<IPageMetadata>.GetInstance();
 
             builder.Add(CSharpProjectDesignerPage.Application);
             builder.Add(CSharpProjectDesignerPage.Build);
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
             builder.Add(CSharpProjectDesignerPage.Signing);
 
-            return Task.FromResult<IReadOnlyCollection<IPageMetadata>>(builder.ToImmutable());
+            return Task.FromResult<IReadOnlyCollection<IPageMetadata>>(builder.ToImmutableAndFree());
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
@@ -4,8 +4,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Text;
-
+using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
 using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.Packaging;
 using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
@@ -203,8 +202,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
             ProcessWrapper process = _runner.Start(pInfo);
 
             // Create strings to hold the output and error text
-            var outputBuilder = new StringBuilder();
-            var errBuilder = new StringBuilder();
+            var outputBuilder = PooledStringBuilder.GetInstance();
+            var errBuilder = PooledStringBuilder.GetInstance();
 
             process.AddOutputDataReceivedHandler(o =>
             {
@@ -221,8 +220,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
 
             process.WaitForExit();
 
-            string output = outputBuilder.ToString().Trim();
-            string err = errBuilder.ToString().Trim();
+            string output = outputBuilder.ToStringAndFree().Trim();
+            string err = errBuilder.ToStringAndFree().Trim();
 
             if (!string.IsNullOrEmpty(output))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
@@ -4,7 +4,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
-using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
+using Microsoft.VisualStudio.Buffers.PooledObjects;
 using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.Packaging;
 using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/ProjectSystem/VS/Properties/FSharpProjectDesignerPageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/ProjectSystem/VS/Properties/FSharpProjectDesignerPageProvider.cs
@@ -3,7 +3,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
+using Microsoft.VisualStudio.Buffers.PooledObjects;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/ProjectSystem/VS/Properties/FSharpProjectDesignerPageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/ProjectSystem/VS/Properties/FSharpProjectDesignerPageProvider.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 {
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
         public Task<IReadOnlyCollection<IPageMetadata>> GetPagesAsync()
         {
-            ImmutableArray<IPageMetadata>.Builder builder = ImmutableArray.CreateBuilder<IPageMetadata>();
+            var builder = PooledArray<IPageMetadata>.GetInstance();
             builder.Add(FSharpProjectDesignerPage.Application);
             builder.Add(FSharpProjectDesignerPage.Build);
             builder.Add(FSharpProjectDesignerPage.BuildEvents);
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
             builder.Add(FSharpProjectDesignerPage.ReferencePaths);
 
-            return Task.FromResult<IReadOnlyCollection<IPageMetadata>>(builder.ToImmutable());
+            return Task.FromResult<IReadOnlyCollection<IPageMetadata>>(builder.ToImmutableAndFree());
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.IO;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
+using Microsoft.VisualStudio.Buffers.PooledObjects;
 using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.ProjectSystem.Properties;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
@@ -4,9 +4,8 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.IO;
-using System.Text;
 using System.Threading.Tasks;
-
+using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
 using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
@@ -476,7 +475,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             }
 
             StringState currentState = StringState.NormalCharacter;
-            var finalBuilder = new StringBuilder();
+            var finalBuilder = PooledStringBuilder.GetInstance();
             foreach (char currentChar in unescaped)
             {
                 switch (currentState)
@@ -537,7 +536,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 }
             }
 
-            return finalBuilder.ToString();
+            return finalBuilder.ToStringAndFree();
         }
 
         private enum StringState

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectDebuggerProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectDebuggerProvider.cs
@@ -5,9 +5,8 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading.Tasks;
-
+using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
@@ -307,7 +306,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             }
 
             // Collect all the variables as a null delimited list of key=value pairs.
-            var result = new StringBuilder();
+            var result = PooledStringBuilder.GetInstance();
             foreach ((string key, string value) in environment)
             {
                 result.Append(key);
@@ -321,7 +320,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             // But the contract of the format of the data requires that this be a null-delimited,
             // null-terminated list.
             result.Append('\0');
-            return result.ToString();
+            return result.ToStringAndFree();
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectDebuggerProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectDebuggerProvider.cs
@@ -6,7 +6,7 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
+using Microsoft.VisualStudio.Buffers.PooledObjects;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 
 using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
+using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {
@@ -205,7 +206,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 
         private static ImmutableArray<ProjectItemElement> GetItemElements(Project project, ImmutableArray<string> includes)
         {
-            ImmutableArray<ProjectItemElement>.Builder elements = ImmutableArray.CreateBuilder<ProjectItemElement>();
+            var elements = PooledArray<ProjectItemElement>.GetInstance();
 
             foreach (string include in includes)
             {
@@ -220,7 +221,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
                 }
             }
 
-            return elements.ToImmutable();
+            return elements.ToImmutableAndFree();
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 using Microsoft.Build.Construction;
 using Microsoft.Build.Evaluation;
-using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
+using Microsoft.VisualStudio.Buffers.PooledObjects;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/StartupProjectHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/StartupProjectHelper.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
-using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
+using Microsoft.VisualStudio.Buffers.PooledObjects;
 using Microsoft.VisualStudio.ProjectSystem.VS.Extensibility;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/StartupProjectHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/StartupProjectHelper.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
+using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
 using Microsoft.VisualStudio.ProjectSystem.VS.Extensibility;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -37,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
                 if (dte.Solution.SolutionBuild.StartupProjects is Array startupProjects && startupProjects.Length > 0)
                 {
                     IVsSolution sln = ServiceProvider.GetService<IVsSolution, SVsSolution>();
-                    ImmutableArray<T>.Builder results = ImmutableArray.CreateBuilder<T>();
+                    var results = PooledArray<T>.GetInstance();
                     foreach (string projectName in startupProjects)
                     {
                         sln.GetProjectOfUniqueName(projectName, out IVsHierarchy hier);
@@ -47,7 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
                             results.Add(ProjectExportProvider.GetExport<T>(projectPath));
                         }
                     }
-                    return results.ToImmutable();
+                    return results.ToImmutableAndFree();
                 }
             }
             return ImmutableArray<T>.Empty;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikersValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikersValueProvider.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
-
+using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectProperties
@@ -22,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
         public override async Task<string> OnGetEvaluatedPropertyValueAsync(string evaluatedPropertyValue, IProjectProperties defaultProperties)
         {
             ActiveConfiguredObjects<ConfiguredProject> configuredProjects = await _projectProvider.GetActiveConfiguredProjectsAsync();
-            ImmutableArray<string>.Builder builder = ImmutableArray.CreateBuilder<string>();
+            var builder = PooledArray<string>.GetInstance();
             foreach (ConfiguredProject configuredProject in configuredProjects.Objects)
             {
                 ProjectProperties projectProperties = configuredProject.Services.ExportProvider.GetExportedValue<ProjectProperties>();
@@ -31,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
                 builder.Add(currentTargetFrameworkMoniker);
             }
 
-            return string.Join(";", builder.ToArray());
+            return string.Join(";", builder.ToArrayAndFree());
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikersValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikersValueProvider.cs
@@ -2,7 +2,7 @@
 
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
+using Microsoft.VisualStudio.Buffers.PooledObjects;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectProperties

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 {
@@ -39,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             ImmutableDictionary<string, ConfiguredProject> configuredProjectsMap = await _activeConfiguredProjectsProvider.GetActiveConfiguredProjectsMapAsync();
 #pragma warning restore CS0618 // Type or member is obsolete
             ProjectConfiguration activeProjectConfiguration = _commonServices.ActiveConfiguredProject.ProjectConfiguration;
-            ImmutableArray<ITargetFramework>.Builder targetFrameworks = ImmutableArray.CreateBuilder<ITargetFramework>(initialCapacity: configuredProjectsMap.Count);
+            var targetFrameworks = PooledArray<ITargetFramework>.GetInstance();
             ITargetFramework activeTargetFramework = TargetFramework.Empty;
 
             foreach ((string tfm, ConfiguredProject configuredProject) in configuredProjectsMap)
@@ -61,7 +62,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 
             return new AggregateCrossTargetProjectContext(
                 isCrossTargeting,
-                targetFrameworks.MoveToImmutable(),
+                targetFrameworks.ToImmutableAndFree(),
                 configuredProjectsMap,
                 activeTargetFramework,
                 _targetFrameworkProvider);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
@@ -6,7 +6,6 @@ using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 {
@@ -40,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             ImmutableDictionary<string, ConfiguredProject> configuredProjectsMap = await _activeConfiguredProjectsProvider.GetActiveConfiguredProjectsMapAsync();
 #pragma warning restore CS0618 // Type or member is obsolete
             ProjectConfiguration activeProjectConfiguration = _commonServices.ActiveConfiguredProject.ProjectConfiguration;
-            var targetFrameworks = PooledArray<ITargetFramework>.GetInstance();
+            ImmutableArray<ITargetFramework>.Builder targetFrameworks = ImmutableArray.CreateBuilder<ITargetFramework>(initialCapacity: configuredProjectsMap.Count);
             ITargetFramework activeTargetFramework = TargetFramework.Empty;
 
             foreach ((string tfm, ConfiguredProject configuredProject) in configuredProjectsMap)
@@ -62,7 +61,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 
             return new AggregateCrossTargetProjectContext(
                 isCrossTargeting,
-                targetFrameworks.ToImmutableAndFree(),
+                targetFrameworks.MoveToImmutable(),
                 configuredProjectsMap,
                 activeTargetFramework,
                 _targetFrameworkProvider);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.Collections.Immutable;
-using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
+using Microsoft.VisualStudio.Buffers.PooledObjects;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Immutable;
-using System.Text;
-
+using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models;
@@ -15,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 {
     internal sealed class Dependency : IDependency
     {
-        private static readonly ConcurrentBag<StringBuilder> s_builderPool = new ConcurrentBag<StringBuilder>();
+        private static readonly DependencyIconSetCache s_iconSetCache = new DependencyIconSetCache();
 
         // These priorities are for graph nodes only and are used to group graph nodes 
         // appropriately in order groups predefined order instead of alphabetically.
@@ -94,10 +92,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             else
             {
                 int count = dependencyModel.DependencyIDs.Count;
-                ImmutableArray<string>.Builder ids = ImmutableArray.CreateBuilder<string>(count);
+                var ids = PooledArray<string>.GetInstance();
                 for (int i = 0; i < count; i++)
                     ids.Add(GetID(TargetFramework, ProviderType, dependencyModel.DependencyIDs[i]));
-                DependencyIDs = ids.MoveToImmutable();
+                DependencyIDs = ids.ToImmutableAndFree();
             }
         }
 
@@ -269,17 +267,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         public override string ToString()
         {
             // Used for debugging only
-
-            var sb = new StringBuilder();
-
-            sb.Append("Id=\"").Append(Id).Append('"');
+            var sb = PooledStringBuilder.GetInstance();
+            sb.Append("Id=\"");
+            sb.Append(Id);
+            sb.Append('"');
 
             if (Resolved) sb.Append(" Resolved");
             if (TopLevel) sb.Append(" TopLevel");
             if (Implicit) sb.Append(" Implicit");
             if (Visible)  sb.Append(" Visible");
 
-            return sb.ToString();
+            return sb.ToStringAndFree();
         }
 
         /// <summary>
@@ -323,7 +321,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
             if (string.Compare(id, index, modelId, 0, modelId.Length - modelSlashCount, StringComparison.OrdinalIgnoreCase) != 0)
                 return false;
-            
+
             return true;
         }
 
@@ -333,39 +331,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             Requires.NotNullOrEmpty(providerType, nameof(providerType));
             Requires.NotNullOrEmpty(modelId, nameof(modelId));
 
-            StringBuilder sb = null;
-            try
-            {
-                int length = targetFramework.ShortName.Length + providerType.Length + modelId.Length + 2;
-
-                if (!s_builderPool.TryTake(out sb))
-                {
-                    sb = new StringBuilder(length);
-                }
-                else
-                {
-                    sb.EnsureCapacity(length);
-                }
-
-                sb.Append(targetFramework.ShortName).Append('\\');
-                sb.Append(providerType).Append('\\');
-                int offset = sb.Length;
-                sb.Append(modelId);
-                // normalize modelId (without allocating)
-                sb.Replace('/', '\\', offset, modelId.Length)
-                  .Replace("..", "__", offset, modelId.Length);
-                sb.TrimEnd(Delimiter.BackSlash);
-                return sb.ToString();
-            }
-            finally
-            {
-                // Prevent holding on to large builders
-                if (sb?.Capacity < 1000)
-                {
-                    sb.Clear();
-                    s_builderPool.Add(sb);
-                }
-            }
+            var sb = PooledStringBuilder.GetInstance();
+            sb.Append(targetFramework.ShortName);
+            sb.Append('\\');
+            sb.Append(providerType);
+            sb.Append('\\');
+            int offset = sb.Length;
+            sb.Append(modelId);
+            // normalize modelId (without allocating)
+            sb.Replace('/', '\\', offset, modelId.Length);
+            sb.Replace("..", "__", offset, modelId.Length);
+            sb.TrimEnd(Delimiter.BackSlash);
+            return sb.ToStringAndFree();
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Dependency.cs
@@ -92,10 +92,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             else
             {
                 int count = dependencyModel.DependencyIDs.Count;
-                var ids = PooledArray<string>.GetInstance();
+                ImmutableArray<string>.Builder ids = ImmutableArray.CreateBuilder<string>(count);
                 for (int i = 0; i < count; i++)
                     ids.Add(GetID(TargetFramework, ProviderType, dependencyModel.DependencyIDs[i]));
-                DependencyIDs = ids.ToImmutableAndFree();
+                DependencyIDs = ids.MoveToImmutable();
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/DesignTimeTelemetryLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/DesignTimeTelemetryLogger.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 using Microsoft.Build.Framework;
-using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
+using Microsoft.VisualStudio.Buffers.PooledObjects;
 
 namespace Microsoft.VisualStudio.Telemetry
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/DesignTimeTelemetryLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/DesignTimeTelemetryLogger.cs
@@ -3,9 +3,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 using Microsoft.Build.Framework;
+using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
 
 namespace Microsoft.VisualStudio.Telemetry
 {
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.Telemetry
 
         public void Shutdown()
         {
-            var builder = new StringBuilder();
+            var builder = PooledStringBuilder.GetInstance();
 
             foreach (TargetRecord target in _targets.Values
                 .Where(v => v.Elapsed != TimeSpan.Zero)
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.Telemetry
                 builder.Append(';');
             }
 
-            string targetResults = builder.ToString();
+            string targetResults = builder.ToStringAndFree();
 
             _telemetryService.PostProperties(TelemetryEventName.DesignTimeBuildComplete, new[]
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildUtilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildUtilities.cs
@@ -7,7 +7,7 @@ using System.Text;
 
 using Microsoft.Build.Construction;
 using Microsoft.Build.Execution;
-using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
+using Microsoft.VisualStudio.Buffers.PooledObjects;
 using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.Build

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildUtilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildUtilities.cs
@@ -7,6 +7,7 @@ using System.Text;
 
 using Microsoft.Build.Construction;
 using Microsoft.Build.Execution;
+using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
 using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.Build
@@ -107,7 +108,7 @@ namespace Microsoft.VisualStudio.Build
             Requires.NotNullOrEmpty(propertyName, nameof(propertyName));
 
             ProjectPropertyElement property = GetOrAddProperty(project, propertyName);
-            var newValue = new StringBuilder();
+            var newValue = PooledStringBuilder.GetInstance();
             foreach (string value in GetPropertyValues(evaluatedPropertyValue, delimiter))
             {
                 newValue.Append(value);
@@ -115,7 +116,7 @@ namespace Microsoft.VisualStudio.Build
             }
 
             newValue.Append(valueToAppend);
-            property.Value = newValue.ToString();
+            property.Value = newValue.ToStringAndFree();
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/ObjectPool.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/ObjectPool.cs
@@ -4,7 +4,7 @@ using System;
 using System.Diagnostics;
 using System.Threading;
 
-namespace Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects
+namespace Microsoft.VisualStudio.Buffers.PooledObjects
 {
     /// <summary>
     /// Generic implementation of object pooling pattern with predefined pool size limit. The main

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/ObjectPool.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/ObjectPool.cs
@@ -31,12 +31,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects
             internal T Value;
         }
 
-        /// <remarks>
-        /// Not using System.Func{T} because this file is linked into the (debugger) Formatter,
-        /// which does not have that type (since it compiles against .NET 2.0).
-        /// </remarks>
-        internal delegate T Factory();
-
         // Storage for the pool objects. The first item is stored in a dedicated field because we
         // expect to be able to satisfy most requests from it.
         private T _firstItem;
@@ -45,13 +39,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects
         // factory is stored for the lifetime of the pool. We will call this only when pool needs to
         // expand. compared to "new T()", Func gives more flexibility to implementers and faster
         // than "new T()".
-        private readonly Factory _factory;  
+        private readonly Func<T> _factory;  
 
-        internal ObjectPool(Factory factory)
+        internal ObjectPool(Func<T> factory)
             : this(factory, Environment.ProcessorCount * 2)
         { }
 
-        internal ObjectPool(Factory factory, int size)
+        internal ObjectPool(Func<T> factory, int size)
         {
             Requires.Argument(size >= 1, nameof(size), "must be greater than or equal to one");
             _factory = factory;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/ObjectPool.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/ObjectPool.cs
@@ -1,0 +1,151 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects
+{
+    /// <summary>
+    /// Generic implementation of object pooling pattern with predefined pool size limit. The main
+    /// purpose is that limited number of frequently used objects can be kept in the pool for
+    /// further recycling.
+    /// 
+    /// Notes: 
+    /// 1) it is not the goal to keep all returned objects. Pool is not meant for storage. If there
+    ///    is no space in the pool, extra returned objects will be dropped.
+    /// 
+    /// 2) it is implied that if object was obtained from a pool, the caller will return it back in
+    ///    a relatively short time. Keeping checked out objects for long durations is ok, but 
+    ///    reduces usefulness of pooling. Just new up your own.
+    /// 
+    /// Not returning objects to the pool in not detrimental to the pool's work, but is a bad practice. 
+    /// Rationale: 
+    ///    If there is no intent for reusing the object, do not use pool - just use "new". 
+    /// </summary>
+    internal class ObjectPool<T> where T : class
+    {
+        [DebuggerDisplay("{Value,nq}")]
+        private struct Element
+        {
+            internal T Value;
+        }
+
+        /// <remarks>
+        /// Not using System.Func{T} because this file is linked into the (debugger) Formatter,
+        /// which does not have that type (since it compiles against .NET 2.0).
+        /// </remarks>
+        internal delegate T Factory();
+
+        // Storage for the pool objects. The first item is stored in a dedicated field because we
+        // expect to be able to satisfy most requests from it.
+        private T _firstItem;
+        private readonly Element[] _items;
+
+        // factory is stored for the lifetime of the pool. We will call this only when pool needs to
+        // expand. compared to "new T()", Func gives more flexibility to implementers and faster
+        // than "new T()".
+        private readonly Factory _factory;  
+
+        internal ObjectPool(Factory factory)
+            : this(factory, Environment.ProcessorCount * 2)
+        { }
+
+        internal ObjectPool(Factory factory, int size)
+        {
+            Requires.Argument(size >= 1, nameof(size), "must be greater than or equal to one");
+            _factory = factory;
+            _items = new Element[size - 1];
+        }
+
+        private T CreateInstance()
+        {
+            T inst = _factory();
+            return inst;
+        }
+
+        /// <summary>
+        /// Produces an instance.
+        /// </summary>
+        /// <remarks>
+        /// Search strategy is a simple linear probing which is chosen for it cache-friendliness.
+        /// Note that Free will try to store recycled objects close to the start thus statistically 
+        /// reducing how far we will typically search.
+        /// </remarks>
+        internal T Allocate()
+        {
+            // PERF: Examine the first element. If that fails, AllocateSlow will look at the remaining elements.
+            // Note that the initial read is optimistically not synchronized. That is intentional. 
+            // We will interlock only when we have a candidate. in a worst case we may miss some
+            // recently returned objects. Not a big deal.
+            T inst = _firstItem;
+            if (inst == null || inst != Interlocked.CompareExchange(ref _firstItem, null, inst))
+            {
+                inst = AllocateSlow();
+            }
+
+            return inst;
+        }
+
+        private T AllocateSlow()
+        {
+            Element[] items = _items;
+
+            for (int i = 0; i < items.Length; i++)
+            {
+                // Note that the initial read is optimistically not synchronized. That is intentional. 
+                // We will interlock only when we have a candidate. in a worst case we may miss some
+                // recently returned objects. Not a big deal.
+                T inst = items[i].Value;
+                if (inst != null)
+                {
+                    if (inst == Interlocked.CompareExchange(ref items[i].Value, null, inst))
+                    {
+                        return inst;
+                    }
+                }
+            }
+
+            return CreateInstance();
+        }
+
+        /// <summary>
+        /// Returns objects to the pool.
+        /// </summary>
+        /// <remarks>
+        /// Search strategy is a simple linear probing which is chosen for it cache-friendliness.
+        /// Note that Free will try to store recycled objects close to the start thus statistically 
+        /// reducing how far we will typically search in Allocate.
+        /// </remarks>
+        internal void Free(T obj)
+        {
+            if (_firstItem == null)
+            {
+                // Intentionally not using interlocked here. 
+                // In a worst case scenario two objects may be stored into same slot.
+                // It is very unlikely to happen and will only mean that one of the objects will get collected.
+                _firstItem = obj;
+            }
+            else
+            {
+                FreeSlow(obj);
+            }
+        }
+
+        private void FreeSlow(T obj)
+        {
+            Element[] items = _items;
+            for (int i = 0; i < items.Length; i++)
+            {
+                if (items[i].Value == null)
+                {
+                    // Intentionally not using interlocked here. 
+                    // In a worst case scenario two objects may be stored into same slot.
+                    // It is very unlikely to happen and will only mean that one of the objects will get collected.
+                    items[i].Value = obj;
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledArray.DebuggerProxy.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledArray.DebuggerProxy.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects
+{
+    internal sealed partial class PooledArray<T>
+    {
+        private sealed class DebuggerProxy
+        {
+            private readonly PooledArray<T> _builder;
+
+            public DebuggerProxy(PooledArray<T> builder)
+            {
+                _builder = builder;
+            }
+
+            [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+            public T[] A
+            {
+                get
+                {
+                    var result = new T[_builder.Count];
+                    for (int i = 0; i < result.Length; i++)
+                    {
+                        result[i] = _builder[i];
+                    }
+
+                    return result;
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledArray.DebuggerProxy.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledArray.DebuggerProxy.cs
@@ -2,7 +2,7 @@
 
 using System.Diagnostics;
 
-namespace Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects
+namespace Microsoft.VisualStudio.Buffers.PooledObjects
 {
     internal sealed partial class PooledArray<T>
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledArray.Enumerator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledArray.Enumerator.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects
+{
+    internal sealed partial class PooledArray<T>
+    {
+        /// <summary>
+        /// struct enumerator used in foreach.
+        /// </summary>
+        public struct Enumerator : IEnumerator<T>
+        {
+            private readonly PooledArray<T> _builder;
+            private int _index;
+
+            public Enumerator(PooledArray<T> builder)
+            {
+                _builder = builder;
+                _index = -1;
+            }
+
+            public T Current => _builder[_index];
+
+            public bool MoveNext()
+            {
+                _index++;
+                return _index < _builder.Count;
+            }
+
+            public void Dispose()
+            {
+            }
+
+            object System.Collections.IEnumerator.Current => Current;
+
+            public void Reset() => _index = -1;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledArray.Enumerator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledArray.Enumerator.cs
@@ -2,7 +2,7 @@
 
 using System.Collections.Generic;
 
-namespace Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects
+namespace Microsoft.VisualStudio.Buffers.PooledObjects
 {
     internal sealed partial class PooledArray<T>
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledArray.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledArray.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 
-namespace Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects
+namespace Microsoft.VisualStudio.Buffers.PooledObjects
 {
     [DebuggerDisplay("Count = {Count,nq}")]
     [DebuggerTypeProxy(typeof(PooledArray<>.DebuggerProxy))]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledArray.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledArray.cs
@@ -264,7 +264,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects
 
         public static ObjectPool<PooledArray<T>> CreatePool()
         {
-            return CreatePool(128); // we rarely need more than 10
+            // We use a default size of 128 objects in the pool
+            // This makes it likely that we can handle all use cases
+            // even if many consumers require objects from the pool
+            // in practice we expect 128 allocated objects in the pool
+            // to be rare.  A normal operating set should be around 10.
+            return CreatePool(128);
         }
 
         public static ObjectPool<PooledArray<T>> CreatePool(int size)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledArray.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledArray.cs
@@ -1,0 +1,437 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects
+{
+    [DebuggerDisplay("Count = {Count,nq}")]
+    [DebuggerTypeProxy(typeof(PooledArray<>.DebuggerProxy))]
+    internal sealed partial class PooledArray<T> : IReadOnlyCollection<T>, IReadOnlyList<T>
+    {
+        private readonly ImmutableArray<T>.Builder _builder;
+
+        private readonly ObjectPool<PooledArray<T>> _pool;
+
+        public PooledArray(int size)
+        {
+            _builder = ImmutableArray.CreateBuilder<T>(size);
+        }
+
+        public PooledArray() :
+            this(8)
+        { }
+
+        private PooledArray(ObjectPool<PooledArray<T>> pool) :
+            this()
+        {
+            _pool = pool;
+        }
+
+        /// <summary>
+        /// Realizes the array.
+        /// </summary>
+        public ImmutableArray<T> ToImmutable()
+        {
+            return _builder.ToImmutable();
+        }
+
+        public int Count
+        {
+            get
+            {
+                return _builder.Count;
+            }
+            set
+            {
+                _builder.Count = value;
+            }
+        }
+
+        public T this[int index]
+        {
+            get
+            {
+                return _builder[index];
+            }
+
+            set
+            {
+                _builder[index] = value;
+            }
+        }
+
+        /// <summary>
+        /// Write <paramref name="value"/> to slot <paramref name="index"/>. 
+        /// Fills in unallocated slots preceding the <paramref name="index"/>, if any.
+        /// </summary>
+        public void SetItem(int index, T value)
+        {
+            while (index > _builder.Count)
+            {
+                _builder.Add(default);
+            }
+
+            if (index == _builder.Count)
+            {
+                _builder.Add(value);
+            }
+            else
+            {
+                _builder[index] = value;
+            }
+        }
+
+        public void Add(T item) => _builder.Add(item);
+
+        public void Insert(int index, T item) => _builder.Insert(index, item);
+
+        public void EnsureCapacity(int capacity)
+        {
+            if (_builder.Capacity < capacity)
+            {
+                _builder.Capacity = capacity;
+            }
+        }
+
+        public void Clear() => _builder.Clear();
+
+        public bool Contains(T item) => _builder.Contains(item);
+
+        public int IndexOf(T item) => _builder.IndexOf(item);
+
+        public int IndexOf(T item, IEqualityComparer<T> equalityComparer)
+            => _builder.IndexOf(item, 0, _builder.Count, equalityComparer);
+
+        public int IndexOf(T item, int startIndex, int count)
+            => _builder.IndexOf(item, startIndex, count);
+
+        public int FindIndex(Predicate<T> match)
+            => FindIndex(0, Count, match);
+
+        public int FindIndex(int startIndex, Predicate<T> match)
+            => FindIndex(startIndex, Count - startIndex, match);
+
+        public int FindIndex(int startIndex, int count, Predicate<T> match)
+        {
+            int endIndex = startIndex + count;
+            for (int i = startIndex; i < endIndex; i++)
+            {
+                if (match(_builder[i]))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        public void RemoveAt(int index) => _builder.RemoveAt(index);
+
+        public void RemoveLast() => _builder.RemoveAt(_builder.Count - 1);
+
+        public void ReverseContents() => _builder.Reverse();
+
+        public void Sort() => _builder.Sort();
+
+        public void Sort(IComparer<T> comparer)
+        {
+            _builder.Sort(comparer);
+        }
+
+        public void Sort(Comparison<T> compare)
+            => Sort(Comparer<T>.Create(compare));
+
+        public void Sort(int startIndex, IComparer<T> comparer)
+            => _builder.Sort(startIndex, _builder.Count - startIndex, comparer);
+
+        public T[] ToArray() => _builder.ToArray();
+
+        public void CopyTo(T[] array, int start) => _builder.CopyTo(array, start);
+
+        public T Last() => _builder[_builder.Count - 1];
+
+        public T First() => _builder[0];
+
+        public bool Any() => _builder.Count > 0;
+
+        /// <summary>
+        /// Realizes the array.
+        /// </summary>
+        public ImmutableArray<T> ToImmutableOrNull()
+            => Count == 0 ? default : ToImmutable();
+
+        /// <summary>
+        /// Realizes the array, downcasting each element to a derived type.
+        /// </summary>
+        public ImmutableArray<U> ToDowncastedImmutable<U>()
+            where U : T
+        {
+            if (Count == 0)
+            {
+                return ImmutableArray<U>.Empty;
+            }
+
+            var tmp = PooledArray<U>.GetInstance(Count);
+            foreach (T i in this)
+            {
+                tmp.Add((U)i);
+            }
+
+            return tmp.ToImmutableAndFree();
+        }
+
+        /// <summary>
+        /// Realizes the array and disposes the builder in one operation.
+        /// </summary>
+        public ImmutableArray<T> ToImmutableAndFree()
+        {
+            ImmutableArray<T> result;
+            if (_builder.Capacity == Count)
+            {
+                result = _builder.MoveToImmutable();
+            }
+            else
+            {
+                result = ToImmutable();
+            }
+
+            Free();
+            return result;
+        }
+
+        public T[] ToArrayAndFree()
+        {
+            T[] result = ToArray();
+            Free();
+            return result;
+        }
+
+        // To implement Poolable, you need two things:
+        // 1) Expose Freeing primitive. 
+        public void Free()
+        {
+            ObjectPool<PooledArray<T>> pool = _pool;
+            if (pool != null)
+            {
+                // We do not want to retain (potentially indefinitely) very large builders 
+                // while the chance that we will need their size is diminishingly small.
+                // It makes sense to constrain the size to some "not too small" number. 
+                // Overall perf does not seem to be very sensitive to this number, so I picked 128 as a limit.
+                if (_builder.Capacity < 128)
+                {
+                    if (Count != 0)
+                    {
+                        Clear();
+                    }
+
+                    pool.Free(this);
+                    return;
+                }
+            }
+        }
+
+        // 2) Expose the pool or the way to create a pool or the way to get an instance.
+        //    for now we will expose both and figure which way works better
+        private static readonly ObjectPool<PooledArray<T>> s_poolInstance = CreatePool();
+        public static PooledArray<T> GetInstance()
+        {
+            PooledArray<T> builder = s_poolInstance.Allocate();
+            return builder;
+        }
+
+        public static PooledArray<T> GetInstance(int capacity)
+        {
+            PooledArray<T> builder = GetInstance();
+            builder.EnsureCapacity(capacity);
+            return builder;
+        }
+
+        public static PooledArray<T> GetInstance(int capacity, T fillWithValue)
+        {
+            PooledArray<T> builder = GetInstance();
+            builder.EnsureCapacity(capacity);
+
+            for (int i = 0; i < capacity; i++)
+            {
+                builder.Add(fillWithValue);
+            }
+
+            return builder;
+        }
+
+        public static ObjectPool<PooledArray<T>> CreatePool()
+        {
+            return CreatePool(128); // we rarely need more than 10
+        }
+
+        public static ObjectPool<PooledArray<T>> CreatePool(int size)
+        {
+            ObjectPool<PooledArray<T>> pool = null;
+            pool = new ObjectPool<PooledArray<T>>(() => new PooledArray<T>(pool), size);
+            return pool;
+        }
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(this);
+        }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        internal Dictionary<K, ImmutableArray<T>> ToDictionary<K>(Func<T, K> keySelector, IEqualityComparer<K> comparer = null)
+        {
+            if (Count == 1)
+            {
+                var dictionary1 = new Dictionary<K, ImmutableArray<T>>(1, comparer);
+                T value = this[0];
+                dictionary1.Add(keySelector(value), ImmutableArray.Create(value));
+                return dictionary1;
+            }
+
+            if (Count == 0)
+            {
+                return new Dictionary<K, ImmutableArray<T>>(comparer);
+            }
+
+            // bucketize
+            // prevent reallocation. it may not have 'count' entries, but it won't have more. 
+            var accumulator = new Dictionary<K, PooledArray<T>>(Count, comparer);
+            for (int i = 0; i < Count; i++)
+            {
+                T item = this[i];
+                K key = keySelector(item);
+                if (!accumulator.TryGetValue(key, out PooledArray<T> bucket))
+                {
+                    bucket = GetInstance();
+                    accumulator.Add(key, bucket);
+                }
+
+                bucket.Add(item);
+            }
+
+            var dictionary = new Dictionary<K, ImmutableArray<T>>(accumulator.Count, comparer);
+
+            // freeze
+            foreach (KeyValuePair<K, PooledArray<T>> pair in accumulator)
+            {
+                dictionary.Add(pair.Key, pair.Value.ToImmutableAndFree());
+            }
+
+            return dictionary;
+        }
+
+        public void AddRange(PooledArray<T> items)
+        {
+            _builder.AddRange(items._builder);
+        }
+
+        public void AddRange<U>(PooledArray<U> items) where U : T
+        {
+            _builder.AddRange(items._builder);
+        }
+
+        public void AddRange(ImmutableArray<T> items)
+        {
+            _builder.AddRange(items);
+        }
+
+        public void AddRange(ImmutableArray<T> items, int length)
+        {
+            _builder.AddRange(items, length);
+        }
+
+        public void AddRange<S>(ImmutableArray<S> items) where S : class, T
+        {
+            AddRange(ImmutableArray<T>.CastUp(items));
+        }
+
+        public void AddRange(T[] items, int start, int length)
+        {
+            for (int i = start, end = start + length; i < end; i++)
+            {
+                Add(items[i]);
+            }
+        }
+
+        public void AddRange(IEnumerable<T> items)
+        {
+            _builder.AddRange(items);
+        }
+
+        public void AddRange(params T[] items)
+        {
+            _builder.AddRange(items);
+        }
+
+        public void AddRange(T[] items, int length)
+        {
+            _builder.AddRange(items, length);
+        }
+
+        public void Clip(int limit)
+        {
+            _builder.Count = limit;
+        }
+
+        public void ZeroInit(int count)
+        {
+            _builder.Clear();
+            _builder.Count = count;
+        }
+
+        public void AddMany(T item, int count)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                Add(item);
+            }
+        }
+
+        public void RemoveDuplicates()
+        {
+            var set = PooledHashSet<T>.GetInstance();
+
+            int j = 0;
+            for (int i = 0; i < Count; i++)
+            {
+                if (set.Add(this[i]))
+                {
+                    this[j] = this[i];
+                    j++;
+                }
+            }
+
+            Clip(j);
+            set.Free();
+        }
+
+        public ImmutableArray<S> SelectDistinct<S>(Func<T, S> selector)
+        {
+            var result = PooledArray<S>.GetInstance(Count);
+            var set = PooledHashSet<S>.GetInstance();
+
+            foreach (T item in this)
+            {
+                S selected = selector(item);
+                if (set.Add(selected))
+                {
+                    result.Add(selected);
+                }
+            }
+
+            set.Free();
+            return result.ToImmutableAndFree();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledDictionary.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledDictionary.cs
@@ -3,7 +3,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 
-namespace Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects
+namespace Microsoft.VisualStudio.Buffers.PooledObjects
 {
     // Dictionary that can be recycled via an object pool
     // NOTE: these dictionaries always have the default comparer.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledDictionary.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledDictionary.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects
+{
+    // Dictionary that can be recycled via an object pool
+    // NOTE: these dictionaries always have the default comparer.
+    internal class PooledDictionary<K, V> : Dictionary<K, V>
+    {
+        private readonly ObjectPool<PooledDictionary<K, V>> _pool;
+
+        private PooledDictionary(ObjectPool<PooledDictionary<K, V>> pool)
+        {
+            _pool = pool;
+        }
+
+        public ImmutableDictionary<K, V> ToImmutableDictionaryAndFree()
+        {
+            var result = this.ToImmutableDictionary();
+            Free();
+            return result;
+        }
+
+        public void Free()
+        {
+            Clear();
+            _pool?.Free(this);
+        }
+
+        // global pool
+        private static readonly ObjectPool<PooledDictionary<K, V>> s_poolInstance = CreatePool();
+
+        // if someone needs to create a pool;
+        public static ObjectPool<PooledDictionary<K, V>> CreatePool()
+        {
+            ObjectPool<PooledDictionary<K, V>> pool = null;
+            pool = new ObjectPool<PooledDictionary<K, V>>(() => new PooledDictionary<K, V>(pool), 128);
+            return pool;
+        }
+
+        public static PooledDictionary<K, V> GetInstance()
+        {
+            PooledDictionary<K, V> instance = s_poolInstance.Allocate();
+            // Debug.Assert(instance.Count == 0);
+            return instance;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledHashSet.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledHashSet.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects
+{
+    // HashSet that can be recycled via an object pool
+    // NOTE: these HashSets always have the default comparer.
+    internal class PooledHashSet<T> : HashSet<T>
+    {
+        private readonly ObjectPool<PooledHashSet<T>> _pool;
+
+        private PooledHashSet(ObjectPool<PooledHashSet<T>> pool)
+        {
+            _pool = pool;
+        }
+
+        public void Free()
+        {
+            Clear();
+            _pool?.Free(this);
+        }
+
+        // global pool
+        private static readonly ObjectPool<PooledHashSet<T>> s_poolInstance = CreatePool();
+
+        // if someone needs to create a pool;
+        public static ObjectPool<PooledHashSet<T>> CreatePool()
+        {
+            ObjectPool<PooledHashSet<T>> pool = null;
+            pool = new ObjectPool<PooledHashSet<T>>(() => new PooledHashSet<T>(pool), 128);
+            return pool;
+        }
+
+        public static PooledHashSet<T> GetInstance()
+        {
+            PooledHashSet<T> instance = s_poolInstance.Allocate();
+            return instance;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledHashSet.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledHashSet.cs
@@ -2,7 +2,7 @@
 
 using System.Collections.Generic;
 
-namespace Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects
+namespace Microsoft.VisualStudio.Buffers.PooledObjects
 {
     // HashSet that can be recycled via an object pool
     // NOTE: these HashSets always have the default comparer.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledStringBuilder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledStringBuilder.cs
@@ -1,0 +1,138 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects
+{
+    /// <summary>
+    /// The usage is:
+    ///        var sb = PooledStringBuilder.GetInstance();
+    ///        ... Do Stuff...
+    ///        sb.ToStringAndFree()
+    /// </summary>
+    internal class PooledStringBuilder
+    {
+        private readonly StringBuilder _builder = new StringBuilder();
+        private readonly ObjectPool<PooledStringBuilder> _pool;
+
+        private PooledStringBuilder(ObjectPool<PooledStringBuilder> pool)
+        {
+            Requires.NotNull(pool, nameof(pool));
+            _pool = pool;
+        }
+
+        public int Length { get => _builder.Length; set => _builder.Length = value; }
+
+        public void Free()
+        {
+            StringBuilder builder = _builder;
+
+            // do not store builders that are too large.
+            if (builder.Capacity <= 1024)
+            {
+                builder.Clear();
+                _pool.Free(this);
+            }
+        }
+
+        public string ToStringAndFree()
+        {
+            string result = _builder.ToString();
+            Free();
+
+            return result;
+        }
+
+        public string ToStringAndFree(int startIndex, int length)
+        {
+            string result = _builder.ToString(startIndex, length);
+            Free();
+
+            return result;
+        }
+
+        // global pool
+        private static readonly ObjectPool<PooledStringBuilder> s_poolInstance = CreatePool();
+
+        // if someone needs to create a private pool;
+        /// <summary>
+        /// If someone need to create a private pool
+        /// </summary>
+        /// <param name="size">The size of the pool.</param>
+        /// <returns></returns>
+        public static ObjectPool<PooledStringBuilder> CreatePool(int size = 32)
+        {
+            ObjectPool<PooledStringBuilder> pool = null;
+            pool = new ObjectPool<PooledStringBuilder>(() => new PooledStringBuilder(pool), size);
+            return pool;
+        }
+
+        public static PooledStringBuilder GetInstance()
+        {
+            PooledStringBuilder builder = s_poolInstance.Allocate();
+            //Debug.Assert(builder.Builder.Length == 0);
+            return builder;
+        }
+
+        public static implicit operator StringBuilder(PooledStringBuilder obj) => obj._builder;
+
+        public char this[int index] { get => _builder[index]; set => _builder[index] = value; }
+        public void Append(double value) => _builder.Append(value);
+        public void Append(char[] value) => _builder.Append(value);
+        public void Append(object value) => _builder.Append(value);
+        public void Append(ulong value) => _builder.Append(value);
+        public void Append(uint value) => _builder.Append(value);
+        public void Append(ushort value) => _builder.Append(value);
+        public void Append(decimal value) => _builder.Append(value);
+        public void Append(float value) => _builder.Append(value);
+        public void Append(int value) => _builder.Append(value);
+        public void Append(short value) => _builder.Append(value);
+        public void Append(char value) => _builder.Append(value);
+        public void Append(long value) => _builder.Append(value);
+        public void Append(sbyte value) => _builder.Append(value);
+        public void Append(byte value) => _builder.Append(value);
+        public void Append(char[] value, int startIndex, int charCount) => _builder.Append(value, startIndex, charCount);
+        public void Append(string value) => _builder.Append(value);
+        public void Append(string value, int startIndex, int count) => _builder.Append(value, startIndex, count);
+        public void Append(char value, int repeatCount) => _builder.Append(value, repeatCount);
+        public void Append(bool value) => _builder.Append(value);
+        public void AppendFormat(IFormatProvider provider, string format, params object[] args) => _builder.AppendFormat(provider, format, args);
+        public void AppendFormat(string format, object arg0, object arg1, object arg2) => _builder.AppendFormat(format, arg0, arg1, arg2);
+        public void AppendFormat(string format, params object[] args) => _builder.AppendFormat(format, args);
+        public void AppendFormat(IFormatProvider provider, string format, object arg0) => _builder.AppendFormat(provider, format, arg0);
+        public void AppendFormat(IFormatProvider provider, string format, object arg0, object arg1) => _builder.AppendFormat(provider, format, arg0, arg1);
+        public void AppendFormat(IFormatProvider provider, string format, object arg0, object arg1, object arg2) => _builder.AppendFormat(provider, format, arg0, arg1, arg2);
+        public void AppendFormat(string format, object arg0) => _builder.AppendFormat(format, arg0);
+        public void AppendFormat(string format, object arg0, object arg1) => _builder.AppendFormat(format, arg0, arg1);
+        public void AppendLine() => _builder.AppendLine();
+        public void AppendLine(string value) => _builder.AppendLine(value);
+        public void Clear() => _builder.Clear();
+        public void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count) => _builder.CopyTo(sourceIndex, destination, destinationIndex, count);
+        public int EnsureCapacity(int capacity) => _builder.EnsureCapacity(capacity);
+        public bool Equals(StringBuilder sb) => _builder.Equals(sb);
+        public void Insert(int index, object value) => _builder.Insert(index, value);
+        public void Insert(int index, byte value) => _builder.Insert(index, value);
+        public void Insert(int index, ulong value) => _builder.Insert(index, value);
+        public void Insert(int index, uint value) => _builder.Insert(index, value);
+        public void Insert(int index, string value) => _builder.Insert(index, value);
+        public void Insert(int index, decimal value) => _builder.Insert(index, value);
+        public void Insert(int index, string value, int count) => _builder.Insert(index, value, count);
+        public void Insert(int index, bool value) => _builder.Insert(index, value);
+        public void Insert(int index, ushort value) => _builder.Insert(index, value);
+        public void Insert(int index, short value) => _builder.Insert(index, value);
+        public void Insert(int index, char value) => _builder.Insert(index, value);
+        public void Insert(int index, sbyte value) => _builder.Insert(index, value);
+        public void Insert(int index, char[] value, int startIndex, int charCount) => _builder.Insert(index, value, startIndex, charCount);
+        public void Insert(int index, int value) => _builder.Insert(index, value);
+        public void Insert(int index, long value) => _builder.Insert(index, value);
+        public void Insert(int index, float value) => _builder.Insert(index, value);
+        public void Insert(int index, double value) => _builder.Insert(index, value);
+        public void Insert(int index, char[] value) => _builder.Insert(index, value);
+        public void Remove(int startIndex, int length) => _builder.Remove(startIndex, length);
+        public void Replace(string oldValue, string newValue) => _builder.Replace(oldValue, newValue);
+        public void Replace(string oldValue, string newValue, int startIndex, int count) => _builder.Replace(oldValue, newValue, startIndex, count);
+        public void Replace(char oldChar, char newChar) => _builder.Replace(oldChar, newChar);
+        public void Replace(char oldChar, char newChar, int startIndex, int count) => _builder.Replace(oldChar, newChar, startIndex, count);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledStringBuilder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledStringBuilder.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Text;
 
-namespace Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects
+namespace Microsoft.VisualStudio.Buffers.PooledObjects
 {
     /// <summary>
     /// The usage is:

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
@@ -6,7 +6,7 @@ using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading.Tasks;
-
+using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
 using Microsoft.VisualStudio.ProjectSystem.Configuration;
 
 namespace Microsoft.VisualStudio.ProjectSystem
@@ -74,7 +74,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public async Task<ImmutableDictionary<string, ConfiguredProject>> GetActiveConfiguredProjectsMapAsync()
         {
-            ImmutableDictionary<string, ConfiguredProject>.Builder builder = ImmutableDictionary.CreateBuilder<string, ConfiguredProject>();
+            var builder = PooledDictionary<string, ConfiguredProject>.GetInstance();
 
             ActiveConfiguredObjects<ConfiguredProject> projects = await GetActiveConfiguredProjectsAsync();
 
@@ -92,7 +92,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 builder.Add(string.Empty, projects.Objects[0]);
             }
 
-            return builder.ToImmutable();
+            return builder.ToImmutableDictionaryAndFree();
         }
 
         public async Task<ActiveConfiguredObjects<ConfiguredProject>> GetActiveConfiguredProjectsAsync()
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             if (configurations == null)
                 return null;
 
-            ImmutableArray<ConfiguredProject>.Builder builder = ImmutableArray.CreateBuilder<ConfiguredProject>(configurations.Objects.Count);
+            var builder = PooledArray<ConfiguredProject>.GetInstance();
 
             foreach (ProjectConfiguration configuration in configurations.Objects)
             {
@@ -110,7 +110,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 builder.Add(project);
             }
 
-            return new ActiveConfiguredObjects<ConfiguredProject>(builder.MoveToImmutable(), configurations.DimensionNames);
+            return new ActiveConfiguredObjects<ConfiguredProject>(builder.ToImmutableAndFree(), configurations.DimensionNames);
         }
 
         public async Task<ActiveConfiguredObjects<ProjectConfiguration>> GetActiveProjectConfigurationsAsync()
@@ -121,7 +121,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             IImmutableSet<ProjectConfiguration> configurations = await _services.ProjectConfigurationsService.GetKnownProjectConfigurationsAsync();
 
-            ImmutableArray<ProjectConfiguration>.Builder builder = ImmutableArray.CreateBuilder<ProjectConfiguration>(configurations.Count);
+            var builder = PooledArray<ProjectConfiguration>.GetInstance();
             IImmutableSet<string> dimensionNames = GetDimensionNames();
 
             foreach (ProjectConfiguration configuration in configurations)
@@ -133,7 +133,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             }
 
             Assumes.True(builder.Count > 0, "We have an active configuration that isn't one of the known configurations");
-            return new ActiveConfiguredObjects<ProjectConfiguration>(builder.ToImmutable(), dimensionNames);
+            return new ActiveConfiguredObjects<ProjectConfiguration>(builder.ToImmutableAndFree(), dimensionNames);
         }
 
         private IImmutableSet<string> GetDimensionNames()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             if (configurations == null)
                 return null;
 
-            var builder = PooledArray<ConfiguredProject>.GetInstance();
+            ImmutableArray<ConfiguredProject>.Builder builder = ImmutableArray.CreateBuilder<ConfiguredProject>(configurations.Objects.Count);
 
             foreach (ProjectConfiguration configuration in configurations.Objects)
             {
@@ -110,7 +110,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 builder.Add(project);
             }
 
-            return new ActiveConfiguredObjects<ConfiguredProject>(builder.ToImmutableAndFree(), configurations.DimensionNames);
+            return new ActiveConfiguredObjects<ConfiguredProject>(builder.MoveToImmutable(), configurations.DimensionNames);
         }
 
         public async Task<ActiveConfiguredObjects<ProjectConfiguration>> GetActiveProjectConfigurationsAsync()
@@ -121,7 +121,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             IImmutableSet<ProjectConfiguration> configurations = await _services.ProjectConfigurationsService.GetKnownProjectConfigurationsAsync();
 
-            var builder = PooledArray<ProjectConfiguration>.GetInstance();
+            ImmutableArray<ProjectConfiguration>.Builder builder = ImmutableArray.CreateBuilder<ProjectConfiguration>(configurations.Count);
             IImmutableSet<string> dimensionNames = GetDimensionNames();
 
             foreach (ProjectConfiguration configuration in configurations)
@@ -133,7 +133,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             }
 
             Assumes.True(builder.Count > 0, "We have an active configuration that isn't one of the known configurations");
-            return new ActiveConfiguredObjects<ProjectConfiguration>(builder.ToImmutableAndFree(), dimensionNames);
+            return new ActiveConfiguredObjects<ProjectConfiguration>(builder.MoveToImmutable(), dimensionNames);
         }
 
         private IImmutableSet<string> GetDimensionNames()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
@@ -121,7 +121,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             IImmutableSet<ProjectConfiguration> configurations = await _services.ProjectConfigurationsService.GetKnownProjectConfigurationsAsync();
 
-            ImmutableArray<ProjectConfiguration>.Builder builder = ImmutableArray.CreateBuilder<ProjectConfiguration>(configurations.Count);
+            var builder = PooledArray<ProjectConfiguration>.GetInstance();
             IImmutableSet<string> dimensionNames = GetDimensionNames();
 
             foreach (ProjectConfiguration configuration in configurations)
@@ -133,7 +133,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             }
 
             Assumes.True(builder.Count > 0, "We have an active configuration that isn't one of the known configurations");
-            return new ActiveConfiguredObjects<ProjectConfiguration>(builder.MoveToImmutable(), dimensionNames);
+            return new ActiveConfiguredObjects<ProjectConfiguration>(builder.ToImmutableAndFree(), dimensionNames);
         }
 
         private IImmutableSet<string> GetDimensionNames()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
@@ -6,7 +6,7 @@ using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
+using Microsoft.VisualStudio.Buffers.PooledObjects;
 using Microsoft.VisualStudio.ProjectSystem.Configuration;
 
 namespace Microsoft.VisualStudio.ProjectSystem

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using Microsoft.Build.Construction;
+using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
 using Microsoft.VisualStudio.Build;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Configuration
@@ -98,9 +99,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
             else
             {
                 // First value is the default one.
-                ImmutableArray<KeyValuePair<string, string>>.Builder defaultValues = ImmutableArray.CreateBuilder<KeyValuePair<string, string>>();
+                var defaultValues = PooledArray<KeyValuePair<string, string>>.GetInstance();
                 defaultValues.Add(new KeyValuePair<string, string>(DimensionName, values.First()));
-                return defaultValues.ToImmutable();
+                return defaultValues.ToImmutableAndFree();
             }
         }
 
@@ -125,9 +126,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
             }
             else
             {
-                ImmutableArray<KeyValuePair<string, IEnumerable<string>>>.Builder dimensionValues = ImmutableArray.CreateBuilder<KeyValuePair<string, IEnumerable<string>>>();
+                var dimensionValues = PooledArray<KeyValuePair<string, IEnumerable<string>>>.GetInstance();
                 dimensionValues.Add(new KeyValuePair<string, IEnumerable<string>>(DimensionName, values));
-                return dimensionValues.ToImmutable();
+                return dimensionValues.ToImmutableAndFree();
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using Microsoft.Build.Construction;
-using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
+using Microsoft.VisualStudio.Buffers.PooledObjects;
 using Microsoft.VisualStudio.Build;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Configuration

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/ImplicitlyActiveDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/ImplicitlyActiveDimensionProvider.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Linq;
+using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Configuration
 {
@@ -44,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
 
         private ImmutableArray<string> CalculateBuiltInImplicitlyActiveDimensions()
         {
-            ImmutableArray<string>.Builder implicitlyActiveDimensions = ImmutableArray.CreateBuilder<string>();
+            var implicitlyActiveDimensions = PooledArray<string>.GetInstance();
 
             foreach (Lazy<IProjectConfigurationDimensionsProvider, IConfigurationDimensionDescriptionMetadataView> provider in DimensionProviders)
             {
@@ -58,7 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
                 }
             }
 
-            return implicitlyActiveDimensions.ToImmutable();
+            return implicitlyActiveDimensions.ToImmutableAndFree();
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/ImplicitlyActiveDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/ImplicitlyActiveDimensionProvider.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Linq;
-using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
+using Microsoft.VisualStudio.Buffers.PooledObjects;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Configuration
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ContextHandlerProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ContextHandlerProvider.cs
@@ -6,6 +6,7 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers;
+using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
@@ -55,8 +56,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         private Handlers CreateHandlers(IWorkspaceProjectContext context)
         {
-            ImmutableArray<(IProjectEvaluationHandler handler, string evaluationRuleName)>.Builder evaluationHandlers = ImmutableArray.CreateBuilder<(IProjectEvaluationHandler handler, string evaluationRuleName)>(s_handlerFactories.Length);
-            ImmutableArray<ICommandLineHandler>.Builder commandLineHandlers = ImmutableArray.CreateBuilder<ICommandLineHandler>(s_handlerFactories.Length);
+            var evaluationHandlers = PooledArray<(IProjectEvaluationHandler handler, string evaluationRuleName)>.GetInstance();
+            var commandLineHandlers = PooledArray<ICommandLineHandler>.GetInstance();
 
             foreach ((HandlerFactory factory, string evaluationRuleName) factory in s_handlerFactories)
             {
@@ -75,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 }
             }
 
-            return new Handlers(evaluationHandlers.MoveToImmutable(), commandLineHandlers.MoveToImmutable());
+            return new Handlers(evaluationHandlers.ToImmutableAndFree(), commandLineHandlers.ToImmutableAndFree());
         }
 
         private static ImmutableArray<(HandlerFactory factory, string evaluationRuleName)> CreateHandlerFactories()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ContextHandlerProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ContextHandlerProvider.cs
@@ -6,7 +6,7 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers;
-using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
+using Microsoft.VisualStudio.Buffers.PooledObjects;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ContextHandlerProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ContextHandlerProvider.cs
@@ -4,7 +4,7 @@ using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Linq;
-
+using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers;
 
@@ -56,8 +56,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         private Handlers CreateHandlers(IWorkspaceProjectContext context)
         {
-            ImmutableArray<(IProjectEvaluationHandler handler, string evaluationRuleName)>.Builder evaluationHandlers = ImmutableArray.CreateBuilder<(IProjectEvaluationHandler handler, string evaluationRuleName)>(s_handlerFactories.Length);
-            ImmutableArray<ICommandLineHandler>.Builder commandLineHandlers = ImmutableArray.CreateBuilder<ICommandLineHandler>(s_handlerFactories.Length);
+            var evaluationHandlers = PooledArray<(IProjectEvaluationHandler handler, string evaluationRuleName)>.GetInstance();
+            var commandLineHandlers = PooledArray<ICommandLineHandler>.GetInstance();
 
             foreach ((HandlerFactory factory, string evaluationRuleName) factory in s_handlerFactories)
             {
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 }
             }
 
-            return new Handlers(evaluationHandlers.ToImmutable(), commandLineHandlers.ToImmutable());
+            return new Handlers(evaluationHandlers.ToImmutableAndFree(), commandLineHandlers.ToImmutableAndFree());
         }
 
         private static ImmutableArray<(HandlerFactory factory, string evaluationRuleName)> CreateHandlerFactories()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ContextHandlerProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ContextHandlerProvider.cs
@@ -4,7 +4,6 @@ using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Linq;
-using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers;
 
@@ -56,8 +55,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         private Handlers CreateHandlers(IWorkspaceProjectContext context)
         {
-            var evaluationHandlers = PooledArray<(IProjectEvaluationHandler handler, string evaluationRuleName)>.GetInstance();
-            var commandLineHandlers = PooledArray<ICommandLineHandler>.GetInstance();
+            ImmutableArray<(IProjectEvaluationHandler handler, string evaluationRuleName)>.Builder evaluationHandlers = ImmutableArray.CreateBuilder<(IProjectEvaluationHandler handler, string evaluationRuleName)>(s_handlerFactories.Length);
+            ImmutableArray<ICommandLineHandler>.Builder commandLineHandlers = ImmutableArray.CreateBuilder<ICommandLineHandler>(s_handlerFactories.Length);
 
             foreach ((HandlerFactory factory, string evaluationRuleName) factory in s_handlerFactories)
             {
@@ -76,7 +75,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 }
             }
 
-            return new Handlers(evaluationHandlers.ToImmutableAndFree(), commandLineHandlers.ToImmutableAndFree());
+            return new Handlers(evaluationHandlers.MoveToImmutable(), commandLineHandlers.MoveToImmutable());
         }
 
         private static ImmutableArray<(HandlerFactory factory, string evaluationRuleName)> CreateHandlerFactories()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/UnconfiguredProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/UnconfiguredProjectContextProvider.cs
@@ -6,7 +6,7 @@ using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.IO;
 using System.Threading.Tasks;
-
+using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 
@@ -224,7 +224,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             var configuredProjectsToRemove = new HashSet<ConfiguredProject>(_configuredProjectHostObjectsMap.Keys);
             ProjectConfiguration activeProjectConfiguration = _commonServices.ActiveConfiguredProject.ProjectConfiguration;
 
-            ImmutableDictionary<string, IWorkspaceProjectContext>.Builder innerProjectContextsBuilder = ImmutableDictionary.CreateBuilder<string, IWorkspaceProjectContext>();
+            var innerProjectContextsBuilder = PooledDictionary<string, IWorkspaceProjectContext>.GetInstance();
             string activeTargetFramework = string.Empty;
             IConfiguredProjectHostObject activeIntellisenseProjectHostObject = null;
 
@@ -265,7 +265,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
 
             _unconfiguredProjectHostObject.ActiveIntellisenseProjectHostObject = activeIntellisenseProjectHostObject;
 
-            return new AggregateWorkspaceProjectContext(innerProjectContextsBuilder.ToImmutable(), configuredProjectsMap, activeTargetFramework, _unconfiguredProjectHostObject);
+            return new AggregateWorkspaceProjectContext(innerProjectContextsBuilder.ToImmutableDictionaryAndFree(), configuredProjectsMap, activeTargetFramework, _unconfiguredProjectHostObject);
         }
 
         private static string GetWorkspaceContextId(ConfiguredProject configuredProject)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/UnconfiguredProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/UnconfiguredProjectContextProvider.cs
@@ -6,7 +6,7 @@ using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.IO;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
+using Microsoft.VisualStudio.Buffers.PooledObjects;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/AssemblyInfoProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/AssemblyInfoProperties.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Properties
 {
@@ -44,14 +45,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             Workspace workspace,
             IProjectThreadingService threadingService)
         {
-            ImmutableDictionary<string, SourceAssemblyAttributePropertyValueProvider>.Builder builder = ImmutableDictionary.CreateBuilder<string, SourceAssemblyAttributePropertyValueProvider>();
+            var builder = PooledDictionary<string, SourceAssemblyAttributePropertyValueProvider>.GetInstance();
             foreach ((string key, (string attributeName, _)) in AssemblyPropertyInfoMap)
             {
                 var provider = new SourceAssemblyAttributePropertyValueProvider(attributeName, getActiveProjectId, workspace, threadingService);
                 builder.Add(key, provider);
             }
 
-            return builder.ToImmutable();
+            return builder.ToImmutableDictionaryAndFree();
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/AssemblyInfoProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/AssemblyInfoProperties.cs
@@ -6,7 +6,7 @@ using System.Collections.Immutable;
 using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis;
-using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
+using Microsoft.VisualStudio.Buffers.PooledObjects;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Properties
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Text/StringBuilderExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Text/StringBuilderExtensions.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.Text;
-using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
+using Microsoft.VisualStudio.Buffers.PooledObjects;
 
 namespace Microsoft.VisualStudio.Text
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Text/StringBuilderExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Text/StringBuilderExtensions.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Text;
+using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
 
 namespace Microsoft.VisualStudio.Text
 {
@@ -48,7 +49,7 @@ namespace Microsoft.VisualStudio.Text
             }
         }
 
-        public static StringBuilder TrimEnd(this StringBuilder builder, params char[] trimChars)
+        public static StringBuilder TrimEnd(this PooledStringBuilder builder, params char[] trimChars)
         {
             while (builder.Length > 0)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Properties/VisualBasicProjectDesignerPageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Properties/VisualBasicProjectDesignerPageProvider.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
+using Microsoft.VisualStudio.Buffers.PooledObjects;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Properties/VisualBasicProjectDesignerPageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Properties/VisualBasicProjectDesignerPageProvider.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem.Managed.PooledObjects;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 {
@@ -24,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
         public Task<IReadOnlyCollection<IPageMetadata>> GetPagesAsync()
         {
-            ImmutableArray<IPageMetadata>.Builder builder = ImmutableArray.CreateBuilder<IPageMetadata>();
+            var builder = PooledArray<IPageMetadata>.GetInstance();
             builder.Add(VisualBasicProjectDesignerPage.Application);
             builder.Add(VisualBasicProjectDesignerPage.Compile);
 
@@ -40,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
                 builder.Add(VisualBasicProjectDesignerPage.Debug);
             }
 
-            return Task.FromResult<IReadOnlyCollection<IPageMetadata>>(builder.ToImmutable());
+            return Task.FromResult<IReadOnlyCollection<IPageMetadata>>(builder.ToImmutableAndFree());
         }
     }
 }


### PR DESCRIPTION
Roslyn has an internal implementation of object pools that they ship as a [source based nuget package](https://dotnet.myget.org/feed/roslyn/package/nuget/Microsoft.CodeAnalysis.PooledObjects/2.11.0-beta3-63519-01).  Unfortunately we cannot consume this package directly without changing our build infrastructure.  

I've added them here as a generalized machanism for re-using common builder objects.