### PR TITLE
Turn off banned APIs for the test projects

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,5 +1,10 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project>
+  <PropertyGroup>
+    <IsTestProject>false</IsTestProject>
+    <IsTestProject Condition="'$(IsUnitTestProject)' == 'true' OR '$(IsIntegrationTestProject)' == 'true'">true</IsTestProject>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(OutDirName)' == ''">
     <OutDirName Condition="$(MSBuildProjectName.EndsWith('.UnitTests'))">UnitTests</OutDirName>
     <OutDirName Condition="$(MSBuildProjectName.EndsWith('.IntegrationTests'))">IntegrationTests</OutDirName>
@@ -57,7 +62,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="$(MSBuildThisFileDirectory)\BannedSymbols.txt" />
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)\BannedSymbols.txt" Condition="!$(IsTestProject)" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
About to ban additional APIs such as Task.Run which is used extensively throughout it. There's no need to enforce this in test projects.