### PR TITLE
Add accessible help text to the debug property page

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
@@ -95,6 +95,7 @@
                     Margin="6,8,1,8"
                     VerticalContentAlignment="Center"
                     VerticalAlignment="Center"
+                    AutomationProperties.HelpText="{x:Static Member=local:PropertyPageResources.NewBtnHelpText}"
                     Content="{x:Static Member=local:PropertyPageResources.NewBtn}"
                     IsEnabled="{Binding Path=NewProfileEnabled, Mode=OneWay}"
                     Command="{Binding Path=NewProfileCommand}">
@@ -107,6 +108,7 @@
                     Margin="6,8,1,8"
                     VerticalContentAlignment="Center"
                     VerticalAlignment="Center"
+                    AutomationProperties.HelpText="{x:Static Member=local:PropertyPageResources.DeleteBtnHelpText}"
                     Content="{x:Static Member=local:PropertyPageResources.DeleteBtn}"
                     IsEnabled="{Binding Path=DeleteProfileEnabled, Mode=OneWay}"
                     Command="{Binding Path=DeleteProfileCommand}">
@@ -250,6 +252,7 @@
                 IsEnabled="{Binding Path=IsProfileSelected, Mode=OneWay}"
                 Visibility="{Binding Path=SupportsLaunchUrl, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
                 VerticalContentAlignment="Center"
+                AutomationProperties.HelpText="{x:Static Member=local:PropertyPageResources.chkLaunchBrowserHelpText}"
                 Content="{x:Static Member=local:PropertyPageResources.LaunchURL}"/>
             <local:WatermarkTextBox 
                 Grid.Row="6"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/GetProfileNameDialog.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/GetProfileNameDialog.xaml
@@ -52,8 +52,12 @@
                 <ColumnDefinition Width="Auto"></ColumnDefinition>
                 <ColumnDefinition Width="Auto"></ColumnDefinition>
             </Grid.ColumnDefinitions>
