### PR TITLE
Fix hang in GetWorkspaceContextIdFromActiveContext

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IActiveEditorContextTrackerFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IActiveEditorContextTrackerFactory.cs
@@ -2,8 +2,6 @@
 
 using System;
 
-using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
-
 using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
@@ -15,28 +13,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             return Mock.Of<IActiveEditorContextTracker>();
         }
 
-        public static IActiveEditorContextTracker ImplementIsActiveEditorContext(Func<IWorkspaceProjectContext, bool> action)
+        public static IActiveEditorContextTracker ImplementIsActiveEditorContext(Func<string, bool> action)
         {
             var mock = new Mock<IActiveEditorContextTracker>();
-            mock.Setup(t => t.IsActiveEditorContext(It.IsAny<IWorkspaceProjectContext>()))
+            mock.Setup(t => t.IsActiveEditorContext(It.IsAny<string>()))
                 .Returns(action);
 
             return mock.Object;
         }
 
-        public static IActiveEditorContextTracker ImplementReleaseContext(Action<IWorkspaceProjectContext> action)
+        public static IActiveEditorContextTracker ImplementUnregisterContext(Action<string> action)
         {
             var mock = new Mock<IActiveEditorContextTracker>();
-            mock.Setup(t => t.UnregisterContext(It.IsAny<IWorkspaceProjectContext>()))
+            mock.Setup(t => t.UnregisterContext(It.IsAny<string>()))
                 .Callback(action);
 
             return mock.Object;
         }
 
