### PR TITLE
Clean and sort rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,9 @@ indent_size = 4
 insert_final_newline = true
 charset = utf-8-bom
 
+[*.xaml]
+indent_size = 2
+
 [*.ps1]
 indent_size = 2
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AnalyzerReference.xaml
@@ -4,7 +4,7 @@
       Description="Analyzer Properties"
       DisplayName="Analyzer Reference"
       PageTemplate="generic"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="Analyzer"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AnalyzerReference.xaml
@@ -1,15 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Rule
-    Name="AnalyzerReference"
-    DisplayName="Analyzer Reference"
-    PageTemplate="generic"
-    Description="Analyzer Properties"
-    xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="AnalyzerReference"
+      Description="Analyzer Properties"
+      DisplayName="Analyzer Reference"
+      PageTemplate="generic"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="Analyzer" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext"
-                SourceType="TargetResults" MSBuildTarget="CollectAnalyzersDesignTime"/>
+    <DataSource HasConfigurationCondition="False"
+                ItemType="Analyzer"
+                MSBuildTarget="CollectAnalyzersDesignTime"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext"
+                SourceType="TargetResults" />
   </Rule.DataSource>
-  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
-  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
+
+  <StringProperty Name="IsImplicitlyDefined"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <BoolProperty Name="Visible"
+                ReadOnly="True"
+                Visible="False" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AppDesigner.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AppDesigner.xaml
@@ -1,27 +1,37 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Rule
-    Name="AppDesigner"
-    PageTemplate="generic"
-    xmlns="http://schemas.microsoft.com/build/2009/properties">
-
+<Rule Name="AppDesigner"
+      PageTemplate="generic"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" Label="Configuration" SourceOfDefaultValue="AfterContext" />
+    <DataSource Label="Configuration"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <StringProperty Name="FolderName" Visible="false" Default="Properties">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" Label="Configuration" HasConfigurationCondition="false"
-                  PersistedName="AppDesignerFolder" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-
-
-  <BoolProperty  Name="ContentsVisibleOnlyInShowAllFiles" Visible="false" Default="false" ReadOnly="true">
+  <BoolProperty Name="ContentsVisibleOnlyInShowAllFiles"
+                Default="false"
+                ReadOnly="true"
+                Visible="false">
     <BoolProperty.DataSource>
-      <DataSource Persistence="ProjectFile" Label="Configuration" HasConfigurationCondition="false"
-                  PersistedName="AppDesignerFolderContentsVisibleOnlyInShowAllFiles" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="false"
+                  Label="Configuration"
+                  PersistedName="AppDesignerFolderContentsVisibleOnlyInShowAllFiles"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
     </BoolProperty.DataSource>
   </BoolProperty>
+
+  <StringProperty Name="FolderName"
+                  Default="Properties"
+                  Visible="false">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="false"
+                  Label="Configuration"
+                  PersistedName="AppDesignerFolder"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AppDesigner.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AppDesigner.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="AppDesigner"
       PageTemplate="generic"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource Label="Configuration"
                 Persistence="ProjectFile"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AssemblyReference.xaml
@@ -1,97 +1,96 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Rule
-    Name="AssemblyReference"
-    DisplayName="Assembly Reference"
-    PageTemplate="generic"
-    Description="Reference Properties"
-    xmlns="http://schemas.microsoft.com/build/2009/properties">
-
+<Rule Name="AssemblyReference"
+      Description="Reference Properties"
+      DisplayName="Assembly Reference"
+      PageTemplate="generic"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile"
+    <DataSource HasConfigurationCondition="False"
                 ItemType="Reference"
-                HasConfigurationCondition="False"
+                Persistence="ProjectFile"
                 SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <!-- Visible properties -->
-
   <StringListProperty Name="Aliases"
-                      DisplayName="Aliases"
                       Description="A comma-delimited list of aliases to this reference."
+                      DisplayName="Aliases"
                       Separator="," />
 
   <BoolProperty Name="CopyLocal"
-                DisplayName="Copy Local"
-                Description="Indicates whether the reference will be copied to the output directory.">
+                Description="Indicates whether the reference will be copied to the output directory."
+                DisplayName="Copy Local">
     <BoolProperty.DataSource>
-      <DataSource Persistence="ProjectFile"
+      <DataSource HasConfigurationCondition="False"
                   ItemType="Reference"
-                  HasConfigurationCondition="False"
                   PersistedName="Private"
+                  Persistence="ProjectFile"
                   SourceOfDefaultValue="AfterContext" />
     </BoolProperty.DataSource>
   </BoolProperty>
 
   <BoolProperty Name="EmbedInteropTypes"
-                DisplayName="Embed Interop Types"
-                Description="Indicates whether types defined in this assembly will be embedded into the target assembly." />
+                Description="Indicates whether types defined in this assembly will be embedded into the target assembly."
+                DisplayName="Embed Interop Types" />
+
+  <StringProperty Name="HintPath"
+                  Visible="false" />
 
   <StringProperty Name="Identity"
-                  ReadOnly="True"
+                  Description="Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence)."
                   DisplayName="Identity"
-                  Description="Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).">
+                  ReadOnly="True">
     <StringProperty.DataSource>
       <DataSource PersistedName="{}{Identity}"
                   SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="ResolvedPath"
+  <StringProperty Name="ImageRuntime"
                   ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="IsImplicitlyDefined"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <BoolProperty Name="IsWinMDFile"
+                Visible="false" />
+
+  <StringProperty Name="RequiredTargetFramework"
+                  Visible="False" />
+
+  <StringProperty Name="ResolvedPath"
+                  Description="Location of the file being referenced."
                   DisplayName="Path"
-                  Description="Location of the file being referenced.">
+                  ReadOnly="True">
     <StringProperty.DataSource>
       <DataSource PersistedName="Identity"
                   SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
+  <StringProperty Name="SDKName"
+                  Visible="false" />
+
   <BoolProperty Name="SpecificVersion"
-                DisplayName="Specific Version"
-                Description="Indicates whether this assembly can be resolved without regard to multi-targeting rules for assembly resolution.">
+                Description="Indicates whether this assembly can be resolved without regard to multi-targeting rules for assembly resolution."
+                DisplayName="Specific Version">
     <BoolProperty.DataSource>
-      <DataSource Persistence="AssemblyReference"
+      <DataSource HasConfigurationCondition="False"
                   ItemType="Reference"
-                  HasConfigurationCondition="False"
+                  Persistence="AssemblyReference"
                   SourceOfDefaultValue="AfterContext" />
     </BoolProperty.DataSource>
   </BoolProperty>
 
   <StringProperty Name="Version"
-                  ReadOnly="True"
+                  Description="Version of reference."
                   DisplayName="Version"
-                  Description="Version of reference.">
-  </StringProperty>
-
-  <!-- Hidden properties -->
-
-  <StringProperty Name="HintPath" Visible="false" />
-
-  <StringProperty Name="ImageRuntime"
-                  Visible="False"
                   ReadOnly="True" />
 
-  <StringProperty Name="IsImplicitlyDefined"
-                  Visible="False"
-                  ReadOnly="True" />
+  <BoolProperty Name="Visible"
+                ReadOnly="True"
+                Visible="False" />
 
-  <BoolProperty Name="IsWinMDFile" Visible="false" />
-
-  <StringProperty Name="RequiredTargetFramework"
-                  Visible="False" />
-
-  <StringProperty Name="SDKName" Visible="false" />
-
-  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AssemblyReference.xaml
@@ -4,7 +4,7 @@
       Description="Reference Properties"
       DisplayName="Assembly Reference"
       PageTemplate="generic"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="Reference"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/COMReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/COMReference.xaml
@@ -1,15 +1,39 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Rule Name="ComReference" DisplayName="COM Reference" PageTemplate="generic" Description="COM Reference Properties" xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="ComReference"
+      Description="COM Reference Properties"
+      DisplayName="COM Reference"
+      PageTemplate="generic"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="COMReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                ItemType="COMReference"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-  <StringProperty Name="Guid" DisplayName="CLSID" Description="The GUID of the COM server." />
-  <StringProperty Name="Lcid" DisplayName="Locale" Description="The LCID of the COM server." />
-  <IntProperty Name="VersionMajor" />
-  <IntProperty Name="VersionMinor" />
+
+  <StringProperty Name="Guid"
+                  Description="The GUID of the COM server."
+                  DisplayName="CLSID" />
+
+  <StringProperty Name="IsImplicitlyDefined"
+                  ReadOnly="True"
+                  Visible="False" />
+
   <BoolProperty Name="Isolated" />
+
+  <StringProperty Name="Lcid"
+                  Description="The LCID of the COM server."
+                  DisplayName="Locale" />
+
+  <IntProperty Name="VersionMajor" />
+
+  <IntProperty Name="VersionMinor" />
+
+  <BoolProperty Name="Visible"
+                ReadOnly="True"
+                Visible="False" />
+
   <StringProperty Name="WrapperTool" />
-  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
-  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/COMReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/COMReference.xaml
@@ -4,7 +4,7 @@
       Description="COM Reference Properties"
       DisplayName="COM Reference"
       PageTemplate="generic"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="COMReference"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CompilerCommandLineArgs.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CompilerCommandLineArgs.xaml
@@ -1,14 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Rule
-    Name="CompilerCommandLineArgs"
-    PageTemplate="generic"
-    xmlns="http://schemas.microsoft.com/build/2009/properties">
-
-  <!-- Rule represents the CompilerCommandLineArgs item containing the split arguments that we get back from CompileDesignTime  -->
+<Rule Name="CompilerCommandLineArgs"
+      PageTemplate="generic"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="CompilerCommandLineArgs " ItemType="CompilerCommandLineArgs " HasConfigurationCondition="False"
-                SourceType="TargetResults" MSBuildTarget="CompileDesignTime" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                ItemType="CompilerCommandLineArgs "
+                MSBuildTarget="CompileDesignTime"
+                Persistence="CompilerCommandLineArgs "
+                SourceOfDefaultValue="AfterContext"
+                SourceType="TargetResults" />
   </Rule.DataSource>
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CompilerCommandLineArgs.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CompilerCommandLineArgs.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="CompilerCommandLineArgs"
       PageTemplate="generic"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="CompilerCommandLineArgs "

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -1,141 +1,311 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Rule
-	Name="ConfigurationGeneral"
-	DisplayName="General"
-	PageTemplate="generic"
-	Description="General"
-    OverrideMode="Replace"
-	xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="ConfigurationGeneral"
+      Description="General"
+      DisplayName="General"
+      OverrideMode="Replace"
+      PageTemplate="generic"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
-    <Category Name="General" DisplayName="General" Description="General" />
+    <Category Name="General"
+              Description="General"
+              DisplayName="General" />
   </Rule.Categories>
+
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" Label="Configuration" SourceOfDefaultValue="AfterContext" />
+    <DataSource Label="Configuration"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-  <StringProperty Name="ApplicationIcon" DisplayName="Application Icon" />
-  <StringListProperty Name="ProjectTypeGuids" Visible="False" />
-  <StringProperty Name="TargetFrameworkIdentifier" DisplayName="Target Framework Identifier">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="TargetFrameworkIdentifier" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="TargetFrameworks" DisplayName="Target Frameworks">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="TargetFrameworks" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="TargetFramework" DisplayName="Target Framework">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="TargetFramework" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="TargetFrameworkProfile" DisplayName="Target Framework Profile">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="TargetFrameworkProfile" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="TargetFrameworkVersion" DisplayName="Target Framework Version">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="TargetFrameworkVersion" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="TargetFrameworkMoniker" DisplayName="Target Framework Moniker">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileWithInterceptionViaSnapshot" PersistedName="TargetFrameworkMoniker" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="TargetFrameworkMonikers" DisplayName="Target Framework Monikers" ReadOnly="True">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileWithInterception" PersistedName="TargetFrameworkMonikers" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext"/>
-    </StringProperty.DataSource>
-  </StringProperty>
-  <BoolProperty Name="DisableFastUpToDateCheck" DisplayName="Disable Fast Up To Date Check">
+
+  <StringProperty Name="AddItemTemplatesGuid"
+                  Visible="False" />
+
+  <BoolProperty Name="AlwaysUseNumericalSuffixInItemNames"
+                Visible="False" />
+
+  <StringProperty Name="ApplicationIcon"
+                  DisplayName="Application Icon" />
+
+  <StringProperty Name="AssemblyName" />
+
+  <StringProperty Name="AssemblyReferenceTabs"
+                  Visible="false" />
+
+  <StringProperty Name="AssemblySearchPaths"
+                  Visible="false" />
+
+  <BoolProperty Name="AutoRefresh"
+                Visible="False">
     <BoolProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="DisableFastUpToDateCheck" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False"
+                  Persistence="UserFile"
+                  SourceOfDefaultValue="AfterContext" />
     </BoolProperty.DataSource>
   </BoolProperty>
 
-  <StringProperty Name="TargetPath" />
-  <StringProperty Name="DocumentationFile" DisplayName="XML doc comments file" />
-  <StringProperty Name="AssemblyName" />
-  <StringProperty Name="Name" />
-  <StringProperty Name="RootNamespace" DisplayName="Root namespace">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" Label="Configuration" HasConfigurationCondition="false" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="OutputName" />
-  <StringProperty Name="OutputPath" />
+  <StringListProperty Name="AvailablePlatforms"
+                      Separator="," />
+
   <StringProperty Name="BaseIntermediateOutputPath" />
+
+  <StringProperty Name="Configuration"
+                  Visible="false" />
+
+  <StringProperty Name="DebuggerSymbolsPath"
+                  Visible="false" />
+
+  <StringProperty Name="DefaultContentType"
+                  Description="The default content type name to use when adding files."
+                  Visible="false" />
+
+  <StringProperty Name="DefaultPlatform"
+                  Visible="false" />
+
+  <BoolProperty Name="DisableFastUpToDateCheck"
+                DisplayName="Disable Fast Up To Date Check">
+    <BoolProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="DisableFastUpToDateCheck"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </BoolProperty.DataSource>
+  </BoolProperty>
+
+  <StringProperty Name="DocumentationFile"
+                  DisplayName="XML doc comments file" />
+
+  <StringProperty Name="IntDir"
+                  Visible="false" />
+
+  <StringProperty Name="LanguageServiceId"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="LanguageServiceName"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="MinimumVisualStudioVersion"
+                  Visible="false" />
+
+  <StringProperty Name="MSBuildAllProjects"
+                  Visible="false" />
+
+  <StringProperty Name="MSBuildProjectDirectory"
+                  Visible="false" />
+
+  <StringProperty Name="MSBuildProjectFullPath"
+                  Visible="false" />
+
+  <StringProperty Name="Name" />
+
+  <StringProperty Name="NETCoreSdkVersion"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="OneAppCapabilities"
+                  Visible="False" />
+
+  <BoolProperty Name="Optimize"
+                Description="Should compiler optimize output?" />
+
+  <StringProperty Name="OutputName" />
+
+  <StringProperty Name="OutputPath" />
+
   <EnumProperty Name="OutputType">
-    <EnumValue Name="Library" DisplayName="Class Library" />
-    <EnumValue Name="Exe" DisplayName="Console Application" />
-    <EnumValue Name="WinExe" DisplayName="Windows Application" />
-    <EnumValue Name="AppContainerExe" DisplayName="Windows Store app" />
-    <EnumValue Name="WinMDObj" DisplayName="WinMD" />
+    <EnumValue Name="Library"
+               DisplayName="Class Library" />
+    <EnumValue Name="Exe"
+               DisplayName="Console Application" />
+    <EnumValue Name="WinExe"
+               DisplayName="Windows Application" />
+    <EnumValue Name="AppContainerExe"
+               DisplayName="Windows Store app" />
+    <EnumValue Name="WinMDObj"
+               DisplayName="WinMD" />
     <EnumProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="OutputType" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="OutputType"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
     </EnumProperty.DataSource>
   </EnumProperty>
-  <StringListProperty Name="AvailablePlatforms" Separator="," />
-  <BoolProperty Name="Optimize" Description="Should compiler optimize output?" />
-  <!-- Same as MSBuildProjectDirectory but has a directory separator '\' appended at the end.-->
-  <StringProperty Name="ProjectDir" Visible="false"/>
-  <StringProperty Name="MSBuildProjectDirectory" Visible="false"/>
-  <StringProperty Name="MSBuildProjectFullPath" Visible="false" />
-  <StringProperty Name="MSBuildAllProjects" Visible="false" />
-  <StringProperty Name="DefaultPlatform" Visible="false" />
-  <StringProperty Name="PackageAction" Visible="false" Description="The MSBuild target to use when packaging a project." />
-  <StringProperty Name="DefaultContentType" Visible="false" Description="The default content type name to use when adding files." />
-  <StringProperty Name="VCInstallDir" Visible="false" />
-  <StringProperty Name="VSInstallDir" Visible="false" />
-  <StringProperty Name="Platform" Visible="false" />
-  <StringProperty Name="Configuration" Visible="false" />
-  <StringProperty Name="DebuggerSymbolsPath" Visible="false" />
-  <StringProperty Name="IntDir" Visible="false" />
-  <StringProperty Name="TargetPlatformWinMDLocation" Visible="false" />
-  <StringProperty Name="SDKReferenceDirectoryRoot" Visible="false" />
-  <StringProperty Name="SDKReferenceRegistryRoot" Visible="false" />
-  <StringProperty Name="SDKExtensionDirectoryRoot" Visible="false" />
-  <StringProperty Name="SDKIdentifier" Visible="false" />
-  <StringProperty Name="SDKVersion" Visible="false" />
-  <StringProperty Name="TargetPlatformIdentifier" Visible="false" />
-  <StringProperty Name="TargetPlatformVersion" Visible="false" />
-  <BoolProperty Name="WindowsAppContainer" Visible="false" />
-  <BoolProperty Name="WinMDAssembly" Visible="false" />
-  <EnumProperty Name="TargetRuntime" Visible="false">
-    <EnumValue Name="Managed" />
-    <EnumValue Name="Native" />
-    <EnumValue Name="AppHost" DisplayName="Windows app" />
-  </EnumProperty>
-  <StringProperty Name="AssemblySearchPaths" Visible="false" />
-  <StringProperty Name="WinRTReferenceTabs" Visible="false" />
-  <StringProperty Name="AssemblyReferenceTabs" Visible="false" />
-  <StringProperty Name="MinimumVisualStudioVersion" Visible="false" />
-  <BoolProperty Name="SuppressOutOfDateMessageOnBuild" Visible="false" Description="True to just build out-of-date projects without ever prompting the user to confirm." />
-  <BoolProperty Name="ShowAllFiles" Visible="False">
-    <BoolProperty.DataSource>
-      <DataSource Persistence="UserFile" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </BoolProperty.DataSource>
-  </BoolProperty>
-  <BoolProperty Name="AutoRefresh" Visible="False">
-    <BoolProperty.DataSource>
-      <DataSource Persistence="UserFile" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </BoolProperty.DataSource>
-  </BoolProperty>
-  <StringProperty Name="AddItemTemplatesGuid" Visible="False" />
-  <StringProperty Name="ProjectUISubcaption" Visible="False" />
-  <StringProperty Name="SharedItemContextSubProjectGuid" Visible="False">
+
+  <StringProperty Name="PackageAction"
+                  Description="The MSBuild target to use when packaging a project."
+                  Visible="false" />
+
+  <StringProperty Name="Platform"
+                  Visible="false" />
+
+  <StringProperty Name="ProjectDir"
+                  Visible="false" />
+
+  <StringListProperty Name="ProjectTypeGuids"
+                      Visible="False" />
+
+  <StringProperty Name="ProjectUISubcaption"
+                  Visible="False" />
+
+  <StringProperty Name="RootNamespace"
+                  DisplayName="Root namespace">
     <StringProperty.DataSource>
-      <DataSource Persistence="UserFile" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="false"
+                  Label="Configuration"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="OneAppCapabilities" Visible="False" />
-  <StringProperty Name="SharedProjectAppliesTo" Visible="False" />
-  <BoolProperty Name="AlwaysUseNumericalSuffixInItemNames" Visible="False" />
-  <StringProperty Name="LanguageServiceName" ReadOnly="True" Visible="False" />
-  <StringProperty Name="LanguageServiceId" ReadOnly="True" Visible="False" />
-  <StringProperty Name="TemplateLanguage" ReadOnly="True" Visible="False" />
-  <StringProperty Name="NETCoreSdkVersion" ReadOnly="True" Visible="False" />
+
+  <StringProperty Name="SDKExtensionDirectoryRoot"
+                  Visible="false" />
+
+  <StringProperty Name="SDKIdentifier"
+                  Visible="false" />
+
+  <StringProperty Name="SDKReferenceDirectoryRoot"
+                  Visible="false" />
+
+  <StringProperty Name="SDKReferenceRegistryRoot"
+                  Visible="false" />
+
+  <StringProperty Name="SDKVersion"
+                  Visible="false" />
+
+  <StringProperty Name="SharedItemContextSubProjectGuid"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  Persistence="UserFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="SharedProjectAppliesTo"
+                  Visible="False" />
+
+  <BoolProperty Name="ShowAllFiles"
+                Visible="False">
+    <BoolProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  Persistence="UserFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </BoolProperty.DataSource>
+  </BoolProperty>
+
+  <BoolProperty Name="SuppressOutOfDateMessageOnBuild"
+                Description="True to just build out-of-date projects without ever prompting the user to confirm."
+                Visible="false" />
+
+  <StringProperty Name="TargetFramework"
+                  DisplayName="Target Framework">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="TargetFramework"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="TargetFrameworkIdentifier"
+                  DisplayName="Target Framework Identifier">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="TargetFrameworkIdentifier"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="TargetFrameworkMoniker"
+                  DisplayName="Target Framework Moniker">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="TargetFrameworkMoniker"
+                  Persistence="ProjectFileWithInterceptionViaSnapshot"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="TargetFrameworkMonikers"
+                  DisplayName="Target Framework Monikers"
+                  ReadOnly="True">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="TargetFrameworkMonikers"
+                  Persistence="ProjectFileWithInterception"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="TargetFrameworkProfile"
+                  DisplayName="Target Framework Profile">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="TargetFrameworkProfile"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="TargetFrameworks"
+                  DisplayName="Target Frameworks">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="TargetFrameworks"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="TargetFrameworkVersion"
+                  DisplayName="Target Framework Version">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="TargetFrameworkVersion"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="TargetPath" />
+
+  <StringProperty Name="TargetPlatformIdentifier"
+                  Visible="false" />
+
+  <StringProperty Name="TargetPlatformVersion"
+                  Visible="false" />
+
+  <StringProperty Name="TargetPlatformWinMDLocation"
+                  Visible="false" />
+
+  <EnumProperty Name="TargetRuntime"
+                Visible="false">
+    <EnumValue Name="Managed" />
+    <EnumValue Name="Native" />
+    <EnumValue Name="AppHost"
+               DisplayName="Windows app" />
+  </EnumProperty>
+
+  <StringProperty Name="TemplateLanguage"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="VCInstallDir"
+                  Visible="false" />
+
+  <StringProperty Name="VSInstallDir"
+                  Visible="false" />
+
+  <BoolProperty Name="WindowsAppContainer"
+                Visible="false" />
+
+  <BoolProperty Name="WinMDAssembly"
+                Visible="false" />
+
+  <StringProperty Name="WinRTReferenceTabs"
+                  Visible="false" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -5,7 +5,7 @@
       DisplayName="General"
       OverrideMode="Replace"
       PageTemplate="generic"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
     <Category Name="General"
               Description="General"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CopyUpToDateMarker.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CopyUpToDateMarker.xaml
@@ -4,7 +4,7 @@
       Description="File Properties"
       DisplayName="Up-to-date check marker for reference assemblies"
       PageTemplate="generic"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
     <Category Name="Advanced"
               DisplayName="Advanced" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CopyUpToDateMarker.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CopyUpToDateMarker.xaml
@@ -1,17 +1,26 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule
-    Name="CopyUpToDateMarker"
-    DisplayName="Up-to-date check marker for reference assemblies"
-    PageTemplate="generic"
-    Description="File Properties"
-    xmlns="http://schemas.microsoft.com/build/2009/properties">
-  <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="CopyUpToDateMarker" SourceOfDefaultValue="AfterContext" />
-  </Rule.DataSource>
+<Rule Name="CopyUpToDateMarker"
+      Description="File Properties"
+      DisplayName="Up-to-date check marker for reference assemblies"
+      PageTemplate="generic"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
-    <Category Name="Advanced" DisplayName="Advanced" />
-    <Category Name="Misc" DisplayName="Misc" />
+    <Category Name="Advanced"
+              DisplayName="Advanced" />
+    <Category Name="Misc"
+              DisplayName="Misc" />
   </Rule.Categories>
-  <BoolProperty Name="Visible" Default="false" Visible="false" />
+
+  <Rule.DataSource>
+    <DataSource HasConfigurationCondition="False"
+                ItemType="CopyUpToDateMarker"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
+  </Rule.DataSource>
+
+  <BoolProperty Name="Visible"
+                Default="false"
+                Visible="false" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DebuggerGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DebuggerGeneral.xaml
@@ -3,7 +3,7 @@
 <Rule Name="DebuggerGeneralProperties"
       Description="General Debugger options"
       DisplayName="Debugger General Properties"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource Persistence="UserFile"
                 SourceOfDefaultValue="AfterContext" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DebuggerGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DebuggerGeneral.xaml
@@ -1,26 +1,32 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
 <Rule Name="DebuggerGeneralProperties"
-      DisplayName="Debugger General Properties"
       Description="General Debugger options"
-      xmlns="http://schemas.microsoft.com/build/2009/properties">
+      DisplayName="Debugger General Properties"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="UserFile" SourceOfDefaultValue="AfterContext" />
+    <DataSource Persistence="UserFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <StringProperty Name="SymbolsPath" DisplayName="Symbol Search Path"
-                  Description="The search path used by the debugger to locate symbols.">
-  </StringProperty>
+  <StringProperty Name="DebuggerFlavor"
+                  Visible="false" />
 
-  <StringProperty Name="DebuggerFlavor" Visible="false">
-  </StringProperty>
-
-  <EnumProperty Name="ImageClrType" Visible="false">
+  <EnumProperty Name="ImageClrType"
+                Visible="false">
     <EnumProperty.DataSource>
-      <DataSource Persistence="UserFile" HasConfigurationCondition="false" PersistedName="_TargetImageClrType" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="false"
+                  PersistedName="_TargetImageClrType"
+                  Persistence="UserFile"
+                  SourceOfDefaultValue="AfterContext" />
     </EnumProperty.DataSource>
     <EnumValue Name="Native" />
     <EnumValue Name="Mixed" />
     <EnumValue Name="Managed" />
   </EnumProperty>
+
+  <StringProperty Name="SymbolsPath"
+                  Description="The search path used by the debugger to locate symbols."
+                  DisplayName="Symbol Search Path" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DotNetCliToolReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DotNetCliToolReference.xaml
@@ -4,7 +4,7 @@
       Description="Package"
       DisplayName="Package"
       PageTemplate="generic"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="DotNetCliToolReference"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DotNetCliToolReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DotNetCliToolReference.xaml
@@ -1,73 +1,74 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Rule
-    Name="DotNetCliToolReference"
-    DisplayName="Package"
-    PageTemplate="generic"
-    Description="Package"
-    xmlns="http://schemas.microsoft.com/build/2009/properties">
-
+<Rule Name="DotNetCliToolReference"
+      Description="Package"
+      DisplayName="Package"
+      PageTemplate="generic"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="DotNetCliToolReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                ItemType="DotNetCliToolReference"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
   <StringProperty Name="Description"
-                  ReadOnly="True"
-                  Visible="True"
+                  Description="Dependency description."
                   DisplayName="Description"
-                  Description="Dependency description." />
-
-  <StringProperty Name="Version"
                   ReadOnly="True"
-                  DisplayName="Version"
-                  Description="Version of dependency.">
-  </StringProperty>
-
-  <StringProperty Name="IncludeAssets"
-                  Visible="True"
-                  DisplayName="IncludeAssets"
-                  Description="Assets to include from this reference" />
+                  Visible="True" />
 
   <StringProperty Name="ExcludeAssets"
-                  Visible="True"
+                  Description="Assets to exclude from this reference"
                   DisplayName="ExcludeAssets"
-                  Description="Assets to exclude from this reference" />
-
-  <StringProperty Name="PrivateAssets"
-                  Visible="True"
-                  DisplayName="PrivateAssets"
-                  Description="Assets that are private in this reference" />
-
-  <StringProperty Name="Name"
-                  Visible="True"
-                  ReadOnly="True" />
-
-  <StringProperty Name="OriginalItemSpec"
-                  Visible="False"
-                  ReadOnly="True"
-                  Description="The evaluated item name of the original reference item whose resolution resulted in this resolved reference item." />
-
-  <StringProperty Name="Path"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="Type"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="RuntimeIdentifier"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="TargetFramework"
-                  Visible="False"
-                  ReadOnly="True" />
+                  Visible="True" />
 
   <StringProperty Name="FrameworkName"
-                  Visible="False"
-                  ReadOnly="True" />
+                  ReadOnly="True"
+                  Visible="False" />
 
   <StringProperty Name="FrameworkVersion"
-                  Visible="False"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="IncludeAssets"
+                  Description="Assets to include from this reference"
+                  DisplayName="IncludeAssets"
+                  Visible="True" />
+
+  <StringProperty Name="Name"
+                  ReadOnly="True"
+                  Visible="True" />
+
+  <StringProperty Name="OriginalItemSpec"
+                  Description="The evaluated item name of the original reference item whose resolution resulted in this resolved reference item."
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="Path"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="PrivateAssets"
+                  Description="Assets that are private in this reference"
+                  DisplayName="PrivateAssets"
+                  Visible="True" />
+
+  <StringProperty Name="RuntimeIdentifier"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="TargetFramework"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="Type"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="Version"
+                  Description="Version of dependency."
+                  DisplayName="Version"
                   ReadOnly="True" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -6,7 +6,7 @@
       OverrideMode="Replace"
       PageTemplate="generic"
       PropertyPagesHidden="true"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
     <Category Name="General"
               Description="General"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -1,207 +1,393 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright, Microsoft Corporation, All rights reserved.-->
-<Rule
-  Name="ConfigurationGeneralBrowseObject"
-  DisplayName="General"
-  PageTemplate="generic"
-  Description="Project Properties"
-  OverrideMode= "Replace"
-  PropertyPagesHidden="true"
-  xmlns="http://schemas.microsoft.com/build/2009/properties">
-
+<Rule Name="ConfigurationGeneralBrowseObject"
+      Description="Project Properties"
+      DisplayName="General"
+      OverrideMode="Replace"
+      PageTemplate="generic"
+      PropertyPagesHidden="true"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
-    <Category Name="General" DisplayName="General" Description="General" />
+    <Category Name="General"
+              Description="General"
+              DisplayName="General" />
   </Rule.Categories>
 
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <StringProperty Name="ApplicationIcon" Visible="False" />
-  <StringProperty Name="TargetFrameworkMoniker" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileWithInterceptionViaSnapshot" PersistedName="TargetFrameworkMoniker" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="TargetFrameworkMonikers" Visible="False" ReadOnly="True">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileWithInterception" PersistedName="TargetFrameworkMonikers" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext"/>
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="AssemblyName" Visible="False"/>
-  <StringProperty Name="Name" Visible="False" />
-  <StringProperty Name="RootNamespace" Visible="False"/>
-  <StringProperty Name="DefaultNamespace" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource PersistedName="RootNamespace" Persistence="ProjectFile" HasConfigurationCondition="false" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="TargetFrameworks" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="TargetFrameworks" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <IntProperty Name="TargetFramework" ReadOnly="True" Visible="False">
-    <IntProperty.DataSource>
-      <DataSource Persistence="ProjectFileWithInterceptionViaSnapshot" PersistedName="TargetFramework" SourceOfDefaultValue="AfterContext" />
-    </IntProperty.DataSource>
-  </IntProperty>
-  <StringProperty Name="OutputName" Visible="False" />
+  <StringProperty Name="ApplicationIcon"
+                  Visible="False" />
 
