### PR TITLE
Normalize rules against none

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/AdditionalFiles.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/AdditionalFiles.BrowseObject.xaml
@@ -127,6 +127,15 @@
     </StringProperty.DataSource>
   </StringProperty>
 
+  <EnumProperty Name="SubType"
+                Visible="false">
+    <EnumValue Name="Designer" />
+    <EnumValue Name="Component" />
+    <EnumValue Name="Control" />
+    <EnumValue Name="Form" />
+    <EnumValue Name="Code" />
+  </EnumProperty>
+
   <StringProperty Name="URL"
                   ReadOnly="true"
                   Visible="false">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/AdditionalFiles.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/AdditionalFiles.xaml
@@ -37,10 +37,26 @@
   <StringProperty Name="CustomToolNamespace" />
 
   <StringProperty Name="DependentUpon"
-                  Visible="false" />
+                  Visible="false">
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
+    </StringProperty.Metadata>
+  </StringProperty>
 
   <BoolProperty Name="DesignTime"
                 Visible="false" />
+
+  <StringProperty Name="FullPath"
+                  ReadOnly="true"
+                  Visible="false">
+    <StringProperty.DataSource>
+      <DataSource ItemType="AdditionalFiles"
+                  PersistedName="FullPath"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 
   <StringProperty Name="Generator" />
 
@@ -53,7 +69,14 @@
       <DataSource PersistenceStyle="Attribute"
                   SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
+    </StringProperty.Metadata>
   </StringProperty>
+
+  <StringProperty Name="SubType"
+                  Visible="false" />
 
   <BoolProperty Name="Visible"
                 Visible="false" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/ApplicationDefinition.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/ApplicationDefinition.BrowseObject.xaml
@@ -127,6 +127,15 @@
     </StringProperty.DataSource>
   </StringProperty>
 
+  <EnumProperty Name="SubType"
+                Visible="false">
+    <EnumValue Name="Designer" />
+    <EnumValue Name="Component" />
+    <EnumValue Name="Control" />
+    <EnumValue Name="Form" />
+    <EnumValue Name="Code" />
+  </EnumProperty>
+
   <StringProperty Name="URL"
                   ReadOnly="true"
                   Visible="false">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/ApplicationDefinition.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/ApplicationDefinition.xaml
@@ -37,10 +37,26 @@
   <StringProperty Name="CustomToolNamespace" />
 
   <StringProperty Name="DependentUpon"
-                  Visible="false" />
+                  Visible="false">
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
+    </StringProperty.Metadata>
+  </StringProperty>
 
   <BoolProperty Name="DesignTime"
                 Visible="false" />
+
+  <StringProperty Name="FullPath"
+                  ReadOnly="true"
+                  Visible="false">
+    <StringProperty.DataSource>
+      <DataSource ItemType="ApplicationDefinition"
+                  PersistedName="FullPath"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 
   <StringProperty Name="Generator" />
 
@@ -53,7 +69,14 @@
       <DataSource PersistenceStyle="Attribute"
                   SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
+    </StringProperty.Metadata>
   </StringProperty>
+
+  <StringProperty Name="SubType"
+                  Visible="false" />
 
   <BoolProperty Name="Visible"
                 Visible="false" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.BrowseObject.xaml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!--Copyright, Microsoft Corporation, All rights reserved.-->
+<!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
 <Rule Name="Compile"
       Description="File Properties"
       DisplayName="File Properties"
@@ -27,6 +27,9 @@
                        DisplayName="Build Action"
                        EnumProvider="ItemTypes" />
 
+  <BoolProperty Name="AutoGen"
+                Visible="false" />
+
   <EnumProperty Name="CopyToOutputDirectory"
                 Category="Advanced"
                 Description="Specifies the source file will be copied to the output directory."
@@ -39,10 +42,27 @@
                DisplayName="Copy if newer" />
   </EnumProperty>
 
