### PR TITLE
Apply consistent order for tree providers

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AppDesignerFolderProjectTreePropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AppDesignerFolderProjectTreePropertiesProvider.cs
@@ -16,6 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
     [Export(typeof(IProjectTreePropertiesProvider))]
     [Export(typeof(IProjectTreeSettingsProvider))]
     [AppliesTo(ProjectCapability.AppDesigner)]
+    [Order(Order.Default)]
     internal class AppDesignerFolderProjectTreePropertiesProvider : AbstractSpecialFolderProjectTreePropertiesProvider, IProjectTreeSettingsProvider
     {
         private static readonly ProjectTreeFlags s_defaultFolderFlags = ProjectTreeFlags.Create(ProjectTreeFlags.Common.AppDesignerFolder | ProjectTreeFlags.Common.BubbleUp);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectRootImageProjectTreePropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectRootImageProjectTreePropertiesProvider.cs
@@ -11,6 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
     /// </summary>
     [Export(typeof(IProjectTreePropertiesProvider))]
     [AppliesTo(ProjectCapability.DotNet)]
+    [Order(Order.Default)]
     internal class ProjectRootImageProjectTreePropertiesProvider : IProjectTreePropertiesProvider
     {
         private readonly IProjectCapabilitiesService _capabilities;


### PR DESCRIPTION
Test icon provider and ourselves were both marked with zero priority, resulting in us being defined in whatever order MEF returned. Make it explicit.

Test provider from the Unit Testing team will update to be higher than us.