### PR TITLE
Pass .editorconfig files to LS

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/BuildOptionsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/BuildOptionsFactory.cs
@@ -13,7 +13,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             return new BuildOptions(ImmutableArray<CommandLineSourceFile>.Empty,
                                     ImmutableArray<CommandLineSourceFile>.Empty,
                                     ImmutableArray<CommandLineReference>.Empty,
-                                    ImmutableArray<CommandLineAnalyzerReference>.Empty);
+                                    ImmutableArray<CommandLineAnalyzerReference>.Empty,
+                                    ImmutableArray<string>.Empty);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AnalyzerConfigItemHandlerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AnalyzerConfigItemHandlerTests.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
+{
+    public class AnalyzerConfigItemHandlerTests : CommandLineHandlerTestBase
+    {
+        internal override ICommandLineHandler CreateInstance()
+        {
+            return CreateInstance(null, null);
+        }
+
+        private AnalyzerConfigItemHandler CreateInstance(UnconfiguredProject project = null, IWorkspaceProjectContext context = null)
+        {
+            project = project ?? UnconfiguredProjectFactory.Create();
+
+            var handler = new AnalyzerConfigItemHandler(project);
+            if (context != null)
+                handler.Initialize(context);
+
+            return handler;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/BuildOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/BuildOptions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Reflection;
 
 using Microsoft.CodeAnalysis;
 
@@ -8,12 +9,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
     internal class BuildOptions
     {
-        public BuildOptions(ImmutableArray<CommandLineSourceFile> sourceFiles, ImmutableArray<CommandLineSourceFile> additionalFiles, ImmutableArray<CommandLineReference> metadataReferences, ImmutableArray<CommandLineAnalyzerReference> analyzerReferences)
+        private static readonly PropertyInfo s_analyzerConfigPathsProperty = typeof(CommandLineArguments).GetProperty("AnalyzerConfigPaths");
+
+        public BuildOptions(
+            ImmutableArray<CommandLineSourceFile> sourceFiles,
+            ImmutableArray<CommandLineSourceFile> additionalFiles,
+            ImmutableArray<CommandLineReference> metadataReferences,
+            ImmutableArray<CommandLineAnalyzerReference> analyzerReferences,
+            ImmutableArray<string> analyzerConfigFiles)
         {
             SourceFiles = sourceFiles;
             AdditionalFiles = additionalFiles;
             MetadataReferences = metadataReferences;
             AnalyzerReferences = analyzerReferences;
+            AnalyzerConfigFiles = analyzerConfigFiles;
         }
 
         public ImmutableArray<CommandLineSourceFile> SourceFiles
@@ -36,15 +45,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             get;
         }
 
+        public ImmutableArray<string> AnalyzerConfigFiles
+        {
+            get;
+        }
+
         public static BuildOptions FromCommandLineArguments(CommandLineArguments commandLineArguments)
         {
             Requires.NotNull(commandLineArguments, nameof(commandLineArguments));
+
+            var analyzerConfigPaths = s_analyzerConfigPathsProperty != null
+                ? (ImmutableArray<string>)s_analyzerConfigPathsProperty.GetValue(commandLineArguments)
+                : ImmutableArray<string>.Empty;
 
             return new BuildOptions(
                 commandLineArguments.SourceFiles,
                 commandLineArguments.AdditionalFiles,
                 commandLineArguments.MetadataReferences,
-                commandLineArguments.AnalyzerReferences);
+                commandLineArguments.AnalyzerReferences,
+                analyzerConfigPaths);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/FSharp/FSharpBuildOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/FSharp/FSharpBuildOptions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.FSharp
                                   ImmutableArray<CommandLineReference> metadataReferences,
                                   ImmutableArray<CommandLineAnalyzerReference> analyzerReferences,
                                   ImmutableArray<string> compileOptions)
-            : base(sourceFiles, additionalFiles, metadataReferences, analyzerReferences)
+            : base(sourceFiles, additionalFiles, metadataReferences, analyzerReferences, ImmutableArray<string>.Empty)
         {
             CompileOptions = compileOptions;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerConfigItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerConfigItemHandler.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Reflection;
+using Microsoft.VisualStudio.ProjectSystem.Logging;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
+{
+    /// <summary>
+    ///     Handles changes to the  &lt;EditorConfigFiles/&gt; items during design-time builds.
+    /// </summary>
+    [Export(typeof(IWorkspaceContextHandler))]
+    internal class AnalyzerConfigItemHandler : AbstractWorkspaceContextHandler, ICommandLineHandler
+    {
+        // WORKAROUND: To avoid Roslyn throwing when we add duplicate additional files, we remember what 
+        // sent to them and avoid sending on duplicates.
+        // See: https://github.com/dotnet/project-system/issues/2230
+
+        private readonly UnconfiguredProject _project;
+        private readonly HashSet<string> _paths = new HashSet<string>(StringComparers.Paths);
+
+        private bool _triedToRetrieveAddAnalyzerConfigFileMethod = false;
+        private bool _triedToRetrieveRemoveAnalyzerConfigFileMethod = false;
+        private MethodInfo _addAnalyzerConfigFileMethod;
+        private MethodInfo _removeAnalyzerConfigFileMethod;
+
+        [ImportingConstructor]
+        public AnalyzerConfigItemHandler(UnconfiguredProject project)
+        {
+            _project = project;
+        }
+
+        public void Handle(IComparable version, BuildOptions added, BuildOptions removed, bool isActiveContext, IProjectLogger logger)
+        {
+            Requires.NotNull(version, nameof(version));
+            Requires.NotNull(added, nameof(added));
+            Requires.NotNull(removed, nameof(removed));
+            Requires.NotNull(logger, nameof(logger));
+
+            VerifyInitialized();
+
+            foreach (string analyzerConfigFile in removed.AnalyzerConfigFiles)
+            {
+                string fullPath = _project.MakeRooted(analyzerConfigFile);
+
+                RemoveFromContextIfPresent(fullPath, logger);
+            }
+
+            foreach (string analyzerConfigFile in added.AnalyzerConfigFiles)
+            {
+                string fullPath = _project.MakeRooted(analyzerConfigFile);
+
+                AddToContextIfNotPresent(fullPath, logger);
+            }
+        }
+
+        private void AddToContextIfNotPresent(string fullPath, IProjectLogger logger)
+        {
+            if (!_paths.Contains(fullPath))
+            {
+                logger.WriteLine("Adding analyzer config file '{0}'", fullPath);
+                AddToContext(fullPath);
+                bool added = _paths.Add(fullPath);
+                Assumes.True(added);
+            }
+        }
+
+        private void RemoveFromContextIfPresent(string fullPath, IProjectLogger logger)
+        {
+            if (_paths.Contains(fullPath))
+            {
+                logger.WriteLine("Removing analyzer config file '{0}'", fullPath);
+                RemoveFromContext(fullPath);
+                bool removed = _paths.Remove(fullPath);
+                Assumes.True(removed);
+            }
+        }
+
+        private void AddToContext(string fullPath)
+        {
+            if (!_triedToRetrieveAddAnalyzerConfigFileMethod)
+            {
+                _addAnalyzerConfigFileMethod = Context.GetType().GetMethod("AddAnalyzerConfigFile");
+                _triedToRetrieveAddAnalyzerConfigFileMethod = true;
+            }
+
+            if (_addAnalyzerConfigFileMethod != null)
+            {
+                _addAnalyzerConfigFileMethod.Invoke(Context, new[] { fullPath });
+            }
+        }
+
+        private void RemoveFromContext(string fullPath)
+        {
+            if (!_triedToRetrieveRemoveAnalyzerConfigFileMethod)
+            {
+                _removeAnalyzerConfigFileMethod = Context.GetType().GetMethod("RemoveAnalyzerConfigFile");
+                _triedToRetrieveRemoveAnalyzerConfigFileMethod = true;
+            }
+
+            if (_removeAnalyzerConfigFileMethod != null)
+            {
+                _removeAnalyzerConfigFileMethod.Invoke(Context, new[] { fullPath });
+            }
+        }
+    }
+}


### PR DESCRIPTION
Basic support for harvesting .editorconfig files from the command line and passing it to the language service via `IWorkspaceProjectContext`.

This breaks out some of the changes in #4619.