### PR TITLE
Centralize ProjectType usage

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
@@ -376,7 +376,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
             Assert.Equal(VSConstants.S_OK,
                 migrator.UpgradeProject_CheckOnly(XprojLocation, logger, out int upgradeRequired, out Guid newProjectFactory, out uint capabilityFlags));
             Assert.Equal((int)__VSPPROJECTUPGRADEVIAFACTORYREPAIRFLAGS.VSPUVF_PROJECT_ONEWAYUPGRADE, upgradeRequired);
-            Assert.Equal(Guid.Parse(CSharpProjectSystemPackage.ProjectTypeGuid), newProjectFactory);
+            Assert.Equal(Guid.Parse(ProjectType.CSharp), newProjectFactory);
             Assert.Equal((uint)(__VSPPROJECTUPGRADEVIAFACTORYFLAGS.PUVFF_BACKUPSUPPORTED | __VSPPROJECTUPGRADEVIAFACTORYFLAGS.PUVFF_COPYBACKUP),
                 capabilityFlags);
         }
@@ -497,7 +497,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
             Assert.False(fileSystem.FileExists(ProjectLockJsonLocation));
             Assert.Equal(CsprojLocation, outCsproj);
             Assert.Equal((int)__VSPPROJECTUPGRADEVIAFACTORYREPAIRFLAGS.VSPUVF_PROJECT_ONEWAYUPGRADE, upgradeRequired);
-            Assert.Equal(Guid.Parse(CSharpProjectSystemPackage.ProjectTypeGuid), newProjectFactory);
+            Assert.Equal(Guid.Parse(ProjectType.CSharp), newProjectFactory);
             Mock.Get(setup).Verify(g => g.SetupRemoval(solution, It.IsAny<IServiceProvider>(), fileSystem));
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests/ProjectSystem/VS/Xproj/MigrateXprojProjectFactoryTests.cs
@@ -376,7 +376,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
             Assert.Equal(VSConstants.S_OK,
                 migrator.UpgradeProject_CheckOnly(XprojLocation, logger, out int upgradeRequired, out Guid newProjectFactory, out uint capabilityFlags));
             Assert.Equal((int)__VSPPROJECTUPGRADEVIAFACTORYREPAIRFLAGS.VSPUVF_PROJECT_ONEWAYUPGRADE, upgradeRequired);
-            Assert.Equal(Guid.Parse(ProjectType.CSharp), newProjectFactory);
+            Assert.Equal(ProjectType.CSharpGuid, newProjectFactory);
             Assert.Equal((uint)(__VSPPROJECTUPGRADEVIAFACTORYFLAGS.PUVFF_BACKUPSUPPORTED | __VSPPROJECTUPGRADEVIAFACTORYFLAGS.PUVFF_COPYBACKUP),
                 capabilityFlags);
         }
@@ -497,7 +497,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
             Assert.False(fileSystem.FileExists(ProjectLockJsonLocation));
             Assert.Equal(CsprojLocation, outCsproj);
             Assert.Equal((int)__VSPPROJECTUPGRADEVIAFACTORYREPAIRFLAGS.VSPUVF_PROJECT_ONEWAYUPGRADE, upgradeRequired);
