### PR TITLE
Always produce NuGet packages

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -12,6 +12,7 @@ set OptDeploy=$true
 set OptTest=$true
 set OptIntegrationTest=$false
 set OptLog=$false
+set OptPack=$true
 
 :ParseArguments
 if "%1" == "" goto :DoneParsing
@@ -21,7 +22,7 @@ if /I "%1" == "/rebuild" set OptBuild=$false&&set OptRebuild=$true&&shift&& goto
 if /I "%1" == "/debug" set BuildConfiguration=Debug&&shift&& goto :ParseArguments
 if /I "%1" == "/release" set BuildConfiguration=Release&&shift&& goto :ParseArguments
 if /I "%1" == "/skiptests" set OptTest=$false&&shift&& goto :ParseArguments
-if /I "%1" == "/restore-only" set OptBuild=$false&&set OptDeploy=$false&&set OptTest=$false&&shift&& goto :ParseArguments
+if /I "%1" == "/restore-only" set OptBuild=$false&&set OptDeploy=$false&&set OptTest=$false&&set OptPack=$false&&shift&& goto :ParseArguments
 if /I "%1" == "/no-deploy-extension" set OptDeploy=$false&&shift&& goto :ParseArguments
 if /I "%1" == "/diagnostic" set OptLog=$true&&shift&& goto :ParseArguments
 if /I "%1" == "/integrationtests" set OptIntegrationTest=$true&&shift&& goto :ParseArguments
@@ -29,7 +30,7 @@ if /I "%1" == "/rootsuffix" set PropRootSuffix=/p:RootSuffix=%2&&shift&&shift&& 
 call :Usage && exit /b 1
 :DoneParsing
 
-powershell -ExecutionPolicy ByPass -Command "& """%Root%build\Build.ps1""" -configuration %BuildConfiguration% -restore -build:%OptBuild% -rebuild:%OptRebuild% -deploy:%OptDeploy% -test:%OptTest% -integrationTest:%OptIntegrationTest% -log:%OptLog% %PropRootSuffix%"
+powershell -ExecutionPolicy ByPass -Command "& """%Root%build\Build.ps1""" -configuration %BuildConfiguration% -restore -pack:%OptPack% -build:%OptBuild% -rebuild:%OptRebuild% -deploy:%OptDeploy% -test:%OptTest% -integrationTest:%OptIntegrationTest% -log:%OptLog% %PropRootSuffix%"
 exit /b %ERRORLEVEL%
 
 :Usage

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -397,11 +397,9 @@ try {
   }
 
   Build
-  
-  if ($pack) {
-    GenerateDependentAssemblyVersionFile
-  }
-  
+
+  GenerateDependentAssemblyVersionFile
+ 
   if($integrationTest){
     RunIntegrationTests
   }

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -237,8 +237,8 @@ function GenerateDependentAssemblyVersionFile() {
 $vsAssemblyName,$visualStudioVersion.0
 $projectSystemAssemblyName,$projectSystemVersion.0
 "@
-  & mkdir $devDivInsertionFiles
-  $csv >> $dependentAssemblyVersionsCsv
+  & mkdir -force $devDivInsertionFiles > $null
+  $csv > $dependentAssemblyVersionsCsv
 }
 
 # Ensure project system is installed to the correct hive


### PR DESCRIPTION
- Always produce NuGet packages during build (this was inadvertently turned off during last infrastructure move). An internal team is building our bits/consuming them and wasn't obvious how to turn this on
- Stop tying GenerateDependentAssemblyVersionFile to "pack" - it's tried to VS insertion assets which we always produce
- Fix GenerateDependentAssemblyVersionFile so that it handles incremental, it was failing if the direction already existed and appending to the file if existed