### PR TITLE
Opt out of banned symbols in AppDesigner/Editors

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,10 +1,5 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project>
-  <PropertyGroup>
-    <IsTestProject>false</IsTestProject>
-    <IsTestProject Condition="'$(IsUnitTestProject)' == 'true' OR '$(IsIntegrationTestProject)' == 'true'">true</IsTestProject>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(OutDirName)' == ''">
     <OutDirName Condition="$(MSBuildProjectName.EndsWith('.UnitTests'))">UnitTests</OutDirName>
     <OutDirName Condition="$(MSBuildProjectName.EndsWith('.IntegrationTests'))">IntegrationTests</OutDirName>
@@ -59,10 +54,6 @@
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)Common\Test\App.config" CopyToOutputDirectory="PreserveNewest" Condition="'$(IsUnitTestProject)' == 'true'" />
     <None Include="$(MSBuildThisFileDirectory)Common\Integration\App.config" CopyToOutputDirectory="PreserveNewest" Condition="'$(IsIntegrationTestProject)' == 'true'" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Include="$(MSBuildThisFileDirectory)\BannedSymbols.txt" Condition="!$(IsTestProject)" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -3,6 +3,10 @@
   <Import Project="..\Directory.Build.targets" />
   <Import Project="$(RepoToolsetDir)Imports.targets" Condition="'$(RepoToolsetDir)' != ''" />
   <Import Project="..\build\VisualStudio.XamlRules.targets"/>
+
+  <ItemGroup>
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)\BannedSymbols.txt" Condition="'$(BannedSymbolsOptOut)' != 'true'" />
+  </ItemGroup> 
   
   <!-- 
     Defining this target will disable the new SDK behavior of implicit transitive project

--- a/src/HostAgnostic.props
+++ b/src/HostAgnostic.props
@@ -1,5 +1,9 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project>
+  <PropertyGroup>
+    <BannedSymbolsOptOut Condition="$(IsTestProject)">true</BannedSymbolsOptOut>
+  </PropertyGroup>
+  
   <ItemGroup>
     <!-- Framework -->
     <Reference Include="System" />

--- a/src/VisualStudioDesigner.props
+++ b/src/VisualStudioDesigner.props
@@ -1,5 +1,10 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project>
+  <PropertyGroup>
+    <!-- Banned symbols are very project-system centric, and not applicable to AppDesigner/Editors -->
+    <BannedSymbolsOptOut>true</BannedSymbolsOptOut>
+  </PropertyGroup>
+  
   <Import Project="VisualStudio.props"/>
 
   <ItemGroup Condition="'$(Language)' == 'VB'">


### PR DESCRIPTION
Adding additional APIs to the BannedSymbols in the future that are very specific to the project system such as IServiceProvider, just opt out to avoid us having to suppress all usage.