### PR TITLE
WIP Use IProjectDynamicLoadComponent over attributed load methods

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsLoaderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsLoaderTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             });
 
             var loader = CreateInstance(project, out ProjectValueDataSource<IConfigurationGroup<ProjectConfiguration>> source);
-            await loader.InitializeAsync();
+            await loader.LoadAsync();
 
             // Change the active configurations
             await source.SendAndCompleteAsync(configurationGroups, loader.TargetBlock);
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             });
 
             var loader = CreateInstance(project, tasksService, out ProjectValueDataSource<IConfigurationGroup<ProjectConfiguration>> source);
-            await loader.InitializeAsync();
+            await loader.LoadAsync();
 
             var configurationGroups = IConfigurationGroupFactory.CreateFromConfigurationNames("Debug|AnyCPU");
 
@@ -71,8 +71,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             var loader = CreateInstance(project, out var source);
 
-            await loader.InitializeAsync();
-            await loader.InitializeAsync();
+            await loader.LoadAsync();
+            await loader.LoadAsync();
 
             var configurationGroups = IConfigurationGroupFactory.CreateFromConfigurationNames("Debug|AnyCPU");
 
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             });
 
             var loader = CreateInstance(project, out ProjectValueDataSource<IConfigurationGroup<ProjectConfiguration>> source);
-            await loader.InitializeAsync();
+            await loader.LoadAsync();
             loader.Dispose();
 
             var configurationGroups = IConfigurationGroupFactory.CreateFromConfigurationNames("Debug|AnyCPU");

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ConfiguredProjectImplicitActivationTrackingTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ConfiguredProjectImplicitActivationTrackingTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             Assert.Throws<ObjectDisposedException>(() =>
             {
-                var ignored = service.IsImplicitlyActive;
+                _ = service.IsImplicitlyActive;
             });
         }
 
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             Assert.Throws<ObjectDisposedException>(() =>
             {
-                var ignored = service.ImplicitlyActive;
+                _ = service.ImplicitlyActive;
             });
         }
 
@@ -206,7 +206,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             var project = ConfiguredProjectFactory.ImplementProjectConfiguration(currentConfiguration);
             var service = CreateInstance(project, out ProjectValueDataSource<IConfigurationGroup<ProjectConfiguration>> source);
-            service.Load();
+            service.LoadAsync().Forget();
 
             int callCount = 0;
             var implicitActiveService = IImplicitlyActiveServiceFactory.ImplementActivateAsync(() =>
@@ -227,7 +227,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             var project = ConfiguredProjectFactory.ImplementProjectConfiguration("Debug|AnyCPU");
             var service = CreateInstance(project, out ProjectValueDataSource<IConfigurationGroup<ProjectConfiguration>> source);
-            service.Load();
+            service.LoadAsync().Forget();
 
             bool? result = null;
             var implicitActiveService = IImplicitlyActiveServiceFactory.ImplementActivateAsync(() =>
@@ -248,7 +248,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             var project = ConfiguredProjectFactory.ImplementProjectConfiguration("Debug|AnyCPU");
             var service = CreateInstance(project, out ProjectValueDataSource<IConfigurationGroup<ProjectConfiguration>> source);
-            service.Load();
+            service.LoadAsync().Forget();
 
             Assert.False(service.IsImplicitlyActive);
 
@@ -277,7 +277,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             var project = ConfiguredProjectFactory.ImplementProjectConfiguration("Debug|AnyCPU");
             var service = CreateInstance(project, out ProjectValueDataSource<IConfigurationGroup<ProjectConfiguration>> source);
-            service.Load();
+            service.LoadAsync().Forget();
 
             Assert.False(service.IsImplicitlyActive);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UnconfiguredProjectTasksServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UnconfiguredProjectTasksServiceTests.cs
@@ -118,7 +118,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             var service = CreateInstance(loadedInHostListener: loadedInHostListener);
 
-            service.OnProjectFactoryCompleted();
+            service.LoadAsync();
 
             Assert.Equal(1, callCount);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -14,6 +14,7 @@ using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.ProjectSystem.Build;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.Telemetry;
+using Microsoft.VisualStudio.Threading;
 
 using Moq;
 
@@ -90,7 +91,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 ITelemetryServiceFactory.Create(telemetryParameters => _telemetryEvents.Add(telemetryParameters)),
                 _fileSystem);
 
-            _buildUpToDateCheck.Load();
+            _buildUpToDateCheck.LoadAsync().Forget();
         }
 
         public void Dispose() => _buildUpToDateCheck.Dispose();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/DebugTests/StartupProjectRegistrarTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/DebugTests/StartupProjectRegistrarTests.cs