-  <StringProperty Name="OutputFileName" ReadOnly="True" Visible="False">
+  <StringProperty Name="ApplicationManifest"
+                  Visible="False">
     <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="TargetFileName" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="false"
+                  PersistedName="ApplicationManifest"
+                  Persistence="ProjectFileWithInterceptionViaSnapshot"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <BoolProperty Name="AutoGenerateBindingRedirects" Visible="false">
+  <StringProperty Name="AssemblyName"
+                  Visible="False" />
+
+  <StringProperty Name="AssemblyOriginatorKeyFile"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  Persistence="ProjectFileWithInterceptionViaSnapshot"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="AssemblyVersion"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  Persistence="ProjectFileOrAssemblyInfo"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="Authors"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  Persistence="ProjectFileWithInterceptionViaSnapshot"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <BoolProperty Name="AutoGenerateBindingRedirects"
+                Visible="false">
     <BoolProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="AutoGenerateBindingRedirects" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="AutoGenerateBindingRedirects"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
     </BoolProperty.DataSource>
   </BoolProperty>
 
-  <!-- This property is used to provide the value of OutputType through BrowseObject, which is used by Property pages-->
-  <IntProperty Name="OutputType" Visible="False">
+  <BoolProperty Name="CanUseTargetFSharpCoreVersion"
+                Visible="False" />
+
+  <StringProperty Name="Company"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  Persistence="ProjectFileOrAssemblyInfo"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="Copyright"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  Persistence="ProjectFileOrAssemblyInfo"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="DefaultNamespace"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="false"
+                  PersistedName="RootNamespace"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <BoolProperty Name="DelaySign"
+                Visible="False" />
+
+  <StringProperty Name="Description"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  Persistence="ProjectFileOrAssemblyInfo"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="FileName"
+                  Category="Misc"
+                  Description="Name of the project file."
+                  DisplayName="File Name"
+                  ReadOnly="True">
+    <StringProperty.DataSource>
+      <DataSource PersistedName="MSBuildProjectFile"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="FileVersion"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  Persistence="ProjectFileOrAssemblyInfo"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="FullPath"
+                  Category="Misc"
+                  Description="Location of the project file."
+                  DisplayName="Project Folder"
+                  ReadOnly="True">
+    <StringProperty.DataSource>
+      <DataSource PersistedName="ProjectDir"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="FullProjectFileName"
+                  Category="Misc"
+                  Description="Full name of the project file."
+                  DisplayName="Full Path"
+                  ReadOnly="True">
+    <StringProperty.DataSource>
+      <DataSource PersistedName="MSBuildProjectFullPath"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <BoolProperty Name="GeneratePackageOnBuild"
+                Default="False"
+                Visible="False" />
+
+  <StringProperty Name="LocalPath"
+                  ReadOnly="True"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource PersistedName="MSBuildProjectDirectory"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="Name"
+                  Visible="False" />
+
+  <StringProperty Name="NeutralLanguage"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  Persistence="ProjectFileOrAssemblyInfo"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="OutputFileName"
+                  ReadOnly="True"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource PersistedName="TargetFileName"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="OutputName"
+                  Visible="False" />
+
+  <IntProperty Name="OutputType"
+               Visible="False">
     <IntProperty.DataSource>
-      <DataSource Persistence="ProjectFileWithInterceptionViaSnapshot" PersistedName="OutputType" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="OutputType"
+                  Persistence="ProjectFileWithInterceptionViaSnapshot"
+                  SourceOfDefaultValue="AfterContext" />
     </IntProperty.DataSource>
   </IntProperty>
-  <!-- This property is used to provide the value of OutputTypeEx through BrowseObject, which is used by Property pages-->
-  <IntProperty Name="OutputTypeEx" Visible="False">
+
+  <IntProperty Name="OutputTypeEx"
+               Visible="False">
     <IntProperty.DataSource>
-      <DataSource Persistence="ProjectFileWithInterceptionViaSnapshot" PersistedName="OutputTypeEx" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="OutputTypeEx"
+                  Persistence="ProjectFileWithInterceptionViaSnapshot"
+                  SourceOfDefaultValue="AfterContext" />
     </IntProperty.DataSource>
   </IntProperty>
-  <DynamicEnumProperty Name="StartupObject" EnumProvider="StartupObjectsEnumProvider" Visible="False"/>
-  <StringProperty Name="ApplicationManifest" Visible="False">
+
+  <StringProperty Name="PackageIconUrl"
+                  Visible="False" />
+
+  <StringProperty Name="PackageId"
+                  DisplayName="Package Id"
+                  Visible="False">
     <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileWithInterceptionViaSnapshot" PersistedName="ApplicationManifest" HasConfigurationCondition="false" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False"
+                  Persistence="ProjectFileWithInterceptionViaSnapshot"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="Win32ResourceFile" Visible="False">
+
+  <StringProperty Name="PackageLicenseExpression"
+                  Visible="False" />
+
+  <StringProperty Name="PackageLicenseFile"
+                  Visible="False" />
+
+  <StringProperty Name="PackageLicenseUrl"
+                  Visible="False" />
+
+  <StringProperty Name="PackageProjectUrl"
+                  Visible="False" />
+
+  <StringProperty Name="PackageReleaseNotes"
+                  Visible="False" />
+
+  <BoolProperty Name="PackageRequireLicenseAcceptance"
+                Default="False"
+                Visible="False" />
+
+  <StringProperty Name="PackageTags"
+                  Visible="False" />
+
+  <StringProperty Name="PostBuildEvent"
+                  Visible="False">
     <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="Win32Resource" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="PostBuildEvent"
+                  Persistence="ProjectFileWithInterception"
+                  SourceOfDefaultValue="BeforeContext" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="PreBuildEvent" Visible="False">
+
+  <StringProperty Name="PreBuildEvent"
+                  Visible="False">
     <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileWithInterception" PersistedName="PreBuildEvent" HasConfigurationCondition="False" SourceOfDefaultValue="BeforeContext"/>
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="PreBuildEvent"
+                  Persistence="ProjectFileWithInterception"
+                  SourceOfDefaultValue="BeforeContext" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="PostBuildEvent" Visible="False">
+
+  <StringProperty Name="Product"
+                  Visible="False">
     <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileWithInterception" PersistedName="PostBuildEvent" HasConfigurationCondition="False" SourceOfDefaultValue="BeforeContext"/>
+      <DataSource HasConfigurationCondition="False"
+                  Persistence="ProjectFileOrAssemblyInfo"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
-  <EnumProperty Name="RunPostBuildEvent" Visible="False">
-    <EnumValue Name="Always" DisplayName="Always" />
-    <EnumValue Name="OnBuildSuccess" DisplayName="On successful build"  IsDefault="True" />
-    <EnumValue Name="OnOutputUpdated" DisplayName="When the build updates the project output" />
+
+  <StringProperty Name="ReferencePath"
+                  Visible="False" />
+
+  <StringProperty Name="RepositoryType"
+                  Visible="False" />
+
+  <StringProperty Name="RepositoryUrl"
+                  Visible="False" />
+
+  <StringProperty Name="RootNamespace"
+                  Visible="False" />
+
+  <EnumProperty Name="RunPostBuildEvent"
+                Visible="False">
+    <EnumValue Name="Always"
+               DisplayName="Always" />
+    <EnumValue Name="OnBuildSuccess"
+               DisplayName="On successful build"
+               IsDefault="True" />
+    <EnumValue Name="OnOutputUpdated"
+               DisplayName="When the build updates the project output" />
   </EnumProperty>
-  <StringProperty Name="ReferencePath" Visible="False"/>
-  <StringProperty Name="FileName" DisplayName="File Name" ReadOnly="True" Category="Misc" Description="Name of the project file.">
+
+  <BoolProperty Name="SignAssembly"
+                Visible="False" />
+
+  <DynamicEnumProperty Name="StartupObject"
+                       EnumProvider="StartupObjectsEnumProvider"
+                       Visible="False" />
+
+  <DynamicEnumProperty Name="SupportedTargetFrameworks"
+                       EnumProvider="SupportedTargetFrameworksEnumProvider"
+                       Visible="False" />
+
+  <IntProperty Name="TargetFramework"
+               ReadOnly="True"
+               Visible="False">
+    <IntProperty.DataSource>
+      <DataSource PersistedName="TargetFramework"
+                  Persistence="ProjectFileWithInterceptionViaSnapshot"
+                  SourceOfDefaultValue="AfterContext" />
+    </IntProperty.DataSource>
+  </IntProperty>
+
+  <StringProperty Name="TargetFrameworkMoniker"
+                  Visible="False">
     <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectFile" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="FullPath" DisplayName="Project Folder" ReadOnly="True" Category="Misc" Description="Location of the project file.">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="ProjectDir" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <!-- NOTE: csproj.dll does not provide this property on the browse object, but calls it "FullProjectFileName" behind the scenes. -->
-  <StringProperty Name="FullProjectFileName" DisplayName="Full Path" ReadOnly="True" Category="Misc" Description="Full name of the project file.">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectFullPath" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="TargetFrameworkMoniker"
+                  Persistence="ProjectFileWithInterceptionViaSnapshot"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="LocalPath" ReadOnly="True" Visible="False">
+  <StringProperty Name="TargetFrameworkMonikers"
+                  ReadOnly="True"
+                  Visible="False">
     <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectDirectory" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="URL" ReadOnly="True" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="MSBuildProjectFullPath" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-
-  <!-- Package properties -->
-  <BoolProperty Name="GeneratePackageOnBuild" Default="False" Visible="False"/>
-  <StringProperty Name="PackageId" DisplayName="Package Id" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileWithInterceptionViaSnapshot" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="Version" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileOrAssemblyInfo" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="Authors" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileWithInterceptionViaSnapshot" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <BoolProperty Name="PackageRequireLicenseAcceptance" Default="False" Visible="False"/>
-  <StringProperty Name="PackageLicenseExpression" Visible="False"/>
-  <StringProperty Name="PackageLicenseFile" Visible="False"/>
-  <StringProperty Name="PackageLicenseUrl" Visible="False"/>
-  <StringProperty Name="PackageProjectUrl" Visible="False"/>
-  <StringProperty Name="PackageIconUrl" Visible="False"/>
-  <StringProperty Name="PackageTags" Visible="False"/>
-  <StringProperty Name="PackageReleaseNotes" Visible="False"/>
-  <StringProperty Name="RepositoryUrl" Visible="False"/>
-  <StringProperty Name="RepositoryType" Visible="False"/>
-
-  <!--AssemblyInfo properties-->
-  <StringProperty Name="Description" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileOrAssemblyInfo" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="Company" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileOrAssemblyInfo" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="Product" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileOrAssemblyInfo" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="Copyright" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileOrAssemblyInfo" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="AssemblyVersion" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileOrAssemblyInfo" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="FileVersion" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileOrAssemblyInfo" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="NeutralLanguage" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileOrAssemblyInfo" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <BoolProperty Name="SignAssembly" Visible="False"/>
-  <BoolProperty Name="DelaySign" Visible="False"/>
-  <StringProperty Name="AssemblyOriginatorKeyFile" Visible="False">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileWithInterceptionViaSnapshot" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="TargetFrameworkMonikers"
+                  Persistence="ProjectFileWithInterception"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <DynamicEnumProperty Name="SupportedTargetFrameworks" EnumProvider="SupportedTargetFrameworksEnumProvider" Visible="False"/>
+  <StringProperty Name="TargetFrameworks"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="TargetFrameworks"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 
-  <!-- F# specific properties-->
-  <BoolProperty Name="CanUseTargetFSharpCoreVersion" Visible="False"/>
-  <StringProperty Name="TargetFSharpCoreVersion" Visible="False" />
+  <StringProperty Name="TargetFSharpCoreVersion"
+                  Visible="False" />
+
+  <StringProperty Name="URL"
+                  ReadOnly="True"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource PersistedName="MSBuildProjectFullPath"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="Version"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  Persistence="ProjectFileOrAssemblyInfo"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="Win32ResourceFile"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="Win32Resource"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
@@ -6,7 +6,7 @@
       OverrideMode="Replace"
       PageTemplate="generic"
       PropertyPagesHidden="true"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
     <Category Name="General"
               Description="General"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralConfiguredBrowseObject.xaml
@@ -1,160 +1,273 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright, Microsoft Corporation, All rights reserved.-->
-<Rule
-  Name="ConfiguredBrowseObject"
-  DisplayName="General"
-  PageTemplate="generic"
-  Description="General"
-  OverrideMode= "Replace"
-  PropertyPagesHidden="true"
-  xmlns="http://schemas.microsoft.com/build/2009/properties">
-
+<Rule Name="ConfiguredBrowseObject"
+      Description="General"
+      DisplayName="General"
+      OverrideMode="Replace"
+      PageTemplate="generic"
+      PropertyPagesHidden="true"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
-    <Category Name="General" DisplayName="General" Description="General" />
+    <Category Name="General"
+              Description="General"
+              DisplayName="General" />
   </Rule.Categories>
 
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" HasConfigurationCondition="True" SourceOfDefaultValue="AfterContext"/>
+    <DataSource HasConfigurationCondition="True"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <!-- Build Page Properties -->
-  <StringProperty Name="DefineConstants" Visible="False">
-    <StringProperty.DataSource>
-      <!-- We mark BeforeContext to avoid picking up implicit framework defines to avoid #2720. -->
-      <DataSource Persistence="ProjectFile" HasConfigurationCondition="True" SourceOfDefaultValue="BeforeContext"/>
-    </StringProperty.DataSource>
-  </StringProperty>
+  <BoolProperty Name="AllowUnsafeBlocks"
+                Default="False"
+                Visible="False" />
 
-  <EnumProperty Name="PlatformTarget" Visible="False"/>
+  <StringProperty Name="BaseAddress"
+                  Visible="False" />
 
-  <StringProperty Name="IntermediatePath" Visible="false">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="IntermediateOutputPath" HasConfigurationCondition="True" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <BoolProperty Name="NullableReferenceTypes" Visible="False">
+  <BoolProperty Name="CheckForOverflowUnderflow"
+                Visible="False">
     <BoolProperty.DataSource>
-      <DataSource Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" HasConfigurationCondition="False" />
+      <DataSource HasConfigurationCondition="True"
+                  PersistedName="CheckForOverflowUnderflow"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
     </BoolProperty.DataSource>
   </BoolProperty>
-  <BoolProperty Name="RunCodeAnalysis" Visible="False" />
-  <BoolProperty Name="Prefer32Bit" Visible="False"/>
-  <BoolProperty Name="AllowUnsafeBlocks"  Default="False"  Visible="False"/>
-  <BoolProperty Name="Optimize" Visible="False"/>
-  <StringProperty Name="NoWarn" Visible="False"/>
-  <BoolProperty Name="TreatWarningsAsErrors"  Default="False" Visible="False"/>
-  <StringProperty Name="TreatSpecificWarningsAsErrors" Visible="False">
+
+  <StringProperty Name="CodeAnalysisRuleSet"
+                  Visible="False" />
+
+  <EnumProperty Name="DebugInfo"
+                Visible="False">
+    <EnumProperty.DataSource>
+      <DataSource PersistedName="DebugType"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </EnumProperty.DataSource>
+  </EnumProperty>
+
+  <StringProperty Name="DebugSymbols"
+                  Visible="False" />
+
+  <StringProperty Name="DefineConstants"
+                  Visible="False">
     <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="WarningsAsErrors" />
+      <DataSource HasConfigurationCondition="True"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="BeforeContext" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="OutputPath" Visible="False">
+
+  <BoolProperty Name="DefineDebug"
+                Visible="False" />
+
+  <BoolProperty Name="DefineTrace"
+                Visible="False" />
+
+  <StringProperty Name="DocumentationFile"
+                  Visible="False" />
+
+  <EnumProperty Name="ErrorReport"
+                Visible="False" />
+
+  <EnumProperty Name="FileAlignment"
+                Visible="False" />
+
+  <StringProperty Name="FullPath"
+                  DisplayName="Project Folder"
+                  ReadOnly="True">
     <StringProperty.DataSource>
-      <!-- We mark BeforeContext to avoid picking up implicit output appending to avoid #2177. -->
-      <DataSource Persistence="ProjectFile" HasConfigurationCondition="True" SourceOfDefaultValue="BeforeContext"/>
+      <DataSource PersistedName="ProjectDir"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="DocumentationFile" Visible="False"/>
-  <EnumProperty Name="GenerateSerializationAssemblies" Visible="False">
-    <EnumValue Name="Auto" IsDefault="True" />
+
+  <EnumProperty Name="GenerateSerializationAssemblies"
+                Visible="False">
+    <EnumValue Name="Auto"
+               IsDefault="True" />
     <EnumValue Name="On" />
     <EnumValue Name="Off" />
   </EnumProperty>
-  <!-- ** removed for RTM: needs translation
-  <BoolProperty Name="RegisterForComInterop" Default="False" DisplayName="Register for COM Interop" Visible="False"/>
-    -->
 
-  <!-- Advanced Build Page Properties -->
-  <EnumProperty Name="LanguageVersion" Visible="False">
-    <EnumProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="LangVersion" SourceOfDefaultValue="AfterContext" HasConfigurationCondition="False" />
-    </EnumProperty.DataSource>
-  </EnumProperty>
-  <StringProperty Name="LangVersion" Visible="False" >
+  <StringProperty Name="IntermediatePath"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" HasConfigurationCondition="False" />
+      <DataSource HasConfigurationCondition="True"
+                  PersistedName="IntermediateOutputPath"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
-  <EnumProperty Name="ErrorReport" Visible="False"/>
-  <EnumProperty Name="DebugInfo" Visible="False">
+
+  <EnumProperty Name="LanguageVersion"
+                Visible="False">
     <EnumProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="DebugType" SourceOfDefaultValue="AfterContext"/>
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="LangVersion"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
     </EnumProperty.DataSource>
   </EnumProperty>
-  <BoolProperty Name="CheckForOverflowUnderflow" Visible="False">
+
+  <StringProperty Name="LangVersion"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="NoWarn"
+                  Visible="False" />
+
+  <BoolProperty Name="NullableReferenceTypes"
+                Visible="False">
     <BoolProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="CheckForOverflowUnderflow" HasConfigurationCondition="True" SourceOfDefaultValue="AfterContext"/>
+      <DataSource HasConfigurationCondition="False"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
     </BoolProperty.DataSource>
   </BoolProperty>
-  <StringProperty Name="DebugSymbols" Visible="False"/>
-  <EnumProperty Name="FileAlignment" Visible="False"/>
-  <StringProperty Name="BaseAddress" Visible="False"/>
-  <StringProperty Name="FullPath" DisplayName="Project Folder" ReadOnly="True">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="ProjectDir" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <DynamicEnumProperty Name="WarningLevel" EnumProvider="WarningLevelEnumProvider" Visible="False">
+
+  <BoolProperty Name="Optimize"
+                Visible="False" />
+
+  <EnumProperty Name="OptionCompare"
+                Visible="False">
+    <EnumProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="OptionCompare"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </EnumProperty.DataSource>
+    <EnumValue Name="Binary"
+               DisplayName="Binary"
+               IsDefault="True" />
+    <EnumValue Name="Text"
+               DisplayName="Text" />
+  </EnumProperty>
+
+  <EnumProperty Name="OptionExplicit"
+                Visible="False">
+    <EnumProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="OptionExplicit"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </EnumProperty.DataSource>
+    <EnumValue Name="Off"
+               DisplayName="Off" />
+    <EnumValue Name="On"
+               DisplayName="On"
+               IsDefault="True" />
+  </EnumProperty>
+
+  <EnumProperty Name="OptionInfer"
+                Visible="False">
+    <EnumProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="OptionInfer"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </EnumProperty.DataSource>
+    <EnumValue Name="Off"
+               DisplayName="Off" />
+    <EnumValue Name="On"
+               DisplayName="On"
+               IsDefault="True" />
+  </EnumProperty>
+
+  <DynamicEnumProperty Name="OptionStrict"
+                       EnumProvider="OptionStrictEnumProvider"
+                       Visible="False">
     <DynamicEnumProperty.DataSource>
-      <DataSource Persistence="ProjectFile" HasConfigurationCondition="True" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
     </DynamicEnumProperty.DataSource>
   </DynamicEnumProperty>
 
-  <!-- VB Compile Page Properties-->
-  <EnumProperty Name="OptionExplicit" Visible="False">
-    <EnumProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="OptionExplicit" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </EnumProperty.DataSource>
-    <EnumValue Name="Off" DisplayName="Off" />
-    <EnumValue Name="On" DisplayName="On" IsDefault="True" />
-  </EnumProperty>
-  <EnumProperty Name="OptionCompare" Visible="False">
-    <EnumProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="OptionCompare" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </EnumProperty.DataSource>
-    <EnumValue Name="Binary" DisplayName="Binary" IsDefault="True" />
-    <EnumValue Name="Text" DisplayName="Text" />
-  </EnumProperty>
-  <EnumProperty Name="OptionInfer" Visible="False">
-    <EnumProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="OptionInfer" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </EnumProperty.DataSource>
-    <EnumValue Name="Off" DisplayName="Off" />
-    <EnumValue Name="On" DisplayName="On" IsDefault="True" />
-  </EnumProperty>
-  <DynamicEnumProperty Name="OptionStrict" EnumProvider="OptionStrictEnumProvider" Visible="False">
-    <DynamicEnumProperty.DataSource>
-      <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </DynamicEnumProperty.DataSource>
-  </DynamicEnumProperty>
-
-  <!-- VB Advanced Compile Options-->
-  <BoolProperty Name="RemoveIntegerChecks" Visible="False" />
-  <BoolProperty Name="DefineDebug" Visible="False" />
-  <BoolProperty Name="DefineTrace" Visible="False" />
-
-  <!-- VB Compile Build Event Page-->
-  <StringProperty Name="PreBuildEvent" Visible="False">
+  <StringProperty Name="OutputPath"
+                  Visible="False">
     <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="True"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="BeforeContext" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="PostBuildEvent" Visible="False">
+
+  <EnumProperty Name="PlatformTarget"
+                Visible="False" />
+
+  <StringProperty Name="PostBuildEvent"
+                  Visible="False">
     <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
-  <EnumProperty Name="RunPostBuildEvent" Visible="False">
+
+  <StringProperty Name="PreBuildEvent"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <BoolProperty Name="Prefer32Bit"
+                Visible="False" />
+
+  <BoolProperty Name="RemoveIntegerChecks"
+                Visible="False" />
+
+  <BoolProperty Name="RunCodeAnalysis"
+                Visible="False" />
+
+  <EnumProperty Name="RunPostBuildEvent"
+                Visible="False">
     <EnumProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="RunPostBuildEvent" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="RunPostBuildEvent"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
     </EnumProperty.DataSource>
     <EnumValue Name="Always" />
-    <EnumValue Name="OnBuildSuccess" IsDefault="True" />
+    <EnumValue Name="OnBuildSuccess"
+               IsDefault="True" />
     <EnumValue Name="OnOutputUpdated" />
   </EnumProperty>
 
-  <StringProperty Name="CodeAnalysisRuleSet" Visible="False"/>
+  <BoolProperty Name="Tailcalls"
+                Visible="False" />
 
-  <!-- F# specific properties-->
-  <BoolProperty Name="Tailcalls" Visible="False" />
+  <StringProperty Name="TreatSpecificWarningsAsErrors"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource PersistedName="WarningsAsErrors"
+                  Persistence="ProjectFile" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <BoolProperty Name="TreatWarningsAsErrors"
+                Default="False"
+                Visible="False" />
+
+  <DynamicEnumProperty Name="WarningLevel"
+                       EnumProvider="WarningLevelEnumProvider"
+                       Visible="False">
+    <DynamicEnumProperty.DataSource>
+      <DataSource HasConfigurationCondition="True"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </DynamicEnumProperty.DataSource>
+  </DynamicEnumProperty>
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/AdditionalFiles.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/AdditionalFiles.BrowseObject.xaml
@@ -1,98 +1,77 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule
-  Name="AdditionalFiles"
-  DisplayName="Additional File"
-  PageTemplate="generic"
-  Description="File Properties"
-  PropertyPagesHidden="true"
-  xmlns="http://schemas.microsoft.com/build/2009/properties">
-  <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="AdditionalFiles" SourceOfDefaultValue="AfterContext" />
-  </Rule.DataSource>
+<Rule Name="AdditionalFiles" Description="File Properties" DisplayName="Additional File" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
     <Category Name="Advanced" DisplayName="Advanced" />
     <Category Name="Misc" DisplayName="Misc" />
   </Rule.Categories>
 
-  <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Build Action"  Category="Advanced"
-                     Description="How the file relates to the build and deployment processes."
-                     EnumProvider="ItemTypes" />
-  <EnumProperty
-      Name="CopyToOutputDirectory"
-      DisplayName="Copy to Output Directory"
-      Category="Advanced"
-      Description="Specifies the source file will be copied to the output directory.">
+  <Rule.DataSource>
+    <DataSource HasConfigurationCondition="False" ItemType="AdditionalFiles" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+  </Rule.DataSource>
+
+  <DynamicEnumProperty Name="{}{ItemType}" Category="Advanced" Description="How the file relates to the build and deployment processes." DisplayName="Build Action" EnumProvider="ItemTypes" />
+
+  <BoolProperty Name="AutoGen" Visible="false" />
+
+  <EnumProperty Name="CopyToOutputDirectory" Category="Advanced" Description="Specifies the source file will be copied to the output directory." DisplayName="Copy to Output Directory">
     <EnumValue Name="Never" DisplayName="Do not copy" />
     <EnumValue Name="Always" DisplayName="Copy always" />
     <EnumValue Name="PreserveNewest" DisplayName="Copy if newer" />
   </EnumProperty>
 
-  <StringProperty
-      Name="Generator"
-      Category="Advanced"
-      DisplayName="Custom Tool"
-      Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
-  <StringProperty
-      Name="CustomToolNamespace"
-      Category="Advanced"
-      DisplayName="Custom Tool Namespace"
-      Description="The namespace into which the output of the custom tool is placed." />
-
-  <StringProperty
-      Name="Identity"
-      Visible="false"
-      ReadOnly="true">
+  <StringProperty Name="CustomTool" Visible="false">
     <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="AdditionalFiles" PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False" ItemType="AdditionalFiles" PersistedName="Generator" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty
-      Name="FullPath"
-      DisplayName="Full Path"
-      ReadOnly="true"
-      Category="Misc"
-      Description="Location of the file.">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="AdditionalFiles" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" Description="The namespace into which the output of the custom tool is placed." DisplayName="Custom Tool Namespace" />
 
-  <StringProperty
-      Name="FileNameAndExtension"
-      DisplayName="File Name"
-      ReadOnly="true"
-      Category="Misc"
-      Description="Name of the file or folder.">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="AdditionalFiles" PersistedName="FileNameAndExtension" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-
-  <StringProperty Name="URL" ReadOnly="true" Visible="false">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="AdditionalFiles" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <BoolProperty Name="Visible" Visible="false" />
   <StringProperty Name="DependentUpon" Visible="false" />
+
+  <BoolProperty Name="DesignTime" Visible="false" />
+
+  <StringProperty Name="Extension" ReadOnly="true" Visible="False">
+    <StringProperty.DataSource>
+      <DataSource ItemType="AdditionalFiles" PersistedName="Extension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="FileNameAndExtension" Category="Misc" Description="Name of the file or folder." DisplayName="File Name" ReadOnly="true">
+    <StringProperty.DataSource>
+      <DataSource ItemType="AdditionalFiles" PersistedName="FileNameAndExtension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="FullPath" Category="Misc" Description="Location of the file." DisplayName="Full Path" ReadOnly="true">
+    <StringProperty.DataSource>
+      <DataSource ItemType="AdditionalFiles" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="Generator" Category="Advanced" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." DisplayName="Custom Tool" />
+
+  <StringProperty Name="Identity" ReadOnly="true" Visible="false">
+    <StringProperty.DataSource>
+      <DataSource ItemType="AdditionalFiles" PersistedName="Identity" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="LastGenOutput" Visible="false" />
+
   <StringProperty Name="Link" Visible="false">
     <StringProperty.DataSource>
       <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="Extension" Visible="False" ReadOnly="true">
+
+  <StringProperty Name="URL" ReadOnly="true" Visible="false">
     <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="AdditionalFiles" PersistedName="Extension" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="AdditionalFiles" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="LastGenOutput" Visible="false" />
-  <BoolProperty Name="DesignTime" Visible="false" />
-  <BoolProperty Name="AutoGen" Visible="false" />
-  <StringProperty Name="CustomTool" Visible="false">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" ItemType="AdditionalFiles" PersistedName="Generator" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+
+  <BoolProperty Name="Visible" Visible="false" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/AdditionalFiles.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/AdditionalFiles.BrowseObject.xaml
@@ -5,7 +5,7 @@
       DisplayName="Additional File"
       PageTemplate="generic"
       PropertyPagesHidden="true"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
     <Category Name="Advanced"
               DisplayName="Advanced" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/AdditionalFiles.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/AdditionalFiles.BrowseObject.xaml
@@ -1,77 +1,144 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule Name="AdditionalFiles" Description="File Properties" DisplayName="Additional File" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="AdditionalFiles"
+      Description="File Properties"
+      DisplayName="Additional File"
+      PageTemplate="generic"
+      PropertyPagesHidden="true"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
-    <Category Name="Advanced" DisplayName="Advanced" />
-    <Category Name="Misc" DisplayName="Misc" />
+    <Category Name="Advanced"
+              DisplayName="Advanced" />
+    <Category Name="Misc"
+              DisplayName="Misc" />
   </Rule.Categories>
 
   <Rule.DataSource>
-    <DataSource HasConfigurationCondition="False" ItemType="AdditionalFiles" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                ItemType="AdditionalFiles"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <DynamicEnumProperty Name="{}{ItemType}" Category="Advanced" Description="How the file relates to the build and deployment processes." DisplayName="Build Action" EnumProvider="ItemTypes" />
+  <DynamicEnumProperty Name="{}{ItemType}"
+                       Category="Advanced"
+                       Description="How the file relates to the build and deployment processes."
+                       DisplayName="Build Action"
+                       EnumProvider="ItemTypes" />
 
-  <BoolProperty Name="AutoGen" Visible="false" />
+  <BoolProperty Name="AutoGen"
+                Visible="false" />
 
-  <EnumProperty Name="CopyToOutputDirectory" Category="Advanced" Description="Specifies the source file will be copied to the output directory." DisplayName="Copy to Output Directory">
-    <EnumValue Name="Never" DisplayName="Do not copy" />
-    <EnumValue Name="Always" DisplayName="Copy always" />
-    <EnumValue Name="PreserveNewest" DisplayName="Copy if newer" />
+  <EnumProperty Name="CopyToOutputDirectory"
+                Category="Advanced"
+                Description="Specifies the source file will be copied to the output directory."
+                DisplayName="Copy to Output Directory">
+    <EnumValue Name="Never"
+               DisplayName="Do not copy" />
+    <EnumValue Name="Always"
+               DisplayName="Copy always" />
+    <EnumValue Name="PreserveNewest"
+               DisplayName="Copy if newer" />
   </EnumProperty>
 
