### PR TITLE
Ban IServiceProvider/IAsyncServiceProvider usage

### DIFF
--- a/src/BannedSymbols.txt
+++ b/src/BannedSymbols.txt
@@ -25,3 +25,11 @@ M:System.Threading.Tasks.Task.Run(System.Action,System.Threading.CancellationTok
 M:System.Threading.Tasks.Task.Run`1(System.Func`1{``0},System.Threading.CancellationToken); Task.Run should be replaced with IProjectThreadingService.Fork, which prevents the project being unloaded while the Task is running
 M:System.Threading.Tasks.Task.Run(System.Func{System.Threading.Tasks.Task},System.Threading.CancellationToken); Task.Run should be replaced with IProjectThreadingService.Fork, which prevents the project being unloaded while the Task is running
 M:System.Threading.Tasks.Task.Run`1(System.Func{System.Threading.Tasks.Task{``0}},System.Threading.CancellationToken); Task.Run should be replaced with IProjectThreadingService.Fork, which prevents the project being unloaded while the Task is running
+
+T:System.IServiceProvider; Import and use IVsUIService<T> and IVsUIService<TService, TInterface> which enforce usage on the UI thread and prevent blocking RPC calls from background threads
+T:Microsoft.VisualStudio.Shell.SVsServiceProvider; Import and use IVsUIService<T> and IVsUIService<TService, TInterface> which enforce usage on the UI thread and prevent blocking RPC calls from background threads
+
+T:Microsoft.VisualStudio.Shell.IAsyncServiceProvider; Import and use IVsService<T> and IVsService<TService, TInterface> which prevent blocking RPC calls from background threads
+T:Microsoft.VisualStudio.Shell.Interop.SAsyncServiceProvider; Import and use IVsService<T> and IVsService<TService, TInterface> which prevent blocking RPC calls from background threads
+
+T:Microsoft.VisualStudio.ProjectSystem.VS.IServiceProviderExtensions; Import and use IVsUIService<T> and IVsUIService<TService, TInterface> which enforce usage on the UI thread and prevent blocking RPC calls from background threads

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,10 +1,5 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project>
-  <PropertyGroup>
-    <IsTestProject>false</IsTestProject>
-    <IsTestProject Condition="'$(IsUnitTestProject)' == 'true' OR '$(IsIntegrationTestProject)' == 'true'">true</IsTestProject>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(OutDirName)' == ''">
     <OutDirName Condition="$(MSBuildProjectName.EndsWith('.UnitTests'))">UnitTests</OutDirName>
     <OutDirName Condition="$(MSBuildProjectName.EndsWith('.IntegrationTests'))">IntegrationTests</OutDirName>
@@ -59,10 +54,6 @@
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)Common\Test\App.config" CopyToOutputDirectory="PreserveNewest" Condition="'$(IsUnitTestProject)' == 'true'" />
     <None Include="$(MSBuildThisFileDirectory)Common\Integration\App.config" CopyToOutputDirectory="PreserveNewest" Condition="'$(IsIntegrationTestProject)' == 'true'" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Include="$(MSBuildThisFileDirectory)\BannedSymbols.txt" Condition="!$(IsTestProject)" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -3,6 +3,10 @@
   <Import Project="..\Directory.Build.targets" />
   <Import Project="$(RepoToolsetDir)Imports.targets" Condition="'$(RepoToolsetDir)' != ''" />
   <Import Project="..\build\VisualStudio.XamlRules.targets"/>
+
+  <ItemGroup>
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)\BannedSymbols.txt" Condition="'$(BannedSymbolsOptOut)' != 'true'" />
+  </ItemGroup> 
   
   <!-- 
     Defining this target will disable the new SDK behavior of implicit transitive project

--- a/src/HostAgnostic.props
+++ b/src/HostAgnostic.props
@@ -1,5 +1,9 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project>
+  <PropertyGroup>
+    <BannedSymbolsOptOut Condition="$(IsTestProject)">true</BannedSymbolsOptOut>
+  </PropertyGroup>
+  
   <ItemGroup>
     <!-- Framework -->
     <Reference Include="System" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/GlobalJsonRemover.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/GlobalJsonRemover.cs
@@ -74,8 +74,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         public int OnAfterOpenSolution(object pUnkReserved, int fNewSolution)
         {
             UIThreadHelper.VerifyOnUIThread();
+#pragma warning disable RS0030 // Do not used banned APIs
             DTE2 dte = _serviceProvider.GetService<DTE2, DTE>();
+#pragma warning restore RS0030 // Do not used banned APIs
+#pragma warning disable RS0030 // Do not used banned APIs
             IVsSolution solution = _serviceProvider.GetService<IVsSolution, SVsSolution>();
+#pragma warning restore RS0030 // Do not used banned APIs
             try
             {
                 Verify.HResult(solution.GetSolutionInfo(out string directory, out string solutionFile, out string optsFile));

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/GlobalJsonRemover.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/GlobalJsonRemover.cs
@@ -76,8 +76,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
             UIThreadHelper.VerifyOnUIThread();
 #pragma warning disable RS0030 // Do not used banned APIs
             DTE2 dte = _serviceProvider.GetService<DTE2, DTE>();
-#pragma warning restore RS0030 // Do not used banned APIs
-#pragma warning disable RS0030 // Do not used banned APIs
             IVsSolution solution = _serviceProvider.GetService<IVsSolution, SVsSolution>();
 #pragma warning restore RS0030 // Do not used banned APIs
             try

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
@@ -58,7 +58,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
                 return VSConstants.VS_E_PROJECTMIGRATIONFAILED;
             }
 
+#pragma warning disable RS0030 // Do not used banned APIs
             IVsSolution solution = _serviceProvider.GetService<IVsSolution, SVsSolution>();
+#pragma warning restore RS0030 // Do not used banned APIs
             Verify.HResult(solution.GetSolutionInfo(out string solutionDirectory, out _, out _));
 
             HResult backupResult = BackupAndDeleteGlobalJson(solutionDirectory, solution, backupDirectory, projectName, logger);

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/Packaging/FSharpProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/Packaging/FSharpProjectSystemPackage.cs
@@ -44,7 +44,9 @@ namespace Microsoft.VisualStudio.Packaging
         {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
+#pragma warning disable RS0030 // Do not used banned APIs
             _projectSelectorService = this.GetService<IVsRegisterProjectSelector, SVsRegisterProjectTypes>();
+#pragma warning restore RS0030 // Do not used banned APIs
             Guid selectorGuid = typeof(FSharpProjectSelector).GUID;
             _projectSelectorService.RegisterProjectSelector(ref selectorGuid, new FSharpProjectSelector(), out _projectSelectorCookie);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IServiceProviderExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IServiceProviderExtensions.cs
@@ -13,7 +13,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             where InterfaceType : class
             where ServiceType : class
         {
+#pragma warning disable RS0030 // Do not used banned APIs
             return (InterfaceType)sp.GetService(typeof(ServiceType));
+#pragma warning restore RS0030 // Do not used banned APIs
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/HACK_AddItemHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/HACK_AddItemHelper.cs
@@ -68,7 +68,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// </summary>
         private static int ShowAddItemDialog(SVsServiceProvider serviceProvider, IProjectTree target, IVsProject vsProject, string strBrowseLocations, AddItemAction addItemAction)
         {
+#pragma warning disable RS0030 // Do not used banned APIs
             IVsAddProjectItemDlg addItemDialog = serviceProvider.GetService<IVsAddProjectItemDlg, SVsAddProjectItemDlg>();
+#pragma warning restore RS0030 // Do not used banned APIs
             Assumes.Present(addItemDialog);
 
             __VSADDITEMFLAGS uiFlags = __VSADDITEMFLAGS.VSADDITEM_AddNewItems | __VSADDITEMFLAGS.VSADDITEM_SuggestTemplateName | __VSADDITEMFLAGS.VSADDITEM_AllowHiddenTreeView;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/NodeHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/NodeHelper.cs
@@ -70,7 +70,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             }
 
 
+#pragma warning disable RS0030 // Do not used banned APIs
             IVsUIShell shell = serviceProvider.GetService<IVsUIShell, SVsUIShell>();
+#pragma warning restore RS0030 // Do not used banned APIs
 
             object pvar = null;
             IVsUIHierarchyWindow uiHierarchyWindow = null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/StartupProjectHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/StartupProjectHelper.cs
@@ -33,12 +33,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         /// </summary>
         public ImmutableArray<T> GetExportFromDotNetStartupProjects<T>(string capabilityMatch) where T : class
         {
+#pragma warning disable RS0030 // Do not used banned APIs
             EnvDTE.DTE dte = ServiceProvider.GetService<EnvDTE.DTE, EnvDTE.DTE>();
+#pragma warning restore RS0030 // Do not used banned APIs
             if (dte != null)
             {
                 if (dte.Solution.SolutionBuild.StartupProjects is Array startupProjects && startupProjects.Length > 0)
                 {
+#pragma warning disable RS0030 // Do not used banned APIs
                     IVsSolution sln = ServiceProvider.GetService<IVsSolution, SVsSolution>();
+#pragma warning restore RS0030 // Do not used banned APIs
                     var results = PooledArray<T>.GetInstance();
                     foreach (string projectName in startupProjects)
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPage.cs
@@ -297,7 +297,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         {
             if (_site is System.IServiceProvider sp)
             {
+#pragma warning disable RS0030 // Do not used banned APIs
                 _debugger = sp.GetService<IVsDebugger, IVsDebugger>();
+#pragma warning restore RS0030 // Do not used banned APIs
                 if (_debugger != null)
                 {
                     _debugger.AdviseDebuggerEvents(this, out _debuggerCookie);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
@@ -243,7 +243,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
 
             public static async Task<GraphIconCache> CreateAsync(IAsyncServiceProvider serviceProvider)
             {
+#pragma warning disable RS0030 // Do not used banned APIs
                 var imageService = (IVsImageService2)await serviceProvider.GetServiceAsync(typeof(SVsImageService));
+#pragma warning restore RS0030 // Do not used banned APIs
 
                 return new GraphIconCache(imageService);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsService`1.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsService`1.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#pragma warning disable RS0030 // Do not used banned APIs (wrapping IAsyncServiceProvider/SAsyncServiceProvider)
+
 using System;
 using System.ComponentModel.Composition;
 using System.Threading.Tasks;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsService`2.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsService`2.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#pragma warning disable RS0030 // Do not used banned APIs (wrapping IAsyncServiceProvider/SAsyncServiceProvider)
+
 using System;
 using System.ComponentModel.Composition;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsUIService`1.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsUIService`1.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#pragma warning disable RS0030 // Do not used banned APIs (wrapping IServiceProvider)
+
 using System;
 using System.ComponentModel.Composition;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsUIService`2.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsUIService`2.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#pragma warning disable RS0030 // Do not used banned APIs (wrapping IServiceProvider)
+
 using System;
 using System.ComponentModel.Composition;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/ServiceProviderToOleServiceProviderAdapter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/ServiceProviderToOleServiceProviderAdapter.cs
@@ -39,7 +39,9 @@ namespace Microsoft.VisualStudio.Shell
         {
             var serviceType = Type.GetTypeFromCLSID(riid, throwOnError: true); // Should only throw on OOM according to MSDN
 
+#pragma warning disable RS0030 // Do not used banned APIs (deliberately adapting)
             service = _serviceProvider.GetService(serviceType);
+#pragma warning restore RS0030 // Do not used banned APIs
             if (service == null)
                 return false;
 

--- a/src/VisualStudioDesigner.props
+++ b/src/VisualStudioDesigner.props
@@ -1,5 +1,10 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project>
+  <PropertyGroup>
+    <!-- Banned symbols are very project-system centric, and not applicable to AppDesigner/Editors -->
+    <BannedSymbolsOptOut>true</BannedSymbolsOptOut>
+  </PropertyGroup>
+  
   <Import Project="VisualStudio.props"/>
 
   <ItemGroup Condition="'$(Language)' == 'VB'">


### PR DESCRIPTION
This includes https://github.com/dotnet/project-system/pull/4555 so only review https://github.com/dotnet/project-system/pull/4556/commits/9e5672dafca8f8518be1e044571ce8f3da43ea01.

Ban IServiceProvider/IAsyncServiceProvider usage

IVsUIService/IVsService should be used instead. Existing usages are baselined and being tracked by #4375.