### PR TITLE
Simplify IVsService<T>/IVsUIService<T>

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ConsoleDebugTargetsProvider.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         private readonly IActiveDebugFrameworkServices _activeDebugFramework;
         private readonly ProjectProperties _properties;
         private readonly IProjectThreadingService _threadingService;
-        private readonly IVsUIService<SVsShellDebugger, IVsDebugger10> _debugger;
+        private readonly IVsUIService<IVsDebugger10> _debugger;
         private readonly UnconfiguredProject _project;
 
         [ImportingConstructor]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectDebuggerProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectDebuggerProvider.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             LaunchSettingsProvider = launchSettingsProvider;
         }
 
-        private readonly IVsService<SVsShellDebugger, IVsDebugger4> _vsDebuggerService;
+        private readonly IVsService<IVsDebugger4> _vsDebuggerService;
 
         /// <summary>
         /// Import the LaunchTargetProviders which know how to run profiles

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DotNetCoreProjectCompatibilityDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DotNetCoreProjectCompatibilityDetector.cs
@@ -75,11 +75,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         private readonly Lazy<IVsShellUtilitiesHelper> _shellUtilitiesHelper;
         private readonly Lazy<IFileSystem> _fileSystem;
         private readonly Lazy<IHttpClient> _httpClient;
-        private readonly IVsService<SVsSettingsPersistenceManager, ISettingsManager> _settingsManagerService;
-        private readonly IVsService<SVsUIShell, IVsUIShell> _vsUIShellService;
-        private readonly IVsService<SVsSolution, IVsSolution> _vsSolutionService;
-        private readonly IVsService<SVsAppId, IVsAppId> _vsAppIdService;
-        private readonly IVsService<SVsShell, IVsShell> _vsShellService;
+        private readonly IVsService<ISettingsManager> _settingsManagerService;
+        private readonly IVsService<IVsUIShell> _vsUIShellService;
+        private readonly IVsService<IVsSolution> _vsSolutionService;
+        private readonly IVsService<IVsAppId> _vsAppIdService;
+        private readonly IVsService<IVsShell> _vsShellService;
 
         private RemoteCacheFile _versionDataCacheFile;
         private Version _ourVSVersion;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommand.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
     internal abstract class AbstractGenerateNuGetPackageCommand : AbstractSingleNodeProjectCommand, IVsUpdateSolutionEvents, IDisposable
     {
         private readonly IProjectThreadingService _threadingService;
-        private readonly IVsService<SVsSolutionBuildManager, IVsSolutionBuildManager2> _vsSolutionBuildManagerService;
+        private readonly IVsService<IVsSolutionBuildManager2> _vsSolutionBuildManagerService;
         private readonly GeneratePackageOnBuildPropertyProvider _generatePackageOnBuildPropertyProvider;
         private IVsSolutionBuildManager2 _buildManager;
         private uint _solutionEventsCookie;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
     [AppliesTo(ProjectCapability.DotNet)]
     internal class VsContainedLanguageComponentsFactory : IVsContainedLanguageComponentsFactory
     {
-        private readonly IVsService<SAsyncServiceProvider, IOleAsyncServiceProvider> _serviceProvider;
+        private readonly IVsService<IOleAsyncServiceProvider> _serviceProvider;
         private readonly IUnconfiguredProjectVsServices _projectVsServices;
         private readonly IActiveWorkspaceProjectContextHost _projectContextHost;
         private readonly AsyncLazy<IVsContainedLanguageFactory> _containedLanguageFactory;


### PR DESCRIPTION
Fields don't need to restate the service type - it's only needed for the import.