### PR TITLE
Add Native Code Debugging CheckBox to the Debug prop page

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
@@ -395,6 +395,17 @@
                     </Button.IsEnabled>
                 </Button>
             </StackPanel>
+            <CheckBox 
+                Grid.Row="8"
+                Grid.Column="0"
+                x:Uid="chkNativeCodeDebugging"
+                x:Name="chkNativeCodeDebugging"
+                IsChecked="{Binding NativeCodeDebugging, Mode=TwoWay}"
+                Margin="9,7,3,7"
+                VerticalAlignment="Center"
+                IsEnabled="{Binding Path=IsProfileSelected, Mode=OneWay}"
+                VerticalContentAlignment="Center"
+                Content="{x:Static Member=local:PropertyPageResources.chkNativeCodeDebuggingText}"/>
             <!-- Where the custom control is placed for the active provider -->
             <ContentPresenter Grid.Row="8" Grid.Column="0"  Grid.ColumnSpan="3" Content="{Binding ActiveProviderUserControl, Mode=OneWay}" />
         </Grid>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
@@ -47,6 +47,7 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
             <Label
                 Grid.Row="0"
@@ -400,6 +401,7 @@
                 Grid.Column="0"
                 x:Uid="chkNativeCodeDebugging"
                 x:Name="chkNativeCodeDebugging"
+                Visibility="{Binding SupportNativeDebugging, Mode=OneWay, Converter={StaticResource visibilityConverter}}"
                 IsChecked="{Binding NativeCodeDebugging, Mode=TwoWay}"
                 Margin="9,7,3,7"
                 VerticalAlignment="Center"
@@ -407,7 +409,7 @@
                 VerticalContentAlignment="Center"
                 Content="{x:Static Member=local:PropertyPageResources.chkNativeCodeDebuggingText}"/>
             <!-- Where the custom control is placed for the active provider -->
-            <ContentPresenter Grid.Row="8" Grid.Column="0"  Grid.ColumnSpan="3" Content="{Binding ActiveProviderUserControl, Mode=OneWay}" />
+            <ContentPresenter Grid.Row="9" Grid.Column="0"  Grid.ColumnSpan="3" Content="{Binding ActiveProviderUserControl, Mode=OneWay}" />
         </Grid>
     </Grid>
 </local:PropertyPageControl>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
@@ -296,6 +296,38 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             }
         }
 
+        public bool NativeCodeDebugging
+        {
+            get
+            {
+                if (!IsProfileSelected)
+                {
+                    return false;
+                }
+
+                if (SelectedDebugProfile.OtherSettings.Keys.Contains("nativeDebugging"))
+                {
+                    return (bool) SelectedDebugProfile.OtherSettings["nativeDebugging"];
+                }
+
+                return false;
+            }
+            set
+            {
+                //Unlike other properties that have default values, nativeDebugging may not be set yet. Because false is the default behavior adding it has no affect
+                if (!SelectedDebugProfile.OtherSettings.ContainsKey("nativeDebugging"))
+                {
+                    SelectedDebugProfile.OtherSettings.Add("nativeDebugging", false);
+                }
+
+                if (SelectedDebugProfile != null && (bool) SelectedDebugProfile.OtherSettings["nativeDebugging"] != value)
+                {
+                    SelectedDebugProfile.OtherSettings["nativeDebugging"] = value;
+                    OnPropertyChanged(nameof(NativeCodeDebugging));
+                }
+            }
+        }
+
         public bool SupportsExecutable
         {
             get
@@ -503,6 +535,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 OnPropertyChanged(nameof(ExecutablePath));
                 OnPropertyChanged(nameof(LaunchPage));
                 OnPropertyChanged(nameof(HasLaunchOption));
+                OnPropertyChanged(nameof(NativeCodeDebugging));
                 OnPropertyChanged(nameof(WorkingDirectory));
 
                 UpdateLaunchTypes();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
@@ -138,6 +138,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                         OnPropertyChanged(nameof(SupportsWorkingDirectory));
                         OnPropertyChanged(nameof(SupportsLaunchUrl));
                         OnPropertyChanged(nameof(SupportsEnvironmentVariables));
+                        OnPropertyChanged(nameof(SupportNativeDebugging));
                         OnPropertyChanged(nameof(ActiveProviderUserControl));
                         OnPropertyChanged(nameof(DoesNotHaveErrors));
                     }
@@ -325,6 +326,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                     SelectedDebugProfile.OtherSettings["nativeDebugging"] = value;
                     OnPropertyChanged(nameof(NativeCodeDebugging));
                 }