-  <StringProperty Name="CustomTool" Visible="false">
+  <StringProperty Name="CustomTool"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource HasConfigurationCondition="False" ItemType="AdditionalFiles" PersistedName="Generator" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="AdditionalFiles"
+                  PersistedName="Generator"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="CustomToolNamespace" Category="Advanced" Description="The namespace into which the output of the custom tool is placed." DisplayName="Custom Tool Namespace" />
+  <StringProperty Name="CustomToolNamespace"
+                  Category="Advanced"
+                  Description="The namespace into which the output of the custom tool is placed."
+                  DisplayName="Custom Tool Namespace" />
 
-  <StringProperty Name="DependentUpon" Visible="false" />
+  <StringProperty Name="DependentUpon"
+                  Visible="false" />
 
-  <BoolProperty Name="DesignTime" Visible="false" />
+  <BoolProperty Name="DesignTime"
+                Visible="false" />
 
-  <StringProperty Name="Extension" ReadOnly="true" Visible="False">
+  <StringProperty Name="Extension"
+                  ReadOnly="true"
+                  Visible="False">
     <StringProperty.DataSource>
-      <DataSource ItemType="AdditionalFiles" PersistedName="Extension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="AdditionalFiles"
+                  PersistedName="Extension"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="FileNameAndExtension" Category="Misc" Description="Name of the file or folder." DisplayName="File Name" ReadOnly="true">
+  <StringProperty Name="FileNameAndExtension"
+                  Category="Misc"
+                  Description="Name of the file or folder."
+                  DisplayName="File Name"
+                  ReadOnly="true">
     <StringProperty.DataSource>
-      <DataSource ItemType="AdditionalFiles" PersistedName="FileNameAndExtension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="AdditionalFiles"
+                  PersistedName="FileNameAndExtension"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="FullPath" Category="Misc" Description="Location of the file." DisplayName="Full Path" ReadOnly="true">
+  <StringProperty Name="FullPath"
+                  Category="Misc"
+                  Description="Location of the file."
+                  DisplayName="Full Path"
+                  ReadOnly="true">
     <StringProperty.DataSource>
-      <DataSource ItemType="AdditionalFiles" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="AdditionalFiles"
+                  PersistedName="FullPath"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="Generator" Category="Advanced" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." DisplayName="Custom Tool" />
+  <StringProperty Name="Generator"
+                  Category="Advanced"
+                  Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool."
+                  DisplayName="Custom Tool" />
 
-  <StringProperty Name="Identity" ReadOnly="true" Visible="false">
+  <StringProperty Name="Identity"
+                  ReadOnly="true"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource ItemType="AdditionalFiles" PersistedName="Identity" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="AdditionalFiles"
+                  PersistedName="Identity"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="LastGenOutput" Visible="false" />
+  <StringProperty Name="LastGenOutput"
+                  Visible="false" />
 
-  <StringProperty Name="Link" Visible="false">
+  <StringProperty Name="Link"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
+      <DataSource PersistenceStyle="Attribute"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="URL" ReadOnly="true" Visible="false">
+  <StringProperty Name="URL"
+                  ReadOnly="true"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource ItemType="AdditionalFiles" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="AdditionalFiles"
+                  PersistedName="FullPath"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <BoolProperty Name="Visible" Visible="false" />
+  <BoolProperty Name="Visible"
+                Visible="false" />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/AdditionalFiles.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/AdditionalFiles.xaml
@@ -3,7 +3,7 @@
 <Rule Name="AdditionalFiles"
       PageTemplate="generic"
       PropertyPagesHidden="true"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="AdditionalFiles"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/AdditionalFiles.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/AdditionalFiles.xaml
@@ -1,13 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule Name="AdditionalFiles" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="AdditionalFiles"
+      PageTemplate="generic"
+      PropertyPagesHidden="true"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource HasConfigurationCondition="False" ItemType="AdditionalFiles" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                ItemType="AdditionalFiles"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <DynamicEnumProperty Name="{}{ItemType}" EnumProvider="ItemTypes" />
+  <DynamicEnumProperty Name="{}{ItemType}"
+                       EnumProvider="ItemTypes" />
 
-  <BoolProperty Name="AutoGen" Visible="false" />
+  <BoolProperty Name="AutoGen"
+                Visible="false" />
 
   <EnumProperty Name="CopyToOutputDirectory">
     <EnumValue Name="Never" />
@@ -15,28 +23,39 @@
     <EnumValue Name="PreserveNewest" />
   </EnumProperty>
 
-  <StringProperty Name="CustomTool" Visible="false">
+  <StringProperty Name="CustomTool"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource HasConfigurationCondition="False" ItemType="AdditionalFiles" PersistedName="Generator" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="AdditionalFiles"
+                  PersistedName="Generator"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
   <StringProperty Name="CustomToolNamespace" />
 
-  <StringProperty Name="DependentUpon" Visible="false" />
+  <StringProperty Name="DependentUpon"
+                  Visible="false" />
 
-  <BoolProperty Name="DesignTime" Visible="false" />
+  <BoolProperty Name="DesignTime"
+                Visible="false" />
 
   <StringProperty Name="Generator" />
 
-  <StringProperty Name="LastGenOutput" Visible="false" />
+  <StringProperty Name="LastGenOutput"
+                  Visible="false" />
 
-  <StringProperty Name="Link" Visible="false">
+  <StringProperty Name="Link"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
+      <DataSource PersistenceStyle="Attribute"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <BoolProperty Name="Visible" Visible="false" />
+  <BoolProperty Name="Visible"
+                Visible="false" />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/AdditionalFiles.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/AdditionalFiles.xaml
@@ -1,41 +1,42 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule
-  Name="AdditionalFiles"
-  PageTemplate="generic"
-  PropertyPagesHidden="true"
-  xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="AdditionalFiles" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="AdditionalFiles" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False" ItemType="AdditionalFiles" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <DynamicEnumProperty Name="{}{ItemType}"
-                     EnumProvider="ItemTypes" />
-  <EnumProperty
-      Name="CopyToOutputDirectory">
+  <DynamicEnumProperty Name="{}{ItemType}" EnumProvider="ItemTypes" />
+
+  <BoolProperty Name="AutoGen" Visible="false" />
+
+  <EnumProperty Name="CopyToOutputDirectory">
     <EnumValue Name="Never" />
     <EnumValue Name="Always" />
     <EnumValue Name="PreserveNewest" />
   </EnumProperty>
 
-  <StringProperty
-      Name="Generator" />
-  <StringProperty
-      Name="CustomToolNamespace" />
+  <StringProperty Name="CustomTool" Visible="false">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False" ItemType="AdditionalFiles" PersistedName="Generator" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 
-  <BoolProperty Name="Visible" Visible="false" />
+  <StringProperty Name="CustomToolNamespace" />
+
   <StringProperty Name="DependentUpon" Visible="false" />
+
+  <BoolProperty Name="DesignTime" Visible="false" />
+
+  <StringProperty Name="Generator" />
+
+  <StringProperty Name="LastGenOutput" Visible="false" />
+
   <StringProperty Name="Link" Visible="false">
     <StringProperty.DataSource>
       <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="LastGenOutput" Visible="false" />
-  <BoolProperty Name="DesignTime" Visible="false" />
-  <BoolProperty Name="AutoGen" Visible="false" />
-  <StringProperty Name="CustomTool" Visible="false">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" ItemType="AdditionalFiles" PersistedName="Generator" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+
+  <BoolProperty Name="Visible" Visible="false" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/ApplicationDefinition.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/ApplicationDefinition.BrowseObject.xaml
@@ -1,77 +1,144 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule Name="ApplicationDefinition" Description="File Properties" DisplayName="ApplicationDefinition" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="ApplicationDefinition"
+      Description="File Properties"
+      DisplayName="ApplicationDefinition"
+      PageTemplate="generic"
+      PropertyPagesHidden="true"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
-    <Category Name="Advanced" DisplayName="Advanced" />
-    <Category Name="Misc" DisplayName="Misc" />
+    <Category Name="Advanced"
+              DisplayName="Advanced" />
+    <Category Name="Misc"
+              DisplayName="Misc" />
   </Rule.Categories>
 
   <Rule.DataSource>
-    <DataSource HasConfigurationCondition="False" ItemType="ApplicationDefinition" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                ItemType="ApplicationDefinition"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <DynamicEnumProperty Name="{}{ItemType}" Category="Advanced" Description="How the file relates to the build and deployment processes." DisplayName="Build Action" EnumProvider="ItemTypes" />
+  <DynamicEnumProperty Name="{}{ItemType}"
+                       Category="Advanced"
+                       Description="How the file relates to the build and deployment processes."
+                       DisplayName="Build Action"
+                       EnumProvider="ItemTypes" />
 
-  <BoolProperty Name="AutoGen" Visible="false" />
+  <BoolProperty Name="AutoGen"
+                Visible="false" />
 
-  <EnumProperty Name="CopyToOutputDirectory" Category="Advanced" Description="Specifies the source file will be copied to the output directory." DisplayName="Copy to Output Directory">
-    <EnumValue Name="Never" DisplayName="Do not copy" />
-    <EnumValue Name="Always" DisplayName="Copy always" />
-    <EnumValue Name="PreserveNewest" DisplayName="Copy if newer" />
+  <EnumProperty Name="CopyToOutputDirectory"
+                Category="Advanced"
+                Description="Specifies the source file will be copied to the output directory."
+                DisplayName="Copy to Output Directory">
+    <EnumValue Name="Never"
+               DisplayName="Do not copy" />
+    <EnumValue Name="Always"
+               DisplayName="Copy always" />
+    <EnumValue Name="PreserveNewest"
+               DisplayName="Copy if newer" />
   </EnumProperty>
 
-  <StringProperty Name="CustomTool" Visible="false">
+  <StringProperty Name="CustomTool"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource HasConfigurationCondition="False" ItemType="ApplicationDefinition" PersistedName="Generator" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="ApplicationDefinition"
+                  PersistedName="Generator"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="CustomToolNamespace" Category="Advanced" Description="The namespace into which the output of the custom tool is placed." DisplayName="Custom Tool Namespace" />
+  <StringProperty Name="CustomToolNamespace"
+                  Category="Advanced"
+                  Description="The namespace into which the output of the custom tool is placed."
+                  DisplayName="Custom Tool Namespace" />
 
-  <StringProperty Name="DependentUpon" Visible="false" />
+  <StringProperty Name="DependentUpon"
+                  Visible="false" />
 
-  <BoolProperty Name="DesignTime" Visible="false" />
+  <BoolProperty Name="DesignTime"
+                Visible="false" />
 
-  <StringProperty Name="Extension" ReadOnly="true" Visible="False">
+  <StringProperty Name="Extension"
+                  ReadOnly="true"
+                  Visible="False">
     <StringProperty.DataSource>
-      <DataSource ItemType="ApplicationDefinition" PersistedName="Extension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="ApplicationDefinition"
+                  PersistedName="Extension"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="FileNameAndExtension" Category="Misc" Description="Name of the file or folder." DisplayName="File Name" ReadOnly="true">
+  <StringProperty Name="FileNameAndExtension"
+                  Category="Misc"
+                  Description="Name of the file or folder."
+                  DisplayName="File Name"
+                  ReadOnly="true">
     <StringProperty.DataSource>
-      <DataSource ItemType="ApplicationDefinition" PersistedName="FileNameAndExtension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="ApplicationDefinition"
+                  PersistedName="FileNameAndExtension"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="FullPath" Category="Misc" Description="Location of the file." DisplayName="Full Path" ReadOnly="true">
+  <StringProperty Name="FullPath"
+                  Category="Misc"
+                  Description="Location of the file."
+                  DisplayName="Full Path"
+                  ReadOnly="true">
     <StringProperty.DataSource>
-      <DataSource ItemType="ApplicationDefinition" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="ApplicationDefinition"
+                  PersistedName="FullPath"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="Generator" Category="Advanced" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." DisplayName="Custom Tool" />
+  <StringProperty Name="Generator"
+                  Category="Advanced"
+                  Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool."
+                  DisplayName="Custom Tool" />
 
-  <StringProperty Name="Identity" ReadOnly="true" Visible="false">
+  <StringProperty Name="Identity"
+                  ReadOnly="true"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource ItemType="ApplicationDefinition" PersistedName="Identity" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="ApplicationDefinition"
+                  PersistedName="Identity"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="LastGenOutput" Visible="false" />
+  <StringProperty Name="LastGenOutput"
+                  Visible="false" />
 
-  <StringProperty Name="Link" Visible="false">
+  <StringProperty Name="Link"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
+      <DataSource PersistenceStyle="Attribute"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="URL" ReadOnly="true" Visible="false">
+  <StringProperty Name="URL"
+                  ReadOnly="true"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource ItemType="ApplicationDefinition" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="ApplicationDefinition"
+                  PersistedName="FullPath"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <BoolProperty Name="Visible" Visible="false" />
+  <BoolProperty Name="Visible"
+                Visible="false" />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/ApplicationDefinition.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/ApplicationDefinition.BrowseObject.xaml
@@ -1,98 +1,77 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule
-    Name="ApplicationDefinition"
-    DisplayName="ApplicationDefinition"
-    PageTemplate="generic"
-    Description="File Properties"
-    PropertyPagesHidden="true"
-    xmlns="http://schemas.microsoft.com/build/2009/properties">
-  <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="ApplicationDefinition" SourceOfDefaultValue="AfterContext" />
-  </Rule.DataSource>
+<Rule Name="ApplicationDefinition" Description="File Properties" DisplayName="ApplicationDefinition" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
     <Category Name="Advanced" DisplayName="Advanced" />
     <Category Name="Misc" DisplayName="Misc" />
   </Rule.Categories>
 
-  <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Build Action"  Category="Advanced"
-                   Description="How the file relates to the build and deployment processes."
-                   EnumProvider="ItemTypes" />
-  <EnumProperty
-    Name="CopyToOutputDirectory"
-    DisplayName="Copy to Output Directory"
-    Category="Advanced"
-    Description="Specifies the source file will be copied to the output directory.">
+  <Rule.DataSource>
+    <DataSource HasConfigurationCondition="False" ItemType="ApplicationDefinition" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+  </Rule.DataSource>
+
+  <DynamicEnumProperty Name="{}{ItemType}" Category="Advanced" Description="How the file relates to the build and deployment processes." DisplayName="Build Action" EnumProvider="ItemTypes" />
+
+  <BoolProperty Name="AutoGen" Visible="false" />
+
+  <EnumProperty Name="CopyToOutputDirectory" Category="Advanced" Description="Specifies the source file will be copied to the output directory." DisplayName="Copy to Output Directory">
     <EnumValue Name="Never" DisplayName="Do not copy" />
     <EnumValue Name="Always" DisplayName="Copy always" />
     <EnumValue Name="PreserveNewest" DisplayName="Copy if newer" />
   </EnumProperty>
 
-  <StringProperty
-    Name="Generator"
-    Category="Advanced"
-    DisplayName="Custom Tool"
-    Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
-  <StringProperty
-    Name="CustomToolNamespace"
-    Category="Advanced"
-    DisplayName="Custom Tool Namespace"
-    Description="The namespace into which the output of the custom tool is placed." />
-
-  <StringProperty
-    Name="Identity"
-    Visible="false"
-    ReadOnly="true">
+  <StringProperty Name="CustomTool" Visible="false">
     <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="ApplicationDefinition" PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False" ItemType="ApplicationDefinition" PersistedName="Generator" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty
-    Name="FullPath"
-    DisplayName="Full Path"
-    ReadOnly="true"
-    Category="Misc"
-    Description="Location of the file.">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="ApplicationDefinition" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" Description="The namespace into which the output of the custom tool is placed." DisplayName="Custom Tool Namespace" />
 
-  <StringProperty
-    Name="FileNameAndExtension"
-    DisplayName="File Name"
-    ReadOnly="true"
-    Category="Misc"
-    Description="Name of the file or folder.">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="ApplicationDefinition" PersistedName="FileNameAndExtension" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-
-  <StringProperty Name="URL" ReadOnly="true" Visible="false">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="ApplicationDefinition" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <BoolProperty Name="Visible" Visible="false" />
   <StringProperty Name="DependentUpon" Visible="false" />
+
+  <BoolProperty Name="DesignTime" Visible="false" />
+
+  <StringProperty Name="Extension" ReadOnly="true" Visible="False">
+    <StringProperty.DataSource>
+      <DataSource ItemType="ApplicationDefinition" PersistedName="Extension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="FileNameAndExtension" Category="Misc" Description="Name of the file or folder." DisplayName="File Name" ReadOnly="true">
+    <StringProperty.DataSource>
+      <DataSource ItemType="ApplicationDefinition" PersistedName="FileNameAndExtension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="FullPath" Category="Misc" Description="Location of the file." DisplayName="Full Path" ReadOnly="true">
+    <StringProperty.DataSource>
+      <DataSource ItemType="ApplicationDefinition" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="Generator" Category="Advanced" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." DisplayName="Custom Tool" />
+
+  <StringProperty Name="Identity" ReadOnly="true" Visible="false">
+    <StringProperty.DataSource>
+      <DataSource ItemType="ApplicationDefinition" PersistedName="Identity" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="LastGenOutput" Visible="false" />
+
   <StringProperty Name="Link" Visible="false">
     <StringProperty.DataSource>
       <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="Extension" Visible="False" ReadOnly="true">
+
+  <StringProperty Name="URL" ReadOnly="true" Visible="false">
     <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="ApplicationDefinition" PersistedName="Extension" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="ApplicationDefinition" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="LastGenOutput" Visible="false" />
-  <BoolProperty Name="DesignTime" Visible="false" />
-  <BoolProperty Name="AutoGen" Visible="false" />
-  <StringProperty Name="CustomTool" Visible="false">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" ItemType="ApplicationDefinition" PersistedName="Generator" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+
+  <BoolProperty Name="Visible" Visible="false" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/ApplicationDefinition.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/ApplicationDefinition.BrowseObject.xaml
@@ -5,7 +5,7 @@
       DisplayName="ApplicationDefinition"
       PageTemplate="generic"
       PropertyPagesHidden="true"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
     <Category Name="Advanced"
               DisplayName="Advanced" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/ApplicationDefinition.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/ApplicationDefinition.xaml
@@ -3,7 +3,7 @@
 <Rule Name="ApplicationDefinition"
       PageTemplate="generic"
       PropertyPagesHidden="true"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="ApplicationDefinition"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/ApplicationDefinition.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/ApplicationDefinition.xaml
@@ -1,13 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule Name="ApplicationDefinition" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="ApplicationDefinition"
+      PageTemplate="generic"
+      PropertyPagesHidden="true"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource HasConfigurationCondition="False" ItemType="ApplicationDefinition" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                ItemType="ApplicationDefinition"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <DynamicEnumProperty Name="{}{ItemType}" EnumProvider="ItemTypes" />
+  <DynamicEnumProperty Name="{}{ItemType}"
+                       EnumProvider="ItemTypes" />
 
-  <BoolProperty Name="AutoGen" Visible="false" />
+  <BoolProperty Name="AutoGen"
+                Visible="false" />
 
   <EnumProperty Name="CopyToOutputDirectory">
     <EnumValue Name="Never" />
@@ -15,28 +23,39 @@
     <EnumValue Name="PreserveNewest" />
   </EnumProperty>
 
-  <StringProperty Name="CustomTool" Visible="false">
+  <StringProperty Name="CustomTool"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource HasConfigurationCondition="False" ItemType="ApplicationDefinition" PersistedName="Generator" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="ApplicationDefinition"
+                  PersistedName="Generator"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
   <StringProperty Name="CustomToolNamespace" />
 
-  <StringProperty Name="DependentUpon" Visible="false" />
+  <StringProperty Name="DependentUpon"
+                  Visible="false" />
 
-  <BoolProperty Name="DesignTime" Visible="false" />
+  <BoolProperty Name="DesignTime"
+                Visible="false" />
 
   <StringProperty Name="Generator" />
 
-  <StringProperty Name="LastGenOutput" Visible="false" />
+  <StringProperty Name="LastGenOutput"
+                  Visible="false" />
 
-  <StringProperty Name="Link" Visible="false">
+  <StringProperty Name="Link"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
+      <DataSource PersistenceStyle="Attribute"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <BoolProperty Name="Visible" Visible="false" />
+  <BoolProperty Name="Visible"
+                Visible="false" />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/ApplicationDefinition.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/ApplicationDefinition.xaml
@@ -1,41 +1,42 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule
-    Name="ApplicationDefinition"
-    PageTemplate="generic"
-    PropertyPagesHidden="true"
-    xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="ApplicationDefinition" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="ApplicationDefinition" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False" ItemType="ApplicationDefinition" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <DynamicEnumProperty Name="{}{ItemType}"
-                   EnumProvider="ItemTypes" />
-  <EnumProperty
-    Name="CopyToOutputDirectory">
+  <DynamicEnumProperty Name="{}{ItemType}" EnumProvider="ItemTypes" />
+
+  <BoolProperty Name="AutoGen" Visible="false" />
+
+  <EnumProperty Name="CopyToOutputDirectory">
     <EnumValue Name="Never" />
     <EnumValue Name="Always" />
     <EnumValue Name="PreserveNewest" />
   </EnumProperty>
 
-  <StringProperty
-    Name="Generator" />
-  <StringProperty
-    Name="CustomToolNamespace" />
+  <StringProperty Name="CustomTool" Visible="false">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False" ItemType="ApplicationDefinition" PersistedName="Generator" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 
-  <BoolProperty Name="Visible" Visible="false" />
+  <StringProperty Name="CustomToolNamespace" />
+
   <StringProperty Name="DependentUpon" Visible="false" />
+
+  <BoolProperty Name="DesignTime" Visible="false" />
+
+  <StringProperty Name="Generator" />
+
+  <StringProperty Name="LastGenOutput" Visible="false" />
+
   <StringProperty Name="Link" Visible="false">
     <StringProperty.DataSource>
       <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="LastGenOutput" Visible="false" />
-  <BoolProperty Name="DesignTime" Visible="false" />
-  <BoolProperty Name="AutoGen" Visible="false" />
-  <StringProperty Name="CustomTool" Visible="false">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" ItemType="ApplicationDefinition" PersistedName="Generator" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+
+  <BoolProperty Name="Visible" Visible="false" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.BrowseObject.xaml
@@ -5,7 +5,7 @@
       DisplayName="File Properties"
       PageTemplate="generic"
       PropertyPagesHidden="true"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
     <Category Name="Advanced"
               DisplayName="Advanced" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.BrowseObject.xaml
@@ -1,84 +1,48 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright, Microsoft Corporation, All rights reserved.-->
-<Rule
-  Name="Compile"
-  DisplayName="File Properties"
-  PageTemplate="generic"
-  Description="File Properties"
-  PropertyPagesHidden="true"
-  xmlns="http://schemas.microsoft.com/build/2009/properties">
-
-  <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" Label="Configuration" ItemType="Compile" HasConfigurationCondition="false" SourceOfDefaultValue="AfterContext" />
-  </Rule.DataSource>
-
+<Rule Name="Compile" Description="File Properties" DisplayName="File Properties" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
     <Category Name="Advanced" DisplayName="Advanced" />
     <Category Name="Misc" DisplayName="Misc" />
   </Rule.Categories>
 
-  <StringProperty
-      Name="Generator"
-      Category="Advanced"
-      DisplayName="Custom Tool"
-      Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
-  <StringProperty
-      Name="CustomToolNamespace"
-      Category="Advanced"
-      DisplayName="Custom Tool Namespace"
-      Description="The namespace into which the output of the custom tool is placed." />
+  <Rule.DataSource>
+    <DataSource HasConfigurationCondition="false" ItemType="Compile" Label="Configuration" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+  </Rule.DataSource>
 
-  <DynamicEnumProperty
-      Name="{}{ItemType}"
-      DisplayName="Build Action"
-      Category="Advanced"
-      Description="How the file relates to the build and deployment processes."
-      EnumProvider="ItemTypes" />
+  <DynamicEnumProperty Name="{}{ItemType}" Category="Advanced" Description="How the file relates to the build and deployment processes." DisplayName="Build Action" EnumProvider="ItemTypes" />
 
-  <EnumProperty
-      Name="CopyToOutputDirectory"
-      DisplayName="Copy to Output Directory"
-      Category="Advanced"
-      Description="Specifies the source file will be copied to the output directory.">
+  <EnumProperty Name="CopyToOutputDirectory" Category="Advanced" Description="Specifies the source file will be copied to the output directory." DisplayName="Copy to Output Directory">
     <EnumValue Name="Never" DisplayName="Do not copy" />
     <EnumValue Name="Always" DisplayName="Copy always" />
     <EnumValue Name="PreserveNewest" DisplayName="Copy if newer" />
   </EnumProperty>
 
-  <StringProperty
-      Name="Identity"
-      Visible="false"
-      ReadOnly="true">
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" Description="The namespace into which the output of the custom tool is placed." DisplayName="Custom Tool Namespace" />
+
+  <StringProperty Name="Extension" ReadOnly="true" Visible="False">
     <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="Compile" PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Compile" PersistedName="Extension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty
-      Name="FullPath"
-      DisplayName="Full Path"
-      ReadOnly="true"
-      Category="Misc"
-      Description="Location of the file.">
+  <StringProperty Name="FileNameAndExtension" Category="Misc" Description="Name of the file or folder." DisplayName="File Name" ReadOnly="true">
     <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="Compile" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Compile" PersistedName="FileNameAndExtension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty
-      Name="FileNameAndExtension"
-      DisplayName="File Name"
-      ReadOnly="true"
-      Category="Misc"
-      Description="Name of the file or folder.">
+  <StringProperty Name="FullPath" Category="Misc" Description="Location of the file." DisplayName="Full Path" ReadOnly="true">
     <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="Compile" PersistedName="FileNameAndExtension" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Compile" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="URL" ReadOnly="true" Visible="false">
+  <StringProperty Name="Generator" Category="Advanced" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." DisplayName="Custom Tool" />
+
+  <StringProperty Name="Identity" ReadOnly="true" Visible="false">
     <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="Compile" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Compile" PersistedName="Identity" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
@@ -90,9 +54,10 @@
     <EnumValue Name="Code" />
   </EnumProperty>
 
-  <StringProperty Name="Extension" Visible="False" ReadOnly="true">
+  <StringProperty Name="URL" ReadOnly="true" Visible="false">
     <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="Compile" PersistedName="Extension" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Compile" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.BrowseObject.xaml
@@ -1,52 +1,104 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright, Microsoft Corporation, All rights reserved.-->
-<Rule Name="Compile" Description="File Properties" DisplayName="File Properties" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="Compile"
+      Description="File Properties"
+      DisplayName="File Properties"
+      PageTemplate="generic"
+      PropertyPagesHidden="true"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
-    <Category Name="Advanced" DisplayName="Advanced" />
-    <Category Name="Misc" DisplayName="Misc" />
+    <Category Name="Advanced"
+              DisplayName="Advanced" />
+    <Category Name="Misc"
+              DisplayName="Misc" />
   </Rule.Categories>
 
   <Rule.DataSource>
-    <DataSource HasConfigurationCondition="false" ItemType="Compile" Label="Configuration" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="false"
+                ItemType="Compile"
+                Label="Configuration"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <DynamicEnumProperty Name="{}{ItemType}" Category="Advanced" Description="How the file relates to the build and deployment processes." DisplayName="Build Action" EnumProvider="ItemTypes" />
+  <DynamicEnumProperty Name="{}{ItemType}"
+                       Category="Advanced"
+                       Description="How the file relates to the build and deployment processes."
+                       DisplayName="Build Action"
+                       EnumProvider="ItemTypes" />
 
-  <EnumProperty Name="CopyToOutputDirectory" Category="Advanced" Description="Specifies the source file will be copied to the output directory." DisplayName="Copy to Output Directory">
-    <EnumValue Name="Never" DisplayName="Do not copy" />
-    <EnumValue Name="Always" DisplayName="Copy always" />
-    <EnumValue Name="PreserveNewest" DisplayName="Copy if newer" />
+  <EnumProperty Name="CopyToOutputDirectory"
+                Category="Advanced"
+                Description="Specifies the source file will be copied to the output directory."
+                DisplayName="Copy to Output Directory">
+    <EnumValue Name="Never"
+               DisplayName="Do not copy" />
+    <EnumValue Name="Always"
+               DisplayName="Copy always" />
+    <EnumValue Name="PreserveNewest"
+               DisplayName="Copy if newer" />
   </EnumProperty>
 
-  <StringProperty Name="CustomToolNamespace" Category="Advanced" Description="The namespace into which the output of the custom tool is placed." DisplayName="Custom Tool Namespace" />
+  <StringProperty Name="CustomToolNamespace"
+                  Category="Advanced"
+                  Description="The namespace into which the output of the custom tool is placed."
+                  DisplayName="Custom Tool Namespace" />
 
-  <StringProperty Name="Extension" ReadOnly="true" Visible="False">
+  <StringProperty Name="Extension"
+                  ReadOnly="true"
+                  Visible="False">
     <StringProperty.DataSource>
-      <DataSource ItemType="Compile" PersistedName="Extension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Compile"
+                  PersistedName="Extension"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="FileNameAndExtension" Category="Misc" Description="Name of the file or folder." DisplayName="File Name" ReadOnly="true">
+  <StringProperty Name="FileNameAndExtension"
+                  Category="Misc"
+                  Description="Name of the file or folder."
+                  DisplayName="File Name"
+                  ReadOnly="true">
     <StringProperty.DataSource>
-      <DataSource ItemType="Compile" PersistedName="FileNameAndExtension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Compile"
+                  PersistedName="FileNameAndExtension"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="FullPath" Category="Misc" Description="Location of the file." DisplayName="Full Path" ReadOnly="true">
+  <StringProperty Name="FullPath"
+                  Category="Misc"
+                  Description="Location of the file."
+                  DisplayName="Full Path"
+                  ReadOnly="true">
     <StringProperty.DataSource>
-      <DataSource ItemType="Compile" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Compile"
+                  PersistedName="FullPath"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="Generator" Category="Advanced" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." DisplayName="Custom Tool" />
+  <StringProperty Name="Generator"
+                  Category="Advanced"
+                  Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool."
+                  DisplayName="Custom Tool" />
 
-  <StringProperty Name="Identity" ReadOnly="true" Visible="false">
+  <StringProperty Name="Identity"
+                  ReadOnly="true"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource ItemType="Compile" PersistedName="Identity" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Compile"
+                  PersistedName="Identity"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <EnumProperty Name="SubType" Visible="false">
+  <EnumProperty Name="SubType"
+                Visible="false">
     <EnumValue Name="Designer" />
     <EnumValue Name="Component" />
     <EnumValue Name="Control" />
@@ -54,9 +106,14 @@
     <EnumValue Name="Code" />
   </EnumProperty>
 
-  <StringProperty Name="URL" ReadOnly="true" Visible="false">
+  <StringProperty Name="URL"
+                  ReadOnly="true"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource ItemType="Compile" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Compile"
+                  PersistedName="FullPath"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.xaml
@@ -1,13 +1,22 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Rule Name="Compile" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="Compile"
+      PageTemplate="generic"
+      PropertyPagesHidden="true"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource HasConfigurationCondition="false" ItemType="Compile" Label="Configuration" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="false"
+                ItemType="Compile"
+                Label="Configuration"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <DynamicEnumProperty Name="{}{ItemType}" EnumProvider="ItemTypes" />
+  <DynamicEnumProperty Name="{}{ItemType}"
+                       EnumProvider="ItemTypes" />
 
-  <BoolProperty Name="AutoGen" Visible="false" />
+  <BoolProperty Name="AutoGen"
+                Visible="false" />
 
   <EnumProperty Name="CopyToOutputDirectory">
     <EnumValue Name="Never" />
@@ -17,41 +26,59 @@
 
   <StringProperty Name="CustomToolNamespace" />
 
-  <StringProperty Name="DependentUpon" Visible="false">
+  <StringProperty Name="DependentUpon"
+                  Visible="false">
     <StringProperty.Metadata>
