### PR TITLE
Remove VisualBasicProjectSystemPackage

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ProjectTypeRegistration.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ProjectTypeRegistration.cs
@@ -1,34 +1,17 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Runtime.InteropServices;
-
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Packaging;
 using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.VS;
-using Microsoft.VisualStudio.Shell;
 
-// Register ourselves as a CPS project type
+// Visual Basic
 [assembly: ProjectTypeRegistration(
     projectTypeGuid: ProjectType.VisualBasic,
     displayName: "#1",                      // "Visual Basic"
     displayProjectFileExtensions: "#2",     // "Visual Basic Project Files (*.vbproj);*.vbproj"
     defaultProjectExtension: "vbproj",
     language: "VisualBasic",
-    resourcePackageGuid: VisualBasicProjectSystemPackage.PackageGuid,
+    resourcePackageGuid: ManagedProjectSystemPackage.PackageGuid,
     Capabilities = ManagedProjectSystemPackage.DefaultCapabilities + "; " + ProjectCapability.VisualBasic,
     DisableAsynchronousProjectTreeLoad = true)]
-
-namespace Microsoft.VisualStudio.Packaging
-{
-    [Guid("D15F5C78-D04F-45FD-AEA2-D7982D8FA429")]
-    [PackageRegistration(AllowsBackgroundLoading = true, RegisterUsing = RegistrationMethod.CodeBase, UseManagedResourcesOnly = true)]
-    internal class VisualBasicProjectSystemPackage : AsyncPackage
-    {
-        public const string PackageGuid = "D15F5C78-D04F-45FD-AEA2-D7982D8FA429";
-
-        public VisualBasicProjectSystemPackage()
-        {
-        }
-    }
-}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSPackage.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSPackage.resx
@@ -117,10 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="#1" xml:space="preserve">
+  <data name="1" xml:space="preserve">
     <value>Visual Basic</value>
   </data>
-  <data name="#2" xml:space="preserve">
+  <data name="2" xml:space="preserve">
     <value>Visual Basic Project Files (*.vbproj);*.vbproj</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.cs.xlf
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="it" original="../VSPackage.resx">
+  <file datatype="xml" source-language="en" target-language="cs" original="../VSPackage.resx">
     <body>
-      <trans-unit id="#1">
+      <trans-unit id="1">
         <source>Visual Basic</source>
         <target state="translated">Visual Basic</target>
         <note />
       </trans-unit>
-      <trans-unit id="#2">
+      <trans-unit id="2">
         <source>Visual Basic Project Files (*.vbproj);*.vbproj</source>
-        <target state="translated">File di progetto Visual Basic (*.vbproj);*.vbproj</target>
+        <target state="translated">Soubory projektu Visual Basicu (*.vbproj);*.vbproj</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.de.xlf
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="fr" original="../VSPackage.resx">
+  <file datatype="xml" source-language="en" target-language="de" original="../VSPackage.resx">
     <body>
-      <trans-unit id="#1">
+      <trans-unit id="1">
         <source>Visual Basic</source>
         <target state="translated">Visual Basic</target>
         <note />
       </trans-unit>
-      <trans-unit id="#2">
+      <trans-unit id="2">
         <source>Visual Basic Project Files (*.vbproj);*.vbproj</source>
-        <target state="translated">Fichiers projet Visual Basic (*.vbproj);*.vbproj</target>
+        <target state="translated">Visual Basic-Projektdateien (*.vbproj);*.vbproj</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.es.xlf
@@ -2,12 +2,12 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../VSPackage.resx">
     <body>
-      <trans-unit id="#1">
+      <trans-unit id="1">
         <source>Visual Basic</source>
         <target state="translated">Visual Basic</target>
         <note />
       </trans-unit>
-      <trans-unit id="#2">
+      <trans-unit id="2">
         <source>Visual Basic Project Files (*.vbproj);*.vbproj</source>
         <target state="translated">Archivos de proyecto de Visual Basic (*.vbproj);*.vbproj</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.fr.xlf
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="ja" original="../VSPackage.resx">
+  <file datatype="xml" source-language="en" target-language="fr" original="../VSPackage.resx">
     <body>
-      <trans-unit id="#1">
+      <trans-unit id="1">
         <source>Visual Basic</source>
         <target state="translated">Visual Basic</target>
         <note />
       </trans-unit>
