### PR TITLE
.NET 4.8 compatibility: Preventing throwing an error from GetHashCode functions

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
+++ b/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
@@ -3,7 +3,7 @@
   <Import Project="..\VisualStudioDesigner.props"/>
   <PropertyGroup>
     <!-- TODO: Function doesn't return a value on all code paths (https://github.com/dotnet/project-system/issues/2592) -->
-    <NoWarn>$(NoWarn);42353</NoWarn>
+    <NoWarn>$(NoWarn);42353;NU5125</NoWarn>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <TargetFramework>net46</TargetFramework>
     <!-- Nuget -->

--- a/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
+++ b/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
@@ -6,7 +6,7 @@
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
     <TargetFramework>net46</TargetFramework>
     <!-- TODO: Function/Property doesn't return a value on all code paths (https://github.com/dotnet/project-system/issues/2592) -->
-    <NoWarn>$(NoWarn);42353;42355;42105</NoWarn>
+    <NoWarn>$(NoWarn);42353;42355;42105;NU5125</NoWarn>
 
     <!-- Nuget -->
     <IsPackable>true</IsPackable>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
@@ -929,10 +929,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                 Return False
             End Function
 
-            Public Overrides Function GetHashCode() As Integer
-                Throw New NotImplementedException()
-            End Function
-
         End Class
 
         <Serializable()>
@@ -961,10 +957,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                 End If
 
                 Return False
-            End Function
-
-            Public Overrides Function GetHashCode() As Integer
-                Throw New NotImplementedException()
             End Function
 
         End Class


### PR DESCRIPTION
.NET 4.8 Accessibility changes expect that ComboBox items provide hash codes and do not throw an exception when calling its GetHashCode function so removing overriden GetHashCode functions (which simpy throw NotImplemented exception) from ApplicationPropPageVBWPF.StartupUri​, StartupObject and StartupObjectOrUri to restore default object's behavior when providing hash code (generating an integer).