+  <StringProperty Name="CustomTool"
+                  Visible="false">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="Compile"
+                  PersistedName="Generator"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
   <StringProperty Name="CustomToolNamespace"
                   Category="Advanced"
                   Description="The namespace into which the output of the custom tool is placed."
                   DisplayName="Custom Tool Namespace" />
+
+  <StringProperty Name="DependentUpon"
+                  Visible="false" />
+
+  <BoolProperty Name="DesignTime"
+                Visible="false" />
 
   <StringProperty Name="Extension"
                   ReadOnly="true"
@@ -97,6 +117,17 @@
     </StringProperty.DataSource>
   </StringProperty>
 
+  <StringProperty Name="LastGenOutput"
+                  Visible="false" />
+
+  <StringProperty Name="Link"
+                  Visible="false">
+    <StringProperty.DataSource>
+      <DataSource PersistenceStyle="Attribute"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
   <EnumProperty Name="SubType"
                 Visible="false">
     <EnumValue Name="Designer" />
@@ -116,5 +147,8 @@
                   SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
+
+  <BoolProperty Name="Visible"
+                Visible="false" />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.xaml
@@ -24,6 +24,17 @@
     <EnumValue Name="PreserveNewest" />
   </EnumProperty>
 
+  <StringProperty Name="CustomTool"
+                  Visible="false">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="Compile"
+                  PersistedName="Generator"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
   <StringProperty Name="CustomToolNamespace" />
 
   <StringProperty Name="DependentUpon"
@@ -36,16 +47,6 @@
 
   <BoolProperty Name="DesignTime"
                 Visible="false" />
-
-  <BoolProperty Name="ExcludedFromBuild">
-    <BoolProperty.DataSource>
-      <DataSource HasConfigurationCondition="true"
-                  ItemType="Compile"
-                  Label="Configuration"
-                  Persistence="ProjectFile"
-                  SourceOfDefaultValue="AfterContext" />
-    </BoolProperty.DataSource>
-  </BoolProperty>
 
   <StringProperty Name="FullPath"
                   ReadOnly="true"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.BrowseObject.xaml
@@ -26,6 +26,9 @@
                        DisplayName="Build Action"
                        EnumProvider="ItemTypes" />
 
+  <BoolProperty Name="AutoGen"
+                Visible="false" />
+
   <EnumProperty Name="CopyToOutputDirectory"
                 Category="Advanced"
                 Description="Specifies the source file will be copied to the output directory."
@@ -38,12 +41,37 @@
                DisplayName="Copy if newer" />
   </EnumProperty>
 
-  <StringProperty Name="DependentUpon"
+  <StringProperty Name="CustomTool"
                   Visible="false">
-    <StringProperty.Metadata>
-      <NameValuePair Name="DoNotCopyAcrossProjects"
-                     Value="true" />
-    </StringProperty.Metadata>
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="Content"
+                  PersistedName="Generator"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="CustomToolNamespace"
+                  Category="Advanced"
+                  Description="The namespace into which the output of the custom tool is placed."
+                  DisplayName="Custom Tool Namespace" />
+
+  <StringProperty Name="DependentUpon"
+                  Visible="false" />
+
+  <BoolProperty Name="DesignTime"
+                Visible="false" />
+
+  <StringProperty Name="Extension"
+                  ReadOnly="true"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource ItemType="Content"
+                  PersistedName="Extension"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
   </StringProperty>
 
   <StringProperty Name="FileNameAndExtension"
@@ -72,6 +100,11 @@
     </StringProperty.DataSource>
   </StringProperty>
 
+  <StringProperty Name="Generator"
+                  Category="Advanced"
+                  Description="Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool."
+                  DisplayName="Custom Tool" />
+
   <StringProperty Name="Identity"
                   ReadOnly="true"
                   Visible="false">
@@ -83,16 +116,35 @@
     </StringProperty.DataSource>
   </StringProperty>
 
