### PR TITLE
Add an IFileWatchProviderDataSource

### DIFF
--- a/build/Packages.targets
+++ b/build/Packages.targets
@@ -97,8 +97,8 @@
     <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers" Version="16.1.163-pre" />
 
     <!-- Roslyn -->
-    <PackageReference Update="Microsoft.VisualStudio.LanguageServices" Version="2.11.0-beta2-63529-05" />
-    <PackageReference Update="Microsoft.CodeAnalysis" Version="2.11.0-beta2-63529-05" />
+    <PackageReference Update="Microsoft.VisualStudio.LanguageServices" Version="3.0.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis" Version="3.0.0" />
     <PackageReference Update="Microsoft.VisualStudio.IntegrationTest.Utilities" Version="2.6.0-beta1-62113-02" />
 
     <!-- Analyzers -->

--- a/build/Packages.targets
+++ b/build/Packages.targets
@@ -13,6 +13,7 @@
       https://dotnet.myget.org/F/project-system-interop/api/v3/index.json;
       https://vside.myget.org/F/vs-impl/api/v3/index.json;
       https://vside.myget.org/F/vssdk/api/v3/index.json;
+      C:\Users\tomescht\Desktop\LocalPackageSource
     </RestoreSources>
   </PropertyGroup>
 
@@ -93,8 +94,8 @@
     <PackageReference Update="Microsoft.Test.Apex.VisualStudio" Version="16.0.28117-pre" />
 
     <!-- CPS -->
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK" Version="16.1.39-pre-gd9225dddee" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers" Version="16.0.201-pre-g7d366164d0" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK" Version="16.1.59-pre-g5b7f85631b" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers" Version="16.1.59-pre-g5b7f85631b" />
 
     <!-- Roslyn -->
     <PackageReference Update="Microsoft.VisualStudio.LanguageServices" Version="2.11.0-beta2-63529-05" />

--- a/build/Packages.targets
+++ b/build/Packages.targets
@@ -13,7 +13,6 @@
       https://dotnet.myget.org/F/project-system-interop/api/v3/index.json;
       https://vside.myget.org/F/vs-impl/api/v3/index.json;
       https://vside.myget.org/F/vssdk/api/v3/index.json;
-      C:\Users\tomescht\Desktop\LocalPackageSource
     </RestoreSources>
   </PropertyGroup>
 
@@ -94,8 +93,8 @@
     <PackageReference Update="Microsoft.Test.Apex.VisualStudio" Version="16.0.28117-pre" />
 
     <!-- CPS -->
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK" Version="16.1.62-pre-gff7146ed84" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers" Version="16.1.62-pre-gff7146ed84" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK" Version="16.1.163-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers" Version="16.1.163-pre" />
 
     <!-- Roslyn -->
     <PackageReference Update="Microsoft.VisualStudio.LanguageServices" Version="2.11.0-beta2-63529-05" />
@@ -116,10 +115,10 @@
     <PackageReference Update="NuGet.VisualStudio" Version="4.9.1" />
 
     <!-- MSBuild -->
-    <PackageReference Update="Microsoft.Build" Version="15.8.166"/>
-    <PackageReference Update="Microsoft.Build.Utilities.Core" Version="15.8.166"/>
-    <PackageReference Update="Microsoft.Build.Engine" Version="15.8.166"/>
-    <PackageReference Update="Microsoft.Build.Tasks.Core" Version="15.8.166"/>
+    <PackageReference Update="Microsoft.Build" Version="16.0.452"/>
+    <PackageReference Update="Microsoft.Build.Utilities.Core" Version="16.0.452"/>
+    <PackageReference Update="Microsoft.Build.Engine" Version="16.0.452"/>
+    <PackageReference Update="Microsoft.Build.Tasks.Core" Version="16.0.452"/>
 
     <!-- Libraries -->
     <PackageReference Update="Newtonsoft.Json" Version="9.0.1"/>

--- a/build/Packages.targets
+++ b/build/Packages.targets
@@ -94,8 +94,8 @@
     <PackageReference Update="Microsoft.Test.Apex.VisualStudio" Version="16.0.28117-pre" />
 
     <!-- CPS -->
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK" Version="16.1.59-pre-g5b7f85631b" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers" Version="16.1.59-pre-g5b7f85631b" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK" Version="16.1.62-pre-gff7146ed84" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers" Version="16.1.62-pre-gff7146ed84" />
 
     <!-- Roslyn -->
     <PackageReference Update="Microsoft.VisualStudio.LanguageServices" Version="2.11.0-beta2-63529-05" />

