### PR TITLE
Make the license file text box editable

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.Designer.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.Designer.vb
@@ -274,7 +274,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             '
             resources.ApplyResources(Me.LicenseFileNameTextBox, "LicenseFileNameTextBox")
             Me.LicenseFileNameTextBox.Name = "LicenseFileNameTextBox"
-            Me.LicenseFileNameTextBox.ReadOnly = True
             '
             'LicenseBrowseButton
             '


### PR DESCRIPTION
Fix for https://github.com/dotnet/project-system/issues/4634

This makes the previously readonly text box for License File editable. The user can either browse for a file or enter a relative or absolute path to a file. The text box will convert any absolute path to a relative path. The text box will also correctly respond to changes in the project file.

More context for the initial feature: https://github.com/dotnet/project-system/pull/4223