-      <NameValuePair Name="DoNotCopyAcrossProjects" Value="true" />
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
     </StringProperty.Metadata>
   </StringProperty>
 
-  <BoolProperty Name="DesignTime" Visible="false" />
+  <BoolProperty Name="DesignTime"
+                Visible="false" />
 
   <BoolProperty Name="ExcludedFromBuild">
     <BoolProperty.DataSource>
-      <DataSource HasConfigurationCondition="true" ItemType="Compile" Label="Configuration" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="true"
+                  ItemType="Compile"
+                  Label="Configuration"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
     </BoolProperty.DataSource>
   </BoolProperty>
 
-  <StringProperty Name="FullPath" ReadOnly="true" Visible="false">
+  <StringProperty Name="FullPath"
+                  ReadOnly="true"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource ItemType="Compile" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Compile"
+                  PersistedName="FullPath"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
   <StringProperty Name="Generator" />
 
-  <StringProperty Name="LastGenOutput" Visible="false" />
+  <StringProperty Name="LastGenOutput"
+                  Visible="false" />
 
-  <StringProperty Name="Link" Visible="false">
+  <StringProperty Name="Link"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
+      <DataSource PersistenceStyle="Attribute"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
     <StringProperty.Metadata>
-      <NameValuePair Name="DoNotCopyAcrossProjects" Value="true" />
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
     </StringProperty.Metadata>
   </StringProperty>
 
-  <StringProperty Name="SubType" Visible="false" />
+  <StringProperty Name="SubType"
+                  Visible="false" />
 
-  <BoolProperty Name="Visible" Visible="false" />
+  <BoolProperty Name="Visible"
+                Visible="false" />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.xaml
@@ -3,7 +3,7 @@
 <Rule Name="Compile"
       PageTemplate="generic"
       PropertyPagesHidden="true"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="false"
                 ItemType="Compile"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.xaml
@@ -1,45 +1,46 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Rule
-    Name="Compile"
-    PageTemplate="generic"
-    PropertyPagesHidden="true"
-    xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="Compile" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" Label="Configuration" ItemType="Compile" HasConfigurationCondition="false" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="false" ItemType="Compile" Label="Configuration" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <DynamicEnumProperty Name="{}{ItemType}"
-                 EnumProvider="ItemTypes" />
-  <EnumProperty
-    Name="CopyToOutputDirectory">
+  <DynamicEnumProperty Name="{}{ItemType}" EnumProvider="ItemTypes" />
+
+  <BoolProperty Name="AutoGen" Visible="false" />
+
+  <EnumProperty Name="CopyToOutputDirectory">
     <EnumValue Name="Never" />
     <EnumValue Name="Always" />
     <EnumValue Name="PreserveNewest" />
   </EnumProperty>
 
-  <StringProperty
-    Name="Generator" />
-  <StringProperty
-    Name="CustomToolNamespace" />
+  <StringProperty Name="CustomToolNamespace" />
 
-  <StringProperty Name="FullPath" Visible="false" ReadOnly="true">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="Compile" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-
-  <BoolProperty Name="ExcludedFromBuild">
-    <BoolProperty.DataSource>
-      <DataSource Persistence="ProjectFile" Label="Configuration" ItemType="Compile" HasConfigurationCondition="true" SourceOfDefaultValue="AfterContext" />
-    </BoolProperty.DataSource>
-  </BoolProperty>
-  <BoolProperty Name="Visible" Visible="false" />
   <StringProperty Name="DependentUpon" Visible="false">
     <StringProperty.Metadata>
       <NameValuePair Name="DoNotCopyAcrossProjects" Value="true" />
     </StringProperty.Metadata>
   </StringProperty>
+
+  <BoolProperty Name="DesignTime" Visible="false" />
+
+  <BoolProperty Name="ExcludedFromBuild">
+    <BoolProperty.DataSource>
+      <DataSource HasConfigurationCondition="true" ItemType="Compile" Label="Configuration" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+    </BoolProperty.DataSource>
+  </BoolProperty>
+
+  <StringProperty Name="FullPath" ReadOnly="true" Visible="false">
+    <StringProperty.DataSource>
+      <DataSource ItemType="Compile" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="Generator" />
+
+  <StringProperty Name="LastGenOutput" Visible="false" />
+
   <StringProperty Name="Link" Visible="false">
     <StringProperty.DataSource>
       <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
@@ -48,8 +49,9 @@
       <NameValuePair Name="DoNotCopyAcrossProjects" Value="true" />
     </StringProperty.Metadata>
   </StringProperty>
+
   <StringProperty Name="SubType" Visible="false" />
-  <StringProperty Name="LastGenOutput" Visible="false" />
-  <BoolProperty Name="DesignTime" Visible="false" />
-  <BoolProperty Name="AutoGen" Visible="false" />
+
+  <BoolProperty Name="Visible" Visible="false" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.BrowseObject.xaml
@@ -1,56 +1,101 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule Name="Content" Description="File Properties" DisplayName="File Properties" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="Content"
+      Description="File Properties"
+      DisplayName="File Properties"
+      PageTemplate="generic"
+      PropertyPagesHidden="true"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
-    <Category Name="Advanced" DisplayName="Advanced" />
-    <Category Name="Misc" DisplayName="Misc" />
+    <Category Name="Advanced"
+              DisplayName="Advanced" />
+    <Category Name="Misc"
+              DisplayName="Misc" />
   </Rule.Categories>
 
   <Rule.DataSource>
-    <DataSource HasConfigurationCondition="False" ItemType="Content" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                ItemType="Content"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <DynamicEnumProperty Name="{}{ItemType}" Category="Advanced" Description="How the file relates to the build and deployment processes." DisplayName="Build Action" EnumProvider="ItemTypes" />
+  <DynamicEnumProperty Name="{}{ItemType}"
+                       Category="Advanced"
+                       Description="How the file relates to the build and deployment processes."
+                       DisplayName="Build Action"
+                       EnumProvider="ItemTypes" />
 
-  <EnumProperty Name="CopyToOutputDirectory" Category="Advanced" Description="Specifies the source file will be copied to the output directory." DisplayName="Copy to Output Directory">
-    <EnumValue Name="Never" DisplayName="Do not copy" />
-    <EnumValue Name="Always" DisplayName="Copy always" />
-    <EnumValue Name="PreserveNewest" DisplayName="Copy if newer" />
+  <EnumProperty Name="CopyToOutputDirectory"
+                Category="Advanced"
+                Description="Specifies the source file will be copied to the output directory."
+                DisplayName="Copy to Output Directory">
+    <EnumValue Name="Never"
+               DisplayName="Do not copy" />
+    <EnumValue Name="Always"
+               DisplayName="Copy always" />
+    <EnumValue Name="PreserveNewest"
+               DisplayName="Copy if newer" />
   </EnumProperty>
 
-  <StringProperty Name="DependentUpon" Visible="false">
+  <StringProperty Name="DependentUpon"
+                  Visible="false">
     <StringProperty.Metadata>
-      <NameValuePair Name="DoNotCopyAcrossProjects" Value="true" />
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
     </StringProperty.Metadata>
   </StringProperty>
 
-  <StringProperty Name="FileNameAndExtension" Category="Misc" Description="Name of the file or folder." DisplayName="File Name" ReadOnly="true">
+  <StringProperty Name="FileNameAndExtension"
+                  Category="Misc"
+                  Description="Name of the file or folder."
+                  DisplayName="File Name"
+                  ReadOnly="true">
     <StringProperty.DataSource>
-      <DataSource ItemType="Content" PersistedName="FileNameAndExtension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Content"
+                  PersistedName="FileNameAndExtension"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="FullPath" Category="Misc" Description="Location of the file." DisplayName="Full Path" ReadOnly="true">
+  <StringProperty Name="FullPath"
+                  Category="Misc"
+                  Description="Location of the file."
+                  DisplayName="Full Path"
+                  ReadOnly="true">
     <StringProperty.DataSource>
-      <DataSource ItemType="Content" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Content"
+                  PersistedName="FullPath"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="Identity" ReadOnly="true" Visible="false">
+  <StringProperty Name="Identity"
+                  ReadOnly="true"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource ItemType="Content" PersistedName="Identity" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Content"
+                  PersistedName="Identity"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="Link" Visible="false">
+  <StringProperty Name="Link"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
+      <DataSource PersistenceStyle="Attribute"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
     <StringProperty.Metadata>
-      <NameValuePair Name="DoNotCopyAcrossProjects" Value="true" />
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
     </StringProperty.Metadata>
   </StringProperty>
 
-  <BoolProperty Name="Visible" Visible="false" />
+  <BoolProperty Name="Visible"
+                Visible="false" />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.BrowseObject.xaml
@@ -5,7 +5,7 @@
       DisplayName="File Properties"
       PageTemplate="generic"
       PropertyPagesHidden="true"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
     <Category Name="Advanced"
               DisplayName="Advanced" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.BrowseObject.xaml
@@ -1,76 +1,47 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule
-  Name="Content"
-  DisplayName="File Properties"
-  PageTemplate="generic"
-  Description="File Properties"
-  PropertyPagesHidden="true"
-  xmlns="http://schemas.microsoft.com/build/2009/properties">
-
-  <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="Content" SourceOfDefaultValue="AfterContext" />
-  </Rule.DataSource>
-
+<Rule Name="Content" Description="File Properties" DisplayName="File Properties" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
     <Category Name="Advanced" DisplayName="Advanced" />
     <Category Name="Misc" DisplayName="Misc" />
   </Rule.Categories>
 
-  <DynamicEnumProperty
-      Name="{}{ItemType}"
-      DisplayName="Build Action"
-      Category="Advanced"
-      Description="How the file relates to the build and deployment processes."
-      EnumProvider="ItemTypes" />
+  <Rule.DataSource>
+    <DataSource HasConfigurationCondition="False" ItemType="Content" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+  </Rule.DataSource>
 
-  <EnumProperty
-      Name="CopyToOutputDirectory"
-      DisplayName="Copy to Output Directory"
-      Category="Advanced"
-      Description="Specifies the source file will be copied to the output directory.">
+  <DynamicEnumProperty Name="{}{ItemType}" Category="Advanced" Description="How the file relates to the build and deployment processes." DisplayName="Build Action" EnumProvider="ItemTypes" />
+
+  <EnumProperty Name="CopyToOutputDirectory" Category="Advanced" Description="Specifies the source file will be copied to the output directory." DisplayName="Copy to Output Directory">
     <EnumValue Name="Never" DisplayName="Do not copy" />
     <EnumValue Name="Always" DisplayName="Copy always" />
     <EnumValue Name="PreserveNewest" DisplayName="Copy if newer" />
   </EnumProperty>
 
-  <StringProperty
-    Name="Identity"
-    Visible="false"
-    ReadOnly="true">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="Content" PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-
-  <StringProperty
-      Name="FullPath"
-      DisplayName="Full Path"
-      ReadOnly="true"
-      Category="Misc"
-      Description="Location of the file.">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="Content" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-
-  <StringProperty
-    Name="FileNameAndExtension"
-    DisplayName="File Name"
-    ReadOnly="true"
-    Category="Misc"
-    Description="Name of the file or folder.">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="Content" PersistedName="FileNameAndExtension" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-
-  <BoolProperty Name="Visible" Visible="false" />
   <StringProperty Name="DependentUpon" Visible="false">
     <StringProperty.Metadata>
       <NameValuePair Name="DoNotCopyAcrossProjects" Value="true" />
     </StringProperty.Metadata>
   </StringProperty>
+
+  <StringProperty Name="FileNameAndExtension" Category="Misc" Description="Name of the file or folder." DisplayName="File Name" ReadOnly="true">
+    <StringProperty.DataSource>
+      <DataSource ItemType="Content" PersistedName="FileNameAndExtension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="FullPath" Category="Misc" Description="Location of the file." DisplayName="Full Path" ReadOnly="true">
+    <StringProperty.DataSource>
+      <DataSource ItemType="Content" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="Identity" ReadOnly="true" Visible="false">
+    <StringProperty.DataSource>
+      <DataSource ItemType="Content" PersistedName="Identity" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
   <StringProperty Name="Link" Visible="false">
     <StringProperty.DataSource>
       <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
@@ -79,4 +50,7 @@
       <NameValuePair Name="DoNotCopyAcrossProjects" Value="true" />
     </StringProperty.Metadata>
   </StringProperty>
+
+  <BoolProperty Name="Visible" Visible="false" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.xaml
@@ -1,57 +1,42 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule
-  Name="Content"
-  PageTemplate="generic"
-  PropertyPagesHidden="true"
-  xmlns="http://schemas.microsoft.com/build/2009/properties">
-
+<Rule Name="Content" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="Content" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False" ItemType="Content" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <DynamicEnumProperty
-      Name="{}{ItemType}"
-      EnumProvider="ItemTypes" />
+  <DynamicEnumProperty Name="{}{ItemType}" EnumProvider="ItemTypes" />
 
-  <EnumProperty
-      Name="CopyToOutputDirectory">
+  <EnumProperty Name="CopyToOutputDirectory">
     <EnumValue Name="Never" />
     <EnumValue Name="Always" />
     <EnumValue Name="PreserveNewest" />
   </EnumProperty>
 
-  <StringProperty
-    Name="Identity"
-    Visible="false"
-    ReadOnly="true">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="Content" PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-
-  <StringProperty
-      Name="FullPath"
-      ReadOnly="true">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="Content" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-
-  <StringProperty
-    Name="FileNameAndExtension"
-    ReadOnly="true">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="Content" PersistedName="FileNameAndExtension" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-
-  <BoolProperty Name="Visible" Visible="false" />
   <StringProperty Name="DependentUpon" Visible="false">
     <StringProperty.Metadata>
       <NameValuePair Name="DoNotCopyAcrossProjects" Value="true" />
     </StringProperty.Metadata>
   </StringProperty>
+
+  <StringProperty Name="FileNameAndExtension" ReadOnly="true">
+    <StringProperty.DataSource>
+      <DataSource ItemType="Content" PersistedName="FileNameAndExtension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="FullPath" ReadOnly="true">
+    <StringProperty.DataSource>
+      <DataSource ItemType="Content" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="Identity" ReadOnly="true" Visible="false">
+    <StringProperty.DataSource>
+      <DataSource ItemType="Content" PersistedName="Identity" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
   <StringProperty Name="Link" Visible="false">
     <StringProperty.DataSource>
       <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
@@ -60,4 +45,7 @@
       <NameValuePair Name="DoNotCopyAcrossProjects" Value="true" />
     </StringProperty.Metadata>
   </StringProperty>
+
+  <BoolProperty Name="Visible" Visible="false" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.xaml
@@ -3,7 +3,7 @@
 <Rule Name="Content"
       PageTemplate="generic"
       PropertyPagesHidden="true"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="Content"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.xaml
@@ -1,11 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule Name="Content" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="Content"
+      PageTemplate="generic"
+      PropertyPagesHidden="true"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource HasConfigurationCondition="False" ItemType="Content" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                ItemType="Content"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <DynamicEnumProperty Name="{}{ItemType}" EnumProvider="ItemTypes" />
+  <DynamicEnumProperty Name="{}{ItemType}"
+                       EnumProvider="ItemTypes" />
 
   <EnumProperty Name="CopyToOutputDirectory">
     <EnumValue Name="Never" />
@@ -13,39 +20,58 @@
     <EnumValue Name="PreserveNewest" />
   </EnumProperty>
 
-  <StringProperty Name="DependentUpon" Visible="false">
+  <StringProperty Name="DependentUpon"
+                  Visible="false">
     <StringProperty.Metadata>
-      <NameValuePair Name="DoNotCopyAcrossProjects" Value="true" />
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
     </StringProperty.Metadata>
   </StringProperty>
 
-  <StringProperty Name="FileNameAndExtension" ReadOnly="true">
+  <StringProperty Name="FileNameAndExtension"
+                  ReadOnly="true">
     <StringProperty.DataSource>
-      <DataSource ItemType="Content" PersistedName="FileNameAndExtension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Content"
+                  PersistedName="FileNameAndExtension"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="FullPath" ReadOnly="true">
+  <StringProperty Name="FullPath"
+                  ReadOnly="true">
     <StringProperty.DataSource>
-      <DataSource ItemType="Content" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Content"
+                  PersistedName="FullPath"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="Identity" ReadOnly="true" Visible="false">
+  <StringProperty Name="Identity"
+                  ReadOnly="true"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource ItemType="Content" PersistedName="Identity" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Content"
+                  PersistedName="Identity"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="Link" Visible="false">
+  <StringProperty Name="Link"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
+      <DataSource PersistenceStyle="Attribute"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
     <StringProperty.Metadata>
-      <NameValuePair Name="DoNotCopyAcrossProjects" Value="true" />
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
     </StringProperty.Metadata>
   </StringProperty>
 
-  <BoolProperty Name="Visible" Visible="false" />
+  <BoolProperty Name="Visible"
+                Visible="false" />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.BrowseObject.xaml
@@ -5,7 +5,7 @@
       DisplayName="Embedded Resource"
       PageTemplate="generic"
       PropertyPagesHidden="true"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
     <Category Name="Advanced"
               DisplayName="Advanced" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.BrowseObject.xaml
@@ -1,77 +1,144 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule Name="EmbeddedResource" Description="File Properties" DisplayName="Embedded Resource" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="EmbeddedResource"
+      Description="File Properties"
+      DisplayName="Embedded Resource"
+      PageTemplate="generic"
+      PropertyPagesHidden="true"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
-    <Category Name="Advanced" DisplayName="Advanced" />
-    <Category Name="Misc" DisplayName="Misc" />
+    <Category Name="Advanced"
+              DisplayName="Advanced" />
+    <Category Name="Misc"
+              DisplayName="Misc" />
   </Rule.Categories>
 
   <Rule.DataSource>
-    <DataSource HasConfigurationCondition="False" ItemType="EmbeddedResource" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                ItemType="EmbeddedResource"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <DynamicEnumProperty Name="{}{ItemType}" Category="Advanced" Description="How the file relates to the build and deployment processes." DisplayName="Build Action" EnumProvider="ItemTypes" />
+  <DynamicEnumProperty Name="{}{ItemType}"
+                       Category="Advanced"
+                       Description="How the file relates to the build and deployment processes."
+                       DisplayName="Build Action"
+                       EnumProvider="ItemTypes" />
 
-  <BoolProperty Name="AutoGen" Visible="false" />
+  <BoolProperty Name="AutoGen"
+                Visible="false" />
 
-  <EnumProperty Name="CopyToOutputDirectory" Category="Advanced" Description="Specifies the source file will be copied to the output directory." DisplayName="Copy to Output Directory">
-    <EnumValue Name="Never" DisplayName="Do not copy" />
-    <EnumValue Name="Always" DisplayName="Copy always" />
-    <EnumValue Name="PreserveNewest" DisplayName="Copy if newer" />
+  <EnumProperty Name="CopyToOutputDirectory"
+                Category="Advanced"
+                Description="Specifies the source file will be copied to the output directory."
+                DisplayName="Copy to Output Directory">
+    <EnumValue Name="Never"
+               DisplayName="Do not copy" />
+    <EnumValue Name="Always"
+               DisplayName="Copy always" />
+    <EnumValue Name="PreserveNewest"
+               DisplayName="Copy if newer" />
   </EnumProperty>
 
-  <StringProperty Name="CustomTool" Visible="false">
+  <StringProperty Name="CustomTool"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource HasConfigurationCondition="False" ItemType="EmbeddedResource" PersistedName="Generator" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="EmbeddedResource"
+                  PersistedName="Generator"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="CustomToolNamespace" Category="Advanced" Description="The namespace into which the output of the custom tool is placed." DisplayName="Custom Tool Namespace" />
+  <StringProperty Name="CustomToolNamespace"
+                  Category="Advanced"
+                  Description="The namespace into which the output of the custom tool is placed."
+                  DisplayName="Custom Tool Namespace" />
 
-  <StringProperty Name="DependentUpon" Visible="false" />
+  <StringProperty Name="DependentUpon"
+                  Visible="false" />
 
-  <BoolProperty Name="DesignTime" Visible="false" />
+  <BoolProperty Name="DesignTime"
+                Visible="false" />
 
-  <StringProperty Name="Extension" ReadOnly="true" Visible="False">
+  <StringProperty Name="Extension"
+                  ReadOnly="true"
+                  Visible="False">
     <StringProperty.DataSource>
-      <DataSource ItemType="EmbeddedResource" PersistedName="Extension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="EmbeddedResource"
+                  PersistedName="Extension"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="FileNameAndExtension" Category="Misc" Description="Name of the file or folder." DisplayName="File Name" ReadOnly="true">
+  <StringProperty Name="FileNameAndExtension"
+                  Category="Misc"
+                  Description="Name of the file or folder."
+                  DisplayName="File Name"
+                  ReadOnly="true">
     <StringProperty.DataSource>
-      <DataSource ItemType="EmbeddedResource" PersistedName="FileNameAndExtension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="EmbeddedResource"
+                  PersistedName="FileNameAndExtension"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="FullPath" Category="Misc" Description="Location of the file." DisplayName="Full Path" ReadOnly="true">
+  <StringProperty Name="FullPath"
+                  Category="Misc"
+                  Description="Location of the file."
+                  DisplayName="Full Path"
+                  ReadOnly="true">
     <StringProperty.DataSource>
-      <DataSource ItemType="EmbeddedResource" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="EmbeddedResource"
+                  PersistedName="FullPath"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="Generator" Category="Advanced" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." DisplayName="Custom Tool" />
+  <StringProperty Name="Generator"
+                  Category="Advanced"
+                  Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool."
+                  DisplayName="Custom Tool" />
 
-  <StringProperty Name="Identity" ReadOnly="true" Visible="false">
+  <StringProperty Name="Identity"
+                  ReadOnly="true"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource ItemType="EmbeddedResource" PersistedName="Identity" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="EmbeddedResource"
+                  PersistedName="Identity"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="LastGenOutput" Visible="false" />
+  <StringProperty Name="LastGenOutput"
+                  Visible="false" />
 
-  <StringProperty Name="Link" Visible="false">
+  <StringProperty Name="Link"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
+      <DataSource PersistenceStyle="Attribute"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="URL" ReadOnly="true" Visible="false">
+  <StringProperty Name="URL"
+                  ReadOnly="true"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource ItemType="EmbeddedResource" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="EmbeddedResource"
+                  PersistedName="FullPath"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <BoolProperty Name="Visible" Visible="false" />
+  <BoolProperty Name="Visible"
+                Visible="false" />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.BrowseObject.xaml
@@ -1,98 +1,77 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule
-    Name="EmbeddedResource"
-    DisplayName="Embedded Resource"
-    PageTemplate="generic"
-    Description="File Properties"
-    PropertyPagesHidden="true"
-    xmlns="http://schemas.microsoft.com/build/2009/properties">
-    <Rule.DataSource>
-        <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="EmbeddedResource" SourceOfDefaultValue="AfterContext" />
-    </Rule.DataSource>
-    <Rule.Categories>
-        <Category Name="Advanced" DisplayName="Advanced" />
-        <Category Name="Misc" DisplayName="Misc" />
-    </Rule.Categories>
+<Rule Name="EmbeddedResource" Description="File Properties" DisplayName="Embedded Resource" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
+  <Rule.Categories>
+    <Category Name="Advanced" DisplayName="Advanced" />
+    <Category Name="Misc" DisplayName="Misc" />
+  </Rule.Categories>
 
-    <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Build Action"  Category="Advanced"
-                     Description="How the file relates to the build and deployment processes."
-                     EnumProvider="ItemTypes" />
-    <EnumProperty
-      Name="CopyToOutputDirectory"
-      DisplayName="Copy to Output Directory"
-      Category="Advanced"
-      Description="Specifies the source file will be copied to the output directory.">
-        <EnumValue Name="Never" DisplayName="Do not copy" />
-        <EnumValue Name="Always" DisplayName="Copy always" />
-        <EnumValue Name="PreserveNewest" DisplayName="Copy if newer" />
-    </EnumProperty>
+  <Rule.DataSource>
+    <DataSource HasConfigurationCondition="False" ItemType="EmbeddedResource" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+  </Rule.DataSource>
 
-    <StringProperty
-      Name="Generator"
-      Category="Advanced"
-      DisplayName="Custom Tool"
-      Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
-    <StringProperty
-      Name="CustomToolNamespace"
-      Category="Advanced"
-      DisplayName="Custom Tool Namespace"
-      Description="The namespace into which the output of the custom tool is placed." />
+  <DynamicEnumProperty Name="{}{ItemType}" Category="Advanced" Description="How the file relates to the build and deployment processes." DisplayName="Build Action" EnumProvider="ItemTypes" />
 
-    <StringProperty
-      Name="Identity"
-      Visible="false"
-      ReadOnly="true">
-        <StringProperty.DataSource>
-            <DataSource Persistence="Intrinsic" ItemType="EmbeddedResource" PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
-        </StringProperty.DataSource>
-    </StringProperty>
+  <BoolProperty Name="AutoGen" Visible="false" />
 
-    <StringProperty
-      Name="FullPath"
-      DisplayName="Full Path"
-      ReadOnly="true"
-      Category="Misc"
-      Description="Location of the file.">
-        <StringProperty.DataSource>
-            <DataSource Persistence="Intrinsic" ItemType="EmbeddedResource" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
-        </StringProperty.DataSource>
-    </StringProperty>
+  <EnumProperty Name="CopyToOutputDirectory" Category="Advanced" Description="Specifies the source file will be copied to the output directory." DisplayName="Copy to Output Directory">
+    <EnumValue Name="Never" DisplayName="Do not copy" />
+    <EnumValue Name="Always" DisplayName="Copy always" />
+    <EnumValue Name="PreserveNewest" DisplayName="Copy if newer" />
+  </EnumProperty>
 
-    <StringProperty
-      Name="FileNameAndExtension"
-      DisplayName="File Name"
-      ReadOnly="true"
-      Category="Misc"
-      Description="Name of the file or folder.">
-        <StringProperty.DataSource>
-            <DataSource Persistence="Intrinsic" ItemType="EmbeddedResource" PersistedName="FileNameAndExtension" SourceOfDefaultValue="AfterContext" />
-        </StringProperty.DataSource>
-    </StringProperty>
+  <StringProperty Name="CustomTool" Visible="false">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False" ItemType="EmbeddedResource" PersistedName="Generator" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 
-    <StringProperty Name="URL" ReadOnly="true" Visible="false">
-        <StringProperty.DataSource>
-            <DataSource Persistence="Intrinsic" ItemType="EmbeddedResource" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
-        </StringProperty.DataSource>
-    </StringProperty>
-    <BoolProperty Name="Visible" Visible="false" />
-    <StringProperty Name="DependentUpon" Visible="false" />
-    <StringProperty Name="Link" Visible="false">
-        <StringProperty.DataSource>
-            <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
-        </StringProperty.DataSource>
-    </StringProperty>
-    <StringProperty Name="Extension" Visible="False" ReadOnly="true">
-        <StringProperty.DataSource>
-            <DataSource Persistence="Intrinsic" ItemType="EmbeddedResource" PersistedName="Extension" SourceOfDefaultValue="AfterContext" />
-        </StringProperty.DataSource>
-    </StringProperty>
-    <StringProperty Name="LastGenOutput" Visible="false" />
-    <BoolProperty Name="DesignTime" Visible="false" />
-    <BoolProperty Name="AutoGen" Visible="false" />
-    <StringProperty Name="CustomTool" Visible="false">
-        <StringProperty.DataSource>
-            <DataSource Persistence="ProjectFile" ItemType="EmbeddedResource" PersistedName="Generator" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-        </StringProperty.DataSource>
-    </StringProperty>
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" Description="The namespace into which the output of the custom tool is placed." DisplayName="Custom Tool Namespace" />
+
+  <StringProperty Name="DependentUpon" Visible="false" />
+
+  <BoolProperty Name="DesignTime" Visible="false" />
+
+  <StringProperty Name="Extension" ReadOnly="true" Visible="False">
+    <StringProperty.DataSource>
+      <DataSource ItemType="EmbeddedResource" PersistedName="Extension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="FileNameAndExtension" Category="Misc" Description="Name of the file or folder." DisplayName="File Name" ReadOnly="true">
+    <StringProperty.DataSource>
+      <DataSource ItemType="EmbeddedResource" PersistedName="FileNameAndExtension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="FullPath" Category="Misc" Description="Location of the file." DisplayName="Full Path" ReadOnly="true">
+    <StringProperty.DataSource>
+      <DataSource ItemType="EmbeddedResource" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="Generator" Category="Advanced" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." DisplayName="Custom Tool" />
+
+  <StringProperty Name="Identity" ReadOnly="true" Visible="false">
+    <StringProperty.DataSource>
+      <DataSource ItemType="EmbeddedResource" PersistedName="Identity" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="LastGenOutput" Visible="false" />
+
+  <StringProperty Name="Link" Visible="false">
+    <StringProperty.DataSource>
+      <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="URL" ReadOnly="true" Visible="false">
+    <StringProperty.DataSource>
+      <DataSource ItemType="EmbeddedResource" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <BoolProperty Name="Visible" Visible="false" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.xaml
@@ -1,46 +1,48 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule
-    Name="EmbeddedResource"
-    PageTemplate="generic"
-    PropertyPagesHidden="true"
-    xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="EmbeddedResource" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="EmbeddedResource" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False" ItemType="EmbeddedResource" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <DynamicEnumProperty Name="{}{ItemType}"
-                   EnumProvider="ItemTypes" />
-  <EnumProperty
-    Name="CopyToOutputDirectory">
+  <DynamicEnumProperty Name="{}{ItemType}" EnumProvider="ItemTypes" />
+
+  <BoolProperty Name="AutoGen" Visible="false" />
+
+  <EnumProperty Name="CopyToOutputDirectory">
     <EnumValue Name="Never" />
     <EnumValue Name="Always" />
     <EnumValue Name="PreserveNewest" />
   </EnumProperty>
 
-  <StringProperty
-    Name="Generator" />
-  <StringProperty
-    Name="CustomToolNamespace" />
+  <StringProperty Name="CustomTool" Visible="false">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False" ItemType="EmbeddedResource" PersistedName="Generator" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 
-  <BoolProperty Name="Visible" Visible="false" />
+  <StringProperty Name="CustomToolNamespace" />
+
   <StringProperty Name="DependentUpon" Visible="false" />
+
+  <BoolProperty Name="DesignTime" Visible="false" />
+
+  <StringProperty Name="Extension" ReadOnly="true" Visible="False">
+    <StringProperty.DataSource>
+      <DataSource ItemType="EmbeddedResource" PersistedName="Extension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="Generator" />
+
+  <StringProperty Name="LastGenOutput" Visible="false" />
+
   <StringProperty Name="Link" Visible="false">
     <StringProperty.DataSource>
       <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="Extension" Visible="False" ReadOnly="true">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="EmbeddedResource" PersistedName="Extension" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="LastGenOutput" Visible="false" />
-  <BoolProperty Name="DesignTime" Visible="false" />
-  <BoolProperty Name="AutoGen" Visible="false" />
-  <StringProperty Name="CustomTool" Visible="false">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" ItemType="EmbeddedResource" PersistedName="Generator" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+
+  <BoolProperty Name="Visible" Visible="false" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.xaml
@@ -3,7 +3,7 @@
 <Rule Name="EmbeddedResource"
       PageTemplate="generic"
       PropertyPagesHidden="true"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="EmbeddedResource"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.xaml
@@ -1,13 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule Name="EmbeddedResource" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="EmbeddedResource"
+      PageTemplate="generic"
+      PropertyPagesHidden="true"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource HasConfigurationCondition="False" ItemType="EmbeddedResource" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                ItemType="EmbeddedResource"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <DynamicEnumProperty Name="{}{ItemType}" EnumProvider="ItemTypes" />
+  <DynamicEnumProperty Name="{}{ItemType}"
+                       EnumProvider="ItemTypes" />
 