--- a/build/Versions.props
+++ b/build/Versions.props
@@ -19,7 +19,7 @@
     <VSWhereVersion>2.3.2</VSWhereVersion>
     <TRXUnitVersion>1.0.0-beta1</TRXUnitVersion>
     <MicrosoftDotNetIBCMergeVersion>4.7.1-alpha-00001</MicrosoftDotNetIBCMergeVersion>
-    <MicrosoftNetCompilersVersion>2.11.0-beta2-63529-05</MicrosoftNetCompilersVersion>
+    <MicrosoftNetCompilersVersion>3.0.0</MicrosoftNetCompilersVersion>
     <MicrosoftDiaSymReaderPdb2PdbVersion>1.1.0-beta1-62624-01</MicrosoftDiaSymReaderPdb2PdbVersion>
     <RoslynAnalyzersPackagesVersion>2.6.3-beta1.19059.2</RoslynAnalyzersPackagesVersion>
     <OpenCoverVersion>4.6.519</OpenCoverVersion>
@@ -40,6 +40,6 @@
     <MicrosoftVisualStudioSetupConfigurationInteropVersion>1.16.30</MicrosoftVisualStudioSetupConfigurationInteropVersion>
 
     <!-- Tests -->
-    <XUnitVersion>2.4.0</XUnitVersion>
+    <XUnitVersion>2.4.1</XUnitVersion>
   </PropertyGroup>
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -65,7 +65,7 @@
     <PropertyGroup Condition="'$(_RunOnCore)' != 'true'">
       <_XUnitConsoleExe>xunit.console.exe</_XUnitConsoleExe>
       <_XUnitConsoleExe Condition="'$(_TestArchitecture)' == 'x86'">xunit.console.x86.exe</_XUnitConsoleExe>
-      <_XUnitRunnerCommand>$(NuGetPackageRoot)xunit.runner.console\$(XUnitVersion)\tools\net452\$(_XUnitConsoleExe)</_XUnitRunnerCommand>
+      <_XUnitRunnerCommand>$(NuGetPackageRoot)xunit.runner.console\$(XUnitVersion)\tools\net472\$(_XUnitConsoleExe)</_XUnitRunnerCommand>
       <_XUnitRunnerCommandArgs>"$(TargetPath)" -noshadow -xml "$(_TestResultsXmlPath)" -html "$(_TestResultsHtmlPath)" $(XUnitRunnerAdditionalArguments)</_XUnitRunnerCommandArgs>
       <_TestRunnerCommand>"$(_XUnitRunnerCommand)" $(_XUnitRunnerCommandArgs)</_TestRunnerCommand>
       <_TestResultsDisplayPath>$(_TestResultsHtmlPath)</_TestResultsDisplayPath>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PotentialEditorConfigDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PotentialEditorConfigDataSource.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    [Export(typeof(IFileWatchProviderDataSource))]
