### PR TITLE
Fixed Shared Projects not being able to be removed from the context menu

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/ImplicitTopLevelDependenciesSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/ImplicitTopLevelDependenciesSnapshotFilterTests.cs
@@ -88,6 +88,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         [Fact]
+        public void BeforeAddOrUpdate_WhenSharedProject_ShouldDoNothing()
+        {
+            VerifyUnchangedOnAdd(
+                new TestDependency
+                {
+                    ClonePropertiesFrom = _acceptable,
+                    Flags = DependencyTreeFlags.SharedProjectFlags
+                },
+                projectItemSpecs: ImmutableHashSet<string>.Empty);
+        }
+
+        [Fact]
         public void BeforeAddOrUpdate_WhenCanApplyImplicitProjectContainsItem_ShouldDoNothing()
         {
             VerifyUnchangedOnAdd(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/ImplicitTopLevelDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/ImplicitTopLevelDependenciesSnapshotFilter.cs
@@ -46,7 +46,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
                 return;
             }
 
-            if (!projectItemSpecs.Contains(dependency.OriginalItemSpec))
+            //The check for SharedProjectDependency is needed because a SharedProject is not a dependency reference
+            if (!projectItemSpecs.Contains(dependency.OriginalItemSpec) && !dependency.Flags.Contains("SharedProjectDependency"))
             {
                 // It is an implicit dependency
                 if (subTreeProviderByProviderType.TryGetValue(dependency.ProviderType, out IProjectDependenciesSubTreeProvider provider) &&

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/ImplicitTopLevelDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/Filters/ImplicitTopLevelDependenciesSnapshotFilter.cs
@@ -30,10 +30,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             IImmutableSet<string> projectItemSpecs,
             IAddDependencyContext context)
         {
+            // The check for SharedProjectDependency is needed because a SharedProject is not a dependency reference
             if (!dependency.TopLevel
                 || dependency.Implicit
                 || !dependency.Resolved
-                || !dependency.Flags.Contains(DependencyTreeFlags.GenericDependencyFlags))
+                || !dependency.Flags.Contains(DependencyTreeFlags.GenericDependencyFlags)
+                || dependency.Flags.Contains(DependencyTreeFlags.SharedProjectFlags))
             {
                 context.Accept(dependency);
                 return;
@@ -46,8 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
                 return;
             }
 
-            //The check for SharedProjectDependency is needed because a SharedProject is not a dependency reference
-            if (!projectItemSpecs.Contains(dependency.OriginalItemSpec) && !dependency.Flags.Contains("SharedProjectDependency"))
+            if (!projectItemSpecs.Contains(dependency.OriginalItemSpec))
             {
                 // It is an implicit dependency
                 if (subTreeProviderByProviderType.TryGetValue(dependency.ProviderType, out IProjectDependenciesSubTreeProvider provider) &&


### PR DESCRIPTION
Fixes: https://github.com/dotnet/project-system/issues/2688

Added a check for SharedProjectDependency flag in ImplicitTopLevelDependenciesSnapshotFilter. Before the check it would be marked as implicit, and there would be no 'remove' option in the context menu.

The reason, to the best of my knowledge, that this was needed is that a shared dependency is _not_ a project reference and therefore not added to the catalog as a project reference. So, in [`DependenciesSnapshotProvider`][DependenciesSnapshotProvider], the shared project is not added to the projectItemsSpecs so the check in ImplicitTopLevelDependenciesSnapshotFilter will mark it implicit.

[DependenciesSnapshotProvider]:           /src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs "DependenciesSnapshotProvider.cs"