### PR TITLE
Move LanguageService rule to ProjectSubscriptionService

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -172,10 +172,6 @@
       <Context>File;BrowseObject</Context>
     </PropertyPageSchema>
 
-    <PropertyPageSchema Include="$(ManagedXamlNeutralResourcesDirectory)LanguageService.xaml">
-      <Context>File</Context>
-    </PropertyPageSchema>
-    
     <PropertyPageSchema Include="$(ManagedXamlNeutralResourcesDirectory)None.xaml">
       <Context>File</Context>
     </PropertyPageSchema>
@@ -230,6 +226,10 @@
     </PropertyPageSchema>
 
     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)CompilerCommandLineArgs.xaml">
+      <Context>ProjectSubscriptionService</Context>
+    </PropertyPageSchema>
+
+    <PropertyPageSchema Include="$(ManagedXamlNeutralResourcesDirectory)LanguageService.xaml">
       <Context>ProjectSubscriptionService</Context>
     </PropertyPageSchema>
 


### PR DESCRIPTION
While the ProjectSubscriptionService will look in Project, File *and* ProjectSubscriptionService for rules to use for its data (see ProjectSubscriptionService.NamesOfCatalogsToTry in CPS), this data isn't need for the project tree so move it to ProjectSubcriptionService only.