### PR TITLE
Prevent ANE when removing item with empty OriginalItemSpec

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
@@ -81,7 +81,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 foreach (string removedItem in projectChange.Difference.RemovedItems)
                 {
                     string dependencyId = resolved
-                        ? projectChange.Before.GetProjectItemProperties(removedItem).GetStringProperty(ResolvedAssemblyReference.OriginalItemSpecProperty)
+                        ? projectChange.Before.GetProjectItemProperties(removedItem).GetStringProperty(ResolvedAssemblyReference.OriginalItemSpecProperty) ?? removedItem
                         : removedItem;
 
                     if (shouldProcess(dependencyId))


### PR DESCRIPTION
This could be triggered by changing the TFM from netcoreapp2.2 to net4.5. In that case:

- A DTB fires off a change
- `removedItem` is "Microsoft.NETCore.App"
- The removed rule is "ResolvedSdkReference"
- The "OriginalItemSpec" item property is an empty string
- `GetStringProperty` therefore returns `null` which is assigned to `dependencyId`
- `shouldProceed` is a delegate referencing `IReadOnlyDictionary<,>.ContainsKey`, and throws ANE for the null key

Although this exception would be thrown back into the Dataflow block, changing the TFM causes new Dataflow subscriptions to be created, so the UI stabilises eventually, with or without this exception.

Using `removedItem` in place of the OriginalItemSpec allows the removal to continue correctly.