-            <Button x:Uid="OKButton" Grid.Row="0"  Grid.Column="0" Margin="5" MinWidth="50" Padding="10,2" IsDefault="True" Click="OKButton_Click" Content="{x:Static Member=local:PropertyPageResources.OKBtn}" />
-            <Button x:Uid="CancelButton" Grid.Row="0"  Grid.Column="1" Margin="5" MinWidth="50" Padding="10,2" IsCancel="True" Content="{x:Static Member=local:PropertyPageResources.CancelBtn}" />
+            <Button x:Uid="OKButton" Grid.Row="0"  Grid.Column="0" Margin="5" MinWidth="50" Padding="10,2" IsDefault="True" Click="OKButton_Click" 
+                    Content="{x:Static Member=local:PropertyPageResources.OKBtn}" 
+                    AutomationProperties.HelpText="{x:Static Member=local:PropertyPageResources.OKBtnHelpText}"/>
+            <Button x:Uid="CancelButton" Grid.Row="0"  Grid.Column="1" Margin="5" MinWidth="50" Padding="10,2" IsCancel="True" 
+                    Content="{x:Static Member=local:PropertyPageResources.CancelBtn}" 
+                    AutomationProperties.HelpText="{x:Static Member=local:PropertyPageResources.CancelBtnHelpText}"/>
         </Grid>
     </Grid>
 </ui:DialogWindow>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class PropertyPageResources {
@@ -115,6 +115,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Return to the debug property page with no changes.
+        /// </summary>
+        public static string CancelBtnHelpText {
+            get {
+                return ResourceManager.GetString("CancelBtnHelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Checking enables a textbox to specify an absolute or relative URl.
+        /// </summary>
+        public static string chkLaunchBrowserHelpText {
+            get {
+                return ResourceManager.GetString("chkLaunchBrowserHelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Debug.
         /// </summary>
         public static string DebugPropertyPageTitle {
@@ -129,6 +147,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         public static string DeleteBtn {
             get {
                 return ResourceManager.GetString("DeleteBtn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Delete the current profile and change to the next available profile.
+        /// </summary>
+        public static string DeleteBtnHelpText {
+            get {
+                return ResourceManager.GetString("DeleteBtnHelpText", resourceCulture);
             }
         }
         
@@ -259,6 +286,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Open the new profile dialog.
+        /// </summary>
+        public static string NewBtnHelpText {
+            get {
+                return ResourceManager.GetString("NewBtnHelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to New profile.
         /// </summary>
         public static string NewProfileCaption {
@@ -282,6 +318,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         public static string OKBtn {
             get {
                 return ResourceManager.GetString("OKBtn", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Create the profile and return to the debug property page with the new profile selected.
+        /// </summary>
+        public static string OKBtnHelpText {
+            get {
+                return ResourceManager.GetString("OKBtnHelpText", resourceCulture);
             }
         }
         

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.resx
@@ -231,4 +231,19 @@
   <data name="ProfileName" xml:space="preserve">
     <value>Profile name:</value>
   </data>
+  <data name="CancelBtnHelpText" xml:space="preserve">
+    <value>Return to the debug property page with no changes</value>
+  </data>
+  <data name="chkLaunchBrowserHelpText" xml:space="preserve">
+    <value>Checking enables a textbox to specify an absolute or relative URl</value>
+  </data>
+  <data name="DeleteBtnHelpText" xml:space="preserve">
+    <value>Delete the current profile and change to the next available profile</value>
+  </data>
+  <data name="NewBtnHelpText" xml:space="preserve">
+    <value>Open the new profile dialog</value>
+  </data>
+  <data name="OKBtnHelpText" xml:space="preserve">
+    <value>Create the profile and return to the debug property page with the new profile selected</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.cs.xlf
@@ -192,6 +192,31 @@
         <target state="translated">Název profilu:</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeleteBtnHelpText">
+        <source>Delete the current profile and change to the next available profile</source>
+        <target state="new">Delete the current profile and change to the next available profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NewBtnHelpText">
+        <source>Open the new profile dialog</source>
+        <target state="new">Open the new profile dialog</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CancelBtnHelpText">
+        <source>Return to the debug property page with no changes</source>
+        <target state="new">Return to the debug property page with no changes</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OKBtnHelpText">
+        <source>Create the profile and return to the debug property page with the new profile selected</source>
+        <target state="new">Create the profile and return to the debug property page with the new profile selected</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="chkLaunchBrowserHelpText">
+        <source>Checking enables a textbox to specify an absolute or relative URl</source>
+        <target state="new">Checking enables a textbox to specify an absolute or relative URl</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.de.xlf
@@ -192,6 +192,31 @@
         <target state="translated">Profilname:</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeleteBtnHelpText">
+        <source>Delete the current profile and change to the next available profile</source>
+        <target state="new">Delete the current profile and change to the next available profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NewBtnHelpText">
+        <source>Open the new profile dialog</source>
+        <target state="new">Open the new profile dialog</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CancelBtnHelpText">
+        <source>Return to the debug property page with no changes</source>
+        <target state="new">Return to the debug property page with no changes</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OKBtnHelpText">
+        <source>Create the profile and return to the debug property page with the new profile selected</source>
+        <target state="new">Create the profile and return to the debug property page with the new profile selected</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="chkLaunchBrowserHelpText">
+        <source>Checking enables a textbox to specify an absolute or relative URl</source>
+        <target state="new">Checking enables a textbox to specify an absolute or relative URl</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.es.xlf
@@ -192,6 +192,31 @@
         <target state="translated">Nombre de perfil:</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeleteBtnHelpText">
+        <source>Delete the current profile and change to the next available profile</source>
+        <target state="new">Delete the current profile and change to the next available profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NewBtnHelpText">
+        <source>Open the new profile dialog</source>
+        <target state="new">Open the new profile dialog</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CancelBtnHelpText">
+        <source>Return to the debug property page with no changes</source>
+        <target state="new">Return to the debug property page with no changes</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OKBtnHelpText">
+        <source>Create the profile and return to the debug property page with the new profile selected</source>
+        <target state="new">Create the profile and return to the debug property page with the new profile selected</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="chkLaunchBrowserHelpText">
+        <source>Checking enables a textbox to specify an absolute or relative URl</source>
+        <target state="new">Checking enables a textbox to specify an absolute or relative URl</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.fr.xlf
@@ -192,6 +192,31 @@
         <target state="translated">Nom du profil :</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeleteBtnHelpText">
+        <source>Delete the current profile and change to the next available profile</source>
+        <target state="new">Delete the current profile and change to the next available profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NewBtnHelpText">
+        <source>Open the new profile dialog</source>
+        <target state="new">Open the new profile dialog</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CancelBtnHelpText">
+        <source>Return to the debug property page with no changes</source>
+        <target state="new">Return to the debug property page with no changes</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OKBtnHelpText">
+        <source>Create the profile and return to the debug property page with the new profile selected</source>
+        <target state="new">Create the profile and return to the debug property page with the new profile selected</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="chkLaunchBrowserHelpText">
+        <source>Checking enables a textbox to specify an absolute or relative URl</source>
+        <target state="new">Checking enables a textbox to specify an absolute or relative URl</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.it.xlf
@@ -192,6 +192,31 @@
         <target state="translated">Nome del profilo:</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeleteBtnHelpText">
+        <source>Delete the current profile and change to the next available profile</source>
+        <target state="new">Delete the current profile and change to the next available profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NewBtnHelpText">
+        <source>Open the new profile dialog</source>
+        <target state="new">Open the new profile dialog</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CancelBtnHelpText">
+        <source>Return to the debug property page with no changes</source>
+        <target state="new">Return to the debug property page with no changes</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OKBtnHelpText">
+        <source>Create the profile and return to the debug property page with the new profile selected</source>
+        <target state="new">Create the profile and return to the debug property page with the new profile selected</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="chkLaunchBrowserHelpText">
+        <source>Checking enables a textbox to specify an absolute or relative URl</source>
+        <target state="new">Checking enables a textbox to specify an absolute or relative URl</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ja.xlf
@@ -192,6 +192,31 @@
         <target state="translated">プロファイル名:</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeleteBtnHelpText">
+        <source>Delete the current profile and change to the next available profile</source>
+        <target state="new">Delete the current profile and change to the next available profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NewBtnHelpText">
+        <source>Open the new profile dialog</source>
+        <target state="new">Open the new profile dialog</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CancelBtnHelpText">
+        <source>Return to the debug property page with no changes</source>
+        <target state="new">Return to the debug property page with no changes</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OKBtnHelpText">
+        <source>Create the profile and return to the debug property page with the new profile selected</source>
+        <target state="new">Create the profile and return to the debug property page with the new profile selected</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="chkLaunchBrowserHelpText">
+        <source>Checking enables a textbox to specify an absolute or relative URl</source>
+        <target state="new">Checking enables a textbox to specify an absolute or relative URl</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ko.xlf
@@ -192,6 +192,31 @@
         <target state="translated">프로필 이름:</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeleteBtnHelpText">
+        <source>Delete the current profile and change to the next available profile</source>
+        <target state="new">Delete the current profile and change to the next available profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NewBtnHelpText">
+        <source>Open the new profile dialog</source>
+        <target state="new">Open the new profile dialog</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CancelBtnHelpText">
+        <source>Return to the debug property page with no changes</source>
+        <target state="new">Return to the debug property page with no changes</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OKBtnHelpText">
+        <source>Create the profile and return to the debug property page with the new profile selected</source>
+        <target state="new">Create the profile and return to the debug property page with the new profile selected</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="chkLaunchBrowserHelpText">
+        <source>Checking enables a textbox to specify an absolute or relative URl</source>
+        <target state="new">Checking enables a textbox to specify an absolute or relative URl</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.pl.xlf
@@ -192,6 +192,31 @@
         <target state="translated">Nazwa profilu:</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeleteBtnHelpText">
+        <source>Delete the current profile and change to the next available profile</source>
+        <target state="new">Delete the current profile and change to the next available profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NewBtnHelpText">
+        <source>Open the new profile dialog</source>
+        <target state="new">Open the new profile dialog</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CancelBtnHelpText">
+        <source>Return to the debug property page with no changes</source>
+        <target state="new">Return to the debug property page with no changes</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OKBtnHelpText">
+        <source>Create the profile and return to the debug property page with the new profile selected</source>
+        <target state="new">Create the profile and return to the debug property page with the new profile selected</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="chkLaunchBrowserHelpText">
+        <source>Checking enables a textbox to specify an absolute or relative URl</source>
+        <target state="new">Checking enables a textbox to specify an absolute or relative URl</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.pt-BR.xlf
@@ -192,6 +192,31 @@
         <target state="translated">Nome de perfil:</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeleteBtnHelpText">
+        <source>Delete the current profile and change to the next available profile</source>
+        <target state="new">Delete the current profile and change to the next available profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NewBtnHelpText">
+        <source>Open the new profile dialog</source>
+        <target state="new">Open the new profile dialog</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CancelBtnHelpText">
+        <source>Return to the debug property page with no changes</source>
+        <target state="new">Return to the debug property page with no changes</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OKBtnHelpText">
+        <source>Create the profile and return to the debug property page with the new profile selected</source>
+        <target state="new">Create the profile and return to the debug property page with the new profile selected</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="chkLaunchBrowserHelpText">
+        <source>Checking enables a textbox to specify an absolute or relative URl</source>
+        <target state="new">Checking enables a textbox to specify an absolute or relative URl</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ru.xlf
@@ -192,6 +192,31 @@
         <target state="translated">Имя профиля</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeleteBtnHelpText">
+        <source>Delete the current profile and change to the next available profile</source>
+        <target state="new">Delete the current profile and change to the next available profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NewBtnHelpText">
+        <source>Open the new profile dialog</source>
+        <target state="new">Open the new profile dialog</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CancelBtnHelpText">
+        <source>Return to the debug property page with no changes</source>
+        <target state="new">Return to the debug property page with no changes</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OKBtnHelpText">
+        <source>Create the profile and return to the debug property page with the new profile selected</source>
+        <target state="new">Create the profile and return to the debug property page with the new profile selected</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="chkLaunchBrowserHelpText">
+        <source>Checking enables a textbox to specify an absolute or relative URl</source>
+        <target state="new">Checking enables a textbox to specify an absolute or relative URl</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.tr.xlf
@@ -192,6 +192,31 @@
         <target state="translated">Profil adı:</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeleteBtnHelpText">
+        <source>Delete the current profile and change to the next available profile</source>
+        <target state="new">Delete the current profile and change to the next available profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NewBtnHelpText">
+        <source>Open the new profile dialog</source>
+        <target state="new">Open the new profile dialog</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CancelBtnHelpText">
+        <source>Return to the debug property page with no changes</source>
+        <target state="new">Return to the debug property page with no changes</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OKBtnHelpText">
+        <source>Create the profile and return to the debug property page with the new profile selected</source>
+        <target state="new">Create the profile and return to the debug property page with the new profile selected</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="chkLaunchBrowserHelpText">
+        <source>Checking enables a textbox to specify an absolute or relative URl</source>
+        <target state="new">Checking enables a textbox to specify an absolute or relative URl</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.zh-Hans.xlf
@@ -192,6 +192,31 @@
         <target state="translated">配置文件名称:</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeleteBtnHelpText">
+        <source>Delete the current profile and change to the next available profile</source>
+        <target state="new">Delete the current profile and change to the next available profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NewBtnHelpText">
+        <source>Open the new profile dialog</source>
+        <target state="new">Open the new profile dialog</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CancelBtnHelpText">
+        <source>Return to the debug property page with no changes</source>
+        <target state="new">Return to the debug property page with no changes</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OKBtnHelpText">
+        <source>Create the profile and return to the debug property page with the new profile selected</source>
+        <target state="new">Create the profile and return to the debug property page with the new profile selected</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="chkLaunchBrowserHelpText">
+        <source>Checking enables a textbox to specify an absolute or relative URl</source>
+        <target state="new">Checking enables a textbox to specify an absolute or relative URl</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.zh-Hant.xlf
@@ -192,6 +192,31 @@
         <target state="translated">設定檔名稱:</target>
         <note />
       </trans-unit>
+      <trans-unit id="DeleteBtnHelpText">
+        <source>Delete the current profile and change to the next available profile</source>
+        <target state="new">Delete the current profile and change to the next available profile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NewBtnHelpText">
+        <source>Open the new profile dialog</source>
+        <target state="new">Open the new profile dialog</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="CancelBtnHelpText">
+        <source>Return to the debug property page with no changes</source>
+        <target state="new">Return to the debug property page with no changes</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="OKBtnHelpText">
+        <source>Create the profile and return to the debug property page with the new profile selected</source>
+        <target state="new">Create the profile and return to the debug property page with the new profile selected</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="chkLaunchBrowserHelpText">
+        <source>Checking enables a textbox to specify an absolute or relative URl</source>
+        <target state="new">Checking enables a textbox to specify an absolute or relative URl</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
@@ -1,0 +1,5 @@
+static Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages.PropertyPageResources.CancelBtnHelpText.get -> string
+static Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages.PropertyPageResources.DeleteBtnHelpText.get -> string
+static Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages.PropertyPageResources.NewBtnHelpText.get -> string
+static Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages.PropertyPageResources.OKBtnHelpText.get -> string
+static Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages.PropertyPageResources.chkLaunchBrowserHelpText.get -> string


### PR DESCRIPTION
Fixes for [785764](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/785764/) and [786001](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/786001/)

Adds AutomationProperties.HelpText to 5 items in the debug property page and the new profile dialog. These strings are read by screen readers to give a better description of what will actually happen when the buttons are used - especially when the result is a UI only change. The strings were just first intuitive strings I thought of - I would appreciate any input @cartermp @AbhitejJohn 

New Button (Debug Property Page) - Open the new profile dialog
Delete Button (Debug Property Page) - Delete the current profile and change to the next available profile
Launch Browser Checkbox (Debug Property Page)  - Checking enables a textbox to specify an absolute or relative URL
OK Button (New Profile Dialog) - Create the profile and return to the debug property page with the new profile selected
Cancel Button (New Profile Dialog) - Return to the debug property page with no changes