+    internal class PotentialEditorConfigDataSource : ProjectValueDataSourceBase<IFileWatchProvider>, IFileWatchProviderDataSource
+    {
+        private readonly ConfiguredProject _project;
+
+        private int _version;
+        private IDisposable _projectRuleSourceLink;
+
+        /// <summary>
+        /// The block that receives updates from the active tree provider.
+        /// </summary>
+        private IBroadcastBlock<IProjectVersionedValue<IFileWatchProvider>> _broadcastBlock;
+
+        /// <summary>
+        /// The public facade for the broadcast block.
+        /// </summary>
+        private IReceivableSourceBlock<IProjectVersionedValue<IFileWatchProvider>> _publicBlock;
+
+        [ImportingConstructor]
+        public PotentialEditorConfigDataSource(ConfiguredProject project)
+            : base(project.Services)
+        {
+            _project = project;
+        }
+
+        public override NamedIdentity DataSourceKey { get; } = new NamedIdentity(nameof(PotentialEditorConfigDataSource));
+
+        public override IComparable DataSourceVersion => _version;
+
+        public override IReceivableSourceBlock<IProjectVersionedValue<IFileWatchProvider>> SourceBlock => _publicBlock;
+
+        public FileChangeKinds ChangeKinds => FileChangeKinds.Added | FileChangeKinds.Removed;
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+
+            _projectRuleSourceLink = _project.Services.ProjectSubscription.ProjectRuleSource.SourceBlock.LinkToAsyncAction(ProcessProjectChanged, ruleNames: PotentialEditorConfigFiles.SchemaName);
+
+            _broadcastBlock = DataflowBlockSlim.CreateBroadcastBlock<IProjectVersionedValue<IFileWatchProvider>>(nameFormat: nameof(PotentialEditorConfigDataSource) + "Broadcast {1}");
+            _publicBlock = _broadcastBlock.SafePublicize();
+        }
+
+        private async Task ProcessProjectChanged(IProjectVersionedValue<IProjectSubscriptionUpdate> projectSnapshot)
+        {
+            if (projectSnapshot.Value.CurrentState.TryGetValue(PotentialEditorConfigFiles.SchemaName, out IProjectRuleSnapshot ruleSnapshot))
+            {
+                var fileWatchProvider = new PotentialEditorConfigFileWatchProvider(this, ruleSnapshot.Items.Keys);
+                _version++;
+                ImmutableDictionary<NamedIdentity, IComparable> dataSources = ImmutableDictionary<NamedIdentity, IComparable>.Empty.Add(DataSourceKey, DataSourceVersion);
+
+                await _broadcastBlock.SendAsync(new ProjectVersionedValue<IFileWatchProvider>(fileWatchProvider, dataSources));
+            }
+        }
+
+        private class PotentialEditorConfigFileWatchProvider : IFileWatchProvider
+        {
+            public PotentialEditorConfigFileWatchProvider(
+                IFileWatchProviderDataSource dataSource,
+                IEnumerable<string> filePathsToWatch)
+            {
+                DataSource = dataSource;
+                FilePathsToWatch = filePathsToWatch;
+            }
+
+            public IFileWatchProviderDataSource DataSource { get; }
+            public IEnumerable<string> FilePathsToWatch { get; }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (IsInitialized)
+            {
+                _projectRuleSourceLink.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -149,6 +149,9 @@
     <Compile Update="ProjectSystem\Rules\Items\Resource.cs">
       <DependentUpon>Resource.xaml</DependentUpon>
     </Compile>
+    <Compile Update="ProjectSystem\Rules\PotentialEditorConfigFiles.cs">
+      <DependentUpon>PotentialEditorConfigFiles.xaml</DependentUpon>
+    </Compile>
     <Compile Update="Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -334,6 +337,11 @@
       <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\Items\XamlAppDef.xaml">
+      <XlfInput>false</XlfInput>
+      <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
+      <SubType>Designer</SubType>
+    </XamlPropertyRule>
+    <XamlPropertyRule Include="ProjectSystem\Rules\PotentialEditorConfigFiles.xaml">
       <XlfInput>false</XlfInput>
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
       <SubType>Designer</SubType>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -190,6 +190,10 @@
       <Context>BrowseObject</Context>
     </PropertyPageSchema>
 
+    <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)PotentialEditorConfigFiles.xaml">
+      <Context>File</Context>
+    </PropertyPageSchema>
+    
     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)SpecialFolder.xaml">
       <Context>File;ProjectSubscriptionService</Context>
     </PropertyPageSchema>
@@ -340,6 +344,7 @@
   <!-- List of external files that trigger design-time builds when they are modified -->
   <ItemGroup>
     <AdditionalDesignTimeBuildInput Include="$(ProjectAssetsFile)" />   <!-- NuGet assets file -->
+    <AdditionalDesignTimeBuildInput Include="@(PotentialEditorConfigFiles)" /> <!-- Places .editorconfig files may appear -->
   </ItemGroup>
 
   <!--

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -23,14 +23,14 @@
     <SuppressOutOfDateMessageOnBuild Condition="'$(SuppressOutOfDateMessageOnBuild)' == ''">true</SuppressOutOfDateMessageOnBuild>
   </PropertyGroup>
 
-  
+
   <!--
     Rule files that don't need localization go in the neutral directory to save duplicating files into each language
   -->
   <PropertyGroup Condition="'$(ManagedXamlNeutralResourcesDirectory)' == ''">
     <ManagedXamlNeutralResourcesDirectory>$(MSBuildThisFileDirectory)</ManagedXamlNeutralResourcesDirectory>
   </PropertyGroup>
-  
+
   <!--
     Locate the approriate localized xaml resources based on the language ID or name.
 
