### PR TITLE
Opt into operation progress

### DIFF
--- a/build/Packages.targets
+++ b/build/Packages.targets
@@ -91,7 +91,7 @@
     <PackageReference Update="Microsoft.Test.Apex.VisualStudio" Version="16.0.28117-pre" />
 
     <!-- CPS -->
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK" Version="16.0.201-pre-g7d366164d0" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK" Version="16.1.39-pre-gd9225dddee" />
     <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers" Version="16.0.201-pre-g7d366164d0" />
 
     <!-- Roslyn -->

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IDataProgressTrackerServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IDataProgressTrackerServiceFactory.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class IDataProgressTrackerServiceFactory
+    {
+        public static IDataProgressTrackerService Create()
+        {
+            var mock = new Mock<IDataProgressTrackerService>();
+            mock.Setup(s => s.RegisterOutputDataSource(It.IsAny<IProgressTrackerOutputDataSource>()))
+                .Returns(IDataProgressTrackerServiceRegistrationFactory.Create());
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IDataProgressTrackerServiceRegistration.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IDataProgressTrackerServiceRegistration.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class IDataProgressTrackerServiceRegistrationFactory
+    {
+        public static IDataProgressTrackerServiceRegistration Create()
+        {
+            var mock = new Mock<IDataProgressTrackerServiceRegistration>();
+            mock.Setup(s => s.NotifyOutputDataCalculated(It.IsAny<IImmutableDictionary<NamedIdentity, IComparable>>()));
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextHostInstanceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextHostInstanceTests.cs
@@ -255,12 +255,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             applyChangesToWorkspaceContext = applyChangesToWorkspaceContext ?? IApplyChangesToWorkspaceContextFactory.Create();
 
             return new WorkspaceProjectContextHostInstance(project,
-                                                    threadingService,
-                                                    tasksService,
-                                                    projectSubscriptionService,
-                                                    workspaceProjectContextProvider,
-                                                    activeWorkspaceProjectContextTracker,
-                                                    ExportFactoryFactory.ImplementCreateValueWithAutoDispose(() => applyChangesToWorkspaceContext));
+                                                           threadingService,
+                                                           tasksService,
+                                                           projectSubscriptionService,
+                                                           workspaceProjectContextProvider,
+                                                           activeWorkspaceProjectContextTracker,
+                                                           ExportFactoryFactory.ImplementCreateValueWithAutoDispose(() => applyChangesToWorkspaceContext));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextHostInstanceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextHostInstanceTests.cs
@@ -253,6 +253,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             activeWorkspaceProjectContextTracker = activeWorkspaceProjectContextTracker ?? IActiveEditorContextTrackerFactory.Create();
             workspaceProjectContextProvider = workspaceProjectContextProvider ?? IWorkspaceProjectContextProviderFactory.ImplementCreateProjectContextAsync(IWorkspaceProjectContextAccessorFactory.Create());
             applyChangesToWorkspaceContext = applyChangesToWorkspaceContext ?? IApplyChangesToWorkspaceContextFactory.Create();
+            IDataProgressTrackerService dataProgressTrackerService = IDataProgressTrackerServiceFactory.Create();
 
             return new WorkspaceProjectContextHostInstance(project,
                                                            threadingService,
@@ -260,7 +261,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                                                            projectSubscriptionService,
                                                            workspaceProjectContextProvider,
                                                            activeWorkspaceProjectContextTracker,
-                                                           ExportFactoryFactory.ImplementCreateValueWithAutoDispose(() => applyChangesToWorkspaceContext));
+                                                           ExportFactoryFactory.ImplementCreateValueWithAutoDispose(() => applyChangesToWorkspaceContext),
+                                                           dataProgressTrackerService);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextHostTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextHostTests.cs
@@ -131,14 +131,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             activeWorkspaceProjectContextTracker = activeWorkspaceProjectContextTracker ?? IActiveEditorContextTrackerFactory.Create();
             workspaceProjectContextProvider = workspaceProjectContextProvider ?? IWorkspaceProjectContextProviderFactory.ImplementCreateProjectContextAsync(IWorkspaceProjectContextAccessorFactory.Create());
             applyChangesToWorkspaceContext = applyChangesToWorkspaceContext ?? IApplyChangesToWorkspaceContextFactory.Create();
+            IDataProgressTrackerService dataProgressTrackerService = IDataProgressTrackerServiceFactory.Create();
 
             return new WorkspaceProjectContextHost(project,
-                                            threadingService,
-                                            tasksService,
-                                            projectSubscriptionService,
-                                            workspaceProjectContextProvider,
-                                            activeWorkspaceProjectContextTracker,
-                                            ExportFactoryFactory.ImplementCreateValueWithAutoDispose(() => applyChangesToWorkspaceContext));
+                                                   threadingService,
+                                                   tasksService,
+                                                   projectSubscriptionService,
+                                                   workspaceProjectContextProvider,
+                                                   activeWorkspaceProjectContextTracker,
+                                                   ExportFactoryFactory.ImplementCreateValueWithAutoDispose(() => applyChangesToWorkspaceContext),
+                                                   dataProgressTrackerService);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DependenciesViewModelFactoryTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DependenciesViewModelFactoryTests.cs
@@ -125,6 +125,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             public string AppliesTo => ProjectCapabilities.AlwaysApplicable;
 
             public int OrderPrecedence => -500;
+
+            public bool SuppressLowerPriority { get; }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
@@ -30,12 +30,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             private ExportLifetimeContext<IApplyChangesToWorkspaceContext> _applyChangesToWorkspaceContext;
 
             public WorkspaceProjectContextHostInstance(ConfiguredProject project,
-                                                IProjectThreadingService threadingService,
-                                                IUnconfiguredProjectTasksService tasksService,
-                                                IProjectSubscriptionService projectSubscriptionService,
-                                                IWorkspaceProjectContextProvider workspaceProjectContextProvider,
-                                                IActiveEditorContextTracker activeWorkspaceProjectContextTracker,
-                                                ExportFactory<IApplyChangesToWorkspaceContext> applyChangesToWorkspaceContextFactory)
+                                                       IProjectThreadingService threadingService,
+                                                       IUnconfiguredProjectTasksService tasksService,
+                                                       IProjectSubscriptionService projectSubscriptionService,
+                                                       IWorkspaceProjectContextProvider workspaceProjectContextProvider,
+                                                       IActiveEditorContextTracker activeWorkspaceProjectContextTracker,
+                                                       ExportFactory<IApplyChangesToWorkspaceContext> applyChangesToWorkspaceContextFactory)
                 : base(threadingService.JoinableTaskContext)
             {
                 _project = project;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.OperationProgress;
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
@@ -24,8 +26,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             private readonly IWorkspaceProjectContextProvider _workspaceProjectContextProvider;
             private readonly IActiveEditorContextTracker _activeWorkspaceProjectContextTracker;
             private readonly ExportFactory<IApplyChangesToWorkspaceContext> _applyChangesToWorkspaceContextFactory;
+            private readonly IDataProgressTrackerService _dataProgressTrackerService;
 
-            private DisposableBag _subscriptions;
+            private IDataProgressTrackerServiceRegistration _evaluationProgressRegistration;
+            private IDataProgressTrackerServiceRegistration _projectBuildProgressRegistration;
+            private DisposableBag _disposables;
             private IWorkspaceProjectContextAccessor _contextAccessor;
             private ExportLifetimeContext<IApplyChangesToWorkspaceContext> _applyChangesToWorkspaceContext;
 
@@ -35,15 +40,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                                                        IProjectSubscriptionService projectSubscriptionService,
                                                        IWorkspaceProjectContextProvider workspaceProjectContextProvider,
                                                        IActiveEditorContextTracker activeWorkspaceProjectContextTracker,
-                                                       ExportFactory<IApplyChangesToWorkspaceContext> applyChangesToWorkspaceContextFactory)
+                                                       ExportFactory<IApplyChangesToWorkspaceContext> applyChangesToWorkspaceContextFactory,
+                                                       IDataProgressTrackerService dataProgressTrackerService)
                 : base(threadingService.JoinableTaskContext)
             {
                 _project = project;
                 _projectSubscriptionService = projectSubscriptionService;
                 _tasksService = tasksService;
                 _workspaceProjectContextProvider = workspaceProjectContextProvider;
-                _applyChangesToWorkspaceContextFactory = applyChangesToWorkspaceContextFactory;
                 _activeWorkspaceProjectContextTracker = activeWorkspaceProjectContextTracker;
+                _applyChangesToWorkspaceContextFactory = applyChangesToWorkspaceContextFactory;
+                _dataProgressTrackerService = dataProgressTrackerService;
             }
 
             public Task InitializeAsync()
