### PR TITLE
Return values for VSHPROPID_DesignerFunctionVisibility and VSHPROPID_DesignerVariableNaming

### DIFF
--- a/docs/well-known-project-properties.md
+++ b/docs/well-known-project-properties.md
@@ -188,6 +188,8 @@ Specifies the designer function access level (for example, `InitializeComponent(
 | _Private_ | The designer function has private visibility.                 |
 | _Public_  | The designer has public visibility (currently not supported). |
 
+These values map to members of the [`VSDESIGNER_FUNCTIONVISIBILITY`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.shell.interop.vsdesigner_functionvisibility) enum in the VS SDK.
+
 ##### __Example__
 ``` XML
 <PropertyGroup>
@@ -208,6 +210,8 @@ Specifies the naming convention used by the designer.
 |---------| ---------------|
 | _Camel_ | Names use camel case (e.g. `checkBox1`).       |
 | _VB_    | Names use VB / Pascal case (e.g. `CheckBox1`). |
+
+These values map to members of the [`VSDESIGNER_VARIABLENAMING`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.shell.interop.vsdesigner_variablenaming) enum in the VS SDK.
 
 ##### __Example__
 ``` XML

--- a/docs/well-known-project-properties.md
+++ b/docs/well-known-project-properties.md
@@ -122,14 +122,14 @@ Specifies whether `CoreCompile` should skip compiler execution.
 
 This property is helpful when used with the [ProvideCommandLineArgs](#providecommandlineargs_(bool)) property.
 
-
-
 ##### __Example__
 ``` XML
   <PropertyGroup>
     <RunPostBuildEvent>Always</RunPostBuildEvent>
   </PropertyGroup>
 ```
+
+---
 
 ## __Design-Time Properties, Items and Item Metadata__
 These properties, items and item metadata are used for solely for Visual Studio and design-time purposes, and have no influence on the resulting build.
@@ -170,6 +170,49 @@ Specifies whether the contents of the _Application Designer_ folder are only vis
 ``` XML
 <PropertyGroup>
     <AppDesignerFolderContentsVisibleOnlyInShowAllFiles>true</AppDesignerFolderContentsVisibleOnlyInShowAllFiles>
+<PropertyGroup>
+```
+
+#### __DesignerFunctionVisibility (enum)__
+
+| Language      | Default            |
+|---------------| -------------------|
+| C#            | Private            |
+| Visual Basic  | Friend             |
+
+Specifies the designer function access level (for example, `InitializeComponent()`).
+
+| Value     | Description    |
+|-----------| ---------------|
+| _Friend_  | The designer function has friend (internal) visibility.       |
+| _Private_ | The designer function has private visibility.                 |
+| _Public_  | The designer has public visibility (currently not supported). |
+
+##### __Example__
+``` XML
+<PropertyGroup>
+    <DesignerFunctionVisibility>Private</DesignerFunctionVisibility>
+<PropertyGroup>
+```
+
+#### __DesignerVariableNaming (enum)__
+
+| Language      | Default |
+|---------------| --------|
+| C#            | Camel   |
+| Visual Basic  | VB      |
+
+Specifies the naming convention used by the designer.
+
+| Value   | Description    |
+|---------| ---------------|
+| _Camel_ | Names use camel case (e.g. `checkBox1`).       |
+| _VB_    | Names use VB / Pascal case (e.g. `CheckBox1`). |
+
+##### __Example__
+``` XML
+<PropertyGroup>
+    <DesignerVariableNaming>Camel</DesignerVariableNaming>
 <PropertyGroup>
 ```
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.CSharp.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.CSharp.DesignTime.targets
@@ -18,6 +18,8 @@
     <AddItemTemplatesGuid Condition="'$(AddItemTemplatesGuid)' == ''">{FAE04EC0-301F-11d3-BF4B-00C04F79EFBC}</AddItemTemplatesGuid>
     <CmdUIContextGuid Condition="'$(CmdUIContextGuid)' == ''">{FAE04EC1-301F-11d3-BF4B-00C04F79EFBC}</CmdUIContextGuid>
     <GeneratorsTypeGuid Condition="'$(GeneratorsTypeGuid)' == ''">{FAE04EC1-301F-11d3-BF4B-00C04F79EFBC}</GeneratorsTypeGuid>
+    <DesignerFunctionVisibility Condition="'$(DesignerFunctionVisibility)' == ''">Private</DesignerFunctionVisibility>
+    <DesignerVariableNaming Condition="'$(DesignerVariableNaming)' == ''">Camel</DesignerVariableNaming>
   
     <!-- Turn off rules and capabilities that are defined in MSBuild so that we can import our own below -->
     <DefineCSharpItemSchemas>false</DefineCSharpItemSchemas>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.VisualBasic.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.VisualBasic.DesignTime.targets
@@ -18,6 +18,8 @@
     <AddItemTemplatesGuid Condition="'$(AddItemTemplatesGuid)' == ''">{F184B08F-C81C-45F6-A57F-5ABD9991F28F}</AddItemTemplatesGuid>
     <CmdUIContextGuid Condition="'$(CmdUIContextGuid)' == ''">{164B10B9-B200-11d0-8C61-00A0C91E29D5}</CmdUIContextGuid>
     <GeneratorsTypeGuid Condition="'$(GeneratorsTypeGuid)' == ''">{164B10B9-B200-11d0-8C61-00A0C91E29D5}</GeneratorsTypeGuid>
+    <DesignerFunctionVisibility Condition="'$(DesignerFunctionVisibility)' == ''">Friend</DesignerFunctionVisibility>
+    <DesignerVariableNaming Condition="'$(DesignerVariableNaming)' == ''">VB</DesignerVariableNaming>
 
     <!-- Turn off rules and capabilities that are defined in MSBuild so that we can import our own below -->
     <DefineVisualBasicItemSchemas>false</DefineVisualBasicItemSchemas>


### PR DESCRIPTION
~First pass at fixing #4478. My goal is to learn more about properties.~

Fixes #4478.

Sets value of two known properties used by designer code generation that determine the visibility and naming style of generated fields.

Can be merged once https://dev.azure.com/devdiv/DevDiv/_git/CPS/pullrequest/180589 completes.