### PR TITLE
Add project capability DynamicDependentFile via targets

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -71,6 +71,7 @@
   
   <ItemGroup Condition="'$(DefineCommonManagedCapabilities)' == 'true'">
     <ProjectCapability Include="UseFileGlobs"/>
+    <ProjectCapability Include="DynamicDependentFile"/>
 
     <!-- DependenciesTree capability lights up a Dependencies tree node and it's sub node providers-->
     <ProjectCapability Include="DependenciesTree" />


### PR DESCRIPTION
Following @davkean's comments in #4376, this PR adds the `DynamicDependentFile` capability via `Microsoft.Managed.DesignTime.targets`.