### PR TITLE
 Scope ActiveEditorContextTracker per project

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/ActiveEditorContextTrackerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/ActiveEditorContextTrackerTests.cs
@@ -236,7 +236,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
 
         private static ActiveEditorContextTracker CreateInstance()
         {
-            return new ActiveEditorContextTracker();
+            return new ActiveEditorContextTracker((UnconfiguredProject)null);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ActiveEditorContextTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ActiveEditorContextTracker.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
         private string _activeIntellisenseProjectContext;
 
         [ImportingConstructor]
-        public ActiveEditorContextTracker()
+        public ActiveEditorContextTracker(UnconfiguredProject project) // For scoping
         {
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IActiveEditorContextTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IActiveEditorContextTracker.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-
+using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
@@ -20,6 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     ///         tracked via <see cref="IActiveWorkspaceProjectContextHost"/>.
     ///     </para>
     /// </remarks>
+    [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
     internal interface IActiveEditorContextTracker
     {
         /// <summary>


### PR DESCRIPTION
#4563 caused ActiveEditorContextTracker to be scoped across the solution instead of per project, resulting in the "default" context for a project to be the first one registered across the solution, instead for the project. This broke Razer for solutions with more than one project.

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/795781.

tag @jjmew for approval.