### PR TITLE
Report errors in graph operation

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
@@ -102,6 +102,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
                         }
                     }
                 }
+                catch (Exception ex)
+                {
+                    context.ReportError(ex);
+                }
                 finally
                 {
                     // OnCompleted must be called to display changes 


### PR DESCRIPTION
We pass off handling `BeginGraphData` to an async operation, so the caller wouldn't receive an exception. This change performs the same operation as the caller in case of exception, but on that async work.