### PR TITLE
Fix regression in app designer picking up project file changes

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
@@ -282,9 +282,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '  property changes
         Private ReadOnly _suspendPropertyChangeListeningDispIds As New List(Of Integer)
 
-        'DISPID_UNKNOWN
-        Public DISPID_UNKNOWN As Integer = DISPID_UNKNOWN
-
         'Cookie for use with IVsShell.{Advise,Unadvise}BroadcastMessages
         Private _cookieBroadcastMessages As UInteger
         Private _vsShellForUnadvisingBroadcastMessages As IVsShell

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
@@ -282,6 +282,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '  property changes
         Private ReadOnly _suspendPropertyChangeListeningDispIds As New List(Of Integer)
 
+        'DISPID_UNKNOWN - This is part of the public API so can't be removed, but be careful to ensure its value matches the Win32 value (-1)
+        Public DISPID_UNKNOWN As Integer = Win32Constant.DISPID_UNKNOWN
+
         'Cookie for use with IVsShell.{Advise,Unadvise}BroadcastMessages
         Private _cookieBroadcastMessages As UInteger
         Private _vsShellForUnadvisingBroadcastMessages As IVsShell


### PR DESCRIPTION
This was regressed here: https://github.com/dotnet/project-system/commit/0f703e739aade8e590b8f881583b736122a04e21#diff-81707917a7981f2eb7606e2abfd61343R286

DISPID_UNKNOWN became set to itself, ie `0`, when it should have been `-1`.
I've restored it and added a comment.

Fixes #4549