### PR TITLE
Always return a new CodeDomProvider

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/CSharp/CSharpCodeDomProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/CSharp/CSharpCodeDomProviderTests.cs
@@ -11,21 +11,5 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices.CSharp
         {
             new CSharpCodeDomProvider();
         }
-
-        [Fact]
-        public void UnconfiguredProject_CanGetSet()
-        {
-            var project = UnconfiguredProjectFactory.Create();
-            var provider = CreateInstance();
-
-            provider.Project = project;
-
-            Assert.Same(project, provider.Project);
-        }
-
-        private static CSharpCodeDomProvider CreateInstance()
-        {
-            return new CSharpCodeDomProvider();
-        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/VisualBasic/VisualBasicCodeDomProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/VisualBasic/VisualBasicCodeDomProviderTests.cs
@@ -11,21 +11,5 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices.VisualBasic
         {
             new VisualBasicCodeDomProvider();
         }
-
-        [Fact]
-        public void UnconfiguredProject_CanGetSet()
-        {
-            var unconfiguredProject = UnconfiguredProjectFactory.Create();
-            var provider = CreateInstance();
-
-            provider.Project = unconfiguredProject;
-
-            Assert.Same(unconfiguredProject, provider.Project);
-        }
-
-        private static VisualBasicCodeDomProvider CreateInstance()
-        {
-            return new VisualBasicCodeDomProvider();
-        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/CSharp/CSharpCodeDomProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/CSharp/CSharpCodeDomProvider.cs
@@ -4,26 +4,25 @@ using System.CodeDom.Compiler;
 using System.ComponentModel.Composition;
 
 using Microsoft.CSharp;
+using Microsoft.VisualStudio.Designer.Interfaces;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices.CSharp
 {
     /// <summary>
     ///     Provides the C# <see cref="CodeDomProvider"/> for use by designers and code generators.
     /// </summary>
+    /// <remarks>
+    ///     This service is requested by <see cref="IVSMDCodeDomCreator.CreateCodeDomProvider(object, int)"/> and 
+    ///     returned by <see cref="IVSMDCodeDomProvider.CodeDomProvider"/>.
+    /// </remarks>
     [ExportVsProfferedProjectService(typeof(CodeDomProvider))]
     [AppliesTo(ProjectCapability.CSharp)]
+    [PartCreationPolicy(CreationPolicy.NonShared)]
     internal class CSharpCodeDomProvider : CSharpCodeProvider
     {
         [ImportingConstructor]
         public CSharpCodeDomProvider()
         {
-        }
-
-        [Import]
-        public UnconfiguredProject Project   // Put ourselves in the UnconfiguredProject scope
-        {
-            get;
-            set;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VisualBasic/VisualBasicCodeDomProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VisualBasic/VisualBasicCodeDomProvider.cs
@@ -4,26 +4,25 @@ using System.CodeDom.Compiler;
 using System.ComponentModel.Composition;
 
 using Microsoft.VisualBasic;
+using Microsoft.VisualStudio.Designer.Interfaces;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices.VisualBasic
 {
     /// <summary>
     ///     Provides the Visual Basic <see cref="CodeDomProvider"/> for use by designers and code generators.
     /// </summary>
+    /// <remarks>
+    ///     This service is requested by <see cref="IVSMDCodeDomCreator.CreateCodeDomProvider(object, int)"/> and 
+    ///     returned by <see cref="IVSMDCodeDomProvider.CodeDomProvider"/>.
+    /// </remarks>
     [ExportVsProfferedProjectService(typeof(CodeDomProvider))]
     [AppliesTo(ProjectCapability.VisualBasic)]
+    [PartCreationPolicy(CreationPolicy.NonShared)]
     internal class VisualBasicCodeDomProvider : VBCodeProvider
     {
         [ImportingConstructor]
         public VisualBasicCodeDomProvider()
         {
-        }
-
-        [Import]
-        public UnconfiguredProject Project // Put ourselves in the UnconfiguredProject scope
-        {
-            get;
-            set;
         }
     }
 }


### PR DESCRIPTION
This mimics legacy behavior. Consumers of IVSMDCodeDomCreator.CreateCodeDomProvider always get a new version of the CodeDomProvider, in CPS we were sharing this per project.

CodeDomProviders indirectly have mutable state via the underlying generators that keeps track of statement depth and options.

There is no current bug that this fixes, but as we start addressing UI delays, async editors we might start using these provides off UI thread, and want to avoid having designers overlap their usage, which would only be a problem in CPS.