### PR TITLE
Merge consecutive iteration loops

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependencyExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependencyExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
     internal static class TestDependencyExtensions
     {
-        public static void AssertEqualTo(this IDependency actual, IDependency expected)
+        public static void AssertEqualTo(this IDependency expected, IDependency actual)
         {
             Xunit.Assert.NotNull(actual);
             Xunit.Assert.NotNull(expected);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DuplicatedDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DuplicatedDependenciesSnapshotFilter.cs
@@ -30,35 +30,39 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             IAddDependencyContext context)
         {
             IDependency matchingDependency = null;
-            foreach ((string _, IDependency x) in context)
-            {
-                if (x.TopLevel 
-                     && !x.Id.Equals(dependency.Id, StringComparison.OrdinalIgnoreCase)
-                     && StringComparers.DependencyProviderTypes.Equals(x.ProviderType, dependency.ProviderType)
-                     && x.Caption.Equals(dependency.Caption, StringComparison.OrdinalIgnoreCase))
-                {
-                    matchingDependency = x;
-                    break;
-                }
-            }
+            bool shouldApplyAlias = false;
 
-            // If found node with same caption, or if there were nodes with same caption but with Alias already applied
-            // NOTE: Performance sensitive, so avoid formatting the Caption with parenthesis if it's possible to avoid it.
-            bool shouldApplyAlias = matchingDependency != null;
-            if (!shouldApplyAlias)
+            foreach ((string _, IDependency other) in context)
             {
-                int adjustedLength = dependency.Caption.Length + " (".Length;
-                foreach ((string _, IDependency x) in context)
+                if (!other.TopLevel ||
+                    other.Id.Equals(dependency.Id, StringComparison.OrdinalIgnoreCase) ||
+                    !StringComparers.DependencyProviderTypes.Equals(other.ProviderType, dependency.ProviderType))
                 {
-                    if (x.TopLevel
-                         && !x.Id.Equals(dependency.Id, StringComparison.OrdinalIgnoreCase)
-                         && StringComparers.DependencyProviderTypes.Equals(x.ProviderType, dependency.ProviderType)
-                         && x.Caption.StartsWith(dependency.Caption, StringComparison.OrdinalIgnoreCase)
-                         && x.Caption.Length >= adjustedLength
-                         && string.Compare(x.Caption, adjustedLength, x.OriginalItemSpec, 0, x.OriginalItemSpec.Length, StringComparison.OrdinalIgnoreCase) == 0)
+                    continue;
+                }
+
+                if (other.Caption.StartsWith(dependency.Caption, StringComparison.OrdinalIgnoreCase))
+                {
+                    if (other.Caption.Length == dependency.Caption.Length)
                     {
+                        // Exact match.
+                        System.Diagnostics.Debug.Assert(matchingDependency == null, "matchingDependency should be null");
+                        matchingDependency = other;
                         shouldApplyAlias = true;
                         break;
+                    }
+
+                    // Prefix matches.
+                    // Check whether we have a match of form "Caption (ItemSpec)".
+
+                    string itemSpec = other.OriginalItemSpec;
+                    int expectedItemSpecIndex = dependency.Caption.Length + 2;
+                    int expectedLength = expectedItemSpecIndex + itemSpec.Length + 1;
+
+                    if (other.Caption.Length == expectedLength && 
+                        string.Compare(other.Caption, expectedItemSpecIndex, itemSpec, 0, itemSpec.Length, StringComparison.OrdinalIgnoreCase) == 0)
+                    {
+                        shouldApplyAlias = true;
                     }
                 }
             }
@@ -67,15 +71,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             {
                 if (matchingDependency != null)
                 {
+                    // Change the matching dependency's alias too
                     context.AddOrUpdate(matchingDependency.SetProperties(caption: matchingDependency.Alias));
                 }
 
+                // Use the alias for the caption
                 context.Accept(dependency.SetProperties(caption: dependency.Alias));
-                return;
             }
-
-            // Accept without changes
-            context.Accept(dependency);
+            else
+            {
+                // Accept without changes
+                context.Accept(dependency);
+            }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DuplicatedDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/DuplicatedDependenciesSnapshotFilter.cs
@@ -46,7 +46,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
                     if (other.Caption.Length == dependency.Caption.Length)
                     {
                         // Exact match.
-                        System.Diagnostics.Debug.Assert(matchingDependency == null, "matchingDependency should be null");
                         matchingDependency = other;
                         shouldApplyAlias = true;
                         break;
@@ -56,8 +55,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
                     // Check whether we have a match of form "Caption (ItemSpec)".
 
                     string itemSpec = other.OriginalItemSpec;
-                    int expectedItemSpecIndex = dependency.Caption.Length + 2;
-                    int expectedLength = expectedItemSpecIndex + itemSpec.Length + 1;
+                    int expectedItemSpecIndex = dependency.Caption.Length + 2;        // " (".Length
+                    int expectedLength = expectedItemSpecIndex + itemSpec.Length + 1; // ")".Length
 
                     if (other.Caption.Length == expectedLength && 
                         string.Compare(other.Caption, expectedItemSpecIndex, itemSpec, 0, itemSpec.Length, StringComparison.OrdinalIgnoreCase) == 0)


### PR DESCRIPTION
CPU profiling shows about 50% of `DependenciesSnapshot.FromChanges` time was spent in `DuplicatedDependenciesSnapshotFilter.BeforeAddOrUpdate`, mostly enumerating immutable dictionaries.

On loading `Roslyn.sln` <sup>1</sup> we spent 4% CPU time producing dependencies snapshots, half of which was in this method:

![image](https://user-images.githubusercontent.com/350947/49768790-78d10d00-fcd5-11e8-99ee-31a775151bde.png)

The normal case here is that no duplicate caption is found. This change halves the number of iterations required.

I'm looking at separating handling of top-level and non-top-level nodes across the dependencies node, at which point the number of items being iterated will drop considerably, along with that CPU percentage. In the meantime, this is an easy win.

<sup>1</sup> Based on a 30 second PerfView capture started when the "Preparing projects" dialog disappears.