### PR TITLE
Enable CA2235 (non serializable fields on serializable types)

### DIFF
--- a/build/Default.ruleset
+++ b/build/Default.ruleset
@@ -65,7 +65,7 @@
   </Rules>
   <Rules AnalyzerId="Microsoft.NetFramework.Analyzers" RuleNamespace="Microsoft.NetFramework.Analyzers">
     <Rule Id="CA2153" Action="None" /> <!-- TODO do not catch CorruptedStateExceptions -->
-    <Rule Id="CA2235" Action="None" /> <!-- TODO mark all non-serializable fields -->
+    <Rule Id="CA2235" Action="Error" />
     <Rule Id="CA3075" Action="Error" />
   </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.Analyzers" RuleNamespace="Microsoft.CodeAnalysis.Analyzers">

--- a/build/Versions.props
+++ b/build/Versions.props
@@ -21,7 +21,7 @@
     <MicrosoftDotNetIBCMergeVersion>4.7.1-alpha-00001</MicrosoftDotNetIBCMergeVersion>
     <MicrosoftNetCompilersVersion>2.11.0-beta2-63529-05</MicrosoftNetCompilersVersion>
     <MicrosoftDiaSymReaderPdb2PdbVersion>1.1.0-beta1-62624-01</MicrosoftDiaSymReaderPdb2PdbVersion>
-    <RoslynAnalyzersPackagesVersion>2.6.3-beta1.18614.2</RoslynAnalyzersPackagesVersion>
+    <RoslynAnalyzersPackagesVersion>2.6.3-beta1.19055.1</RoslynAnalyzersPackagesVersion>
     <OpenCoverVersion>4.6.519</OpenCoverVersion>
     <CodecovVersion>1.1.0</CodecovVersion>
    

--- a/src/Microsoft.VisualStudio.Editors/SettingsGlobalObject/SettingsGlobalObjectProvider.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsGlobalObject/SettingsGlobalObjectProvider.vb
@@ -2313,7 +2313,6 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' 
         ''' </summary>
         ''' <remarks></remarks>
-        <Serializable()>
         Private Class ConcreteApplicationSettings
             Inherits ApplicationSettingsBase
 


### PR DESCRIPTION
Relates to #4377

~These changes fix the errors, but looking at these I wonder whether the types wouldn't failed serialisation anyway, and if it wouldn't be better to just make them non-serialisable.~