### PR TITLE
 Add an implemention of IActiveWorkspaceProjectContext for new language service

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ActiveWorkspaceProjectContextHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ActiveWorkspaceProjectContextHost.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
+{
+    /// <summary>
+    ///     Provides an implementation of <see cref="IActiveWorkspaceProjectContextHost"/> that delegates 
+    ///     onto the active configuration's <see cref="IWorkspaceProjectContextHost"/>.
+    /// </summary>
+    [Export(typeof(IActiveWorkspaceProjectContextHost))]
+    [AppliesTo(ProjectCapability.DotNetLanguageService)]
+    internal class ActiveWorkspaceProjectContextHost : IActiveWorkspaceProjectContextHost
+    {
+        private readonly ActiveConfiguredProject<IWorkspaceProjectContextHost> _activeHost;
+        private readonly ActiveConfiguredProject<IConfiguredProjectImplicitActivationTracking> _activeConfiguredProject;
+
+        [ImportingConstructor]
+        public ActiveWorkspaceProjectContextHost(ActiveConfiguredProject<IWorkspaceProjectContextHost> activeHost, ActiveConfiguredProject<IConfiguredProjectImplicitActivationTracking> activeConfiguredProject)
+        {
+            _activeHost = activeHost;
+            _activeConfiguredProject = activeConfiguredProject;
+        }
+
+        public Task PublishAsync(CancellationToken cancellationToken = default)
+        {
+            return _activeHost.Value.PublishAsync(cancellationToken);
+        }
+
+        public async Task OpenContextForWriteAsync(Func<IWorkspaceProjectContextAccessor, Task> action)
+        {
+            while (true)
+            {
+                try
+                {
+                    await _activeHost.Value.OpenContextForWriteAsync(action);
+                }
+                catch (ActiveProjectConfigurationChangedException)
+                {   // Host was unloaded because configuration changed, retry on new config
+                }
+            }
+        }
+
+        public async Task<T> OpenContextForWriteAsync<T>(Func<IWorkspaceProjectContextAccessor, Task<T>> action)
+        {
+            while (true)
+            {
+                try
+                {
+                    return await _activeHost.Value.OpenContextForWriteAsync(action);
+                }
+                catch (ActiveProjectConfigurationChangedException)
+                {   // Host was unloaded because configuration changed, retry on new config
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IWorkspaceProjectContextHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IWorkspaceProjectContextHost.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ///     it will join the load when it starts.
         /// </remarks>
         Task PublishAsync(CancellationToken cancellationToken = default);
-               
+
         /// <summary>
         ///     Opens the <see cref="IWorkspaceProjectContext"/>, passing it to the specified action for writing.
         /// </summary>
@@ -41,6 +41,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         /// </exception>
         /// <exception cref="OperationCanceledException">
         ///     The result is awaited and the <see cref="ConfiguredProject"/> is unloaded.
+        /// </exception>
+        /// <exception cref="ActiveProjectConfigurationChangedException">
+        ///     The <see cref="IWorkspaceProjectContextHost"/> represents the active one, and 
+        ///     the configuration changed.
         /// </exception>
         Task OpenContextForWriteAsync(Func<IWorkspaceProjectContextAccessor, Task> action);
 
@@ -58,6 +62,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         /// </exception>
         /// <exception cref="OperationCanceledException">
         ///     The result is awaited and the <see cref="ConfiguredProject"/> is unloaded.
+        /// </exception>
+        /// <exception cref="ActiveProjectConfigurationChangedException">
+        ///     The <see cref="IWorkspaceProjectContextHost"/> represents the active one, and 
+        ///     the configuration changed.
         /// </exception>
         Task<T> OpenContextForWriteAsync<T>(Func<IWorkspaceProjectContextAccessor, Task<T>> action);
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceContextHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceContextHost.cs
@@ -14,6 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     ///     on changes to the project to the <see cref="IApplyChangesToWorkspaceContext"/> service.
     /// </summary>
     [Export(typeof(IImplicitlyActiveService))]
+    [Export(typeof(IWorkspaceProjectContextHost))]
     [AppliesTo(ProjectCapability.DotNetLanguageService)]
     internal partial class WorkspaceContextHost : AbstractMultiLifetimeComponent<WorkspaceContextHost.WorkspaceContextHostInstance>, IImplicitlyActiveService, IWorkspaceProjectContextHost
     {
@@ -65,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             WorkspaceContextHostInstance instance = await WaitForLoadedAsync();
 
-            // Throws OperationCanceledException if 'instance' is Disposed
+            // Throws ActiveProjectConfigurationChangedException if 'instance' is Disposed
             await instance.OpenContextForWriteAsync(action);
         }
 
@@ -75,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             WorkspaceContextHostInstance instance = await WaitForLoadedAsync();
 
-            // Throws OperationCanceledException if 'instance' is Disposed
+            // Throws ActiveProjectConfigurationChangedException if 'instance' is Disposed
             return await instance.OpenContextForWriteAsync(action);
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHostInitiator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHostInitiator.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
+{
+    /// <summary>
+    ///     Ensures that the <see cref="IWorkspaceProjectContext"/> for the "active" configuration has 
+    ///     been loaded by the time users and extensions can interact with the project.
+    /// </summary>
+    /// <remarks>
+    ///     It is important to make sure Roslyn is aware of the project by the time the project can be 
+    ///     interacted with so that restored documents and other features used quickly after solution 
+    ///     load behave correctly and have "project context".
+    /// </remarks>
+    internal class WorkspaceProjectContextHostInitiator
+    {
+        private readonly IUnconfiguredProjectTasksService _tasksService;
+        private readonly IActiveWorkspaceProjectContextHost _activeWorkspaceProjectContextHost;
+
+        [ImportingConstructor]
+        public WorkspaceProjectContextHostInitiator(IUnconfiguredProjectTasksService tasksService, IActiveWorkspaceProjectContextHost activeWorkspaceProjectContextHost)
+        {
+            _tasksService = tasksService;
+            _activeWorkspaceProjectContextHost = activeWorkspaceProjectContextHost;
+        }
+
+        [ProjectAutoLoad(startAfter: ProjectLoadCheckpoint.AfterLoadInitialConfiguration, completeBy: ProjectLoadCheckpoint.ProjectFactoryCompleted)]
+        [AppliesTo(ProjectCapability.DotNetLanguageService)]
+        public Task InitializeAsync()
+        {
+            // While we want make sure it's loaded before PrioritizedProjectLoadedInHost, 
+            // we don't want to block project factory completion on its load, so fire and forget
+            _tasksService.PrioritizedProjectLoadedInHostAsync(() => _activeWorkspaceProjectContextHost.PublishAsync())
+                         .Forget();
+
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
- Add an implemention IActiveWorkspaceProjectContext for the new language service integration
  - This lets non-multi-targeting aware consumers to use the "active" configuration's version of the workspace host

- Ensure that we've initialized the language service before project load has completed

This is the last of the changes needed to make the language-service rewrite work.