### PR TITLE
Dependencies subscription host part 1

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContext.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 {
@@ -51,48 +50,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         public ConfiguredProject GetInnerConfiguredProject(ITargetFramework target)
         {
             return _configuredProjectByTargetFramework.FirstOrDefault((x, t) => t.Equals(x.Key), target).Value;
-        }
-
-        /// <summary>
-        /// Returns true if this cross-targeting aggregate project context has the same set of target frameworks and active target framework as the given active and known configurations.
-        /// </summary>
-        public bool HasMatchingTargetFrameworks(ProjectConfiguration activeProjectConfiguration,
-                                                IReadOnlyCollection<ProjectConfiguration> knownProjectConfigurations)
-        {
-            Assumes.True(IsCrossTargeting);
-            Assumes.True(activeProjectConfiguration.IsCrossTargeting());
-            Assumes.True(knownProjectConfigurations.All(c => c.IsCrossTargeting()));
-
-            ITargetFramework activeTargetFramework = _targetFrameworkProvider.GetTargetFramework(activeProjectConfiguration.Dimensions[ConfigurationGeneral.TargetFrameworkProperty]);
-            if (!ActiveTargetFramework.Equals(activeTargetFramework))
-            {
-                // Active target framework is different.
-                return false;
-            }
-
-            var targetFrameworkMonikers = knownProjectConfigurations
-                .Select(c => c.Dimensions[ConfigurationGeneral.TargetFrameworkProperty])
-                .Distinct()
-                .ToList();
-
-            if (targetFrameworkMonikers.Count != TargetFrameworks.Length)
-            {
-                // Different number of target frameworks.
-                return false;
-            }
-
-            foreach (string targetFrameworkMoniker in targetFrameworkMonikers)
-            {
-                ITargetFramework targetFramework = _targetFrameworkProvider.GetTargetFramework(targetFrameworkMoniker);
-
-                if (!TargetFrameworks.Contains(targetFramework))
-                {
-                    // Differing TargetFramework
-                    return false;
-                }
-            }
-
-            return true;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySubscriptionsHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySubscriptionsHost.cs
@@ -141,7 +141,33 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
         [AppliesTo(ProjectCapability.DependenciesTree)]
         public Task OnProjectFactoryCompletedAsync()
         {
-            return AddInitialSubscriptionsAsync();
+            return _tasksService.LoadedProjectAsync(AddInitialSubscriptionsAsync).Task;
+
+            Task AddInitialSubscriptionsAsync()
+            {
+                SubscribeToConfiguredProjectEvaluation(
+                    _activeConfiguredProjectSubscriptionService, 
+                    OnActiveConfiguredProjectEvaluatedAsync);
+
+                foreach (IDependencyCrossTargetSubscriber subscriber in Subscribers)
+                {
+                    subscriber.InitializeSubscriber(this, _activeConfiguredProjectSubscriptionService);
+                }
+
+                return Task.CompletedTask;
+            }
+
+            async Task OnActiveConfiguredProjectEvaluatedAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> e)
+            {
+                if (IsDisposing || IsDisposed)
+                {
+                    return;
+                }
+
+                await EnsureInitializedAsync();
+
+                await OnConfiguredProjectEvaluatedAsync(e);
+            }
         }
 
         /// <summary>
@@ -214,44 +240,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             SnapshotRenamed?.Invoke(this, e);
 
             return Task.CompletedTask;
-        }
-
-        private void OnAggregateContextChanged(
-            AggregateCrossTargetProjectContext oldContext,
-            AggregateCrossTargetProjectContext newContext)
-        {
-            if (oldContext == null)
-            {
-                // all new rules will be sent to new context , we don't need to clean up anything
-                return;
-            }
-
-            var targetsToClean = new HashSet<ITargetFramework>();
-
-            ImmutableArray<ITargetFramework> oldTargets = oldContext.TargetFrameworks;
-
-            if (newContext == null)
-            {
-                targetsToClean.AddRange(oldTargets);
-            }
-            else
-            {
-                ImmutableArray<ITargetFramework> newTargets = newContext.TargetFrameworks;
-
-                targetsToClean.AddRange(oldTargets.Except(newTargets));
-            }
-
-            if (targetsToClean.Count == 0)
-            {
-                return;
-            }
-
-            lock (_snapshotLock)
-            {
-                _currentSnapshot = _currentSnapshot.RemoveTargets(targetsToClean);
-            }
-
-            ScheduleDependenciesUpdate();
         }
 
         private void OnSubscriberDependenciesChanged(object sender, DependencySubscriptionChangedEventArgs e)
@@ -389,46 +377,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             return ExecuteWithinLockAsync(() => _currentAggregateProjectContext.GetInnerConfiguredProject(target));
         }
 