@@ -59,7 +59,7 @@
     <ManagedXamlResourcesDirectory Condition="!HasTrailingSlash('$(ManagedXamlResourcesDirectory)')">$(ManagedXamlResourcesDirectory)\</ManagedXamlResourcesDirectory>
     <DebuggerFlavor Condition = "'$(DebuggerFlavor)' == ''">ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
-  
+
   <!-- Project Capabilities -->
 
   <!-- Capabilities shared between shared projects & binary-producing projects.  -->
@@ -68,7 +68,7 @@
   </ItemGroup>
 
   <!-- Capabilities for binary producing projects -->
-  
+
   <ItemGroup Condition="'$(DefineCommonManagedCapabilities)' == 'true'">
     <ProjectCapability Include="UseFileGlobs"/>
     <ProjectCapability Include="DynamicDependentFile"/>
@@ -107,7 +107,7 @@
 
     <!-- Settings page capability -->
     <ProjectCapability Include="AppSettings" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'"/>
-  
+
     <!-- Publish capability enables the Publish command for the Project -->
     <ProjectCapability Include="Publish"/>
     <ProjectCapability Include="FolderPublish"/>
@@ -120,7 +120,7 @@
     <ProjectCapability Include="WindowsForms" Condition="'$(UseWindowsForms)' == 'true'" />
     <ProjectCapability Include="DataSourceWindow" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '3.0')"/>
   </ItemGroup>
-  
+
   <!-- Common Project System rules that override rules defined in msbuild. These are exact copy of the rules defined in msbuild. -->
   <ItemGroup Condition="'$(DefineCommonManagedItemSchemas)' == 'true'">
 
@@ -128,7 +128,7 @@
     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)ProjectItemsSchema.xaml">
       <Context>Project</Context>
     </PropertyPageSchema>
-    
+
     <!-- Files/Folders -->
     <PropertyPageSchema Include="$(ManagedXamlNeutralResourcesDirectory)AdditionalFiles.xaml">
       <Context>File</Context>
@@ -149,7 +149,7 @@
     <PropertyPageSchema Include="$(ManagedXamlNeutralResourcesDirectory)Compile.xaml;">
       <Context>File</Context>
     </PropertyPageSchema>
-    
+
     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)Compile.BrowseObject.xaml;">
       <Context>BrowseObject</Context>
     </PropertyPageSchema>
@@ -189,7 +189,7 @@
     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)Page.BrowseObject.xaml">
       <Context>BrowseObject</Context>
     </PropertyPageSchema>
-    
+
     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)SpecialFolder.xaml">
       <Context>File;ProjectSubscriptionService</Context>
     </PropertyPageSchema>
@@ -222,21 +222,21 @@
     <PropertyPageSchema Include="$(ManagedXamlNeutralResourcesDirectory)LanguageService.xaml">
       <Context>ProjectSubscriptionService</Context>
     </PropertyPageSchema>
-      
+
     <!-- NuGet Restore Properties -->
     <PropertyPageSchema Include="$(ManagedXamlNeutralResourcesDirectory)NuGetRestore.xaml">
       <Context>ProjectSubscriptionService</Context>
     </PropertyPageSchema>
-    
+
     <!-- Up-to-date check -->
     <PropertyPageSchema Include="$(ManagedXamlNeutralResourcesDirectory)ResolvedCompilationReference.xaml">
       <Context>ProjectSubscriptionService</Context>
     </PropertyPageSchema>
-        
+
     <PropertyPageSchema Include="$(ManagedXamlNeutralResourcesDirectory)CopyUpToDateMarker.xaml">
       <Context>ProjectSubscriptionService</Context>
     </PropertyPageSchema>
-    
+
     <PropertyPageSchema Include="$(ManagedXamlNeutralResourcesDirectory)UpToDateCheckInput.xaml">
       <Context>ProjectSubscriptionService</Context>
     </PropertyPageSchema>
@@ -252,7 +252,7 @@
     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)ConfigurationGeneral.xaml">
       <Context>Project;ProjectSubscriptionService</Context>
     </PropertyPageSchema>
-    
+
     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)DebuggerGeneral.xaml">
       <Context>Project</Context>
     </PropertyPageSchema>
@@ -272,7 +272,7 @@
     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)SourceControl.xaml">
       <Context>Invisible</Context>
     </PropertyPageSchema>
-    
+
   </ItemGroup>
 
   <ItemGroup Condition="'$(DefineCommonManagedReferenceSchemas)' == 'true'">