-  <BoolProperty Name="AutoGen" Visible="false" />
+  <BoolProperty Name="AutoGen"
+                Visible="false" />
 
   <EnumProperty Name="CopyToOutputDirectory">
     <EnumValue Name="Never" />
@@ -15,34 +23,50 @@
     <EnumValue Name="PreserveNewest" />
   </EnumProperty>
 
-  <StringProperty Name="CustomTool" Visible="false">
+  <StringProperty Name="CustomTool"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource HasConfigurationCondition="False" ItemType="EmbeddedResource" PersistedName="Generator" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="EmbeddedResource"
+                  PersistedName="Generator"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
   <StringProperty Name="CustomToolNamespace" />
 
-  <StringProperty Name="DependentUpon" Visible="false" />
+  <StringProperty Name="DependentUpon"
+                  Visible="false" />
 
-  <BoolProperty Name="DesignTime" Visible="false" />
+  <BoolProperty Name="DesignTime"
+                Visible="false" />
 
-  <StringProperty Name="Extension" ReadOnly="true" Visible="False">
+  <StringProperty Name="Extension"
+                  ReadOnly="true"
+                  Visible="False">
     <StringProperty.DataSource>
-      <DataSource ItemType="EmbeddedResource" PersistedName="Extension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="EmbeddedResource"
+                  PersistedName="Extension"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
   <StringProperty Name="Generator" />
 
-  <StringProperty Name="LastGenOutput" Visible="false" />
+  <StringProperty Name="LastGenOutput"
+                  Visible="false" />
 
-  <StringProperty Name="Link" Visible="false">
+  <StringProperty Name="Link"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
+      <DataSource PersistenceStyle="Attribute"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <BoolProperty Name="Visible" Visible="false" />
+  <BoolProperty Name="Visible"
+                Visible="false" />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Folder.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Folder.xaml
@@ -5,7 +5,7 @@
       DisplayName="General"
       PageTemplate="generic"
       PropertyPagesHidden="true"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="Folder"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Folder.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Folder.xaml
@@ -1,14 +1,32 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Rule Name="Folder" Description="Folder Properties" DisplayName="General" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="Folder"
+      Description="Folder Properties"
+      DisplayName="General"
+      PageTemplate="generic"
+      PropertyPagesHidden="true"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource HasConfigurationCondition="False" ItemType="Folder" Persistence="ProjectFileFolderItems" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                ItemType="Folder"
+                Persistence="ProjectFileFolderItems"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <StringProperty Name="FolderName" Category="Misc" Description="Name of this folder" DisplayName="Folder Name" ReadOnly="true" />
+  <StringProperty Name="FolderName"
+                  Category="Misc"
+                  Description="Name of this folder"
+                  DisplayName="Folder Name"
+                  ReadOnly="true" />
 
-  <StringProperty Name="FullPath" Category="Misc" Description="Location of the folder" DisplayName="Full Path" ReadOnly="true" />
+  <StringProperty Name="FullPath"
+                  Category="Misc"
+                  Description="Location of the folder"
+                  DisplayName="Full Path"
+                  ReadOnly="true" />
 
-  <StringProperty Name="Identity" ReadOnly="true" Visible="false" />
+  <StringProperty Name="Identity"
+                  ReadOnly="true"
+                  Visible="false" />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Folder.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Folder.xaml
@@ -1,17 +1,14 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Rule
-  Name="Folder"
-  DisplayName="General"
-  PageTemplate="generic"
-  Description="Folder Properties"
-  PropertyPagesHidden="true"
-  xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="Folder" Description="Folder Properties" DisplayName="General" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFileFolderItems" HasConfigurationCondition="False" ItemType="Folder" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False" ItemType="Folder" Persistence="ProjectFileFolderItems" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <StringProperty Name="Identity" Visible="false" ReadOnly="true" />
-  <StringProperty Name="FullPath" DisplayName="Full Path" ReadOnly="true" Category="Misc" Description="Location of the folder" />
-  <StringProperty Name="FolderName" DisplayName="Folder Name" ReadOnly="true" Category="Misc" Description="Name of this folder" />
+  <StringProperty Name="FolderName" Category="Misc" Description="Name of this folder" DisplayName="Folder Name" ReadOnly="true" />
+
+  <StringProperty Name="FullPath" Category="Misc" Description="Location of the folder" DisplayName="Full Path" ReadOnly="true" />
+
+  <StringProperty Name="Identity" ReadOnly="true" Visible="false" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.BrowseObject.xaml
@@ -1,77 +1,144 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule Name="None" Description="File Properties" DisplayName="General" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="None"
+      Description="File Properties"
+      DisplayName="General"
+      PageTemplate="generic"
+      PropertyPagesHidden="true"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
-    <Category Name="Advanced" DisplayName="Advanced" />
-    <Category Name="Misc" DisplayName="Misc" />
+    <Category Name="Advanced"
+              DisplayName="Advanced" />
+    <Category Name="Misc"
+              DisplayName="Misc" />
   </Rule.Categories>
 
   <Rule.DataSource>
-    <DataSource HasConfigurationCondition="False" ItemType="None" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                ItemType="None"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <DynamicEnumProperty Name="{}{ItemType}" Category="Advanced" Description="How the file relates to the build and deployment processes." DisplayName="Build Action" EnumProvider="ItemTypes" />
+  <DynamicEnumProperty Name="{}{ItemType}"
+                       Category="Advanced"
+                       Description="How the file relates to the build and deployment processes."
+                       DisplayName="Build Action"
+                       EnumProvider="ItemTypes" />
 
-  <BoolProperty Name="AutoGen" Visible="false" />
+  <BoolProperty Name="AutoGen"
+                Visible="false" />
 
-  <EnumProperty Name="CopyToOutputDirectory" Category="Advanced" Description="Specifies the source file will be copied to the output directory." DisplayName="Copy to Output Directory">
-    <EnumValue Name="Never" DisplayName="Do not copy" />
-    <EnumValue Name="Always" DisplayName="Copy always" />
-    <EnumValue Name="PreserveNewest" DisplayName="Copy if newer" />
+  <EnumProperty Name="CopyToOutputDirectory"
+                Category="Advanced"
+                Description="Specifies the source file will be copied to the output directory."
+                DisplayName="Copy to Output Directory">
+    <EnumValue Name="Never"
+               DisplayName="Do not copy" />
+    <EnumValue Name="Always"
+               DisplayName="Copy always" />
+    <EnumValue Name="PreserveNewest"
+               DisplayName="Copy if newer" />
   </EnumProperty>
 
-  <StringProperty Name="CustomTool" Visible="false">
+  <StringProperty Name="CustomTool"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource HasConfigurationCondition="False" ItemType="None" PersistedName="Generator" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="None"
+                  PersistedName="Generator"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="CustomToolNamespace" Category="Advanced" Description="The namespace into which the output of the custom tool is placed." DisplayName="Custom Tool Namespace" />
+  <StringProperty Name="CustomToolNamespace"
+                  Category="Advanced"
+                  Description="The namespace into which the output of the custom tool is placed."
+                  DisplayName="Custom Tool Namespace" />
 
-  <StringProperty Name="DependentUpon" Visible="false" />
+  <StringProperty Name="DependentUpon"
+                  Visible="false" />
 
-  <BoolProperty Name="DesignTime" Visible="false" />
+  <BoolProperty Name="DesignTime"
+                Visible="false" />
 
-  <StringProperty Name="Extension" ReadOnly="true" Visible="False">
+  <StringProperty Name="Extension"
+                  ReadOnly="true"
+                  Visible="False">
     <StringProperty.DataSource>
-      <DataSource ItemType="None" PersistedName="Extension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="None"
+                  PersistedName="Extension"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="FileNameAndExtension" Category="Misc" Description="Name of the file or folder." DisplayName="File Name" ReadOnly="true">
+  <StringProperty Name="FileNameAndExtension"
+                  Category="Misc"
+                  Description="Name of the file or folder."
+                  DisplayName="File Name"
+                  ReadOnly="true">
     <StringProperty.DataSource>
-      <DataSource ItemType="None" PersistedName="FileNameAndExtension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="None"
+                  PersistedName="FileNameAndExtension"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="FullPath" Category="Misc" Description="Location of the file." DisplayName="Full Path" ReadOnly="true">
+  <StringProperty Name="FullPath"
+                  Category="Misc"
+                  Description="Location of the file."
+                  DisplayName="Full Path"
+                  ReadOnly="true">
     <StringProperty.DataSource>
-      <DataSource ItemType="None" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="None"
+                  PersistedName="FullPath"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="Generator" Category="Advanced" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." DisplayName="Custom Tool" />
+  <StringProperty Name="Generator"
+                  Category="Advanced"
+                  Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool."
+                  DisplayName="Custom Tool" />
 
-  <StringProperty Name="Identity" ReadOnly="true" Visible="false">
+  <StringProperty Name="Identity"
+                  ReadOnly="true"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource ItemType="None" PersistedName="Identity" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="None"
+                  PersistedName="Identity"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="LastGenOutput" Visible="false" />
+  <StringProperty Name="LastGenOutput"
+                  Visible="false" />
 
-  <StringProperty Name="Link" Visible="false">
+  <StringProperty Name="Link"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
+      <DataSource PersistenceStyle="Attribute"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="URL" ReadOnly="true" Visible="false">
+  <StringProperty Name="URL"
+                  ReadOnly="true"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource ItemType="None" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="None"
+                  PersistedName="FullPath"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <BoolProperty Name="Visible" Visible="false" />
+  <BoolProperty Name="Visible"
+                Visible="false" />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.BrowseObject.xaml
@@ -5,7 +5,7 @@
       DisplayName="General"
       PageTemplate="generic"
       PropertyPagesHidden="true"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
     <Category Name="Advanced"
               DisplayName="Advanced" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.BrowseObject.xaml
@@ -1,98 +1,77 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule
-  Name="None"
-  DisplayName="General"
-  PageTemplate="generic"
-  Description="File Properties"
-  PropertyPagesHidden="true"
-  xmlns="http://schemas.microsoft.com/build/2009/properties">
-  <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="None" SourceOfDefaultValue="AfterContext" />
-  </Rule.DataSource>
+<Rule Name="None" Description="File Properties" DisplayName="General" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
     <Category Name="Advanced" DisplayName="Advanced" />
     <Category Name="Misc" DisplayName="Misc" />
   </Rule.Categories>
 
-  <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Build Action"  Category="Advanced"
-                     Description="How the file relates to the build and deployment processes."
-                     EnumProvider="ItemTypes" />
-  <EnumProperty
-      Name="CopyToOutputDirectory"
-      DisplayName="Copy to Output Directory"
-      Category="Advanced"
-      Description="Specifies the source file will be copied to the output directory.">
+  <Rule.DataSource>
+    <DataSource HasConfigurationCondition="False" ItemType="None" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+  </Rule.DataSource>
+
+  <DynamicEnumProperty Name="{}{ItemType}" Category="Advanced" Description="How the file relates to the build and deployment processes." DisplayName="Build Action" EnumProvider="ItemTypes" />
+
+  <BoolProperty Name="AutoGen" Visible="false" />
+
+  <EnumProperty Name="CopyToOutputDirectory" Category="Advanced" Description="Specifies the source file will be copied to the output directory." DisplayName="Copy to Output Directory">
     <EnumValue Name="Never" DisplayName="Do not copy" />
     <EnumValue Name="Always" DisplayName="Copy always" />
     <EnumValue Name="PreserveNewest" DisplayName="Copy if newer" />
   </EnumProperty>
 
-  <StringProperty
-      Name="Generator"
-      Category="Advanced"
-      DisplayName="Custom Tool"
-      Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
-  <StringProperty
-      Name="CustomToolNamespace"
-      Category="Advanced"
-      DisplayName="Custom Tool Namespace"
-      Description="The namespace into which the output of the custom tool is placed." />
-
-  <StringProperty
-      Name="Identity"
-      Visible="false"
-      ReadOnly="true">
+  <StringProperty Name="CustomTool" Visible="false">
     <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="None" PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False" ItemType="None" PersistedName="Generator" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty
-      Name="FullPath"
-      DisplayName="Full Path"
-      ReadOnly="true"
-      Category="Misc"
-      Description="Location of the file.">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="None" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" Description="The namespace into which the output of the custom tool is placed." DisplayName="Custom Tool Namespace" />
 
-  <StringProperty
-      Name="FileNameAndExtension"
-      DisplayName="File Name"
-      ReadOnly="true"
-      Category="Misc"
-      Description="Name of the file or folder.">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="None" PersistedName="FileNameAndExtension" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-
-  <StringProperty Name="URL" ReadOnly="true" Visible="false">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="None" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <BoolProperty Name="Visible" Visible="false" />
   <StringProperty Name="DependentUpon" Visible="false" />
+
+  <BoolProperty Name="DesignTime" Visible="false" />
+
+  <StringProperty Name="Extension" ReadOnly="true" Visible="False">
+    <StringProperty.DataSource>
+      <DataSource ItemType="None" PersistedName="Extension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="FileNameAndExtension" Category="Misc" Description="Name of the file or folder." DisplayName="File Name" ReadOnly="true">
+    <StringProperty.DataSource>
+      <DataSource ItemType="None" PersistedName="FileNameAndExtension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="FullPath" Category="Misc" Description="Location of the file." DisplayName="Full Path" ReadOnly="true">
+    <StringProperty.DataSource>
+      <DataSource ItemType="None" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="Generator" Category="Advanced" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." DisplayName="Custom Tool" />
+
+  <StringProperty Name="Identity" ReadOnly="true" Visible="false">
+    <StringProperty.DataSource>
+      <DataSource ItemType="None" PersistedName="Identity" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="LastGenOutput" Visible="false" />
+
   <StringProperty Name="Link" Visible="false">
     <StringProperty.DataSource>
       <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="Extension" Visible="False" ReadOnly="true">
+
+  <StringProperty Name="URL" ReadOnly="true" Visible="false">
     <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="None" PersistedName="Extension" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="None" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="LastGenOutput" Visible="false" />
-  <BoolProperty Name="DesignTime" Visible="false" />
-  <BoolProperty Name="AutoGen" Visible="false" />
-  <StringProperty Name="CustomTool" Visible="false">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" ItemType="None" PersistedName="Generator" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+
+  <BoolProperty Name="Visible" Visible="false" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.xaml
@@ -3,7 +3,7 @@
 <Rule Name="None"
       PageTemplate="generic"
       PropertyPagesHidden="true"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="None"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.xaml
@@ -1,49 +1,46 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule
-  Name="None"
-  PageTemplate="generic"
-  PropertyPagesHidden="true"
-  xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="None" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="None" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False" ItemType="None" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <DynamicEnumProperty Name="{}{ItemType}"
-                   EnumProvider="ItemTypes" />
-  <EnumProperty
-    Name="CopyToOutputDirectory">
+  <DynamicEnumProperty Name="{}{ItemType}" EnumProvider="ItemTypes" />
+
+  <BoolProperty Name="AutoGen" Visible="false" />
+
+  <EnumProperty Name="CopyToOutputDirectory">
     <EnumValue Name="Never" />
     <EnumValue Name="Always" />
     <EnumValue Name="PreserveNewest" />
   </EnumProperty>
 
-  <StringProperty
-    Name="Generator" />
-  <StringProperty
-    Name="CustomToolNamespace" />
-
-  <StringProperty Name="LastGenOutput" Visible="false" />
-  <BoolProperty Name="DesignTime" Visible="false" />
-  <BoolProperty Name="AutoGen" Visible="false" />
   <StringProperty Name="CustomTool" Visible="false">
     <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" ItemType="None" PersistedName="Generator" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False" ItemType="None" PersistedName="Generator" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="FullPath" Visible="false" ReadOnly="true">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="None" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+  <StringProperty Name="CustomToolNamespace" />
 
-  <BoolProperty Name="Visible" Visible="false" />
   <StringProperty Name="DependentUpon" Visible="false">
     <StringProperty.Metadata>
       <NameValuePair Name="DoNotCopyAcrossProjects" Value="true" />
     </StringProperty.Metadata>
   </StringProperty>
+
+  <BoolProperty Name="DesignTime" Visible="false" />
+
+  <StringProperty Name="FullPath" ReadOnly="true" Visible="false">
+    <StringProperty.DataSource>
+      <DataSource ItemType="None" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="Generator" />
+
+  <StringProperty Name="LastGenOutput" Visible="false" />
+
   <StringProperty Name="Link" Visible="false">
     <StringProperty.DataSource>
       <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
@@ -52,5 +49,7 @@
       <NameValuePair Name="DoNotCopyAcrossProjects" Value="true" />
     </StringProperty.Metadata>
   </StringProperty>
+
+  <BoolProperty Name="Visible" Visible="false" />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.xaml
@@ -1,13 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule Name="None" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="None"
+      PageTemplate="generic"
+      PropertyPagesHidden="true"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource HasConfigurationCondition="False" ItemType="None" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                ItemType="None"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <DynamicEnumProperty Name="{}{ItemType}" EnumProvider="ItemTypes" />
+  <DynamicEnumProperty Name="{}{ItemType}"
+                       EnumProvider="ItemTypes" />
 
-  <BoolProperty Name="AutoGen" Visible="false" />
+  <BoolProperty Name="AutoGen"
+                Visible="false" />
 
   <EnumProperty Name="CopyToOutputDirectory">
     <EnumValue Name="Never" />
@@ -15,41 +23,59 @@
     <EnumValue Name="PreserveNewest" />
   </EnumProperty>
 
-  <StringProperty Name="CustomTool" Visible="false">
+  <StringProperty Name="CustomTool"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource HasConfigurationCondition="False" ItemType="None" PersistedName="Generator" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="None"
+                  PersistedName="Generator"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
   <StringProperty Name="CustomToolNamespace" />
 
-  <StringProperty Name="DependentUpon" Visible="false">
+  <StringProperty Name="DependentUpon"
+                  Visible="false">
     <StringProperty.Metadata>
-      <NameValuePair Name="DoNotCopyAcrossProjects" Value="true" />
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
     </StringProperty.Metadata>
   </StringProperty>
 
-  <BoolProperty Name="DesignTime" Visible="false" />
+  <BoolProperty Name="DesignTime"
+                Visible="false" />
 
-  <StringProperty Name="FullPath" ReadOnly="true" Visible="false">
+  <StringProperty Name="FullPath"
+                  ReadOnly="true"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource ItemType="None" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="None"
+                  PersistedName="FullPath"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
   <StringProperty Name="Generator" />
 
-  <StringProperty Name="LastGenOutput" Visible="false" />
+  <StringProperty Name="LastGenOutput"
+                  Visible="false" />
 
-  <StringProperty Name="Link" Visible="false">
+  <StringProperty Name="Link"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
+      <DataSource PersistenceStyle="Attribute"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
     <StringProperty.Metadata>
-      <NameValuePair Name="DoNotCopyAcrossProjects" Value="true" />
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
     </StringProperty.Metadata>
   </StringProperty>
 
-  <BoolProperty Name="Visible" Visible="false" />
+  <BoolProperty Name="Visible"
+                Visible="false" />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Page.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Page.BrowseObject.xaml
@@ -5,7 +5,7 @@
       DisplayName="Page"
       PageTemplate="generic"
       PropertyPagesHidden="true"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
     <Category Name="Advanced"
               DisplayName="Advanced" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Page.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Page.BrowseObject.xaml
@@ -1,98 +1,77 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule
-    Name="Page"
-    DisplayName="Page"
-    PageTemplate="generic"
-    Description="File Properties"
-    PropertyPagesHidden="true"
-    xmlns="http://schemas.microsoft.com/build/2009/properties">
-  <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="Page" SourceOfDefaultValue="AfterContext" />
-  </Rule.DataSource>
+<Rule Name="Page" Description="File Properties" DisplayName="Page" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
     <Category Name="Advanced" DisplayName="Advanced" />
     <Category Name="Misc" DisplayName="Misc" />
   </Rule.Categories>
 
-  <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Build Action"  Category="Advanced"
-                   Description="How the file relates to the build and deployment processes."
-                   EnumProvider="ItemTypes" />
-  <EnumProperty
-    Name="CopyToOutputDirectory"
-    DisplayName="Copy to Output Directory"
-    Category="Advanced"
-    Description="Specifies the source file will be copied to the output directory.">
+  <Rule.DataSource>
+    <DataSource HasConfigurationCondition="False" ItemType="Page" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+  </Rule.DataSource>
+
+  <DynamicEnumProperty Name="{}{ItemType}" Category="Advanced" Description="How the file relates to the build and deployment processes." DisplayName="Build Action" EnumProvider="ItemTypes" />
+
+  <BoolProperty Name="AutoGen" Visible="false" />
+
+  <EnumProperty Name="CopyToOutputDirectory" Category="Advanced" Description="Specifies the source file will be copied to the output directory." DisplayName="Copy to Output Directory">
     <EnumValue Name="Never" DisplayName="Do not copy" />
     <EnumValue Name="Always" DisplayName="Copy always" />
     <EnumValue Name="PreserveNewest" DisplayName="Copy if newer" />
   </EnumProperty>
 
-  <StringProperty
-    Name="Generator"
-    Category="Advanced"
-    DisplayName="Custom Tool"
-    Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
-  <StringProperty
-    Name="CustomToolNamespace"
-    Category="Advanced"
-    DisplayName="Custom Tool Namespace"
-    Description="The namespace into which the output of the custom tool is placed." />
-
-  <StringProperty
-    Name="Identity"
-    Visible="false"
-    ReadOnly="true">
+  <StringProperty Name="CustomTool" Visible="false">
     <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="Page" PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False" ItemType="Page" PersistedName="Generator" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty
-    Name="FullPath"
-    DisplayName="Full Path"
-    ReadOnly="true"
-    Category="Misc"
-    Description="Location of the file.">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="Page" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" Description="The namespace into which the output of the custom tool is placed." DisplayName="Custom Tool Namespace" />
 
-  <StringProperty
-    Name="FileNameAndExtension"
-    DisplayName="File Name"
-    ReadOnly="true"
-    Category="Misc"
-    Description="Name of the file or folder.">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="Page" PersistedName="FileNameAndExtension" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-
-  <StringProperty Name="URL" ReadOnly="true" Visible="false">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="Page" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <BoolProperty Name="Visible" Visible="false" />
   <StringProperty Name="DependentUpon" Visible="false" />
+
+  <BoolProperty Name="DesignTime" Visible="false" />
+
+  <StringProperty Name="Extension" ReadOnly="true" Visible="False">
+    <StringProperty.DataSource>
+      <DataSource ItemType="Page" PersistedName="Extension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="FileNameAndExtension" Category="Misc" Description="Name of the file or folder." DisplayName="File Name" ReadOnly="true">
+    <StringProperty.DataSource>
+      <DataSource ItemType="Page" PersistedName="FileNameAndExtension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="FullPath" Category="Misc" Description="Location of the file." DisplayName="Full Path" ReadOnly="true">
+    <StringProperty.DataSource>
+      <DataSource ItemType="Page" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="Generator" Category="Advanced" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." DisplayName="Custom Tool" />
+
+  <StringProperty Name="Identity" ReadOnly="true" Visible="false">
+    <StringProperty.DataSource>
+      <DataSource ItemType="Page" PersistedName="Identity" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="LastGenOutput" Visible="false" />
+
   <StringProperty Name="Link" Visible="false">
     <StringProperty.DataSource>
       <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="Extension" Visible="False" ReadOnly="true">
+
+  <StringProperty Name="URL" ReadOnly="true" Visible="false">
     <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="Page" PersistedName="Extension" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Page" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="LastGenOutput" Visible="false" />
-  <BoolProperty Name="DesignTime" Visible="false" />
-  <BoolProperty Name="AutoGen" Visible="false" />
-  <StringProperty Name="CustomTool" Visible="false">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" ItemType="Page" PersistedName="Generator" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+
+  <BoolProperty Name="Visible" Visible="false" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Page.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Page.BrowseObject.xaml
@@ -1,77 +1,144 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule Name="Page" Description="File Properties" DisplayName="Page" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="Page"
+      Description="File Properties"
+      DisplayName="Page"
+      PageTemplate="generic"
+      PropertyPagesHidden="true"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
-    <Category Name="Advanced" DisplayName="Advanced" />
-    <Category Name="Misc" DisplayName="Misc" />
+    <Category Name="Advanced"
+              DisplayName="Advanced" />
+    <Category Name="Misc"
+              DisplayName="Misc" />
   </Rule.Categories>
 
   <Rule.DataSource>
-    <DataSource HasConfigurationCondition="False" ItemType="Page" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                ItemType="Page"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <DynamicEnumProperty Name="{}{ItemType}" Category="Advanced" Description="How the file relates to the build and deployment processes." DisplayName="Build Action" EnumProvider="ItemTypes" />
+  <DynamicEnumProperty Name="{}{ItemType}"
+                       Category="Advanced"
+                       Description="How the file relates to the build and deployment processes."
+                       DisplayName="Build Action"
+                       EnumProvider="ItemTypes" />
 
-  <BoolProperty Name="AutoGen" Visible="false" />
+  <BoolProperty Name="AutoGen"
+                Visible="false" />
 
-  <EnumProperty Name="CopyToOutputDirectory" Category="Advanced" Description="Specifies the source file will be copied to the output directory." DisplayName="Copy to Output Directory">
-    <EnumValue Name="Never" DisplayName="Do not copy" />
-    <EnumValue Name="Always" DisplayName="Copy always" />
-    <EnumValue Name="PreserveNewest" DisplayName="Copy if newer" />
+  <EnumProperty Name="CopyToOutputDirectory"
+                Category="Advanced"
+                Description="Specifies the source file will be copied to the output directory."
+                DisplayName="Copy to Output Directory">
+    <EnumValue Name="Never"
+               DisplayName="Do not copy" />
+    <EnumValue Name="Always"
+               DisplayName="Copy always" />
+    <EnumValue Name="PreserveNewest"
+               DisplayName="Copy if newer" />
   </EnumProperty>
 
-  <StringProperty Name="CustomTool" Visible="false">
+  <StringProperty Name="CustomTool"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource HasConfigurationCondition="False" ItemType="Page" PersistedName="Generator" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="Page"
+                  PersistedName="Generator"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="CustomToolNamespace" Category="Advanced" Description="The namespace into which the output of the custom tool is placed." DisplayName="Custom Tool Namespace" />
+  <StringProperty Name="CustomToolNamespace"
+                  Category="Advanced"
+                  Description="The namespace into which the output of the custom tool is placed."
+                  DisplayName="Custom Tool Namespace" />
 
-  <StringProperty Name="DependentUpon" Visible="false" />
+  <StringProperty Name="DependentUpon"
+                  Visible="false" />
 
-  <BoolProperty Name="DesignTime" Visible="false" />
+  <BoolProperty Name="DesignTime"
+                Visible="false" />
 
-  <StringProperty Name="Extension" ReadOnly="true" Visible="False">
+  <StringProperty Name="Extension"
+                  ReadOnly="true"
+                  Visible="False">
     <StringProperty.DataSource>
-      <DataSource ItemType="Page" PersistedName="Extension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Page"
+                  PersistedName="Extension"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="FileNameAndExtension" Category="Misc" Description="Name of the file or folder." DisplayName="File Name" ReadOnly="true">
+  <StringProperty Name="FileNameAndExtension"
+                  Category="Misc"
+                  Description="Name of the file or folder."
+                  DisplayName="File Name"
+                  ReadOnly="true">
     <StringProperty.DataSource>
-      <DataSource ItemType="Page" PersistedName="FileNameAndExtension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Page"
+                  PersistedName="FileNameAndExtension"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="FullPath" Category="Misc" Description="Location of the file." DisplayName="Full Path" ReadOnly="true">
+  <StringProperty Name="FullPath"
+                  Category="Misc"
+                  Description="Location of the file."
+                  DisplayName="Full Path"
+                  ReadOnly="true">
     <StringProperty.DataSource>
-      <DataSource ItemType="Page" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Page"
+                  PersistedName="FullPath"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="Generator" Category="Advanced" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." DisplayName="Custom Tool" />
+  <StringProperty Name="Generator"
+                  Category="Advanced"
+                  Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool."
+                  DisplayName="Custom Tool" />
 
-  <StringProperty Name="Identity" ReadOnly="true" Visible="false">
+  <StringProperty Name="Identity"
+                  ReadOnly="true"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource ItemType="Page" PersistedName="Identity" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Page"
+                  PersistedName="Identity"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="LastGenOutput" Visible="false" />
+  <StringProperty Name="LastGenOutput"
+                  Visible="false" />
 
-  <StringProperty Name="Link" Visible="false">
+  <StringProperty Name="Link"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
+      <DataSource PersistenceStyle="Attribute"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="URL" ReadOnly="true" Visible="false">
+  <StringProperty Name="URL"
+                  ReadOnly="true"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource ItemType="Page" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Page"
+                  PersistedName="FullPath"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <BoolProperty Name="Visible" Visible="false" />
+  <BoolProperty Name="Visible"
+                Visible="false" />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Page.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Page.xaml
@@ -1,13 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule Name="Page" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="Page"
+      PageTemplate="generic"
+      PropertyPagesHidden="true"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource HasConfigurationCondition="False" ItemType="Page" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                ItemType="Page"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <DynamicEnumProperty Name="{}{ItemType}" EnumProvider="ItemTypes" />
+  <DynamicEnumProperty Name="{}{ItemType}"
+                       EnumProvider="ItemTypes" />
 
-  <BoolProperty Name="AutoGen" Visible="false" />
+  <BoolProperty Name="AutoGen"
+                Visible="false" />
 
   <EnumProperty Name="CopyToOutputDirectory">
     <EnumValue Name="Never" />
@@ -15,28 +23,39 @@
     <EnumValue Name="PreserveNewest" />
   </EnumProperty>
 
-  <StringProperty Name="CustomTool" Visible="false">
+  <StringProperty Name="CustomTool"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource HasConfigurationCondition="False" ItemType="Page" PersistedName="Generator" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="Page"
+                  PersistedName="Generator"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
   <StringProperty Name="CustomToolNamespace" />
 
-  <StringProperty Name="DependentUpon" Visible="false" />
+  <StringProperty Name="DependentUpon"
+                  Visible="false" />
 
-  <BoolProperty Name="DesignTime" Visible="false" />
+  <BoolProperty Name="DesignTime"
+                Visible="false" />
 
   <StringProperty Name="Generator" />
 
-  <StringProperty Name="LastGenOutput" Visible="false" />
+  <StringProperty Name="LastGenOutput"
+                  Visible="false" />
 
-  <StringProperty Name="Link" Visible="false">
+  <StringProperty Name="Link"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
+      <DataSource PersistenceStyle="Attribute"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <BoolProperty Name="Visible" Visible="false" />
+  <BoolProperty Name="Visible"
+                Visible="false" />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Page.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Page.xaml
@@ -1,41 +1,42 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule
-    Name="Page"
-    PageTemplate="generic"
-    PropertyPagesHidden="true"
-    xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="Page" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="Page" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False" ItemType="Page" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <DynamicEnumProperty Name="{}{ItemType}"
-                   EnumProvider="ItemTypes" />
-  <EnumProperty
-    Name="CopyToOutputDirectory">
+  <DynamicEnumProperty Name="{}{ItemType}" EnumProvider="ItemTypes" />
+
+  <BoolProperty Name="AutoGen" Visible="false" />
+
+  <EnumProperty Name="CopyToOutputDirectory">
     <EnumValue Name="Never" />
     <EnumValue Name="Always" />
     <EnumValue Name="PreserveNewest" />
   </EnumProperty>
 