+  <StringProperty Name="LastGenOutput"
+                  Visible="false" />
+
   <StringProperty Name="Link"
                   Visible="false">
     <StringProperty.DataSource>
       <DataSource PersistenceStyle="Attribute"
                   SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
-    <StringProperty.Metadata>
-      <NameValuePair Name="DoNotCopyAcrossProjects"
-                     Value="true" />
-    </StringProperty.Metadata>
+  </StringProperty>
+
+  <EnumProperty Name="SubType"
+                Visible="false">
+    <EnumValue Name="Designer" />
+    <EnumValue Name="Component" />
+    <EnumValue Name="Control" />
+    <EnumValue Name="Form" />
+    <EnumValue Name="Code" />
+  </EnumProperty>
+
+  <StringProperty Name="URL"
+                  ReadOnly="true"
+                  Visible="false">
+    <StringProperty.DataSource>
+      <DataSource ItemType="Content"
+                  PersistedName="FullPath"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
   </StringProperty>
 
   <BoolProperty Name="Visible"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.xaml
@@ -14,11 +14,27 @@
   <DynamicEnumProperty Name="{}{ItemType}"
                        EnumProvider="ItemTypes" />
 
+  <BoolProperty Name="AutoGen"
+                Visible="false" />
+
   <EnumProperty Name="CopyToOutputDirectory">
     <EnumValue Name="Never" />
     <EnumValue Name="Always" />
     <EnumValue Name="PreserveNewest" />
   </EnumProperty>
+
+  <StringProperty Name="CustomTool"
+                  Visible="false">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="Content"
+                  PersistedName="Generator"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="CustomToolNamespace" />
 
   <StringProperty Name="DependentUpon"
                   Visible="false">
@@ -28,18 +44,12 @@
     </StringProperty.Metadata>
   </StringProperty>
 
-  <StringProperty Name="FileNameAndExtension"
-                  ReadOnly="true">
-    <StringProperty.DataSource>
-      <DataSource ItemType="Content"
-                  PersistedName="FileNameAndExtension"
-                  Persistence="Intrinsic"
-                  SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+  <BoolProperty Name="DesignTime"
+                Visible="false" />
 
   <StringProperty Name="FullPath"
-                  ReadOnly="true">
+                  ReadOnly="true"
+                  Visible="false">
     <StringProperty.DataSource>
       <DataSource ItemType="Content"
                   PersistedName="FullPath"
@@ -48,16 +58,10 @@
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="Identity"
-                  ReadOnly="true"
-                  Visible="false">
-    <StringProperty.DataSource>
-      <DataSource ItemType="Content"
-                  PersistedName="Identity"
-                  Persistence="Intrinsic"
-                  SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+  <StringProperty Name="Generator" />
+
+  <StringProperty Name="LastGenOutput"
+                  Visible="false" />
 
   <StringProperty Name="Link"
                   Visible="false">
@@ -70,6 +74,9 @@
                      Value="true" />
     </StringProperty.Metadata>
   </StringProperty>
+
+  <StringProperty Name="SubType"
+                  Visible="false" />
 
   <BoolProperty Name="Visible"
                 Visible="false" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.BrowseObject.xaml
@@ -127,6 +127,15 @@
     </StringProperty.DataSource>
   </StringProperty>
 
+  <EnumProperty Name="SubType"
+                Visible="false">
+    <EnumValue Name="Designer" />
+    <EnumValue Name="Component" />
+    <EnumValue Name="Control" />
+    <EnumValue Name="Form" />
+    <EnumValue Name="Code" />
+  </EnumProperty>
+
   <StringProperty Name="URL"
                   ReadOnly="true"
                   Visible="false">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.xaml
@@ -37,17 +37,22 @@
   <StringProperty Name="CustomToolNamespace" />
 
   <StringProperty Name="DependentUpon"
-                  Visible="false" />
+                  Visible="false">
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
+    </StringProperty.Metadata>
+  </StringProperty>
 
   <BoolProperty Name="DesignTime"
                 Visible="false" />
 
