### PR TITLE
Opt into the new integrated console experience

### DIFF
--- a/build/Packages.targets
+++ b/build/Packages.targets
@@ -59,6 +59,7 @@
     <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime" Version="15.0.26932" />
     <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime" Version="15.0.26929" />
     <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.15.7.DesignTime" Version="15.7.1" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Interop.15.8.DesignTime" Version="15.8.1" />
     <PackageReference Update="Microsoft.VisualStudio.TemplateWizardInterface" Version="8.0.0-alpha" />
     <PackageReference Update="Microsoft.VisualStudio.Threading" Version="15.8.145" />
     <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers" Version="15.8.145" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IActiveDebugFrameworkServicesFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IActiveDebugFrameworkServicesFactory.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+    internal static class IActiveDebugFrameworkServicesFactory
+    {
+        public static IActiveDebugFrameworkServices ImplementGetConfiguredProjectForActiveFrameworkAsync(ConfiguredProject project)
+        {
+            var service = new IActiveDebugFrameworkServicesMock();
+            service.ImplementGetConfiguredProjectForActiveFrameworkAsync(project);
+
+            return service.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IEnvironmentHelperFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IEnvironmentHelperFactory.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Utilities
+{
+    internal static class IEnvironmentHelperFactory
+    {
+        public static IEnvironmentHelper ImplementGetEnvironmentVariable(string result)
+        {
+            var mock = new Mock<IEnvironmentHelper>();
+
+            mock.Setup(s => s.GetEnvironmentVariable(It.IsAny<string>()))
+                .Returns(() => result);
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITokenReplacerFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITokenReplacerFactory.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug
+{
+    internal static class IDebugTokenReplacerFactory
+    {
+        public static IDebugTokenReplacer Create()
+        {
+            var mock = new Mock<IDebugTokenReplacer>();
+            mock.Setup(s => s.ReplaceTokensInProfileAsync(It.IsAny<ILaunchProfile>()))
+                .Returns<ILaunchProfile>(p => Task.FromResult(p));
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsDebugger10Factory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsDebugger10Factory.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Moq;
+
+namespace Microsoft.VisualStudio.Shell.Interop
+{
+    internal static class IVsDebugger10Factory 
+    {
+        public static IVsDebugger10 ImplementIsIntegratedConsoleEnabled(bool enabled)
+        {
+            var mock = new Mock<IVsDebugger10>();
+            mock.Setup(d => d.IsIntegratedConsoleEnabled(out enabled));
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/VisualStudio.props
+++ b/src/VisualStudio.props
@@ -55,6 +55,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime"/>
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime"/>
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.7.DesignTime"/>
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Interop.15.8.DesignTime"/>
     <PackageReference Include="Microsoft.VisualStudio.Shell.Design" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" />
@@ -89,6 +90,7 @@
            or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.15.0.DesignTime'
            or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime'
            or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.15.7.DesignTime'
+           or '%(FileName)' == 'Microsoft.VisualStudio.Shell.Interop.15.8.DesignTime'
            or '%(Filename)' == 'Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime'
            or '%(FileName)' == 'Microsoft.VisualStudio.TextManager.Interop.12.1.DesignTime'
            or '%(FileName)' == 'Microsoft.VisualStudio.ProjectSystem.Interop'


### PR DESCRIPTION
Fixes: https://github.com/dotnet/project-system/issues/3667 for new project system.

The integrated console experience causes F5 to leave the console open similar to CTRL+F5, but unlike CTRL+F5 it will reuse the window on future F5s. When turned on (by default), it affects both F5 and CTRL+F5. It has added advantage of being able to snap the console window next to VS, and continually F5 over and over again without it changing position.

It can be dismissed by pressing a key while it is open, or can be turned off by checking _Tools_ -> _Options_ -> _Automatically close the console when debugging stops,_ after which the old behavior is reinstated.

**CTRL+F5:**
![image](https://user-images.githubusercontent.com/1103906/49986754-16258d00-ffc5-11e8-8c8e-cd7305b2261f.png)

**F5:**
![image](https://user-images.githubusercontent.com/1103906/49986780-29385d00-ffc5-11e8-967f-3faa40d92ea3.png)

This required to me move more code than I'd like due to the order in which things were calculated.