-  <StringProperty
-    Name="Generator" />
-  <StringProperty
-    Name="CustomToolNamespace" />
+  <StringProperty Name="CustomTool" Visible="false">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False" ItemType="Page" PersistedName="Generator" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 
-  <BoolProperty Name="Visible" Visible="false" />
+  <StringProperty Name="CustomToolNamespace" />
+
   <StringProperty Name="DependentUpon" Visible="false" />
+
+  <BoolProperty Name="DesignTime" Visible="false" />
+
+  <StringProperty Name="Generator" />
+
+  <StringProperty Name="LastGenOutput" Visible="false" />
+
   <StringProperty Name="Link" Visible="false">
     <StringProperty.DataSource>
       <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="LastGenOutput" Visible="false" />
-  <BoolProperty Name="DesignTime" Visible="false" />
-  <BoolProperty Name="AutoGen" Visible="false" />
-  <StringProperty Name="CustomTool" Visible="false">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" ItemType="Page" PersistedName="Generator" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+
+  <BoolProperty Name="Visible" Visible="false" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Page.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Page.xaml
@@ -3,7 +3,7 @@
 <Rule Name="Page"
       PageTemplate="generic"
       PropertyPagesHidden="true"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="Page"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Resource.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Resource.BrowseObject.xaml
@@ -1,98 +1,77 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule
-  Name="Resource"
-  DisplayName="General"
-  PageTemplate="generic"
-  Description="File Properties"
-  PropertyPagesHidden="true"
-  xmlns="http://schemas.microsoft.com/build/2009/properties">
-  <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="Resource" SourceOfDefaultValue="AfterContext" />
-  </Rule.DataSource>
+<Rule Name="Resource" Description="File Properties" DisplayName="General" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
     <Category Name="Advanced" DisplayName="Advanced" />
     <Category Name="Misc" DisplayName="Misc" />
   </Rule.Categories>
 
-  <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Build Action"  Category="Advanced"
-                     Description="How the file relates to the build and deployment processes."
-                     EnumProvider="ItemTypes" />
-  <EnumProperty
-      Name="CopyToOutputDirectory"
-      DisplayName="Copy to Output Directory"
-      Category="Advanced"
-      Description="Specifies the source file will be copied to the output directory.">
+  <Rule.DataSource>
+    <DataSource HasConfigurationCondition="False" ItemType="Resource" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+  </Rule.DataSource>
+
+  <DynamicEnumProperty Name="{}{ItemType}" Category="Advanced" Description="How the file relates to the build and deployment processes." DisplayName="Build Action" EnumProvider="ItemTypes" />
+
+  <BoolProperty Name="AutoGen" Visible="false" />
+
+  <EnumProperty Name="CopyToOutputDirectory" Category="Advanced" Description="Specifies the source file will be copied to the output directory." DisplayName="Copy to Output Directory">
     <EnumValue Name="Never" DisplayName="Do not copy" />
     <EnumValue Name="Always" DisplayName="Copy always" />
     <EnumValue Name="PreserveNewest" DisplayName="Copy if newer" />
   </EnumProperty>
 
-  <StringProperty
-      Name="Generator"
-      Category="Advanced"
-      DisplayName="Custom Tool"
-      Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
-  <StringProperty
-      Name="CustomToolNamespace"
-      Category="Advanced"
-      DisplayName="Custom Tool Namespace"
-      Description="The namespace into which the output of the custom tool is placed." />
-
-  <StringProperty
-      Name="Identity"
-      Visible="false"
-      ReadOnly="true">
+  <StringProperty Name="CustomTool" Visible="false">
     <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="Resource" PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False" ItemType="Resource" PersistedName="Generator" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty
-      Name="FullPath"
-      DisplayName="Full Path"
-      ReadOnly="true"
-      Category="Misc"
-      Description="Location of the file.">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="Resource" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" Description="The namespace into which the output of the custom tool is placed." DisplayName="Custom Tool Namespace" />
 
-  <StringProperty
-      Name="FileNameAndExtension"
-      DisplayName="File Name"
-      ReadOnly="true"
-      Category="Misc"
-      Description="Name of the file or folder.">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="Resource" PersistedName="FileNameAndExtension" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-
-  <StringProperty Name="URL" ReadOnly="true" Visible="false">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="Resource" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <BoolProperty Name="Visible" Visible="false" />
   <StringProperty Name="DependentUpon" Visible="false" />
+
+  <BoolProperty Name="DesignTime" Visible="false" />
+
+  <StringProperty Name="Extension" ReadOnly="true" Visible="False">
+    <StringProperty.DataSource>
+      <DataSource ItemType="Resource" PersistedName="Extension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="FileNameAndExtension" Category="Misc" Description="Name of the file or folder." DisplayName="File Name" ReadOnly="true">
+    <StringProperty.DataSource>
+      <DataSource ItemType="Resource" PersistedName="FileNameAndExtension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="FullPath" Category="Misc" Description="Location of the file." DisplayName="Full Path" ReadOnly="true">
+    <StringProperty.DataSource>
+      <DataSource ItemType="Resource" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="Generator" Category="Advanced" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." DisplayName="Custom Tool" />
+
+  <StringProperty Name="Identity" ReadOnly="true" Visible="false">
+    <StringProperty.DataSource>
+      <DataSource ItemType="Resource" PersistedName="Identity" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="LastGenOutput" Visible="false" />
+
   <StringProperty Name="Link" Visible="false">
     <StringProperty.DataSource>
       <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="Extension" Visible="False" ReadOnly="true">
+
+  <StringProperty Name="URL" ReadOnly="true" Visible="false">
     <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="Resource" PersistedName="Extension" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Resource" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="LastGenOutput" Visible="false" />
-  <BoolProperty Name="DesignTime" Visible="false" />
-  <BoolProperty Name="AutoGen" Visible="false" />
-  <StringProperty Name="CustomTool" Visible="false">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" ItemType="Resource" PersistedName="Generator" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+
+  <BoolProperty Name="Visible" Visible="false" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Resource.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Resource.BrowseObject.xaml
@@ -5,7 +5,7 @@
       DisplayName="General"
       PageTemplate="generic"
       PropertyPagesHidden="true"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
     <Category Name="Advanced"
               DisplayName="Advanced" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Resource.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Resource.BrowseObject.xaml
@@ -1,77 +1,144 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule Name="Resource" Description="File Properties" DisplayName="General" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="Resource"
+      Description="File Properties"
+      DisplayName="General"
+      PageTemplate="generic"
+      PropertyPagesHidden="true"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
-    <Category Name="Advanced" DisplayName="Advanced" />
-    <Category Name="Misc" DisplayName="Misc" />
+    <Category Name="Advanced"
+              DisplayName="Advanced" />
+    <Category Name="Misc"
+              DisplayName="Misc" />
   </Rule.Categories>
 
   <Rule.DataSource>
-    <DataSource HasConfigurationCondition="False" ItemType="Resource" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                ItemType="Resource"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <DynamicEnumProperty Name="{}{ItemType}" Category="Advanced" Description="How the file relates to the build and deployment processes." DisplayName="Build Action" EnumProvider="ItemTypes" />
+  <DynamicEnumProperty Name="{}{ItemType}"
+                       Category="Advanced"
+                       Description="How the file relates to the build and deployment processes."
+                       DisplayName="Build Action"
+                       EnumProvider="ItemTypes" />
 
-  <BoolProperty Name="AutoGen" Visible="false" />
+  <BoolProperty Name="AutoGen"
+                Visible="false" />
 
-  <EnumProperty Name="CopyToOutputDirectory" Category="Advanced" Description="Specifies the source file will be copied to the output directory." DisplayName="Copy to Output Directory">
-    <EnumValue Name="Never" DisplayName="Do not copy" />
-    <EnumValue Name="Always" DisplayName="Copy always" />
-    <EnumValue Name="PreserveNewest" DisplayName="Copy if newer" />
+  <EnumProperty Name="CopyToOutputDirectory"
+                Category="Advanced"
+                Description="Specifies the source file will be copied to the output directory."
+                DisplayName="Copy to Output Directory">
+    <EnumValue Name="Never"
+               DisplayName="Do not copy" />
+    <EnumValue Name="Always"
+               DisplayName="Copy always" />
+    <EnumValue Name="PreserveNewest"
+               DisplayName="Copy if newer" />
   </EnumProperty>
 
-  <StringProperty Name="CustomTool" Visible="false">
+  <StringProperty Name="CustomTool"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource HasConfigurationCondition="False" ItemType="Resource" PersistedName="Generator" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="Resource"
+                  PersistedName="Generator"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="CustomToolNamespace" Category="Advanced" Description="The namespace into which the output of the custom tool is placed." DisplayName="Custom Tool Namespace" />
+  <StringProperty Name="CustomToolNamespace"
+                  Category="Advanced"
+                  Description="The namespace into which the output of the custom tool is placed."
+                  DisplayName="Custom Tool Namespace" />
 
-  <StringProperty Name="DependentUpon" Visible="false" />
+  <StringProperty Name="DependentUpon"
+                  Visible="false" />
 
-  <BoolProperty Name="DesignTime" Visible="false" />
+  <BoolProperty Name="DesignTime"
+                Visible="false" />
 
-  <StringProperty Name="Extension" ReadOnly="true" Visible="False">
+  <StringProperty Name="Extension"
+                  ReadOnly="true"
+                  Visible="False">
     <StringProperty.DataSource>
-      <DataSource ItemType="Resource" PersistedName="Extension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Resource"
+                  PersistedName="Extension"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="FileNameAndExtension" Category="Misc" Description="Name of the file or folder." DisplayName="File Name" ReadOnly="true">
+  <StringProperty Name="FileNameAndExtension"
+                  Category="Misc"
+                  Description="Name of the file or folder."
+                  DisplayName="File Name"
+                  ReadOnly="true">
     <StringProperty.DataSource>
-      <DataSource ItemType="Resource" PersistedName="FileNameAndExtension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Resource"
+                  PersistedName="FileNameAndExtension"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="FullPath" Category="Misc" Description="Location of the file." DisplayName="Full Path" ReadOnly="true">
+  <StringProperty Name="FullPath"
+                  Category="Misc"
+                  Description="Location of the file."
+                  DisplayName="Full Path"
+                  ReadOnly="true">
     <StringProperty.DataSource>
-      <DataSource ItemType="Resource" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Resource"
+                  PersistedName="FullPath"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="Generator" Category="Advanced" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." DisplayName="Custom Tool" />
+  <StringProperty Name="Generator"
+                  Category="Advanced"
+                  Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool."
+                  DisplayName="Custom Tool" />
 
-  <StringProperty Name="Identity" ReadOnly="true" Visible="false">
+  <StringProperty Name="Identity"
+                  ReadOnly="true"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource ItemType="Resource" PersistedName="Identity" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Resource"
+                  PersistedName="Identity"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="LastGenOutput" Visible="false" />
+  <StringProperty Name="LastGenOutput"
+                  Visible="false" />
 
-  <StringProperty Name="Link" Visible="false">
+  <StringProperty Name="Link"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
+      <DataSource PersistenceStyle="Attribute"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="URL" ReadOnly="true" Visible="false">
+  <StringProperty Name="URL"
+                  ReadOnly="true"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource ItemType="Resource" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Resource"
+                  PersistedName="FullPath"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <BoolProperty Name="Visible" Visible="false" />
+  <BoolProperty Name="Visible"
+                Visible="false" />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Resource.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Resource.xaml
@@ -3,7 +3,7 @@
 <Rule Name="Resource"
       PageTemplate="generic"
       PropertyPagesHidden="true"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="Resource"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Resource.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Resource.xaml
@@ -1,40 +1,42 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule
-  Name="Resource"
-  PageTemplate="generic"
-  PropertyPagesHidden="true"
-  xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="Resource" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="Resource" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False" ItemType="Resource" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
   <DynamicEnumProperty Name="{}{ItemType}" EnumProvider="ItemTypes" />
-  <EnumProperty
-      Name="CopyToOutputDirectory">
+
+  <BoolProperty Name="AutoGen" Visible="false" />
+
+  <EnumProperty Name="CopyToOutputDirectory">
     <EnumValue Name="Never" />
     <EnumValue Name="Always" />
     <EnumValue Name="PreserveNewest" />
   </EnumProperty>
 
-  <StringProperty
-      Name="Generator" />
-  <StringProperty
-      Name="CustomToolNamespace" />
+  <StringProperty Name="CustomTool" Visible="false">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False" ItemType="Resource" PersistedName="Generator" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 
-  <BoolProperty Name="Visible" Visible="false" />
+  <StringProperty Name="CustomToolNamespace" />
+
   <StringProperty Name="DependentUpon" Visible="false" />
+
+  <BoolProperty Name="DesignTime" Visible="false" />
+
+  <StringProperty Name="Generator" />
+
+  <StringProperty Name="LastGenOutput" Visible="false" />
+
   <StringProperty Name="Link" Visible="false">
     <StringProperty.DataSource>
       <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="LastGenOutput" Visible="false" />
-  <BoolProperty Name="DesignTime" Visible="false" />
-  <BoolProperty Name="AutoGen" Visible="false" />
-  <StringProperty Name="CustomTool" Visible="false">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" ItemType="Resource" PersistedName="Generator" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+
+  <BoolProperty Name="Visible" Visible="false" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Resource.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Resource.xaml
@@ -1,13 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule Name="Resource" PageTemplate="generic" PropertyPagesHidden="true" xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="Resource"
+      PageTemplate="generic"
+      PropertyPagesHidden="true"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource HasConfigurationCondition="False" ItemType="Resource" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                ItemType="Resource"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <DynamicEnumProperty Name="{}{ItemType}" EnumProvider="ItemTypes" />
+  <DynamicEnumProperty Name="{}{ItemType}"
+                       EnumProvider="ItemTypes" />
 
-  <BoolProperty Name="AutoGen" Visible="false" />
+  <BoolProperty Name="AutoGen"
+                Visible="false" />
 
   <EnumProperty Name="CopyToOutputDirectory">
     <EnumValue Name="Never" />
@@ -15,28 +23,39 @@
     <EnumValue Name="PreserveNewest" />
   </EnumProperty>
 
-  <StringProperty Name="CustomTool" Visible="false">
+  <StringProperty Name="CustomTool"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource HasConfigurationCondition="False" ItemType="Resource" PersistedName="Generator" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="Resource"
+                  PersistedName="Generator"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
   <StringProperty Name="CustomToolNamespace" />
 
-  <StringProperty Name="DependentUpon" Visible="false" />
+  <StringProperty Name="DependentUpon"
+                  Visible="false" />
 
-  <BoolProperty Name="DesignTime" Visible="false" />
+  <BoolProperty Name="DesignTime"
+                Visible="false" />
 
   <StringProperty Name="Generator" />
 
-  <StringProperty Name="LastGenOutput" Visible="false" />
+  <StringProperty Name="LastGenOutput"
+                  Visible="false" />
 
-  <StringProperty Name="Link" Visible="false">
+  <StringProperty Name="Link"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
+      <DataSource PersistenceStyle="Attribute"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <BoolProperty Name="Visible" Visible="false" />
+  <BoolProperty Name="Visible"
+                Visible="false" />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/XamlAppDef.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/XamlAppDef.BrowseObject.xaml
@@ -5,7 +5,7 @@
       DisplayName="General"
       PageTemplate="generic"
       PropertyPagesHidden="True"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
     <Category Name="Advanced"
               DisplayName="Advanced" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/XamlAppDef.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/XamlAppDef.BrowseObject.xaml
@@ -1,65 +1,123 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule Name="XamlAppDef" Description="File Properties" DisplayName="General" PageTemplate="generic" PropertyPagesHidden="True" xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="XamlAppDef"
+      Description="File Properties"
+      DisplayName="General"
+      PageTemplate="generic"
+      PropertyPagesHidden="True"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
-    <Category Name="Advanced" DisplayName="Advanced" />
-    <Category Name="Misc" DisplayName="Misc" />
+    <Category Name="Advanced"
+              DisplayName="Advanced" />
+    <Category Name="Misc"
+              DisplayName="Misc" />
   </Rule.Categories>
 
   <Rule.DataSource>
-    <DataSource HasConfigurationCondition="False" ItemType="XamlAppDef" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                ItemType="XamlAppDef"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <DynamicEnumProperty Name="{}{ItemType}" Category="Advanced" Description="How the file relates to the build and deployment processes." DisplayName="Build Action" EnumProvider="ItemTypes" />
+  <DynamicEnumProperty Name="{}{ItemType}"
+                       Category="Advanced"
+                       Description="How the file relates to the build and deployment processes."
+                       DisplayName="Build Action"
+                       EnumProvider="ItemTypes" />
 
-  <EnumProperty Name="CopyToOutputDirectory" Category="Advanced" Description="Specifies the source file will be copied to the output directory." DisplayName="Copy to Output Directory">
-    <EnumValue Name="Never" DisplayName="Do not copy" />
-    <EnumValue Name="Always" DisplayName="Copy always" />
-    <EnumValue Name="PreserveNewest" DisplayName="Copy if newer" />
+  <EnumProperty Name="CopyToOutputDirectory"
+                Category="Advanced"
+                Description="Specifies the source file will be copied to the output directory."
+                DisplayName="Copy to Output Directory">
+    <EnumValue Name="Never"
+               DisplayName="Do not copy" />
+    <EnumValue Name="Always"
+               DisplayName="Copy always" />
+    <EnumValue Name="PreserveNewest"
+               DisplayName="Copy if newer" />
   </EnumProperty>
 
-  <StringProperty Name="CustomToolNamespace" Category="Advanced" Description="The namespace into which the output of the custom tool is placed." DisplayName="Custom Tool Namespace" />
+  <StringProperty Name="CustomToolNamespace"
+                  Category="Advanced"
+                  Description="The namespace into which the output of the custom tool is placed."
+                  DisplayName="Custom Tool Namespace" />
 
-  <StringProperty Name="DependentUpon" Visible="false" />
+  <StringProperty Name="DependentUpon"
+                  Visible="false" />
 
-  <StringProperty Name="Extension" ReadOnly="true" Visible="False">
+  <StringProperty Name="Extension"
+                  ReadOnly="true"
+                  Visible="False">
     <StringProperty.DataSource>
-      <DataSource ItemType="XamlAppDef" PersistedName="Extension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="XamlAppDef"
+                  PersistedName="Extension"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="FileNameAndExtension" Category="Misc" Description="Name of the file or folder." DisplayName="File Name" ReadOnly="true">
+  <StringProperty Name="FileNameAndExtension"
+                  Category="Misc"
+                  Description="Name of the file or folder."
+                  DisplayName="File Name"
+                  ReadOnly="true">
     <StringProperty.DataSource>
-      <DataSource ItemType="XamlAppDef" PersistedName="FileNameAndExtension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="XamlAppDef"
+                  PersistedName="FileNameAndExtension"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="FullPath" Category="Misc" Description="Location of the file." DisplayName="Full Path" ReadOnly="true">
+  <StringProperty Name="FullPath"
+                  Category="Misc"
+                  Description="Location of the file."
+                  DisplayName="Full Path"
+                  ReadOnly="true">
     <StringProperty.DataSource>
-      <DataSource ItemType="XamlAppDef" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="XamlAppDef"
+                  PersistedName="FullPath"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="Generator" Category="Advanced" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." DisplayName="Custom Tool" />
+  <StringProperty Name="Generator"
+                  Category="Advanced"
+                  Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool."
+                  DisplayName="Custom Tool" />
 
-  <StringProperty Name="Identity" ReadOnly="true" Visible="false">
+  <StringProperty Name="Identity"
+                  ReadOnly="true"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource ItemType="XamlAppDef" PersistedName="Identity" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="XamlAppDef"
+                  PersistedName="Identity"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="Link" Visible="false">
+  <StringProperty Name="Link"
+                  Visible="false">
     <StringProperty.DataSource>
       <DataSource SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="URL" ReadOnly="true" Visible="false">
+  <StringProperty Name="URL"
+                  ReadOnly="true"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource ItemType="XamlAppDef" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="XamlAppDef"
+                  PersistedName="FullPath"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <BoolProperty Name="Visible" Visible="false" />
+  <BoolProperty Name="Visible"
+                Visible="false" />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/XamlAppDef.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/XamlAppDef.BrowseObject.xaml
@@ -1,90 +1,65 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule
-  Name="XamlAppDef"
-  DisplayName="General"
-  PageTemplate="generic"
-  Description="File Properties"
-  PropertyPagesHidden="True"
-  xmlns="http://schemas.microsoft.com/build/2009/properties">
-  <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="XamlAppDef" SourceOfDefaultValue="AfterContext" />
-  </Rule.DataSource>
+<Rule Name="XamlAppDef" Description="File Properties" DisplayName="General" PageTemplate="generic" PropertyPagesHidden="True" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.Categories>
     <Category Name="Advanced" DisplayName="Advanced" />
     <Category Name="Misc" DisplayName="Misc" />
   </Rule.Categories>
 
-  <DynamicEnumProperty Name="{}{ItemType}" DisplayName="Build Action"  Category="Advanced"
-                     Description="How the file relates to the build and deployment processes."
-                     EnumProvider="ItemTypes" />
-  <EnumProperty
-      Name="CopyToOutputDirectory"
-      DisplayName="Copy to Output Directory"
-      Category="Advanced"
-      Description="Specifies the source file will be copied to the output directory.">
+  <Rule.DataSource>
+    <DataSource HasConfigurationCondition="False" ItemType="XamlAppDef" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+  </Rule.DataSource>
+
+  <DynamicEnumProperty Name="{}{ItemType}" Category="Advanced" Description="How the file relates to the build and deployment processes." DisplayName="Build Action" EnumProvider="ItemTypes" />
+
+  <EnumProperty Name="CopyToOutputDirectory" Category="Advanced" Description="Specifies the source file will be copied to the output directory." DisplayName="Copy to Output Directory">
     <EnumValue Name="Never" DisplayName="Do not copy" />
     <EnumValue Name="Always" DisplayName="Copy always" />
     <EnumValue Name="PreserveNewest" DisplayName="Copy if newer" />
   </EnumProperty>
 
-  <StringProperty
-      Name="Generator"
-      Category="Advanced"
-      DisplayName="Custom Tool"
-      Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." />
-  <StringProperty
-      Name="CustomToolNamespace"
-      Category="Advanced"
-      DisplayName="Custom Tool Namespace"
-      Description="The namespace into which the output of the custom tool is placed." />
+  <StringProperty Name="CustomToolNamespace" Category="Advanced" Description="The namespace into which the output of the custom tool is placed." DisplayName="Custom Tool Namespace" />
 
-  <StringProperty
-      Name="Identity"
-      Visible="false"
-      ReadOnly="true">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="XamlAppDef" PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-
-  <StringProperty
-      Name="FullPath"
-      DisplayName="Full Path"
-      ReadOnly="true"
-      Category="Misc"
-      Description="Location of the file.">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="XamlAppDef" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-
-  <StringProperty
-      Name="FileNameAndExtension"
-      DisplayName="File Name"
-      ReadOnly="true"
-      Category="Misc"
-      Description="Name of the file or folder.">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="XamlAppDef" PersistedName="FileNameAndExtension" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-
-  <StringProperty Name="URL" ReadOnly="true" Visible="false">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="XamlAppDef" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <BoolProperty Name="Visible" Visible="false" />
   <StringProperty Name="DependentUpon" Visible="false" />
+
+  <StringProperty Name="Extension" ReadOnly="true" Visible="False">
+    <StringProperty.DataSource>
+      <DataSource ItemType="XamlAppDef" PersistedName="Extension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="FileNameAndExtension" Category="Misc" Description="Name of the file or folder." DisplayName="File Name" ReadOnly="true">
+    <StringProperty.DataSource>
+      <DataSource ItemType="XamlAppDef" PersistedName="FileNameAndExtension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="FullPath" Category="Misc" Description="Location of the file." DisplayName="Full Path" ReadOnly="true">
+    <StringProperty.DataSource>
+      <DataSource ItemType="XamlAppDef" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="Generator" Category="Advanced" Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool." DisplayName="Custom Tool" />
+
+  <StringProperty Name="Identity" ReadOnly="true" Visible="false">
+    <StringProperty.DataSource>
+      <DataSource ItemType="XamlAppDef" PersistedName="Identity" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
   <StringProperty Name="Link" Visible="false">
     <StringProperty.DataSource>
       <DataSource SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="Extension" Visible="False" ReadOnly="true">
+
+  <StringProperty Name="URL" ReadOnly="true" Visible="false">
     <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="XamlAppDef" PersistedName="Extension" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="XamlAppDef" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
+
+  <BoolProperty Name="Visible" Visible="false" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/XamlAppDef.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/XamlAppDef.xaml
@@ -3,7 +3,7 @@
 <Rule Name="XamlAppDef"
       PageTemplate="generic"
       PropertyPagesHidden="True"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="XamlAppDef"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/XamlAppDef.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/XamlAppDef.xaml
@@ -1,68 +1,60 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule
-  Name="XamlAppDef"
-  PageTemplate="generic"
-  PropertyPagesHidden="True"
-  xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="XamlAppDef" PageTemplate="generic" PropertyPagesHidden="True" xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="XamlAppDef" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False" ItemType="XamlAppDef" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <DynamicEnumProperty Name="{}{ItemType}"
-                     EnumProvider="ItemTypes" />
-  <EnumProperty
-      Name="CopyToOutputDirectory">
+  <DynamicEnumProperty Name="{}{ItemType}" EnumProvider="ItemTypes" />
+
+  <EnumProperty Name="CopyToOutputDirectory">
     <EnumValue Name="Never" />
     <EnumValue Name="Always" />
     <EnumValue Name="PreserveNewest" />
   </EnumProperty>
 
-  <StringProperty
-      Name="Generator" />
-  <StringProperty
-      Name="CustomToolNamespace" />
+  <StringProperty Name="CustomToolNamespace" />
 
-  <StringProperty
-      Name="Identity"
-      Visible="false"
-      ReadOnly="true">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="XamlAppDef" PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-
-  <StringProperty
-      Name="FullPath"
-      ReadOnly="true">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="XamlAppDef" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-
-  <StringProperty
-      Name="FileNameAndExtension"
-      ReadOnly="true">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="XamlAppDef" PersistedName="FileNameAndExtension" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-
-  <StringProperty Name="URL" ReadOnly="true" Visible="false">
-    <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="XamlAppDef" PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <BoolProperty Name="Visible" Visible="false" />
   <StringProperty Name="DependentUpon" Visible="false" />
+
+  <StringProperty Name="Extension" ReadOnly="true" Visible="False">
+    <StringProperty.DataSource>
+      <DataSource ItemType="XamlAppDef" PersistedName="Extension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="FileNameAndExtension" ReadOnly="true">
+    <StringProperty.DataSource>
+      <DataSource ItemType="XamlAppDef" PersistedName="FileNameAndExtension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="FullPath" ReadOnly="true">
+    <StringProperty.DataSource>
+      <DataSource ItemType="XamlAppDef" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="Generator" />
+
+  <StringProperty Name="Identity" ReadOnly="true" Visible="false">
+    <StringProperty.DataSource>
+      <DataSource ItemType="XamlAppDef" PersistedName="Identity" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
   <StringProperty Name="Link" Visible="false">
     <StringProperty.DataSource>
       <DataSource SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="Extension" Visible="False" ReadOnly="true">
+
+  <StringProperty Name="URL" ReadOnly="true" Visible="false">
     <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="XamlAppDef" PersistedName="Extension" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="XamlAppDef" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
+
+  <BoolProperty Name="Visible" Visible="false" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/XamlAppDef.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/XamlAppDef.xaml
@@ -1,11 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule Name="XamlAppDef" PageTemplate="generic" PropertyPagesHidden="True" xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="XamlAppDef"
+      PageTemplate="generic"
+      PropertyPagesHidden="True"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource HasConfigurationCondition="False" ItemType="XamlAppDef" Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                ItemType="XamlAppDef"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <DynamicEnumProperty Name="{}{ItemType}" EnumProvider="ItemTypes" />
+  <DynamicEnumProperty Name="{}{ItemType}"
+                       EnumProvider="ItemTypes" />
 
   <EnumProperty Name="CopyToOutputDirectory">
     <EnumValue Name="Never" />
@@ -15,46 +22,72 @@
 
   <StringProperty Name="CustomToolNamespace" />
 
-  <StringProperty Name="DependentUpon" Visible="false" />
+  <StringProperty Name="DependentUpon"
+                  Visible="false" />
 
-  <StringProperty Name="Extension" ReadOnly="true" Visible="False">
+  <StringProperty Name="Extension"
+                  ReadOnly="true"
+                  Visible="False">
     <StringProperty.DataSource>
-      <DataSource ItemType="XamlAppDef" PersistedName="Extension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="XamlAppDef"
+                  PersistedName="Extension"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="FileNameAndExtension" ReadOnly="true">
+  <StringProperty Name="FileNameAndExtension"
+                  ReadOnly="true">
     <StringProperty.DataSource>
-      <DataSource ItemType="XamlAppDef" PersistedName="FileNameAndExtension" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="XamlAppDef"
+                  PersistedName="FileNameAndExtension"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="FullPath" ReadOnly="true">
+  <StringProperty Name="FullPath"
+                  ReadOnly="true">
     <StringProperty.DataSource>
-      <DataSource ItemType="XamlAppDef" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="XamlAppDef"
+                  PersistedName="FullPath"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
   <StringProperty Name="Generator" />
 
-  <StringProperty Name="Identity" ReadOnly="true" Visible="false">
+  <StringProperty Name="Identity"
+                  ReadOnly="true"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource ItemType="XamlAppDef" PersistedName="Identity" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="XamlAppDef"
+                  PersistedName="Identity"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="Link" Visible="false">
+  <StringProperty Name="Link"
+                  Visible="false">
     <StringProperty.DataSource>
       <DataSource SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="URL" ReadOnly="true" Visible="false">
+  <StringProperty Name="URL"
+                  ReadOnly="true"
+                  Visible="false">
     <StringProperty.DataSource>
-      <DataSource ItemType="XamlAppDef" PersistedName="FullPath" Persistence="Intrinsic" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="XamlAppDef"
+                  PersistedName="FullPath"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <BoolProperty Name="Visible" Visible="false" />
+  <BoolProperty Name="Visible"
+                Visible="false" />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/LanguageService.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/LanguageService.xaml
@@ -1,21 +1,20 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Rule
-    Name="LanguageService"
-    DisplayName="LanguageService"
-    PageTemplate="generic"
-    xmlns="http://schemas.microsoft.com/build/2009/properties">
-
+<Rule Name="LanguageService"
+      DisplayName="LanguageService"
+      PageTemplate="generic"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" SourceOfDefaultValue="AfterContext" />
+    <DataSource Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
   <StringProperty Name="RootNamespace"
-                  Visible="False"
-                  ReadOnly="True" />
+                  ReadOnly="True"
+                  Visible="False" />
 
   <StringProperty Name="TargetPath"
-                  Visible="False"
-                  ReadOnly="True" />
+                  ReadOnly="True"
+                  Visible="False" />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/LanguageService.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/LanguageService.xaml
@@ -3,7 +3,7 @@
 <Rule Name="LanguageService"
       DisplayName="LanguageService"
       PageTemplate="generic"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource Persistence="ProjectFile"
                 SourceOfDefaultValue="AfterContext" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="NuGetRestore"
       PageTemplate="generic"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource Label="Configuration"
                 Persistence="ProjectFile"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -1,147 +1,176 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Rule
