### PR TITLE
Fix both NeutralLanguageComboBox and AssemblyInfoPropPage closing on Escape

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/AssemblyInfoPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AssemblyInfoPropPage.vb
@@ -172,6 +172,27 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Common.SetComboBoxDropdownWidth(NeutralLanguageComboBox)
         End Sub
 
+        Private _neutralLanguageWasDroppedDown As Boolean = False
+
+        ''' <summary>
+        ''' For checking if the NeutralLanguageComboBox was DroppedDown when the escape key was pressed.
+        ''' With a combination of AutoCompleteMode.SuggestAppend and AutoCompleteSource.ListItems the 
+        ''' NeutralLanguageComboBox and the Assembly Info window will both handle a Escape key press and both close.
+        ''' We only want the NeutralLanguageComboBox to close in that case.
+        ''' </summary>
+        Private Sub NeutralLanguageComboBox_PreviewKeyDown(sender As Object, e As PreviewKeyDownEventArgs) Handles NeutralLanguageComboBox.PreviewKeyDown
+            If (e.KeyData And Keys.KeyCode) = Keys.Escape And NeutralLanguageComboBox.DroppedDown Then
+                _neutralLanguageWasDroppedDown = True
+            End If
+        End Sub
+
+        Protected Overrides Function ProcessDialogKey(keyData As Keys) As Boolean
+            If _neutralLanguageWasDroppedDown Then
+                _neutralLanguageWasDroppedDown = False
+                Return True
+            End If
+            Return MyBase.ProcessDialogKey(keyData)
+        End Function
 
         Protected Overrides Function GetF1HelpKeyword() As String
             Return HelpKeywords.VBProjPropAssemblyInfo


### PR DESCRIPTION
Fixes: [646590](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/646590/)

On the Assembly Information property page, if the Neutral Language ComboBox is dropped down the escape key will close both the ComboBox and the property page. This will preview the key pressed and not close the property page if escape was used to close the ComboBox.