### PR TITLE
fail build on failed test run

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -317,8 +317,14 @@ function RunIntegrationTests {
     $runSettingsContents >> $runSettings
   }
 
+  Disable-WindowsErrorReporting
   Write-Host "Using $VSTestExe"
   & $VSTestExe /blame /logger:$LogFileArgs /ResultsDirectory:"$IntegrationTestTempDir" /Settings:$runSettings $TestAssembly
+  $integrationTestsFailed = $false
+  if ((-not $?) -or ($lastExitCode -ne 0)) {
+    $integrationTestsFailed = $true
+  }
+  Enable-WindowsErrorReporting
   
   # Kill any VS processes left over
   Stop-Process-Name "devenv"
@@ -334,6 +340,12 @@ function RunIntegrationTests {
   # Uninstall extensions as other test runs could happen on the VM
   # NOTE: it sometimes takes 2 tries for it to succeed
   UninstallVSIXes $rootSuffix
+  
+  if ($integrationTestsFailed) {
+    # Copy screenshots and video files on failure
+    Copy-Item -Path $IntegrationTestTempDir -Recurse -Destination $TestResultsDir -Container
+    throw "Aborting after integration test failure."
+  }
 }
 
 try {


### PR DESCRIPTION
Ensure that integration tests run using build.cmd fail the build appropriately