### PR TITLE
Fix a timing issue inside dependencies tree code:

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Snapshot/IDependenciesSnapshotProvider.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks.Dataflow;
 using Microsoft.VisualStudio.Composition;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
@@ -19,6 +20,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         /// Never null.
         /// </remarks>
         IDependenciesSnapshot CurrentSnapshot { get; }
+
+        /// <summary>
+        /// Dataflow to monitor the project snapshot changes.
+        /// </summary>
+        IReceivableSourceBlock<SnapshotChangedEventArgs> SnapshotChangedSource { get; }
 
         /// <summary>
         /// Raised when the project's full path changes (i.e. due to being renamed).

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
@@ -219,6 +219,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             _dependenciesUpdateScheduler.Dispose();
 
             _contextUpdateGate.Dispose();
+            _snapshotChangedSource.Complete();
 
             if (initialized)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
@@ -7,7 +7,7 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-
+using System.Threading.Tasks.Dataflow;
 using Microsoft.Build.Execution;
 using Microsoft.VisualStudio.Build;
 using Microsoft.VisualStudio.Composition;
@@ -54,6 +54,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
         private ImmutableArray<IDependencyCrossTargetSubscriber> _subscribers;
         private DependenciesSnapshot _currentSnapshot;
         private int _isInitialized;
+
+        private readonly IBroadcastBlock<SnapshotChangedEventArgs> _snapshotChangedSource;
 
         /// <summary>
         ///     Current <see cref="AggregateCrossTargetProjectContext"/>, which is an immutable map of
@@ -113,10 +115,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 commonServices.ThreadingService,
                 tasksService.UnloadCancellationToken);
 
+            _snapshotChangedSource = DataflowBlockSlim.CreateBroadcastBlock<SnapshotChangedEventArgs>("DependenciesSnapshot {1}", skipIntermediateInputData: true);
+
             aggregateSnapshotProvider.RegisterSnapshotProvider(this);
         }
 
         public IDependenciesSnapshot CurrentSnapshot => _currentSnapshot;
+
+        IReceivableSourceBlock<SnapshotChangedEventArgs> IDependenciesSnapshotProvider.SnapshotChangedSource => _snapshotChangedSource;
 
         private ImmutableArray<IDependencyCrossTargetSubscriber> Subscribers
         {
@@ -539,7 +545,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                     // Always publish the latest snapshot
                     IDependenciesSnapshot snapshot = _currentSnapshot;
 
-                    SnapshotChanged?.Invoke(this, new SnapshotChangedEventArgs(snapshot, ct));
+                    var events = new SnapshotChangedEventArgs(snapshot, ct);
+                    _snapshotChangedSource.Post(events);
+                    SnapshotChanged?.Invoke(this, events);
 
                     return Task.CompletedTask;
                 }, token);


### PR DESCRIPTION
When the tree provider is initialized later, it can register an event handler after the event is fired.  This can lead into an empty tree.  It happens when it is hosted outside of VS.