### PR TITLE
Ignore integration test artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,5 @@ $RECYCLE.BIN/
 
 # Mac desktop service store files
 .DS_Store
+TRXUnit.zip
+RoslynTools.VSIXExpInstaller.zip


### PR DESCRIPTION
Update the gitignore file to not list some of the CIBuild.cmd artifacts that are created for integration tests