-  <StringProperty Name="Extension"
+  <StringProperty Name="FullPath"
                   ReadOnly="true"
-                  Visible="False">
+                  Visible="false">
     <StringProperty.DataSource>
       <DataSource ItemType="EmbeddedResource"
-                  PersistedName="Extension"
+                  PersistedName="FullPath"
                   Persistence="Intrinsic"
                   SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
@@ -64,7 +69,14 @@
       <DataSource PersistenceStyle="Attribute"
                   SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
+    </StringProperty.Metadata>
   </StringProperty>
+
+  <StringProperty Name="SubType"
+                  Visible="false" />
 
   <BoolProperty Name="Visible"
                 Visible="false" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.BrowseObject.xaml
@@ -127,6 +127,15 @@
     </StringProperty.DataSource>
   </StringProperty>
 
+  <EnumProperty Name="SubType"
+                Visible="false">
+    <EnumValue Name="Designer" />
+    <EnumValue Name="Component" />
+    <EnumValue Name="Control" />
+    <EnumValue Name="Form" />
+    <EnumValue Name="Code" />
+  </EnumProperty>
+
   <StringProperty Name="URL"
                   ReadOnly="true"
                   Visible="false">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.xaml
@@ -75,6 +75,9 @@
     </StringProperty.Metadata>
   </StringProperty>
 
+  <StringProperty Name="SubType"
+                  Visible="false" />
+
   <BoolProperty Name="Visible"
                 Visible="false" />
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Page.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Page.BrowseObject.xaml
@@ -127,6 +127,15 @@
     </StringProperty.DataSource>
   </StringProperty>
 
+  <EnumProperty Name="SubType"
+                Visible="false">
+    <EnumValue Name="Designer" />
+    <EnumValue Name="Component" />
+    <EnumValue Name="Control" />
+    <EnumValue Name="Form" />
+    <EnumValue Name="Code" />
+  </EnumProperty>
+
   <StringProperty Name="URL"
                   ReadOnly="true"
                   Visible="false">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Page.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Page.xaml
@@ -37,10 +37,26 @@
   <StringProperty Name="CustomToolNamespace" />
 
   <StringProperty Name="DependentUpon"
-                  Visible="false" />
+                  Visible="false">
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
+    </StringProperty.Metadata>
+  </StringProperty>
 
   <BoolProperty Name="DesignTime"
                 Visible="false" />
+
+  <StringProperty Name="FullPath"
+                  ReadOnly="true"
+                  Visible="false">
+    <StringProperty.DataSource>
+      <DataSource ItemType="Page"
+                  PersistedName="FullPath"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 
   <StringProperty Name="Generator" />
 
@@ -53,7 +69,14 @@
       <DataSource PersistenceStyle="Attribute"
                   SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
+    </StringProperty.Metadata>
   </StringProperty>
+
+  <StringProperty Name="SubType"
+                  Visible="false" />
 
   <BoolProperty Name="Visible"
                 Visible="false" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Resource.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Resource.BrowseObject.xaml
@@ -127,6 +127,15 @@
     </StringProperty.DataSource>
   </StringProperty>
 
+  <EnumProperty Name="SubType"
+                Visible="false">
+    <EnumValue Name="Designer" />
+    <EnumValue Name="Component" />
+    <EnumValue Name="Control" />
+    <EnumValue Name="Form" />
+    <EnumValue Name="Code" />
+  </EnumProperty>
+
   <StringProperty Name="URL"
                   ReadOnly="true"
                   Visible="false">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Resource.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Resource.xaml
@@ -37,10 +37,26 @@
   <StringProperty Name="CustomToolNamespace" />
 
   <StringProperty Name="DependentUpon"
-                  Visible="false" />
+                  Visible="false">
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
+    </StringProperty.Metadata>
+  </StringProperty>
 
   <BoolProperty Name="DesignTime"
                 Visible="false" />
