### PR TITLE
Small bits pulled from larger work

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Extensibility/IProjectExportProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Extensibility/IProjectExportProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Extensibility
 {
     /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Extensibility/ProjectExportProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Extensibility/ProjectExportProvider.cs
@@ -4,8 +4,6 @@ using System;
 using System.ComponentModel.Composition;
 using System.Linq;
 
-using Microsoft.VisualStudio.Composition;
-
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Extensibility
 {
     /// <summary>
@@ -36,14 +34,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Extensibility
             }
 
             IProjectService projectService = _projectServiceAccessor.GetProjectService();
-            if (projectService == null)
-            {
-                return null;
-            }
 
-            UnconfiguredProject project = projectService.LoadedUnconfiguredProjects
-                                                    .FirstOrDefault(x => x.FullPath.Equals(projectFilePath,
-                                                                            StringComparison.OrdinalIgnoreCase));
+            UnconfiguredProject project = projectService?.LoadedUnconfiguredProjects
+                .FirstOrDefault(x => x.FullPath.Equals(projectFilePath, StringComparison.OrdinalIgnoreCase));
+
             return project?.Services.ExportProvider.GetExportedValueOrDefault<T>();
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContext.cs
@@ -38,10 +38,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 
         public ITargetFramework GetProjectFramework(ProjectConfiguration projectConfiguration)
         {
-            if (projectConfiguration.IsCrossTargeting())
+            if (projectConfiguration.Dimensions.TryGetValue(ConfigurationGeneral.TargetFrameworkProperty, out string targetFrameworkMoniker))
             {
-                string targetFrameworkMoniker = projectConfiguration.Dimensions[ConfigurationGeneral.TargetFrameworkProperty];
-
                 return _targetFrameworkProvider.GetTargetFramework(targetFrameworkMoniker);
             }
             else

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContext.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 {
     internal sealed class AggregateCrossTargetProjectContext
     {
-        private readonly ImmutableDictionary<string, ConfiguredProject> _configuredProjectsByTargetFramework;
+        private readonly ImmutableDictionary<string, ConfiguredProject> _configuredProjectByTargetFramework;
         private readonly ITargetFrameworkProvider _targetFrameworkProvider;
 
         public bool IsCrossTargeting { get; }
@@ -18,23 +18,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         public AggregateCrossTargetProjectContext(
             bool isCrossTargeting,
             ImmutableArray<ITargetFramework> targetFrameworks,
-            ImmutableDictionary<string, ConfiguredProject> configuredProjectsByTargetFramework,
+            ImmutableDictionary<string, ConfiguredProject> configuredProjectByTargetFramework,
             ITargetFramework activeTargetFramework,
             ITargetFrameworkProvider targetFrameworkProvider)
         {
             Requires.Argument(!targetFrameworks.IsDefaultOrEmpty, nameof(targetFrameworks), "Must contain at least one item.");
-            Requires.NotNullOrEmpty(configuredProjectsByTargetFramework, nameof(configuredProjectsByTargetFramework));
+            Requires.NotNullOrEmpty(configuredProjectByTargetFramework, nameof(configuredProjectByTargetFramework));
             Requires.NotNull(activeTargetFramework, nameof(activeTargetFramework));
             Requires.Argument(targetFrameworks.Contains(activeTargetFramework), nameof(targetFrameworks), "Must contain 'activeTargetFramework'.");
 
             IsCrossTargeting = isCrossTargeting;
             TargetFrameworks = targetFrameworks;
-            _configuredProjectsByTargetFramework = configuredProjectsByTargetFramework;
+            _configuredProjectByTargetFramework = configuredProjectByTargetFramework;
             ActiveTargetFramework = activeTargetFramework;
             _targetFrameworkProvider = targetFrameworkProvider;
         }
 
-        public IEnumerable<ConfiguredProject> InnerConfiguredProjects => _configuredProjectsByTargetFramework.Values;
+        public IEnumerable<ConfiguredProject> InnerConfiguredProjects => _configuredProjectByTargetFramework.Values;
 
         public ITargetFramework GetProjectFramework(ProjectConfiguration projectConfiguration)
         {
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 
         public ConfiguredProject GetInnerConfiguredProject(ITargetFramework target)
         {
-            return _configuredProjectsByTargetFramework.FirstOrDefault((x, t) => t.Equals(x.Key), target).Value;
+            return _configuredProjectByTargetFramework.FirstOrDefault((x, t) => t.Equals(x.Key), target).Value;
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/AggregateDependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/AggregateDependenciesSnapshotProvider.cs
@@ -91,10 +91,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
         public IDependenciesSnapshotProvider GetSnapshotProvider(string projectFilePath)
         {
-            if (string.IsNullOrEmpty(projectFilePath))
-            {
-                throw new ArgumentException(nameof(projectFilePath));
-            }
+            Requires.NotNullOrEmpty(projectFilePath, nameof(projectFilePath));
 
             lock (_snapshotProviders)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySubscriptionsHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySubscriptionsHost.cs
@@ -27,6 +27,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
     {
         public const string DependencySubscriptionsHostContract = "DependencySubscriptionsHostContract";
 
+        public event EventHandler<ProjectRenamedEventArgs> SnapshotRenamed;
+        public event EventHandler<SnapshotChangedEventArgs> SnapshotChanged;
+        public event EventHandler<SnapshotProviderUnloadingEventArgs> SnapshotProviderUnloading;
+
         private readonly TimeSpan _dependenciesUpdateThrottleInterval = TimeSpan.FromMilliseconds(250);
 
         private readonly SemaphoreSlim _gate = new SemaphoreSlim(initialCount: 1);
@@ -105,17 +109,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             ProjectFilePath = commonServices.Project.FullPath;
         }
 
-        #region IDependenciesSnapshotProvider
 
         public IDependenciesSnapshot CurrentSnapshot => _currentSnapshot;
 
         public string ProjectFilePath { get; }
-
-        public event EventHandler<ProjectRenamedEventArgs> SnapshotRenamed;
-        public event EventHandler<SnapshotChangedEventArgs> SnapshotChanged;
-        public event EventHandler<SnapshotProviderUnloadingEventArgs> SnapshotProviderUnloading;
-
-        #endregion
 
         private ImmutableArray<IDependencyCrossTargetSubscriber> Subscribers
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySubscriptionsHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySubscriptionsHost.cs
@@ -90,8 +90,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 projectCapabilityCheckProvider: commonServices.Project);
 
             _snapshotFilters = new OrderPrecedenceImportCollection<IDependenciesSnapshotFilter>(
-                projectCapabilityCheckProvider: commonServices.Project,
-                orderingStyle: ImportOrderPrecedenceComparer.PreferenceOrder.PreferredComesLast);
+                ImportOrderPrecedenceComparer.PreferenceOrder.PreferredComesLast,
+                projectCapabilityCheckProvider: commonServices.Project);
 
             _subTreeProviders = new OrderPrecedenceImportCollection<IProjectDependenciesSubTreeProvider>(
                 ImportOrderPrecedenceComparer.PreferenceOrder.PreferredComesLast,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySubscriptionsHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySubscriptionsHost.cs
@@ -105,14 +105,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 _dependenciesUpdateThrottleInterval,
                 commonServices.ThreadingService,
                 tasksService.UnloadCancellationToken);
-
-            ProjectFilePath = commonServices.Project.FullPath;
         }
-
 
         public IDependenciesSnapshot CurrentSnapshot => _currentSnapshot;
 
-        public string ProjectFilePath { get; }
+        public string ProjectFilePath => _commonServices.Project.FullPath;
 
         private ImmutableArray<IDependencyCrossTargetSubscriber> Subscribers
         {


### PR DESCRIPTION
To keep the size of a future PR down a bit, here's a grab bag of small tidy ups.

The only functional change here is in e89b1f955024d2860a7c2b24c96554a8054c6aaf which fixes a memory leak in `AggregateDependenciesSnapshotProvider` in cases where the project path changes, as it will not be removed from its collection.