@@ -170,7 +170,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
            ActiveConfiguredProject<DebuggerLaunchProviders> launchProviders = null)
         {
             var instance = CreateInstance(vsStartupProjectsListService, threadingService, projectGuidService, projectSubscriptionService, launchProviders);
-            await instance.InitializeAsync();
+            await instance.LoadAsync();
 
             return instance;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/NuGet/ProjectAssetFileWatcherTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/NuGet/ProjectAssetFileWatcherTests.cs
@@ -5,6 +5,7 @@ using System.Threading;
 
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
 
 using Moq;
 
@@ -47,7 +48,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\foo.proj""
             {
                 var tree = ProjectTreeParser.Parse(inputTree);
                 var projectUpdate = IProjectSubscriptionUpdateFactory.FromJson(ProjectCurrentStateJson);
-                watcher.Load();
+                watcher.LoadAsync().Forget();
                 await watcher.DataFlow_ChangedAsync(IProjectVersionedValueFactory.Create(Tuple.Create(IProjectTreeSnapshotFactory.Create(tree), projectUpdate)));
 
                 // If fileToWatch is null then we expect to not register any filewatcher.
@@ -101,7 +102,7 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\foo.proj""
                 tasksService,
                 IActiveConfiguredProjectSubscriptionServiceFactory.Create()))
             {
-                watcher.Load();
+                watcher.LoadAsync().Forget();
                 var projectUpdate = IProjectSubscriptionUpdateFactory.FromJson(ProjectCurrentStateJson);
 
                 var firstTree = ProjectTreeParser.Parse(inputTree);
@@ -144,7 +145,8 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\foo.proj""
     }
 }");
 
-                watcher.Load();
+                watcher.LoadAsync().Forget();
+
                 await watcher.DataFlow_ChangedAsync(IProjectVersionedValueFactory.Create(Tuple.Create(IProjectTreeSnapshotFactory.Create(tree), projectUpdate)));
 
                 var fileChangeServiceMock = Mock.Get(fileChangeService);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using Microsoft.VisualStudio.Shell;
@@ -20,9 +21,10 @@ using Task = System.Threading.Tasks.Task;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
 {
     /// <summary>
-    ///     Watches for writes to the project.assets.json, triggering a evaluation if it changes.
+    ///     Watches for writes to the project.assets.json, triggering an evaluation if it changes.
     /// </summary>
-    internal class ProjectAssetFileWatcher : OnceInitializedOnceDisposedAsync, IVsFreeThreadedFileChangeEvents2
+    [AppliesTo(ProjectCapability.DotNet)]
+    internal class ProjectAssetFileWatcher : OnceInitializedOnceDisposedAsync, IVsFreeThreadedFileChangeEvents2, IProjectDynamicLoadComponent
     {
         private static readonly TimeSpan s_notifyDelay = TimeSpan.FromMilliseconds(100);
 
@@ -61,17 +63,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             _activeConfiguredProjectSubscriptionService = activeConfiguredProjectSubscriptionService;
         }
 
-        /// <summary>
-        /// Called on project load.
-        /// </summary>
-#pragma warning disable RS0030 // symbol ConfiguredProjectAutoLoad is banned
-        [ConfiguredProjectAutoLoad(RequiresUIThread = false)]
-#pragma warning restore RS0030 // symbol ConfiguredProjectAutoLoad is banned
-        [AppliesTo(ProjectCapability.DotNet)]
-        internal void Load()
-        {
-            InitializeAsync();
-        }
+        public Task LoadAsync() => InitializeAsync();
+
+        public Task UnloadAsync() => Task.CompletedTask;
 
         /// <summary>
         /// Called on changes to the project tree.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySubscriptionsHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySubscriptionsHost.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
     [Export(DependencySubscriptionsHostContract, typeof(ICrossTargetSubscriptionsHost))]
     [Export(typeof(IDependenciesSnapshotProvider))]
     [AppliesTo(ProjectCapability.DependenciesTree)]
-    internal sealed class DependencySubscriptionsHost : OnceInitializedOnceDisposedAsync, ICrossTargetSubscriptionsHost, IDependenciesSnapshotProvider
+    internal sealed class DependencySubscriptionsHost : OnceInitializedOnceDisposedAsync, ICrossTargetSubscriptionsHost, IDependenciesSnapshotProvider, IProjectDynamicLoadComponent
     {
         public const string DependencySubscriptionsHostContract = "DependencySubscriptionsHostContract";
 
@@ -135,14 +135,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             }
         }
 
