### PR TITLE
Dependencies tree and graph changes

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/DependenciesTreeViewProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/DependenciesTreeViewProviderTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    public sealed class GroupedByTargetTreeViewProviderTests
+    public sealed class DependenciesTreeViewProviderTests
     {
         private const string ProjectPath = @"c:\myfolder\mysubfolder\myproject.csproj";
 
@@ -804,7 +804,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Null(result);
         }
 
-        private static GroupedByTargetTreeViewProvider CreateProvider(
+        private static DependenciesTreeViewProvider CreateProvider(
             IEnumerable<IDependencyModel> rootModels = null,
             IEnumerable<IDependencyModel> targetModels = null)
         {
@@ -818,7 +818,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(
                 project: UnconfiguredProjectFactory.Create(filePath: ProjectPath));
 
-            return new GroupedByTargetTreeViewProvider(treeServices, treeViewModelFactory, commonServices);
+            return new DependenciesTreeViewProvider(treeServices, treeViewModelFactory, commonServices);
         }
 
         private static IDependenciesSnapshot GetSnapshot(params (ITargetFramework tfm, IReadOnlyList<IDependency> dependencies)[] testData)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -94,13 +94,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         /// <summary>
-        /// See <see cref="IProjectTreeProvider"/>
+        /// Gets the source block for the <see cref="IProjectTreeSnapshot" />.
         /// </summary>
         /// <remarks>
         /// This stub defined for code contracts.
         /// </remarks>
-        IReceivableSourceBlock<IProjectVersionedValue<IProjectTreeSnapshot>> IProjectTreeProvider.Tree 
-            => Tree;
+        IReceivableSourceBlock<IProjectVersionedValue<IProjectTreeSnapshot>> IProjectTreeProvider.Tree => Tree;
 
         /// <summary>
         /// Gets a value indicating whether a given set of nodes can be copied or moved underneath some given node.
@@ -275,26 +274,37 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         /// <summary>
-        /// Finds dependencies child nodes by their path. We need to override it since
-        /// we need to find children under either:
-        ///     - our dependencies root node.
-        ///     - dependency sub tree nodes
-        ///     - dependency sub tree top level nodes
-        /// (deeper levels will be graph nodes with additional info, not direct dependencies
-        /// specified in the project file)
+        /// Efficiently finds a descendent with the given path in the given tree.
         /// </summary>
+        /// <param name="root">The root of the tree.</param>
+        /// <param name="path">The absolute or project-relative path to the item sought.</param>
+        /// <returns>The item in the tree if found; otherwise <c>null</c>.</returns>
         public override IProjectTree FindByPath(IProjectTree root, string path)
         {
+            // We override this since we need to find children under either:
+            //
+            // - our dependencies root node
+            // - dependency sub tree nodes
+            // - dependency sub tree top level nodes
+            //
+            // Deeper levels will be graph nodes with additional info, not direct dependencies
+            // specified in the project file.
+
             return _viewProviders.FirstOrDefault()?.Value.FindByPath(root, path);
         }
 
         /// <summary>
-        /// This is still needed for graph nodes search
+        /// Gets the path to a given node that can later be provided to <see cref="IProjectTreeProvider.FindByPath" /> to locate the node again.
         /// </summary>
-        /// <param name="node"></param>
-        /// <returns></returns>
+        /// <param name="node">The node whose path is sought.</param>
+        /// <returns>
+        /// A non-empty string, or <c>null</c> if searching is not supported.
+        /// For nodes that represent files on disk, this is the project-relative path to that file.
+        /// The root node of a project is the absolute path to the project file.
+        /// </returns>
         public override string GetPath(IProjectTree node)
         {
+            // Needed for graph nodes search
             return node.FilePath;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesTreeViewProvider.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     [Export(typeof(IDependenciesTreeViewProvider))]
     [AppliesTo(ProjectCapability.DependenciesTree)]
     [Order(Order)]
-    internal class GroupedByTargetTreeViewProvider : IDependenciesTreeViewProvider
+    internal sealed class DependenciesTreeViewProvider : IDependenciesTreeViewProvider
     {
         private const int Order = 1000;
 
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         private readonly OrderPrecedenceImportCollection<IProjectTreePropertiesProvider> _projectTreePropertiesProviders;
 
         [ImportingConstructor]
-        public GroupedByTargetTreeViewProvider(
+        public DependenciesTreeViewProvider(
             IDependenciesTreeServices treeServices,
             IDependenciesViewModelFactory viewModelFactory,
             IUnconfiguredProjectCommonServices commonServices)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/SearchGraphActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/SearchGraphActionHandler.cs
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
                     continue;
                 }
 
-                searchResultsPerContext[snapshotProvider.ProjectFilePath] = SearchFlat(
+                searchResultsPerContext[snapshot.ProjectPath] = SearchFlat(
                     searchTerm.ToLowerInvariant(),
                     snapshot);
             }
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
                 }
 
                 IEnumerable<IDependency> allTopLevelDependencies = snapshot.GetFlatTopLevelDependencies();
-                HashSet<IDependency> matchedDependencies = searchResultsPerContext[snapshotProvider.ProjectFilePath];
+                HashSet<IDependency> matchedDependencies = searchResultsPerContext[snapshot.ProjectPath];
 
                 using (var scope = new GraphTransactionScope())
                 {
@@ -105,7 +105,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
                             }
 
                             bool processed = viewProvider.MatchSearchResults(
-                                snapshotProvider.ProjectFilePath,
+                                snapshot.ProjectPath,
                                 topLevelDependency,
                                 searchResultsPerContext,
                                 out topLevelDependencyMatches);
@@ -133,12 +133,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
                         }
 
                         GraphNode topLevelNode = Builder.AddTopLevelGraphNode(graphContext,
-                                                                snapshotProvider.ProjectFilePath,
+                                                                snapshot.ProjectPath,
                                                                 topLevelDependency.ToViewModel(targetedSnapshot));
                         foreach (IDependency matchedDependency in topLevelDependencyMatches)
                         {
                             GraphNode matchedDependencyNode = Builder.AddGraphNode(graphContext,
-                                                                    snapshotProvider.ProjectFilePath,
+                                                                    snapshot.ProjectPath,
                                                                     topLevelNode,
                                                                     matchedDependency.ToViewModel(targetedSnapshot));
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/TrackChangesGraphActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/TrackChangesGraphActionHandler.cs
@@ -39,6 +39,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
                 return false;
             }
 
+            bool anyChanges = false;
+
             foreach (GraphNode inputGraphNode in graphContext.InputNodes.ToList())
             {
                 string existingDependencyId = inputGraphNode.GetValue<string>(DependenciesGraphSchema.DependencyIdProperty);
@@ -73,18 +75,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
 
                 using (var scope = new GraphTransactionScope())
                 {
-                    viewProvider.TrackChanges(
+                    if (viewProvider.TrackChanges(
                         graphContext,
                         projectPath,
                         updatedDependency,
                         inputGraphNode,
-                        updatedSnapshot.Targets[updatedDependency.TargetFramework]);
+                        updatedSnapshot.Targets[updatedDependency.TargetFramework]))
+                    {
+                        anyChanges = true;
+                    }
 
                     scope.Complete();
                 }
             }
 
-            return false;
+            return anyChanges;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphChangeTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphChangeTracker.cs
@@ -98,17 +98,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
 
                 foreach (IGraphContext graphContext in expandedContexts)
                 {
+                    bool anyChanges = false;
+
                     try
                     {
                         foreach (IDependenciesGraphActionHandler actionHandler in actionHandlers)
                         {
-                            actionHandler.HandleChanges(graphContext, e);
+                            if (actionHandler.HandleChanges(graphContext, e))
+                            {
+                                anyChanges = true;
+                            }
                         }
                     }
                     finally
                     {
                         // Calling OnCompleted ensures that the changes are reflected in UI
-                        graphContext.OnCompleted();
+                        if (anyChanges)
+                        {
+                            graphContext.OnCompleted();
+                        }
                     }
                 }
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphChangeTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphChangeTracker.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+
+using Microsoft.VisualStudio.GraphModel;
+using Microsoft.VisualStudio.PlatformUI;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.Actions;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
+{
+    [Export(typeof(IDependenciesGraphChangeTracker))]
+    [AppliesTo(ProjectCapability.DependenciesTree)]
+    internal sealed class DependenciesGraphChangeTracker : IDependenciesGraphChangeTracker
+    {
+        private readonly object _snapshotChangeHandlerLock = new object();
+
+        /// <summary>
+        /// Remembers expanded graph nodes to track changes in their children.
+        /// </summary>
+        private readonly WeakCollection<IGraphContext> _expandedGraphContexts = new WeakCollection<IGraphContext>();
+
+        [ImportMany] private readonly OrderPrecedenceImportCollection<IDependenciesGraphActionHandler> _graphActionHandlers;
+
+        private readonly IAggregateDependenciesSnapshotProvider _aggregateSnapshotProvider;
+
+        [ImportingConstructor]
+        public DependenciesGraphChangeTracker(IAggregateDependenciesSnapshotProvider aggregateSnapshotProvider)
+        {
+            _aggregateSnapshotProvider = aggregateSnapshotProvider;
+            _aggregateSnapshotProvider.SnapshotChanged += OnSnapshotChanged;
+
+            _graphActionHandlers = new OrderPrecedenceImportCollection<IDependenciesGraphActionHandler>(
+                ImportOrderPrecedenceComparer.PreferenceOrder.PreferredComesLast);
+        }
+
+        public void RegisterGraphContext(IGraphContext context)
+        {
+            bool shouldTrackChanges = false;
+
+            foreach (Lazy<IDependenciesGraphActionHandler, IOrderPrecedenceMetadataView> handler in _graphActionHandlers)
+            {
+                if (handler.Value.CanHandleRequest(context) &&
+                    handler.Value.HandleRequest(context))
+                {
+                    shouldTrackChanges = true;
+                    break;
+                }
+            }
+
+            if (!shouldTrackChanges)
+            {
+                return;
+            }
+
+            lock (_expandedGraphContexts)
+            {
+                if (!_expandedGraphContexts.Contains(context))
+                {
+                    // Remember this graph context in order to track changes.
+                    // When references change, we will adjust children of this graph as necessary
+                    _expandedGraphContexts.Add(context);
+                }
+            }
+        }
+
+        /// <summary>
+        /// ProjectContextChanged gets fired every time dependencies change for projects across solution.
+        /// <see cref="_expandedGraphContexts"/> contains all nodes that we need to check for potential updates
+        /// in their children dependencies.
+        /// </summary>
+        private void OnSnapshotChanged(object sender, SnapshotChangedEventArgs e)
+        {
+            if (e.Snapshot == null || e.Token.IsCancellationRequested)
+            {
+                return;
+            }
+
+            // _expandedGraphContexts remembers graph expanded or checked so far.
+            // Each context represents one level in the graph, i.e. a node and its first level dependencies
+            // Tracking changes over all expanded contexts ensures that all levels are processed
+            // and updated when there are any changes in nodes data.
+            lock (_snapshotChangeHandlerLock)
+            {
+                IList<IGraphContext> expandedContexts;
+                lock (_expandedGraphContexts)
+                {
+                    expandedContexts = _expandedGraphContexts.ToList();
+                }
+
+                if (expandedContexts.Count == 0)
+                {
+                    return;
+                }
+
+                var actionHandlers = _graphActionHandlers.Select(x => x.Value).Where(x => x.CanHandleChanges()).ToList();
+
+                if (actionHandlers.Count == 0)
+                {
+                    return;
+                }
+
+                foreach (IGraphContext graphContext in expandedContexts)
+                {
+                    try
+                    {
+                        foreach (IDependenciesGraphActionHandler actionHandler in actionHandlers)
+                        {
+                            actionHandler.HandleChanges(graphContext, e);
+                        }
+                    }
+                    finally
+                    {
+                        // Calling OnCompleted ensures that the changes are reflected in UI
+                        graphContext.OnCompleted();
+                    }
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            _aggregateSnapshotProvider.SnapshotChanged -= OnSnapshotChanged;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.VisualStudio.GraphModel;
@@ -13,7 +14,9 @@ using Microsoft.VisualStudio.GraphModel.Schemas;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
 
 using IAsyncServiceProvider = Microsoft.VisualStudio.Shell.IAsyncServiceProvider;
 using Task = System.Threading.Tasks.Task;
@@ -27,9 +30,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
     /// </summary>
     [Export(typeof(DependenciesGraphProvider))]
     [Export(typeof(IDependenciesGraphBuilder))]
-    [Export(ExportContractNames.Scopes.UnconfiguredProject, typeof(IProjectDynamicLoadComponent))]
     [AppliesTo(ProjectCapability.DependenciesTree)]
-    internal sealed class DependenciesGraphProvider : IGraphProvider, IDependenciesGraphBuilder, IProjectDynamicLoadComponent
+    internal sealed class DependenciesGraphProvider : OnceInitializedOnceDisposedAsync, IGraphProvider, IDependenciesGraphBuilder
     {
         private static readonly GraphCommand[] s_containsGraphCommand =
         {
@@ -49,21 +51,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
         [ImportingConstructor]
         public DependenciesGraphProvider(
             IDependenciesGraphChangeTracker changeTracker,
-            [Import(typeof(SAsyncServiceProvider))] IAsyncServiceProvider serviceProvider)
+            [Import(typeof(SAsyncServiceProvider))] IAsyncServiceProvider serviceProvider,
+            JoinableTaskContext joinableTaskContext)
+            : base(new JoinableTaskContextNode(joinableTaskContext))
         {
             _serviceProvider = serviceProvider;
             _changeTracker = changeTracker;
         }
 
-        public async Task LoadAsync()
+        protected override async Task InitializeCoreAsync(CancellationToken cancellationToken)
         {
-            if (_iconCache == null)
-            {
-                _iconCache = await GraphIconCache.CreateAsync(_serviceProvider);
-            }
+            _iconCache = await GraphIconCache.CreateAsync(_serviceProvider);
         }
 
-        public Task UnloadAsync()
+        protected override Task DisposeCoreAsync(bool initialized)
         {
             return Task.CompletedTask;
         }
@@ -77,15 +78,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
         /// </summary>
         public void BeginGetGraphData(IGraphContext context)
         {
-            try
+            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
-                _changeTracker.RegisterGraphContext(context);
-            }
-            finally
-            {
-                // OnCompleted must be called to display changes 
-                context.OnCompleted();
-            }
+                try
+                {
+                    await InitializeAsync();
+
+                    _changeTracker.RegisterGraphContext(context);
+                }
+                finally
+                {
+                    // OnCompleted must be called to display changes 
+                    context.OnCompleted();
+                }
+            });
         }
 
         /// <summary>
@@ -115,6 +121,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
             GraphNode parentNode,
             IDependencyViewModel viewModel)
         {
+            Assumes.True(IsInitialized);
+
             string modelId = viewModel.OriginalModel == null ? viewModel.Caption : viewModel.OriginalModel.Id;
             GraphNodeId newNodeId = GetGraphNodeId(projectPath, parentNode, modelId);
             return DoAddGraphNode(newNodeId, graphContext, projectPath, parentNode, viewModel);
@@ -126,6 +134,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
             IDependencyViewModel viewModel)
         {
             Requires.NotNull(viewModel.OriginalModel, nameof(viewModel.OriginalModel));
+            
+            Assumes.True(IsInitialized);
 
             GraphNodeId newNodeId = GetTopLevelGraphNodeId(projectPath, viewModel.OriginalModel.GetTopLevelId());
             return DoAddGraphNode(newNodeId, graphContext, projectPath, parentNode: null, viewModel);
@@ -138,8 +148,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
             GraphNode parentNode,
             IDependencyViewModel viewModel)
         {
-            Assumes.NotNull(_iconCache);
-
             _iconCache.Register(viewModel.Icon);
             _iconCache.Register(viewModel.ExpandedIcon);
 
@@ -172,6 +180,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
             string modelId,
             GraphNode parentNode)
         {
+            Assumes.True(IsInitialized);
+
             GraphNodeId id = GetGraphNodeId(projectPath, parentNode, modelId);
             GraphNode nodeToRemove = graphContext.Graph.Nodes.Get(id);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/IDependenciesGraphChangeTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/IDependenciesGraphChangeTracker.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+using Microsoft.VisualStudio.GraphModel;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
+{
+    /// <summary>
+    /// Keeps registered graph contexts up to date with project dependency changes.
+    /// </summary>
+    internal interface IDependenciesGraphChangeTracker : IDisposable
+    {
+        /// <summary>
+        /// Registers <paramref name="context"/> to be updated as project dependencies change.
+        /// </summary>
+        /// <remarks>
+        /// There is no way to unregister these contexts. Internally, weak references are held
+        /// so that registered context objects may still be garbage collected.
+        /// </remarks>
+        void RegisterGraphContext(IGraphContext context);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/GraphViewProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/GraphViewProviderBase.cs
@@ -61,8 +61,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
                 return false;
             }
 
+            bool anyChanges = false;
+
             foreach (DependencyNodeInfo nodeToRemove in nodesToRemove)
             {
+                anyChanges = true;
                 Builder.RemoveGraphNode(graphContext, projectPath, nodeToRemove.Id, dependencyGraphNode);
             }
 
@@ -75,6 +78,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
                     continue;
                 }
 
+                anyChanges = true;
                 Builder.AddGraphNode(
                     graphContext,
                     projectPath,
@@ -86,7 +90,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
             dependencyGraphNode.SetValue(DependenciesGraphSchema.DependencyIdProperty, updatedDependency.Id);
             dependencyGraphNode.SetValue(DependenciesGraphSchema.ResolvedProperty, updatedDependency.Resolved);
 
-            return true;
+            return anyChanges;
         }
 
         public virtual bool MatchSearchResults(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/IDependenciesGraphViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/IDependenciesGraphViewProvider.cs
@@ -24,6 +24,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
             GraphNode dependencyGraphNode,
             ITargetedDependenciesSnapshot targetedSnapshot);
 
+        /// <summary>
+        ///     Gets whether this provider would like to apply changes to a graph node in response to a snapshot update,
+        ///     based on the provided arguments.
+        /// </summary>
+        /// <param name="projectPath">The project path stored on the graph node that we want to update.</param>
+        /// <param name="updatedProjectPath">The project path according to the updated snapshot we want to apply changes from.</param>
+        /// <param name="dependency">The dependency from the updated snapshot with ID matching the graph node we want to update.</param>
         bool ShouldTrackChanges(string projectPath, string updatedProjectPath, IDependency dependency);
 
         bool TrackChanges(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/PackageGraphViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/PackageGraphViewProvider.cs
@@ -89,8 +89,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
 
                 if (fxAssembliesChildren.Count > 0)
                 {
-                    var fxAssembliesViewModel = new PackageFrameworkAssembliesViewModel();
-                    GraphNode fxAssembliesNode = Builder.AddGraphNode(graphContext, projectPath, dependencyGraphNode, fxAssembliesViewModel);
+                    GraphNode fxAssembliesNode = Builder.AddGraphNode(graphContext, projectPath, dependencyGraphNode, PackageFrameworkAssembliesViewModel.Instance);
                     fxAssembliesNode.SetValue(DgmlNodeProperties.ContainsChildren, true);
                     fxAssembliesNode.SetValue(DependenciesGraphSchema.IsFrameworkAssemblyFolderProperty, true);
                     fxAssembliesNode.SetValue(DependenciesGraphSchema.DependencyIdProperty, dependency.Id);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/ProjectGraphViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/ProjectGraphViewProvider.cs
@@ -11,6 +11,10 @@ using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.ViewProviders
 {
+    /// <summary>
+    /// Provides the graph of project reference dependencies.
+    /// Allows drilling into the transitive dependencies of a given <c>&lt;ProjectReference&gt;</c>.
+    /// </summary>
     [Export(typeof(IDependenciesGraphViewProvider))]
     [AppliesTo(ProjectCapability.DependenciesTree)]
     [Order(Order)]
@@ -96,6 +100,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
             return snapshot.Targets[targetFramework];
         }
 
+        /// <summary>
+        /// Returns true if the updated dependency's path matches the updated snapshot's project path,
+        /// meaning the project dependency has changed and we want to try and update.
+        /// </summary>
+        /// <inheritdoc />
         public override bool ShouldTrackChanges(string projectPath, string updatedProjectPath, IDependency dependency)
         {
             string dependencyProjectPath = dependency.FullPath;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/ProjectGraphViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/ProjectGraphViewProvider.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Linq;
 
@@ -123,7 +124,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
                             dependencyGraphNode,
                             out IReadOnlyList<DependencyNodeInfo> nodesToAdd,
                             out IReadOnlyList<DependencyNodeInfo> nodesToRemove,
-                            out System.Collections.Generic.IReadOnlyCollection<IDependency> updatedChildren,
+                            out ImmutableArray<IDependency> updatedChildren,
                             out string dependencyProjectPath))
             {
                 return false;
@@ -201,7 +202,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
             GraphNode dependencyGraphNode,
             out IReadOnlyList<DependencyNodeInfo> nodesToAdd,
             out IReadOnlyList<DependencyNodeInfo> nodesToRemove,
-            out System.Collections.Generic.IReadOnlyCollection<IDependency> updatedChildren,
+            out ImmutableArray<IDependency> updatedChildren,
             out string dependencyProjectPath)
         {
             ITargetedDependenciesSnapshot snapshot = GetSnapshot(updatedDependency);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/ProjectGraphViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/ProjectGraphViewProvider.cs
@@ -130,8 +130,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
                 return false;
             }
 
+            bool anyChanges = false;
+
             foreach (DependencyNodeInfo nodeToRemove in nodesToRemove)
             {
+                anyChanges = true;
                 Builder.RemoveGraphNode(graphContext, dependencyProjectPath, nodeToRemove.Id, dependencyGraphNode);
             }
 
@@ -143,6 +146,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
                     continue;
                 }
 
+                anyChanges = true;
                 Builder.AddGraphNode(
                     graphContext,
                     dependencyProjectPath,
@@ -154,7 +158,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
             dependencyGraphNode.SetValue(DependenciesGraphSchema.DependencyIdProperty, updatedDependency.Id);
             dependencyGraphNode.SetValue(DependenciesGraphSchema.ResolvedProperty, updatedDependency.Resolved);
 
-            return true;
+            return anyChanges;
         }
 
         public override bool MatchSearchResults(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageFrameworkAssembliesViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/PackageFrameworkAssembliesViewModel.cs
@@ -11,6 +11,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
     internal sealed class PackageFrameworkAssembliesViewModel : IDependencyViewModel
     {
+        public static PackageFrameworkAssembliesViewModel Instance { get; } = new PackageFrameworkAssembliesViewModel();
+
         public static readonly ImageMoniker RegularIcon = KnownMonikers.Library;
 
         public string Caption => VSResources.FrameworkAssembliesNodeName;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/AggregateDependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/AggregateDependenciesSnapshotProvider.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
             lock (_snapshotProviders)
             {
-                _snapshotProviders[snapshotProvider.ProjectFilePath] = snapshotProvider;
+                _snapshotProviders[snapshotProvider.CurrentSnapshot.ProjectPath] = snapshotProvider;
                 snapshotProvider.SnapshotRenamed += OnSnapshotRenamed;
                 snapshotProvider.SnapshotChanged += OnSnapshotChanged;
                 snapshotProvider.SnapshotProviderUnloading += OnSnapshotProviderUnloading;
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
                 lock (_snapshotProviders)
                 {
-                    _snapshotProviders.Remove(snapshotProvider.ProjectFilePath);
+                    _snapshotProviders.Remove(snapshotProvider.CurrentSnapshot.ProjectPath);
                     snapshotProvider.SnapshotRenamed -= OnSnapshotRenamed;
                     snapshotProvider.SnapshotChanged -= OnSnapshotChanged;
                     snapshotProvider.SnapshotProviderUnloading -= OnSnapshotProviderUnloading;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/AggregateDependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/AggregateDependenciesSnapshotProvider.cs
@@ -9,10 +9,7 @@ using Microsoft.VisualStudio.ProjectSystem.VS.Extensibility;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 {
-    /// <summary>
-    /// Global scope contract that provides information about project level 
-    /// dependencies graph contexts.
-    /// </summary>
+    /// <inheritdoc />
     [Export(typeof(IAggregateDependenciesSnapshotProvider))]
     [AppliesTo(ProjectCapability.DependenciesTree)]
     internal class AggregateDependenciesSnapshotProvider : IAggregateDependenciesSnapshotProvider
@@ -26,10 +23,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             _projectExportProvider = projectExportProvider;
         }
 
+        /// <inheritdoc />
         public event EventHandler<SnapshotChangedEventArgs> SnapshotChanged;
 
+        /// <inheritdoc />
         public event EventHandler<SnapshotProviderUnloadingEventArgs> SnapshotProviderUnloading;
 
+        /// <inheritdoc />
         public void RegisterSnapshotProvider(IDependenciesSnapshotProvider snapshotProvider)
         {
             if (snapshotProvider == null)
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 snapshotProvider.SnapshotProviderUnloading += OnSnapshotProviderUnloading;
             }
 
-            // When a given project context is unloaded, remove it form the cache and unregister event handlers
+            // When a given project context is unloaded, remove it from the cache and unregister event handlers
             void OnSnapshotProviderUnloading(object sender, SnapshotProviderUnloadingEventArgs e)
             {
                 SnapshotProviderUnloading?.Invoke(this, e);
@@ -63,7 +63,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             {
                 lock (_snapshotProviders)
                 {
-                    // remove and re-add provider with new project path
+                    // Remove and re-add provider with new project path
                     if (!string.IsNullOrEmpty(e.OldFullPath)
                         && _snapshotProviders.TryGetValue(e.OldFullPath, out IDependenciesSnapshotProvider provider)
                         && _snapshotProviders.Remove(e.OldFullPath)
@@ -81,6 +81,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             }
         }
 
+        /// <inheritdoc />
         public IDependenciesSnapshotProvider GetSnapshotProvider(string projectFilePath)
         {
             Requires.NotNullOrEmpty(projectFilePath, nameof(projectFilePath));
@@ -102,6 +103,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             }
         }
 
+        /// <inheritdoc />
         public IReadOnlyCollection<IDependenciesSnapshotProvider> GetSnapshotProviders()
         {
             lock (_snapshotProviders)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependenciesSnapshotProvider.cs
@@ -16,11 +16,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         IDependenciesSnapshot CurrentSnapshot { get; }
 
         /// <summary>
-        /// Provider's project path.
-        /// </summary>
-        string ProjectFilePath { get; }
-
-        /// <summary>
         /// Triggered when snapshot's project was renamed.
         /// </summary>
         event EventHandler<ProjectRenamedEventArgs> SnapshotRenamed;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySubscriptionsHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependencySubscriptionsHost.cs
@@ -109,8 +109,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
         public IDependenciesSnapshot CurrentSnapshot => _currentSnapshot;
 
-        public string ProjectFilePath => _commonServices.Project.FullPath;
-
         private ImmutableArray<IDependencyCrossTargetSubscriber> Subscribers
         {
             get


### PR DESCRIPTION
Following #4429, more changes to the dependencies node's tree and graph logic.

In particular:

- 97f66bb6c18c2c1a9c6cf25867e1470b64c1e381 Rename `GroupedByTargetTreeViewProvider` to `DependenciesTreeViewProvider`
- 6cdde4b36082aa654bfac3e6b1f957586d840222 Extract tracking of changes to graph contexts from `DependenciesGraphProvider` to new `DependenciesGraphChangeTracker` class
- 81b81c0a1268f305f7ff71c2e6a1725e3bdfcc63 More API documentation
- da983990ed8294a6644753d95df2b2ab0089eb90 Remove duplication of project path from `IDependenciesSnapshotProvider` and its snapshot&mdash;allow the snapshot to be the source of truth over time, as mentioned in https://github.com/dotnet/project-system/pull/4386#discussion_r241693587
- 141f7453c1f4984d69aca64164c411d28c6c8b13 Remove `JTF.RunAsync` from `DependenciesGraphProvider.BeginGetGraphData` by implementing/exporting `IProjectDynamicLoadComponent` for async initialisation
- 16071092a58f71a3ad50fac22ed47e0dade002ab `DependenciesGraphChangeTracker` avoids notifying of graph context changes when nothing actually changed