### PR TITLE
Reduce the number of fields in VsService/VSUIService

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsService`1.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsService`1.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     ///     Provides an implementation of <see cref="IVsService{T}"/> that calls into Visual Studio's <see cref="IAsyncServiceProvider"/>.
     /// </summary>
     [Export(typeof(IVsService<>))]
-    internal class VsService<T>
+    internal class VsService<T> : IVsService<T>
     {
         private readonly AsyncLazy<T> _value;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsUIService`1.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsUIService`1.cs
@@ -15,7 +15,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     {
         private readonly Lazy<T> _value;
         private readonly IProjectThreadingService _threadingService;
-        private readonly IServiceProvider _serviceProvider;
 
         [ImportingConstructor]
         public VsUIService([Import(typeof(SVsServiceProvider))]IServiceProvider serviceProvider, IProjectThreadingService threadingService)
@@ -23,8 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             Requires.NotNull(serviceProvider, nameof(serviceProvider));
             Requires.NotNull(threadingService, nameof(threadingService));
 
-            _value = new Lazy<T>(GetService);
-            _serviceProvider = serviceProvider;
+            _value = new Lazy<T>(() => (T)serviceProvider.GetService(ServiceType));
             _threadingService = threadingService;
         }
 
@@ -44,11 +42,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         protected virtual Type ServiceType
         {
             get { return typeof(T); }
-        }
-
-        protected virtual T GetService()
-        {
-            return (T)_serviceProvider.GetService(ServiceType);
         }
     }
 }


### PR DESCRIPTION
Turn class fields into capture class fields which will get collected when the delegate falls out of scope (when the AsyncLazy/Lazy value is created).