### PR TITLE
Move components out of UnconfiguredProject-scope

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/CSharp/CSharpSyntaxFactsServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/CSharp/CSharpSyntaxFactsServiceTests.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.CSharp
 {
     public class CSharpSyntaxFactsServiceTests
     {
-        private static readonly ISyntaxFactsService s_service = new CSharpSyntaxFactsService(null);
+        private static readonly ISyntaxFactsService s_service = new CSharpSyntaxFactsService();
 
         [Fact]
         public void TestIsValidIdentifier()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/VisualBasic/VisualBasicSyntaxFactsServiceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/VisualBasic/VisualBasicSyntaxFactsServiceTests.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.VisualBasic
 {
     public class VisualBasicSyntaxFactsServiceTests
     {
-        private static readonly ISyntaxFactsService s_service = new VisualBasicSyntaxFactsService(null);
+        private static readonly ISyntaxFactsService s_service = new VisualBasicSyntaxFactsService();
 
         [Fact]
         public void TestIsValidIdentifier()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/CSharp/CSharpProjectTypeGuidProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/CSharp/CSharpProjectTypeGuidProviderTests.cs
@@ -20,9 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.CSharp
 
         private static CSharpProjectTypeGuidProvider CreateInstance()
         {
-            var unconfiguredProject = UnconfiguredProjectFactory.Create();
-
-            return new CSharpProjectTypeGuidProvider(unconfiguredProject);
+            return new CSharpProjectTypeGuidProvider();
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/CSharp/CSharpSimpleRenamerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/CSharp/CSharpSimpleRenamerTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.CSharp
         public async Task Rename_Symbol_Should_TriggerUserConfirmationAsync(string sourceCode, string oldFilePath, string newFilePath)
         {
             var userNotificationServices = IUserNotificationServicesFactory.Create();
-            var roslynServices = IRoslynServicesFactory.Implement(new CSharpSyntaxFactsService(null));
+            var roslynServices = IRoslynServicesFactory.Implement(new CSharpSyntaxFactsService());
 
             await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, LanguageNames.CSharp);
 
@@ -51,7 +51,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.CSharp
         public async Task Rename_Symbol_Should_Not_HappenAsync(string sourceCode, string oldFilePath, string newFilePath)
         {
             var userNotificationServices = IUserNotificationServicesFactory.Create();
-            var roslynServices = IRoslynServicesFactory.Implement(new CSharpSyntaxFactsService(null));
+            var roslynServices = IRoslynServicesFactory.Implement(new CSharpSyntaxFactsService());
 
             await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, LanguageNames.CSharp).TimeoutAfter(TimeSpan.FromSeconds(1));
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/VisualBasic/VisualBasicSimpleRenameTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/VisualBasic/VisualBasicSimpleRenameTests.cs
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.VisualBasic
         {
 
             var userNotificationServices = IUserNotificationServicesFactory.Create();
-            var roslynServices = IRoslynServicesFactory.Implement(new VisualBasicSyntaxFactsService(null));
+            var roslynServices = IRoslynServicesFactory.Implement(new VisualBasicSyntaxFactsService());
 
             await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, LanguageNames.VisualBasic);
 
@@ -114,7 +114,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.VisualBasic
         public async Task Rename_Symbol_Should_TriggerUserConfirmationAsync(string oldFilePath, string newFilePath, string sourceCode)
         {
             var userNotificationServices = IUserNotificationServicesFactory.Create();
-            var roslynServices = IRoslynServicesFactory.Implement(new VisualBasicSyntaxFactsService(null));
+            var roslynServices = IRoslynServicesFactory.Implement(new VisualBasicSyntaxFactsService());
 
             await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, LanguageNames.VisualBasic);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/VisualBasic/VisualBasicProjectTypeGuidProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/VisualBasic/VisualBasicProjectTypeGuidProviderTests.cs
@@ -20,9 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.VisualBasic
 
         private static VisualBasicProjectTypeGuidProvider CreateInstance()
         {
-            var unconfiguredProject = UnconfiguredProjectFactory.Create();
-
-            return new VisualBasicProjectTypeGuidProvider(unconfiguredProject);
+            return new VisualBasicProjectTypeGuidProvider();
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/CSharp/CSharpProjectTypeGuidProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/CSharp/CSharpProjectTypeGuidProvider.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.CSharp
     internal class CSharpProjectTypeGuidProvider : IItemTypeGuidProvider
     {
         [ImportingConstructor]
-        public CSharpProjectTypeGuidProvider(UnconfiguredProject project)
+        public CSharpProjectTypeGuidProvider()
         {
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/FSharp/FSharpProjectTypeGuidProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/FSharp/FSharpProjectTypeGuidProvider.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.FSharp
     internal class FSharpProjectTypeGuidProvider : IItemTypeGuidProvider
     {
         [ImportingConstructor]
-        public FSharpProjectTypeGuidProvider(UnconfiguredProject project)
+        public FSharpProjectTypeGuidProvider()
         {
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VisualBasic/VisualBasicProjectTypeGuidProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VisualBasic/VisualBasicProjectTypeGuidProvider.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.VisualBasic
     internal class VisualBasicProjectTypeGuidProvider : IItemTypeGuidProvider
     {
         [ImportingConstructor]
-        public VisualBasicProjectTypeGuidProvider(UnconfiguredProject project)
+        public VisualBasicProjectTypeGuidProvider()
         {
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/CSharp/CSharpSyntaxFactsService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/CSharp/CSharpSyntaxFactsService.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.CSharp
     internal class CSharpSyntaxFactsService : ISyntaxFactsService
     {
         [ImportingConstructor]
-        public CSharpSyntaxFactsService(UnconfiguredProject project)
+        public CSharpSyntaxFactsService()
         {
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/VisualBasic/VisualBasicSyntaxFactsService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/VisualBasic/VisualBasicSyntaxFactsService.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.VisualBasic
     internal class VisualBasicSyntaxFactsService : ISyntaxFactsService
     {
         [ImportingConstructor]
-        public VisualBasicSyntaxFactsService(UnconfiguredProject project)
+        public VisualBasicSyntaxFactsService()
         {
         }
 


### PR DESCRIPTION
These components use no project state, or store state on a per project basis, push to them out to the global scope so that they can be shared across all C#/VB/F# projects. In a 1000 project-solution, this reduces the number of these components from 1000 to 1.