### PR TITLE
Use FullPath metadata instead of calculating ourselves

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/NuGet/ProjectRestoreInfoBuilderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/NuGet/ProjectRestoreInfoBuilderTests.cs
@@ -13,17 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         {
             Assert.Throws<ArgumentNullException>("updates", () =>
             {
-                ProjectRestoreInfoBuilder.Build(null, GetMockProject());
-            });
-        }
-
-        [Fact]
-        public void NullProject_ThrowsArgumentNull()
-        {
-            Assert.Throws<ArgumentNullException>("project", () =>
-            {
-                var projectSubscriptionUpdates = GetVersionedUpdatesFromJson(_sampleSubscriptionUpdate);
-                ProjectRestoreInfoBuilder.Build(projectSubscriptionUpdates, null);
+                ProjectRestoreInfoBuilder.Build(null);
             });
         }
 
@@ -54,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         }
     }
 }");
-            var restoreInfo = ProjectRestoreInfoBuilder.Build(projectSubscriptionUpdates, GetMockProject());
+            var restoreInfo = ProjectRestoreInfoBuilder.Build(projectSubscriptionUpdates);
             Assert.Null(restoreInfo);
         }
 
@@ -62,7 +52,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         public void WithAnyChanges_ReturnsFullRestoreInfo()
         {
             var projectSubscriptionUpdates = GetVersionedUpdatesFromJson(_sampleSubscriptionUpdate);
-            var restoreInfo = ProjectRestoreInfoBuilder.Build(projectSubscriptionUpdates, GetMockProject());
+            var restoreInfo = ProjectRestoreInfoBuilder.Build(projectSubscriptionUpdates);
 
             Assert.NotNull(restoreInfo);
             Assert.Equal(@"obj\", restoreInfo.BaseIntermediatePath);
@@ -169,7 +159,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         }
     }
 }");
-            var restoreInfo = ProjectRestoreInfoBuilder.Build(projectSubscriptionUpdates, GetMockProject());
+            var restoreInfo = ProjectRestoreInfoBuilder.Build(projectSubscriptionUpdates);
 
             Assert.NotNull(restoreInfo);
             Assert.Single(restoreInfo.TargetFrameworks);
@@ -227,7 +217,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         }
     }
 }");
-            var restoreInfo = ProjectRestoreInfoBuilder.Build(projectSubscriptionUpdates, GetMockProject());
+            var restoreInfo = ProjectRestoreInfoBuilder.Build(projectSubscriptionUpdates);
             Assert.Null(restoreInfo);
         }
 
@@ -237,7 +227,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             var projectSubscriptionUpdates = GetVersionedUpdatesFromJson(
                 _sampleSubscriptionUpdate,
                 _sampleSubscriptionUpdate);
-            var restoreInfo = ProjectRestoreInfoBuilder.Build(projectSubscriptionUpdates, GetMockProject());
+            var restoreInfo = ProjectRestoreInfoBuilder.Build(projectSubscriptionUpdates);
 
             Assert.NotNull(restoreInfo);
             Assert.Single(restoreInfo.TargetFrameworks);
@@ -343,7 +333,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         }
     }
 }");
-            var restoreInfo = ProjectRestoreInfoBuilder.Build(projectSubscriptionUpdates, GetMockProject());
+            var restoreInfo = ProjectRestoreInfoBuilder.Build(projectSubscriptionUpdates);
 
             Assert.NotNull(restoreInfo);
             AssertEx.CollectionLength(restoreInfo.TargetFrameworks, 2);
@@ -461,7 +451,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         }
     }
 }");
-            var restoreInfo = ProjectRestoreInfoBuilder.Build(projectSubscriptionUpdates, GetMockProject());
+            var restoreInfo = ProjectRestoreInfoBuilder.Build(projectSubscriptionUpdates);
 
             Assert.NotNull(restoreInfo);
             AssertEx.CollectionLength(restoreInfo.TargetFrameworks, 2);
@@ -470,78 +460,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             Assert.Equal(toolRef, restoreInfo.ToolReferences.Item("Microsoft.AspNet.EF.Tools"));
             Assert.Equal("Microsoft.AspNet.EF.Tools", toolRef.Name);
             Assert.Equal("1.0.0", toolRef.Properties.Item("Version").Value);
