### PR TITLE
Update Package Version to get the correct property

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.vb
@@ -238,7 +238,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     datalist.Add(data)
                     data = New PropertyControlData(101, "PackageId", PackageId, ControlDataFlags.None, New Control() {PackageIdLabel})
                     datalist.Add(data)
-                    data = New PropertyControlData(102, "Version", PackageVersion, ControlDataFlags.None, New Control() {PackageVersionLabel})
+                    data = New PropertyControlData(102, "PackageVersion", PackageVersion, ControlDataFlags.None, New Control() {PackageVersionLabel})
                     datalist.Add(data)
                     data = New PropertyControlData(103, "Authors", Authors, ControlDataFlags.None, New Control() {AuthorsLabel})
                     datalist.Add(data)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -371,7 +371,7 @@
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="Version"
+  <StringProperty Name="PackageVersion"
                   Visible="False">
     <StringProperty.DataSource>
       <DataSource HasConfigurationCondition="False"


### PR DESCRIPTION
Fixes https://github.com/dotnet/project-system/issues/4466

Summary: The ``Package Version`` field on the Package property page was picking up the ``Version`` property instead of the ``Package Version`` property. 