+
+  <StringProperty Name="FullPath"
+                  ReadOnly="true"
+                  Visible="false">
+    <StringProperty.DataSource>
+      <DataSource ItemType="Resource"
+                  PersistedName="FullPath"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
 
   <StringProperty Name="Generator" />
 
@@ -53,7 +69,14 @@
       <DataSource PersistenceStyle="Attribute"
                   SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
+    </StringProperty.Metadata>
   </StringProperty>
+
+  <StringProperty Name="SubType"
+                  Visible="false" />
 
   <BoolProperty Name="Visible"
                 Visible="false" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/XamlAppDef.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/XamlAppDef.BrowseObject.xaml
@@ -26,6 +26,9 @@
                        DisplayName="Build Action"
                        EnumProvider="ItemTypes" />
 
+  <BoolProperty Name="AutoGen"
+                Visible="false" />
+
   <EnumProperty Name="CopyToOutputDirectory"
                 Category="Advanced"
                 Description="Specifies the source file will be copied to the output directory."
@@ -38,6 +41,17 @@
                DisplayName="Copy if newer" />
   </EnumProperty>
 
+  <StringProperty Name="CustomTool"
+                  Visible="false">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="XamlAppDef"
+                  PersistedName="Generator"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
   <StringProperty Name="CustomToolNamespace"
                   Category="Advanced"
                   Description="The namespace into which the output of the custom tool is placed."
@@ -45,6 +59,9 @@
 
   <StringProperty Name="DependentUpon"
                   Visible="false" />
+
+  <BoolProperty Name="DesignTime"
+                Visible="false" />
 
   <StringProperty Name="Extension"
                   ReadOnly="true"
@@ -99,12 +116,25 @@
     </StringProperty.DataSource>
   </StringProperty>
 
+  <StringProperty Name="LastGenOutput"
+                  Visible="false" />
+
   <StringProperty Name="Link"
                   Visible="false">
     <StringProperty.DataSource>
-      <DataSource SourceOfDefaultValue="AfterContext" />
+      <DataSource PersistenceStyle="Attribute"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
+
+  <EnumProperty Name="SubType"
+                Visible="false">
+    <EnumValue Name="Designer" />
+    <EnumValue Name="Component" />
+    <EnumValue Name="Control" />
+    <EnumValue Name="Form" />
+    <EnumValue Name="Code" />
+  </EnumProperty>
 
   <StringProperty Name="URL"
                   ReadOnly="true"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/XamlAppDef.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/XamlAppDef.xaml
@@ -2,7 +2,7 @@
 <!--Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.-->
 <Rule Name="XamlAppDef"
       PageTemplate="generic"
-      PropertyPagesHidden="True"
+      PropertyPagesHidden="true"
       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
@@ -14,40 +14,42 @@
   <DynamicEnumProperty Name="{}{ItemType}"
                        EnumProvider="ItemTypes" />
 
+  <BoolProperty Name="AutoGen"
+                Visible="false" />
+
   <EnumProperty Name="CopyToOutputDirectory">
     <EnumValue Name="Never" />
     <EnumValue Name="Always" />
     <EnumValue Name="PreserveNewest" />
   </EnumProperty>
 
+  <StringProperty Name="CustomTool"
+                  Visible="false">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="XamlAppDef"
+                  PersistedName="Generator"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
   <StringProperty Name="CustomToolNamespace" />
 
   <StringProperty Name="DependentUpon"
-                  Visible="false" />
-
-  <StringProperty Name="Extension"
-                  ReadOnly="true"
-                  Visible="False">
-    <StringProperty.DataSource>
-      <DataSource ItemType="XamlAppDef"
-                  PersistedName="Extension"
-                  Persistence="Intrinsic"
-                  SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
+                  Visible="false">
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
+    </StringProperty.Metadata>
   </StringProperty>
 
