### PR TITLE
Dependency node ProviderType fixes

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DependenciesViewModelFactoryTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DependenciesViewModelFactoryTests.cs
@@ -58,13 +58,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         public void CreateRootViewModel()
         {
             var project = UnconfiguredProjectFactory.Create();
-            var dependencyModel = IDependencyModelFactory.FromJson(@"
-{
-    ""ProviderType"": ""MyProvider1"",
-    ""Id"": ""ZzzDependencyRoot"",
-    ""Name"":""ZzzDependencyRoot"",
-    ""Caption"":""ZzzDependencyRoot""
-}", icon: KnownMonikers.AboutBox);
+
+            var dependencyModel = new TestDependencyModel
+            {
+                ProviderType = "MyProvider1",
+                Id = "ZzzDependencyRoot",
+                Name = "ZzzDependencyRoot",
+                Caption = "ZzzDependencyRoot",
+                Icon = KnownMonikers.AboutBox
+            };
 
             var subTreeProvider1 = IProjectDependenciesSubTreeProviderFactory.Implement(
                 providerType: "MyProvider1",
@@ -79,6 +81,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.NotNull(result);
             Assert.Equal("ZzzDependencyRoot", result.Caption);
             Assert.Equal(KnownMonikers.AboutBox, result.Icon);
+        }
+
+        [Fact]
+        public void CreateRootViewModelReturnsNullForUnknownProviderType()
+        {
+            var project = UnconfiguredProjectFactory.Create();
+
+            var subTreeProvider1 = IProjectDependenciesSubTreeProviderFactory.Implement(providerType: "MyProvider1");
+
+            var factory = new TestableDependenciesViewModelFactory(project, new[] { subTreeProvider1 });
+
+            var result = factory.CreateRootViewModel("UnknownProviderType", hasUnresolvedDependency: false);
+
+            Assert.Null(result);
         }
 
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/DependenciesTreeViewProvider.cs
@@ -196,6 +196,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             {
                 IDependencyViewModel subTreeViewModel = _viewModelFactory.CreateRootViewModel(
                     providerType, targetedSnapshot.CheckForUnresolvedDependencies(providerType));
+
+                if (subTreeViewModel == null)
+                {
+                    // In theory this should never happen, as it means we have a dependency model of a type
+                    // that no provider claims. https://github.com/dotnet/project-system/issues/3653
+                    continue;
+                }
+
                 IProjectTree subTreeNode = rootNode.FindChildWithCaption(subTreeViewModel.Caption);
                 bool isNewSubTreeNode = subTreeNode == null;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DependenciesViewModelFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Models/DependenciesViewModelFactory.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.ComponentModel.Composition;
-using System.Linq;
 
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
@@ -31,8 +30,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
         public IDependencyViewModel CreateRootViewModel(string providerType, bool hasUnresolvedDependency)
         {
             IProjectDependenciesSubTreeProvider provider = GetProvider(providerType);
-            IDependencyModel dependencyModel = provider.CreateRootDependencyNode();
-            return dependencyModel.ToViewModel(hasUnresolvedDependency);
+
+            IDependencyModel dependencyModel = provider?.CreateRootDependencyNode();
+
+            return dependencyModel?.ToViewModel(hasUnresolvedDependency);
         }
 
         public ImageMoniker GetDependenciesRootIcon(bool hasUnresolvedDependencies)
@@ -44,7 +45,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 
         private IProjectDependenciesSubTreeProvider GetProvider(string providerType)
         {
-            return SubTreeProviders.First(x => StringComparers.DependencyProviderTypes.Equals(x.Value.ProviderType, providerType)).Value;
+            return SubTreeProviders
+                .FirstOrDefault((x, t) => StringComparers.DependencyProviderTypes.Equals(x.Value.ProviderType, t), providerType)
+                ?.Value;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
@@ -292,7 +292,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                     catalogs,
                     activeTargetFramework,
                     _snapshotFilters.ToImmutableValueArray(),
-                    _subTreeProviders.ToValueDictionary(p => p.ProviderType),
+                    _subTreeProviders.ToValueDictionary(p => p.ProviderType, StringComparers.DependencyProviderTypes),
                     projectItemSpecs),
                 token);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Composition/OrderPrecedenceImportCollectionExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Composition/OrderPrecedenceImportCollectionExtensions.cs
@@ -102,9 +102,9 @@ namespace Microsoft.VisualStudio.Composition
             return builder.MoveToImmutable();
         }
 
-        public static Dictionary<TKey, TImport> ToValueDictionary<TKey, TImport>(this OrderPrecedenceImportCollection<TImport> imports, Func<TImport, TKey> keySelector)
+        public static Dictionary<TKey, TImport> ToValueDictionary<TKey, TImport>(this OrderPrecedenceImportCollection<TImport> imports, Func<TImport, TKey> keySelector, IEqualityComparer<TKey> comparer = default)
         {
-            var dictionary = new Dictionary<TKey, TImport>();
+            var dictionary = new Dictionary<TKey, TImport>(comparer);
 
             foreach (Lazy<TImport> import in imports)
             {


### PR DESCRIPTION
- Fix NRE for unknown provider type by returning and handling `null`. Fixes #3653.
- Pass correct comparer for use when looking up providers by type. Was previously using `Ordinal` (via `EqualityComparer<string>.Default`) rather than the required `OrdinalIgnoreCase`.
