### PR TITLE
Provide an implementation of VSLangProj.BuildManager

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Automation/VsLangProjectPropertiesTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Automation/VsLangProjectPropertiesTests.cs
@@ -77,7 +77,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
                                 innerVSProjectMock.Object,
                                 threadingService: Mock.Of<IProjectThreadingService>(),
                                 projectProperties: Mock.Of<ActiveConfiguredProject<ProjectProperties>>(),
-                                project: unconfiguredProjectMock.Object);
+                                project: unconfiguredProjectMock.Object,
+                                buildManager: Mock.Of<BuildManager>());
 
             vsproject.SetImportsImpl(importsImpl);
             vsproject.SetVSProjectEventsImpl(vsProjectEventsImpl);
@@ -199,7 +200,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             var vsproject = CreateInstance(
                 Mock.Of<VSLangProj.VSProject>(),
                 threadingService: Mock.Of<IProjectThreadingService>(),
-                projectProperties: Mock.Of<ActiveConfiguredProject<ProjectProperties>>());
+                projectProperties: Mock.Of<ActiveConfiguredProject<ProjectProperties>>(),
+                buildManager: Mock.Of<BuildManager>());
             Assert.Null(vsproject.ExtenderCATID);
         }
 
@@ -207,14 +209,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             VSLangProj.VSProject vsproject = null,
             IProjectThreadingService threadingService = null,
             ActiveConfiguredProject<ProjectProperties> projectProperties = null,
-            UnconfiguredProject project = null)
+            UnconfiguredProject project = null,
+            BuildManager buildManager = null)
         {
             if (project == null)
             {
                 project = UnconfiguredProjectFactory.Create();
             }
 
-            return new VSProject(vsproject, threadingService, projectProperties, project);
+            return new VSProject(vsproject, threadingService, projectProperties, project, buildManager);
         }
 
         internal class VSProjectTestImpl : VSProject
@@ -223,8 +226,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
                 VSLangProj.VSProject vsProject,
                 IProjectThreadingService threadingService,
                 ActiveConfiguredProject<ProjectProperties> projectProperties,
