### PR TITLE
Fix Service Fabric Application package crash

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DotNetCoreProjectCompatibilityDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DotNetCoreProjectCompatibilityDetector.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Threading.Tasks;
 
@@ -63,7 +62,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                                                       IVsService<SVsUIShell, IVsUIShell> vsUIShellService,
                                                       IVsService<SVsSettingsPersistenceManager, ISettingsManager> settingsManagerService,
                                                       IVsService<SVsSolution, IVsSolution> vsSolutionService,
-                                                      IVsService<SVsAppId, IVsAppId> vsAppIdService,
+                                                      IVsService<IVsAppId> vsAppIdService,
                                                       IVsService<SVsShell, IVsShell> vsShellService)
         {
             _projectServiceAccessor = projectAccessor;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Interop/IVsAppId.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Interop/IVsAppId.cs
@@ -5,17 +5,8 @@ using System.Runtime.InteropServices;
 
 using IOleServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
 
-
-
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Interop
 {
-    [Guid("1EAA526A-0898-11d3-B868-00C04F79F802"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-#pragma warning disable IDE1006 // Naming Styles
-    public interface SVsAppId
-#pragma warning restore IDE1006 // Naming Styles
-    {
-    }
-
     [Guid("1EAA526A-0898-11d3-B868-00C04F79F802"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     public interface IVsAppId
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/CSharp/CSharpProjectDesignerPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/CSharp/CSharpProjectDesignerPage.cs
@@ -15,6 +15,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.CSharp
         public static readonly ProjectDesignerPageMetadata Package = new ProjectDesignerPageMetadata(new Guid("{21b78be8-3957-4caa-bf2f-e626107da58e}"), pageOrder: 3, hasConfigurationCondition: false);
         public static readonly ProjectDesignerPageMetadata Debug = new ProjectDesignerPageMetadata(new Guid("{0273C280-1882-4ED0-9308-52914672E3AA}"), pageOrder: 4, hasConfigurationCondition: false);
         public static readonly ProjectDesignerPageMetadata ReferencePaths = new ProjectDesignerPageMetadata(new Guid("{031911C8-6148-4e25-B1B1-44BCA9A0C45C}"), pageOrder: 5, hasConfigurationCondition: false);
-        public static readonly ProjectDesignerPageMetadata Signing = new ProjectDesignerPageMetadata(new Guid("{F8D6553F-F752-4DBF-ACB6-F291B744A792}"), pageOrder: 6, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata Security = new ProjectDesignerPageMetadata(new Guid("{DF8F7042-0BB1-47D1-8E6D-DEB3D07698BD}"), pageOrder: 6, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata Signing = new ProjectDesignerPageMetadata(new Guid("{F8D6553F-F752-4DBF-ACB6-F291B744A792}"), pageOrder: 7, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata XBAPSecurity = new ProjectDesignerPageMetadata(new Guid("{00A2C8FE-3844-41BE-9637-167454A7F1A7}"), pageOrder: 6, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata XBAPSigning = new ProjectDesignerPageMetadata(new Guid("{E4B54061-084D-4484-9D21-ECAE95A78A56}"), pageOrder: 7, hasConfigurationCondition: false);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/VisualBasicProjectDesignerPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/VisualBasicProjectDesignerPage.cs
@@ -14,6 +14,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.VisualBasic
         public static readonly ProjectDesignerPageMetadata Package = new ProjectDesignerPageMetadata(new Guid("{21b78be8-3957-4caa-bf2f-e626107da58e}"), pageOrder: 0, hasConfigurationCondition: false);
         public static readonly ProjectDesignerPageMetadata References = new ProjectDesignerPageMetadata(new Guid("{4E43F4AB-9F03-4129-95BF-B8FF870AF6AB}"), pageOrder: 1, hasConfigurationCondition: false);
         public static readonly ProjectDesignerPageMetadata Debug = new ProjectDesignerPageMetadata(new Guid("{0273C280-1882-4ED0-9308-52914672E3AA}"), pageOrder: 2, hasConfigurationCondition: false);
-        public static readonly ProjectDesignerPageMetadata Signing = new ProjectDesignerPageMetadata(new Guid("{F8D6553F-F752-4DBF-ACB6-F291B744A792}"), pageOrder: 6, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata Security = new ProjectDesignerPageMetadata(new Guid("{DF8F7042-0BB1-47D1-8E6D-DEB3D07698BD}"), pageOrder: 6, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata Signing = new ProjectDesignerPageMetadata(new Guid("{F8D6553F-F752-4DBF-ACB6-F291B744A792}"), pageOrder: 7, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata WPFApplication = new ProjectDesignerPageMetadata(new Guid("{00AA1F44-2BA3-4EAA-B54A-CE18000E6C5D}"), pageOrder: 0, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata XBAPSecurity = new ProjectDesignerPageMetadata(new Guid("{00A2C8FE-3844-41BE-9637-167454A7F1A7}"), pageOrder: 6, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata XBAPSigning = new ProjectDesignerPageMetadata(new Guid("{E4B54061-084D-4484-9D21-ECAE95A78A56}"), pageOrder: 7, hasConfigurationCondition: false);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/VisualBasicProjectDesignerPageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/VisualBasicProjectDesignerPageProvider.cs
@@ -26,7 +26,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.VisualBasic
         public Task<IReadOnlyCollection<IPageMetadata>> GetPagesAsync()
         {
             var builder = PooledArray<IPageMetadata>.GetInstance();
-            builder.Add(VisualBasicProjectDesignerPage.Application);
+            if (_capabilities.Contains(ProjectCapability.WPF))
+            {
+                builder.Add(VisualBasicProjectDesignerPage.WPFApplication);
+            }
+            else
+            {
+                builder.Add(VisualBasicProjectDesignerPage.Application);
+            }
             builder.Add(VisualBasicProjectDesignerPage.Compile);
 
             if (_capabilities.Contains(ProjectCapability.Pack))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Shipped.txt
@@ -105,7 +105,6 @@ Microsoft.VisualStudio.ProjectSystem.VS.Interop.IVsAppId.Initialize() -> int
 Microsoft.VisualStudio.ProjectSystem.VS.Interop.IVsAppId.SetGuidProperty(int propid, ref System.Guid rguid) -> int
 Microsoft.VisualStudio.ProjectSystem.VS.Interop.IVsAppId.SetProperty(int propid, object var) -> int
 Microsoft.VisualStudio.ProjectSystem.VS.Interop.IVsAppId.SetSite(Microsoft.VisualStudio.OLE.Interop.IServiceProvider pSP) -> int
-Microsoft.VisualStudio.ProjectSystem.VS.Interop.SVsAppId
 Microsoft.VisualStudio.ProjectSystem.VS.Interop.VSAPropID
 Microsoft.VisualStudio.ProjectSystem.VS.Interop.VSAPropID.AboutBoxTheme = -8565 -> Microsoft.VisualStudio.ProjectSystem.VS.Interop.VSAPropID
 Microsoft.VisualStudio.ProjectSystem.VS.Interop.VSAPropID.AddinsAllowed = -8556 -> Microsoft.VisualStudio.ProjectSystem.VS.Interop.VSAPropID

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -114,6 +114,12 @@
 
     <!-- All Microsoft.NET.Sdk Exe projects, except WPF and WinForms exes, can be published to app service -->
     <ProjectCapability Include="AppServicePublish" Condition="'$(OutputType)' == 'Exe'" />
+
+    <!-- Capabilities for WPF and WinForms -->
+    <ProjectCapability Include="WPF" Condition="'$(UseWPF)' == 'true'" />
+    <ProjectCapability Include="WindowsForms" Condition="'$(UseWindowsForms)' == 'true'" />
+    <!-- XBAP is not supported in .NET Core -->
+    <ProjectCapability Include="XBAP" Condition="'$(HostInBrowser)' == 'true' And '$(TargetFrameworkIdentifier)' == '.NETFramework'" />
   </ItemGroup>
   
   <!-- Common Project System rules that override rules defined in msbuild. These are exact copy of the rules defined in msbuild. -->

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapability.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapability.cs
@@ -37,5 +37,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public const string DotNetLanguageService = DotNet + " & " + LanguageService;
         public const string SortByDisplayOrder = ProjectCapabilities.SortByDisplayOrder;
         public const string DotNet = ".NET";
+        public const string WPF = "WPF";
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/VBMyApplicationPropertyProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/VBMyApplicationPropertyProvider.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties
+{
+    [Export("VBMyApplicationProperty", typeof(IProjectPropertiesProvider))]
+    [Export(typeof(IProjectPropertiesProvider))]
+    [Export("VBMyApplicationProperty", typeof(IProjectInstancePropertiesProvider))]
+    [Export(typeof(IProjectInstancePropertiesProvider))]
+    [ExportMetadata("Name", "VBMyApplicationProperty")]
+    internal sealed class VBMyApplicationPropertyProvider : InterceptedProjectPropertiesProviderBase
+    {
+        [ImportingConstructor]
+        public VBMyApplicationPropertyProvider(
+            [Import(ContractNames.ProjectPropertyProviders.ProjectFile)] IProjectPropertiesProvider provider,
+            [Import(ContractNames.ProjectPropertyProviders.ProjectFile)] IProjectInstancePropertiesProvider instanceProvider,
+            UnconfiguredProject project,
+            [ImportMany(ContractNames.ProjectPropertyProviders.ProjectFile)]IEnumerable<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>> interceptingValueProviders)
+            : base(provider, instanceProvider, project, interceptingValueProviders)
+        {
+        }
+
+        public override IProjectProperties GetCommonProperties()
+        {
+            return base.GetCommonProperties();
+        }
+        public override IProjectProperties GetCommonProperties(ProjectInstance projectInstance)
+        {
+            return base.GetCommonProperties(projectInstance);
+        }
+
+        public override IProjectProperties GetItemProperties(ITaskItem taskItem)
+        {
+            return base.GetItemProperties(taskItem);
+        }
+
+        public override IProjectProperties GetItemProperties(ProjectInstance projectInstance, string itemType, string itemName)
+        {
+            return base.GetItemProperties(projectInstance, itemType, itemName);
+        }
+
+        public override IProjectProperties GetItemProperties(string itemType, string item)
+        {
+            return base.GetItemProperties(itemType, item);
+        }
+
+        public override IProjectProperties GetItemTypeProperties(ProjectInstance projectInstance, string itemType)
+        {
+            return base.GetItemTypeProperties(projectInstance, itemType);
+        }
+
+        public override IProjectProperties GetItemTypeProperties(string itemType)
+        {
+            return base.GetItemTypeProperties(itemType);
+        }
+
+        public override IProjectProperties GetProperties(string file, string itemType, string item)
+        {
+            return base.GetProperties(file, itemType, item);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -174,6 +174,19 @@
     </StringProperty.DataSource>
   </StringProperty>
 
+  <StringProperty Name="MyApplication"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="false"
+                  PersistedName="MyApplication"
+                  Persistence="VBMyApplicationProperty"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="MyType"
+                  Visible="False" />
+
   <StringProperty Name="Name"
                   Visible="False" />
 


### PR DESCRIPTION
When packaging or F5ing a Service Fabric Application VS errors complaining about COM definitions:

```
Type library exporter encountered an error while processing 'Microsoft.VisualStudio.ProjectSystem.VS.Interop.IVsAppId, Microsoft.VisualStudio.ProjectSystem.Managed.VS'. Error: Type 'IVsAppId' and type 'SVsAppId' both have the same UUID.
```

This resolves the problem, and since the two IIDs were the same, there was no need to have two anyway.

Fixes internal bug [823377](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/823377)