-        }
-
-        [Fact]
-        public void WithoutDefiningProjectDirectory_UsesUnconfiguredProjectRoot()
-        {
-            var projectSubscriptionUpdates = GetVersionedUpdatesFromJson(@"{
-    ""ProjectConfiguration"": {
-        ""Name"": ""Debug|AnyCPU|netcoreapp1.0"",
-        ""Dimensions"": {
-            ""Configuration"": ""Debug"",
-            ""TargetFramework"": ""netcoreapp1.0"",
-            ""Platform"": ""AnyCPU""
-        }
-    },
-    ""ProjectChanges"": {
-        ""NuGetRestore"": {
-            ""Difference"": {
-                ""AnyChanges"": ""false""
-            },
-            ""After"": {
-                ""Properties"": {
-                   ""MSBuildProjectExtensionsPath"": ""obj\\"",
-                   ""TargetFrameworks"": """",
-                   ""TargetFrameworkMoniker"": "".NETCoreApp,Version=v1.0""
-                }
-            }
-        },
-        ""PackageReference"": {
-            ""Difference"": {
-                ""AnyChanges"": ""false""
-            },
-            ""After"": {
-                ""Items"": { }
-            }
-        },
-        ""DotNetCliToolReference"": {
-            ""Difference"": {
-                ""AnyChanges"": ""false""
-            },
-            ""After"": {
-                ""Items"": { }
-            }
-        },
-        ""ProjectReference"": {
-            ""Difference"": {
-                ""AnyChanges"": ""true"",
-                ""AddedItems"": [ ""..\\TestLib\\TestLib.csproj"" ]
-            },
-            ""After"": {
-                ""Items"": {
-                    ""..\\TestLib\\TestLib.csproj"": { }
-                }
-            }
-        }
-    }
-}");
-            var restoreInfo = ProjectRestoreInfoBuilder.Build(projectSubscriptionUpdates, GetMockProject());
-
-            Assert.NotNull(restoreInfo);
-            Assert.Single(restoreInfo.TargetFrameworks);
-
-            var tfm = restoreInfo.TargetFrameworks.Item("netcoreapp1.0");
-            Assert.Equal("netcoreapp1.0", tfm.TargetFrameworkMoniker);
-            Assert.Single(tfm.ProjectReferences);
-
-            // project references
-            var projectRef = tfm.ProjectReferences.Item(0);
-            Assert.Equal(projectRef, tfm.ProjectReferences.Item("..\\TestLib\\TestLib.csproj"));
-            Assert.Equal("..\\TestLib\\TestLib.csproj", projectRef.Name);
-            Assert.Equal("D:\\Test\\Projects\\TestLib\\TestLib.csproj", projectRef.Properties.Item("ProjectFileFullPath").Value);
-            Assert.Null(projectRef.Properties.Item("DefiningProjectDirectory"));
-            Assert.Null(projectRef.Properties.Item("DefiningProjectFullPath"));
         }
 
         private const string _sampleSubscriptionUpdate = @"{
@@ -604,7 +522,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
                 ""Items"": {
                     ""..\\TestLib\\TestLib.csproj"": {
                         ""DefiningProjectDirectory"": ""C:\\Test\\Projects\\TestProj"",
-                        ""DefiningProjectFullPath"": ""C:\\Test\\Projects\\TestProj\\TestProj.csproj""
+                        ""DefiningProjectFullPath"": ""C:\\Test\\Projects\\TestProj\\TestProj.csproj"",
+                        ""FullPath"": ""C:\\Test\\Projects\\TestLib\\TestLib.csproj"",
                     }
                 }
             }
@@ -625,9 +544,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         }
     }
 }";
-
-        private static UnconfiguredProject GetMockProject(string projectFullPath = "D:\\Test\\Projects\\UCProject\\UCProject.csproj") =>
-            UnconfiguredProjectFactory.Create(filePath: projectFullPath);
 
         private static ImmutableList<IProjectVersionedValue<IProjectSubscriptionUpdate>> GetVersionedUpdatesFromJson(
             params string[] jsonStrings) =>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/PackageRestoreInitiator.PackageRestoreInitiatorInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/PackageRestoreInitiator.PackageRestoreInitiatorInstance.cs
@@ -135,7 +135,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
 
             private void NominateProject(IEnumerable<IProjectVersionedValue<IProjectSubscriptionUpdate>> updates)
             {
-                IVsProjectRestoreInfo projectRestoreInfo = ProjectRestoreInfoBuilder.Build(updates, _projectVsServices.Project);
+                IVsProjectRestoreInfo projectRestoreInfo = ProjectRestoreInfoBuilder.Build(updates);
 
                 if (projectRestoreInfo != null)
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/PackageRestoreInitiator.PackageRestoreInitiatorInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/PackageRestoreInitiator.PackageRestoreInitiatorInstance.cs
@@ -129,13 +129,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
                 var capabilitiesSnapshot = sources.Item1[0] as IProjectVersionedValue<IProjectCapabilitiesSnapshot>;
                 using (ProjectCapabilitiesContext.CreateIsolatedContext(_projectVsServices.Project, capabilitiesSnapshot.Value))
                 {
-                    NominateProject(sources.Item1.RemoveAt(0));
+                    NominateProject(sources.Item1.RemoveAt(0).Cast<IProjectVersionedValue<IProjectSubscriptionUpdate>>());
                 }
             }
 
-            private void NominateProject(ImmutableList<IProjectValueVersions> sources)
+            private void NominateProject(IEnumerable<IProjectVersionedValue<IProjectSubscriptionUpdate>> updates)
             {
-                IVsProjectRestoreInfo projectRestoreInfo = ProjectRestoreInfoBuilder.Build(sources, _projectVsServices.Project);
+                IVsProjectRestoreInfo projectRestoreInfo = ProjectRestoreInfoBuilder.Build(updates, _projectVsServices.Project);
 
                 if (projectRestoreInfo != null)
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectRestoreInfoBuilder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectRestoreInfoBuilder.cs
@@ -16,15 +16,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         private const string DefiningProjectDirectoryProperty = "DefiningProjectDirectory";
         private const string ProjectFileFullPathProperty = "ProjectFileFullPath";
 
-        internal static IVsProjectRestoreInfo Build(IEnumerable<IProjectValueVersions> updates,
-            UnconfiguredProject project)
-        {
-            Requires.NotNull(updates, nameof(updates));
-            Requires.NotNull(project, nameof(project));
-
-            return Build(updates.Cast<IProjectVersionedValue<IProjectSubscriptionUpdate>>(), project);
-        }
-
         internal static IVsProjectRestoreInfo Build(IEnumerable<IProjectVersionedValue<IProjectSubscriptionUpdate>> updates,
             UnconfiguredProject project)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectRestoreInfoBuilder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectRestoreInfoBuilder.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.IO;
 using System.Linq;
 
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
@@ -13,14 +12,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
 {
     internal static class ProjectRestoreInfoBuilder
     {
-        private const string DefiningProjectDirectoryProperty = "DefiningProjectDirectory";
         private const string ProjectFileFullPathProperty = "ProjectFileFullPath";
 
-        internal static IVsProjectRestoreInfo Build(IEnumerable<IProjectVersionedValue<IProjectSubscriptionUpdate>> updates,
-            UnconfiguredProject project)
+        internal static IVsProjectRestoreInfo Build(IEnumerable<IProjectVersionedValue<IProjectSubscriptionUpdate>> updates)
         {
             Requires.NotNull(updates, nameof(updates));
-            Requires.NotNull(project, nameof(project));
 
             // if none of the underlying subscriptions have any changes
             if (!updates.Any(u => u.Value.ProjectChanges.Any(c => c.Value.Difference.AnyChanges)))
@@ -58,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
                     targetFrameworks.Add(new TargetFrameworkInfo
                     {
                         TargetFrameworkMoniker = targetFramework,
-                        ProjectReferences = GetProjectReferences(projectReferencesChanges.After.Items, project),
+                        ProjectReferences = GetProjectReferences(projectReferencesChanges.After.Items),
                         PackageReferences = GetReferences(packageReferencesChanges.After.Items),
                         Properties = GetProperties(nugetRestoreChanges.After.Properties)
                     });
@@ -121,34 +117,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             return new ReferenceItems(items.Select(p => GetReferenceItem(p)));
         }
 
-        private static IVsReferenceItems GetProjectReferences(
-            IImmutableDictionary<string, IImmutableDictionary<string, string>> projectReferenceItems,
-            UnconfiguredProject project)
+        private static IVsReferenceItems GetProjectReferences(IImmutableDictionary<string, IImmutableDictionary<string, string>> projectReferenceItems)
         {
             IVsReferenceItems referenceItems = GetReferences(projectReferenceItems);
 
             // compute project file full path property for each reference
             foreach (ReferenceItem item in referenceItems)
             {
-                IVsReferenceProperty definingProjectDirectory = item.Properties.Item(DefiningProjectDirectoryProperty);
-                string projectFileFullPath = definingProjectDirectory != null
-                    ? MakeRooted(definingProjectDirectory.Value, item.Name)
-                    : project.MakeRooted(item.Name);
+                IVsReferenceProperty fullPathProperty = item.Properties.Item(ProjectReference.FullPathProperty);
 
                 ((ReferenceProperties)item.Properties).Add(new ReferenceProperty
                 {
                     Name = ProjectFileFullPathProperty,
-                    Value = projectFileFullPath
+                    Value = fullPathProperty?.Value
                 });
             }
 
             return referenceItems;
-        }
-
-        private static string MakeRooted(string basePath, string path)
-        {
-            basePath = basePath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-            return PathHelper.MakeRooted(basePath + Path.DirectorySeparatorChar, path);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.xaml
@@ -66,6 +66,9 @@
                   DisplayName="Exclude Assets"
                   Visible="True" />
 
+  <StringProperty Name="FullPath"
+                  Visible="False" />
+  
   <StringProperty Name="Identity"
                   Description="Security identity of the referenced assembly (see System.Reflection.Assembly.Evidence or System.Security.Policy.Evidence)."
                   DisplayName="Identity"
@@ -120,5 +123,4 @@
   <BoolProperty Name="Visible"
                 ReadOnly="True"
                 Visible="False" />
-
 </Rule>


### PR DESCRIPTION
We were calculating full path ourselves, when we can just pull it from the built-in metadata.