### PR TITLE
Remove lock from TargetFrameworkProvider

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetFrameworkProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/TargetFrameworkProvider.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Runtime.Versioning;
@@ -10,12 +12,16 @@ using NuGet.VisualStudio;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 {
     [Export(typeof(ITargetFrameworkProvider))]
-    internal class TargetFrameworkProvider : ITargetFrameworkProvider
+    internal sealed class TargetFrameworkProvider : ITargetFrameworkProvider
     {
         private readonly IVsFrameworkCompatibility _nuGetComparer;
         private readonly IVsFrameworkParser _nuGetFrameworkParser;
-        private readonly object _targetsLock = new object();
-        private readonly List<ITargetFramework> _cachedTargetFrameworks = new List<ITargetFramework>();
+
+        /// <summary>
+        /// Lookup for known <see cref="ITargetFramework"/> objects, keyed by both
+        /// <see cref="ITargetFramework.ShortName"/> and <see cref="ITargetFramework.FullName"/>.
+        /// </summary>
+        private ImmutableDictionary<string, ITargetFramework> _targetFrameworkByName = ImmutableDictionary.Create<string, ITargetFramework>(StringComparer.Ordinal);
 
         [ImportingConstructor]
         public TargetFrameworkProvider(
@@ -33,39 +39,52 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
                 return null;
             }
 
-            ITargetFramework targetFramework;
+            // Fast path for an exact name match
+            if (_targetFrameworkByName.TryGetValue(shortOrFullName, out ITargetFramework existing))
+            {
+                return existing;
+            }
+
             try
             {
-                lock (_targetsLock)
+                // Try to parse a short or full framework name
+                FrameworkName frameworkName = _nuGetFrameworkParser.ParseFrameworkName(shortOrFullName);
+
+                if (frameworkName == null)
                 {
-                    if (!TryGetCachedTargetFramework(shortOrFullName, out targetFramework))
-                    {
-                        FrameworkName frameworkName = _nuGetFrameworkParser.ParseFrameworkName(shortOrFullName);
-                        if (frameworkName != null &&
-                            !TryGetCachedTargetFramework(frameworkName.FullName, out targetFramework))
-                        {
-                            string shortName = _nuGetFrameworkParser.GetShortFrameworkName(frameworkName);
-                            targetFramework = new TargetFramework(frameworkName, shortName);
-                            // remember target framework - there can not be too many of them across the solution.
-                            _cachedTargetFrameworks.Add(targetFramework);
-                        }
-                    }
+                    return null;
                 }
+
+                if (_targetFrameworkByName.TryGetValue(frameworkName.FullName, out ITargetFramework exitingByFullName))
+                {
+                    // The full name was known, so cache by the provided (unknown) name too for next time
+                    ImmutableInterlocked.TryAdd(ref _targetFrameworkByName, shortOrFullName, exitingByFullName);
+
+                    return exitingByFullName;
+                }
+
+                string shortName = _nuGetFrameworkParser.GetShortFrameworkName(frameworkName);
+
+                if (shortName != null && _targetFrameworkByName.TryGetValue(shortName, out ITargetFramework exitingByShortName))
+                {
+                    // The short name was known, so cache by the provided (unknown) name too for next time
+                    ImmutableInterlocked.TryAdd(ref _targetFrameworkByName, shortOrFullName, exitingByShortName);
+
+                    return exitingByShortName;
+                }
+
+                // This is a completely new target framework. Create, cache and return it.
+                var targetFramework = new TargetFramework(frameworkName, shortName);
+                
+                ImmutableInterlocked.TryAdd(ref _targetFrameworkByName, shortOrFullName, targetFramework);
+
+                return targetFramework;
             }
             catch
             {
                 // Note: catching all exceptions and return a generic TargetFramework for given shortOrFullName
-                targetFramework = new TargetFramework(shortOrFullName);
+                return new TargetFramework(shortOrFullName);
             }
-
-            return targetFramework;
-        }
-
-        private bool TryGetCachedTargetFramework(string shortOrFullName, out ITargetFramework targetFramework)
-        {
-            // use linear search here, since there not many target frameworks and it would most efficient.
-            targetFramework = _cachedTargetFrameworks.FirstOrDefault((x, name) => x.Equals(name), shortOrFullName);
-            return targetFramework != null;
         }
 
         public ITargetFramework GetNearestFramework(ITargetFramework targetFramework,


### PR DESCRIPTION
Fixes #2714, which identified `TargetFrameworkProvider.GetTargetFramework` as a source of high contention, albeit under the influence of a since-fixed evaluation loop bug.

`GetTargetFramework` looks up `ITargetFramework` instances by name. It did this via O(N) scanning of a mutable list within a lock (where N is usually a very small number, but still required the protection of a lock).

This change introduces lock-free caching of these instances using O(1) lookup in an immutable dictionary keyed by the input string. Cache misses should be very rare. Hits are now the fast path and have zero contention.