### PR TITLE
Allow running a task on a TaskDelayScheduler immediately

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Threading/Tasks/TaskDelaySchedulerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Threading/Tasks/TaskDelaySchedulerTests.cs
@@ -66,6 +66,32 @@ namespace Microsoft.VisualStudio.Threading.Tasks
         }
 
         [Fact]
+        public async Task RunAsyncTask_SkipsPendingTasks()
+        {
+            using (var scheduler = new TaskDelayScheduler(TimeSpan.FromMilliseconds(250), IProjectThreadingServiceFactory.Create(), CancellationToken.None))
+            {
+                bool taskRan = false;
+                var task = scheduler.ScheduleAsyncTask(ct =>
+                {
+                    taskRan = true;
+                    return Task.CompletedTask;
+                });
+
+                bool immediateTaskRan = false;
+                var task2 = scheduler.RunAsyncTask(ct =>
+                {
+                    immediateTaskRan = true;
+                    return Task.CompletedTask;
+                });
+
+                await task;
+                await task2;
+                Assert.False(taskRan);
+                Assert.True(immediateTaskRan);
+            }
+        }
+
+        [Fact]
         public async Task Dispose_SkipsPendingTasks()
         {
             using (var scheduler = new TaskDelayScheduler(TimeSpan.FromMilliseconds(250), IProjectThreadingServiceFactory.Create(), CancellationToken.None))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/ITaskDelayScheduler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/ITaskDelayScheduler.cs
@@ -28,5 +28,11 @@ namespace Microsoft.VisualStudio.Threading.Tasks
         /// </remarks>
         /// <exception cref="ObjectDisposedException">The object has been disposed.</exception>
         JoinableTask ScheduleAsyncTask(Func<CancellationToken, Task> operation, CancellationToken token = default);
+
+        /// <summary>
+        /// Runs an asynchronous operation immediately, cancelling any previously scheduled tasks.
+        /// See <see cref="ScheduleAsyncTask(Func{CancellationToken, Task}, CancellationToken)"/> for more information.
+        /// </summary>
+        JoinableTask RunAsyncTask(Func<CancellationToken, Task> operation, CancellationToken token = default);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/ITaskDelayScheduler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/ITaskDelayScheduler.cs
@@ -33,6 +33,7 @@ namespace Microsoft.VisualStudio.Threading.Tasks
         /// Runs an asynchronous operation immediately, cancelling any previously scheduled tasks.
         /// See <see cref="ScheduleAsyncTask(Func{CancellationToken, Task}, CancellationToken)"/> for more information.
         /// </summary>
+        /// <exception cref="ObjectDisposedException">The object has been disposed.</exception>
         JoinableTask RunAsyncTask(Func<CancellationToken, Task> operation, CancellationToken token = default);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/TaskDelayScheduler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/TaskDelayScheduler.cs
@@ -33,13 +33,13 @@ namespace Microsoft.VisualStudio.Threading.Tasks
         /// <inheritdoc />
         public JoinableTask RunAsyncTask(Func<CancellationToken, Task> operation, CancellationToken token = default)
         {
-            return ScheduleAsyncTaskInternal(operation, true, token);
+            return ScheduleAsyncTaskInternal(operation, immediate: true, token);
         }
 
         /// <inheritdoc />
         public JoinableTask ScheduleAsyncTask(Func<CancellationToken, Task> operation, CancellationToken token = default)
         {
-            return ScheduleAsyncTaskInternal(operation, false, token);
+            return ScheduleAsyncTaskInternal(operation, immediate: false, token);
         }
 
         private JoinableTask ScheduleAsyncTaskInternal(Func<CancellationToken, Task> operation, bool immediate, CancellationToken token)
@@ -64,12 +64,14 @@ namespace Microsoft.VisualStudio.Threading.Tasks
                     {
                         return;
                     }
+
+                    if (nextToken.IsCancellationRequested)
+                    {
+                        return;
+                    }
                 }
 
-                if (!nextToken.IsCancellationRequested)
-                {
-                    await operation(nextToken);
-                }
+                await operation(nextToken);
             });
         }
 


### PR DESCRIPTION
Part of #4163

This adds a mechanism to TaskDelayScheduler to run a task without delay, cancelling any pending tasks that hadn't run yet.