### PR TITLE
Make HandleLaunchSettingsFileChangedAsync return Task.CompletedTask

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -458,7 +458,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 // Set the ignore flag. It should be ignored.
                 provider.LastSettingsFileSyncTimeTest = DateTime.MinValue;
                 provider.SetIgnoreFileChanges(true);
-                Assert.Null(provider.LaunchSettingsFile_ChangedTest());
+                Assert.Equal(provider.LaunchSettingsFile_ChangedTest(), Task.CompletedTask);
                 Assert.Null(provider.CurrentSnapshot);
 
                 // Should run this time
@@ -482,7 +482,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 // Write new file, but set the timestamp to match
                 moqFS.WriteAllText(provider.LaunchSettingsFile, JsonStringWithWebSettings);
                 provider.LastSettingsFileSyncTimeTest = moqFS.LastFileWriteTime(provider.LaunchSettingsFile);
-                Assert.Null(provider.LaunchSettingsFile_ChangedTest());
+                Assert.Equal(provider.LaunchSettingsFile_ChangedTest(), Task.CompletedTask);
                 AssertEx.CollectionLength(provider.CurrentSnapshot.Profiles, 4);
 
                 moqFS.WriteAllText(provider.LaunchSettingsFile, JsonStringWithWebSettings);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -624,7 +624,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 }
             }
 
-            return null;
+            return Task.CompletedTask;
         }
 
         /// <summary>


### PR DESCRIPTION
Fix for: https://github.com/dotnet/project-system/issues/4622

Even if the logic in HandleLaunchSettingsFileChangedAsync was regressed and a different change is needed, we should probably still have this check. 