-    Name="NuGetRestore"
-    PageTemplate="generic"
-    xmlns="http://schemas.microsoft.com/build/2009/properties">
-
+<Rule Name="NuGetRestore"
+      PageTemplate="generic"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" Label="Configuration" SourceOfDefaultValue="AfterContext" />
+    <DataSource Label="Configuration"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <StringProperty Name="TargetFrameworkIdentifier" DisplayName="Target Framework Identifier">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="TargetFrameworkIdentifier" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="TargetFrameworks" DisplayName="Target Frameworks">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="TargetFrameworks" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="TargetFramework" DisplayName="Target Framework">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="TargetFramework" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="TargetFrameworkProfile" DisplayName="Target Framework Profile">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="TargetFrameworkProfile" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="TargetFrameworkVersion" DisplayName="Target Framework Version">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile" PersistedName="TargetFrameworkVersion" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <StringProperty Name="TargetFrameworkMoniker" DisplayName="Target Framework Moniker">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFileWithInterceptionViaSnapshot" PersistedName="TargetFrameworkMoniker" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-
-  <StringProperty Name="MSBuildProjectDirectory"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="MSBuildProjectExtensionsPath"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="MSBuildProjectFile"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="PackageTargetFallback"
-                  Visible="False"
-                  ReadOnly="True" />
-
   <StringProperty Name="AssetTargetFallback"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="RuntimeIdentifier"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="RuntimeIdentifiers"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="PackageId"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="PackageVersion"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="Version"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="VersionPrefix"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="VersionSuffix"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="EmitAssetsLogMessages"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="RestoreSources"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="RestoreFallbackFolders"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="RestorePackagesPath"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="RestoreAdditionalProjectSources"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="RestoreAdditionalProjectFallbackFolders"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="RestoreAdditionalProjectFallbackFoldersExcludes"
-                  Visible="False"
-                  ReadOnly="True" />
+                  ReadOnly="True"
+                  Visible="False" />
 
   <StringProperty Name="DotnetCliToolTargetFramework"
-                  Visible="False"
-                  ReadOnly="True" />
+                  ReadOnly="True"
+                  Visible="False" />
 
-  <StringProperty Name="TreatWarningsAsErrors"
-                  Visible="False"
-                  ReadOnly="True" />
+  <StringProperty Name="EmitAssetsLogMessages"
+                  ReadOnly="True"
+                  Visible="False" />
 
-  <StringProperty Name="WarningsAsErrors"
-                  Visible="False"
-                  ReadOnly="True" />
+  <StringProperty Name="MSBuildProjectDirectory"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="MSBuildProjectExtensionsPath"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="MSBuildProjectFile"
+                  ReadOnly="True"
+                  Visible="False" />
 
   <StringProperty Name="NoWarn"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="RestorePackagesWithLockFile"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="RestoreLockedMode"
-                  Visible="False"
-                  ReadOnly="True" />
+                  ReadOnly="True"
+                  Visible="False" />
 
   <StringProperty Name="NuGetLockFilePath"
-                  Visible="False"
-                  ReadOnly="True" />
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="PackageId"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="PackageTargetFallback"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="PackageVersion"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="RestoreAdditionalProjectFallbackFolders"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="RestoreAdditionalProjectFallbackFoldersExcludes"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="RestoreAdditionalProjectSources"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="RestoreFallbackFolders"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="RestoreLockedMode"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="RestorePackagesPath"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="RestorePackagesWithLockFile"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="RestoreSources"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="RuntimeIdentifier"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="RuntimeIdentifiers"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="TargetFramework"
+                  DisplayName="Target Framework">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="TargetFramework"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="TargetFrameworkIdentifier"
+                  DisplayName="Target Framework Identifier">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="TargetFrameworkIdentifier"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="TargetFrameworkMoniker"
+                  DisplayName="Target Framework Moniker">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="TargetFrameworkMoniker"
+                  Persistence="ProjectFileWithInterceptionViaSnapshot"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="TargetFrameworkProfile"
+                  DisplayName="Target Framework Profile">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="TargetFrameworkProfile"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="TargetFrameworks"
+                  DisplayName="Target Frameworks">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="TargetFrameworks"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="TargetFrameworkVersion"
+                  DisplayName="Target Framework Version">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="TargetFrameworkVersion"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="TreatWarningsAsErrors"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="Version"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="VersionPrefix"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="VersionSuffix"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="WarningsAsErrors"
+                  ReadOnly="True"
+                  Visible="False" />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
@@ -1,95 +1,99 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Rule
-    Name="PackageReference"
-    DisplayName="Package"
-    PageTemplate="generic"
-    Description="Package Properties"
-    xmlns="http://schemas.microsoft.com/build/2009/properties">
-
+<Rule Name="PackageReference"
+      Description="Package Properties"
+      DisplayName="Package"
+      PageTemplate="generic"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="PackageReference" HasConfigurationCondition="False"
-                SourceType="TargetResults" MSBuildTarget="CollectPackageReferences" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                ItemType="PackageReference"
+                MSBuildTarget="CollectPackageReferences"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext"
+                SourceType="TargetResults" />
   </Rule.DataSource>
 
   <StringProperty Name="Description"
-                  ReadOnly="True"
-                  Visible="True"
+                  Description="Dependency description."
                   DisplayName="Description"
-                  Description="Dependency description." />
+                  ReadOnly="True"
+                  Visible="True" />
+
+  <StringProperty Name="ExcludeAssets"
+                  Description="Assets to exclude from this reference"
+                  DisplayName="Excluded assets"
+                  Visible="True" />
+
+  <StringProperty Name="FrameworkName"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="FrameworkVersion"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <BoolProperty Name="GeneratePathProperty"
+                Description="Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'."
+                DisplayName="Generate path property"
+                Visible="True" />
+
+  <StringProperty Name="IncludeAssets"
+                  Description="Assets to include from this reference"
+                  DisplayName="Included assets"
+                  Visible="True" />
+
+  <StringProperty Name="IsImplicitlyDefined"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="Name"
+                  ReadOnly="True"
+                  Visible="True" />
+
+  <StringProperty Name="NoWarn"
+                  Description="Comma-delimited list of warnings that should be suppressed for this package"
+                  DisplayName="Suppress warnings"
+                  Visible="True" />
+
+  <StringProperty Name="OriginalItemSpec"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="Path"
+                  Description="Location of the package being referenced."
+                  ReadOnly="True"
+                  Visible="True" />
+
+  <StringProperty Name="PrivateAssets"
+                  Description="Assets that are private in this reference"
+                  DisplayName="Private assets"
+                  Visible="True" />
+
+  <StringProperty Name="RuntimeIdentifier"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="TargetFramework"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="Type"
+                  ReadOnly="True"
+                  Visible="False" />
 
   <StringProperty Name="Version"
-                  ReadOnly="True"
+                  Description="Version of dependency."
                   DisplayName="Version"
-                  Description="Version of dependency.">
+                  ReadOnly="True">
     <StringProperty.DataSource>
-      <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
+      <DataSource PersistenceStyle="Attribute"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="IncludeAssets"
-                  Visible="True"
-                  DisplayName="Included assets"
-                  Description="Assets to include from this reference" />
-
-  <StringProperty Name="ExcludeAssets"
-                  Visible="True"
-                  DisplayName="Excluded assets"
-                  Description="Assets to exclude from this reference" />
-
-  <StringProperty Name="PrivateAssets"
-                  Visible="True"
-                  DisplayName="Private assets"
-                  Description="Assets that are private in this reference" />
-
-  <StringProperty Name="Name"
-                  Visible="True"
-                  ReadOnly="True" />
-
-  <StringProperty Name="OriginalItemSpec"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="Path"
-                  Visible="True"
-                  ReadOnly="True"
-                  Description="Location of the package being referenced." />
-
-  <StringProperty Name="Type"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="RuntimeIdentifier"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="TargetFramework"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="FrameworkName"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="FrameworkVersion"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="IsImplicitlyDefined"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="NoWarn"
-                  Visible="True"
-                  DisplayName="Suppress warnings"
-                  Description="Comma-delimited list of warnings that should be suppressed for this package" />
-
-  <BoolProperty Name="GeneratePathProperty"
-                  Visible="True"
-                  DisplayName="Generate path property"
-                  Description="Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'." />
-
   <BoolProperty Name="Visible"
-                Visible="False"
-                ReadOnly="True" />
+                ReadOnly="True"
+                Visible="False" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
@@ -4,7 +4,7 @@
       Description="Package Properties"
       DisplayName="Package"
       PageTemplate="generic"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="PackageReference"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.xaml
@@ -1,81 +1,75 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Rule
-    Name="ProjectReference"
-    DisplayName="Project Reference"
-    PageTemplate="generic"
-    Description="Reference Properties"
-    xmlns="http://schemas.microsoft.com/build/2009/properties">
-
+<Rule Name="ProjectReference"
+      Description="Reference Properties"
+      DisplayName="Project Reference"
+      PageTemplate="generic"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile"
+    <DataSource HasConfigurationCondition="False"
                 ItemType="ProjectReference"
-                HasConfigurationCondition="False"
+                Persistence="ProjectFile"
                 SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <!-- Visible properties -->
-
   <StringListProperty Name="Aliases"
-                      DisplayName="Aliases"
                       Description="A comma-delimited list of aliases to this reference."
+                      DisplayName="Aliases"
                       Separator=",">
     <StringListProperty.DataSource>
-      <DataSource Persistence="ProjectFile"
+      <DataSource HasConfigurationCondition="False"
                   ItemType="ProjectReference"
-                  HasConfigurationCondition="False"
+                  Persistence="ProjectFile"
                   SourceOfDefaultValue="AfterContext" />
     </StringListProperty.DataSource>
   </StringListProperty>
 
   <BoolProperty Name="CopyLocal"
-                DisplayName="Copy Local"
-                Description="Indicates whether the reference will be copied to the output directory.">
+                Description="Indicates whether the reference will be copied to the output directory."
+                DisplayName="Copy Local">
     <BoolProperty.DataSource>
-      <DataSource Persistence="ProjectFile"
+      <DataSource HasConfigurationCondition="False"
                   ItemType="ProjectReference"
-                  HasConfigurationCondition="False"
                   PersistedName="Private"
+                  Persistence="ProjectFile"
                   SourceOfDefaultValue="AfterContext" />
     </BoolProperty.DataSource>
   </BoolProperty>
 
   <BoolProperty Name="CopyLocalSatelliteAssemblies"
-                DisplayName="Copy Local Satellite Assemblies"
-                Description="Indicates whether the satellite assemblies of the reference target should be copied into this project's output directory." />
+                Description="Indicates whether the satellite assemblies of the reference target should be copied into this project's output directory."
+                DisplayName="Copy Local Satellite Assemblies" />
 
   <StringProperty Name="Culture"
-                  ReadOnly="True"
+                  Description="The value of the culture field from the assembly metadata."
                   DisplayName="Culture"
-                  Description="The value of the culture field from the assembly metadata.">
-  </StringProperty>
+                  ReadOnly="True" />
 
   <StringProperty Name="Description"
-                  ReadOnly="True"
+                  Description="The value of the Title field from the assembly metadata."
                   DisplayName="Description"
-                  Description="The value of the Title field from the assembly metadata.">
-  </StringProperty>
+                  ReadOnly="True" />
 
   <BoolProperty Name="EmbedInteropTypes"
-                DisplayName="Embed Interop Types"
-                Description="Indicates whether types defined in this assembly will be embedded into the target assembly.">
+                Description="Indicates whether types defined in this assembly will be embedded into the target assembly."
+                DisplayName="Embed Interop Types">
     <BoolProperty.DataSource>
-      <DataSource Persistence="ProjectFile"
+      <DataSource HasConfigurationCondition="False"
                   ItemType="ProjectReference"
-                  HasConfigurationCondition="False"
+                  Persistence="ProjectFile"
                   SourceOfDefaultValue="AfterContext" />
     </BoolProperty.DataSource>
   </BoolProperty>
 
   <StringProperty Name="ExcludeAssets"
-                  Visible="True"
+                  Description="Assets to exclude from this reference"
                   DisplayName="Exclude Assets"
-                  Description="Assets to exclude from this reference" />
+                  Visible="True" />
 
   <StringProperty Name="Identity"
-                  ReadOnly="True"
+                  Description="Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence)."
                   DisplayName="Identity"
-                  Description="Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).">
+                  ReadOnly="True">
     <StringProperty.DataSource>
       <DataSource PersistedName="{}{Identity}"
                   SourceOfDefaultValue="AfterContext" />
@@ -83,38 +77,17 @@
   </StringProperty>
 
   <StringProperty Name="IncludeAssets"
-                  Visible="True"
+                  Description="Assets to include from this reference"
                   DisplayName="Include Assets"
-                  Description="Assets to include from this reference" />
+                  Visible="True" />
 
-  <BoolProperty Name="ReferenceOutputAssembly"
-                DisplayName="Reference Output Assembly"
-                Description="A value indicating whether the compiler should include a reference to the target project's primary output assembly." />
-
-  <StringProperty Name="PrivateAssets"
-                  Visible="True"
-                  DisplayName="Private Assets"
-                  Description="Assets that are private in this reference" />
-
-  <StringProperty Name="ResolvedPath"
-                  ReadOnly="True"
-                  DisplayName="Path"
-                  Description="Location of the file being referenced.">
-    <StringProperty.DataSource>
-      <DataSource PersistedName="Identity"
-                  SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-
-  <StringProperty Name="Version"
-                  ReadOnly="True"
-                  DisplayName="Version"
-                  Description="Version of reference.">
-  </StringProperty>
-
-  <!-- Hidden properties -->
   <BoolProperty Name="LinkLibraryDependencies"
                 Visible="False" />
+
+  <StringProperty Name="PrivateAssets"
+                  Description="Assets that are private in this reference"
+                  DisplayName="Private Assets"
+                  Visible="True" />
 
   <StringProperty Name="Project"
                   Visible="False" />
@@ -122,10 +95,30 @@
   <StringProperty Name="ReferencedProjectIdentifier"
                   Visible="False" />
 
+  <BoolProperty Name="ReferenceOutputAssembly"
+                Description="A value indicating whether the compiler should include a reference to the target project's primary output assembly."
+                DisplayName="Reference Output Assembly" />
+
+  <StringProperty Name="ResolvedPath"
+                  Description="Location of the file being referenced."
+                  DisplayName="Path"
+                  ReadOnly="True">
+    <StringProperty.DataSource>
+      <DataSource PersistedName="Identity"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
   <BoolProperty Name="UseLibraryDependencyInputs"
                 Visible="False" />
 
+  <StringProperty Name="Version"
+                  Description="Version of reference."
+                  DisplayName="Version"
+                  ReadOnly="True" />
+
   <BoolProperty Name="Visible"
-                Visible="False"
-                ReadOnly="True" />
+                ReadOnly="True"
+                Visible="False" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.xaml
@@ -4,7 +4,7 @@
       Description="Reference Properties"
       DisplayName="Project Reference"
       PageTemplate="generic"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="ProjectReference"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAnalyzerReference.xaml
@@ -1,33 +1,46 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Rule
-    Name="ResolvedAnalyzerReference"
-    DisplayName="Resolved Analyzer Reference"
-    PageTemplate="generic"
-    Description="Analyzer Properties"
-    xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="ResolvedAnalyzerReference"
+      Description="Analyzer Properties"
+      DisplayName="Resolved Analyzer Reference"
+      PageTemplate="generic"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ResolvedReference" ItemType="Analyzer" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext"
-                SourceType="TargetResults" MSBuildTarget="CollectAnalyzersDesignTime"/>
+    <DataSource HasConfigurationCondition="False"
+                ItemType="Analyzer"
+                MSBuildTarget="CollectAnalyzersDesignTime"
+                Persistence="ResolvedReference"
+                SourceOfDefaultValue="AfterContext"
+                SourceType="TargetResults" />
   </Rule.DataSource>
 
+  <StringProperty Name="IsImplicitlyDefined"
+                  ReadOnly="True"
+                  Visible="False" />
+
   <StringProperty Name="OriginalItemSpec"
-                  Visible="False"
-                  ReadOnly="True" >
+                  ReadOnly="True"
+                  Visible="False">
     <StringProperty.DataSource>
-      <DataSource Persistence="Intrinsic" ItemType="Analyzer" PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
+      <DataSource ItemType="Analyzer"
+                  PersistedName="Identity"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
-  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
 
   <StringProperty Name="ResolvedPath"
-                  ReadOnly="True"
+                  Description="Location of the analyzer assembly."
                   DisplayName="Path"
-                  Description="Location of the analyzer assembly.">
+                  ReadOnly="True">
     <StringProperty.DataSource>
-      <DataSource PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
+      <DataSource PersistedName="Identity"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible"
+                ReadOnly="True"
+                Visible="False" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAnalyzerReference.xaml
@@ -4,7 +4,7 @@
       Description="Analyzer Properties"
       DisplayName="Resolved Analyzer Reference"
       PageTemplate="generic"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="Analyzer"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAssemblyReference.xaml
@@ -4,7 +4,7 @@
       Description="Reference Properties"
       DisplayName="Resolved Assembly Reference"
       PageTemplate="generic"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="Reference"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAssemblyReference.xaml
@@ -1,96 +1,42 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Rule
-    Name="ResolvedAssemblyReference"
-    DisplayName="Resolved Assembly Reference"
-    PageTemplate="generic"
-    Description="Reference Properties"
-    xmlns="http://schemas.microsoft.com/build/2009/properties">
-
+<Rule Name="ResolvedAssemblyReference"
+      Description="Reference Properties"
+      DisplayName="Resolved Assembly Reference"
+      PageTemplate="generic"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ResolvedReference"
+    <DataSource HasConfigurationCondition="False"
                 ItemType="Reference"
-                HasConfigurationCondition="False"
-                SourceType="TargetResults"
                 MSBuildTarget="ResolveAssemblyReferencesDesignTime"
-                SourceOfDefaultValue="AfterContext" />
+                Persistence="ResolvedReference"
+                SourceOfDefaultValue="AfterContext"
+                SourceType="TargetResults" />
   </Rule.DataSource>
 
-  <!-- Visible properties -->
-
   <StringListProperty Name="Aliases"
-                      DisplayName="Aliases"
                       Description="A comma-delimited list of aliases to this reference."
+                      DisplayName="Aliases"
                       Separator=",">
     <StringListProperty.DataSource>
-      <DataSource Persistence="ProjectFile"
+      <DataSource HasConfigurationCondition="False"
                   ItemType="Reference"
-                  HasConfigurationCondition="False"
+                  Persistence="ProjectFile"
                   SourceOfDefaultValue="AfterContext" />
     </StringListProperty.DataSource>
   </StringListProperty>
 
   <BoolProperty Name="CopyLocal"
-                DisplayName="Copy Local"
-                Description="Indicates whether the reference will be copied to the output directory.">
+                Description="Indicates whether the reference will be copied to the output directory."
+                DisplayName="Copy Local">
     <BoolProperty.DataSource>
-      <DataSource Persistence="ProjectFile"
+      <DataSource HasConfigurationCondition="False"
                   ItemType="Reference"
-                  HasConfigurationCondition="False"
                   PersistedName="Private"
+                  Persistence="ProjectFile"
                   SourceOfDefaultValue="AfterContext" />
     </BoolProperty.DataSource>
   </BoolProperty>
-
-  <BoolProperty Name="EmbedInteropTypes"
-                DisplayName="Embed Interop Types"
-                Description="Indicates whether types defined in this assembly will be embedded into the target assembly.">
-    <BoolProperty.DataSource>
-      <DataSource Persistence="ProjectFile"
-                  ItemType="Reference"
-                  HasConfigurationCondition="False"
-                  SourceOfDefaultValue="AfterContext" />
-    </BoolProperty.DataSource>
-  </BoolProperty>
-
-  <StringProperty Name="Identity"
-                  ReadOnly="True"
-                  DisplayName="Identity"
-                  Description="Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).">
-    <StringProperty.DataSource>
-      <DataSource PersistedName="{}{Identity}"
-                  SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-
-  <StringProperty Name="ResolvedPath"
-                  ReadOnly="True"
-                  DisplayName="Path"
-                  Description="Location of the file being referenced.">
-    <StringProperty.DataSource>
-      <DataSource PersistedName="Identity"
-                  SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-
-  <BoolProperty Name="SpecificVersion"
-                DisplayName="Specific Version"
-                Description="Indicates whether this assembly can be resolved without regard to multi-targeting rules for assembly resolution.">
-    <BoolProperty.DataSource>
-      <DataSource Persistence="AssemblyReference"
-                  ItemType="Reference"
-                  HasConfigurationCondition="False"
-                  SourceOfDefaultValue="AfterContext" />
-    </BoolProperty.DataSource>
-  </BoolProperty>
-
-  <StringProperty Name="Version"
-                  ReadOnly="True"
-                  DisplayName="Version"
-                  Description="Version of reference.">
-  </StringProperty>
-
-  <!-- Hidden properties -->
 
   <StringProperty Name="Culture"
                   ReadOnly="True"
@@ -100,6 +46,17 @@
                   ReadOnly="True"
                   Visible="False" />
 
+  <BoolProperty Name="EmbedInteropTypes"
+                Description="Indicates whether types defined in this assembly will be embedded into the target assembly."
+                DisplayName="Embed Interop Types">
+    <BoolProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="Reference"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </BoolProperty.DataSource>
+  </BoolProperty>
+
   <EnumProperty Name="FileType"
                 ReadOnly="True"
                 Visible="False">
@@ -108,60 +65,96 @@
     <EnumValue Name="Native Assembly" />
   </EnumProperty>
 
-  <StringProperty Name="HintPath" Visible="false" />
+  <StringProperty Name="FrameworkFile"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="FusionName"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="HintPath"
+                  Visible="false" />
+
+  <StringProperty Name="Identity"
+                  Description="Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence)."
+                  DisplayName="Identity"
+                  ReadOnly="True">
+    <StringProperty.DataSource>
+      <DataSource PersistedName="{}{Identity}"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="IsImplicitlyDefined"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <BoolProperty Name="IsWinMDFile"
+                Visible="false" />
+
+  <StringProperty Name="Name"
+                  ReadOnly="True"
+                  Visible="false" />
+
+  <StringProperty Name="OriginalItemSpec"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="ReferenceFromSDK"
+                  ReadOnly="True"
+                  Visible="False" />
 
   <StringProperty Name="RequiredTargetFramework"
                   Visible="False" />
 
-  <StringProperty Name="RuntimeVersion"
+  <StringProperty Name="ResolvedFrom"
                   ReadOnly="True"
-                  Visible="False">
+                  Visible="False" />
+
+  <StringProperty Name="ResolvedPath"
+                  Description="Location of the file being referenced."
+                  DisplayName="Path"
+                  ReadOnly="True">
+    <StringProperty.DataSource>
+      <DataSource PersistedName="Identity"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="SDKIdentity" Visible="false" />
+  <StringProperty Name="RuntimeVersion"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="SDKIdentity"
+                  Visible="false" />
+
+  <BoolProperty Name="SpecificVersion"
+                Description="Indicates whether this assembly can be resolved without regard to multi-targeting rules for assembly resolution."
+                DisplayName="Specific Version">
+    <BoolProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="Reference"
+                  Persistence="AssemblyReference"
+                  SourceOfDefaultValue="AfterContext" />
+    </BoolProperty.DataSource>
+  </BoolProperty>
 
   <BoolProperty Name="StrongName"
                 ReadOnly="True"
-                Visible="False">
-  </BoolProperty>
+                Visible="False" />
 
-  <!-- This is the metadata we store on the reference item when we add it. -->
-  <BoolProperty Name="IsWinMDFile"
-                Visible="false" />
-
-  <!-- These are metadata added to the resolved item by MSBuild that we don't show to the user but use internally. -->
-
-  <StringProperty Name="FrameworkFile"
-                  Visible="False"
+  <StringProperty Name="Version"
+                  Description="Version of reference."
+                  DisplayName="Version"
                   ReadOnly="True" />
 
-  <StringProperty Name="FusionName"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="IsImplicitlyDefined"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="Name"
-                  Visible="false"
-                  ReadOnly="True" />
-
-  <StringProperty Name="OriginalItemSpec"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="ReferenceFromSDK"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="ResolvedFrom"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible"
+                ReadOnly="True"
+                Visible="False" />
 
   <BoolProperty Name="WinMDFile"
-                Visible="false"
-                ReadOnly="True" />
+                ReadOnly="True"
+                Visible="false" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedCOMReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedCOMReference.xaml
@@ -1,36 +1,40 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Rule
-    Name="ResolvedCOMReference"
-    DisplayName="Resolved COM Reference"
-    PageTemplate="generic"
-    Description="COM Reference Properties"
-    xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="ResolvedCOMReference"
+      Description="COM Reference Properties"
+      DisplayName="Resolved COM Reference"
+      PageTemplate="generic"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ResolvedReference" ItemType="COMReference" HasConfigurationCondition="False"
-                SourceType="TargetResults" MSBuildTarget="ResolveComReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                ItemType="COMReference"
+                MSBuildTarget="ResolveComReferencesDesignTime"
+                Persistence="ResolvedReference"
+                SourceOfDefaultValue="AfterContext"
+                SourceType="TargetResults" />
   </Rule.DataSource>
 
-  <StringProperty Name="Guid"
-                  Visible="False" />
-  <IntProperty Name="VersionMajor" Visible="False" />
-  <IntProperty Name="VersionMinor" Visible="False" />
-  <StringProperty Name="WrapperTool" Visible="False" />
-
   <StringListProperty Name="Aliases"
-                      DisplayName="Aliases"
                       Description="A comma-delimited list of aliases to this reference."
+                      DisplayName="Aliases"
                       Separator=",">
     <StringListProperty.DataSource>
-      <DataSource Persistence="ProjectFile" ItemType="COMReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="COMReference"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
     </StringListProperty.DataSource>
   </StringListProperty>
 
   <BoolProperty Name="CopyLocal"
-                DisplayName="Copy Local"
-                Description="Indicates whether the reference will be copied to the output directory.">
+                Description="Indicates whether the reference will be copied to the output directory."
+                DisplayName="Copy Local">
     <BoolProperty.DataSource>
-      <DataSource Persistence="ProjectFile" ItemType="COMReference" HasConfigurationCondition="False" PersistedName="Private" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="COMReference"
+                  PersistedName="Private"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
     </BoolProperty.DataSource>
   </BoolProperty>
 
@@ -43,70 +47,109 @@
                   Visible="False" />
 
   <BoolProperty Name="EmbedInteropTypes"
-                DisplayName="Embed Interop Types"
-                Description="Indicates whether types defined in this assembly will be embedded into the target assembly.">
+                Description="Indicates whether types defined in this assembly will be embedded into the target assembly."
+                DisplayName="Embed Interop Types">
     <BoolProperty.DataSource>
-      <DataSource Persistence="ProjectFile" ItemType="COMReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="COMReference"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
     </BoolProperty.DataSource>
   </BoolProperty>
 
   <EnumProperty Name="FileType"
                 ReadOnly="True"
                 Visible="False">
-    <EnumValue Name="Assembly" DisplayName=".NET assembly" />
-    <EnumValue Name="ActiveX" DisplayName="COM type library" />
-    <EnumValue Name="Native Assembly" DisplayName="Native Assembly" />
+    <EnumValue Name="Assembly"
+               DisplayName=".NET assembly" />
+    <EnumValue Name="ActiveX"
+               DisplayName="COM type library" />
+    <EnumValue Name="Native Assembly"
+               DisplayName="Native Assembly" />
   </EnumProperty>
 
-  <StringProperty Name="Identity"
+  <StringProperty Name="FusionName"
                   ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="Guid"
+                  Visible="False" />
+
+  <StringProperty Name="HintPath"
+                  Visible="false" />
+
+  <StringProperty Name="Identity"
+                  Description="Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence)."
                   DisplayName="Identity"
-                  Description="Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).">
+                  ReadOnly="True">
     <StringProperty.DataSource>
-      <DataSource PersistedName="{}{Identity}" SourceOfDefaultValue="AfterContext" />
+      <DataSource PersistedName="{}{Identity}"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="ResolvedPath"
+  <StringProperty Name="IsImplicitlyDefined"
                   ReadOnly="True"
+                  Visible="False" />
+
+  <BoolProperty Name="IsWinMDFile"
+                Visible="false" />
+
+  <StringProperty Name="Name"
+                  ReadOnly="True"
+                  Visible="false" />
+
+  <StringProperty Name="OriginalItemSpec"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="RequiredTargetFramework"
+                  Visible="False" />
+
+  <StringProperty Name="ResolvedPath"
+                  Description="Location of the file being referenced."
                   DisplayName="Path"
-                  Description="Location of the file being referenced.">
+                  ReadOnly="True">
     <StringProperty.DataSource>
-      <DataSource PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
+      <DataSource PersistedName="Identity"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
   <StringProperty Name="RuntimeVersion"
                   ReadOnly="True"
-                  Visible="False">
-  </StringProperty>
+                  Visible="False" />
+
+  <StringProperty Name="SDKIdentity"
+                  Visible="false" />
 
   <BoolProperty Name="SpecificVersion"
                 Visible="False" />
 
   <BoolProperty Name="StrongName"
                 ReadOnly="True"
-                Visible="False">
-  </BoolProperty>
+                Visible="False" />
 
   <StringProperty Name="Version"
-                  ReadOnly="True"
+                  Description="Version of reference."
                   DisplayName="Version"
-                  Description="Version of reference.">
-  </StringProperty>
+                  ReadOnly="True" />
 
-  <StringProperty Name="RequiredTargetFramework" Visible="False" />
-  <StringProperty Name="HintPath" Visible="false" />
-  <StringProperty Name="SDKIdentity" Visible="false" />
+  <IntProperty Name="VersionMajor"
+               Visible="False" />
 
-  <!-- This is the metadata we store on the reference item when we add it. -->
-  <BoolProperty Name="IsWinMDFile" Visible="false" />
+  <IntProperty Name="VersionMinor"
+               Visible="False" />
 
-  <!-- These are metadata added to the resolved item by MSBuild that we don't show to the user but use internally. -->
-  <BoolProperty Name="WinMDFile" Visible="false" ReadOnly="True" />
-  <StringProperty Name="OriginalItemSpec" Visible="False" ReadOnly="True" />
-  <StringProperty Name="FusionName" Visible="False" ReadOnly="True" />
-  <StringProperty Name="Name" Visible="false" ReadOnly="True" />
-  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
-  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
+  <BoolProperty Name="Visible"
+                ReadOnly="True"
+                Visible="False" />
+
+  <BoolProperty Name="WinMDFile"
+                ReadOnly="True"
+                Visible="false" />
+
+  <StringProperty Name="WrapperTool"
+                  Visible="False" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedCOMReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedCOMReference.xaml
@@ -4,7 +4,7 @@
       Description="COM Reference Properties"
       DisplayName="Resolved COM Reference"
       PageTemplate="generic"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="COMReference"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedCompilationReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedCompilationReference.xaml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="ResolvedCompilationReference"
       PageTemplate="generic"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="ReferencePathWithRefAssemblies"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedCompilationReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedCompilationReference.xaml
@@ -1,20 +1,31 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Rule
-    Name="ResolvedCompilationReference"
-    PageTemplate="generic"
-    xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="ResolvedCompilationReference"
+      PageTemplate="generic"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ResolvedReference" ItemType="ReferencePathWithRefAssemblies" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext"
-                SourceType="TargetResults" MSBuildTarget="CollectResolvedCompilationReferencesDesignTime"/>
+    <DataSource HasConfigurationCondition="False"
+                ItemType="ReferencePathWithRefAssemblies"
+                MSBuildTarget="CollectResolvedCompilationReferencesDesignTime"
+                Persistence="ResolvedReference"
+                SourceOfDefaultValue="AfterContext"
+                SourceType="TargetResults" />
   </Rule.DataSource>
 
-  <StringProperty Name="ResolvedPath" ReadOnly="True">
+  <StringProperty Name="CopyUpToDateMarker"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="OriginalPath"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="ResolvedPath"
+                  ReadOnly="True">
     <StringProperty.DataSource>
