### PR TITLE
Match legacy behaviour and don't restore designer on solution open

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerWindowPane.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerWindowPane.vb
@@ -71,6 +71,9 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                 'Must marshal ourselves as IUnknown wrapper
                 VSErrorHandler.ThrowOnFailure(WindowFrame.SetProperty(__VSFPROPID.VSFPROPID_ViewHelper, New UnknownWrapper(_viewHelper)))
 
+                'Don't reopen the designer during solution restore
+                VSErrorHandler.ThrowOnFailure(WindowFrame.SetProperty(__VSFPROPID5.VSFPROPID_DontAutoOpen, True))
+
                 ' make sure scrollbars in the view are not themed
                 VSErrorHandler.ThrowOnFailure(WindowFrame.SetProperty(__VSFPROPID5.VSFPROPID_NativeScrollbarThemeMode, __VSNativeScrollbarThemeMode.NSTM_None))
             End If


### PR DESCRIPTION
Fixes #1486

The current app designer code is littered with spots where it forcibly "needs" to show the designer in order to do its work, but that breaks when it is restored to a background tab during solution load, in particular when Find is used (see issue). Since this is a regression from legacy which never restored app designer tabs, this PR reinstates that behaviour. In future if the app designer code changes significantly this could potentially be removed.