### PR TITLE
Dev16.0 - .NET 4.8 compatibility: Preventing throwing an error from GetHashCode functions

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
@@ -934,10 +934,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                 Return False
             End Function
 
-            Public Overrides Function GetHashCode() As Integer
-                Throw New NotImplementedException()
-            End Function
-
         End Class
 
         <Serializable()>
@@ -966,10 +962,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
                 End If
 
                 Return False
-            End Function
-
-            Public Overrides Function GetHashCode() As Integer
-                Throw New NotImplementedException()
             End Function
 
         End Class


### PR DESCRIPTION
.NET 4.8 Accessibility changes expect that ComboBox items provide hash codes and do not throw an exception when calling its GetHashCode function so removing overriden GetHashCode functions (which simpy throw NotImplemented exception) from ApplicationPropPageVBWPF.StartupUri​, StartupObject and StartupObjectOrUri to restore default object's behavior when providing hash code (generating an integer).