-      <DataSource PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
+      <DataSource PersistedName="Identity"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="OriginalPath" ReadOnly="True" Visible="False"/>
-  <StringProperty Name="CopyUpToDateMarker" ReadOnly="True" Visible="False"/>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedPackageReference.xaml
@@ -1,129 +1,136 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Rule
-    Name="ResolvedPackageReference"
-    DisplayName="Package"
-    PageTemplate="generic"
-    Description="Package Properties"
-    xmlns="http://schemas.microsoft.com/build/2009/properties">
-
+<Rule Name="ResolvedPackageReference"
+      Description="Package Properties"
+      DisplayName="Package"
+      PageTemplate="generic"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ResolvedReference" ItemType="PackageReference" HasConfigurationCondition="False"
-                SourceType="TargetResults" MSBuildTarget="ResolvePackageDependenciesDesignTime" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                ItemType="PackageReference"
+                MSBuildTarget="ResolvePackageDependenciesDesignTime"
+                Persistence="ResolvedReference"
+                SourceOfDefaultValue="AfterContext"
+                SourceType="TargetResults" />
   </Rule.DataSource>
 
-  <StringProperty Name="Description"
-                  ReadOnly="True"
-                  Visible="True"
-                  DisplayName="Description"
-                  Description="Dependency description." />
+  <StringListProperty Name="Dependencies"
+                      Separator=";"
+                      Visible="false">
+    <StringListProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="PackageReference"
+                  Persistence="ResolvedReference"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringListProperty.DataSource>
+  </StringListProperty>
 
-  <StringProperty Name="Version"
+  <StringProperty Name="Description"
+                  Description="Dependency description."
+                  DisplayName="Description"
                   ReadOnly="True"
-                  DisplayName="Version"
-                  Description="Version of dependency.">
+                  Visible="True" />
+
+  <StringProperty Name="ExcludeAssets"
+                  Description="Assets to exclude from this reference"
+                  DisplayName="ExcludeAssets"
+                  Visible="True">
     <StringProperty.DataSource>
-      <DataSource PersistenceStyle="Attribute" SourceOfDefaultValue="AfterContext" />
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="PackageReference"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
+  <StringProperty Name="FrameworkName"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="FrameworkVersion"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="IncludeAssets"
+                  Description="Assets to include from this reference"
+                  DisplayName="IncludeAssets"
+                  Visible="True">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="PackageReference"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="IsImplicitlyDefined"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <BoolProperty Name="IsTopLevelDependency"
+                ReadOnly="True"
+                Visible="False" />
+
   <StringProperty Name="Name"
-                  Visible="True"
-                  ReadOnly="True" />
+                  ReadOnly="True"
+                  Visible="True" />
+
+  <StringProperty Name="NoWarn"
+                  Description="Comma-delimited list of warnings that should be suppressed for this package"
+                  DisplayName="NoWarn"
+                  Visible="True">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="PackageReference"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 
   <StringProperty Name="OriginalItemSpec"
                   Visible="False" />
 
   <StringProperty Name="Path"
-                  Visible="True"
+                  Description="Location of the package being referenced."
                   ReadOnly="True"
-                  Description="Location of the package being referenced." />
-
-  <StringProperty Name="Type"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="RuntimeIdentifier"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="TargetFramework"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="FrameworkName"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="IsImplicitlyDefined"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="FrameworkVersion"
-                  Visible="False"
-                  ReadOnly="True" />
-
-  <StringProperty Name="NoWarn"
-                  Visible="True"
-                  DisplayName="NoWarn"
-                  Description="Comma-delimited list of warnings that should be suppressed for this package">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile"
-                  ItemType="PackageReference"
-                  HasConfigurationCondition="False"
-                  SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-
-  <StringProperty Name="IncludeAssets"
-                  Visible="True"
-                  DisplayName="IncludeAssets"
-                  Description="Assets to include from this reference">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile"
-                  ItemType="PackageReference"
-                  HasConfigurationCondition="False"
-                  SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-
-  <StringProperty Name="ExcludeAssets"
-                  Visible="True"
-                  DisplayName="ExcludeAssets"
-                  Description="Assets to exclude from this reference">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile"
-                  ItemType="PackageReference"
-                  HasConfigurationCondition="False"
-                  SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+                  Visible="True" />
 
   <StringProperty Name="PrivateAssets"
-                  Visible="True"
+                  Description="Assets that are private in this reference"
                   DisplayName="PrivateAssets"
-                  Description="Assets that are private in this reference">
+                  Visible="True">
     <StringProperty.DataSource>
-      <DataSource Persistence="ProjectFile"
+      <DataSource HasConfigurationCondition="False"
                   ItemType="PackageReference"
-                  HasConfigurationCondition="False"
+                  Persistence="ProjectFile"
                   SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringListProperty Name="Dependencies"
-                      Visible="false"
-                      Separator=";">
-    <StringListProperty.DataSource>
-      <DataSource Persistence="ResolvedReference" ItemType="PackageReference" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
-    </StringListProperty.DataSource>
-  </StringListProperty>
+  <StringProperty Name="RuntimeIdentifier"
+                  ReadOnly="True"
+                  Visible="False" />
 
-  <BoolProperty Name="IsTopLevelDependency"
-                Visible="False"
-                ReadOnly="True"/>
+  <StringProperty Name="TargetFramework"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="Type"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="Version"
+                  Description="Version of dependency."
+                  DisplayName="Version"
+                  ReadOnly="True">
+    <StringProperty.DataSource>
+      <DataSource PersistenceStyle="Attribute"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 
   <BoolProperty Name="Visible"
-                Visible="False"
-                ReadOnly="True" />
+                ReadOnly="True"
+                Visible="False" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedPackageReference.xaml
@@ -4,7 +4,7 @@
       Description="Package Properties"
       DisplayName="Package"
       PageTemplate="generic"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="PackageReference"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedProjectReference.xaml
@@ -4,7 +4,7 @@
       Description="Reference Properties"
       DisplayName="Resolved Project Reference"
       PageTemplate="generic"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="ProjectReference"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedProjectReference.xaml
@@ -1,178 +1,164 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Rule
-    Name="ResolvedProjectReference"
-    DisplayName="Resolved Project Reference"
-    PageTemplate="generic"
-    Description="Reference Properties"
-    xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="ResolvedProjectReference"
+      Description="Reference Properties"
+      DisplayName="Resolved Project Reference"
+      PageTemplate="generic"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
+  <Rule.DataSource>
+    <DataSource HasConfigurationCondition="False"
+                ItemType="ProjectReference"
+                MSBuildTarget="ResolveProjectReferencesDesignTime"
+                Persistence="ResolvedReference"
+                SourceOfDefaultValue="AfterContext"
+                SourceType="TargetResults" />
+  </Rule.DataSource>
 
-    <Rule.DataSource>
-        <DataSource Persistence="ResolvedReference"
-                    ItemType="ProjectReference"
-                    HasConfigurationCondition="False" 
-                    SourceType="TargetResults"
-                    MSBuildTarget="ResolveProjectReferencesDesignTime"
-                    SourceOfDefaultValue="AfterContext" />
-    </Rule.DataSource>
+  <StringListProperty Name="Aliases"
+                      Description="A comma-delimited list of aliases to this reference."
+                      DisplayName="Aliases"
+                      Separator=",">
+    <StringListProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="ProjectReference"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringListProperty.DataSource>
+  </StringListProperty>
 
-    <!-- Visible properties -->
+  <BoolProperty Name="CopyLocal"
+                Description="Indicates whether the reference will be copied to the output directory."
+                DisplayName="Copy Local">
+    <BoolProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="ProjectReference"
+                  PersistedName="Private"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </BoolProperty.DataSource>
+  </BoolProperty>
 
-    <StringListProperty Name="Aliases"
-                        DisplayName="Aliases"
-                        Description="A comma-delimited list of aliases to this reference."
-                        Separator=",">
-        <StringListProperty.DataSource>
-            <DataSource Persistence="ProjectFile"
-                        ItemType="ProjectReference"
-                        HasConfigurationCondition="False"
-                        SourceOfDefaultValue="AfterContext" />
-        </StringListProperty.DataSource>
-    </StringListProperty>
+  <BoolProperty Name="CopyLocalSatelliteAssemblies"
+                Description="Indicates whether the satellite assemblies of the reference target should be copied into this project's output directory."
+                DisplayName="Copy Local Satellite Assemblies" />
 
-    <BoolProperty Name="CopyLocal"
-                  DisplayName="Copy Local"
-                  Description="Indicates whether the reference will be copied to the output directory.">
-        <BoolProperty.DataSource>
-            <DataSource Persistence="ProjectFile"
-                        ItemType="ProjectReference"
-                        HasConfigurationCondition="False"
-                        PersistedName="Private"
-                        SourceOfDefaultValue="AfterContext" />
-        </BoolProperty.DataSource>
-    </BoolProperty>
+  <StringProperty Name="Culture"
+                  Description="The value of the culture field from the assembly metadata."
+                  DisplayName="Culture"
+                  ReadOnly="True" />
 
-    <BoolProperty Name="CopyLocalSatelliteAssemblies"
-                  DisplayName="Copy Local Satellite Assemblies"
-                  Description="Indicates whether the satellite assemblies of the reference target should be copied into this project's output directory." />
+  <StringProperty Name="Description"
+                  Description="The value of the Title field from the assembly metadata."
+                  DisplayName="Description"
+                  ReadOnly="True" />
 
-    <StringProperty Name="Culture" 
-                    ReadOnly="True"
-                    DisplayName="Culture" 
-                    Description="The value of the culture field from the assembly metadata.">
-    </StringProperty>
+  <BoolProperty Name="EmbedInteropTypes"
+                Description="Indicates whether types defined in this assembly will be embedded into the target assembly."
+                DisplayName="Embed Interop Types">
+    <BoolProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="ProjectReference"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </BoolProperty.DataSource>
+  </BoolProperty>
 
-    <StringProperty Name="Description" 
-                    ReadOnly="True" 
-                    DisplayName="Description" 
-                    Description="The value of the Title field from the assembly metadata.">
-    </StringProperty>
+  <StringProperty Name="ExcludeAssets"
+                  Description="Assets to exclude from this reference"
+                  DisplayName="Exclude Assets"
+                  Visible="True" />
 
-    <BoolProperty Name="EmbedInteropTypes"
-                  DisplayName="Embed Interop Types"
-                  Description="Indicates whether types defined in this assembly will be embedded into the target assembly.">
-        <BoolProperty.DataSource>
-            <DataSource Persistence="ProjectFile"
-                        ItemType="ProjectReference"
-                        HasConfigurationCondition="False"
-                        SourceOfDefaultValue="AfterContext" />
-        </BoolProperty.DataSource>
-    </BoolProperty>
+  <EnumProperty Name="FileType"
+                ReadOnly="True"
+                Visible="False">
+    <EnumValue Name="Assembly" />
+    <EnumValue Name="ActiveX" />
+    <EnumValue Name="Native Assembly" />
+  </EnumProperty>
 
-    <StringProperty Name="ExcludeAssets" 
-                    Visible="True"
-                    DisplayName="Exclude Assets"
-                    Description="Assets to exclude from this reference" />
-
-    <StringProperty Name="Identity"
-                    ReadOnly="True"
-                    DisplayName="Identity"
-                    Description="Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence).">
-        <StringProperty.DataSource>
-            <DataSource PersistedName="{}{Identity}"
-                        SourceOfDefaultValue="AfterContext" />
-        </StringProperty.DataSource>
-    </StringProperty>
-
-    <StringProperty Name="IncludeAssets" 
-                    Visible="True"
-                    DisplayName="Include Assets"
-                    Description="Assets to include from this reference" />
-
-    <BoolProperty Name="ReferenceOutputAssembly"
-                  DisplayName="Reference Output Assembly"
-                  Description="A value indicating whether the compiler should include a reference to the target project's primary output assembly." />
-
-    <StringProperty Name="PrivateAssets" 
-                    Visible="True"
-                    DisplayName="Private Assets"
-                    Description="Assets that are private in this reference" />
-
-    <StringProperty Name="ResolvedPath"
-                    ReadOnly="True"
-                    DisplayName="Path"
-                    Description="Location of the file being referenced.">
-        <StringProperty.DataSource>
-            <DataSource PersistedName="Identity"
-                        SourceOfDefaultValue="AfterContext" />
-        </StringProperty.DataSource>
-    </StringProperty>
-
-    <StringProperty Name="Version"
-                    ReadOnly="True"
-                    DisplayName="Version"
-                    Description="Version of reference.">
-    </StringProperty>
-
-    <!-- Hidden properties -->
-
-    <EnumProperty Name="FileType"
+  <StringProperty Name="FusionName"
                   ReadOnly="True"
-                  Visible="False">
-        <EnumValue Name="Assembly" />
-        <EnumValue Name="ActiveX" />
-        <EnumValue Name="Native Assembly" />
-    </EnumProperty>
-
-    <StringProperty Name="HintPath"
-                    Visible="false" />
-
-    <StringProperty Name="RequiredTargetFramework"
-                    Visible="False" />
-
-    <StringProperty Name="RuntimeVersion"
-                    ReadOnly="True"
-                    Visible="False">
-    </StringProperty>
-
-    <StringProperty Name="SDKIdentity"
-                    Visible="false" />
-
-    <BoolProperty Name="SpecificVersion" 
                   Visible="False" />
 
-    <BoolProperty Name="StrongName"
-                  ReadOnly="True"
-                  Visible="False">
-    </BoolProperty>
-
-    <!-- This is the metadata we store on the reference item when we add it. -->
-
-    <BoolProperty Name="IsWinMDFile"
+  <StringProperty Name="HintPath"
                   Visible="false" />
 
-    <StringProperty Name="Project" 
-                    Visible="False" />
+  <StringProperty Name="Identity"
+                  Description="Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence)."
+                  DisplayName="Identity"
+                  ReadOnly="True">
+    <StringProperty.DataSource>
+      <DataSource PersistedName="{}{Identity}"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 
-    <!-- These are metadata added to the resolved item by MSBuild that we don't show to the user but use internally. -->
+  <StringProperty Name="IncludeAssets"
+                  Description="Assets to include from this reference"
+                  DisplayName="Include Assets"
+                  Visible="True" />
 
-    <BoolProperty Name="WinMDFile"
-                  Visible="false"
+  <BoolProperty Name="IsWinMDFile"
+                Visible="false" />
+
+  <StringProperty Name="Name"
+                  ReadOnly="True"
+                  Visible="false" />
+
+  <StringProperty Name="OriginalItemSpec"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="PrivateAssets"
+                  Description="Assets that are private in this reference"
+                  DisplayName="Private Assets"
+                  Visible="True" />
+
+  <StringProperty Name="Project"
+                  Visible="False" />
+
+  <BoolProperty Name="ReferenceOutputAssembly"
+                Description="A value indicating whether the compiler should include a reference to the target project's primary output assembly."
+                DisplayName="Reference Output Assembly" />
+
+  <StringProperty Name="RequiredTargetFramework"
+                  Visible="False" />
+
+  <StringProperty Name="ResolvedPath"
+                  Description="Location of the file being referenced."
+                  DisplayName="Path"
+                  ReadOnly="True">
+    <StringProperty.DataSource>
+      <DataSource PersistedName="Identity"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="RuntimeVersion"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="SDKIdentity"
+                  Visible="false" />
+
+  <BoolProperty Name="SpecificVersion"
+                Visible="False" />
+
+  <BoolProperty Name="StrongName"
+                ReadOnly="True"
+                Visible="False" />
+
+  <StringProperty Name="Version"
+                  Description="Version of reference."
+                  DisplayName="Version"
                   ReadOnly="True" />
 
-    <StringProperty Name="OriginalItemSpec"
-                    Visible="False"
-                    ReadOnly="True" />
+  <BoolProperty Name="Visible"
+                ReadOnly="True"
+                Visible="False" />
 
-    <StringProperty Name="FusionName"
-                    Visible="False"
-                    ReadOnly="True" />
+  <BoolProperty Name="WinMDFile"
+                ReadOnly="True"
+                Visible="false" />
 
-    <StringProperty Name="Name"
-                    Visible="false"
-                    ReadOnly="True" />
-
-    <BoolProperty Name="Visible"
-                  Visible="False"
-                  ReadOnly="True" />
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedSdkReference.xaml
@@ -4,7 +4,7 @@
       Description="SDK Reference Properties"
       DisplayName="Resolved SDK Reference"
       PageTemplate="generic"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="SDKReference"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedSdkReference.xaml
@@ -1,29 +1,77 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Rule
-    Name="ResolvedSdkReference"
-    DisplayName="Resolved SDK Reference"
-    PageTemplate="generic"
-    Description="SDK Reference Properties"
-    xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="ResolvedSdkReference"
+      Description="SDK Reference Properties"
+      DisplayName="Resolved SDK Reference"
+      PageTemplate="generic"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ResolvedReference" ItemType="SDKReference" HasConfigurationCondition="False"
-                SourceType="TargetResults" MSBuildTarget="CollectResolvedSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                ItemType="SDKReference"
+                MSBuildTarget="CollectResolvedSDKReferencesDesignTime"
+                Persistence="ResolvedReference"
+                SourceOfDefaultValue="AfterContext"
+                SourceType="TargetResults" />
   </Rule.DataSource>
-  <StringProperty Name="AppXLocation" DisplayName="App Package Location" ReadOnly="True" />
-  <!-- This property should be the same as the one for the ResolvedReference item -->
-  <StringProperty Name="OriginalItemSpec" Visible="false" ReadOnly="True" />
-  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" ReadOnly="True" />
-  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
-  <StringProperty Name="DisplayName" Visible="False" ReadOnly="True" />
-  <StringProperty Name="Name" DisplayName="Name" ReadOnly="True"/>
-  <StringProperty Name="Version" DisplayName="Version" ReadOnly="True"/>
-  <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True"/>
-  <BoolProperty Name="CopyPayload" DisplayName="Copy Payload" ReadOnly="True" />
-  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" ReadOnly="True" />
-  <BoolProperty Name="ExpandContent" DisplayName="Expand Content" ReadOnly="True" />
-  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Expand Reference Assemblies" ReadOnly="True" />
-  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copy Local Expanded Reference Assemblies" ReadOnly="True" />
-  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
-  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
+
+  <StringProperty Name="AppXLocation"
+                  DisplayName="App Package Location"
+                  ReadOnly="True" />
+
+  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies"
+                DisplayName="Copy Local Expanded Reference Assemblies"
+                ReadOnly="True" />
+
+  <BoolProperty Name="CopyPayload"
+                DisplayName="Copy Payload"
+                ReadOnly="True" />
+
+  <StringProperty Name="CopyPayloadToSubDirectory"
+                  DisplayName="Copy Payload to Subdirectory"
+                  ReadOnly="True" />
+
+  <StringProperty Name="DisplayName"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <BoolProperty Name="ExpandContent"
+                DisplayName="Expand Content"
+                ReadOnly="True" />
+
+  <BoolProperty Name="ExpandReferenceAssemblies"
+                DisplayName="Expand Reference Assemblies"
+                ReadOnly="True" />
+
+  <StringProperty Name="FrameworkIdentity"
+                  DisplayName="FrameworkIdentity"
+                  ReadOnly="True" />
+
+  <StringProperty Name="IsImplicitlyDefined"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="Name"
+                  DisplayName="Name"
+                  ReadOnly="True" />
+
+  <StringProperty Name="OriginalItemSpec"
+                  ReadOnly="True"
+                  Visible="false" />
+
+  <StringProperty Name="SDKPackageItemSpec"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="SDKRootFolder"
+                  DisplayName="SDK Root"
+                  ReadOnly="True" />
+
+  <StringProperty Name="Version"
+                  DisplayName="Version"
+                  ReadOnly="True" />
+
+  <BoolProperty Name="Visible"
+                ReadOnly="True"
+                Visible="False" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SdkReference.xaml
@@ -4,7 +4,7 @@
       Description="SDK Reference Properties"
       DisplayName="SDK Reference"
       PageTemplate="generic"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="SDKReference"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SdkReference.xaml
@@ -1,27 +1,73 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Rule
-    Name="SdkReference"
-    DisplayName="SDK Reference"
-    PageTemplate="generic"
-    Description="SDK Reference Properties"
-    xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="SdkReference"
+      Description="SDK Reference Properties"
+      DisplayName="SDK Reference"
+      PageTemplate="generic"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="SDKReference" HasConfigurationCondition="False"
-                SourceType="TargetResults" MSBuildTarget="CollectSDKReferencesDesignTime" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                ItemType="SDKReference"
+                MSBuildTarget="CollectSDKReferencesDesignTime"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext"
+                SourceType="TargetResults" />
   </Rule.DataSource>
-  <StringProperty Name="SDKRootFolder" DisplayName="SDK Root" ReadOnly="True" />
-  <StringProperty Name="AppXLocation" DisplayName="App Package Location" ReadOnly="True" />
-  <StringProperty Name="FrameworkIdentity" DisplayName="FrameworkIdentity" ReadOnly="True" />
-  <StringProperty Name="DisplayName" Visible="False" ReadOnly="True" />
-  <StringProperty Name="Name" DisplayName="Name" ReadOnly="True" />
-  <StringProperty Name="Version" DisplayName="Version" ReadOnly="True" />
-  <StringProperty Name="SDKPackageItemSpec" Visible="False" ReadOnly="True" />
-  <BoolProperty Name="CopyPayload" DisplayName="Copy Payload" ReadOnly="True" />
-  <StringProperty Name="CopyPayloadToSubDirectory" DisplayName="Copy Payload to Subdirectory" ReadOnly="True" />
-  <BoolProperty Name="ExpandContent" DisplayName="Expand Content" ReadOnly="True" />
-  <BoolProperty Name="ExpandReferenceAssemblies" DisplayName="Expand Reference Assemblies" ReadOnly="True" />
-  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies" DisplayName="Copy Local Expanded Reference Assemblies" ReadOnly="True" />
-  <StringProperty Name="IsImplicitlyDefined" Visible="False" ReadOnly="True" />
-  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
+
+  <StringProperty Name="AppXLocation"
+                  DisplayName="App Package Location"
+                  ReadOnly="True" />
+
+  <BoolProperty Name="CopyLocalExpandedReferenceAssemblies"
+                DisplayName="Copy Local Expanded Reference Assemblies"
+                ReadOnly="True" />
+
+  <BoolProperty Name="CopyPayload"
+                DisplayName="Copy Payload"
+                ReadOnly="True" />
+
+  <StringProperty Name="CopyPayloadToSubDirectory"
+                  DisplayName="Copy Payload to Subdirectory"
+                  ReadOnly="True" />
+
+  <StringProperty Name="DisplayName"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <BoolProperty Name="ExpandContent"
+                DisplayName="Expand Content"
+                ReadOnly="True" />
+
+  <BoolProperty Name="ExpandReferenceAssemblies"
+                DisplayName="Expand Reference Assemblies"
+                ReadOnly="True" />
+
+  <StringProperty Name="FrameworkIdentity"
+                  DisplayName="FrameworkIdentity"
+                  ReadOnly="True" />
+
+  <StringProperty Name="IsImplicitlyDefined"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="Name"
+                  DisplayName="Name"
+                  ReadOnly="True" />
+
+  <StringProperty Name="SDKPackageItemSpec"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="SDKRootFolder"
+                  DisplayName="SDK Root"
+                  ReadOnly="True" />
+
+  <StringProperty Name="Version"
+                  DisplayName="Version"
+                  ReadOnly="True" />
+
+  <BoolProperty Name="Visible"
+                ReadOnly="True"
+                Visible="False" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SourceControl.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SourceControl.xaml
@@ -4,7 +4,7 @@
       Description="General"
       DisplayName="Source control"
       PageTemplate="generic"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 Label="Globals"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SourceControl.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SourceControl.xaml
@@ -1,16 +1,23 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule
-  Name="SourceControl"
-  DisplayName="Source control"
-  PageTemplate="generic"
-  Description="General"
-  xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="SourceControl"
+      Description="General"
+      DisplayName="Source control"
+      PageTemplate="generic"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" Label="Globals" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                Label="Globals"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-  <StringProperty Name="SccProjectName" />
-  <StringProperty Name="SccProvider" />
+
   <StringProperty Name="SccAuxPath" />
+
   <StringProperty Name="SccLocalPath" />
+
+  <StringProperty Name="SccProjectName" />
+
+  <StringProperty Name="SccProvider" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SpecialFolder.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SpecialFolder.xaml
@@ -4,7 +4,7 @@
       Description="Special folders"
       DisplayName="General"
       PageTemplate="generic"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="SpecialFolder"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SpecialFolder.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SpecialFolder.xaml
@@ -1,24 +1,42 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule
-	Name="SpecialFolder"
-	DisplayName="General"
-	PageTemplate="generic"
-	Description="Special folders"
-	xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="SpecialFolder"
+      Description="Special folders"
+      DisplayName="General"
+      PageTemplate="generic"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectInstance" HasConfigurationCondition="False" ItemType="SpecialFolder" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                ItemType="SpecialFolder"
+                Persistence="ProjectInstance"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <StringProperty Name="Identity" Visible="false" ReadOnly="true" />
-  <StringProperty Name="FullPath" DisplayName="Full Path" ReadOnly="true" Category="Misc" />
-  <StringProperty Name="FileNameAndExtension" DisplayName="Folder Name" ReadOnly="true" Category="Misc">
-    <StringProperty.DataSource>
-      <DataSource Persistence="ProjectInstance" ItemType="SpecialFolder" PersistedName="FileNameAndExtension" SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-  <EnumProperty Name="DisableAddItem" Visible="False">
+  <EnumProperty Name="DisableAddItem"
+                Visible="False">
     <EnumValue Name="Recursive" />
     <EnumValue Name="TopDirectoryOnly" />
   </EnumProperty>
+
+  <StringProperty Name="FileNameAndExtension"
+                  Category="Misc"
+                  DisplayName="Folder Name"
+                  ReadOnly="true">
+    <StringProperty.DataSource>
+      <DataSource ItemType="SpecialFolder"
+                  PersistedName="FileNameAndExtension"
+                  Persistence="ProjectInstance"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="FullPath"
+                  Category="Misc"
+                  DisplayName="Full Path"
+                  ReadOnly="true" />
+
+  <StringProperty Name="Identity"
+                  ReadOnly="true"
+                  Visible="false" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SubProject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SubProject.xaml
@@ -4,7 +4,7 @@
       Description="Projects that must be built as part of the containing project, but without an actual build dependency"
       DisplayName="General"
       PageTemplate="generic"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="SubProject"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SubProject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SubProject.xaml
@@ -1,16 +1,24 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright, Microsoft Corporation, All rights reserved.-->
-<Rule
-  Name="SubProject"
-  DisplayName="General"
-  PageTemplate="generic"
-  Description="Projects that must be built as part of the containing project, but without an actual build dependency"
-  xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="SubProject"
+      Description="Projects that must be built as part of the containing project, but without an actual build dependency"
+      DisplayName="General"
+      PageTemplate="generic"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" ItemType="SubProject" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                ItemType="SubProject"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <StringProperty Name="ProjectTypeGuid" Visible="False" />
-  <StringProperty Name="ProjectId" Visible="False" />
-  <BoolProperty Name="VirtualProject" Visible="False" />
+  <StringProperty Name="ProjectId"
+                  Visible="False" />
+
+  <StringProperty Name="ProjectTypeGuid"
+                  Visible="False" />
+
+  <BoolProperty Name="VirtualProject"
+                Visible="False" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckBuilt.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckBuilt.xaml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
 <Rule Name="UpToDateCheckBuilt"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 MSBuildTarget="CollectUpToDateCheckBuiltDesignTime"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckBuilt.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckBuilt.xaml
@@ -1,10 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule Name="UpToDateCheckBuilt" xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="UpToDateCheckBuilt"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext"
-                SourceType="TargetResults" MSBuildTarget="CollectUpToDateCheckBuiltDesignTime"/>
+    <DataSource HasConfigurationCondition="False"
+                MSBuildTarget="CollectUpToDateCheckBuiltDesignTime"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext"
+                SourceType="TargetResults" />
   </Rule.DataSource>
-  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
-  <StringProperty Name="Original" />  <!-- If set, specifies that this built output comes from this source file. -->
+
+  <StringProperty Name="Original" />
+
+  <BoolProperty Name="Visible"
+                ReadOnly="True"
+                Visible="False" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckInput.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckInput.xaml
@@ -1,9 +1,17 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule Name="UpToDateCheckInput" xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="UpToDateCheckInput"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext"
-                SourceType="TargetResults" MSBuildTarget="CollectUpToDateCheckInputDesignTime"/>
+    <DataSource HasConfigurationCondition="False"
+                MSBuildTarget="CollectUpToDateCheckInputDesignTime"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext"
+                SourceType="TargetResults" />
   </Rule.DataSource>
-  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
+
+  <BoolProperty Name="Visible"
+                ReadOnly="True"
+                Visible="False" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckInput.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckInput.xaml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
 <Rule Name="UpToDateCheckInput"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 MSBuildTarget="CollectUpToDateCheckInputDesignTime"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckOutput.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckOutput.xaml
@@ -1,9 +1,17 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
-<Rule Name="UpToDateCheckOutput" xmlns="http://schemas.microsoft.com/build/2009/properties">
+<Rule Name="UpToDateCheckOutput"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext"
-                SourceType="TargetResults" MSBuildTarget="CollectUpToDateCheckOutputDesignTime"/>
+    <DataSource HasConfigurationCondition="False"
+                MSBuildTarget="CollectUpToDateCheckOutputDesignTime"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext"
+                SourceType="TargetResults" />
   </Rule.DataSource>
-  <BoolProperty Name="Visible" Visible="False" ReadOnly="True" />
+
+  <BoolProperty Name="Visible"
+                ReadOnly="True"
+                Visible="False" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckOutput.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckOutput.xaml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
 <Rule Name="UpToDateCheckOutput"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 MSBuildTarget="CollectUpToDateCheckOutputDesignTime"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/VisualBasic.NamespaceImport.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/VisualBasic.NamespaceImport.xaml
@@ -1,14 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
-<Rule
-    Name="NamespaceImport"
-    DisplayName="NamespaceImport"
-    PageTemplate="generic"
-    Description="Visual Basic Namespace Import"
-    xmlns="http://schemas.microsoft.com/build/2009/properties">
-
+<Rule Name="NamespaceImport"
+      Description="Visual Basic Namespace Import"
+      DisplayName="NamespaceImport"
+      PageTemplate="generic"
+       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile" ItemType="Import" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+    <DataSource HasConfigurationCondition="False"
+                ItemType="Import"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/VisualBasic.NamespaceImport.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/VisualBasic.NamespaceImport.xaml
@@ -4,7 +4,7 @@
       Description="Visual Basic Namespace Import"
       DisplayName="NamespaceImport"
       PageTemplate="generic"
-       xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="Import"


### PR DESCRIPTION
Apologies for the size of the review, but this baselines all of the item type XAML rules to be sorted, allowing for much easier future comparisons.

What was done:

* Sort nodes:
  * Metadata appears first (ie, nodes named [Parent].[Thing])
  * Child elements sorted alphabetically by Name attribute if it exists
  * Remaining child elements sorted by element name
* Sort attributes:
  * Name attribute output first
  * Remaining attributes sorted alphabetically 
* Misc
  * EnumProperty child nodes not sorted to maintian UI order
  * Blank line between each 2nd level node

I wanted to get the attributes to be one-per-line and wrapped nicely but it turns out none of the XML writers in .NET support any whitespace between attributes. I could change the tool I used to write out the XML manually to do this if people feel strongly about it.

If its easier to review the tool that made the changes its here: https://github.com/davidwengier/XamlRuleCleaner/blob/master/Program.cs

In future I'm tempted to make this validate more rules and perhaps put something in place as a PR check so we don't regress things. Things like not having localizable strings in non-BrowseObject or invisible properties would be straight forward enough.