-#pragma warning disable RS0030 // symbol ProjectAutoLoad is banned
-        [ProjectAutoLoad(ProjectLoadCheckpoint.ProjectFactoryCompleted)]
-#pragma warning restore RS0030 // symbol ProjectAutoLoad is banned
-        [AppliesTo(ProjectCapability.DependenciesTree)]
-        public Task OnProjectFactoryCompletedAsync()
-        {
-            return AddInitialSubscriptionsAsync();
-        }
+        public Task LoadAsync() => AddInitialSubscriptionsAsync();
+
+        public Task UnloadAsync() => Task.CompletedTask;
 
         /// <summary>
         /// Workaround for CPS bug 375276 which causes double entry on InitializeAsync and exception

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
@@ -11,7 +11,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
     ///     Force loads the active <see cref="ConfiguredProject"/> objects so that any configured project-level 
     ///     services, such as evaluation and build services, are started.
     /// </summary>
-    internal class ActiveConfiguredProjectsLoader : OnceInitializedOnceDisposed
+    [AppliesTo(ProjectCapability.DotNetLanguageServiceOrLanguageService2)]
+    internal class ActiveConfiguredProjectsLoader : OnceInitializedOnceDisposed, IProjectDynamicLoadComponent
     {
         private readonly UnconfiguredProject _project;
         private readonly IActiveConfigurationGroupService _activeConfigurationGroupService;
@@ -29,15 +30,13 @@ namespace Microsoft.VisualStudio.ProjectSystem
             _targetBlock = DataflowBlockSlim.CreateActionBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>>(OnActiveConfigurationsChanged);
         }
 
-#pragma warning disable RS0030 // symbol ProjectAutoLoad is banned
-        [ProjectAutoLoad(ProjectLoadCheckpoint.ProjectInitialCapabilitiesEstablished)]
-#pragma warning restore RS0030 // symbol ProjectAutoLoad is banned
-        [AppliesTo(ProjectCapability.DotNetLanguageServiceOrLanguageService2)]
-        public Task InitializeAsync()
+        public Task LoadAsync()
         {
             EnsureInitialized();
             return Task.CompletedTask;
         }
+
+        public Task UnloadAsync() => Task.CompletedTask;
 
         public ITargetBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>> TargetBlock => _targetBlock;
 
@@ -65,7 +64,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 await _tasksService.LoadedProjectAsync(() =>
                 {
                     return _project.LoadConfiguredProjectAsync(configuration);
-
                 });
             }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ConfiguredProjectImplicitActivationTracking.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ConfiguredProjectImplicitActivationTracking.cs
@@ -16,7 +16,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
     ///     Provides an implementation of <see cref="IConfiguredProjectActivationTracking"/> that is based on the results of <see cref="IActiveConfigurationGroupService"/>.
     /// </summary>
     [Export(typeof(IConfiguredProjectImplicitActivationTracking))]