@@ -60,25 +67,36 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
                 _activeWorkspaceProjectContextTracker.RegisterContext(_contextAccessor.ContextId);
 
+                _disposables = new DisposableBag(CancellationToken.None);
+
                 _applyChangesToWorkspaceContext = _applyChangesToWorkspaceContextFactory.CreateExport();
                 _applyChangesToWorkspaceContext.Value.Initialize(_contextAccessor.Context);
+                _disposables.AddDisposable(_applyChangesToWorkspaceContext);
 
-                _subscriptions = new DisposableBag(CancellationToken.None);
-                _subscriptions.AddDisposable(_projectSubscriptionService.ProjectRuleSource.SourceBlock.LinkToAsyncAction(
+                // We avoid suppressing version updates, so that progress tracker doesn't
+                // think we're still "in progress" in the case of an empty change
+                _disposables.AddDisposable(_projectSubscriptionService.ProjectRuleSource.SourceBlock.LinkToAsyncAction(
                         target: e => OnProjectChangedAsync(e, evaluation: true),
+                        suppressVersionOnlyUpdates: false,
                         ruleNames: _applyChangesToWorkspaceContext.Value.GetProjectEvaluationRules()));
 
-                _subscriptions.AddDisposable(_projectSubscriptionService.ProjectBuildRuleSource.SourceBlock.LinkToAsyncAction(
+                _disposables.AddDisposable(_projectSubscriptionService.ProjectBuildRuleSource.SourceBlock.LinkToAsyncAction(
                         target: e => OnProjectChangedAsync(e, evaluation: false),
+                        suppressVersionOnlyUpdates: false,
                         ruleNames: _applyChangesToWorkspaceContext.Value.GetProjectBuildRules()));
+
+                _evaluationProgressRegistration = _dataProgressTrackerService.RegisterForIntelliSense(_project, nameof(WorkspaceProjectContextHostInstance) + ".Evaluation");
+                _disposables.AddDisposable(_evaluationProgressRegistration);
+
+                _projectBuildProgressRegistration = _dataProgressTrackerService.RegisterForIntelliSense(_project, nameof(WorkspaceProjectContextHostInstance) + ".ProjectBuild");
+                _disposables.AddDisposable(_projectBuildProgressRegistration);
             }
 
             protected override async Task DisposeCoreUnderLockAsync(bool initialized)
             {
                 if (initialized)
                 {
-                    _subscriptions?.Dispose();
-                    _applyChangesToWorkspaceContext?.Dispose();
+                    _disposables?.Dispose();
 
                     if (_contextAccessor != null)
                     {
@@ -147,6 +165,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                 finally
                 {
                     context.EndBatch();
+                }
+
+                NotifyOutputDataCalculated(update.DataSourceVersions, evaluation);
+            }
+
+            private void NotifyOutputDataCalculated(IImmutableDictionary<NamedIdentity, IComparable> dataSourceVersions, bool evaluation)
+            {
+                // Notify operation progress that we've now processed these versions of our input, if they are
+                // up-to-date with the latest version that produced, then we no longer considered "in progress".
+                if (evaluation)
+                {
+                    _evaluationProgressRegistration.NotifyOutputDataCalculated(dataSourceVersions);
+                }
+                else
+                {
+                    _projectBuildProgressRegistration.NotifyOutputDataCalculated(dataSourceVersions);
                 }
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.cs
@@ -25,6 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         private readonly IWorkspaceProjectContextProvider _workspaceProjectContextProvider;
         private readonly IActiveEditorContextTracker _activeWorkspaceProjectContextTracker;
         private readonly ExportFactory<IApplyChangesToWorkspaceContext> _applyChangesToWorkspaceContextFactory;
+        private readonly IDataProgressTrackerService _dataProgressTrackerService;
 
         [ImportingConstructor]
         public WorkspaceProjectContextHost(ConfiguredProject project,
@@ -33,7 +34,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                                            IProjectSubscriptionService projectSubscriptionService,
                                            IWorkspaceProjectContextProvider workspaceProjectContextProvider,
                                            IActiveEditorContextTracker activeWorkspaceProjectContextTracker,
-                                           ExportFactory<IApplyChangesToWorkspaceContext> applyChangesToWorkspaceContextFactory)
+                                           ExportFactory<IApplyChangesToWorkspaceContext> applyChangesToWorkspaceContextFactory,
+                                           IDataProgressTrackerService dataProgressTrackerService)
             : base(threadingService.JoinableTaskContext)
         {
             _project = project;
@@ -43,6 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             _workspaceProjectContextProvider = workspaceProjectContextProvider;
             _activeWorkspaceProjectContextTracker = activeWorkspaceProjectContextTracker;
             _applyChangesToWorkspaceContextFactory = applyChangesToWorkspaceContextFactory;
+            _dataProgressTrackerService = dataProgressTrackerService;
         }
 
         public Task ActivateAsync()
@@ -82,7 +85,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         protected override WorkspaceProjectContextHostInstance CreateInstance()
         {
-            return new WorkspaceProjectContextHostInstance(_project, _threadingService, _tasksService, _projectSubscriptionService, _workspaceProjectContextProvider, _activeWorkspaceProjectContextTracker, _applyChangesToWorkspaceContextFactory);
+            return new WorkspaceProjectContextHostInstance(_project, _threadingService, _tasksService, _projectSubscriptionService, _workspaceProjectContextProvider, _activeWorkspaceProjectContextTracker, _applyChangesToWorkspaceContextFactory, _dataProgressTrackerService);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.cs
@@ -28,12 +28,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         [ImportingConstructor]
         public WorkspaceProjectContextHost(ConfiguredProject project,
-                                    IProjectThreadingService threadingService,
-                                    IUnconfiguredProjectTasksService tasksService,
-                                    IProjectSubscriptionService projectSubscriptionService,
-                                    IWorkspaceProjectContextProvider workspaceProjectContextProvider,
-                                    IActiveEditorContextTracker activeWorkspaceProjectContextTracker,
-                                    ExportFactory<IApplyChangesToWorkspaceContext> applyChangesToWorkspaceContextFactory)
+                                           IProjectThreadingService threadingService,
+                                           IUnconfiguredProjectTasksService tasksService,
+                                           IProjectSubscriptionService projectSubscriptionService,
+                                           IWorkspaceProjectContextProvider workspaceProjectContextProvider,
+                                           IActiveEditorContextTracker activeWorkspaceProjectContextTracker,
+                                           ExportFactory<IApplyChangesToWorkspaceContext> applyChangesToWorkspaceContextFactory)
             : base(threadingService.JoinableTaskContext)
         {
             _project = project;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/OperationProgress/DataProgressTrackerServiceExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/OperationProgress/DataProgressTrackerServiceExtensions.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.OperationProgress
+{
+    /// <summary>
+    ///     Provides extension methods for <see cref="IDataProgressTrackerService"/>.
+    /// </summary>
+    internal static class DataProgressTrackerServiceExtensions
+    {
+        /// <summary>
+        ///    Registers an output to be monitored for the "IntelliSense" stage. The returned registration needs to be notified when new data is calculated.
+        /// </summary>
+        public static IDataProgressTrackerServiceRegistration RegisterForIntelliSense(this IDataProgressTrackerService service, ConfiguredProject project, string name)
+        {
+            // We deliberately do not want these individual operations in a stage (such as pushing evaluation
+            // results to Roslyn) to be visible to the user, so we avoiding specifying a display message.
+            var dataSource = new ProgressTrackerOutputDataSource(project, operationProgressStageId: OperationProgressStageId.IntelliSense, name, displayMessage: null);
+
+            return service.RegisterOutputDataSource(dataSource);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/OperationProgress/OperationProgressStageId.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/OperationProgress/OperationProgressStageId.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.OperationProgress
+{
+    internal static class OperationProgressStageId
+    {
+        /// <summary>
+        ///     Represents the stage that represents all the operations that contribute to IntelliSense results.
+        /// </summary>
+        public const string IntelliSense = "IntelliSense";
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/OperationProgress/ProgressTrackerOutputDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/OperationProgress/ProgressTrackerOutputDataSource.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.OperationProgress
+{
+    internal class ProgressTrackerOutputDataSource : IProgressTrackerOutputDataSource
+    {
+        public ProgressTrackerOutputDataSource(ConfiguredProject configuredProject, string operationProgressStageId, string name, string displayMessage)
+        {
+            ConfiguredProject = configuredProject;
+            OperationProgressStageId = operationProgressStageId;
+            Name = name;
+            DisplayMessage = displayMessage;
+        }
+
+        public ConfiguredProject ConfiguredProject
+        {
+            get;
+        }
+
+        public string OperationProgressStageId
+        {
+            get;
+        }
+
+        public string Name
+        {
+            get;
+        }
+
+        public string DisplayMessage
+        {
+            get;
+        }
+    }
+}


### PR DESCRIPTION
**Background**

In the old day of the legacy project system, after solution load had completed - the project was guaranteed to have finished running a IntelliSense & references design-time build. Also modifications to the projects also were guaranteed to have finished running design-time builds by the time the API that modified the project had returned. 

This was a simple life and meant designers could open and query the project for stuff that required a design-time (such as CodeModel or references) without worrying if the data was present. Either it was present and the design-time build completed, or it wasn't and the design-time build failed. There was no querying an in-between "in progress" state.

In turns out design-time builds are slow, this resulted in large solution load times and delays while the UI blocked waiting for the build to complete. We made some advancement over the years, by reading cached results if nothing had changed between solution loads and by being smarter around how we group builds, but in the end, builds are an open system and large solutions tend to, over time, trend towards long design-time builds as custom and NuGet package targets are added that contribute to build time.

**Async Design-Time Builds**
In the new project system (based on CPS), to avoid these UI delays and long solution load times, we stopped blocking on them. Solution load and modifications to the project, no longer guarantee that design-time builds have completed.

This presents a problem; how to consumers of this project data made aware when the design-time build has finished and they can query the project? For features that are aware of CPS projects can opt into CPS-only APIs to query this data asynchronously, but the vast majority of features are project-system agnostic and this presents a large burden on the consumer. On top of this, legacy project system is planning on moving to a similar mechanism to CPS and stop blocking on design-time builds - it doesn't have any asynchronous APIs, would be need to add the same set of APIs that CPS has?

**Operation Progress**
Enter operation progress. Operation progress is a new set of APIs (entry point via IVsOperationProgress/IVsOperationProgress2) that lets consumers easily query whether a solution in currently "in-progress" running design-time builds or other operations that need to be finished before a project can be queried for results. These APIs are currently very simplified, are in a prototype state and not designed for consumers that need very specific data. For now, a consumer can ask very simple questions; "is IntelliSense ready for the solution?" Roslyn IntelliSense, for example, will use this result to show an indication to the user that IntelliSense results are not complete, or block operations such as rename, etc.  Long term, we'll see more granular APIs that let us answer questions such as "Is IntelliSense ready for this project and its dependencies?" or "Is IntelliSense ready for this project and its consumers?" but for the prototype we're focusing on solution wide.

**CPS's version of operation progress** 

CPS provides its own set of APIs that let producers of "operations" that enable IntelliSense contribute to operation progress. It does it in very natural and CPS-like manner. Most services in CPS consume data from a set of inputs via data flow. Given these inputs have versions, "in-progress" state is easy to calculate; "is the version that I've processed, up-to-date with the latest version of that data"? This is all tracked via the IDataProgressTrackerService service. A given service registers a "data source" and simply notifies the returned registration every time that they process a version of their inputs and it worries about publishing progress/completion state to the solution-wide `IVsOperationProgress` service.

This is exactly what we've implemented for the language service; this PR informs (indirectly) informs operation progress about the state of pushing evaluation/design-time build results to Roslyn. 

This is in no way handles restore state, ie in unrestored state it takes two design-time builds for "System.Runtime/mscorlib" to be pushed to Roslyn. Designers, etc don't care about the in-between state after the first design-time build,  this will be implemented in a followup.
