### PR TITLE
Enable the COM tab in the Reference Manager for NETCoreApp >=3.0

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -100,7 +100,7 @@
     <!-- Reference Manager capabilities -->
     <ProjectCapability Include="ReferenceManagerAssemblies" />
     <ProjectCapability Include="ReferenceManagerBrowse" />
-    <ProjectCapability Include="ReferenceManagerCOM" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '3.0'"/>
+    <ProjectCapability Include="ReferenceManagerCOM" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '3.0')"/>
     <ProjectCapability Include="ReferenceManagerProjects" />
     <ProjectCapability Include="ReferenceManagerSharedProjects" />
     <ProjectCapability Include="ReferenceManagerWinRT" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -100,7 +100,7 @@
     <!-- Reference Manager capabilities -->
     <ProjectCapability Include="ReferenceManagerAssemblies" />
     <ProjectCapability Include="ReferenceManagerBrowse" />
-    <ProjectCapability Include="ReferenceManagerCOM" />
+    <ProjectCapability Include="ReferenceManagerCOM" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '3.0'"/>
     <ProjectCapability Include="ReferenceManagerProjects" />
     <ProjectCapability Include="ReferenceManagerSharedProjects" />
     <ProjectCapability Include="ReferenceManagerWinRT" />


### PR DESCRIPTION
Fix for: https://github.com/dotnet/project-system/issues/4355 along with https://github.com/dotnet/sdk/pull/2994

https://github.com/dotnet/sdk/pull/2994 stops the SDK targets from removing the ``ReferenceManagerCOM`` ``ProjectCapability`` for all NET Core projects 
This PR only enables ``ReferenceManagerCOM`` if NETCoreApp >=3.0