-    internal class ConfiguredProjectImplicitActivationTracking : OnceInitializedOnceDisposed, IConfiguredProjectImplicitActivationTracking
+    [AppliesTo(ProjectCapability.DotNet)]
+    internal class ConfiguredProjectImplicitActivationTracking : OnceInitializedOnceDisposed, IConfiguredProjectImplicitActivationTracking, IProjectDynamicLoadComponent
     {
         private readonly ConfiguredProject _project;
         private readonly IProjectAsynchronousTasksService _tasksService;
@@ -42,14 +43,13 @@ namespace Microsoft.VisualStudio.ProjectSystem
             get;
         }
 
-#pragma warning disable RS0030 // symbol ConfiguredProjectAutoLoad is banned
-        [ConfiguredProjectAutoLoad]
-#pragma warning restore RS0030 // symbol ConfiguredProjectAutoLoad is banned
-        [AppliesTo(ProjectCapability.DotNet)]
-        public void Load()
+        public Task LoadAsync()
         {
             EnsureInitialized();
+            return Task.CompletedTask;
         }
+
+        public Task UnloadAsync() => Task.CompletedTask;
 
         public ITargetBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>> TargetBlock => _targetBlock;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     /// </summary>
     [Export(typeof(ILanguageServiceHost))]
     [AppliesTo(ProjectCapability.DotNetLanguageService)]