+            }
+        }
+
+        public bool SupportNativeDebugging
+        {
+            get
+            {
+                return ActiveProviderSupportsProperty(UIProfilePropertyName.NativeDebugging);
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
@@ -305,9 +305,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                     return false;
                 }
 
-                if (SelectedDebugProfile.OtherSettings.Keys.Contains("nativeDebugging"))
+                if (SelectedDebugProfile.OtherSettings.ContainsKey("nativeDebugging"))
                 {
-                    return (bool) SelectedDebugProfile.OtherSettings["nativeDebugging"];
+                    return (bool)SelectedDebugProfile.OtherSettings["nativeDebugging"];
                 }
 
                 return false;
@@ -315,12 +315,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             set
             {
                 //Unlike other properties that have default values, nativeDebugging may not be set yet. Because false is the default behavior adding it has no affect
-                if (!SelectedDebugProfile.OtherSettings.ContainsKey("nativeDebugging"))
+                if (!SelectedDebugProfile.OtherSettings.TryGetValue("nativeDebugging", out object previousValue))
                 {
-                    SelectedDebugProfile.OtherSettings.Add("nativeDebugging", false);
+                    previousValue = false;
                 }
 
-                if (SelectedDebugProfile != null && (bool) SelectedDebugProfile.OtherSettings["nativeDebugging"] != value)
+                if ((bool)previousValue != value)
                 {
                     SelectedDebugProfile.OtherSettings["nativeDebugging"] = value;
                     OnPropertyChanged(nameof(NativeCodeDebugging));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.Designer.cs
@@ -133,6 +133,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Enable native code debugging.
+        /// </summary>
+        public static string chkNativeCodeDebuggingText {
+            get {
+                return ResourceManager.GetString("chkNativeCodeDebuggingText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Debug.
         /// </summary>
         public static string DebugPropertyPageTitle {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageResources.resx
@@ -246,4 +246,7 @@
   <data name="OKBtnHelpText" xml:space="preserve">
     <value>Create the profile and return to the debug property page with the new profile selected</value>
   </data>
+  <data name="chkNativeCodeDebuggingText" xml:space="preserve">
+    <value>Enable native code debugging</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.cs.xlf
@@ -217,6 +217,11 @@
         <target state="new">Checking enables a textbox to specify an absolute or relative URl</target>
         <note />
       </trans-unit>
+      <trans-unit id="chkNativeCodeDebuggingText">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.de.xlf
@@ -217,6 +217,11 @@
         <target state="new">Checking enables a textbox to specify an absolute or relative URl</target>
         <note />
       </trans-unit>
+      <trans-unit id="chkNativeCodeDebuggingText">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.es.xlf
@@ -217,6 +217,11 @@
         <target state="new">Checking enables a textbox to specify an absolute or relative URl</target>
         <note />
       </trans-unit>
+      <trans-unit id="chkNativeCodeDebuggingText">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.fr.xlf
@@ -217,6 +217,11 @@
         <target state="new">Checking enables a textbox to specify an absolute or relative URl</target>
         <note />
       </trans-unit>
+      <trans-unit id="chkNativeCodeDebuggingText">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.it.xlf
@@ -217,6 +217,11 @@
         <target state="new">Checking enables a textbox to specify an absolute or relative URl</target>
         <note />
       </trans-unit>
+      <trans-unit id="chkNativeCodeDebuggingText">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ja.xlf
@@ -217,6 +217,11 @@
         <target state="new">Checking enables a textbox to specify an absolute or relative URl</target>
         <note />
       </trans-unit>
+      <trans-unit id="chkNativeCodeDebuggingText">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ko.xlf
@@ -217,6 +217,11 @@
         <target state="new">Checking enables a textbox to specify an absolute or relative URl</target>
         <note />
       </trans-unit>
+      <trans-unit id="chkNativeCodeDebuggingText">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.pl.xlf
@@ -217,6 +217,11 @@
         <target state="new">Checking enables a textbox to specify an absolute or relative URl</target>
         <note />
       </trans-unit>
+      <trans-unit id="chkNativeCodeDebuggingText">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.pt-BR.xlf
@@ -217,6 +217,11 @@
         <target state="new">Checking enables a textbox to specify an absolute or relative URl</target>
         <note />
       </trans-unit>
+      <trans-unit id="chkNativeCodeDebuggingText">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.ru.xlf
@@ -217,6 +217,11 @@
         <target state="new">Checking enables a textbox to specify an absolute or relative URl</target>
         <note />
       </trans-unit>
+      <trans-unit id="chkNativeCodeDebuggingText">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.tr.xlf
@@ -217,6 +217,11 @@
         <target state="new">Checking enables a textbox to specify an absolute or relative URl</target>
         <note />
       </trans-unit>
+      <trans-unit id="chkNativeCodeDebuggingText">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.zh-Hans.xlf
@@ -217,6 +217,11 @@
         <target state="new">Checking enables a textbox to specify an absolute or relative URl</target>
         <note />
       </trans-unit>
+      <trans-unit id="chkNativeCodeDebuggingText">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/xlf/PropertyPageResources.zh-Hant.xlf
@@ -217,6 +217,11 @@
         <target state="new">Checking enables a textbox to specify an absolute or relative URl</target>
         <note />
       </trans-unit>
+      <trans-unit id="chkNativeCodeDebuggingText">
+        <source>Enable native code debugging</source>
+        <target state="new">Enable native code debugging</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
@@ -7,3 +7,4 @@ static Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages.PropertyPageResourc
 static Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages.PropertyPageResources.NewBtnHelpText.get -> string
 static Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages.PropertyPageResources.OKBtnHelpText.get -> string
 static Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages.PropertyPageResources.chkLaunchBrowserHelpText.get -> string
+static Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages.PropertyPageResources.chkNativeCodeDebuggingText.get -> string

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsUIProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsUIProvider.cs
@@ -11,6 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         public const string LaunchUrl = "LaunchUrl";
         public const string EnvironmentVariables = "EnvironmentVariables";
         public const string WorkingDirectory = "WorkingDirectory";
+        public const string NativeDebugging = "NativeDebugging";
     }
 
     /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+const Microsoft.VisualStudio.ProjectSystem.Debug.UIProfilePropertyName.NativeDebugging = "NativeDebugging" -> string


### PR DESCRIPTION
Fix for https://github.com/dotnet/project-system/issues/1125
Assuming I am reading the issue correctly, this only changes "nativeDebugging" in launchSettings.json for the currently selected profile 

Adds the check box to the bottom:
<img width="551" alt="new_debug" src="https://user-images.githubusercontent.com/36282608/53600818-5d043700-3b5f-11e9-8a36-5eb9938048ff.PNG">
Like non-Core projects:
<img width="460" alt="old_debug" src="https://user-images.githubusercontent.com/36282608/53600673-f5e68280-3b5e-11e9-8db0-47c3381f605e.PNG">