### PR TITLE
Synchronise up-to-date check query and project updates

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -82,15 +82,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             _fileSystem.AddFolder(_msBuildProjectDirectory);
             _fileSystem.AddFolder(_outputPath);
 
+            var threadingService = IProjectThreadingServiceFactory.Create();
+
             _buildUpToDateCheck = new BuildUpToDateCheck(
                 projectSystemOptions.Object,
                 configuredProject.Object,
                 projectAsynchronousTasksService.Object,
                 IProjectItemSchemaServiceFactory.Create(),
                 ITelemetryServiceFactory.Create(telemetryParameters => _telemetryEvents.Add(telemetryParameters)),
+                threadingService,
                 _fileSystem);
-
-            _buildUpToDateCheck.Load();
         }
 
         public void Dispose() => _buildUpToDateCheck.Dispose();
@@ -100,6 +101,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             Dictionary<string, IProjectRuleSnapshotModel> sourceSnapshot = null,
             bool expectUpToDate = true)
         {
+            await _buildUpToDateCheck.LoadAsync();
+
             // Run one change event to set things up.
             BroadcastChange(projectSnapshot, sourceSnapshot);
 
@@ -145,7 +148,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 identity: ProjectDataSources.ConfiguredProjectVersion,
                 version: _projectVersion);
 
-            _buildUpToDateCheck.OnChanged(value);
+            _buildUpToDateCheck.OnChangedAsync(value);
 
             return;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -108,7 +108,32 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
         public Task UnloadAsync()
         {
-            return Task.CompletedTask;
+            return ExecuteUnderLockAsync(_ =>
+            {
+                _link?.Dispose();
+                _link = null;
+
+                _lastCheckTimeUtc = DateTime.MinValue;
+                _isDisabled = true;
+                _itemsChangedSinceLastCheck = true;
+                _msBuildProjectFullPath = null;
+                _msBuildProjectDirectory = null;
+                _markerFile = null;
+                _outputRelativeOrFullPath = null;
+                _newestImportInput = null;
+
+                _itemTypes.Clear();
+                _items.Clear();
+                _customInputs.Clear();
+                _customOutputs.Clear();
+                _builtOutputs.Clear();
+                _copiedOutputFiles.Clear();
+                _analyzerReferences.Clear();
+                _compilationReferences.Clear();
+                _copyReferenceInputs.Clear();
+
+                return Task.CompletedTask;
+            });
         }
 
         protected override Task InitializeCoreAsync(CancellationToken cancellationToken)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -20,8 +20,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 {
     [AppliesTo(ProjectCapability.DotNet + "+ !" + ProjectCapabilities.SharedAssetsProject)]
     [Export(typeof(IBuildUpToDateCheckProvider))]
+    [Export(ExportContractNames.Scopes.ConfiguredProject, typeof(IProjectDynamicLoadComponent))]
     [ExportMetadata("BeforeDrainCriticalTasks", true)]
-    internal sealed class BuildUpToDateCheck : OnceInitializedOnceDisposed, IBuildUpToDateCheckProvider
+    internal sealed class BuildUpToDateCheck : OnceInitializedOnceDisposedUnderLockAsync, IBuildUpToDateCheckProvider, IProjectDynamicLoadComponent
     {
         private const string CopyToOutputDirectory = "CopyToOutputDirectory";
         private const string PreserveNewest = "PreserveNewest";
@@ -88,7 +89,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             [Import(ExportContractNames.Scopes.ConfiguredProject)] IProjectAsynchronousTasksService tasksService,
             IProjectItemSchemaService projectItemSchemaService,
             ITelemetryService telemetryService,
+            IProjectThreadingService threadingService,
             IFileSystem fileSystem)
+            : base(threadingService.JoinableTaskContext)
         {
             _projectSystemOptions = projectSystemOptions;
             _configuredProject = configuredProject;
@@ -98,26 +101,33 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             _fileSystem = fileSystem;
         }
 
-        /// <summary>
-        /// Called on project load.
-        /// </summary>
-#pragma warning disable RS0030 // symbol ConfiguredProjectAutoLoad is banned
-        [ConfiguredProjectAutoLoad]
-#pragma warning restore RS0030 // symbol ConfiguredProjectAutoLoad is banned
-        [AppliesTo(ProjectCapability.DotNet + "+ !" + ProjectCapabilities.SharedAssetsProject)]
-        internal void Load()
+        public Task LoadAsync()
         {
-            EnsureInitialized();
+            return InitializeAsync();
         }
 
-        protected override void Initialize()
+        public Task UnloadAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        protected override Task InitializeCoreAsync(CancellationToken cancellationToken)
         {
             _link = ProjectDataSources.SyncLinkTo(
                 _configuredProject.Services.ProjectSubscription.JointRuleSource.SourceBlock.SyncLinkOptions(DataflowOption.WithRuleNames(ProjectPropertiesSchemas)),
                 _configuredProject.Services.ProjectSubscription.SourceItemsRuleSource.SourceBlock.SyncLinkOptions(),
                 _projectItemSchemaService.SourceBlock.SyncLinkOptions(),
-                target: DataflowBlockSlim.CreateActionBlock<IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectSubscriptionUpdate, IProjectItemSchema>>>(e => OnChanged(e)),
+                target: DataflowBlockSlim.CreateActionBlock<IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectSubscriptionUpdate, IProjectItemSchema>>>(OnChangedAsync),
                 linkOptions: DataflowOption.PropagateCompletion);
+
+            return Task.CompletedTask;
+        }
+
+        protected override Task DisposeCoreUnderLockAsync(bool initialized)
+        {
+            _link?.Dispose();
+
+            return Task.CompletedTask;
         }
 
         private void OnProjectChanged(IProjectSubscriptionUpdate e)
@@ -259,16 +269,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             }
         }
 
