### PR TITLE
Ensure PackageLicenseExpression property is set

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.vb
@@ -315,6 +315,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 LicenseFileNameTextBox.Text = ""
             ElseIf Not setLicenseExpression AndAlso Not PackageLicenseExpression.Text = "" Then
                 PackageLicenseExpression.Text = ""
+                SetDirty(PackageLicenseExpression)
             End If
         End Sub
 


### PR DESCRIPTION
Fix for: [795312](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/795312)

Switching the radio button choice from Package License Expression to Package License File does not properly set the value of PackageLicenseExpression to empty in the project file. It needs to be explicitly set to dirty so that it will pick up the change. 