### PR TITLE
Locking, allocations, documentation and cleanup

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IProjectDependenciesSubTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/IProjectDependenciesSubTreeProvider.cs
@@ -15,18 +15,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     public interface IProjectDependenciesSubTreeProvider
     {
         /// <summary>
-        /// Must be unique, represents a type of the provider that will be associated
-        /// with provider's nodes (via project tree flags)
+        /// Gets a string that uniquely identifies the type of dependency nodes emitted by this provider.
         /// </summary>
+        /// <remarks>
+        /// This string will be associated with provider's nodes (via project tree flags).
+        /// </remarks>
         string ProviderType { get; }
 
         /// <summary>
-        /// Returns a node metadata for given nodeId.
+        /// Returns the root node for this provider's dependency nodes.
         /// </summary>
+        /// <remarks>
+        /// Despite the method's name, implementations may return the same instance for repeated
+        /// calls, so long as the returned value is immutable.
+        /// </remarks>
         IDependencyModel CreateRootDependencyNode();
 
         /// <summary>
-        /// Raised when provider's dependencies changed 
+        /// Raised when this provider's dependencies changed.
         /// </summary>
         event EventHandler<DependenciesChangedEventArgs> DependenciesChanged;
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/IDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/IDependenciesSnapshotFilter.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
         /// <param name="targetFramework">Target framework for which dependency was resolved.</param>
         /// <param name="dependency">The dependency to which filter should be applied.</param>
         /// <param name="subTreeProviderByProviderType">All dictionary of subtree providers keyed by <see cref="IProjectDependenciesSubTreeProvider.ProviderType"/>.</param>
-        /// <param name="projectItemSpecs">List of all items contained in project's xml at given moment, otherwise, <see langword="null"/> if we do not have any data.</param>
+        /// <param name="projectItemSpecs">List of all items contained in project's xml at given moment (non-imported items), otherwise, <see langword="null"/> if we do not have any data.</param>
         /// <param name="context">An object via which the filter must signal acceptance or rejection, in addition to making further changes to other dependencies.</param>
         void BeforeAddOrUpdate(
             string projectPath,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
@@ -51,26 +51,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
             var worldBuilder = previousSnapshot.DependenciesWorld.ToBuilder();
 
-            IImmutableList<IDependencyModel> removedNodes = changes.RemovedNodes;
-
-            if (removedNodes.Count != 0)
+            if (changes.RemovedNodes.Count != 0)
             {
                 var context = new RemoveDependencyContext(worldBuilder);
 
-                foreach (IDependencyModel removed in removedNodes)
+                foreach (IDependencyModel removed in changes.RemovedNodes)
                 {
                     Remove(context, removed);
                 }
             }
 
-            // Call property once as implementation allocates
-            IImmutableList<IDependencyModel> addedNodes = changes.AddedNodes;
-
             if (changes.AddedNodes.Count != 0)
             {
                 var context = new AddDependencyContext(worldBuilder);
 
-                foreach (IDependencyModel added in addedNodes)
+                foreach (IDependencyModel added in changes.AddedNodes)
                 {
                     Add(context, added);
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
@@ -251,10 +251,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
                     if (projectChanges.Any(x => x.Value.Difference.AnyChanges))
                     {
-                        // Handlers respond to rule changes in a way that's specific to the rule change context
-                        // type (T). For example, DependencyRulesSubscriber uses DependenciesRuleChangeContext
-                        // which holds IDependencyModel, so its IDependenciesRuleHandler implementations will
-                        // produce IDependencyModel objects in response to rule changes.
                         handler.Value.Handle(projectChanges, targetFrameworkToUpdate, changesBuilder);
                     }
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
@@ -213,8 +213,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 return;
             }
 
-            IEnumerable<IDependenciesRuleHandler> handlers = _handlers.Select(h => h.Value);
-
             ITargetFramework targetFrameworkToUpdate;
 
             // We need to process the update within a lock to ensure that we do not release this context during processing.
@@ -242,9 +240,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 var changesBuilder = new CrossTargetDependenciesChangesBuilder();
 
                 // Give each handler a chance to register dependency changes.
-                foreach (IDependenciesRuleHandler handler in handlers)
+                foreach (Lazy<IDependenciesRuleHandler, IOrderPrecedenceMetadataView> handler in _handlers)
                 {
-                    ImmutableHashSet<string> handlerRules = handler.GetRuleNames(handlerType);
+                    ImmutableHashSet<string> handlerRules = handler.Value.GetRuleNames(handlerType);
 
                     // Slice project changes to include only rules the handler claims an interest in.
                     var projectChanges = projectUpdate.ProjectChanges
@@ -257,7 +255,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                         // type (T). For example, DependencyRulesSubscriber uses DependenciesRuleChangeContext
                         // which holds IDependencyModel, so its IDependenciesRuleHandler implementations will
                         // produce IDependencyModel objects in response to rule changes.
-                        handler.Handle(projectChanges, targetFrameworkToUpdate, changesBuilder);
+                        handler.Value.Handle(projectChanges, targetFrameworkToUpdate, changesBuilder);
                     }
                 }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 
@@ -13,7 +12,6 @@ using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
-using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions
 {
@@ -24,7 +22,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
         public const string DependencyRulesSubscriberContract = "DependencyRulesSubscriberContract";
 
 #pragma warning disable CA2213 // OnceInitializedOnceDisposedAsync are not tracked correctly by the IDisposeable analyzer
-        private readonly SemaphoreSlim _gate = new SemaphoreSlim(initialCount: 1);
         private DisposableBag _subscriptions;
 #pragma warning restore CA2213
         private readonly IUnconfiguredProjectCommonServices _commonServices;
@@ -213,60 +210,52 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 return;
             }
 
-            ITargetFramework targetFrameworkToUpdate;
+            // Get the inner workspace project context to update for this change.
+            ITargetFramework targetFrameworkToUpdate = currentAggregateContext.GetProjectFramework(projectUpdate.ProjectConfiguration);
 
-            // We need to process the update within a lock to ensure that we do not release this context during processing.
-            // TODO: Enable concurrent execution of updates themselves, i.e. two separate invocations of HandleAsync
-            //       should be able to run concurrently.
-            using (await _gate.DisposableWaitAsync())
+            if (targetFrameworkToUpdate == null)
             {
-                // Get the inner workspace project context to update for this change.
-                targetFrameworkToUpdate = currentAggregateContext.GetProjectFramework(projectUpdate.ProjectConfiguration);
+                return;
+            }
 
-                if (targetFrameworkToUpdate == null)
+            // Broken design time builds sometimes cause updates with no project changes and sometimes
+            // cause updates with a project change that has no difference.
+            // We handle the former case here, and the latter case is handled in the CommandLineItemHandler.
+            if (projectUpdate.ProjectChanges.Count == 0)
+            {
+                return;
+            }
+
+            // Create an object to track dependency changes.
+            var changesBuilder = new CrossTargetDependenciesChangesBuilder();
+
+            // Give each handler a chance to register dependency changes.
+            foreach (Lazy<IDependenciesRuleHandler, IOrderPrecedenceMetadataView> handler in _handlers)
+            {
+                ImmutableHashSet<string> handlerRules = handler.Value.GetRuleNames(handlerType);
+
+                // Slice project changes to include only rules the handler claims an interest in.
+                var projectChanges = projectUpdate.ProjectChanges
+                    .Where(x => handlerRules.Contains(x.Key))
+                    .ToImmutableDictionary();
+
+                if (projectChanges.Any(x => x.Value.Difference.AnyChanges))
                 {
-                    return;
+                    handler.Value.Handle(projectChanges, targetFrameworkToUpdate, changesBuilder);
                 }
+            }
 
-                // Broken design time builds sometimes cause updates with no project changes and sometimes
-                // cause updates with a project change that has no difference.
-                // We handle the former case here, and the latter case is handled in the CommandLineItemHandler.
-                if (projectUpdate.ProjectChanges.Count == 0)
-                {
-                    return;
-                }
+            ImmutableDictionary<ITargetFramework, IDependenciesChanges> changes = changesBuilder.TryBuildChanges();
 
-                // Create an object to track dependency changes.
-                var changesBuilder = new CrossTargetDependenciesChangesBuilder();
-
-                // Give each handler a chance to register dependency changes.
-                foreach (Lazy<IDependenciesRuleHandler, IOrderPrecedenceMetadataView> handler in _handlers)
-                {
-                    ImmutableHashSet<string> handlerRules = handler.Value.GetRuleNames(handlerType);
-
-                    // Slice project changes to include only rules the handler claims an interest in.
-                    var projectChanges = projectUpdate.ProjectChanges
-                        .Where(x => handlerRules.Contains(x.Key))
-                        .ToImmutableDictionary();
-
-                    if (projectChanges.Any(x => x.Value.Difference.AnyChanges))
-                    {
-                        handler.Value.Handle(projectChanges, targetFrameworkToUpdate, changesBuilder);
-                    }
-                }
-
-                ImmutableDictionary<ITargetFramework, IDependenciesChanges> changes = changesBuilder.TryBuildChanges();
-
-                if (changes != null)
-                {
-                    // Notify subscribers of a change in dependency data
-                    DependenciesChanged?.Invoke(
-                        this,
-                        new DependencySubscriptionChangedEventArgs(
-                            currentAggregateContext.ActiveTargetFramework,
-                            catalogSnapshot,
-                            changes));
-                }
+            if (changes != null)
+            {
+                // Notify subscribers of a change in dependency data
+                DependenciesChanged?.Invoke(
+                    this,
+                    new DependencySubscriptionChangedEventArgs(
+                        currentAggregateContext.ActiveTargetFramework,
+                        catalogSnapshot,
+                        changes));
             }
 
             // record all the rules that have occurred
@@ -279,8 +268,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
         protected override void Dispose(bool disposing)
         {
-            _gate.Dispose();
-
             if (disposing)
             {
                 ReleaseSubscriptions();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 
@@ -14,7 +13,6 @@ using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions.RuleHandlers;
-using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 {
@@ -22,9 +20,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
     [AppliesTo(ProjectCapability.DependenciesTree)]
     internal class DependencySharedProjectsSubscriber : OnceInitializedOnceDisposed, IDependencyCrossTargetSubscriber
     {
-#pragma warning disable CA2213 // OnceInitializedOnceDisposedAsync are not tracked correctly by the IDisposeable analyzer
-        private readonly SemaphoreSlim _gate = new SemaphoreSlim(initialCount: 1);
-#pragma warning restore CA2213
         private readonly List<IDisposable> _subscriptionLinks = new List<IDisposable>();
         private readonly IProjectAsynchronousTasksService _tasksService;
         private readonly IDependenciesSnapshotProvider _dependenciesSnapshotProvider;
@@ -131,34 +126,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             IProjectSharedFoldersSnapshot sharedProjectsUpdate = e.Item2;
             IProjectCatalogSnapshot catalogs = e.Item3;
 
-            // We need to process the update within a lock to ensure that we do not release this context during processing.
-            // TODO: Enable concurrent execution of updates themselves, i.e. two separate invocations of HandleAsync
-            //       should be able to run concurrently.
-            using (await _gate.DisposableWaitAsync())
+            // Get the target framework to update for this change.
+            ITargetFramework targetFrameworkToUpdate = currentAggregateContext.GetProjectFramework(projectUpdate.ProjectConfiguration);
+
+            if (targetFrameworkToUpdate == null)
             {
-                // Get the target framework to update for this change.
-                ITargetFramework targetFrameworkToUpdate = currentAggregateContext.GetProjectFramework(projectUpdate.ProjectConfiguration);
+                return;
+            }
 
-                if (targetFrameworkToUpdate == null)
-                {
-                    return;
-                }
+            var changesBuilder = new CrossTargetDependenciesChangesBuilder();
 
-                var changesBuilder = new CrossTargetDependenciesChangesBuilder();
+            ProcessSharedProjectsUpdates(sharedProjectsUpdate, targetFrameworkToUpdate, changesBuilder);
 
-                ProcessSharedProjectsUpdates(sharedProjectsUpdate, targetFrameworkToUpdate, changesBuilder);
+            ImmutableDictionary<ITargetFramework, IDependenciesChanges> changes = changesBuilder.TryBuildChanges();
 
-                ImmutableDictionary<ITargetFramework, IDependenciesChanges> changes = changesBuilder.TryBuildChanges();
-
-                if (changes != null)
-                {
-                    DependenciesChanged?.Invoke(
-                        this,
-                        new DependencySubscriptionChangedEventArgs(
-                            currentAggregateContext.ActiveTargetFramework,
-                            catalogs,
-                            changes));
-                }
+            if (changes != null)
+            {
+                DependenciesChanged?.Invoke(
+                    this,
+                    new DependencySubscriptionChangedEventArgs(
+                        currentAggregateContext.ActiveTargetFramework,
+                        catalogs,
+                        changes));
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySubscriptionsHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySubscriptionsHost.cs
@@ -340,6 +340,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
             return;
 
+            // Gets the set of items defined directly the project, and not included by imports.
             IImmutableSet<string> GetProjectItemSpecsFromSnapshot()
             {
                 // We don't have catalog snapshot, we're likely updating because one of our project 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySubscriptionsHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySubscriptionsHost.cs
@@ -589,7 +589,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
         private Task<T> ExecuteWithinLockAsync<T>(Func<T> func)
         {
-            return _gate.ExecuteWithinLockAsync(JoinableCollection, JoinableFactory, func);
+            return _gate.ExecuteWithinLockAsync(JoinableCollection, func);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ImmutableCollectionLinqExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ImmutableCollectionLinqExtensions.cs
@@ -39,6 +39,14 @@ namespace Microsoft.VisualStudio
             return false;
         }
 
+        public static IEnumerable<TResult> Select<TSource, TResult>(this ImmutableArray<TSource> immutableArray, Func<TSource, TResult> selector)
+        {
+            foreach (TSource obj in immutableArray)
+            {
+                yield return selector(obj);
+            }
+        }
+
         public static T FirstOrDefault<T, TArg>(this ImmutableArray<T> immutableArray, Func<T, TArg, bool> predicate, TArg arg)
         {
             foreach (T obj in immutableArray)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ImmutableCollectionLinqExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ImmutableCollectionLinqExtensions.cs
@@ -39,14 +39,6 @@ namespace Microsoft.VisualStudio
             return false;
         }
 
-        public static IEnumerable<TResult> Select<TSource, TResult>(this ImmutableArray<TSource> immutableArray, Func<TSource, TResult> selector)
-        {
-            foreach (TSource obj in immutableArray)
-            {
-                yield return selector(obj);
-            }
-        }
-
         public static T FirstOrDefault<T, TArg>(this ImmutableArray<T> immutableArray, Func<T, TArg, bool> predicate, TArg arg)
         {
             foreach (T obj in immutableArray)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ImmutableCollectionLinqExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ImmutableCollectionLinqExtensions.cs
@@ -28,6 +28,17 @@ namespace Microsoft.VisualStudio
             return count;
         }
 
+        public static bool Any<TKey, TValue>(this ImmutableDictionary<TKey, TValue> immutableDictionary, Func<KeyValuePair<TKey, TValue>, bool> predicate)
+        {
+            foreach (KeyValuePair<TKey, TValue> pair in immutableDictionary)
+            {
+                if (predicate(pair))
+                    return true;
+            }
+
+            return false;
+        }
+
         public static T FirstOrDefault<T, TArg>(this ImmutableArray<T> immutableArray, Func<T, TArg, bool> predicate, TArg arg)
         {
             foreach (T obj in immutableArray)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/SemaphoreSlimExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/SemaphoreSlimExtensions.cs
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.Threading
             }
         }
 
-        public static async Task ExecuteWithinLockAsync(this SemaphoreSlim semaphore, JoinableTaskCollection collection, JoinableTaskFactory factory, Action action)
+        public static async Task ExecuteWithinLockAsync(this SemaphoreSlim semaphore, JoinableTaskCollection collection, Action action)
         {
             // Join the caller to our collection, so that if the lock is already held by another task that needs UI 
             // thread access we don't deadlock if we're also being waited on by the UI thread. For example, when CPS
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.Threading
             }
         }
 
-        public static async Task<T> ExecuteWithinLockAsync<T>(this SemaphoreSlim semaphore, JoinableTaskCollection collection, JoinableTaskFactory factory, Func<T> func)
+        public static async Task<T> ExecuteWithinLockAsync<T>(this SemaphoreSlim semaphore, JoinableTaskCollection collection, Func<T> func)
         {
             // Join the caller to our collection, so that if the lock is already held by another task that needs UI 
             // thread access we don't deadlock if we're also being waited on by the UI thread. For example, when CPS


### PR DESCRIPTION
While working through #3548 I found a few places we could tighten things up, which I've pulled out into this PR.

- 91560a37e15fa7d797002e124ef1dc72465aa3f8 remove locks made redundant by previous changes
- 21abe962d98829591d296a1213a7960dd3b5970e 144ac2a9d697378454bd6fcc5a8856fde1035bb0 7310b4052000f3a308bcf9632708559dc221cf68 d9c83c6aeacf6cb539326447904e78bff1d5d994 f92789ddb7175bf51d74ecdfc3a811e2815a99f9 reduce allocations
- 2cd92e1e95e03b7d088ebdb1a2a5aa2aa060c064 documentation