@@ -336,11 +336,11 @@
     </PropertyPageSchema>
 
     <!-- .editorconfig files -->
-    
+
     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)PotentialEditorConfigFiles.xaml">
       <Context>ProjectSubscriptionService</Context>
     </PropertyPageSchema>
-    
+
   </ItemGroup>
 
   <!-- List of external files that trigger design-time builds when they are modified -->
@@ -382,10 +382,10 @@
 
   <!-- This target collects all Analyzers in the project. -->
   <Target Name="CollectAnalyzersDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(Analyzer)" />
-  
+
   <!-- This target collects all the resolved references that are used to actually compile. -->
   <Target Name="CollectResolvedCompilationReferencesDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(ReferencePathWithRefAssemblies)" />
-  
+
   <!-- This target collects all the extra inputs for the up to date check. -->
   <Target Name="CollectUpToDateCheckInputDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(UpToDateCheckInput)">
     <ItemGroup>
@@ -412,7 +412,7 @@
       <!-- Symbols, bin and obj -->
       <UpToDateCheckBuilt Condition="'$(_DebugSymbolsProduced)'=='true'" Include="@(_DebugSymbolsIntermediatePath)"/>
       <UpToDateCheckBuilt Condition="'$(_DebugSymbolsProduced)'=='true' and '$(SkipCopyingSymbolsToOutputDirectory)' != 'true' and '$(CopyOutputSymbolsToOutputDirectory)' != 'false'" Include="@(_DebugSymbolsOutputPath)"/>
-      
+
       <!-- app.config -->
       <UpToDateCheckBuilt Condition=" '@(AppConfigWithTargetPath)' != '' " Include="@(AppConfigWithTargetPath->'$(OutDir)%(TargetPath)')" Original="@(AppConfigWithTargetPath)"/>
     </ItemGroup>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -189,10 +189,6 @@
     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)Page.BrowseObject.xaml">
       <Context>BrowseObject</Context>
     </PropertyPageSchema>
-
-    <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)PotentialEditorConfigFiles.xaml">
-      <Context>File</Context>
-    </PropertyPageSchema>
     
     <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)SpecialFolder.xaml">
       <Context>File;ProjectSubscriptionService</Context>
@@ -339,12 +335,17 @@
       <Context>ProjectSubscriptionService;BrowseObject</Context>
     </PropertyPageSchema>
 
+    <!-- .editorconfig files -->
+    
+    <PropertyPageSchema Include="$(ManagedXamlResourcesDirectory)PotentialEditorConfigFiles.xaml">
+      <Context>ProjectSubscriptionService</Context>
+    </PropertyPageSchema>
+    
   </ItemGroup>
 
   <!-- List of external files that trigger design-time builds when they are modified -->
   <ItemGroup>
     <AdditionalDesignTimeBuildInput Include="$(ProjectAssetsFile)" />   <!-- NuGet assets file -->
-    <AdditionalDesignTimeBuildInput Include="@(PotentialEditorConfigFiles)" /> <!-- Places .editorconfig files may appear -->
   </ItemGroup>
 
   <!--

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PotentialEditorConfigFiles.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PotentialEditorConfigFiles.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
+    internal partial class PotentialEditorConfigFiles
+    {
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PotentialEditorConfigFiles.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PotentialEditorConfigFiles.xaml
@@ -9,5 +9,4 @@
                 Persistence="ProjectFile"
                 SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
-
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PotentialEditorConfigFiles.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PotentialEditorConfigFiles.xaml
@@ -1,8 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="PotentialEditorConfigFiles"
-      Description="Potential .editorconfig files"
-      DisplayName="NamespaceImport"
       PageTemplate="generic"
       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PotentialEditorConfigFiles.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PotentialEditorConfigFiles.xaml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Rule Name="PotentialEditorConfigFiles"
+      Description="Potential .editorconfig files"
+      DisplayName="NamespaceImport"
+      PageTemplate="generic"
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
+  <Rule.DataSource>
+    <DataSource HasConfigurationCondition="False"
+                ItemType="PotentialEditorConfigFiles"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
+  </Rule.DataSource>
+
+</Rule>


### PR DESCRIPTION
Add an `IFileWatchProviderDataSource` for potential .editorconfig files.

Note that this is dependent on the changes in https://devdiv.visualstudio.com/DevDiv/_git/CPS/pullrequest/171765 so you may want to review that first.