-            Assert.Equal(Guid.Parse(ProjectType.CSharp), newProjectFactory);
+            Assert.Equal(ProjectType.CSharpGuid, newProjectFactory);
             Mock.Get(setup).Verify(g => g.SetupRemoval(solution, It.IsAny<IServiceProvider>(), fileSystem));
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Packaging/CSharpProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Packaging/CSharpProjectSystemPackage.cs
@@ -17,8 +17,8 @@ using Task = System.Threading.Tasks.Task;
 // Register ourselves as a CPS project type
 [assembly: ProjectTypeRegistration(
     projectTypeGuid: CSharpProjectSystemPackage.ProjectTypeGuid,
-    displayName: "#1",
-    displayProjectFileExtensions: "#2",
+    displayName: "#1",                      // "C#"
+    displayProjectFileExtensions: "#2",     // "C# Project Files (*.csproj);*.csproj"
     defaultProjectExtension: "csproj",
     language: "CSharp",
     resourcePackageGuid: CSharpProjectSystemPackage.PackageGuid,

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Packaging/CSharpProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/Packaging/CSharpProjectSystemPackage.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;
-
+using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.Packaging;
 using Microsoft.VisualStudio.ProjectSystem;
@@ -16,7 +16,7 @@ using Task = System.Threading.Tasks.Task;
 
 // Register ourselves as a CPS project type
 [assembly: ProjectTypeRegistration(
-    projectTypeGuid: CSharpProjectSystemPackage.ProjectTypeGuid,
+    projectTypeGuid: ProjectType.CSharp,
     displayName: "#1",                      // "C#"
     displayProjectFileExtensions: "#2",     // "C# Project Files (*.csproj);*.csproj"
     defaultProjectExtension: "csproj",
@@ -32,8 +32,6 @@ namespace Microsoft.VisualStudio.Packaging
     [ProvideProjectFactory(typeof(MigrateXprojProjectFactory), null, "#8", "xproj", "xproj", null)]
     internal class CSharpProjectSystemPackage : AsyncPackage
     {
-        public const string ProjectTypeGuid = "9A19103F-16F7-4668-BE54-9A1E7A4F7556";
-        public const string LegacyProjectTypeGuid = "FAE04EC0-301F-11d3-BF4B-00C04F79EFBC";
         public const string PackageGuid = "860A27C0-B665-47F3-BC12-637E16A1050A";
 
         private IVsProjectFactory _factory;

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/CSharpProjectCompatibilityProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/CSharpProjectCompatibilityProvider.cs
@@ -4,7 +4,6 @@ using System.ComponentModel.Composition;
 using System.Threading.Tasks;
 
 using Microsoft.Build.Construction;
-using Microsoft.VisualStudio.Packaging;
 using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
@@ -12,10 +11,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     /// <summary>
     ///     Checks a legacy VB project for compability with the new project system.
     /// </summary>
-    [SupportedProjectTypeGuid(CSharpProjectSystemPackage.LegacyProjectTypeGuid)]
+    [SupportedProjectTypeGuid(ProjectType.LegacyCSharp)]
     [Export(ExportContractNames.Extensions.SupportedProjectTypeGuid)]
     [Export(typeof(IFlavoredProjectCompatibilityProvider))]
-    [ProjectTypeGuidFilter(CSharpProjectSystemPackage.LegacyProjectTypeGuid)]
+    [ProjectTypeGuidFilter(ProjectType.LegacyCSharp)]
     [AppliesTo(ProjectCapabilities.AlwaysApplicable)]
     internal class CSharpProjectCompatibilityProvider : IFlavoredProjectCompatibilityProvider
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/CSharpProjectTypeGuidProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/CSharpProjectTypeGuidProvider.cs
@@ -3,8 +3,6 @@
 using System;
 using System.ComponentModel.Composition;
 
-using Microsoft.VisualStudio.Packaging;
-
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
     /// <summary>
@@ -14,8 +12,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     [AppliesTo(ProjectCapabilities.CSharp)]
     internal class CSharpProjectTypeGuidProvider : IItemTypeGuidProvider
     {
-        private static readonly Guid s_csharpProjectType = new Guid(CSharpProjectSystemPackage.LegacyProjectTypeGuid);
-
         [ImportingConstructor]
         public CSharpProjectTypeGuidProvider(UnconfiguredProject project)
         {
@@ -23,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         public Guid ProjectTypeGuid
         {
-            get { return s_csharpProjectType; }
+            get { return ProjectType.LegacyCSharpGuid; }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
@@ -7,7 +7,6 @@ using System.Runtime.InteropServices;
 
 using Microsoft.VisualStudio.Buffers.PooledObjects;
 using Microsoft.VisualStudio.IO;
-using Microsoft.VisualStudio.Packaging;
 using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
 using Microsoft.VisualStudio.Shell.Flavor;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -17,7 +16,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
 {
-    [Guid("8bb2217d-0f2d-49d1-97bc-3654ed321f3b")]
+    [Guid(ProjectType.LegacyXProj)]
     internal sealed class MigrateXprojProjectFactory : FlavoredProjectFactoryBase, IVsProjectUpgradeViaFactory, IVsProjectUpgradeViaFactory4
     {
         private readonly ProcessRunner _runner;
@@ -316,7 +315,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
 
             if (isXproj)
             {
-                migratedProjectFactory = new Guid(CSharpProjectSystemPackage.ProjectTypeGuid);
+                migratedProjectFactory = new Guid(ProjectType.CSharp);
                 upgradeProjectCapabilityFlags = (uint)(__VSPPROJECTUPGRADEVIAFACTORYFLAGS.PUVFF_BACKUPSUPPORTED | __VSPPROJECTUPGRADEVIAFACTORYFLAGS.PUVFF_COPYBACKUP);
             }
             else

--- a/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.CSharp.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
@@ -315,7 +315,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
 
             if (isXproj)
             {
-                migratedProjectFactory = new Guid(ProjectType.CSharp);
+                migratedProjectFactory = ProjectType.CSharpGuid;
                 upgradeProjectCapabilityFlags = (uint)(__VSPPROJECTUPGRADEVIAFACTORYFLAGS.PUVFF_BACKUPSUPPORTED | __VSPPROJECTUPGRADEVIAFACTORYFLAGS.PUVFF_COPYBACKUP);
             }
             else

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests/ProjectSystem/VS/FSharpProjectSelectorTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests/ProjectSystem/VS/FSharpProjectSelectorTests.cs
@@ -2,8 +2,6 @@
 
 using System.Xml.Linq;
 
-using Microsoft.VisualStudio.Packaging;
-
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
@@ -17,14 +15,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Theory]
-        [InlineData(@"<Project Sdk = ""FSharp.SDK""> </Project>", FSharpProjectSystemPackage.ProjectTypeGuid)]
-        [InlineData(@"<Project ToolsVersion=""15.0""> </Project>", FSharpProjectSystemPackage.LegacyProjectTypeGuid)]
-        [InlineData(@"<Project Sdk = ""FSharp.SDK"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003""> </Project>", FSharpProjectSystemPackage.ProjectTypeGuid)]
-        [InlineData(@"<Project ToolsVersion=""15.0"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003""> </Project>", FSharpProjectSystemPackage.LegacyProjectTypeGuid)]
-        [InlineData(@"<Project> <Import Project=""Sdk.props"" Sdk=""FSharp.Sdk"" /> </Project>", FSharpProjectSystemPackage.ProjectTypeGuid)]
-        [InlineData(@"<Project> <Import Project=""Sdk.props"" /> </Project>", FSharpProjectSystemPackage.LegacyProjectTypeGuid)]
-        [InlineData(@"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003""> <Import Project=""Sdk.props"" Sdk=""FSharp.Sdk"" /> </Project>", FSharpProjectSystemPackage.ProjectTypeGuid)]
-        [InlineData(@"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003""> <Import Project=""Sdk.props"" /> </Project>", FSharpProjectSystemPackage.LegacyProjectTypeGuid)]
+        [InlineData(@"<Project Sdk = ""FSharp.SDK""> </Project>", ProjectType.FSharp)]
+        [InlineData(@"<Project ToolsVersion=""15.0""> </Project>", ProjectType.LegacyFSharp)]
+        [InlineData(@"<Project Sdk = ""FSharp.SDK"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003""> </Project>", ProjectType.FSharp)]
+        [InlineData(@"<Project ToolsVersion=""15.0"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003""> </Project>", ProjectType.LegacyFSharp)]
+        [InlineData(@"<Project> <Import Project=""Sdk.props"" Sdk=""FSharp.Sdk"" /> </Project>", ProjectType.FSharp)]
+        [InlineData(@"<Project> <Import Project=""Sdk.props"" /> </Project>", ProjectType.LegacyFSharp)]
+        [InlineData(@"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003""> <Import Project=""Sdk.props"" Sdk=""FSharp.Sdk"" /> </Project>", ProjectType.FSharp)]
+        [InlineData(@"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003""> <Import Project=""Sdk.props"" /> </Project>", ProjectType.LegacyFSharp)]
 
         public void GetProjectFactoryGuid(string projectFile, string expectedGuid)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/Packaging/FSharpProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/Packaging/FSharpProjectSystemPackage.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;
-
+using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Packaging;
 using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.VS;
@@ -14,7 +14,7 @@ using Task = System.Threading.Tasks.Task;
 
 // Register ourselves as a CPS project type
 [assembly: ProjectTypeRegistration(
-    projectTypeGuid: FSharpProjectSystemPackage.ProjectTypeGuid,
+    projectTypeGuid: ProjectType.FSharp,
     displayName: "#1",                      // "F#"
     displayProjectFileExtensions: "#2",     // "F# Project Files (*.fsproj);*.fsproj"
     defaultProjectExtension: "fsproj",
@@ -29,8 +29,6 @@ namespace Microsoft.VisualStudio.Packaging
     [PackageRegistration(AllowsBackgroundLoading = true, RegisterUsing = RegistrationMethod.CodeBase, UseManagedResourcesOnly = true)]
     internal class FSharpProjectSystemPackage : AsyncPackage
     {
-        public const string ProjectTypeGuid = "6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705";
-        public const string LegacyProjectTypeGuid = "F2A71F9B-5D33-465A-A702-920D77279786";
         public const string PackageGuid = "a724c878-e8fd-4feb-b537-60baba7eda83";
 
         private IVsRegisterProjectSelector _projectSelectorService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/Packaging/FSharpProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/Packaging/FSharpProjectSystemPackage.cs
@@ -15,8 +15,8 @@ using Task = System.Threading.Tasks.Task;
 // Register ourselves as a CPS project type
 [assembly: ProjectTypeRegistration(
     projectTypeGuid: FSharpProjectSystemPackage.ProjectTypeGuid,
-    displayName: "#1",
-    displayProjectFileExtensions: "#2",
+    displayName: "#1",                      // "F#"
+    displayProjectFileExtensions: "#2",     // "F# Project Files (*.fsproj);*.fsproj"
     defaultProjectExtension: "fsproj",
     language: "FSharp",
     resourcePackageGuid: FSharpProjectSystemPackage.PackageGuid,

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/ProjectSystem/VS/FSharpProjectSelector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/ProjectSystem/VS/FSharpProjectSelector.cs
@@ -4,7 +4,6 @@ using System.Xml;
 using System.Xml.Linq;
 using System.Xml.XPath;
 
-using Microsoft.VisualStudio.Packaging;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 
@@ -35,11 +34,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             if (hasProjectElementWithSdkAttribute || hasImportElementWithSdkAttribute)
             {
-                guidProjectFactory = Guid.Parse(FSharpProjectSystemPackage.ProjectTypeGuid);
+                guidProjectFactory = Guid.Parse(ProjectType.FSharp);
                 return;
             }
 
-            guidProjectFactory = Guid.Parse(FSharpProjectSystemPackage.LegacyProjectTypeGuid);
+            guidProjectFactory = Guid.Parse(ProjectType.LegacyFSharp);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/ProjectSystem/VS/FSharpProjectSelector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/ProjectSystem/VS/FSharpProjectSelector.cs
@@ -34,11 +34,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             if (hasProjectElementWithSdkAttribute || hasImportElementWithSdkAttribute)
             {
-                guidProjectFactory = Guid.Parse(ProjectType.FSharp);
+                guidProjectFactory = ProjectType.FSharpGuid;
                 return;
             }
 
-            guidProjectFactory = Guid.Parse(ProjectType.LegacyFSharp);
+            guidProjectFactory = ProjectType.LegacyFSharpGuid;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/ProjectSystem/VS/FSharpProjectTypeGuidProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.FSharp.VS/ProjectSystem/VS/FSharpProjectTypeGuidProvider.cs
@@ -3,8 +3,6 @@
 using System;
 using System.ComponentModel.Composition;
 
-using Microsoft.VisualStudio.Packaging;
-
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
     /// <summary>
@@ -14,8 +12,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     [AppliesTo(ProjectCapability.FSharp)]
     internal class FSharpProjectTypeGuidProvider : IItemTypeGuidProvider
     {
-        private static readonly Guid s_fsharpProjectType = new Guid(FSharpProjectSystemPackage.LegacyProjectTypeGuid);
-
         [ImportingConstructor]
         public FSharpProjectTypeGuidProvider(UnconfiguredProject project)
         {
@@ -23,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         public Guid ProjectTypeGuid
         {
-            get { return s_fsharpProjectType; }
+            get { return ProjectType.LegacyFSharpGuid; }
         }
 
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -25,6 +25,7 @@
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.CSharp.VS.UnitTests" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.UnitTests" />
+    <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.FSharp.VS.UnitTests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/ProjectType.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/ProjectType.cs
@@ -37,6 +37,11 @@ namespace Microsoft.VisualStudio
         public const string CSharp = "9A19103F-16F7-4668-BE54-9A1E7A4F7556";
 
         /// <summary>
+        ///     A <see cref="Guid"/> representing the C# project type based on the Common Project System (CPS).
+        /// </summary>
+        public static readonly Guid CSharpGuid = new Guid(CSharp);
+
+        /// <summary>
         ///     A <see cref="string"/> representing the legacy C# project type based on the native project system in csproj.dll.
         /// </summary>
         public const string LegacyCSharp = "FAE04EC0-301F-11d3-BF4B-00C04F79EFBC";
@@ -50,6 +55,11 @@ namespace Microsoft.VisualStudio
         ///     A <see cref="string"/> representing the F# project type based on the Common Project System (CPS).
         /// </summary>
         public const string FSharp = "6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705";
+
+        /// <summary>
+        ///     A <see cref="Guid"/> representing the F# project type based on the Common Project System (CPS).
+        /// </summary>
+        public static readonly Guid FSharpGuid = new Guid(FSharp);
 
         /// <summary>
         ///     A <see cref="string"/> representing the legacy F# project type based on the Managed Package Framework (MPF).

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/ProjectType.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/ProjectType.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.VisualStudio
+{
+    /// <summary>
+    ///     Represents the managed project types in Visual Studio.
+    /// </summary>
+    /// <remarks>
+    ///     A project type points to a factory that implements <see cref="IVsProjectFactory"/> and is responsible for creating an in-memory 
+    ///     representation (implementing <see cref="IVsHierarchy"/>, <see cref="IVsProject"/>) that features through out Visual Studio 
+    ///     interact with.
+    /// </remarks>
+    internal static class ProjectType
+    {
+        /// <summary>
+        ///     A <see cref="string"/> representing the Visual Basic project type based on the Common Project System (CPS).
+        /// </summary>
+        public const string VisualBasic = "778DAE3C-4631-46EA-AA77-85C1314464D9";
+
+        /// <summary>
+        ///     A <see cref="string"/> representing the legacy Visual Basic project type based on the native project system in msvbprj.dll.
+        /// </summary>
+        public const string LegacyVisualBasic = "F184B08F-C81C-45F6-A57F-5ABD9991F28F";
+
+        /// <summary>
+        ///     A <see cref="Guid"/> representing the legacy Visual Basic project type based on the native project system in msvbprj.dll.
+        /// </summary>
+        public static readonly Guid LegacyVisualBasicGuid = new Guid(LegacyVisualBasic);
+
+        /// <summary>
+        ///     A <see cref="string"/> representing the C# project type based on the Common Project System (CPS).
+        /// </summary>
+        public const string CSharp = "9A19103F-16F7-4668-BE54-9A1E7A4F7556";
+
+        /// <summary>
+        ///     A <see cref="string"/> representing the legacy C# project type based on the native project system in csproj.dll.
+        /// </summary>
+        public const string LegacyCSharp = "FAE04EC0-301F-11d3-BF4B-00C04F79EFBC";
+
+        /// <summary>
+        ///     A <see cref="Guid"/> representing the legacy C# project type based on the native project system in csproj.dll.
+        /// </summary>
+        public static readonly Guid LegacyCSharpGuid = new Guid(LegacyCSharp);
+
+        /// <summary>
+        ///     A <see cref="string"/> representing the F# project type based on the Common Project System (CPS).
+        /// </summary>
+        public const string FSharp = "6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705";
+
+        /// <summary>
+        ///     A <see cref="string"/> representing the legacy F# project type based on the Managed Package Framework (MPF).
+        /// </summary>
+        public const string LegacyFSharp = "F2A71F9B-5D33-465A-A702-920D77279786";
+
+        /// <summary>
+        ///     A <see cref="Guid"/> representing the legacy F# project type based on the Managed Package Framework (MPF).
+        /// </summary>
+        public static readonly Guid LegacyFSharpGuid = new Guid(LegacyFSharp);
+
+        /// <summary>
+        ///     A <see cref="string"/> representing the legacy C# (xproj) project type based on the Common Project System (CPS).
+        /// </summary>
+        public const string LegacyXProj = "8BB2217D-0F2D-49D1-97BC-3654ED321F3B";
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/Packaging/VisualBasicProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/Packaging/VisualBasicProjectSystemPackage.cs
@@ -10,8 +10,8 @@ using Microsoft.VisualStudio.Shell;
 // Register ourselves as a CPS project type
 [assembly: ProjectTypeRegistration(
     projectTypeGuid: VisualBasicProjectSystemPackage.ProjectTypeGuid,
-    displayName: "#1",
-    displayProjectFileExtensions: "#2",
+    displayName: "#1",                      // "Visual Basic"
+    displayProjectFileExtensions: "#2",     // "Visual Basic Project Files (*.vbproj);*.vbproj"
     defaultProjectExtension: "vbproj",
     language: "VisualBasic",
     resourcePackageGuid: VisualBasicProjectSystemPackage.PackageGuid,

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/Packaging/VisualBasicProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/Packaging/VisualBasicProjectSystemPackage.cs
@@ -2,6 +2,7 @@
 
 using System.Runtime.InteropServices;
 
+using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Packaging;
 using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.VS;
@@ -9,7 +10,7 @@ using Microsoft.VisualStudio.Shell;
 
 // Register ourselves as a CPS project type
 [assembly: ProjectTypeRegistration(
-    projectTypeGuid: VisualBasicProjectSystemPackage.ProjectTypeGuid,
+    projectTypeGuid: ProjectType.VisualBasic,
     displayName: "#1",                      // "Visual Basic"
     displayProjectFileExtensions: "#2",     // "Visual Basic Project Files (*.vbproj);*.vbproj"
     defaultProjectExtension: "vbproj",
@@ -24,8 +25,6 @@ namespace Microsoft.VisualStudio.Packaging
     [PackageRegistration(AllowsBackgroundLoading = true, RegisterUsing = RegistrationMethod.CodeBase, UseManagedResourcesOnly = true)]
     internal class VisualBasicProjectSystemPackage : AsyncPackage
     {
-        public const string ProjectTypeGuid = "778DAE3C-4631-46EA-AA77-85C1314464D9";
-        public const string LegacyProjectTypeGuid = "F184B08F-C81C-45F6-A57F-5ABD9991F28F";
         public const string PackageGuid = "D15F5C78-D04F-45FD-AEA2-D7982D8FA429";
 
         public VisualBasicProjectSystemPackage()

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/VisualBasicProjectCompatibilityProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/VisualBasicProjectCompatibilityProvider.cs
@@ -4,7 +4,6 @@ using System.ComponentModel.Composition;
 using System.Threading.Tasks;
 
 using Microsoft.Build.Construction;
-using Microsoft.VisualStudio.Packaging;
 using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
@@ -12,10 +11,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     /// <summary>
     ///     Checks a legacy C# project for compability with the new project system.
     /// </summary>
-    [SupportedProjectTypeGuid(VisualBasicProjectSystemPackage.LegacyProjectTypeGuid)]
+    [SupportedProjectTypeGuid(ProjectType.LegacyVisualBasic)]
     [Export(ExportContractNames.Extensions.SupportedProjectTypeGuid)]
     [Export(typeof(IFlavoredProjectCompatibilityProvider))]
-    [ProjectTypeGuidFilter(VisualBasicProjectSystemPackage.LegacyProjectTypeGuid)]
+    [ProjectTypeGuidFilter(ProjectType.LegacyVisualBasic)]
     [AppliesTo(ProjectCapabilities.AlwaysApplicable)]
     internal class VisualBasicProjectCompatibilityProvider : IFlavoredProjectCompatibilityProvider
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/VisualBasicProjectTypeGuidProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/ProjectSystem/VS/VisualBasicProjectTypeGuidProvider.cs
@@ -3,8 +3,6 @@
 using System;
 using System.ComponentModel.Composition;
 
-using Microsoft.VisualStudio.Packaging;
-
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
     /// <summary>
@@ -14,8 +12,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     [AppliesTo(ProjectCapabilities.VB)]
     internal class VisualBasicProjectTypeGuidProvider : IItemTypeGuidProvider
     {
-        private static readonly Guid s_visualBasicProjectType = new Guid(VisualBasicProjectSystemPackage.LegacyProjectTypeGuid);
-
         [ImportingConstructor]
         public VisualBasicProjectTypeGuidProvider(UnconfiguredProject project)
         {
@@ -23,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         public Guid ProjectTypeGuid
         {
-            get { return s_visualBasicProjectType; }
+            get { return ProjectType.LegacyVisualBasicGuid; }
         }
     }
 }


### PR DESCRIPTION
In preparation for merging of the language-specific dlls & packages, centralize ProjectType GUID definitions into a single type.