### PR TITLE
Stop non-fatal watsoning source control exceptions

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
@@ -229,6 +229,8 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
             Debug.Assert(Not String.IsNullOrEmpty(throwingComponentName))
             Debug.Assert(Not String.IsNullOrEmpty(exceptionEventDescription))
 
+            If IsCheckoutCanceledException(ex) Then Return True
+
             ' Follow naming convention for entity name: A string to identify the entity in the feature. E.g. open-project, build-project, fix-error.
             throwingComponentName = Regex.Replace(throwingComponentName, "([A-Z])", "-$1").TrimPrefix("-").ToLower() + "-fault"
 

--- a/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
@@ -331,6 +331,8 @@ Namespace Microsoft.VisualStudio.Editors.Common
             Debug.Assert(Not String.IsNullOrEmpty(throwingComponentName))
             Debug.Assert(Not String.IsNullOrEmpty(exceptionEventDescription))
 
+            If IsCheckoutCanceledException(ex) Then Return True
+
             ' Follow naming convention for entity name: A string to identify the entity in the feature. E.g. open-project, build-project, fix-error.
             throwingComponentName = Regex.Replace(throwingComponentName, "([A-Z])", "-$1").TrimPrefix("-").ToLower() + "-fault"
 


### PR DESCRIPTION
CheckoutException and OLE_E_PROMPTSAVECANCELLED (user cancelled a dialog) are being reported as NFW. Avoid this as they are expected to be hit in normal user usage.