### PR TITLE
Don't switch to UI thread to subscribe

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySubscriptionsHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySubscriptionsHost.cs
@@ -518,13 +518,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             });
         }
 
-        private async Task AddSubscriptionsAsync(AggregateCrossTargetProjectContext newProjectContext)
+        private Task AddSubscriptionsAsync(AggregateCrossTargetProjectContext newProjectContext)
         {
             Requires.NotNull(newProjectContext, nameof(newProjectContext));
 
-            await _commonServices.ThreadingService.SwitchToUIThread();
-
-            await _tasksService.LoadedProjectAsync(() =>
+            JoinableTask joinableTask = _tasksService.LoadedProjectAsync(() =>
             {
                 lock (_linksLock)
                 {
@@ -543,6 +541,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
                 return Task.CompletedTask;
             });
+
+            return joinableTask.Task;
         }
 
         private void SubscribeToConfiguredProject(


### PR DESCRIPTION
Following discussion in Teams, there doesn't seem to be a reason to switch onto the UI thread to add a subscription.

I've tested this change and it runs without blowing up.

@abpiskunov can you see any issue here?