### PR TITLE
remove unneeded test dependencies

### DIFF
--- a/src/HostAgnostic.props
+++ b/src/HostAgnostic.props
@@ -44,9 +44,5 @@
   <ItemGroup Condition="'$(IsTestProject)' == 'true'" >
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit.analyzers" />
-
-    <!-- TODO: Some tests need this. Seems wrong. -->
-    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Text.UI" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
It does not appear that any tests needs this anymore (at least on my machine)