### PR TITLE
Use "real" hierarchy for Razor

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IUnconfiguredProjectVsServicesMock.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IUnconfiguredProjectVsServicesMock.cs
@@ -7,6 +7,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
     internal class IUnconfiguredProjectVsServicesMock : AbstractMock<IUnconfiguredProjectVsServices>
     {
+        public IUnconfiguredProjectVsServicesMock ImplementVsHierarchy(IVsHierarchy hierarchy)
+        {
+            SetupGet(m => m.VsHierarchy)
+                .Returns(hierarchy);
+
+            return this;
+        }
+
         public IUnconfiguredProjectVsServicesMock ImplementVsProject(IVsProject4 project)
         {
             SetupGet(m => m.VsProject)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
@@ -21,19 +21,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
     {
         private readonly IVsService<SAsyncServiceProvider, IOleAsyncServiceProvider> _serviceProvider;
         private readonly IUnconfiguredProjectVsServices _projectVsServices;
-        private readonly IProjectHostProvider _projectHostProvider;
         private readonly IActiveWorkspaceProjectContextHost _projectContextHost;
         private readonly AsyncLazy<IVsContainedLanguageFactory> _containedLanguageFactory;
 
         [ImportingConstructor]
         public VsContainedLanguageComponentsFactory(IVsService<SAsyncServiceProvider, IOleAsyncServiceProvider> serviceProvider,
                                                     IUnconfiguredProjectVsServices projectVsServices,
-                                                    IProjectHostProvider projectHostProvider,
                                                     IActiveWorkspaceProjectContextHost projectContextHost)
         {
             _serviceProvider = serviceProvider;
             _projectVsServices = projectVsServices;
-            _projectHostProvider = projectHostProvider;
             _projectContextHost = projectContextHost;
 
             _containedLanguageFactory = new AsyncLazy<IVsContainedLanguageFactory>(GetContainedLanguageFactoryAsync, projectVsServices.ThreadingService.JoinableTaskFactory);
@@ -70,11 +67,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             if (containedLanguageFactory == null)
                 return (HierarchyId.Nil, null, null);
 
-            var hierarchy = (IVsHierarchy)_projectHostProvider.UnconfiguredProjectHostObject.ActiveIntellisenseProjectHostObject;
-            if (hierarchy == null)
-                return (HierarchyId.Nil, null, null);
-
-            return (itemid, hierarchy, containedLanguageFactory);
+            return (itemid, _projectVsServices.VsHierarchy, containedLanguageFactory);
         }
 
         private async Task<IVsContainedLanguageFactory> GetContainedLanguageFactoryAsync()


### PR DESCRIPTION
In the new language-service integration, we pass the real hierarchy to Roslyn. Make sure Razor gets the same hiearchy.