-      <trans-unit id="#2">
+      <trans-unit id="2">
         <source>Visual Basic Project Files (*.vbproj);*.vbproj</source>
-        <target state="translated">Visual Basic プロジェクト ファイル (*.vbproj);*.vbproj</target>
+        <target state="translated">Fichiers projet Visual Basic (*.vbproj);*.vbproj</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.it.xlf
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="pl" original="../VSPackage.resx">
+  <file datatype="xml" source-language="en" target-language="it" original="../VSPackage.resx">
     <body>
-      <trans-unit id="#1">
+      <trans-unit id="1">
         <source>Visual Basic</source>
         <target state="translated">Visual Basic</target>
         <note />
       </trans-unit>
-      <trans-unit id="#2">
+      <trans-unit id="2">
         <source>Visual Basic Project Files (*.vbproj);*.vbproj</source>
-        <target state="translated">Pliki projektu Visual Basic (*.vbproj);*.vbproj</target>
+        <target state="translated">File di progetto Visual Basic (*.vbproj);*.vbproj</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.ja.xlf
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="cs" original="../VSPackage.resx">
+  <file datatype="xml" source-language="en" target-language="ja" original="../VSPackage.resx">
     <body>
-      <trans-unit id="#1">
+      <trans-unit id="1">
         <source>Visual Basic</source>
         <target state="translated">Visual Basic</target>
         <note />
       </trans-unit>
-      <trans-unit id="#2">
+      <trans-unit id="2">
         <source>Visual Basic Project Files (*.vbproj);*.vbproj</source>
-        <target state="translated">Soubory projektu Visual Basicu (*.vbproj);*.vbproj</target>
+        <target state="translated">Visual Basic プロジェクト ファイル (*.vbproj);*.vbproj</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.ko.xlf
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="de" original="../VSPackage.resx">
+  <file datatype="xml" source-language="en" target-language="ko" original="../VSPackage.resx">
     <body>
-      <trans-unit id="#1">
+      <trans-unit id="1">
         <source>Visual Basic</source>
         <target state="translated">Visual Basic</target>
         <note />
       </trans-unit>
-      <trans-unit id="#2">
+      <trans-unit id="2">
         <source>Visual Basic Project Files (*.vbproj);*.vbproj</source>
-        <target state="translated">Visual Basic-Projektdateien (*.vbproj);*.vbproj</target>
+        <target state="translated">Visual Basic 프로젝트 파일(*.vbproj);*.vbproj</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.pl.xlf
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../VSPackage.resx">
+  <file datatype="xml" source-language="en" target-language="pl" original="../VSPackage.resx">
     <body>
-      <trans-unit id="#1">
+      <trans-unit id="1">
         <source>Visual Basic</source>
         <target state="translated">Visual Basic</target>
         <note />
       </trans-unit>
-      <trans-unit id="#2">
+      <trans-unit id="2">
         <source>Visual Basic Project Files (*.vbproj);*.vbproj</source>
-        <target state="translated">Visual Basic 项目文件(*.vbproj);*.vbproj</target>
+        <target state="translated">Pliki projektu Visual Basic (*.vbproj);*.vbproj</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.pt-BR.xlf
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="ru" original="../VSPackage.resx">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../VSPackage.resx">
     <body>
-      <trans-unit id="#1">
+      <trans-unit id="1">
         <source>Visual Basic</source>
         <target state="translated">Visual Basic</target>
         <note />
       </trans-unit>
-      <trans-unit id="#2">
+      <trans-unit id="2">
         <source>Visual Basic Project Files (*.vbproj);*.vbproj</source>
-        <target state="translated">Файлы проектов Visual Basic (*.vbproj);*.vbproj</target>
+        <target state="translated">Arquivos de Projeto do Visual Basic (*.vbproj);*.vbproj</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.ru.xlf
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="ko" original="../VSPackage.resx">
+  <file datatype="xml" source-language="en" target-language="ru" original="../VSPackage.resx">
     <body>
-      <trans-unit id="#1">
+      <trans-unit id="1">
         <source>Visual Basic</source>
         <target state="translated">Visual Basic</target>
         <note />
       </trans-unit>
-      <trans-unit id="#2">
+      <trans-unit id="2">
         <source>Visual Basic Project Files (*.vbproj);*.vbproj</source>
