### PR TITLE
Avoid crash via resource drag drop

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
@@ -345,6 +345,10 @@ Namespace Microsoft.VisualStudio.Editors.Common
             Return True
         End Function
 
+        Public Function IsIOException(ex As Exception) As Boolean
+            Return TypeOf ex Is IOException OrElse TypeOf ex Is UnauthorizedAccessException
+        End Function
+
         ''' <summary>
         ''' Given an exception, returns True if it is a CheckOut exception.
         ''' </summary>

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/CSVEncoder.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/CSVEncoder.vb
@@ -199,14 +199,18 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 If Resource.IsConvertibleFromToString() Then
                     Dim Name As String = Resource.Name
                     Dim Comment As String = Resource.Comment
-                    Dim ValueAsString As String = Resource.GetTypeConverter().ConvertToString(Resource.GetValue())
+                    Dim value = Resource.TryGetValue()
 
-                    Results.Append(EscapeField(Name, EncodingType))
-                    Results.Append(Delimiter)
-                    Results.Append(EscapeField(ValueAsString, EncodingType))
-                    Results.Append(Delimiter)
-                    Results.Append(EscapeField(Comment, EncodingType))
-                    Results.AppendLine()
+                    If value IsNot Nothing Then
+                        Dim ValueAsString As String = Resource.GetTypeConverter().ConvertToString(value)
+
+                        Results.Append(EscapeField(Name, EncodingType))
+                        Results.Append(Delimiter)
+                        Results.Append(EscapeField(ValueAsString, EncodingType))
+                        Results.Append(Delimiter)
+                        Results.Append(EscapeField(Comment, EncodingType))
+                        Results.AppendLine()
+                    End If
                 End If
             Next
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
@@ -1378,6 +1378,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Public Function TryGetValue() As Object
             Try
                 Return GetValue()
+            Catch ex As Exception When IsIOException(ex)
+                ' I/O failures are expected when the linked file from the RESX is missing on disk
+
             Catch ex As Exception When ReportWithoutCrash(ex, NameOf(TryGetValue), NameOf(Resource)) 'We ignore OOM - the resource may simply be big.  We're okay dealing with that.
                 Return Nothing
             End Try

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
@@ -2738,6 +2738,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     If TempFileName <> "" Then
                         ResourceFileNames.Add(TempFileName)
                     End If
+                Catch ex As Exception When IsIOException(ex)
+                    ' I/O failures are expected when the linked file from the RESX is missing on disk
+
                 Catch ex As Exception When ReportWithoutCrash(ex,
                                                                            $"Failed trying to copy linked or non-linked resource {Resource.Name} to temporary file {TempFileName} - ignoring and moving to next resource",
                                                                            NameOf(ResourceEditorView))


### PR DESCRIPTION
When a project has a RESX with a linked resource file, and that file is missing on disk, Visual Studio crashes when you attempt to drag drop the resource to another application.
Also avoided NFW in these situations - these exceptions are expected to occur.

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/785726.