-        internal void OnChanged(IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectSubscriptionUpdate, IProjectItemSchema>> e)
+        internal Task OnChangedAsync(IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectSubscriptionUpdate, IProjectItemSchema>> e)
         {
-            OnProjectChanged(e.Value.Item1);
-            OnSourceItemChanged(e.Value.Item2, e.Value.Item3);
-            _lastVersionSeen = e.DataSourceVersions[ProjectDataSources.ConfiguredProjectVersion];
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            _link?.Dispose();
+            return ExecuteUnderLockAsync(
+                token =>
+                {
+                    OnProjectChanged(e.Value.Item1);
+                    OnSourceItemChanged(e.Value.Item2, e.Value.Item3);
+                    _lastVersionSeen = e.DataSourceVersions[ProjectDataSources.ConfiguredProjectVersion];
+                    return Task.CompletedTask;
+                });
         }
 
         private DateTime? GetTimestampUtc(string path, IDictionary<string, DateTime> timestampCache)
@@ -662,43 +672,50 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             return true;
         }
 
-        public async Task<bool> IsUpToDateAsync(BuildAction buildAction, TextWriter logWriter, CancellationToken cancellationToken = default)
+        public Task<bool> IsUpToDateAsync(BuildAction buildAction, TextWriter logWriter, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var sw = Stopwatch.StartNew();
+            return ExecuteUnderLockAsync(IsUpToDateInternalAsync, cancellationToken);
 
-            EnsureInitialized();
-
-            LogLevel requestedLogLevel = await _projectSystemOptions.GetFastUpToDateLoggingLevelAsync(cancellationToken);
-            var logger = new BuildUpToDateCheckLogger(logWriter, requestedLogLevel, _configuredProject.UnconfiguredProject.FullPath);
-
-            try
+            async Task<bool> IsUpToDateInternalAsync(CancellationToken token)
             {
-                if (!CheckGlobalConditions(buildAction, logger))
+                token.ThrowIfCancellationRequested();
+
+                var sw = Stopwatch.StartNew();
+
+                await InitializeAsync(token);
+
+                LogLevel requestedLogLevel = await _projectSystemOptions.GetFastUpToDateLoggingLevelAsync(token);
+                var logger = new BuildUpToDateCheckLogger(logWriter, requestedLogLevel, _configuredProject.UnconfiguredProject.FullPath);
+
+                try
                 {
-                    return false;
+                    if (!CheckGlobalConditions(buildAction, logger))
+                    {
+                        return false;
+                    }
+
+                    // Short-lived cache of timestamp by path
+                    var timestampCache = new Dictionary<string, DateTime>(StringComparers.Paths);
+
+                    if (!CheckOutputs(logger, timestampCache) ||
+                        !CheckMarkers(logger, timestampCache) ||
+                        !CheckCopyToOutputDirectoryFiles(logger, timestampCache) ||
+                        !CheckCopiedOutputFiles(logger, timestampCache))
+                    {
+                        return false;
+                    }
+
+                    _telemetryService.PostEvent(TelemetryEventName.UpToDateCheckSuccess);
+                    logger.Info("Project is up to date.");
+                    return true;
                 }
-
-                // Short-lived cache of timestamp by path
-                var timestampCache = new Dictionary<string, DateTime>(StringComparers.Paths);
-
-                if (!CheckOutputs(logger, timestampCache) ||
-                    !CheckMarkers(logger, timestampCache) ||
-                    !CheckCopyToOutputDirectoryFiles(logger, timestampCache) ||
-                    !CheckCopiedOutputFiles(logger, timestampCache))
+                finally
                 {
-                    return false;
+                    _lastCheckTimeUtc = DateTime.UtcNow;
+                    logger.Verbose("Up to date check completed in {0:#,##0.#} ms", sw.Elapsed.TotalMilliseconds);
                 }
-
-                _telemetryService.PostEvent(TelemetryEventName.UpToDateCheckSuccess);
-                logger.Info("Project is up to date.");
-                return true;
-            }
-            finally
-            {
-                _lastCheckTimeUtc = DateTime.UtcNow;
-                logger.Verbose("Up to date check completed in {0:#,##0.#} ms", sw.Elapsed.TotalMilliseconds);
             }
         }
 


### PR DESCRIPTION
Previously it was possible for an update to occur during the up to date computation. Its collections are not thread safe so could report incorrect values or even raise exceptions.

This commit makes the following changes:

- Derive from `OnceInitializedOnceDisposedUnderLockAsync`
- Export `IProjectDynamicLoadComponent` to respond to project capabilites
- Perform update and query within `ExecuteUnderLockAsync` for isolation