### PR TITLE
Add minimal project for documentation

### DIFF
--- a/ProjectSystem.sln
+++ b/ProjectSystem.sln
@@ -76,6 +76,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Nuget", "Nuget", "{6A95E22E
 		src\VisualStudioDesigner.props = src\VisualStudioDesigner.props
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Documentation", "docs\Documentation.csproj", "{C51202A5-0C1F-4146-8059-5F7B8A048232}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -187,6 +189,8 @@ Global
 		{C16993CC-6063-4447-AE16-BE671AFDE08A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C16993CC-6063-4447-AE16-BE671AFDE08A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C16993CC-6063-4447-AE16-BE671AFDE08A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C51202A5-0C1F-4146-8059-5F7B8A048232}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C51202A5-0C1F-4146-8059-5F7B8A048232}.Release|Any CPU.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/Documentation.csproj
+++ b/docs/Documentation.csproj
@@ -1,0 +1,7 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <None Include="**/*.md" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This brings the documentation files into the solution so that they are easier to edit and appear in search results.

This probably shouldn't be a `csproj` file. If there's a better project format that allows globbing and is in-box, let me know.

I looked at shared projects but concluded they didn't support globbing (IIRC&mdash;I authored this a while back).