### PR TITLE
Only Apply Two Space Indent on Rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,9 +17,6 @@ charset = utf-8-bom
 [*.xaml]
 indent_size = 4
 
-[src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/*.xaml]
-indent_size = 2
-
 [*.ps1]
 indent_size = 2
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,9 @@ insert_final_newline = true
 charset = utf-8-bom
 
 [*.xaml]
+indent_size = 4
+
+[src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/*.xaml]
 indent_size = 2
 
 [*.ps1]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/.editorconfig
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/.editorconfig
@@ -1,0 +1,2 @@
+[*.xaml]
+indent_size = 2


### PR DESCRIPTION
Two space indent makes sense for the rules, but I think four spaces is easier to work with - especially for WPF. 