-                UnconfiguredProject project)
-                : base(vsProject, threadingService, projectProperties, project)
+                UnconfiguredProject project,
+                BuildManager buildManager)
+                : base(vsProject, threadingService, projectProperties, project, buildManager)
             {
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsBuildManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsBuildManager.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
     /// Manages the portable executable (PE) files produced by running custom tools.
     /// </summary>
     [Export(typeof(BuildManager))]
-    [AppliesTo(ProjectCapability.CSharpOrVisualBasicLanguageService)]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
     [Order(Order.Default)]
     internal class VSBuildManager : ConnectionPointContainer,
                                     IEventSource<_dispBuildManagerEvents>,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsBuildManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsBuildManager.cs
@@ -1,0 +1,117 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+
+using Microsoft.VisualStudio.ProjectSystem.VS.ConnectionPoint;
+using VSLangProj;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
+{
+    /// <summary>
+    /// Manages the portable executable (PE) files produced by running custom tools.
+    /// </summary>
+    [Export(typeof(BuildManager))]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicLanguageService)]
+    [Order(Order.Default)]
+    internal class VSBuildManager : ConnectionPointContainer,
+                                    IEventSource<_dispBuildManagerEvents>,
+                                    BuildManager,
+                                    BuildManagerEvents
+    {
+        private readonly IProjectThreadingService _threadingService;
+        private readonly IUnconfiguredProjectCommonServices _unconfiguredProjectServices;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VSBuildManager"/> class.
+        /// </summary>
+        [ImportingConstructor]
+        internal VSBuildManager(IProjectThreadingService threadingService, IUnconfiguredProjectCommonServices unconfiguredProjectServices)
+        {
+            AddEventSource(this);
+            _threadingService = threadingService;
+            _unconfiguredProjectServices = unconfiguredProjectServices;
+
+            Project = new OrderPrecedenceImportCollection<VSLangProj.VSProject>(projectCapabilityCheckProvider: _unconfiguredProjectServices.Project);
+        }
+
+        [ImportMany(ExportContractNames.VsTypes.VSProject)]
+        internal OrderPrecedenceImportCollection<VSLangProj.VSProject> Project { get; }
+
+        /// <summary>
+        /// Occurs when a design time output moniker is deleted.
+        /// </summary>
+        public event _dispBuildManagerEvents_DesignTimeOutputDeletedEventHandler DesignTimeOutputDeleted;
+
+        /// <summary>
+        /// Occurs when a design time output moniker is dirty
+        /// </summary>
+        public event _dispBuildManagerEvents_DesignTimeOutputDirtyEventHandler DesignTimeOutputDirty;
+
+        /// <summary>
+        /// Gets the project of which the selected item is a part.
+        /// </summary>
+        public EnvDTE.Project ContainingProject => Project.FirstOrDefault()?.Value.Project;
+
+        /// <summary>
+        /// Gets the top-level extensibility object.
+        /// </summary>
+        public EnvDTE.DTE DTE => Project.FirstOrDefault()?.Value.DTE;
+
+        /// <summary>
+        /// Gets the immediate parent object of a given object.
+        /// </summary>
+        public object Parent => Project.FirstOrDefault()?.Value;
+
+        /// <summary>
+        /// Gets the temporary portable executable (PE) monikers for a project.
+        /// </summary>
+        public object DesignTimeOutputMonikers
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        /// <summary>
+        /// Builds a temporary portable executable (PE) and returns its description in an XML string.
+        /// </summary>
+        public string BuildDesignTimeOutput(string bstrOutputMoniker)
+        {
+            throw new NotImplementedException();
+        }
+
+        void IEventSource<_dispBuildManagerEvents>.OnSinkAdded(_dispBuildManagerEvents sink)
+        {
+            DesignTimeOutputDeleted += new _dispBuildManagerEvents_DesignTimeOutputDeletedEventHandler(sink.DesignTimeOutputDeleted);
+            DesignTimeOutputDirty += new _dispBuildManagerEvents_DesignTimeOutputDirtyEventHandler(sink.DesignTimeOutputDirty);
+        }
+
+        void IEventSource<_dispBuildManagerEvents>.OnSinkRemoved(_dispBuildManagerEvents sink)
+        {
+            DesignTimeOutputDeleted -= new _dispBuildManagerEvents_DesignTimeOutputDeletedEventHandler(sink.DesignTimeOutputDeleted);
+            DesignTimeOutputDirty -= new _dispBuildManagerEvents_DesignTimeOutputDirtyEventHandler(sink.DesignTimeOutputDirty);
+        }
+
+        /// <summary>
+        /// Occurs when a design time output moniker is deleted.
+        /// </summary>
+        internal virtual void OnDesignTimeOutputDeleted(string outputMoniker)
+        {
+            _threadingService.VerifyOnUIThread();
+
+            DesignTimeOutputDeleted?.Invoke(outputMoniker);
+        }
+
+        /// <summary>
+        /// Occurs when a design time output moniker is dirty.
+        /// </summary>
+        internal virtual void OnDesignTimeOutputDirty(string outputMoniker)
+        {
+            _threadingService.VerifyOnUIThread();
+
+            DesignTimeOutputDirty?.Invoke(outputMoniker);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsProject.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsProject.cs
@@ -30,17 +30,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
         private readonly VSLangProj.VSProject _vsProject;
         private readonly IProjectThreadingService _threadingService;
         private readonly ActiveConfiguredProject<ProjectProperties> _projectProperties;
+        private readonly BuildManager _buildManager;
 
         [ImportingConstructor]
         internal VSProject(
             [Import(ExportContractNames.VsTypes.CpsVSProject)] VSLangProj.VSProject vsProject,
             IProjectThreadingService threadingService,
             ActiveConfiguredProject<ProjectProperties> projectProperties,
-            UnconfiguredProject project)
+            UnconfiguredProject project,
+            BuildManager buildManager)
         {
             _vsProject = vsProject;
             _threadingService = threadingService;
             _projectProperties = projectProperties;
+            _buildManager = buildManager;
 
             ImportsImpl = new OrderPrecedenceImportCollection<Imports>(projectCapabilityCheckProvider: project);
             VSProjectEventsImpl = new OrderPrecedenceImportCollection<VSProjectEvents>(projectCapabilityCheckProvider: project);
@@ -54,7 +57,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
 
         public VSLangProj.References References => _vsProject.References;
 
-        public BuildManager BuildManager => _vsProject.BuildManager;
+        public BuildManager BuildManager => _buildManager;
 
         public DTE DTE => _vsProject.DTE;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapability.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapability.cs
@@ -15,6 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public const string CSharpAppDesigner = ProjectCapabilities.CSharp + " & " + AppDesigner;
         public const string FSharpAppDesigner = FSharp + " & " + AppDesigner;
         public const string CSharpOrVisualBasic = "(" + ProjectCapabilities.CSharp + " | " + ProjectCapabilities.VB + ")";
+        public const string CSharpOrVisualBasicLanguageService = CSharpOrVisualBasic + " & " + LanguageService;
 
         public const string AppDesigner = nameof(AppDesigner);
         public const string AppSettings = nameof(AppSettings);


### PR DESCRIPTION
Part of #4163

Initially this implementation just matches the [CPS implementation](https://devdiv.visualstudio.com/DevDiv/_git/CPS?path=%2Fsrc%2FMicrosoft.VisualStudio.ProjectSystem.VS.Implementation%2FPackage%2FAutomation%2FVSProject%2FOAVSBuildManager.cs&version=GBmaster). The two TempPE related methods will be filled out in a future PR.