### PR TITLE
Unresolved child test excludes non-visible children

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
@@ -260,6 +260,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
                 foreach (IDependency child in GetDependencyChildren(parent))
                 {
+                    if (!child.Visible)
+                    {
+                        return false;
+                    }
+
                     if (!child.Resolved)
                     {
                         return true;
@@ -295,6 +300,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             foreach ((string _, IDependency dependency) in DependenciesWorld)
             {
                 if (StringComparers.DependencyProviderTypes.Equals(dependency.ProviderType, providerType) &&
+                    dependency.Visible &&
                     !dependency.Resolved)
                 {
                     return true;


### PR DESCRIPTION
These tests are used to determine whether a parent dependency tree node should be displayed as unresolved. If an invisible child makes the parent unresolved, it's confusing to the user.

For example, the NuGet node may be unresolved and the unresolved package supplies an SDK, and is hidden from the tree. In such a case, the SDK node will be marked as unresolved, and annotating the NuGet node is just confusing and misleading.

Fixes #4577.

### Before

![image](https://user-images.githubusercontent.com/350947/53044463-002fbf00-3483-11e9-8d99-5ebc0d066b51.png)

### After

![image](https://user-images.githubusercontent.com/350947/53046379-c8774600-3487-11e9-8fe4-36dfc11a56ca.png)
