### PR TITLE
Use HResult over VSConstants

### DIFF
--- a/src/BannedSymbols.txt
+++ b/src/BannedSymbols.txt
@@ -52,3 +52,17 @@ M:Microsoft.VisualStudio.ProjectSystem.IProjectThreadingService.Fork(System.Func
 T:System.Threading.Tasks.Dataflow.ActionBlock`1;Use DataflowUtilities.LinkToAction/LinkToAsyncAction or DataflowBlockSlim.CreateActionBlock to reduce memory and avoid the overhead of the built-in blocks
 T:System.Threading.Tasks.Dataflow.BroadcastBlock`1;Use DataflowBlockSlim.CreateBroadcastBlock to reduce memory and avoid the overhead of the built-in blocks
 T:System.Threading.Tasks.Dataflow.TransformManyBlock`2;Use DataflowBlockSlim.CreateTransformManyBlock to reduce memory and avoid the overhead of the built-in blocks
+
+M:Microsoft.VisualStudio.VSConstants.S_OK;Use HResult.OK or HResult.IsOK
+M:Microsoft.VisualStudio.VSConstants.E_FAIL;Use HResult.Fail or HResult.Failed
+M:Microsoft.VisualStudio.VSConstants.S_FALSE;Use HResult.False or HResult.IsFalse
+M:Microsoft.VisualStudio.VSConstants.E_NOTIMPL;Use HResult.NotImplemented or HResult.IsNotImplemented
+M:Microsoft.VisualStudio.VSConstants.E_INVALIDARG;Use HResult.InvalidArg
+M:Microsoft.VisualStudio.VSConstants.RPC_E_WRONG_THREAD;Use HResult.WrongThread
+M:Microsoft.VisualStudio.VSConstants.E_ABORT;Use HResult.Abort
+M:Microsoft.VisualStudio.VSConstants.E_PENDING;Use HResult.Pending
+M:Microsoft.VisualStudio.VSConstants.DISP_E_MEMBERNOTFOUND;Use HResult.MemberNotFound
+M:Microsoft.VisualStudio.VSConstants.E_NOINTERFACE;Use HResult.NoInterface
+M:Microsoft.VisualStudio.VSConstants.E_UNEXPECTED;Use HResult.Unexpected
+M:Microsoft.VisualStudio.OLE.Interop.Constants.OLECMDERR_E_NOTSUPPORTED;Use HResult.Ole.Cmd.NotSupported
+M:Microsoft.VisualStudio.OLE.Interop.Constants.OLECMDERR_E_UNKNOWNGROUP;Use HResult.Ole.Cmd.UnknownGroup

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ConnectionPoint/ConnectionPoint.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ConnectionPoint/ConnectionPoint.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.ConnectionPoint
             var sink = pUnkSink as TSinkType;
             if (null == sink)
             {
-                Marshal.ThrowExceptionForHR(VSConstants.E_NOINTERFACE);
+                Marshal.ThrowExceptionForHR(HResult.NoInterface);
             }
 
             _sinks.Add(_nextCookie, sink);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractAddClassProjectCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractAddClassProjectCommand.cs
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 
             // Return true here regardless of whether or not the user clicked OK or they clicked Cancel. This ensures that some other
             // handler isn't called after we run.
-            return res == VSConstants.S_OK || res == VSConstants.OLE_E_PROMPTSAVECANCELLED;
+            return res == HResult.OK || res == HResult.Ole.PromptSaveCancelled;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommand.cs
@@ -106,29 +106,29 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         #region IVsUpdateSolutionEvents members
         public int UpdateSolution_Begin(ref int pfCancelUpdate)
         {
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         public int UpdateSolution_Done(int fSucceeded, int fModified, int fCancelCommand)
         {
             _generatePackageOnBuildPropertyProvider.OverrideGeneratePackageOnBuild(false);
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         public int UpdateSolution_Cancel()
         {
             _generatePackageOnBuildPropertyProvider.OverrideGeneratePackageOnBuild(false);
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         public int UpdateSolution_StartUpdate(ref int pfCancelUpdate)
         {
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         public int OnActiveProjectCfgChange(IVsHierarchy pIVsHierarchy)
         {
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
         #endregion
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.ProjectAssetFileWatcherInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/ProjectAssetFileWatcher.ProjectAssetFileWatcherInstance.cs
@@ -294,22 +294,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
                 // the kind of change since we are interested in all changes.
                 _taskDelayScheduler.ScheduleAsyncTask(HandleFileChangedAsync);
 
-                return VSConstants.S_OK;
+                return HResult.OK;
             }
 
             public int DirectoryChanged(string pszDirectory)
             {
-                return VSConstants.E_NOTIMPL;
+                return HResult.NotImplemented;
             }
 
             public int DirectoryChangedEx(string pszDirectory, string pszFile)
             {
-                return VSConstants.E_NOTIMPL;
+                return HResult.NotImplemented;
             }
 
             public int DirectoryChangedEx2(string pszDirectory, uint cChanges, string[] rgpszFile, uint[] rggrfChange)
             {
-                return VSConstants.E_NOTIMPL;
+                return HResult.NotImplemented;
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/BuildMacroInfo.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/BuildMacroInfo.cs
@@ -52,11 +52,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             if (pbstrBuildMacroValue == null)
             {
                 pbstrBuildMacroValue = string.Empty;
-                return VSConstants.E_FAIL;
+                return HResult.Fail;
             }
             else
             {
-                return VSConstants.S_OK;
+                return HResult.OK;
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
@@ -797,7 +797,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 
             await SaveLaunchSettings();
 
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPage.cs
@@ -28,12 +28,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         // WIN32 Constants
         private const int SW_HIDE = 0;
 
-        internal static class NativeMethods
-        {
-            public const int
-                S_OK = 0x00000000;
-        }
-
         protected abstract string PropertyPageName { get; }
 
         internal PropertyPage()
@@ -183,8 +177,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         public int IsPageDirty()
         {
             if (IsDirty)
-                return VSConstants.S_OK;
-            return VSConstants.S_FALSE;
+                return HResult.OK;
+
+            return HResult.False;
         }
 
         ///--------------------------------------------------------------------------------------------
@@ -212,7 +207,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         public int OnModeChange(DBGMODE dbgmodeNew)
         {
             Enabled = (dbgmodeNew == DBGMODE.DBGMODE_Design);
-            return NativeMethods.S_OK;
+            return HResult.OK;
         }
 
         /// <summary>
@@ -277,7 +272,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 pMsg[0].wParam = m.WParam;
                 pMsg[0].lParam = m.LParam;
                 // Returning S_OK indicates we handled the message ourselves
-                return VSConstants.S_OK;
+                return HResult.OK;
             }
 
 
@@ -350,8 +345,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             {
                 if (ppunk[i] is IVsBrowseObject browseObj)
                 {
-                    int hr = browseObj.GetProjectItem(out IVsHierarchy hier, out uint itemid);
-                    if (hr == VSConstants.S_OK && itemid == VSConstants.VSITEMID_ROOT)
+                    HResult hr = browseObj.GetProjectItem(out IVsHierarchy hier, out uint itemid);
+                    if (hr.IsOK && itemid == VSConstants.VSITEMID_ROOT)
                     {
                         UnconfiguredProject = hier.GetUnconfiguredProject();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageControl.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPageControl.cs
@@ -67,12 +67,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 
         public async Task<int> Apply()
         {
-            int result = VSConstants.S_OK;
+            HResult result = HResult.OK;
 
             if (IsDirty)
             {
                 result = await OnApply();
-                if (result == VSConstants.S_OK)
+                if (result.IsOK)
                 {
                     IsDirty = false;
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/DesignTimeAssemblyResolution.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/DesignTimeAssemblyResolution.cs
@@ -81,7 +81,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             }
 
             pcResolvedAssemblyPaths = ResolveReferences(prgAssemblySpecs, assemblyNames, prgResolvedAssemblyPaths);
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         private uint ResolveReferences(string[] originalNames, AssemblyName[] assemblyName, [In, Out]VsResolvedAssemblyPath[] assemblyPaths)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VersionCompatibility/DotNetCoreProjectCompatibilityDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VersionCompatibility/DotNetCoreProjectCompatibilityDetector.cs
@@ -170,7 +170,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 }
             }
 
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         // This method is overridden in test code
@@ -222,7 +222,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             // Clear state flags
             CompatibilityLevelWarnedForCurrentSolution = CompatibilityLevel.Recommended;
             SolutionOpen = false;
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         private async Task CheckCompatibilityAsync()
@@ -265,7 +265,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             // Schedule this to run on idle
             _threadHandling.Value.RunAndForget(() => CheckCompatibilityAsync(), unconfiguredProject: null);
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         private async Task WarnUserOfIncompatibleProjectAsync(CompatibilityLevel compatLevel, VersionCompatibilityData compatData, bool isPreviewSDKInUse)
@@ -550,42 +550,42 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         /// </summary>
         public int OnAfterOpenSolution(object pUnkReserved, int fNewSolution)
         {
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         public int OnQueryCloseProject(IVsHierarchy pHierarchy, int fRemoving, ref int pfCancel)
         {
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         public int OnBeforeCloseProject(IVsHierarchy pHierarchy, int fRemoved)
         {
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         public int OnAfterLoadProject(IVsHierarchy pStubHierarchy, IVsHierarchy pRealHierarchy)
         {
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         public int OnQueryUnloadProject(IVsHierarchy pRealHierarchy, ref int pfCancel)
         {
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         public int OnBeforeUnloadProject(IVsHierarchy pRealHierarchy, IVsHierarchy pStubHierarchy)
         {
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         public int OnQueryCloseSolution(object pUnkReserved, ref int pfCancel)
         {
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         public int OnBeforeCloseSolution(object pUnkReserved)
         {
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         /// <summary>
@@ -593,28 +593,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         /// </summary>
         public int OnAfterLoadProjectBatch(bool fIsBackgroundIdleBatch)
         {
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         public int OnBeforeBackgroundSolutionLoadBegins()
         {
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         public int OnBeforeLoadProjectBatch(bool fIsBackgroundIdleBatch)
         {
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         public int OnBeforeOpenSolution(string pszSolutionFilename)
         {
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         public int OnQueryBackgroundLoadProjectBatch(out bool pfShouldDelayLoadToNextIdle)
         {
             pfShouldDelayLoadToNextIdle = false;
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         #endregion

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsUIService`1.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsUIService`1.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                     return _value.Value;
                 }
 
-                throw new COMException("This method must be called on the UI thread.", VSConstants.RPC_E_WRONG_THREAD);
+                throw new COMException("This method must be called on the UI thread.", HResult.WrongThread);
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Xproj/GlobalJsonRemover.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Xproj/GlobalJsonRemover.cs
@@ -89,7 +89,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
                     _fileSystem.RemoveFile(globalJsonPath);
                 }
                 catch (FileNotFoundException) { }
-                return VSConstants.S_OK;
+                return HResult.OK;
             }
             finally
             {
@@ -105,47 +105,47 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         #region Unused
         public int OnAfterOpenProject(IVsHierarchy pHierarchy, int fAdded)
         {
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         public int OnQueryCloseProject(IVsHierarchy pHierarchy, int fRemoving, ref int pfCancel)
         {
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         public int OnBeforeCloseProject(IVsHierarchy pHierarchy, int fRemoved)
         {
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         public int OnAfterLoadProject(IVsHierarchy pStubHierarchy, IVsHierarchy pRealHierarchy)
         {
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         public int OnQueryUnloadProject(IVsHierarchy pRealHierarchy, ref int pfCancel)
         {
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         public int OnBeforeUnloadProject(IVsHierarchy pRealHierarchy, IVsHierarchy pStubHierarchy)
         {
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         public int OnQueryCloseSolution(object pUnkReserved, ref int pfCancel)
         {
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         public int OnBeforeCloseSolution(object pUnkReserved)
         {
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         public int OnAfterCloseSolution(object pUnkReserved)
         {
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
         #endregion
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Xproj/MigrateXprojProjectFactory.cs
@@ -180,7 +180,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
                     }
                 }
             }
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         internal (string logFile, int exitCode) MigrateProject(string solutionDirectory, string projectDirectory, string xprojLocation, string projectName, IVsUpgradeLogger pLogger)
@@ -324,7 +324,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
                 upgradeProjectCapabilityFlags = 0;
             }
 
-            return VSConstants.S_OK;
+            return HResult.OK;
         }
 
         private static string GetDotnetArguments(string xprojLocation, string projectDirectory, string logFile) =>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/VsHierarchyExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/VsHierarchyExtensions.cs
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
                 return HResult.OK;
             }
 
-            if (hr == VSConstants.DISP_E_MEMBERNOTFOUND)
+            if (hr == HResult.MemberNotFound)
             {
                 result = defaultValue;
                 return HResult.OK;


### PR DESCRIPTION
Consistently use HResult vs VSConstants across the tree.