### PR TITLE
Mark ProjectAssetsFileWatcher with "PackageReferences"

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.ProjectAssetFileWatcherInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.ProjectAssetFileWatcherInstance.cs
@@ -6,14 +6,12 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Threading;
-using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.Threading;
 using Microsoft.VisualStudio.Threading.Tasks;
 
 using Task = System.Threading.Tasks.Task;
@@ -97,9 +95,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         /// <summary>
         /// Initialize the watcher.
         /// </summary>
-        protected override async Task InitializeCoreAsync(CancellationToken cancellationToken)
+        protected override Task InitializeCoreAsync(CancellationToken cancellationToken)
         {
-            await _projectTasksService.LoadedProjectAsync(() =>
+            return _projectTasksService.LoadedProjectAsync(() =>
             {
                 // The tree source to get changes to the tree so that we can identify when the assets file changes.
                 ProjectDataSources.SourceBlockAndLink<IProjectVersionedValue<IProjectTreeSnapshot>> treeSource = _fileSystemTreeProvider.Tree.SyncLinkOptions();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.ProjectAssetFileWatcherInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.ProjectAssetFileWatcherInstance.cs
@@ -68,8 +68,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         /// </summary>
         internal async Task DataFlow_ChangedAsync(IProjectVersionedValue<Tuple<IProjectTreeSnapshot, IProjectSubscriptionUpdate>> dataFlowUpdate)
         {
-            await InitializeAsync();
-
             IProjectTreeSnapshot treeSnapshot = dataFlowUpdate.Value.Item1;
             IProjectTree newTree = treeSnapshot.Tree;
             if (newTree == null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.ProjectAssetFileWatcherInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.ProjectAssetFileWatcherInstance.cs
@@ -18,296 +18,299 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
 {
-    internal class ProjectAssetFileWatcherInstance : OnceInitializedOnceDisposedAsync, IMultiLifetimeInstance, IVsFreeThreadedFileChangeEvents2
+    internal partial class ProjectAssetFileWatcher
     {
-        private static readonly TimeSpan s_notifyDelay = TimeSpan.FromMilliseconds(100);
-
-        private readonly IVsService<IVsAsyncFileChangeEx> _fileChangeService;
-        private readonly IUnconfiguredProjectCommonServices _projectServices;
-        private readonly IUnconfiguredProjectTasksService _projectTasksService;
-        private readonly IActiveConfiguredProjectSubscriptionService _activeConfiguredProjectSubscriptionService;
-        private readonly IProjectTreeProvider _fileSystemTreeProvider;
-
-        private CancellationTokenSource _watchedFileResetCancellationToken;
-        private ITaskDelayScheduler _taskDelayScheduler;
-        private IDisposable _treeWatcher;
-        private uint _filechangeCookie;
-        private string _fileBeingWatched;
-        private byte[] _previousContentsHash;
-
-        public ProjectAssetFileWatcherInstance(
-            IVsService<IVsAsyncFileChangeEx> fileChangeService,
-            IProjectTreeProvider fileSystemTreeProvider,
-            IUnconfiguredProjectCommonServices projectServices,
-            IUnconfiguredProjectTasksService projectTasksService,
-            IActiveConfiguredProjectSubscriptionService activeConfiguredProjectSubscriptionService)
-            : base(projectServices.ThreadingService.JoinableTaskContext)
+        internal class ProjectAssetFileWatcherInstance : OnceInitializedOnceDisposedAsync, IMultiLifetimeInstance, IVsFreeThreadedFileChangeEvents2
         {
-            Requires.NotNull(fileChangeService, nameof(fileChangeService));
-            Requires.NotNull(fileSystemTreeProvider, nameof(fileSystemTreeProvider));
-            Requires.NotNull(projectServices, nameof(projectServices));
-            Requires.NotNull(projectTasksService, nameof(projectTasksService));
-            Requires.NotNull(activeConfiguredProjectSubscriptionService, nameof(activeConfiguredProjectSubscriptionService));
+            private static readonly TimeSpan s_notifyDelay = TimeSpan.FromMilliseconds(100);
 
-            _fileChangeService = fileChangeService;
-            _fileSystemTreeProvider = fileSystemTreeProvider;
-            _projectServices = projectServices;
-            _projectTasksService = projectTasksService;
-            _activeConfiguredProjectSubscriptionService = activeConfiguredProjectSubscriptionService;
-        }
+            private readonly IVsService<IVsAsyncFileChangeEx> _fileChangeService;
+            private readonly IUnconfiguredProjectCommonServices _projectServices;
+            private readonly IUnconfiguredProjectTasksService _projectTasksService;
+            private readonly IActiveConfiguredProjectSubscriptionService _activeConfiguredProjectSubscriptionService;
+            private readonly IProjectTreeProvider _fileSystemTreeProvider;
 
-        public Task InitializeAsync()
-        {
-            return InitializeAsync(CancellationToken.None);
-        }
+            private CancellationTokenSource _watchedFileResetCancellationToken;
+            private ITaskDelayScheduler _taskDelayScheduler;
+            private IDisposable _treeWatcher;
+            private uint _filechangeCookie;
+            private string _fileBeingWatched;
+            private byte[] _previousContentsHash;
 
-        /// <summary>
-        /// Called on changes to the project tree.
-        /// </summary>
-        internal async Task DataFlow_ChangedAsync(IProjectVersionedValue<Tuple<IProjectTreeSnapshot, IProjectSubscriptionUpdate>> dataFlowUpdate)
-        {
-            IProjectTreeSnapshot treeSnapshot = dataFlowUpdate.Value.Item1;
-            IProjectTree newTree = treeSnapshot.Tree;
-            if (newTree == null)
+            public ProjectAssetFileWatcherInstance(
+                IVsService<IVsAsyncFileChangeEx> fileChangeService,
+                IProjectTreeProvider fileSystemTreeProvider,
+                IUnconfiguredProjectCommonServices projectServices,
+                IUnconfiguredProjectTasksService projectTasksService,
+                IActiveConfiguredProjectSubscriptionService activeConfiguredProjectSubscriptionService)
+                : base(projectServices.ThreadingService.JoinableTaskContext)
             {
-                return;
+                Requires.NotNull(fileChangeService, nameof(fileChangeService));
+                Requires.NotNull(fileSystemTreeProvider, nameof(fileSystemTreeProvider));
+                Requires.NotNull(projectServices, nameof(projectServices));
+                Requires.NotNull(projectTasksService, nameof(projectTasksService));
+                Requires.NotNull(activeConfiguredProjectSubscriptionService, nameof(activeConfiguredProjectSubscriptionService));
+
+                _fileChangeService = fileChangeService;
+                _fileSystemTreeProvider = fileSystemTreeProvider;
+                _projectServices = projectServices;
+                _projectTasksService = projectTasksService;
+                _activeConfiguredProjectSubscriptionService = activeConfiguredProjectSubscriptionService;
             }
 
-            // If tree changed when we are disposing then ignore the change.
-            if (IsDisposing)
+            public Task InitializeAsync()
             {
-                return;
+                return InitializeAsync(CancellationToken.None);
             }
 
-            // NOTE: Project lock file path may be null
-            IProjectSubscriptionUpdate projectUpdate = dataFlowUpdate.Value.Item2;
-            string projectLockFilePath = GetProjectAssetsFilePath(newTree, projectUpdate);
-
-            // project.json may have been renamed to {projectName}.project.json or in the case of the project.assets.json,
-            // the immediate path could have changed. In either case, change the file watcher.
-            if (!PathHelper.IsSamePath(projectLockFilePath, _fileBeingWatched))
+            /// <summary>
+            /// Called on changes to the project tree.
+            /// </summary>
+            internal async Task DataFlow_ChangedAsync(IProjectVersionedValue<Tuple<IProjectTreeSnapshot, IProjectSubscriptionUpdate>> dataFlowUpdate)
             {
-                await UnregisterFileWatcherIfAnyAsync();
-                await RegisterFileWatcherAsync(projectLockFilePath);
+                IProjectTreeSnapshot treeSnapshot = dataFlowUpdate.Value.Item1;
+                IProjectTree newTree = treeSnapshot.Tree;
+                if (newTree == null)
+                {
+                    return;
+                }
+
+                // If tree changed when we are disposing then ignore the change.
+                if (IsDisposing)
+                {
+                    return;
+                }
+
+                // NOTE: Project lock file path may be null
+                IProjectSubscriptionUpdate projectUpdate = dataFlowUpdate.Value.Item2;
+                string projectLockFilePath = GetProjectAssetsFilePath(newTree, projectUpdate);
+
+                // project.json may have been renamed to {projectName}.project.json or in the case of the project.assets.json,
+                // the immediate path could have changed. In either case, change the file watcher.
+                if (!PathHelper.IsSamePath(projectLockFilePath, _fileBeingWatched))
+                {
+                    await UnregisterFileWatcherIfAnyAsync();
+                    await RegisterFileWatcherAsync(projectLockFilePath);
+                }
             }
-        }
 
-        /// <summary>
-        /// Initialize the watcher.
-        /// </summary>
-        protected override Task InitializeCoreAsync(CancellationToken cancellationToken)
-        {
-            return _projectTasksService.LoadedProjectAsync(() =>
+            /// <summary>
+            /// Initialize the watcher.
+            /// </summary>
+            protected override Task InitializeCoreAsync(CancellationToken cancellationToken)
             {
+                return _projectTasksService.LoadedProjectAsync(() =>
+                {
                 // The tree source to get changes to the tree so that we can identify when the assets file changes.
                 ProjectDataSources.SourceBlockAndLink<IProjectVersionedValue<IProjectTreeSnapshot>> treeSource = _fileSystemTreeProvider.Tree.SyncLinkOptions();
 
                 // The property source used to get the value of the $ProjectAssetsFile property so that we can identify the location of the assets file.
                 StandardRuleDataflowLinkOptions sourceLinkOptions = DataflowOption.WithRuleNames(ConfigurationGeneral.SchemaName);
 
-                ProjectDataSources.SourceBlockAndLink<IProjectVersionedValue<IProjectSubscriptionUpdate>> propertySource = _activeConfiguredProjectSubscriptionService.ProjectRuleSource.SourceBlock.SyncLinkOptions(sourceLinkOptions);
-                ITargetBlock<IProjectVersionedValue<Tuple<IProjectTreeSnapshot, IProjectSubscriptionUpdate>>> target = DataflowBlockSlim.CreateActionBlock<IProjectVersionedValue<Tuple<IProjectTreeSnapshot, IProjectSubscriptionUpdate>>>(DataFlow_ChangedAsync);
+                    ProjectDataSources.SourceBlockAndLink<IProjectVersionedValue<IProjectSubscriptionUpdate>> propertySource = _activeConfiguredProjectSubscriptionService.ProjectRuleSource.SourceBlock.SyncLinkOptions(sourceLinkOptions);
+                    ITargetBlock<IProjectVersionedValue<Tuple<IProjectTreeSnapshot, IProjectSubscriptionUpdate>>> target = DataflowBlockSlim.CreateActionBlock<IProjectVersionedValue<Tuple<IProjectTreeSnapshot, IProjectSubscriptionUpdate>>>(DataFlow_ChangedAsync);
 
                 // Join the two sources so that we get synchronized versions of the data.
                 _treeWatcher = ProjectDataSources.SyncLinkTo(treeSource, propertySource, target);
 
-                return Task.CompletedTask;
-            });
-        }
-
-        protected override async Task DisposeCoreAsync(bool initialized)
-        {
-            if (initialized)
-            {
-                _taskDelayScheduler?.Dispose();
-                _treeWatcher.Dispose();
-                await UnregisterFileWatcherIfAnyAsync();
+                    return Task.CompletedTask;
+                });
             }
-        }
 
-        private static byte[] GetFileHashOrNull(string path)
-        {
-            byte[] hash = null;
-
-            try
+            protected override async Task DisposeCoreAsync(bool initialized)
             {
-                using (var hasher = SHA256.Create())
-                using (FileStream file = File.OpenRead(path))
+                if (initialized)
                 {
-                    file.Position = 0;
-                    hash = hasher.ComputeHash(file);
+                    _taskDelayScheduler?.Dispose();
+                    _treeWatcher.Dispose();
+                    await UnregisterFileWatcherIfAnyAsync();
                 }
             }
-            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+
+            private static byte[] GetFileHashOrNull(string path)
             {
+                byte[] hash = null;
+
+                try
+                {
+                    using (var hasher = SHA256.Create())
+                    using (FileStream file = File.OpenRead(path))
+                    {
+                        file.Position = 0;
+                        hash = hasher.ComputeHash(file);
+                    }
+                }
+                catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+                {
+                }
+
+                return hash;
             }
 
-            return hash;
-        }
-
-        private static string GetProjectAssetsFilePath(IProjectTree newTree, IProjectSubscriptionUpdate projectUpdate)
-        {
-            string projectFilePath = projectUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildProjectFullPathProperty, null);
-
-            // First check to see if the project has a project.json.
-            IProjectTree projectJsonNode = FindProjectJsonNode(newTree, projectFilePath);
-            if (projectJsonNode != null)
+            private static string GetProjectAssetsFilePath(IProjectTree newTree, IProjectSubscriptionUpdate projectUpdate)
             {
-                string projectDirectory = Path.GetDirectoryName(projectFilePath);
-                string projectLockJsonFilePath = Path.ChangeExtension(PathHelper.Combine(projectDirectory, projectJsonNode.Caption), ".lock.json");
-                return projectLockJsonFilePath;
+                string projectFilePath = projectUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildProjectFullPathProperty, null);
+
+                // First check to see if the project has a project.json.
+                IProjectTree projectJsonNode = FindProjectJsonNode(newTree, projectFilePath);
+                if (projectJsonNode != null)
+                {
+                    string projectDirectory = Path.GetDirectoryName(projectFilePath);
+                    string projectLockJsonFilePath = Path.ChangeExtension(PathHelper.Combine(projectDirectory, projectJsonNode.Caption), ".lock.json");
+                    return projectLockJsonFilePath;
+                }
+
+                // If there is no project.json then get the patch to obj\project.assets.json file which is generated for projects
+                // with <PackageReference> items.
+                string objDirectory = projectUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.BaseIntermediateOutputPathProperty, null);
+
+                if (string.IsNullOrEmpty(objDirectory))
+                {
+                    // Don't have an intermediate directory set, probably missing SDK attribute or Microsoft.Common.props
+                    return null;
+                }
+
+                objDirectory = PathHelper.MakeRooted(projectFilePath, objDirectory);
+                string projectAssetsFilePath = PathHelper.Combine(objDirectory, "project.assets.json");
+                return projectAssetsFilePath;
             }
 
-            // If there is no project.json then get the patch to obj\project.assets.json file which is generated for projects
-            // with <PackageReference> items.
-            string objDirectory = projectUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.BaseIntermediateOutputPathProperty, null);
-
-            if (string.IsNullOrEmpty(objDirectory))
+            private static IProjectTree FindProjectJsonNode(IProjectTree newTree, string projectFilePath)
             {
-                // Don't have an intermediate directory set, probably missing SDK attribute or Microsoft.Common.props
+                if (newTree.TryFindImmediateChild("project.json", out IProjectTree projectJsonNode))
+                {
+                    return projectJsonNode;
+                }
+
+                string projectName = Path.GetFileNameWithoutExtension(projectFilePath);
+                if (newTree.TryFindImmediateChild($"{projectName}.project.json", out projectJsonNode))
+                {
+                    return projectJsonNode;
+                }
+
                 return null;
             }
 
-            objDirectory = PathHelper.MakeRooted(projectFilePath, objDirectory);
-            string projectAssetsFilePath = PathHelper.Combine(objDirectory, "project.assets.json");
-            return projectAssetsFilePath;
-        }
-
-        private static IProjectTree FindProjectJsonNode(IProjectTree newTree, string projectFilePath)
-        {
-            if (newTree.TryFindImmediateChild("project.json", out IProjectTree projectJsonNode))
+            private async Task RegisterFileWatcherAsync(string projectLockJsonFilePath)
             {
-                return projectJsonNode;
-            }
-
-            string projectName = Path.GetFileNameWithoutExtension(projectFilePath);
-            if (newTree.TryFindImmediateChild($"{projectName}.project.json", out projectJsonNode))
-            {
-                return projectJsonNode;
-            }
-
-            return null;
-        }
-
-        private async Task RegisterFileWatcherAsync(string projectLockJsonFilePath)
-        {
-            // Note file change service is free-threaded
-            if (projectLockJsonFilePath != null)
-            {
-                _previousContentsHash = GetFileHashOrNull(projectLockJsonFilePath);
-                _taskDelayScheduler?.Dispose();
-                _taskDelayScheduler = new TaskDelayScheduler(
-                    s_notifyDelay,
-                    _projectServices.ThreadingService,
-                    CreateLinkedCancellationToken());
-
-                IVsAsyncFileChangeEx fileChangeService = await _fileChangeService.GetValueAsync();
-                _filechangeCookie = await fileChangeService.AdviseFileChangeAsync(
-                    projectLockJsonFilePath,
-                    _VSFILECHANGEFLAGS.VSFILECHG_Time | _VSFILECHANGEFLAGS.VSFILECHG_Size | _VSFILECHANGEFLAGS.VSFILECHG_Add | _VSFILECHANGEFLAGS.VSFILECHG_Del,
-                    sink: this);
-            }
-
-            _fileBeingWatched = projectLockJsonFilePath;
-        }
-
-        private async Task UnregisterFileWatcherIfAnyAsync()
-        {
-            // Note file change service is free-threaded
-            if (_filechangeCookie != VSConstants.VSCOOKIE_NIL)
-            {
-                IVsAsyncFileChangeEx fileChangeService = await _fileChangeService.GetValueAsync();
-
-                // There's nothing for us to do if this fails. So ignore the return value.
-                await fileChangeService.UnadviseFileChangeAsync(_filechangeCookie);
-                _watchedFileResetCancellationToken?.Cancel();
-                _watchedFileResetCancellationToken?.Dispose();
-                _taskDelayScheduler?.Dispose();
-            }
-        }
-
-        private CancellationToken CreateLinkedCancellationToken()
-        {
-            // we want to cancel when we switch what file is watched, or when the project is unloaded
-            if (_projectServices?.Project?.Services?.ProjectAsynchronousTasks?.UnloadCancellationToken != null)
-            {
-                _watchedFileResetCancellationToken = CancellationTokenSource.CreateLinkedTokenSource(
-                    _projectServices.Project.Services.ProjectAsynchronousTasks.UnloadCancellationToken);
-            }
-            else
-            {
-                _watchedFileResetCancellationToken = new CancellationTokenSource();
-            }
-
-            return _watchedFileResetCancellationToken.Token;
-        }
-
-        private async Task HandleFileChangedAsync(CancellationToken cancellationToken)
-        {
-            try
-            {
-                // Only notify the project if the contents of the watched file have changed.
-                // In the case if we fail to read the contents, we will opt to notify the project.
-                byte[] newHash = GetFileHashOrNull(_fileBeingWatched);
-                if (newHash == null || _previousContentsHash == null || !newHash.SequenceEqual(_previousContentsHash))
+                // Note file change service is free-threaded
+                if (projectLockJsonFilePath != null)
                 {
-                    TraceUtilities.TraceVerbose("{0} changed on disk. Marking project dirty", _fileBeingWatched);
-                    _previousContentsHash = newHash;
-                    cancellationToken.ThrowIfCancellationRequested();
-                    await _projectTasksService.LoadedProjectAsync(() =>
-                    {
-                        return _projectServices.ProjectAccessor.EnterWriteLockAsync(async (collection, token) =>
-                        {
-                            // notify all the loaded configured projects
-                            IEnumerable<ConfiguredProject> currentProjects = _projectServices.Project.LoadedConfiguredProjects;
-                            foreach (ConfiguredProject configuredProject in currentProjects)
-                            {
-                                await _projectServices.ProjectAccessor.OpenProjectForWriteAsync(configuredProject, project =>
-                                {
-                                    project.MarkDirty();
-                                    configuredProject.NotifyProjectChange();
+                    _previousContentsHash = GetFileHashOrNull(projectLockJsonFilePath);
+                    _taskDelayScheduler?.Dispose();
+                    _taskDelayScheduler = new TaskDelayScheduler(
+                        s_notifyDelay,
+                        _projectServices.ThreadingService,
+                        CreateLinkedCancellationToken());
 
-                                }, ProjectCheckoutOption.DoNotCheckout, cancellationToken); // Stay on same thread that took lock
-                            }
-                        }, cancellationToken); // Stay on same thread that took lock
-                    });
+                    IVsAsyncFileChangeEx fileChangeService = await _fileChangeService.GetValueAsync();
+                    _filechangeCookie = await fileChangeService.AdviseFileChangeAsync(
+                        projectLockJsonFilePath,
+                        _VSFILECHANGEFLAGS.VSFILECHG_Time | _VSFILECHANGEFLAGS.VSFILECHG_Size | _VSFILECHANGEFLAGS.VSFILECHG_Add | _VSFILECHANGEFLAGS.VSFILECHG_Del,
+                        sink: this);
+                }
+
+                _fileBeingWatched = projectLockJsonFilePath;
+            }
+
+            private async Task UnregisterFileWatcherIfAnyAsync()
+            {
+                // Note file change service is free-threaded
+                if (_filechangeCookie != VSConstants.VSCOOKIE_NIL)
+                {
+                    IVsAsyncFileChangeEx fileChangeService = await _fileChangeService.GetValueAsync();
+
+                    // There's nothing for us to do if this fails. So ignore the return value.
+                    await fileChangeService.UnadviseFileChangeAsync(_filechangeCookie);
+                    _watchedFileResetCancellationToken?.Cancel();
+                    _watchedFileResetCancellationToken?.Dispose();
+                    _taskDelayScheduler?.Dispose();
+                }
+            }
+
+            private CancellationToken CreateLinkedCancellationToken()
+            {
+                // we want to cancel when we switch what file is watched, or when the project is unloaded
+                if (_projectServices?.Project?.Services?.ProjectAsynchronousTasks?.UnloadCancellationToken != null)
+                {
+                    _watchedFileResetCancellationToken = CancellationTokenSource.CreateLinkedTokenSource(
+                        _projectServices.Project.Services.ProjectAsynchronousTasks.UnloadCancellationToken);
                 }
                 else
                 {
-                    TraceUtilities.TraceWarning("{0} changed on disk, but has no actual content change.", _fileBeingWatched);
+                    _watchedFileResetCancellationToken = new CancellationTokenSource();
+                }
+
+                return _watchedFileResetCancellationToken.Token;
+            }
+
+            private async Task HandleFileChangedAsync(CancellationToken cancellationToken)
+            {
+                try
+                {
+                    // Only notify the project if the contents of the watched file have changed.
+                    // In the case if we fail to read the contents, we will opt to notify the project.
+                    byte[] newHash = GetFileHashOrNull(_fileBeingWatched);
+                    if (newHash == null || _previousContentsHash == null || !newHash.SequenceEqual(_previousContentsHash))
+                    {
+                        TraceUtilities.TraceVerbose("{0} changed on disk. Marking project dirty", _fileBeingWatched);
+                        _previousContentsHash = newHash;
+                        cancellationToken.ThrowIfCancellationRequested();
+                        await _projectTasksService.LoadedProjectAsync(() =>
+                        {
+                            return _projectServices.ProjectAccessor.EnterWriteLockAsync(async (collection, token) =>
+                            {
+                            // notify all the loaded configured projects
+                            IEnumerable<ConfiguredProject> currentProjects = _projectServices.Project.LoadedConfiguredProjects;
+                                foreach (ConfiguredProject configuredProject in currentProjects)
+                                {
+                                    await _projectServices.ProjectAccessor.OpenProjectForWriteAsync(configuredProject, project =>
+                                    {
+                                        project.MarkDirty();
+                                        configuredProject.NotifyProjectChange();
+
+                                    }, ProjectCheckoutOption.DoNotCheckout, cancellationToken); // Stay on same thread that took lock
+                            }
+                            }, cancellationToken); // Stay on same thread that took lock
+                    });
+                    }
+                    else
+                    {
+                        TraceUtilities.TraceWarning("{0} changed on disk, but has no actual content change.", _fileBeingWatched);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // Project is already unloaded
                 }
             }
-            catch (OperationCanceledException)
+
+            /// <summary>
+            /// Called when a project.lock.json file changes.
+            /// </summary>
+            public int FilesChanged(uint cChanges, string[] rgpszFile, uint[] rggrfChange)
             {
-                // Project is already unloaded
+                // Kick off the operation to notify the project change in a different thread regardless of
+                // the kind of change since we are interested in all changes.
+                _taskDelayScheduler.ScheduleAsyncTask(HandleFileChangedAsync);
+
+                return VSConstants.S_OK;
             }
-        }
 
-        /// <summary>
-        /// Called when a project.lock.json file changes.
-        /// </summary>
-        public int FilesChanged(uint cChanges, string[] rgpszFile, uint[] rggrfChange)
-        {
-            // Kick off the operation to notify the project change in a different thread regardless of
-            // the kind of change since we are interested in all changes.
-            _taskDelayScheduler.ScheduleAsyncTask(HandleFileChangedAsync);
+            public int DirectoryChanged(string pszDirectory)
+            {
+                return VSConstants.E_NOTIMPL;
+            }
 
-            return VSConstants.S_OK;
-        }
+            public int DirectoryChangedEx(string pszDirectory, string pszFile)
+            {
+                return VSConstants.E_NOTIMPL;
+            }
 
-        public int DirectoryChanged(string pszDirectory)
-        {
-            return VSConstants.E_NOTIMPL;
-        }
-
-        public int DirectoryChangedEx(string pszDirectory, string pszFile)
-        {
-            return VSConstants.E_NOTIMPL;
-        }
-
-        public int DirectoryChangedEx2(string pszDirectory, uint cChanges, string[] rgpszFile, uint[] rggrfChange)
-        {
-            return VSConstants.E_NOTIMPL;
+            public int DirectoryChangedEx2(string pszDirectory, uint cChanges, string[] rgpszFile, uint[] rggrfChange)
+            {
+                return VSConstants.E_NOTIMPL;
+            }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.ProjectAssetFileWatcherInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.ProjectAssetFileWatcherInstance.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.Composition;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -102,9 +101,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         /// </summary>
         protected override async Task InitializeCoreAsync(CancellationToken cancellationToken)
         {
-            // Explicitly get back to the thread pool for the rest of this method so we don't tie up the UI thread;
-            await TaskScheduler.Default;
-
             await _projectTasksService.LoadedProjectAsync(() =>
             {
                 // The tree source to get changes to the tree so that we can identify when the assets file changes.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.ProjectAssetFileWatcherInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.ProjectAssetFileWatcherInstance.cs
@@ -1,0 +1,322 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.Utilities;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
+using Microsoft.VisualStudio.Threading.Tasks;
+
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
+{
+    internal class ProjectAssetFileWatcherInstance : OnceInitializedOnceDisposedAsync, IMultiLifetimeInstance, IVsFreeThreadedFileChangeEvents2
+    {
+        private static readonly TimeSpan s_notifyDelay = TimeSpan.FromMilliseconds(100);
+
+        private readonly IVsService<IVsAsyncFileChangeEx> _fileChangeService;
+        private readonly IUnconfiguredProjectCommonServices _projectServices;
+        private readonly IUnconfiguredProjectTasksService _projectTasksService;
+        private readonly IActiveConfiguredProjectSubscriptionService _activeConfiguredProjectSubscriptionService;
+        private readonly IProjectTreeProvider _fileSystemTreeProvider;
+
+        private CancellationTokenSource _watchedFileResetCancellationToken;
+        private ITaskDelayScheduler _taskDelayScheduler;
+        private IDisposable _treeWatcher;
+        private uint _filechangeCookie;
+        private string _fileBeingWatched;
+        private byte[] _previousContentsHash;
+
+        public ProjectAssetFileWatcherInstance(
+            IVsService<IVsAsyncFileChangeEx> fileChangeService,
+            IProjectTreeProvider fileSystemTreeProvider,
+            IUnconfiguredProjectCommonServices projectServices,
+            IUnconfiguredProjectTasksService projectTasksService,
+            IActiveConfiguredProjectSubscriptionService activeConfiguredProjectSubscriptionService)
+            : base(projectServices.ThreadingService.JoinableTaskContext)
+        {
+            Requires.NotNull(fileChangeService, nameof(fileChangeService));
+            Requires.NotNull(fileSystemTreeProvider, nameof(fileSystemTreeProvider));
+            Requires.NotNull(projectServices, nameof(projectServices));
+            Requires.NotNull(projectTasksService, nameof(projectTasksService));
+            Requires.NotNull(activeConfiguredProjectSubscriptionService, nameof(activeConfiguredProjectSubscriptionService));
+
+            _fileChangeService = fileChangeService;
+            _fileSystemTreeProvider = fileSystemTreeProvider;
+            _projectServices = projectServices;
+            _projectTasksService = projectTasksService;
+            _activeConfiguredProjectSubscriptionService = activeConfiguredProjectSubscriptionService;
+        }
+
+        public Task InitializeAsync()
+        {
+            return InitializeAsync(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Called on changes to the project tree.
+        /// </summary>
+        internal async Task DataFlow_ChangedAsync(IProjectVersionedValue<Tuple<IProjectTreeSnapshot, IProjectSubscriptionUpdate>> dataFlowUpdate)
+        {
+            await InitializeAsync();
+
+            IProjectTreeSnapshot treeSnapshot = dataFlowUpdate.Value.Item1;
+            IProjectTree newTree = treeSnapshot.Tree;
+            if (newTree == null)
+            {
+                return;
+            }
+
+            // If tree changed when we are disposing then ignore the change.
+            if (IsDisposing)
+            {
+                return;
+            }
+
+            // NOTE: Project lock file path may be null
+            IProjectSubscriptionUpdate projectUpdate = dataFlowUpdate.Value.Item2;
+            string projectLockFilePath = GetProjectAssetsFilePath(newTree, projectUpdate);
+
+            // project.json may have been renamed to {projectName}.project.json or in the case of the project.assets.json,
+            // the immediate path could have changed. In either case, change the file watcher.
+            if (!PathHelper.IsSamePath(projectLockFilePath, _fileBeingWatched))
+            {
+                await UnregisterFileWatcherIfAnyAsync();
+                await RegisterFileWatcherAsync(projectLockFilePath);
+            }
+        }
+
+        /// <summary>
+        /// Initialize the watcher.
+        /// </summary>
+        protected override async Task InitializeCoreAsync(CancellationToken cancellationToken)
+        {
+            // Explicitly get back to the thread pool for the rest of this method so we don't tie up the UI thread;
+            await TaskScheduler.Default;
+
+            await _projectTasksService.LoadedProjectAsync(() =>
+            {
+                // The tree source to get changes to the tree so that we can identify when the assets file changes.
+                ProjectDataSources.SourceBlockAndLink<IProjectVersionedValue<IProjectTreeSnapshot>> treeSource = _fileSystemTreeProvider.Tree.SyncLinkOptions();
+
+                // The property source used to get the value of the $ProjectAssetsFile property so that we can identify the location of the assets file.
+                StandardRuleDataflowLinkOptions sourceLinkOptions = DataflowOption.WithRuleNames(ConfigurationGeneral.SchemaName);
+
+                ProjectDataSources.SourceBlockAndLink<IProjectVersionedValue<IProjectSubscriptionUpdate>> propertySource = _activeConfiguredProjectSubscriptionService.ProjectRuleSource.SourceBlock.SyncLinkOptions(sourceLinkOptions);
+                ITargetBlock<IProjectVersionedValue<Tuple<IProjectTreeSnapshot, IProjectSubscriptionUpdate>>> target = DataflowBlockSlim.CreateActionBlock<IProjectVersionedValue<Tuple<IProjectTreeSnapshot, IProjectSubscriptionUpdate>>>(DataFlow_ChangedAsync);
+
+                // Join the two sources so that we get synchronized versions of the data.
+                _treeWatcher = ProjectDataSources.SyncLinkTo(treeSource, propertySource, target);
+
+                return Task.CompletedTask;
+            });
+        }
+
+        protected override async Task DisposeCoreAsync(bool initialized)
+        {
+            if (initialized)
+            {
+                _taskDelayScheduler?.Dispose();
+                _treeWatcher.Dispose();
+                await UnregisterFileWatcherIfAnyAsync();
+            }
+        }
+
+        private static byte[] GetFileHashOrNull(string path)
+        {
+            byte[] hash = null;
+
+            try
+            {
+                using (var hasher = SHA256.Create())
+                using (FileStream file = File.OpenRead(path))
+                {
+                    file.Position = 0;
+                    hash = hasher.ComputeHash(file);
+                }
+            }
+            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
+            {
+            }
+
+            return hash;
+        }
+
+        private static string GetProjectAssetsFilePath(IProjectTree newTree, IProjectSubscriptionUpdate projectUpdate)
+        {
+            string projectFilePath = projectUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildProjectFullPathProperty, null);
+
+            // First check to see if the project has a project.json.
+            IProjectTree projectJsonNode = FindProjectJsonNode(newTree, projectFilePath);
+            if (projectJsonNode != null)
+            {
+                string projectDirectory = Path.GetDirectoryName(projectFilePath);
+                string projectLockJsonFilePath = Path.ChangeExtension(PathHelper.Combine(projectDirectory, projectJsonNode.Caption), ".lock.json");
+                return projectLockJsonFilePath;
+            }
+
+            // If there is no project.json then get the patch to obj\project.assets.json file which is generated for projects
+            // with <PackageReference> items.
+            string objDirectory = projectUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.BaseIntermediateOutputPathProperty, null);
+
+            if (string.IsNullOrEmpty(objDirectory))
+            {
+                // Don't have an intermediate directory set, probably missing SDK attribute or Microsoft.Common.props
+                return null;
+            }
+
+            objDirectory = PathHelper.MakeRooted(projectFilePath, objDirectory);
+            string projectAssetsFilePath = PathHelper.Combine(objDirectory, "project.assets.json");
+            return projectAssetsFilePath;
+        }
+
+        private static IProjectTree FindProjectJsonNode(IProjectTree newTree, string projectFilePath)
+        {
+            if (newTree.TryFindImmediateChild("project.json", out IProjectTree projectJsonNode))
+            {
+                return projectJsonNode;
+            }
+
+            string projectName = Path.GetFileNameWithoutExtension(projectFilePath);
+            if (newTree.TryFindImmediateChild($"{projectName}.project.json", out projectJsonNode))
+            {
+                return projectJsonNode;
+            }
+
+            return null;
+        }
+
+        private async Task RegisterFileWatcherAsync(string projectLockJsonFilePath)
+        {
+            // Note file change service is free-threaded
+            if (projectLockJsonFilePath != null)
+            {
+                _previousContentsHash = GetFileHashOrNull(projectLockJsonFilePath);
+                _taskDelayScheduler?.Dispose();
+                _taskDelayScheduler = new TaskDelayScheduler(
+                    s_notifyDelay,
+                    _projectServices.ThreadingService,
+                    CreateLinkedCancellationToken());
+
+                IVsAsyncFileChangeEx fileChangeService = await _fileChangeService.GetValueAsync();
+                _filechangeCookie = await fileChangeService.AdviseFileChangeAsync(
+                    projectLockJsonFilePath,
+                    _VSFILECHANGEFLAGS.VSFILECHG_Time | _VSFILECHANGEFLAGS.VSFILECHG_Size | _VSFILECHANGEFLAGS.VSFILECHG_Add | _VSFILECHANGEFLAGS.VSFILECHG_Del,
+                    sink: this);
+            }
+
+            _fileBeingWatched = projectLockJsonFilePath;
+        }
+
+        private async Task UnregisterFileWatcherIfAnyAsync()
+        {
+            // Note file change service is free-threaded
+            if (_filechangeCookie != VSConstants.VSCOOKIE_NIL)
+            {
+                IVsAsyncFileChangeEx fileChangeService = await _fileChangeService.GetValueAsync();
+
+                // There's nothing for us to do if this fails. So ignore the return value.
+                await fileChangeService.UnadviseFileChangeAsync(_filechangeCookie);
+                _watchedFileResetCancellationToken?.Cancel();
+                _watchedFileResetCancellationToken?.Dispose();
+                _taskDelayScheduler?.Dispose();
+            }
+        }
+
+        private CancellationToken CreateLinkedCancellationToken()
+        {
+            // we want to cancel when we switch what file is watched, or when the project is unloaded
+            if (_projectServices?.Project?.Services?.ProjectAsynchronousTasks?.UnloadCancellationToken != null)
+            {
+                _watchedFileResetCancellationToken = CancellationTokenSource.CreateLinkedTokenSource(
+                    _projectServices.Project.Services.ProjectAsynchronousTasks.UnloadCancellationToken);
+            }
+            else
+            {
+                _watchedFileResetCancellationToken = new CancellationTokenSource();
+            }
+
+            return _watchedFileResetCancellationToken.Token;
+        }
+
+        private async Task HandleFileChangedAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                // Only notify the project if the contents of the watched file have changed.
+                // In the case if we fail to read the contents, we will opt to notify the project.
+                byte[] newHash = GetFileHashOrNull(_fileBeingWatched);
+                if (newHash == null || _previousContentsHash == null || !newHash.SequenceEqual(_previousContentsHash))
+                {
+                    TraceUtilities.TraceVerbose("{0} changed on disk. Marking project dirty", _fileBeingWatched);
+                    _previousContentsHash = newHash;
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await _projectTasksService.LoadedProjectAsync(() =>
+                    {
+                        return _projectServices.ProjectAccessor.EnterWriteLockAsync(async (collection, token) =>
+                        {
+                            // notify all the loaded configured projects
+                            IEnumerable<ConfiguredProject> currentProjects = _projectServices.Project.LoadedConfiguredProjects;
+                            foreach (ConfiguredProject configuredProject in currentProjects)
+                            {
+                                await _projectServices.ProjectAccessor.OpenProjectForWriteAsync(configuredProject, project =>
+                                {
+                                    project.MarkDirty();
+                                    configuredProject.NotifyProjectChange();
+
+                                }, ProjectCheckoutOption.DoNotCheckout, cancellationToken); // Stay on same thread that took lock
+                            }
+                        }, cancellationToken); // Stay on same thread that took lock
+                    });
+                }
+                else
+                {
+                    TraceUtilities.TraceWarning("{0} changed on disk, but has no actual content change.", _fileBeingWatched);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Project is already unloaded
+            }
+        }
+
+        /// <summary>
+        /// Called when a project.lock.json file changes.
+        /// </summary>
+        public int FilesChanged(uint cChanges, string[] rgpszFile, uint[] rggrfChange)
+        {
+            // Kick off the operation to notify the project change in a different thread regardless of
+            // the kind of change since we are interested in all changes.
+            _taskDelayScheduler.ScheduleAsyncTask(HandleFileChangedAsync);
+
+            return VSConstants.S_OK;
+        }
+
+        public int DirectoryChanged(string pszDirectory)
+        {
+            return VSConstants.E_NOTIMPL;
+        }
+
+        public int DirectoryChangedEx(string pszDirectory, string pszFile)
+        {
+            return VSConstants.E_NOTIMPL;
+        }
+
+        public int DirectoryChangedEx2(string pszDirectory, uint cChanges, string[] rgpszFile, uint[] rggrfChange)
+        {
+            return VSConstants.E_NOTIMPL;
+        }
+    }
+}
+

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
@@ -1,61 +1,34 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.IO;
-using System.Linq;
-using System.Security.Cryptography;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Threading.Tasks.Dataflow;
 
-using Microsoft.VisualStudio.ProjectSystem.Properties;
-using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.Threading;
-using Microsoft.VisualStudio.Threading.Tasks;
-
-using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
 {
     /// <summary>
     ///     Watches for writes to the project.assets.json, triggering a evaluation if it changes.
     /// </summary>
-    internal class ProjectAssetFileWatcher : OnceInitializedOnceDisposedAsync, IVsFreeThreadedFileChangeEvents2
+    [Export(ExportContractNames.Scopes.ConfiguredProject, typeof(IProjectDynamicLoadComponent))]
+    [AppliesTo(ProjectCapability.PackageReferences)]
+    internal class ProjectAssetFileWatcher : AbstractMultiLifetimeComponent<ProjectAssetFileWatcherInstance>, IProjectDynamicLoadComponent
     {
-        private static readonly TimeSpan s_notifyDelay = TimeSpan.FromMilliseconds(100);
-
         private readonly IVsService<IVsAsyncFileChangeEx> _fileChangeService;
         private readonly IUnconfiguredProjectCommonServices _projectServices;
         private readonly IUnconfiguredProjectTasksService _projectTasksService;
         private readonly IActiveConfiguredProjectSubscriptionService _activeConfiguredProjectSubscriptionService;
         private readonly IProjectTreeProvider _fileSystemTreeProvider;
 
-        private CancellationTokenSource _watchedFileResetCancellationToken;
-        private ITaskDelayScheduler _taskDelayScheduler;
-        private IDisposable _treeWatcher;
-        private uint _filechangeCookie;
-        private string _fileBeingWatched;
-        private byte[] _previousContentsHash;
-
         [ImportingConstructor]
         public ProjectAssetFileWatcher(
-            IVsService<SVsFileChangeEx, IVsAsyncFileChangeEx> fileChangeService,
-            [Import(ContractNames.ProjectTreeProviders.FileSystemDirectoryTree)] IProjectTreeProvider fileSystemTreeProvider,
-            IUnconfiguredProjectCommonServices projectServices,
-            IUnconfiguredProjectTasksService projectTasksService,
-            IActiveConfiguredProjectSubscriptionService activeConfiguredProjectSubscriptionService)
-            : base(projectServices.ThreadingService.JoinableTaskContext)
+          IVsService<SVsFileChangeEx, IVsAsyncFileChangeEx> fileChangeService,
+          [Import(ContractNames.ProjectTreeProviders.FileSystemDirectoryTree)]IProjectTreeProvider fileSystemTreeProvider,
+          IUnconfiguredProjectCommonServices projectServices,
+          IUnconfiguredProjectTasksService projectTasksService,
+          IActiveConfiguredProjectSubscriptionService activeConfiguredProjectSubscriptionService)
+          : base(projectServices.ThreadingService.JoinableTaskContext)
         {
-            Requires.NotNull(fileChangeService, nameof(fileChangeService));
-            Requires.NotNull(fileSystemTreeProvider, nameof(fileSystemTreeProvider));
-            Requires.NotNull(projectServices, nameof(projectServices));
-            Requires.NotNull(projectTasksService, nameof(projectTasksService));
-            Requires.NotNull(activeConfiguredProjectSubscriptionService, nameof(activeConfiguredProjectSubscriptionService));
-
             _fileChangeService = fileChangeService;
             _fileSystemTreeProvider = fileSystemTreeProvider;
             _projectServices = projectServices;
@@ -63,270 +36,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             _activeConfiguredProjectSubscriptionService = activeConfiguredProjectSubscriptionService;
         }
 
-        /// <summary>
-        /// Called on project load.
-        /// </summary>
-#pragma warning disable RS0030 // symbol ConfiguredProjectAutoLoad is banned
-        [ConfiguredProjectAutoLoad(RequiresUIThread = false)]
-#pragma warning restore RS0030 // symbol ConfiguredProjectAutoLoad is banned
-        [AppliesTo(ProjectCapability.DotNet)]
-        internal void Load()
+        protected override ProjectAssetFileWatcherInstance CreateInstance()
         {
-            InitializeAsync();
-        }
-
-        /// <summary>
-        /// Called on changes to the project tree.
-        /// </summary>
-        internal async Task DataFlow_ChangedAsync(IProjectVersionedValue<Tuple<IProjectTreeSnapshot, IProjectSubscriptionUpdate>> dataFlowUpdate)
-        {
-            await InitializeAsync();
-
-            IProjectTreeSnapshot treeSnapshot = dataFlowUpdate.Value.Item1;
-            IProjectTree newTree = treeSnapshot.Tree;
-            if (newTree == null)
-            {
-                return;
-            }
-
-            // If tree changed when we are disposing then ignore the change.
-            if (IsDisposing)
-            {
-                return;
-            }
-
-            // NOTE: Project lock file path may be null
-            IProjectSubscriptionUpdate projectUpdate = dataFlowUpdate.Value.Item2;
-            string projectLockFilePath = GetProjectAssetsFilePath(newTree, projectUpdate);
-
-            // project.json may have been renamed to {projectName}.project.json or in the case of the project.assets.json,
-            // the immediate path could have changed. In either case, change the file watcher.
-            if (!PathHelper.IsSamePath(projectLockFilePath, _fileBeingWatched))
-            {
-                await UnregisterFileWatcherIfAnyAsync();
-                await RegisterFileWatcherAsync(projectLockFilePath);
-            }
-        }
-
-        /// <summary>
-        /// Initialize the watcher.
-        /// </summary>
-        protected override async Task InitializeCoreAsync(CancellationToken cancellationToken)
-        {
-            // Explicitly get back to the thread pool for the rest of this method so we don't tie up the UI thread;
-            await TaskScheduler.Default;
-
-            await _projectTasksService.LoadedProjectAsync(() =>
-                {
-                    // The tree source to get changes to the tree so that we can identify when the assets file changes.
-                    ProjectDataSources.SourceBlockAndLink<IProjectVersionedValue<IProjectTreeSnapshot>> treeSource = _fileSystemTreeProvider.Tree.SyncLinkOptions();
-
-                    // The property source used to get the value of the $ProjectAssetsFile property so that we can identify the location of the assets file.
-                    StandardRuleDataflowLinkOptions sourceLinkOptions = DataflowOption.WithRuleNames(ConfigurationGeneral.SchemaName);
-
-                    ProjectDataSources.SourceBlockAndLink<IProjectVersionedValue<IProjectSubscriptionUpdate>> propertySource = _activeConfiguredProjectSubscriptionService.ProjectRuleSource.SourceBlock.SyncLinkOptions(sourceLinkOptions);
-                    ITargetBlock<IProjectVersionedValue<Tuple<IProjectTreeSnapshot, IProjectSubscriptionUpdate>>> target = DataflowBlockSlim.CreateActionBlock<IProjectVersionedValue<Tuple<IProjectTreeSnapshot, IProjectSubscriptionUpdate>>>(DataFlow_ChangedAsync);
-
-                    // Join the two sources so that we get synchronized versions of the data.
-                    _treeWatcher = ProjectDataSources.SyncLinkTo(treeSource, propertySource, target);
-
-                    return Task.CompletedTask;
-                });
-        }
-
-        protected override async Task DisposeCoreAsync(bool initialized)
-        {
-            if (initialized)
-            {
-                _taskDelayScheduler?.Dispose();
-                _treeWatcher.Dispose();
-                await UnregisterFileWatcherIfAnyAsync();
-            }
-        }
-
-        private static byte[] GetFileHashOrNull(string path)
-        {
-            byte[] hash = null;
-
-            try
-            {
-                using (var hasher = SHA256.Create())
-                using (FileStream file = File.OpenRead(path))
-                {
-                    file.Position = 0;
-                    hash = hasher.ComputeHash(file);
-                }
-            }
-            catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException)
-            {
-            }
-
-            return hash;
-        }
-
-        private static string GetProjectAssetsFilePath(IProjectTree newTree, IProjectSubscriptionUpdate projectUpdate)
-        {
-            string projectFilePath = projectUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildProjectFullPathProperty, null);
-
-            // First check to see if the project has a project.json.
-            IProjectTree projectJsonNode = FindProjectJsonNode(newTree, projectFilePath);
-            if (projectJsonNode != null)
-            {
-                string projectDirectory = Path.GetDirectoryName(projectFilePath);
-                string projectLockJsonFilePath = Path.ChangeExtension(PathHelper.Combine(projectDirectory, projectJsonNode.Caption), ".lock.json");
-                return projectLockJsonFilePath;
-            }
-
-            // If there is no project.json then get the patch to obj\project.assets.json file which is generated for projects
-            // with <PackageReference> items.
-            string objDirectory = projectUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.BaseIntermediateOutputPathProperty, null);
-
-            if (string.IsNullOrEmpty(objDirectory))
-            {
-                // Don't have an intermediate directory set, probably missing SDK attribute or Microsoft.Common.props
-                return null;
-            }
-
-            objDirectory = PathHelper.MakeRooted(projectFilePath, objDirectory);
-            string projectAssetsFilePath = PathHelper.Combine(objDirectory, "project.assets.json");
-            return projectAssetsFilePath;
-        }
-
-        private static IProjectTree FindProjectJsonNode(IProjectTree newTree, string projectFilePath)
-        {
-            if (newTree.TryFindImmediateChild("project.json", out IProjectTree projectJsonNode))
-            {
-                return projectJsonNode;
-            }
-
-            string projectName = Path.GetFileNameWithoutExtension(projectFilePath);
-            if (newTree.TryFindImmediateChild($"{projectName}.project.json", out projectJsonNode))
-            {
-                return projectJsonNode;
-            }
-
-            return null;
-        }
-
-        private async Task RegisterFileWatcherAsync(string projectLockJsonFilePath)
-        {
-            // Note file change service is free-threaded
-            if (projectLockJsonFilePath != null)
-            {
-                _previousContentsHash = GetFileHashOrNull(projectLockJsonFilePath);
-                _taskDelayScheduler?.Dispose();
-                _taskDelayScheduler = new TaskDelayScheduler(
-                    s_notifyDelay,
-                    _projectServices.ThreadingService,
-                    CreateLinkedCancellationToken());
-
-                IVsAsyncFileChangeEx fileChangeService = await _fileChangeService.GetValueAsync();
-                _filechangeCookie = await fileChangeService.AdviseFileChangeAsync(
-                    projectLockJsonFilePath,
-                    _VSFILECHANGEFLAGS.VSFILECHG_Time | _VSFILECHANGEFLAGS.VSFILECHG_Size | _VSFILECHANGEFLAGS.VSFILECHG_Add | _VSFILECHANGEFLAGS.VSFILECHG_Del,
-                    sink: this);
-            }
-
-            _fileBeingWatched = projectLockJsonFilePath;
-        }
-
-        private async Task UnregisterFileWatcherIfAnyAsync()
-        {
-            // Note file change service is free-threaded
-            if (_filechangeCookie != VSConstants.VSCOOKIE_NIL)
-            {
-                IVsAsyncFileChangeEx fileChangeService = await _fileChangeService.GetValueAsync();
-
-                // There's nothing for us to do if this fails. So ignore the return value.
-                await fileChangeService.UnadviseFileChangeAsync(_filechangeCookie);
-                _watchedFileResetCancellationToken?.Cancel();
-                _watchedFileResetCancellationToken?.Dispose();
-                _taskDelayScheduler?.Dispose();
-            }
-        }
-
-        private CancellationToken CreateLinkedCancellationToken()
-        {
-            // we want to cancel when we switch what file is watched, or when the project is unloaded
-            if (_projectServices?.Project?.Services?.ProjectAsynchronousTasks?.UnloadCancellationToken != null)
-            {
-                _watchedFileResetCancellationToken = CancellationTokenSource.CreateLinkedTokenSource(
-                    _projectServices.Project.Services.ProjectAsynchronousTasks.UnloadCancellationToken);
-            }
-            else
-            {
-                _watchedFileResetCancellationToken = new CancellationTokenSource();
-            }
-
-            return _watchedFileResetCancellationToken.Token;
-        }
-
-        private async Task HandleFileChangedAsync(CancellationToken cancellationToken)
-        {
-            try
-            {
-                // Only notify the project if the contents of the watched file have changed.
-                // In the case if we fail to read the contents, we will opt to notify the project.
-                byte[] newHash = GetFileHashOrNull(_fileBeingWatched);
-                if (newHash == null || _previousContentsHash == null || !newHash.SequenceEqual(_previousContentsHash))
-                {
-                    TraceUtilities.TraceVerbose("{0} changed on disk. Marking project dirty", _fileBeingWatched);
-                    _previousContentsHash = newHash;
-                    cancellationToken.ThrowIfCancellationRequested();
-                    await _projectTasksService.LoadedProjectAsync(() =>
-                    {
-                        return _projectServices.ProjectAccessor.EnterWriteLockAsync(async (collection, token) =>
-                        {
-                            // notify all the loaded configured projects
-                            IEnumerable<ConfiguredProject> currentProjects = _projectServices.Project.LoadedConfiguredProjects;
-                            foreach (ConfiguredProject configuredProject in currentProjects)
-                            {
-                                await _projectServices.ProjectAccessor.OpenProjectForWriteAsync(configuredProject, project =>
-                                {
-                                    project.MarkDirty();
-                                    configuredProject.NotifyProjectChange();
-
-                                }, ProjectCheckoutOption.DoNotCheckout, cancellationToken); // Stay on same thread that took lock
-                            }
-                        }, cancellationToken); // Stay on same thread that took lock
-                    });
-                }
-                else
-                {
-                    TraceUtilities.TraceWarning("{0} changed on disk, but has no actual content change.", _fileBeingWatched);
-                }
-            }
-            catch (OperationCanceledException)
-            {
-                // Project is already unloaded
-            }
-        }
-
-        /// <summary>
-        /// Called when a project.lock.json file changes.
-        /// </summary>
-        public int FilesChanged(uint cChanges, string[] rgpszFile, uint[] rggrfChange)
-        {
-            // Kick off the operation to notify the project change in a different thread regardless of
-            // the kind of change since we are interested in all changes.
-            _taskDelayScheduler.ScheduleAsyncTask(HandleFileChangedAsync);
-
-            return VSConstants.S_OK;
-        }
-
-        public int DirectoryChanged(string pszDirectory)
-        {
-            return VSConstants.E_NOTIMPL;
-        }
-
-        public int DirectoryChangedEx(string pszDirectory, string pszFile)
-        {
-            return VSConstants.E_NOTIMPL;
-        }
-
-        public int DirectoryChangedEx2(string pszDirectory, uint cChanges, string[] rgpszFile, uint[] rggrfChange)
-        {
-            return VSConstants.E_NOTIMPL;
+            return new ProjectAssetFileWatcherInstance(
+                _fileChangeService,
+                _fileSystemTreeProvider,
+                _projectServices,
+                _projectTasksService,
+                _activeConfiguredProjectSubscriptionService);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
     /// </summary>
     [Export(ExportContractNames.Scopes.UnconfiguredProject, typeof(IProjectDynamicLoadComponent))]
     [AppliesTo(ProjectCapability.PackageReferences)]
-    internal class ProjectAssetFileWatcher : AbstractMultiLifetimeComponent<ProjectAssetFileWatcherInstance>, IProjectDynamicLoadComponent
+    internal partial class ProjectAssetFileWatcher : AbstractMultiLifetimeComponent<ProjectAssetFileWatcher.ProjectAssetFileWatcherInstance>, IProjectDynamicLoadComponent
     {
         private readonly IVsService<IVsAsyncFileChangeEx> _fileChangeService;
         private readonly IUnconfiguredProjectCommonServices _projectServices;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
     /// <summary>
     ///     Watches for writes to the project.assets.json, triggering a evaluation if it changes.
     /// </summary>
-    [Export(ExportContractNames.Scopes.ConfiguredProject, typeof(IProjectDynamicLoadComponent))]
+    [Export(ExportContractNames.Scopes.UnconfiguredProject, typeof(IProjectDynamicLoadComponent))]
     [AppliesTo(ProjectCapability.PackageReferences)]
     internal class ProjectAssetFileWatcher : AbstractMultiLifetimeComponent<ProjectAssetFileWatcherInstance>, IProjectDynamicLoadComponent
     {


### PR DESCRIPTION
This marks ProjectAssetsFileWatcher with "PackageReferences". Given that PackageReferences is a dynamic capability this involved moving over to IProjectDynamicLoadComponent as per https://github.com/dotnet/project-system/blob/master/docs/repo/loading-components-with-projects.md.

The diff is much easier if you skip the first one, which is just a boilerplate move to that pattern, and just read the commits onwards which are changes to the existing code.

This opens ProjectAssetsFileWatcher for other uses as called out in https://github.com/dotnet/project-system/issues/2491.