### PR TITLE
Add missing DesignTimeSharedInput property from File and BrowseObject Rules

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/AdditionalFiles.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/AdditionalFiles.BrowseObject.xaml
@@ -63,6 +63,9 @@
   <BoolProperty Name="DesignTime"
                 Visible="false" />
 
+  <BoolProperty Name="DesignTimeSharedInput"
+                Visible="false" />
+
   <StringProperty Name="Extension"
                   ReadOnly="true"
                   Visible="False">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/AdditionalFiles.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/AdditionalFiles.xaml
@@ -47,6 +47,9 @@
   <BoolProperty Name="DesignTime"
                 Visible="false" />
 
+  <BoolProperty Name="DesignTimeSharedInput"
+                Visible="false" />
+
   <StringProperty Name="FullPath"
                   ReadOnly="true"
                   Visible="false">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/ApplicationDefinition.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/ApplicationDefinition.BrowseObject.xaml
@@ -63,6 +63,9 @@
   <BoolProperty Name="DesignTime"
                 Visible="false" />
 
+  <BoolProperty Name="DesignTimeSharedInput"
+                Visible="false" />
+
   <StringProperty Name="Extension"
                   ReadOnly="true"
                   Visible="False">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/ApplicationDefinition.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/ApplicationDefinition.xaml
@@ -47,6 +47,9 @@
   <BoolProperty Name="DesignTime"
                 Visible="false" />
 
+  <BoolProperty Name="DesignTimeSharedInput"
+                Visible="false" />
+
   <StringProperty Name="FullPath"
                   ReadOnly="true"
                   Visible="false">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.BrowseObject.xaml
@@ -63,6 +63,9 @@
   <BoolProperty Name="DesignTime"
                 Visible="false" />
 
+  <BoolProperty Name="DesignTimeSharedInput"
+                Visible="false" />
+
   <StringProperty Name="Extension"
                   ReadOnly="true"
                   Visible="False">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.xaml
@@ -47,6 +47,9 @@
   <BoolProperty Name="DesignTime"
                 Visible="false" />
 
+  <BoolProperty Name="DesignTimeSharedInput"
+                Visible="false" />
+
   <StringProperty Name="FullPath"
                   ReadOnly="true"
                   Visible="false">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.BrowseObject.xaml
@@ -63,6 +63,9 @@
   <BoolProperty Name="DesignTime"
                 Visible="false" />
 
+  <BoolProperty Name="DesignTimeSharedInput"
+                Visible="false" />
+
   <StringProperty Name="Extension"
                   ReadOnly="true"
                   Visible="False">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.xaml
@@ -47,6 +47,9 @@
   <BoolProperty Name="DesignTime"
                 Visible="false" />
 
+  <BoolProperty Name="DesignTimeSharedInput"
+                Visible="false" />
+
   <StringProperty Name="FullPath"
                   ReadOnly="true"
                   Visible="false">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.BrowseObject.xaml
@@ -63,6 +63,9 @@
   <BoolProperty Name="DesignTime"
                 Visible="false" />
 
+  <BoolProperty Name="DesignTimeSharedInput"
+                Visible="false" />
+
   <StringProperty Name="Extension"
                   ReadOnly="true"
                   Visible="False">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.xaml
@@ -47,6 +47,9 @@
   <BoolProperty Name="DesignTime"
                 Visible="false" />
 
+  <BoolProperty Name="DesignTimeSharedInput"
+                Visible="false" />
+
   <StringProperty Name="FullPath"
                   ReadOnly="true"
                   Visible="false">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.BrowseObject.xaml
@@ -63,6 +63,9 @@
   <BoolProperty Name="DesignTime"
                 Visible="false" />
 
+  <BoolProperty Name="DesignTimeSharedInput"
+                Visible="false" />
+
   <StringProperty Name="Extension"
                   ReadOnly="true"
                   Visible="False">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.xaml
@@ -47,6 +47,9 @@
   <BoolProperty Name="DesignTime"
                 Visible="false" />
 
+  <BoolProperty Name="DesignTimeSharedInput"
+                Visible="false" />
+
   <StringProperty Name="FullPath"
                   ReadOnly="true"
                   Visible="false">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Page.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Page.BrowseObject.xaml
@@ -63,6 +63,9 @@
   <BoolProperty Name="DesignTime"
                 Visible="false" />
 
+  <BoolProperty Name="DesignTimeSharedInput"
+                Visible="false" />
+
   <StringProperty Name="Extension"
                   ReadOnly="true"
                   Visible="False">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Page.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Page.xaml
@@ -47,6 +47,9 @@
   <BoolProperty Name="DesignTime"
                 Visible="false" />
 
+  <BoolProperty Name="DesignTimeSharedInput"
+                Visible="false" />
+
   <StringProperty Name="FullPath"
                   ReadOnly="true"
                   Visible="false">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Resource.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Resource.BrowseObject.xaml
@@ -63,6 +63,9 @@
   <BoolProperty Name="DesignTime"
                 Visible="false" />
 
+  <BoolProperty Name="DesignTimeSharedInput"
+                Visible="false" />
+
   <StringProperty Name="Extension"
                   ReadOnly="true"
                   Visible="False">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Resource.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Resource.xaml
@@ -47,6 +47,9 @@
   <BoolProperty Name="DesignTime"
                 Visible="false" />
 
+  <BoolProperty Name="DesignTimeSharedInput"
+                Visible="false" />
+
   <StringProperty Name="FullPath"
                   ReadOnly="true"
                   Visible="false">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/XamlAppDef.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/XamlAppDef.BrowseObject.xaml
@@ -63,6 +63,9 @@
   <BoolProperty Name="DesignTime"
                 Visible="false" />
 
+  <BoolProperty Name="DesignTimeSharedInput"
+                Visible="false" />
+
   <StringProperty Name="Extension"
                   ReadOnly="true"
                   Visible="False">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/XamlAppDef.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/XamlAppDef.xaml
@@ -47,6 +47,9 @@
   <BoolProperty Name="DesignTime"
                 Visible="false" />
 
+  <BoolProperty Name="DesignTimeSharedInput"
+                Visible="false" />
+
   <StringProperty Name="FullPath"
                   ReadOnly="true"
                   Visible="false">


### PR DESCRIPTION
Needed for #4163 but also parity with legacy.