### PR TITLE
Ban ConfigureAwait method

### DIFF
--- a/src/BannedSymbols.txt
+++ b/src/BannedSymbols.txt
@@ -9,3 +9,5 @@ M:Microsoft.VisualStudio.ProjectSystem.CommonProjectSystemTools.LoadedProject(Mi
 
 T:Microsoft.VisualStudio.ProjectSystem.ProjectAutoLoadAttribute; Using IProjectDynamicLoadComponent avoids accidently reloading the project while loading, switching branches, installing NuGet package, etc.
 T:Microsoft.VisualStudio.ProjectSystem.ConfiguredProjectAutoLoadAttribute; Using IProjectDynamicLoadComponent avoids accidently reloading the project while loading, switching branches, installing NuGet package, etc.
+
+M:System.Threading.Tasks.Task.ConfigureAwait(System.Boolean); "ConfigureAwait(true)" should be removed, and "ConfigureAwait(false)" should be replaced with "await TashScheduler.Default"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/PasteOrdering.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/PasteOrdering.cs
@@ -101,7 +101,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         {
             Assumes.NotNull(_dropTarget);
 
-            // ConfigureAwait is true because we need to come back for PasteItemsAsync to work. If not, PasteItemsAsync will throw.
             ImmutableHashSet<string> previousIncludes = await OrderingHelper.GetAllEvaluatedIncludes(_configuredProject, _accessor);
             PasteItemsResult result = await PasteHandler.PasteItemsAsync(items, effect);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectAccessor.cs
@@ -19,9 +19,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
     [Export(typeof(IProjectAccessor))]
     internal class ProjectAccessor : IProjectAccessor
     {
-        // NOTE: It is very deliberate that we ConfigureAwait(true) in this class to switch 
-        // back to the thread type ("threadpool") where XXXLockAsync switched us too.
-
         private readonly IProjectLockService _projectLockService;
 
         [ImportingConstructor]


### PR DESCRIPTION
Fixes #4389

There were no usages, so nothing else to tidy up.

Searching for the string "ConfigureAwait" turned up two comments, both of which are pretty much redundant, so removed.