-  <StringProperty Name="FileNameAndExtension"
-                  ReadOnly="true">
-    <StringProperty.DataSource>
-      <DataSource ItemType="XamlAppDef"
-                  PersistedName="FileNameAndExtension"
-                  Persistence="Intrinsic"
-                  SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+  <BoolProperty Name="DesignTime"
+                Visible="false" />
 
   <StringProperty Name="FullPath"
-                  ReadOnly="true">
+                  ReadOnly="true"
+                  Visible="false">
     <StringProperty.DataSource>
       <DataSource ItemType="XamlAppDef"
                   PersistedName="FullPath"
@@ -58,34 +60,23 @@
 
   <StringProperty Name="Generator" />
 
-  <StringProperty Name="Identity"
-                  ReadOnly="true"
-                  Visible="false">
-    <StringProperty.DataSource>
-      <DataSource ItemType="XamlAppDef"
-                  PersistedName="Identity"
-                  Persistence="Intrinsic"
-                  SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
+  <StringProperty Name="LastGenOutput"
+                  Visible="false" />
 
   <StringProperty Name="Link"
                   Visible="false">
     <StringProperty.DataSource>
-      <DataSource SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-
-  <StringProperty Name="URL"
-                  ReadOnly="true"
-                  Visible="false">
-    <StringProperty.DataSource>
-      <DataSource ItemType="XamlAppDef"
-                  PersistedName="FullPath"
-                  Persistence="Intrinsic"
+      <DataSource PersistenceStyle="Attribute"
                   SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
+    </StringProperty.Metadata>
   </StringProperty>
+
+  <StringProperty Name="SubType"
+                  Visible="false" />
 
   <BoolProperty Name="Visible"
                 Visible="false" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.cs.xlf
@@ -77,6 +77,26 @@
         <target state="translated">Název souboru nebo složky</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.de.xlf
@@ -77,6 +77,26 @@
         <target state="translated">Name der Datei oder des Ordners.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.es.xlf
@@ -77,6 +77,26 @@
         <target state="translated">Nombre del archivo o carpeta.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.fr.xlf
@@ -77,6 +77,26 @@
         <target state="translated">Nom du fichier ou du dossier.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.it.xlf
@@ -77,6 +77,26 @@
         <target state="translated">Nome del file o della cartella.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.ja.xlf
@@ -77,6 +77,26 @@
         <target state="translated">ファイルまたはフォルダーの名前です。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.ko.xlf
@@ -77,6 +77,26 @@
         <target state="translated">파일 또는 폴더의 이름입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.pl.xlf
@@ -77,6 +77,26 @@
         <target state="translated">Nazwa pliku lub folderu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.pt-BR.xlf
@@ -77,6 +77,26 @@
         <target state="translated">Nome do arquivo ou da pasta.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.ru.xlf
@@ -77,6 +77,26 @@
         <target state="translated">Имя файла или папки.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.tr.xlf
@@ -77,6 +77,26 @@
         <target state="translated">Dosya veya klasörün adı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.zh-Hans.xlf
@@ -77,6 +77,26 @@
         <target state="translated">文件或文件夹的名称。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.zh-Hant.xlf
@@ -77,6 +77,26 @@
         <target state="translated">檔案或資料夾的名稱。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|Description">
+        <source>The namespace into which the output of the custom tool is placed.</source>
+        <target state="new">The namespace into which the output of the custom tool is placed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CustomToolNamespace|DisplayName">
+        <source>Custom Tool Namespace</source>
+        <target state="new">Custom Tool Namespace</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|Description">
+        <source>Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</source>
+        <target state="new">Specifies the tool that transforms a file at design time and places the output of that transformation into another file. For example, a dataset (.xsd) file comes with a default custom tool.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Generator|DisplayName">
+        <source>Custom Tool</source>
+        <target state="new">Custom Tool</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Now that the rule files are sorted and neat, I was able to easily see what was missing from various files. This PR brings all file rules up to date with `None.xaml` (including SubType which was missing from `None.xaml` itself) and all browse object rules up to date with `None.BrowseObject.xaml`.

Part of #4105