### PR TITLE
Make CancellationSeries internal

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Shipped.txt
@@ -85,7 +85,3 @@ Microsoft.VisualStudio.ProjectSystem.Debug.IWritablePersistOption.DoNotPersist.s
 Microsoft.VisualStudio.ProjectSystem.Debug.UIProfilePropertyName
 Microsoft.VisualStudio.ProjectSystem.Properties.IInterceptingPropertyValueProviderMetadata
 Microsoft.VisualStudio.ProjectSystem.Properties.IInterceptingPropertyValueProviderMetadata.PropertyName.get -> string
-Microsoft.VisualStudio.Threading.Tasks.CancellationSeries
-Microsoft.VisualStudio.Threading.Tasks.CancellationSeries.CancellationSeries(System.Threading.CancellationToken token = default(System.Threading.CancellationToken)) -> void
-Microsoft.VisualStudio.Threading.Tasks.CancellationSeries.CreateNext(System.Threading.CancellationToken token = default(System.Threading.CancellationToken)) -> System.Threading.CancellationToken
-Microsoft.VisualStudio.Threading.Tasks.CancellationSeries.Dispose() -> void

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/CancellationSeries.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/CancellationSeries.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.Threading.Tasks
     /// <para>Consuming code is responsible for managing overlapping asynchronous operations.</para>
     /// <para>This class has a lock-free implementation to minimise latency and contention.</para>
     /// </remarks>
-    public sealed class CancellationSeries : IDisposable
+    internal sealed class CancellationSeries : IDisposable
     {
         private CancellationTokenSource _cts = new CancellationTokenSource();
 


### PR DESCRIPTION
This type was not intended for consumption outside this repo and should have been internal.

This type will exist in 16.0, but the the likelihood of someone taking a dependency on it is very small, and if someone found it useful they could always copy the source from this repo directly. It's a small type.