### PR TITLE
Show the signing page in the App Designer for VB

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Properties/VisualBasicProjectDesignerPageProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests/ProjectSystem/VS/Properties/VisualBasicProjectDesignerPageProviderTests.cs
@@ -27,7 +27,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
                VisualBasicProjectDesignerPage.Compile,
                VisualBasicProjectDesignerPage.Package,
                VisualBasicProjectDesignerPage.References,
-               VisualBasicProjectDesignerPage.Debug
+               VisualBasicProjectDesignerPage.Debug,
+               VisualBasicProjectDesignerPage.Signing
             );
 
             Assert.Equal(expected, result);

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Properties/VisualBasicProjectDesignerPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Properties/VisualBasicProjectDesignerPage.cs
@@ -14,5 +14,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         public static readonly ProjectDesignerPageMetadata Package = new ProjectDesignerPageMetadata(new Guid("{21b78be8-3957-4caa-bf2f-e626107da58e}"), pageOrder: 0, hasConfigurationCondition: false);
         public static readonly ProjectDesignerPageMetadata References = new ProjectDesignerPageMetadata(new Guid("{4E43F4AB-9F03-4129-95BF-B8FF870AF6AB}"), pageOrder: 1, hasConfigurationCondition: false);
         public static readonly ProjectDesignerPageMetadata Debug = new ProjectDesignerPageMetadata(new Guid("{0273C280-1882-4ED0-9308-52914672E3AA}"), pageOrder: 2, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata Signing = new ProjectDesignerPageMetadata(new Guid("{F8D6553F-F752-4DBF-ACB6-F291B744A792}"), pageOrder: 6, hasConfigurationCondition: false);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Properties/VisualBasicProjectDesignerPageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/Properties/VisualBasicProjectDesignerPageProvider.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;
+
 using Microsoft.VisualStudio.Buffers.PooledObjects;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
@@ -40,6 +40,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             {
                 builder.Add(VisualBasicProjectDesignerPage.Debug);
             }
+
+            builder.Add(VisualBasicProjectDesignerPage.Signing);
 
             return Task.FromResult<IReadOnlyCollection<IPageMetadata>>(builder.ToImmutableAndFree());
         }


### PR DESCRIPTION
Needed this to do some testing for TempPE.

We don't show the Signing property page for Visual Basic projects. Seems to work fine once added though, which can't be said of F# so will leave #3660 open.