### PR TITLE
save a video video on integration test runs

### DIFF
--- a/build/Packages.targets
+++ b/build/Packages.targets
@@ -26,6 +26,8 @@
     <PackageReference Update="Microsoft.DiaSymReader.Pdb2Pdb" Version="$(MicrosoftDiaSymReaderPdb2PdbVersion)" />
     <PackageReference Update="OpenCover" Version="$(OpenCoverVersion)" />
     <PackageReference Update="Codecov" Version="$(CodecovVersion)" />
+    <PackageReference Update="Microsoft.DevDiv.Validation.MediaRecorder" Version="$(MicrosoftDevDivValidationMediaRecorderVersion)" />
+    <PackageReference Update="Microsoft.DevDiv.Validation.Logging.ScreenshotCollector" Version="$(MicrosoftDevDivValidationLoggingScreenshotCollectorVersion)" />
 
     <!-- VS SDK -->
     <PackageReference Update="Microsoft.VSSDK.BuildTools" Version="15.8.3252" />

--- a/build/Toolset.proj
+++ b/build/Toolset.proj
@@ -14,6 +14,8 @@
     <PackageReference Include="Codecov" />
     <PackageReference Include="OpenCover" />
     <PackageReference Include="Microsoft.DiaSymReader.Pdb2Pdb" />
+    <PackageReference Include="Microsoft.DevDiv.Validation.MediaRecorder" />
+    <PackageReference Include="Microsoft.DevDiv.Validation.Logging.ScreenshotCollector" />
   </ItemGroup>
 
 </Project>

--- a/build/Versions.props
+++ b/build/Versions.props
@@ -24,6 +24,8 @@
     <RoslynAnalyzersPackagesVersion>2.6.3-beta1.19059.2</RoslynAnalyzersPackagesVersion>
     <OpenCoverVersion>4.6.519</OpenCoverVersion>
     <CodecovVersion>1.1.0</CodecovVersion>
+    <MicrosoftDevDivValidationMediaRecorderVersion>15.0.199</MicrosoftDevDivValidationMediaRecorderVersion>
+    <MicrosoftDevDivValidationLoggingScreenshotCollectorVersion>1.1.86</MicrosoftDevDivValidationLoggingScreenshotCollectorVersion>
 
     <!--
       TODO:

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -304,14 +304,37 @@ function RunIntegrationTests {
   $LogFileArgs = "trx;LogFileName=Microsoft.VisualStudio.ProjectSystem.IntegrationTests.trx"
   $TestAssembly = Join-Path (Join-Path $ArtifactsDir $configuration) "bin\IntegrationTests\Microsoft.VisualStudio.ProjectSystem.IntegrationTests.dll"
   # create runsettings file
+  $ScreenshotCollectorVersion = GetVersion("MicrosoftDevDivValidationLoggingScreenshotCollectorVersion")
+  $pathToScreenShotCollector = Join-Path $NuGetPackageRoot "Microsoft.DevDiv.Validation.Logging.ScreenshotCollector\$ScreenshotCollectorVersion\lib\net461"
+  
+  $MediaRecorderVersion = GetVersion("MicrosoftDevDivValidationMediaRecorderVersion")
+  $pathToMediaRecorder = Join-Path $NuGetPackageRoot "Microsoft.DevDiv.Validation.MediaRecorder\$MediaRecorderVersion\lib\net461"
+  
   $runSettings = Join-Path $IntegrationTestTempDir "integration.runsettings"
   if (!(Test-Path $runSettings)) {
     $runSettingsContents = @"
 <?xml version="1.0" encoding="utf-8"?>  
 <RunSettings>  
-  <TestRunParameters>  
+  <TestRunParameters>
     <Parameter name="VsRootSuffix" value="$rootsuffix" />
   </TestRunParameters>
+  <RunConfiguration>
+    <MaxCpuCount>1</MaxCpuCount>
+    <!-- Path to Test Adapters -->
+    <TestAdaptersPaths>$pathToScreenShotCollector;$pathToMediaRecorder</TestAdaptersPaths>
+  </RunConfiguration>
+  
+  <!-- Configurations for DataCollectors -->
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="Screen and Voice Recorder" uri="datacollector://Microsoft/DevDiv/VideoRecorder/2.0" assemblyQualifiedName="Microsoft.DevDiv.Validation.MediaRecorder.Collector, Microsoft.DevDiv.Validation.MediaRecorder.Collector.VideoRecorderDataCollector, Version=15.0.0.0, Culture=neutral, PublicKeyToken=null" enabled="true"/>
+      <DataCollector friendlyName="Screenshot Collector" uri="datacollector://Microsoft/DevDiv/Validation/Logging/Screenshot/v1" assemblyQualifiedName="Microsoft.DevDiv.Validation.Logging.ScreenshotCollector, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <Configuration>
+          <Triggers>OnTestCaseFail</Triggers>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
 </RunSettings>
 "@
     $runSettingsContents >> $runSettings


### PR DESCRIPTION
Add a media-recorder-logger to integration tests run with CIBuild.cmd so its easier to diagnose failures