### PR TITLE
Support getting compatible property values via GetCommonProperties

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectInstancePropertiesProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectInstancePropertiesProviderFactory.cs
@@ -19,5 +19,15 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             return mock.Object;
         }
+
+        public static IProjectInstancePropertiesProvider ImplementsGetCommonProperties(IProjectProperties projectProperties = null)
+        {
+            var mock = new Mock<IProjectInstancePropertiesProvider>();
+
+            mock.Setup(d => d.GetCommonProperties(It.IsAny<ProjectInstance>()))
+                .Returns(() => projectProperties ?? Mock.Of<IProjectProperties>());
+
+            return mock.Object;
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectPropertiesProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectPropertiesProviderTests.cs
@@ -46,5 +46,83 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             await properties.SetPropertyValueAsync(MockPropertyName, "NewValue", null);
             Assert.True(setValueInvoked);
         }
+
+
+        [Fact]
+        public async Task VerifyInterceptedViaSnapshotCommonPropertiesProviderAsync()
+        {
+            var delegatePropertiesMock = IProjectPropertiesFactory
+                .MockWithPropertiesAndValues(new Dictionary<string, string>() {
+                    { MockPropertyName, "DummyValue" }
+                });
+
+            var delegateProperties = delegatePropertiesMock.Object;
+            var delegateProvider = IProjectPropertiesProviderFactory.Create(commonProps: delegateProperties);
+
+            bool getEvaluatedInvoked = false;
+            bool getUnevaluatedInvoked = false;
+            bool setValueInvoked = false;
+
+            var mockPropertyProvider = IInterceptingPropertyValueProviderFactory.Create(MockPropertyName,
+                onGetEvaluatedPropertyValue: (v, p) => { getEvaluatedInvoked = true; return v; },
+                onGetUnevaluatedPropertyValue: (v, p) => { getUnevaluatedInvoked = true; return v; },
+                onSetPropertyValue: (v, p, d) => { setValueInvoked = true; return v; });
+            var unconfiguredProject = UnconfiguredProjectFactory.Create();
+            var instanceProvider = IProjectInstancePropertiesProviderFactory.Create();
+
+            var interceptedProvider = new ProjectFileInterceptedViaSnapshotProjectPropertiesProvider(delegateProvider, instanceProvider, unconfiguredProject, new[] { mockPropertyProvider });
+            var properties = interceptedProvider.GetCommonProperties();
+
+            // Verify interception for GetEvaluatedPropertyValueAsync.
+            var propertyValue = await properties.GetEvaluatedPropertyValueAsync(MockPropertyName);
+            Assert.True(getEvaluatedInvoked);
+
+            // Verify interception for GetUnevaluatedPropertyValueAsync.
+            propertyValue = await properties.GetUnevaluatedPropertyValueAsync(MockPropertyName);
+            Assert.True(getUnevaluatedInvoked);
+
+            // Verify interception for SetPropertyValueAsync.
+            await properties.SetPropertyValueAsync(MockPropertyName, "NewValue", null);
+            Assert.True(setValueInvoked);
+        }
+
+        [Fact]
+        public async Task VerifyInterceptedViaSnapshotInstanceCommonPropertiesProviderAsync()
+        {
+            var delegatePropertiesMock = IProjectPropertiesFactory
+                .MockWithPropertiesAndValues(new Dictionary<string, string>() {
+                    { MockPropertyName, "DummyValue" }
+                });
+
+            var delegateProperties = delegatePropertiesMock.Object;
+            var delegateInstanceProvider = IProjectInstancePropertiesProviderFactory.ImplementsGetCommonProperties(delegateProperties);
+
+            bool getEvaluatedInvoked = false;
+            bool getUnevaluatedInvoked = false;
+            bool setValueInvoked = false;
+
+            var mockPropertyProvider = IInterceptingPropertyValueProviderFactory.Create(MockPropertyName,
+                onGetEvaluatedPropertyValue: (v, p) => { getEvaluatedInvoked = true; return v; },
+                onGetUnevaluatedPropertyValue: (v, p) => { getUnevaluatedInvoked = true; return v; },
+                onSetPropertyValue: (v, p, d) => { setValueInvoked = true; return v; });
+
+            var unconfiguredProject = UnconfiguredProjectFactory.Create();
+            var provider = IProjectPropertiesProviderFactory.Create();
+
+            var interceptedProvider = new ProjectFileInterceptedViaSnapshotProjectPropertiesProvider(provider, delegateInstanceProvider, unconfiguredProject, new[] { mockPropertyProvider });
+            var properties = interceptedProvider.GetCommonProperties(projectInstance: null);
+
+            // Verify interception for GetEvaluatedPropertyValueAsync.
+            var propertyValue = await properties.GetEvaluatedPropertyValueAsync(MockPropertyName);
+            Assert.True(getEvaluatedInvoked);
+
+            // Verify interception for GetUnevaluatedPropertyValueAsync.
+            propertyValue = await properties.GetUnevaluatedPropertyValueAsync(MockPropertyName);
+            Assert.True(getUnevaluatedInvoked);
+
+            // Verify interception for SetPropertyValueAsync.
+            await properties.SetPropertyValueAsync(MockPropertyName, "NewValue", null);
+            Assert.True(setValueInvoked);
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectPropertiesProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectPropertiesProviderBase.cs
@@ -28,6 +28,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         public override IProjectProperties GetProperties(string file, string itemType, string item)
         {
             IProjectProperties defaultProperties = base.GetProperties(file, itemType, item);
+            return InterceptProperties(defaultProperties);
+        }
+
+        protected IProjectProperties InterceptProperties(IProjectProperties defaultProperties)
+        {
             return _interceptingValueProviders.IsDefaultOrEmpty ? defaultProperties : new InterceptedProjectProperties(_interceptingValueProviders, defaultProperties);
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ProjectFileInterceptedViaSnapshotProjectPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ProjectFileInterceptedViaSnapshotProjectPropertiesProvider.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using Microsoft.Build.Execution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties
+{
+    [Export("ProjectFileWithInterceptionViaSnapshot", typeof(IProjectPropertiesProvider))]
+    [Export(typeof(IProjectPropertiesProvider))]
+    [Export("ProjectFileWithInterceptionViaSnapshot", typeof(IProjectInstancePropertiesProvider))]
+    [Export(typeof(IProjectInstancePropertiesProvider))]
+    [ExportMetadata("Name", "ProjectFileWithInterceptionViaSnapshot")]
+    [ExportMetadata("HasEquivalentProjectInstancePropertiesProvider", true)]
+    [AppliesTo(ProjectCapability.DotNet)]
+    internal sealed class ProjectFileInterceptedViaSnapshotProjectPropertiesProvider : InterceptedProjectPropertiesProviderBase
+    {
+        [ImportingConstructor]
+        public ProjectFileInterceptedViaSnapshotProjectPropertiesProvider(
+            [Import(ContractNames.ProjectPropertyProviders.ProjectFile)] IProjectPropertiesProvider provider,
+            [Import(ContractNames.ProjectPropertyProviders.ProjectFile)] IProjectInstancePropertiesProvider instanceProvider,
+            UnconfiguredProject project,
+            [ImportMany(ContractNames.ProjectPropertyProviders.ProjectFile)]IEnumerable<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>> interceptingValueProviders)
+            : base(provider, instanceProvider, project, interceptingValueProviders)
+        {
+        }
+
+        public override IProjectProperties GetCommonProperties()
+        {
+            var defaultProperties = base.GetCommonProperties();
+            return InterceptProperties(defaultProperties);
+        }
+
+        public override IProjectProperties GetCommonProperties(ProjectInstance projectInstance)
+        {
+            var defaultProperties = base.GetCommonProperties(projectInstance);
+            return InterceptProperties(defaultProperties);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -42,7 +42,7 @@
     </StringProperty>    
     <StringProperty Name="TargetFrameworkMoniker" DisplayName="Target Framework Moniker">
         <StringProperty.DataSource>
-            <DataSource Persistence="ProjectFileWithInterception" PersistedName="TargetFrameworkMoniker" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+            <DataSource Persistence="ProjectFileWithInterceptionViaSnapshot" PersistedName="TargetFrameworkMoniker" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
     </StringProperty>
     <StringProperty Name="TargetFrameworkMonikers" DisplayName="Target Framework Monikers" ReadOnly="True">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -20,7 +20,7 @@
     <StringProperty Name="ApplicationIcon" Visible="False" />
     <StringProperty Name="TargetFrameworkMoniker" Visible="False">
         <StringProperty.DataSource>
-            <DataSource Persistence="ProjectFileWithInterception" PersistedName="TargetFrameworkMoniker" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+            <DataSource Persistence="ProjectFileWithInterceptionViaSnapshot" PersistedName="TargetFrameworkMoniker" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
     </StringProperty>
     <StringProperty Name="TargetFrameworkMonikers" Visible="False" ReadOnly="True">
@@ -43,7 +43,7 @@
     </StringProperty>
     <IntProperty Name="TargetFramework" ReadOnly="True" Visible="False">
         <IntProperty.DataSource>
-            <DataSource Persistence="ProjectFileWithInterception" PersistedName="TargetFramework" SourceOfDefaultValue="AfterContext" />
+            <DataSource Persistence="ProjectFileWithInterceptionViaSnapshot" PersistedName="TargetFramework" SourceOfDefaultValue="AfterContext" />
         </IntProperty.DataSource>
     </IntProperty>
     <StringProperty Name="OutputName" Visible="False" />
@@ -63,19 +63,19 @@
     <!-- This property is used to provide the value of OutputType through BrowseObject, which is used by Property pages-->
     <IntProperty Name="OutputType" Visible="False">
         <IntProperty.DataSource>
-            <DataSource Persistence="ProjectFileWithInterception" PersistedName="OutputType" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+            <DataSource Persistence="ProjectFileWithInterceptionViaSnapshot" PersistedName="OutputType" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
         </IntProperty.DataSource>
     </IntProperty>
     <!-- This property is used to provide the value of OutputTypeEx through BrowseObject, which is used by Property pages-->
     <IntProperty Name="OutputTypeEx" Visible="False">
         <IntProperty.DataSource>
-            <DataSource Persistence="ProjectFileWithInterception" PersistedName="OutputTypeEx" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+            <DataSource Persistence="ProjectFileWithInterceptionViaSnapshot" PersistedName="OutputTypeEx" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
         </IntProperty.DataSource>
     </IntProperty>
     <DynamicEnumProperty Name="StartupObject" EnumProvider="StartupObjectsEnumProvider" Visible="False"/>
     <StringProperty Name="ApplicationManifest" Visible="False">
         <StringProperty.DataSource>
-            <DataSource Persistence="ProjectFileWithInterception" PersistedName="ApplicationManifest" HasConfigurationCondition="false" SourceOfDefaultValue="AfterContext" />
+            <DataSource Persistence="ProjectFileWithInterceptionViaSnapshot" PersistedName="ApplicationManifest" HasConfigurationCondition="false" SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
     </StringProperty>
     <StringProperty Name="Win32ResourceFile" Visible="False">
@@ -131,7 +131,7 @@
     <BoolProperty Name="GeneratePackageOnBuild" Default="False" Visible="False"/>
     <StringProperty Name="PackageId" DisplayName="Package Id" Visible="False">
         <StringProperty.DataSource>
-            <DataSource Persistence="ProjectFileWithInterception" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+            <DataSource Persistence="ProjectFileWithInterceptionViaSnapshot" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
     </StringProperty>
     <StringProperty Name="Version" Visible="False">
@@ -141,7 +141,7 @@
     </StringProperty>
     <StringProperty Name="Authors" Visible="False">
         <StringProperty.DataSource>
-            <DataSource Persistence="ProjectFileWithInterception" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+            <DataSource Persistence="ProjectFileWithInterceptionViaSnapshot" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
     </StringProperty>
     <BoolProperty Name="PackageRequireLicenseAcceptance" Default="False" Visible="False"/>
@@ -193,7 +193,7 @@
     <BoolProperty Name="DelaySign" Visible="False"/>
     <StringProperty Name="AssemblyOriginatorKeyFile" Visible="False">
         <StringProperty.DataSource>
-            <DataSource Persistence="ProjectFileWithInterception" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+            <DataSource Persistence="ProjectFileWithInterceptionViaSnapshot" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
     </StringProperty>
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -38,7 +38,7 @@
     </StringProperty>    
     <StringProperty Name="TargetFrameworkMoniker" DisplayName="Target Framework Moniker">
         <StringProperty.DataSource>
-            <DataSource Persistence="ProjectFileWithInterception" PersistedName="TargetFrameworkMoniker" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+            <DataSource Persistence="ProjectFileWithInterceptionViaSnapshot" PersistedName="TargetFrameworkMoniker" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
         </StringProperty.DataSource>
     </StringProperty>
 


### PR DESCRIPTION
CPS supports tagging properties providers that can get property values from a ProjectInstance, which is more efficient, so this PR creates a new provider that opts into it (via the `HasEquivalentProjectInstancePropertiesProvider` metadata), and then moves any of our intercepted properties that are compatible with it, to that provider.

Compatibility was determined by simply testing within Visual Studio - TargetFrameworkMonikers fails here, as it needs access to all configured projects, which is not available sometimes with this model - and by querying each property via DTE - PreBuildEvent and PostBuildEvent fail here because of a NotSupportedException in the PageProperty class.

The two tests in `InterceptedProjectPropertiesProviderTests.cs` have been cribbed from the now-reverted https://github.com/dotnet/project-system/pull/3464 (thanks @Pilchie 😄)

Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/593209