-    internal partial class LanguageServiceHost : OnceInitializedOnceDisposedAsync, ILanguageServiceHost
+    internal partial class LanguageServiceHost : OnceInitializedOnceDisposedAsync, ILanguageServiceHost, IProjectDynamicLoadComponent
     {
 #pragma warning disable CA2213 // OnceInitializedOnceDisposedAsync are not tracked correctly by the IDisposeable analyzer
         private readonly SemaphoreSlim _gate = new SemaphoreSlim(initialCount: 1);
@@ -76,14 +76,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         public object HostSpecificEditAndContinueService => _currentAggregateProjectContext?.ENCProjectConfig;
 
-#pragma warning disable RS0030 // symbol ProjectAutoLoad is banned
-        [ProjectAutoLoad(completeBy: ProjectLoadCheckpoint.ProjectFactoryCompleted)]
-#pragma warning restore RS0030 // symbol ProjectAutoLoad is banned
-        [AppliesTo(ProjectCapability.DotNetLanguageService)]
-        public Task OnProjectFactoryCompletedAsync()
-        {
-            return InitializeAsync();
-        }
+        public Task LoadAsync() => InitializeAsync();
+
+        public Task UnloadAsync() => Task.CompletedTask;
 
         protected override Task InitializeCoreAsync(CancellationToken cancellationToken)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectTasksService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectTasksService.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.ComponentModel.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
     [Export]
     [Export(typeof(IUnconfiguredProjectTasksService))]
     [AppliesTo(ProjectCapability.DotNet)]
-    internal class UnconfiguredProjectTasksService : IUnconfiguredProjectTasksService
+    internal class UnconfiguredProjectTasksService : IUnconfiguredProjectTasksService, IProjectDynamicLoadComponent
     {
         private readonly IProjectAsynchronousTasksService _tasksService;
         private readonly IProjectThreadingService _threadingService;
@@ -31,14 +30,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
             _loadedInHostListener = loadedInHostListener;
         }
 
-#pragma warning disable RS0030 // symbol ProjectAutoLoad is banned
-        [ProjectAutoLoad(completeBy: ProjectLoadCheckpoint.ProjectFactoryCompleted)]
-#pragma warning restore RS0030 // symbol ProjectAutoLoad is banned
-        [AppliesTo(ProjectCapability.DotNet)]
-        public Task OnProjectFactoryCompleted()
-        {
-            return _loadedInHostListener.StartListeningAsync();
-        }
+        public Task LoadAsync() => _loadedInHostListener.StartListeningAsync();
+
+        public Task UnloadAsync() => Task.CompletedTask;
 
         public Task ProjectLoadedInHost
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
     [AppliesTo(ProjectCapability.DotNet + "+ !" + ProjectCapabilities.SharedAssetsProject)]
     [Export(typeof(IBuildUpToDateCheckProvider))]
     [ExportMetadata("BeforeDrainCriticalTasks", true)]
-    internal sealed class BuildUpToDateCheck : OnceInitializedOnceDisposed, IBuildUpToDateCheckProvider
+    internal sealed class BuildUpToDateCheck : OnceInitializedOnceDisposed, IBuildUpToDateCheckProvider, IProjectDynamicLoadComponent
     {
         private const string CopyToOutputDirectory = "CopyToOutputDirectory";
         private const string PreserveNewest = "PreserveNewest";
@@ -99,17 +99,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             _fileSystem = fileSystem;
         }
 
-        /// <summary>
-        /// Called on project load.
-        /// </summary>
-#pragma warning disable RS0030 // symbol ConfiguredProjectAutoLoad is banned
-        [ConfiguredProjectAutoLoad]
-#pragma warning restore RS0030 // symbol ConfiguredProjectAutoLoad is banned
-        [AppliesTo(ProjectCapability.DotNet + "+ !" + ProjectCapabilities.SharedAssetsProject)]
-        internal void Load()
+        public Task LoadAsync()
         {
             EnsureInitialized();
+            return Task.CompletedTask;
         }
+
+        public Task UnloadAsync() => Task.CompletedTask;
 
         protected override void Initialize()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Automation/VisualBasicNamespaceImportsList.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Automation/VisualBasicNamespaceImportsList.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
 {
     [Export(typeof(VisualBasicNamespaceImportsList))]
     [AppliesTo(ProjectCapability.VisualBasic)]
-    internal class VisualBasicNamespaceImportsList : OnceInitializedOnceDisposed
+    internal class VisualBasicNamespaceImportsList : OnceInitializedOnceDisposed, IProjectDynamicLoadComponent
     {
         private readonly IActiveConfiguredProjectSubscriptionService _activeConfiguredProjectSubscriptionService;
 
@@ -54,15 +54,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             return _list.GetEnumerator();
         }
 
-#pragma warning disable RS0030 // symbol ProjectAutoLoad is banned
-        [ProjectAutoLoad(startAfter: ProjectLoadCheckpoint.ProjectFactoryCompleted)]
-#pragma warning restore RS0030 // symbol ProjectAutoLoad is banned
-        [AppliesTo(ProjectCapability.VisualBasic)]
-        internal Task OnProjectFactoryCompletedAsync()
+        public Task LoadAsync()
         {
             EnsureInitialized();
             return Task.CompletedTask;
         }
+
+        public Task UnloadAsync() => Task.CompletedTask;
 
         internal void OnNamespaceImportChanged(IProjectVersionedValue<IProjectSubscriptionUpdate> e)
         {


### PR DESCRIPTION
Use `IProjectDynamicLoadComponent` over `ProjectAutoLoad` and `ConfiguredProjectAutoLoad` which were banned in #4374.

Relates to #3777, #4375.

## THIS IS CURRENTLY COMPLETELY BROKEN

These changes were made mechanically given my interpretation of advice in #3777. 

The removed attributes make specifications that `IProjectDynamicLoadComponent` does not allow for! Distinct examples from the base code:

```c#
[ProjectAutoLoad(startAfter: ProjectLoadCheckpoint.ProjectInitialCapabilitiesEstablished)]
[ProjectAutoLoad(startAfter: ProjectLoadCheckpoint.ProjectFactoryCompleted)]
[ProjectAutoLoad(completeBy: ProjectLoadCheckpoint.ProjectFactoryCompleted)]
[ConfiguredProjectAutoLoad(RequiresUIThread = false)]
```

Loading `ProjectSystem.sln` in d16.0stg under the debugger and the dependencies node doesn't populate. Probably more stuff is broken.

Leaving this here to start a discussion about what's needed if we do indeed wish to ban `ProjectAutoLoad` and `ConfiguredProjectAutoLoad`.