-        public static IActiveEditorContextTracker ImplementRegisterContext(Action<IWorkspaceProjectContext, string> action)
+        public static IActiveEditorContextTracker ImplementRegisterContext(Action<string> action)
         {
             var mock = new Mock<IActiveEditorContextTracker>();
-            mock.Setup(t => t.RegisterContext(It.IsAny<IWorkspaceProjectContext>(), It.IsAny<string>()))
+            mock.Setup(t => t.RegisterContext(It.IsAny<string>()))
                 .Callback(action);
 
             return mock.Object;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextHostInstanceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextHostInstanceTests.cs
@@ -87,9 +87,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         [Fact]
         public async Task InitializedAsync_WhenInitializedWithContext_RegistersContextWithTracker()
         {
-            IWorkspaceProjectContext contextResult = null;
             string contextIdResult = null;
-            var activeWorkspaceProjectContextTracker = IActiveEditorContextTrackerFactory.ImplementRegisterContext((c, id) => { contextResult = c; contextIdResult = id; });
+            var activeWorkspaceProjectContextTracker = IActiveEditorContextTrackerFactory.ImplementRegisterContext(id => { contextIdResult = id; });
 
             var context = IWorkspaceProjectContextMockFactory.Create();
             var accessor = IWorkspaceProjectContextAccessorFactory.ImplementContext(context, "ContextId");
@@ -98,7 +97,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             var instance = await CreateInitializedInstanceAsync(workspaceProjectContextProvider: provider.Object, activeWorkspaceProjectContextTracker: activeWorkspaceProjectContextTracker);
 
-            Assert.Same(context, contextResult);
             Assert.Equal("ContextId", contextIdResult);
         }
 
@@ -122,11 +120,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         [Fact]
         public async Task Dispose_WhenInitializedWithContext_UnregistersContextWithTracker()
         {
-            IWorkspaceProjectContext result = null;
-            var activeWorkspaceProjectContextTracker = IActiveEditorContextTrackerFactory.ImplementReleaseContext(c => { result = c; });
+            string result = null;
+            var activeWorkspaceProjectContextTracker = IActiveEditorContextTrackerFactory.ImplementUnregisterContext(c => { result = c; });
 
             var context = IWorkspaceProjectContextMockFactory.Create();
-            var accessor = IWorkspaceProjectContextAccessorFactory.ImplementContext(context);
+            var accessor = IWorkspaceProjectContextAccessorFactory.ImplementContext(context, "ContextId");
             var provider = new WorkspaceProjectContextProviderMock();
             provider.ImplementCreateProjectContextAsync(project => accessor);
 
@@ -134,7 +132,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             await instance.DisposeAsync();
 
-            Assert.Same(context, result);
+            Assert.Equal("ContextId", result);
         }
 
         [Theory]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/ActiveEditorContextTrackerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/ActiveEditorContextTrackerTests.cs
@@ -2,8 +2,6 @@
 
 using System;
 
-using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
-using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 using Microsoft.VisualStudio.Shell;
 
 using Xunit;
@@ -13,37 +11,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
     public class ActiveEditorContextTrackerTests
     {
         [Fact]
-        public void IsActiveEditorContext_NullAsContext_ThrowsArgumentNull()
+        public void IsActiveEditorContext_NullAsContextId_ThrowsArgumentNull()
         {
             var instance = CreateInstance();
-
-            Assert.Throws<ArgumentNullException>("context", () =>
-            {
-                instance.IsActiveEditorContext((IWorkspaceProjectContext)null);
-            });
-        }
-
-        [Fact]
-        public void RegisterContext_NullAsContext_ThrowsArgumentNull()
-        {
-            var instance = CreateInstance();
-
-            Assert.Throws<ArgumentNullException>("context", () =>
-            {
-                instance.RegisterContext((IWorkspaceProjectContext)null, "ContextId");
-            });
-        }
-
-        [Fact]
-        public void RegisterContext_NullAsContextId_ThrowsArgumentNull()
-        {
-            var instance = CreateInstance();
-
-            var context = IWorkspaceProjectContextMockFactory.Create();
 
             Assert.Throws<ArgumentNullException>("contextId", () =>
             {
-                instance.RegisterContext(context, (string)null);
+                instance.IsActiveEditorContext((string)null);
             });
         }
 
@@ -52,22 +26,32 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         {
             var instance = CreateInstance();
 
-            var context = IWorkspaceProjectContextMockFactory.Create();
-
             Assert.Throws<ArgumentException>("contextId", () =>
             {
-                instance.RegisterContext(context, string.Empty);
+                instance.RegisterContext(string.Empty);
             });
         }
 
         [Fact]
-        public void UnregisterContext_NullAsContext_ThrowsArgumentNull()
+        public void UnregisterContext_NullAsContextId_ThrowsArgumentNull()
         {
             var instance = CreateInstance();
 
-            Assert.Throws<ArgumentNullException>("context", () =>
+            Assert.Throws<ArgumentNullException>("contextId", () =>
             {
-                instance.UnregisterContext((IWorkspaceProjectContext)null);
+                instance.UnregisterContext((string)null);
+            });
+        }
+
+
+        [Fact]
+        public void UnregisterContext_EmptyAsContextId_ThrowsArgument()
+        {
+            var instance = CreateInstance();
+
+            Assert.Throws<ArgumentException>("contextId", () =>
+            {
+                instance.UnregisterContext(string.Empty);
             });
         }
 
@@ -86,73 +70,64 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         }
 
         [Fact]
-        public void IsActiveEditorContext_UnregisteredContextAsContext_ThrowsInvalidOperation()
+        public void IsActiveEditorContext_NotRegisteredContextAsContextId_ThrowsInvalidOperation()
         {
             var instance = CreateInstance();
 
-            var context = IWorkspaceProjectContextMockFactory.Create();
-
             Assert.Throws<InvalidOperationException>(() =>
             {
-                instance.IsActiveEditorContext(context);
+                instance.IsActiveEditorContext("NotRegistered");
             });
         }
 
         [Fact]
-        public void RegisteredContext_AlreadyRegisteredContextAsContext_ThrowsInvalidOperation()
+        public void RegisteredContext_AlreadyRegisteredContextAsContextId_ThrowsInvalidOperation()
         {
             var instance = CreateInstance();
 
-            var context = IWorkspaceProjectContextMockFactory.Create();
-
-            instance.RegisterContext(context, "ContextId");
+            instance.RegisterContext("ContextId");
 
             Assert.Throws<InvalidOperationException>(() =>
             {
-                instance.RegisterContext(context, "ContextId");
+                instance.RegisterContext("ContextId");
             });
         }
 
         [Fact]
-        public void UnregisteredContext_UnregisteredContextAsContext_ThrowsInvalidOperation()
+        public void UnregisteredContext_NotRegisteredContextAsContextId_ThrowsInvalidOperation()
         {
             var instance = CreateInstance();
 
-            var context = IWorkspaceProjectContextMockFactory.Create();
-
             Assert.Throws<InvalidOperationException>(() =>
             {
-                instance.UnregisterContext(context);
+                instance.UnregisterContext("NotRegistered");
             });
         }
 
         [Fact]
-        public void UnregisterContext_RegisteredContextAsContext_CanUnregister()
+        public void UnregisterContext_RegisteredContextAsContextId_CanUnregister()
         {
             var instance = CreateInstance();
 
-            var context = IWorkspaceProjectContextMockFactory.Create();
+            instance.RegisterContext("ContextId");
 
-            instance.RegisterContext(context, "ContextId");
-
-            instance.UnregisterContext(context);
+            instance.UnregisterContext("ContextId");
 
             // Should be unregistered
-            Assert.Throws<InvalidOperationException>(() => instance.IsActiveEditorContext(context));
+            Assert.Throws<InvalidOperationException>(() => instance.IsActiveEditorContext("ContextId"));
         }
 
         [Theory]
         [InlineData("AnotherContextId")]
         [InlineData("contextId")]           // Case-sensitive
-        public void IsActiveEditorContext_WhenActiveIntellisenseProjectContextNotSet_UsesActiveHostContextId(string contextId)
+        public void IsActiveEditorContext_WhenActiveIntellisenseProjectContextIdNotSet_UsesFirstRegisteredContext(string contextId)
         {
-            var activeWorkspaceProjectContextHost = IActiveWorkspaceProjectContextHostFactory.ImplementContextId(contextId);
-            var instance = CreateInstance(activeWorkspaceProjectContextHost);
+            var instance = CreateInstance();
 
-            var context = IWorkspaceProjectContextMockFactory.Create();
-            instance.RegisterContext(context, contextId);
+            instance.RegisterContext("ContextId");
+            instance.RegisterContext(contextId);
 
-            var result = instance.IsActiveEditorContext(context);
+            var result = instance.IsActiveEditorContext("ContextId");
 
             Assert.True(result);
         }
@@ -160,13 +135,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         [Theory]
         [InlineData("AnotherContextId")]
         [InlineData("contextId")]           // Case-sensitive
-        public void IsActiveEditorContext_WhenActiveIntellisenseProjectContextSetToNull_UsesActiveHostContextId(string contextId)
+        public void IsActiveEditorContext_WhenActiveIntellisenseProjectContextIdSetToNull_UsesFirstRegisteredContext(string contextId)
         {
-            var activeWorkspaceProjectContextHost = IActiveWorkspaceProjectContextHostFactory.ImplementContextId(contextId);
-            var instance = CreateInstance(activeWorkspaceProjectContextHost);
+            var instance = CreateInstance();
 
-            var context = IWorkspaceProjectContextMockFactory.Create();
-            instance.RegisterContext(context, contextId);
+            instance.RegisterContext("FirstContextId");
+            instance.RegisterContext(contextId);
 
             // Set it the value first
             instance.ActiveIntellisenseProjectContext = contextId;
@@ -174,7 +148,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
             // Now explicitly set to null
             instance.ActiveIntellisenseProjectContext = null;
 
-            var result = instance.IsActiveEditorContext(context);
+            var result = instance.IsActiveEditorContext("FirstContextId");
 
             Assert.True(result);
         }
@@ -183,31 +157,29 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         [InlineData("")]
         [InlineData("AnotherContextId")]
         [InlineData("contextId")]           // Case-sensitive
-        public void IsActiveEditorContext_WhenActiveIntellisenseProjectContextDoesNotMatch_ReturnsFalse(string activeIntellisenseProjectContext)
+        public void IsActiveEditorContext_WhenActiveIntellisenseProjectContextIdDoesNotMatch_ReturnsFalse(string activeIntellisenseProjectContextId)
         {
             var instance = CreateInstance();
 
-            var context = IWorkspaceProjectContextMockFactory.Create();
-            instance.RegisterContext(context, "ContextId");
+            instance.RegisterContext("ContextId");
 
-            instance.ActiveIntellisenseProjectContext = activeIntellisenseProjectContext;
+            instance.ActiveIntellisenseProjectContext = activeIntellisenseProjectContextId;
 
-            var result = instance.IsActiveEditorContext(context);
+            var result = instance.IsActiveEditorContext("ContextId");
 
             Assert.False(result);
         }
 
         [Fact]
-        public void IsActiveEditorContext_WhenActiveIntellisenseProjectContextMatches_ReturnsTrue()
+        public void IsActiveEditorContext_WhenActiveIntellisenseProjectContextIdMatches_ReturnsTrue()
         {
             var instance = CreateInstance();
 
-            var context = IWorkspaceProjectContextMockFactory.Create();
-            instance.RegisterContext(context, "ContextId");
+            instance.RegisterContext("ContextId");
 
             instance.ActiveIntellisenseProjectContext = "ContextId";
 
-            var result = instance.IsActiveEditorContext(context);
+            var result = instance.IsActiveEditorContext("ContextId");
 
             Assert.True(result);
         }
@@ -215,43 +187,41 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         [Theory]
         [InlineData("")]
         [InlineData("ContextId")]
-        public void GetProjectName_ReturnsActiveIntellisenseProjectContext(string activeIntellisenseProjectContext)
+        public void GetProjectName_ReturnsActiveIntellisenseProjectContextId(string activeIntellisenseProjectContextId)
         {
             var instance = CreateInstance();
 
-            instance.ActiveIntellisenseProjectContext = activeIntellisenseProjectContext;
+            instance.ActiveIntellisenseProjectContext = activeIntellisenseProjectContextId;
 
             instance.GetProjectName(HierarchyId.Root, out string result);
 
-            Assert.Equal(activeIntellisenseProjectContext, result);
+            Assert.Equal(activeIntellisenseProjectContextId, result);
         }
 
         [Theory]
         [InlineData("AnotherContextId")]
         [InlineData("contextId")]
-        public void GetProjectName_WhenActiveIntellisenseProjectContextNotSet_ReturnsActiveHostContextId(string contextId)
+        public void GetProjectName_WhenActiveIntellisenseProjectContextIdNotSet_ReturnsFirstRegisteredContext(string contextId)
         {
-            var activeWorkspaceProjectContextHost = IActiveWorkspaceProjectContextHostFactory.ImplementContextId(contextId);
-            var instance = CreateInstance(activeWorkspaceProjectContextHost);
+            var instance = CreateInstance();
 
-            var context = IWorkspaceProjectContextMockFactory.Create();
-            instance.RegisterContext(context, contextId);
+            instance.RegisterContext("FirstContextId");
+            instance.RegisterContext(contextId);
 
             instance.GetProjectName(HierarchyId.Root, out string result);
 
-            Assert.Equal(contextId, result);
+            Assert.Equal("FirstContextId", result);
         }
 
         [Theory]
         [InlineData("AnotherContextId")]
         [InlineData("contextId")]
-        public void GetProjectName_WhenActiveIntellisenseProjectContextSetToNull_ReturnsActiveHostContextId(string contextId)
+        public void GetProjectName_WhenActiveIntellisenseProjectContextIdSetToNull_ReturnsFirstRegisteredContext(string contextId)
         {
-            var activeWorkspaceProjectContextHost = IActiveWorkspaceProjectContextHostFactory.ImplementContextId(contextId);
-            var instance = CreateInstance(activeWorkspaceProjectContextHost);
+            var instance = CreateInstance();
 
-            var context = IWorkspaceProjectContextMockFactory.Create();
-            instance.RegisterContext(context, contextId);
+            instance.RegisterContext("FirstContextId");
+            instance.RegisterContext(contextId);
 
             // Set it the value first
             instance.ActiveIntellisenseProjectContext = contextId;
@@ -261,19 +231,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
 
             instance.GetProjectName(HierarchyId.Root, out string result);
 
-            Assert.Equal(contextId, result);
+            Assert.Equal("FirstContextId", result);
         }
 
         private static ActiveEditorContextTracker CreateInstance()
         {
-            return CreateInstance(activeWorkspaceProjectContextHost: null);
-        }
-
-        private static ActiveEditorContextTracker CreateInstance(IActiveWorkspaceProjectContextHost activeWorkspaceProjectContextHost)
-        {
-            IProjectThreadingService threadingService = IProjectThreadingServiceFactory.Create();
-
-            return new ActiveEditorContextTracker(threadingService, activeWorkspaceProjectContextHost);
+            return new ActiveEditorContextTracker();
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IActiveEditorContextTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IActiveEditorContextTracker.cs
@@ -26,40 +26,42 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ///     Returns a value indicating whether the specified <see cref="IWorkspaceProjectContext"/> is the active one for the editor.
         /// </summary>
         /// <exception cref="ArgumentNullException">
-        ///     <paramref name="context"/> is <see langword="null" />
+        ///     <paramref name="contextId"/> is <see langword="null" />
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="contextId"/> is an empty string ("").
         /// </exception>
         /// <exception cref="InvalidOperationException">
-        ///     <paramref name="context"/> has not been registered or has already been unregistered.
+        ///     <paramref name="contextId"/> has not been registered or has already been unregistered.
         /// </exception>
-        bool IsActiveEditorContext(IWorkspaceProjectContext context);
+        bool IsActiveEditorContext(string contextId);
 
         /// <summary>
         ///     Registers the <see cref="IWorkspaceProjectContext"/> with the tracker.
         /// </summary>
         /// <exception cref="ArgumentNullException">
-        ///     <paramref name="context"/> is <see langword="null" />.
-        ///     <para>
-        ///         -or-
-        ///     </para>
         ///     <paramref name="contextId"/> is <see langword="null" />.
         /// </exception>
         /// <exception cref="ArgumentException">
         ///     <paramref name="contextId"/> is an empty string ("").
         /// </exception>
         /// <exception cref="InvalidOperationException">
-        ///     <paramref name="context"/> has already been been registered.
+        ///     <paramref name="contextId"/> has already been been registered.
         /// </exception>
-        void RegisterContext(IWorkspaceProjectContext context, string contextId);
+        void RegisterContext(string contextId);
 
         /// <summary>
         ///     Unregisters the <see cref="IWorkspaceProjectContext"/> with the tracker.
         /// </summary>
         /// <exception cref="ArgumentNullException">
-        ///     <paramref name="context"/> is <see langword="null" />
+        ///     <paramref name="contextId"/> is <see langword="null" />
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="contextId"/> is an empty string ("").
         /// </exception>
         /// <exception cref="InvalidOperationException">
-        ///     <paramref name="context"/> has not been registered or has already been unregistered.
+        ///     <paramref name="contextId"/> has not been registered or has already been unregistered.
         /// </exception>
-        void UnregisterContext(IWorkspaceProjectContext context);
+        void UnregisterContext(string contextId);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 if (_contextAccessor == null)
                     return;
 
-                _activeWorkspaceProjectContextTracker.RegisterContext(_contextAccessor.Context, _contextAccessor.ContextId);
+                _activeWorkspaceProjectContextTracker.RegisterContext(_contextAccessor.ContextId);
 
                 _applyChangesToWorkspaceContext = _applyChangesToWorkspaceContextFactory.CreateExport();
                 _applyChangesToWorkspaceContext.Value.Initialize(_contextAccessor.Context);
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
                     if (_contextAccessor != null)
                     {
-                        _activeWorkspaceProjectContextTracker.UnregisterContext(_contextAccessor.Context);
+                        _activeWorkspaceProjectContextTracker.UnregisterContext(_contextAccessor.ContextId);
 
                         await _workspaceProjectContextProvider.ReleaseProjectContextAsync(_contextAccessor);
                     }
@@ -133,7 +133,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
                 try
                 {
-                    bool isActiveContext = _activeWorkspaceProjectContextTracker.IsActiveEditorContext(context);
+                    bool isActiveContext = _activeWorkspaceProjectContextTracker.IsActiveEditorContext(_contextAccessor.ContextId);
 
                     if (evaluation)
                     {


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/782754.

Avoid blocking on initialization of the active workspace context just to get the default workspace context id for a multi-targeting projects it hasn't been set. Instead, just return the first one that is registered. This returns the behavior to what it was previously before the new language-service integration was checked in. 

This means that there is a chance that it may return no longer the "active configuration" context but instead the first one to register itself - but practically won't occur because we block on the active config registration in WorkspaceProjectContextHostInitiator.

Due to a flaw in the new integration, there's timing bug where IActiveWorkspaceProjectContext.OpenContextForWrite can hang (or never complete) if it is called on a configuration that previously was, but behind the scenes is no longer implicitly active. This will be fixed by https://github.com/dotnet/project-system/issues/3425, but in the meantime just avoid calling in this case.

To simplify this, I've:

- Remove the need to store the actual context in the tracker, we only use the "id"
- Replaced the hash table with a list so that we have guaranteed order (and therefore can return the first one registered). We only have a small number of elements anyway (1 per TFM in a project), so lookup should not be a concern.

@jjmew Like to take this to shiproom for Preview 4, will fill in ask mode tomorrow after I've finished testing it.