-        private Task AddInitialSubscriptionsAsync()
-        {
-            JoinableTask joinableTask = _tasksService.LoadedProjectAsync(() =>
-            {
-                SubscribeToConfiguredProject(
-                    _activeConfiguredProjectSubscriptionService,
-                    e => OnProjectChangedAsync(e)); // evaluation
-
-                foreach (IDependencyCrossTargetSubscriber subscriber in Subscribers)
-                {
-                    subscriber.InitializeSubscriber(this, _activeConfiguredProjectSubscriptionService);
-                }
-
-                return Task.CompletedTask;
-            });
-
-            return joinableTask.Task;
-        }
-
-        private async Task OnProjectChangedAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> e)
-        {
-            if (IsDisposing || IsDisposed)
-            {
-                return;
-            }
-
-            await EnsureInitializedAsync();
-
-            await OnProjectChangedCoreAsync(e);
-        }
-
-        private Task OnProjectChangedCoreAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> e)
+        private Task OnConfiguredProjectEvaluatedAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> e)
         {
             // If "TargetFrameworks" property has changed, we need to refresh the project context and subscriptions.
-            if (HasTargetFrameworksChanged(e))
+            if (HasTargetFrameworksChanged())
             {
                 return UpdateProjectContextAndSubscriptionsAsync();
             }
 
             return Task.CompletedTask;
+
+            bool HasTargetFrameworksChanged()
+            {
+                // remember actual property value and compare
+                return e.Value.ProjectChanges.TryGetValue(ConfigurationGeneral.SchemaName, out IProjectChangeDescription projectChange) &&
+                       (projectChange.Difference.ChangedProperties.Contains(ConfigurationGeneral.TargetFrameworkProperty) ||
+                        projectChange.Difference.ChangedProperties.Contains(ConfigurationGeneral.TargetFrameworksProperty));
+            }
         }
 
         private async Task UpdateProjectContextAndSubscriptionsAsync()
@@ -454,7 +419,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
         private Task<AggregateCrossTargetProjectContext> UpdateProjectContextAsync()
         {
             // Ensure that only single thread is attempting to create a project context.
-            return ExecuteWithinLockAsync(async () =>
+            return ExecuteWithinLockAsync(UpdateProjectContextUnsafeAsync);
+
+            async Task<AggregateCrossTargetProjectContext> UpdateProjectContextUnsafeAsync()
             {
                 AggregateCrossTargetProjectContext previousContext = _currentAggregateProjectContext;
 
@@ -497,7 +464,43 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 OnAggregateContextChanged(previousContext, _currentAggregateProjectContext);
 
                 return _currentAggregateProjectContext;
-            });
+            }
+
+            void OnAggregateContextChanged(
+                AggregateCrossTargetProjectContext oldContext,
+                AggregateCrossTargetProjectContext newContext)
+            {
+                if (oldContext == null)
+                {
+                    // all new rules will be sent to new context, we don't need to clean up anything
+                    return;
+                }
+
+                var targetsToClean = new HashSet<ITargetFramework>();
+
+                ImmutableArray<ITargetFramework> oldTargets = oldContext.TargetFrameworks;
+
+                if (newContext == null)
+                {
+                    targetsToClean.AddRange(oldTargets);
+                }
+                else
+                {
+                    ImmutableArray<ITargetFramework> newTargets = newContext.TargetFrameworks;
+
+                    targetsToClean.AddRange(oldTargets.Except(newTargets));
+                }
+
+                if (targetsToClean.Count != 0)
+                {
+                    lock (_snapshotLock)
+                    {
+                        _currentSnapshot = _currentSnapshot.RemoveTargets(targetsToClean);
+                    }
+
+                    ScheduleDependenciesUpdate();
+                }
+            }
         }
 
         private Task AddSubscriptionsAsync(AggregateCrossTargetProjectContext newProjectContext)
@@ -510,9 +513,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 {
                     foreach (ConfiguredProject configuredProject in newProjectContext.InnerConfiguredProjects)
                     {
-                        SubscribeToConfiguredProject(
+                        SubscribeToConfiguredProjectEvaluation(
                             configuredProject.Services.ProjectSubscription,
-                            e => OnProjectChangedCoreAsync(e)); // evaluation
+                            OnConfiguredProjectEvaluatedAsync);
                     }
 
                     foreach (IDependencyCrossTargetSubscriber subscriber in Subscribers)
@@ -527,7 +530,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             return joinableTask.Task;
         }
 
-        private void SubscribeToConfiguredProject(
+        private void SubscribeToConfiguredProjectEvaluation(
             IProjectSubscriptionService subscriptionService,
             Func<IProjectVersionedValue<IProjectSubscriptionUpdate>, Task> action)
         {
@@ -535,14 +538,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 subscriptionService.ProjectRuleSource.SourceBlock.LinkToAsyncAction(
                     action,
                     ruleNames: ConfigurationGeneral.SchemaName));
-        }
-
-        private static bool HasTargetFrameworksChanged(IProjectVersionedValue<IProjectSubscriptionUpdate> e)
-        {
-            // remember actual property value and compare
-            return e.Value.ProjectChanges.TryGetValue(ConfigurationGeneral.SchemaName, out IProjectChangeDescription projectChange) &&
-                   (projectChange.Difference.ChangedProperties.Contains(ConfigurationGeneral.TargetFrameworkProperty) ||
-                    projectChange.Difference.ChangedProperties.Contains(ConfigurationGeneral.TargetFrameworksProperty));
         }
 
         private void DisposeAndClearSubscriptions()


### PR DESCRIPTION
> I have a [branch](https://github.com/drewnoakes/project-system/tree/dep-node-review) with 65 small and focussed commits that improve the approachability of the dependencies node code by moving things around, remove duplicate code, document APIs, as well as reducing allocations and locking. These commits complete my end-to-end review of the dependencies node, and my ongoing work targetting specific bugs continues from the tip of that branch.

This PR is the first few commits and should be reviewable on its own. I'll feed the rest in as they're reviewed.

- Move code to local functions
- Reduce logic in AggregateCrossTargetProjectContext
- Merge consecutive locks into a single lock