### PR TITLE
Add check for empty Include attribute when adding License item 

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.vb
@@ -405,9 +405,11 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                         Async Function(access)
                             Await access.CheckoutAsync(_unconfiguredProject.FullPath)
                             Dim projectXML = Await access.GetProjectXmlAsync(_unconfiguredProject.FullPath)
-                            Dim foundItem = projectXML.ItemGroups.SelectMany(Function(x) x.Items).FirstOrDefault(Function(x) x.Include = oldInclude)
-                            If foundItem IsNot Nothing Then
-                                foundItem.Include = newInclude
+                            If Not String.IsNullOrEmpty(oldInclude) Then
+                                Dim foundItem = projectXML.ItemGroups.SelectMany(Function(x) x.Items).FirstOrDefault(Function(x) x.Include = oldInclude)
+                                If foundItem IsNot Nothing Then
+                                    foundItem.Include = newInclude
+                                End If
                             Else
                                 'We couldn't find one to change so we should add it 
                                 projectXML.AddItem("None", newInclude, {New KeyValuePair(Of String, String)("Pack", "True"), New KeyValuePair(Of String, String)("PackagePath", "")})


### PR DESCRIPTION
Fix for https://github.com/dotnet/project-system/issues/4633

When a user selects a License item, it will first try to find an existing item with the same Include attribute as the selected relative path. In a case where there was no existing license item chosen and an item had an empty Include and either a Remove or Update attribute there would be a System.InvalidOperationException because it would try to add the Include but items can only have one of Include, Update or Remove. 

This will ensure that we don't even try to look for the item if the previous include value is empty. We should only be modifying an item that has exactly the same Include.