### PR TITLE
Make ConcreteApplicationSettings Serializable Again

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/SettingsGlobalObject/SettingsGlobalObjectProvider.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsGlobalObject/SettingsGlobalObjectProvider.vb
@@ -2312,11 +2312,17 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         ''' <summary>
         ''' 
         ''' </summary>
-        ''' <remarks></remarks>
+        ''' <remarks>
+        ''' This type must be serializable to satisfy the VS shell.
+        ''' https://devdiv.visualstudio.com/DevDiv/_workitems/edit/765098
+        ''' </remarks>
+        <Serializable>
         Private Class ConcreteApplicationSettings
             Inherits ApplicationSettingsBase
 
+            <NonSerialized>
             Private ReadOnly _globalObject As SettingsFileGlobalObject
+            <NonSerialized>
             Private _properties As SettingsPropertyCollection
 
             ''' <summary>


### PR DESCRIPTION
Provides an alternative fix to that in #4402 where we enabled an analyzer that detects serializable types with non-serializable fields.

The VS shell needs this type to be serializable even though it must not be doing any serialization (or was swallowing exceptions).

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/765098