-        <target state="translated">Visual Basic 프로젝트 파일(*.vbproj);*.vbproj</target>
+        <target state="translated">Файлы проектов Visual Basic (*.vbproj);*.vbproj</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.tr.xlf
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="pt-BR" original="../VSPackage.resx">
+  <file datatype="xml" source-language="en" target-language="tr" original="../VSPackage.resx">
     <body>
-      <trans-unit id="#1">
+      <trans-unit id="1">
         <source>Visual Basic</source>
         <target state="translated">Visual Basic</target>
         <note />
       </trans-unit>
-      <trans-unit id="#2">
+      <trans-unit id="2">
         <source>Visual Basic Project Files (*.vbproj);*.vbproj</source>
-        <target state="translated">Arquivos de Projeto do Visual Basic (*.vbproj);*.vbproj</target>
+        <target state="translated">Visual Basic Proje Dosyaları (*.vbproj);*.vbproj</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.zh-Hans.xlf
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
-  <file datatype="xml" source-language="en" target-language="tr" original="../VSPackage.resx">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../VSPackage.resx">
     <body>
-      <trans-unit id="#1">
+      <trans-unit id="1">
         <source>Visual Basic</source>
         <target state="translated">Visual Basic</target>
         <note />
       </trans-unit>
-      <trans-unit id="#2">
+      <trans-unit id="2">
         <source>Visual Basic Project Files (*.vbproj);*.vbproj</source>
-        <target state="translated">Visual Basic Proje Dosyaları (*.vbproj);*.vbproj</target>
+        <target state="translated">Visual Basic 项目文件(*.vbproj);*.vbproj</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.zh-Hant.xlf
@@ -2,12 +2,12 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../VSPackage.resx">
     <body>
-      <trans-unit id="#1">
+      <trans-unit id="1">
         <source>Visual Basic</source>
         <target state="translated">Visual Basic</target>
         <note />
       </trans-unit>
-      <trans-unit id="#2">
+      <trans-unit id="2">
         <source>Visual Basic Project Files (*.vbproj);*.vbproj</source>
         <target state="translated">Visual Basic 專案檔 (*.vbproj);*.vbproj</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS/Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
     <!-- VSIX -->
-    <GeneratePkgDefFile>true</GeneratePkgDefFile>
+    <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <CreateVsixContainer>false</CreateVsixContainer>
   </PropertyGroup>
   <ItemGroup>
@@ -27,7 +27,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="xlf\*" />
-    <EmbeddedResource Update="VSPackage.resx" />
     <EmbeddedResource Update="VisualBasicVSResources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>VisualBasicVSResources.Designer.cs</LastGenOutput>

--- a/src/ProjectSystemSetup/ProjectSystemSetup.csproj
+++ b/src/ProjectSystemSetup/ProjectSystemSetup.csproj
@@ -40,7 +40,7 @@
     </ProjectReference>
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS\Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS.csproj">
       <Name>Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS</Name>
-      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;GetCopyToOutputDirectoryItems;SatelliteDllsProjectOutputGroup;PkgdefProjectOutputGroup</IncludeOutputGroupsInVSIX>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;GetCopyToOutputDirectoryItems;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
     </ProjectReference>
     <ProjectReference Include="..\VisualStudioEditorsSetup\VisualStudioEditorsSetup.csproj">

--- a/src/ProjectSystemSetup/source.extension.vsixmanifest
+++ b/src/ProjectSystemSetup/source.extension.vsixmanifest
@@ -28,7 +28,6 @@
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="ProjectSelectors.pkgdef" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="Microsoft.VisualStudio.ProjectSystem.CSharp.VS" Path="|Microsoft.VisualStudio.ProjectSystem.CSharp.VS;PkgdefProjectOutputGroup|" />
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS" Path="|Microsoft.VisualStudio.ProjectSystem.VisualBasic.VS;PkgdefProjectOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="Microsoft.VisualStudio.ProjectSystem.FSharp.VS" Path="|Microsoft.VisualStudio.ProjectSystem.FSharp.VS;PkgdefProjectOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="Microsoft.VisualStudio.ProjectSystem.Managed.VS" Path="|Microsoft.VisualStudio.ProjectSystem.Managed.VS;PkgdefProjectOutputGroup|" />
   </Assets>


### PR DESCRIPTION
Fixes part of https://github.com/dotnet/project-system/issues/3817.

This package was never used and was solely present to find two strings. Delete package and move registration to Managed.VS.