### PR TITLE
Add WinForms, WPF and XBAP capabilities

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -118,8 +118,6 @@
     <!-- Capabilities for WPF and WinForms -->
     <ProjectCapability Include="WPF" Condition="'$(UseWPF)' == 'true'" />
     <ProjectCapability Include="WindowsForms" Condition="'$(UseWindowsForms)' == 'true'" />
-    <!-- XBAP is not supported in .NET Core -->
-    <ProjectCapability Include="XBAP" Condition="'$(HostInBrowser)' == 'true' And '$(TargetFrameworkIdentifier)' == '.NETFramework'" />
   </ItemGroup>
   
   <!-- Common Project System rules that override rules defined in msbuild. These are exact copy of the rules defined in msbuild. -->

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -114,6 +114,12 @@
 
     <!-- All Microsoft.NET.Sdk Exe projects, except WPF and WinForms exes, can be published to app service -->
     <ProjectCapability Include="AppServicePublish" Condition="'$(OutputType)' == 'Exe'" />
+
+    <!-- Capabilities for WPF and WinForms -->
+    <ProjectCapability Include="WPF" Condition="'$(UseWPF)' == 'true'" />
+    <ProjectCapability Include="WindowsForms" Condition="'$(UseWindowsForms)' == 'true'" />
+    <!-- XBAP is not supported in .NET Core -->
+    <ProjectCapability Include="XBAP" Condition="'$(HostInBrowser)' == 'true' And '$(TargetFrameworkIdentifier)' == '.NETFramework'" />
   </ItemGroup>
   
   <!-- Common Project System rules that override rules defined in msbuild. These are exact copy of the rules defined in msbuild. -->


### PR DESCRIPTION
Added basic WPF and WindowsForms capabilities, as well as one for XBAP for property pages, just in case. Legacy WPF flavors detect XBAP just by checking the `HostInBrowser` property so I've just mimicked that.

We might need more differentiation later in these, for different target frameworks, but I figure that can come later.

Fixes #4248