### PR TITLE
Do not set properties if the value is equal to what is already set

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropertyControlData.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropertyControlData.vb
@@ -1714,20 +1714,18 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
                 _valueChangedWasFired = False
                 Try
-                    Dim didNotSetEqualValue = False
-                    If String.Equals(TryCast(GetCommonPropertyValue(Descriptor, Component), String), TryCast(Value, String)) Then
+                    If Equals(GetCommonPropertyValue(Descriptor, Component), Value) Then
                         'Setting a value equal to its current value can create a useless empty value in the proj file
-                        didNotSetEqualValue = True
-                    Else
-                        'Go ahead and do the SetValue.  It will throw if there's an exception
-                        '  (other than cancel/checkout exceptions).
-                        Descriptor.SetValue(Component, Value)
+                        Return
                     End If
 
-                    'If we made it here, either the value was successfully changed,
-                    '  the value was not changed because it was already equal, or
+                    'Go ahead and do the SetValue.  It will throw if there's an exception
+                    '  (other than cancel/checkout exceptions).
+                    Descriptor.SetValue(Component, Value)
+
+                    'If we made it here, either the value was successfully changed, or
                     '  the set was canceled by the user in a checkout dialog, etc.
-                    If _valueChangedWasFired OrElse didNotSetEqualValue Then
+                    If _valueChangedWasFired Then
                         'The set was successful
                         Return
                     Else

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropertyControlData.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropertyControlData.vb
@@ -1714,10 +1714,10 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
                 _valueChangedWasFired = False
                 Try
-                    Dim _didNotSetEqualValue = False
+                    Dim didNotSetEqualValue = False
                     If String.Equals(TryCast(GetCommonPropertyValue(Descriptor, Component), String), TryCast(Value, String)) Then
                         'Setting a value equal to its current value can create a useless empty value in the proj file
-                        _didNotSetEqualValue = True
+                        didNotSetEqualValue = True
                     Else
                         'Go ahead and do the SetValue.  It will throw if there's an exception
                         '  (other than cancel/checkout exceptions).
@@ -1727,7 +1727,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     'If we made it here, either the value was successfully changed,
                     '  the value was not changed because it was already equal, or
                     '  the set was canceled by the user in a checkout dialog, etc.
-                    If _valueChangedWasFired OrElse _didNotSetEqualValue Then
+                    If _valueChangedWasFired OrElse didNotSetEqualValue Then
                         'The set was successful
                         Return
                     Else

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropertyControlData.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropertyControlData.vb
@@ -1714,13 +1714,20 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
                 _valueChangedWasFired = False
                 Try
-                    'Go ahead and do the SetValue.  It will throw if there's an exception
-                    '  (other than cancel/checkout exceptions).
-                    Descriptor.SetValue(Component, Value)
+                    Dim _didNotSetEqualValue = False
+                    If String.Equals(TryCast(GetCommonPropertyValue(Descriptor, Component), String), TryCast(Value, String)) Then
+                        'Setting a value equal to its current value can create a useless empty value in the proj file
+                        _didNotSetEqualValue = True
+                    Else
+                        'Go ahead and do the SetValue.  It will throw if there's an exception
+                        '  (other than cancel/checkout exceptions).
+                        Descriptor.SetValue(Component, Value)
+                    End If
 
-                    'If we made it here, either the value was successfully changed, or
+                    'If we made it here, either the value was successfully changed,
+                    '  the value was not changed because it was already equal, or
                     '  the set was canceled by the user in a checkout dialog, etc.
-                    If _valueChangedWasFired Then
+                    If _valueChangedWasFired OrElse _didNotSetEqualValue Then
                         'The set was successful
                         Return
                     Else


### PR DESCRIPTION
Fixes: https://github.com/dotnet/project-system/issues/4519

There are a couple of scenarios where this is relevant:

1) As in https://github.com/dotnet/project-system/issues/4519, values are set in response to other values being set - even if they are empty.
2) If a property is edited, it will be marked as dirty. If it is edited again before a save back to its current value and then saved, it will still be marked as dirty and the value will be set. If this property was empty, it will create a new empty property in the .*proj file. If the property was being pulled from some default value (like PackageId), then a property will be added with the default value. 

Both of these will clutter up the .*proj file.

Ideally, I would like to never have empty properties - but there might be some legitimate uses for having them so it is out of the scope for this PR. 