### PR TITLE
Add AppServicePublish capability to all SDK projects that output to exe

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -108,6 +108,7 @@
   
     <!-- Publish capability enables the Publish command for the Project -->
     <ProjectCapability Include="Publish"/>
+    <ProjectCapability Include="FolderPublish"/>
 
     <!-- All Microsoft.NET.Sdk Exe projects, except WPF and WinForms exes, can be published to app service -->
     <ProjectCapability Include="AppServicePublish" Condition="'$(OutputType)' == 'Exe'" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -108,8 +108,11 @@
   
     <!-- Publish capability enables the Publish command for the Project -->
     <ProjectCapability Include="Publish"/>
-  </ItemGroup>
 
+    <!-- All Microsoft.NET.Sdk Exe projects, except WPF and WinForms exes, can be published to app service -->
+    <ProjectCapability Include="AppServicePublish" Condition="'$(OutputType)' == 'Exe'" />
+  </ItemGroup>
+  
   <!-- Common Project System rules that override rules defined in msbuild. These are exact copy of the rules defined in msbuild. -->
   <ItemGroup Condition="'$(DefineCommonManagedItemSchemas)' == 'true'">
 


### PR DESCRIPTION
Fixes #4397

I've tested this and it works for C# and VB projects, but for some reason doesn't for F# projects. Hopefully someone knows why, or its just my local environment being weird. I can't see F# opting out of `DefineCommonManagedCapabilities` or anything, but I don't really know where to look either.