### PR TITLE
 Handle missing/out of date rules 

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectSubscriptionUpdateFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectSubscriptionUpdateFactory.cs
@@ -42,6 +42,16 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return mock.Object;
         }
 
+        public static IProjectSubscriptionUpdate CreateEmpty()
+        {
+            return FromJson(@"
+{
+    ""CurrentState"": {
+    }
+}
+");
+        }
+
         public static IProjectSubscriptionUpdate FromJson(string jsonString)
         {
             var model = new IProjectSubscriptionUpdateModel();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/NuGet/Snapshots/RestoreBuilderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/NuGet/Snapshots/RestoreBuilderTests.cs
@@ -1,22 +1,28 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using NuGet.SolutionRestoreManager;
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
 {
     public class RestoreBuilderTests
     {
-        private const string ProjectWithEmptyItems =
-@"{
+        [Fact]
+        public void ToProjectRestoreInfo_WhenItemsAreMissing_ReturnsEmptyItemCollections()
+        {
+            var update = IProjectSubscriptionUpdateFactory.CreateEmpty();
+
+            var result = RestoreBuilder.ToProjectRestoreInfo(update.CurrentState);
+
+            AssertNoItems(result);
+        }
+
+        [Fact]
+        public void ToProjectRestoreInfo_WhenNoItems_ReturnsEmptyItemCollections()
+        {
+            var update = IProjectSubscriptionUpdateFactory.FromJson(@"
+{
     ""CurrentState"": {
-        ""NuGetRestore"": {
-            ""Properties"": {
-                ""MSBuildProjectExtensionsPath"": ""C:\\Project\\obj"",
-                ""TargetFrameworks"": ""net45"",               
-                ""TargetFrameworkMoniker"": "".NETFramework, Version=v4.5"",
-                ""Property"": ""Value""
-            },
-        },
         ""ProjectReference"": {
             ""Items"" : {}
         },
@@ -27,45 +33,115 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             ""Items"" : {}
         }
     }
-}";
-        private const string ProjectWithItems =
-@"{
+}
+");
+            var result = RestoreBuilder.ToProjectRestoreInfo(update.CurrentState);
+
+            AssertNoItems(result);
+        }
+
+        [Fact]
+        public void ToProjectRestoreInfo_WhenNuGetRestoreRuleMissing_ReturnsEmpty()
+        {
+            var update = IProjectSubscriptionUpdateFactory.CreateEmpty();
+            var result = RestoreBuilder.ToProjectRestoreInfo(update.CurrentState);
+
+            Assert.Empty(result.BaseIntermediatePath);
+            Assert.Empty(result.OriginalTargetFrameworks);
+            Assert.Equal(1, result.TargetFrameworks.Count);
+
+            var targetFramework = result.TargetFrameworks.Item(0);
+
+            Assert.Empty(targetFramework.TargetFrameworkMoniker);
+            Assert.Empty(targetFramework.Properties);
+        }
+
+        [Fact]
+        public void ToProjectRestoreInfo_SetsCoreProperties()
+        {
+            var update = IProjectSubscriptionUpdateFactory.FromJson(@"
+{
     ""CurrentState"": {
         ""NuGetRestore"": {
             ""Properties"": {
-               ""TargetFrameworkMoniker"": "".NETFramework, Version=v4.5"",
-               ""TargetFrameworks"": ""net45"",
-               ""MSBuildProjectExtensionsPath"": ""C:\\Project\\obj"",
-               ""Property"": ""Value""
+                ""MSBuildProjectExtensionsPath"": ""C:\\Project\\obj"",
+                ""TargetFrameworks"": ""net45"",               
+                ""TargetFrameworkMoniker"": "".NETFramework, Version=v4.5""
             },
-        },
-        ""ProjectReference"": {
-            ""Items"" : {
-                ""..\\Project\\Project1.csproj"" : {
-                    ""ProjectFileFullPath"" : ""C:\\Solution\\Project\\Project1.csproj"",
-                },
-                ""..\\Project\\Project2.csproj"" : {
-                    ""ProjectFileFullPath"" : ""C:\\Solution\\Project\\Project2.csproj"",
-                },
-                ""..\\Project\\Project3.csproj"" : {
-                    ""ProjectFileFullPath"" : ""C:\\Solution\\Project\\Project3.csproj"",
-                    ""Property"": ""Value""
-                }
-            }
-        },
-        ""PackageReference"": {
-            ""Items"" : {
-                ""PackageReference1"" : {
-                    ""Version"" : ""1.0.0.0"",
-                },
-                ""PackageReference2"" : {
-                    ""Version"" : ""2.0.0.0"",
-                },
-                ""PackageReference3"" : {
-                    ""Name"" : ""Value""
-                }
-            }
-        },
+        }
+    }
+}
+");
+            var result = RestoreBuilder.ToProjectRestoreInfo(update.CurrentState);
+
+            Assert.Equal("C:\\Project\\obj", result.BaseIntermediatePath);
+            Assert.Equal("net45", result.OriginalTargetFrameworks);
+            Assert.Equal(1, result.TargetFrameworks.Count);
+
+            var targetFramework = result.TargetFrameworks.Item(0);
+
+            Assert.Equal(".NETFramework, Version=v4.5", targetFramework.TargetFrameworkMoniker);
+        }
+
+        [Fact]
+        public void ToProjectRestoreInfo_WhenEmpty_SetsCorePropertiesToEmpty()
+        {
+            var update = IProjectSubscriptionUpdateFactory.FromJson(@"
+{
+    ""CurrentState"": {
+        ""NuGetRestore"": {
+            ""Properties"": {
+                ""MSBuildProjectExtensionsPath"": """",
+                ""TargetFrameworks"": """",               
+                ""TargetFrameworkMoniker"": """"
+            },
+        }
+    }
+}
+");
+            var result = RestoreBuilder.ToProjectRestoreInfo(update.CurrentState);
+
+            Assert.Empty(result.BaseIntermediatePath);
+            Assert.Empty(result.OriginalTargetFrameworks);
+            Assert.Equal(1, result.TargetFrameworks.Count);
+
+            var targetFramework = result.TargetFrameworks.Item(0);
+
+            Assert.Empty(targetFramework.TargetFrameworkMoniker);
+        }
+
+        [Fact]
+        public void ToProjectRestoreInfo_SetsTargetFrameworkProperties()
+        {   // All NuGetRestore properties end up in the "target framework" property bag
+
+            var update = IProjectSubscriptionUpdateFactory.FromJson(@"
+{
+    ""CurrentState"": {
+        ""NuGetRestore"": {
+            ""Properties"": {
+                ""Property"": ""Value"",
+                ""AnotherProperty"": ""AnotherValue""
+            },
+        }
+    }
+}
+");
+            var result = RestoreBuilder.ToProjectRestoreInfo(update.CurrentState);
+
+            Assert.Equal(1, result.TargetFrameworks.Count);
+
+            var properties = result.TargetFrameworks.Item(0).Properties;
+
+            AssertContainsProperty("Property", "Value", properties);
+            AssertContainsProperty("AnotherProperty", "AnotherValue", properties);
+        }
+
+        [Fact]
+        public void ToProjectRestoreInfo_SetsToolReferences()
+        {
+            var update = IProjectSubscriptionUpdateFactory.FromJson(@"
+{
+    ""CurrentState"": {
         ""DotNetCliToolReference"": {
             ""Items"" : {
                 ""ToolReference1"" : {
@@ -80,89 +156,45 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
             }
         }
     }
-}";
-
-        [Fact]
-        public void ToProjectRestoreInfo_WhenNoItems_ReturnsEmptyItemCollections()
-        {
-            var update = IProjectSubscriptionUpdateFactory.FromJson(ProjectWithEmptyItems);
-
-            var result = RestoreBuilder.ToProjectRestoreInfo(update.CurrentState);
-
-            Assert.Empty(result.ToolReferences);
-            Assert.Equal(1, result.TargetFrameworks.Count);
-
-            var targetFramework = result.TargetFrameworks.Item(0);
-
-            Assert.Empty(targetFramework.PackageReferences);
-            Assert.Empty(targetFramework.ProjectReferences);
-        }
-
-        [Fact]
-        public void ToProjectRestoreInfo_SetsCoreProperties()
-        {
-            var update = IProjectSubscriptionUpdateFactory.FromJson(ProjectWithEmptyItems);
-
-            var result = RestoreBuilder.ToProjectRestoreInfo(update.CurrentState);
-
-            Assert.Equal("C:\\Project\\obj",            result.BaseIntermediatePath);
-            Assert.Equal("net45",                       result.OriginalTargetFrameworks);
-            Assert.Equal(1,                             result.TargetFrameworks.Count);
-            Assert.Equal(".NETFramework, Version=v4.5", result.TargetFrameworks.Item(0).TargetFrameworkMoniker);
-        }
-
-        [Fact]
-        public void ToProjectRestoreInfo_SetsTargetFrameworkPropertiesToAllProperties()
-        {
-            var update = IProjectSubscriptionUpdateFactory.FromJson(ProjectWithEmptyItems);
-
-            var result = RestoreBuilder.ToProjectRestoreInfo(update.CurrentState);
-
-            Assert.Equal(1, result.TargetFrameworks.Count);
-
-            var properties = result.TargetFrameworks.Item(0).Properties;
-
-            Assert.Equal("MSBuildProjectExtensionsPath",    properties.Item("MSBuildProjectExtensionsPath").Name);
-            Assert.Equal("C:\\Project\\obj",                properties.Item("MSBuildProjectExtensionsPath").Value);
-
-            Assert.Equal("TargetFrameworks",                properties.Item("TargetFrameworks").Name);
-            Assert.Equal("net45",                           properties.Item("TargetFrameworks").Value);
-
-            Assert.Equal("TargetFrameworkMoniker",          properties.Item("TargetFrameworkMoniker").Name);
-            Assert.Equal(".NETFramework, Version=v4.5",     properties.Item("TargetFrameworkMoniker").Value);
-
-            Assert.Equal("Property",                        properties.Item("Property").Name);
-            Assert.Equal("Value",                           properties.Item("Property").Value);
-        }
-
-        [Fact]
-        public void ToProjectRestoreInfo_SetsToolReferences()
-        {
-            var update = IProjectSubscriptionUpdateFactory.FromJson(ProjectWithItems);
-
+}
+");
             var result = RestoreBuilder.ToProjectRestoreInfo(update.CurrentState);
             var references = result.ToolReferences;
 
             Assert.Equal(3, references.Count);
 
-            Assert.Equal("ToolReference1",      references.Item("ToolReference1").Name);
-            Assert.Equal("Version",             references.Item("ToolReference1").Properties.Item("Version").Name);
-            Assert.Equal("1.0.0.0",             references.Item("ToolReference1").Properties.Item("Version").Value);
+            Assert.Equal("ToolReference1", references.Item("ToolReference1").Name);
+            AssertContainsProperty("Version", "1.0.0.0", references.Item("ToolReference1").Properties);
 
-            Assert.Equal("ToolReference2",      references.Item("ToolReference2").Name);
-            Assert.Equal("Version",             references.Item("ToolReference2").Properties.Item("Version").Name);
-            Assert.Equal("2.0.0.0",             references.Item("ToolReference2").Properties.Item("Version").Value);
+            Assert.Equal("ToolReference2", references.Item("ToolReference2").Name);
+            AssertContainsProperty("Version", "2.0.0.0", references.Item("ToolReference2").Properties);
 
-            Assert.Equal("ToolReference3",      references.Item("ToolReference3").Name);
-            Assert.Equal("Name",                references.Item("ToolReference3").Properties.Item("Name").Name);
-            Assert.Equal("Value",               references.Item("ToolReference3").Properties.Item("Name").Value);
+            Assert.Equal("ToolReference3", references.Item("ToolReference3").Name);
+            AssertContainsProperty("Name", "Value", references.Item("ToolReference3").Properties);
         }
 
         [Fact]
         public void ToProjectRestoreInfo_SetsPackageReferences()
         {
-            var update = IProjectSubscriptionUpdateFactory.FromJson(ProjectWithItems);
-
+            var update = IProjectSubscriptionUpdateFactory.FromJson(@"
+{
+    ""CurrentState"": {
+        ""PackageReference"": {
+            ""Items"" : {
+                ""PackageReference1"" : {
+                    ""Version"" : ""1.0.0.0"",
+                },
+                ""PackageReference2"" : {
+                    ""Version"" : ""2.0.0.0"",
+                },
+                ""PackageReference3"" : {
+                    ""Name"" : ""Value""
+                }
+            }
+        }
+    }
+}
+");
             var result = RestoreBuilder.ToProjectRestoreInfo(update.CurrentState);
 
             Assert.Equal(1, result.TargetFrameworks.Count);
@@ -171,24 +203,38 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
 
             Assert.Equal(3, references.Count);
 
-            Assert.Equal("PackageReference1",   references.Item("PackageReference1").Name);
-            Assert.Equal("Version",             references.Item("PackageReference1").Properties.Item("Version").Name);
-            Assert.Equal("1.0.0.0",             references.Item("PackageReference1").Properties.Item("Version").Value);
+            Assert.Equal("PackageReference1", references.Item("PackageReference1").Name);
+            AssertContainsProperty("Version", "1.0.0.0", references.Item("PackageReference1").Properties);
 
-            Assert.Equal("PackageReference2",   references.Item("PackageReference2").Name);
-            Assert.Equal("Version",             references.Item("PackageReference2").Properties.Item("Version").Name);
-            Assert.Equal("2.0.0.0",             references.Item("PackageReference2").Properties.Item("Version").Value);
+            Assert.Equal("PackageReference2", references.Item("PackageReference2").Name);
+            AssertContainsProperty("Version", "2.0.0.0", references.Item("PackageReference2").Properties);
 
-            Assert.Equal("PackageReference3",   references.Item("PackageReference3").Name);
-            Assert.Equal("Name",                references.Item("PackageReference3").Properties.Item("Name").Name);
-            Assert.Equal("Value",               references.Item("PackageReference3").Properties.Item("Name").Value);
+            Assert.Equal("PackageReference3", references.Item("PackageReference3").Name);
+            AssertContainsProperty("Name", "Value", references.Item("PackageReference3").Properties);
         }
 
         [Fact]
         public void ToProjectRestoreInfo_SetsProjectReferences()
         {
-            var update = IProjectSubscriptionUpdateFactory.FromJson(ProjectWithItems);
-
+            var update = IProjectSubscriptionUpdateFactory.FromJson(@"
+{
+    ""CurrentState"": {
+        ""ProjectReference"": {
+            ""Items"" : {
+                ""..\\Project\\Project1.csproj"" : {
+                    ""ProjectFileFullPath"" : ""C:\\Solution\\Project\\Project1.csproj"",
+                },
+                ""..\\Project\\Project2.csproj"" : {
+                    ""ProjectFileFullPath"" : ""C:\\Solution\\Project\\Project2.csproj"",
+                },
+                ""..\\Project\\Project3.csproj"" : {
+                    ""ProjectFileFullPath"" : ""C:\\Solution\\Project\\Project3.csproj"",
+                    ""MetadataName"": ""MetadataValue""
+                }
+            }
+        }
+    }
+}");
             var result = RestoreBuilder.ToProjectRestoreInfo(update.CurrentState);
 
             Assert.Equal(1, result.TargetFrameworks.Count);
@@ -197,19 +243,50 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
 
             Assert.Equal(3, references.Count);
 
-            Assert.Equal("..\\Project\\Project1.csproj",             references.Item("..\\Project\\Project1.csproj").Name);
-            Assert.Equal("ProjectFileFullPath",                      references.Item("..\\Project\\Project1.csproj").Properties.Item("ProjectFileFullPath").Name);
-            Assert.Equal("C:\\Solution\\Project\\Project1.csproj",   references.Item("..\\Project\\Project1.csproj").Properties.Item("ProjectFileFullPath").Value);
+            var reference1 = references.Item("..\\Project\\Project1.csproj");
+            Assert.Equal("..\\Project\\Project1.csproj", reference1.Name);
 
-            Assert.Equal("..\\Project\\Project2.csproj",             references.Item("..\\Project\\Project2.csproj").Name);
-            Assert.Equal("ProjectFileFullPath",                      references.Item("..\\Project\\Project2.csproj").Properties.Item("ProjectFileFullPath").Name);
-            Assert.Equal("C:\\Solution\\Project\\Project2.csproj",   references.Item("..\\Project\\Project2.csproj").Properties.Item("ProjectFileFullPath").Value);
+            AssertContainsProperty("ProjectFileFullPath", "C:\\Solution\\Project\\Project1.csproj", reference1.Properties);
 
-            Assert.Equal("..\\Project\\Project3.csproj",             references.Item("..\\Project\\Project3.csproj").Name);
-            Assert.Equal("ProjectFileFullPath",                      references.Item("..\\Project\\Project3.csproj").Properties.Item("ProjectFileFullPath").Name);
-            Assert.Equal("C:\\Solution\\Project\\Project3.csproj",   references.Item("..\\Project\\Project3.csproj").Properties.Item("ProjectFileFullPath").Value);
-            Assert.Equal("Property",                                 references.Item("..\\Project\\Project3.csproj").Properties.Item("Property").Name);
-            Assert.Equal("Value",                                    references.Item("..\\Project\\Project3.csproj").Properties.Item("Property").Value);
+            var reference2 = references.Item("..\\Project\\Project2.csproj");
+            Assert.Equal("..\\Project\\Project2.csproj", reference2.Name);
+
+            AssertContainsProperty("ProjectFileFullPath", "C:\\Solution\\Project\\Project2.csproj", reference2.Properties);
+
+            var reference3 = references.Item("..\\Project\\Project3.csproj");
+            Assert.Equal("..\\Project\\Project3.csproj", reference3.Name);
+
+            AssertContainsProperty("ProjectFileFullPath", "C:\\Solution\\Project\\Project3.csproj", reference3.Properties);
+            AssertContainsProperty("MetadataName", "MetadataValue", reference3.Properties);
+        }
+
+        private static void AssertContainsProperty(string name, string value, IVsProjectProperties properties)
+        {
+            var property = properties.Item(name);
+
+            Assert.NotNull(property);
+            Assert.Equal(name, property.Name);
+            Assert.Equal(value, property.Value);
+        }
+
+        private static void AssertContainsProperty(string name, string value, IVsReferenceProperties properties)
+        {
+            var property = properties.Item(name);
+
+            Assert.NotNull(property);
+            Assert.Equal(name, property.Name);
+            Assert.Equal(value, property.Value);
+        }
+
+        private static void AssertNoItems(IVsProjectRestoreInfo result)
+        {
+            Assert.Empty(result.ToolReferences);
+            Assert.Equal(1, result.TargetFrameworks.Count);
+
+            var targetFramework = result.TargetFrameworks.Item(0);
+
+            Assert.Empty(targetFramework.PackageReferences);
+            Assert.Empty(targetFramework.ProjectReferences);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/Snapshots/RestoreBuilder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/NuGet/Snapshots/RestoreBuilder.cs
@@ -21,19 +21,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.NuGet
         {
             Requires.NotNull(update, nameof(update));
 
-            IImmutableDictionary<string, string> properties = update[NuGetRestore.SchemaName].Properties;
+            IImmutableDictionary<string, string> properties = update.GetSnapshotOrEmpty(NuGetRestore.SchemaName).Properties;
+            IProjectRuleSnapshot projectReferences = update.GetSnapshotOrEmpty(ProjectReference.SchemaName);
+            IProjectRuleSnapshot packageReferences = update.GetSnapshotOrEmpty(PackageReference.SchemaName);
+            IProjectRuleSnapshot toolReferences = update.GetSnapshotOrEmpty(DotNetCliToolReference.SchemaName);
 
             IVsTargetFrameworkInfo frameworkInfo = new TargetFrameworkInfo(
-                properties[NuGetRestore.TargetFrameworkMonikerProperty],
-                ToReferenceItems(update[ProjectReference.SchemaName].Items),
-                ToReferenceItems(update[PackageReference.SchemaName].Items),
+                properties.GetPropertyOrEmpty(NuGetRestore.TargetFrameworkMonikerProperty),
+                ToReferenceItems(projectReferences.Items),
+                ToReferenceItems(packageReferences.Items),
                 ToProjectProperties(properties));
 
             return new ProjectRestoreInfo(
-                properties[NuGetRestore.MSBuildProjectExtensionsPathProperty],
-                properties[NuGetRestore.TargetFrameworksProperty],
+                properties.GetPropertyOrEmpty(NuGetRestore.MSBuildProjectExtensionsPathProperty),
+                properties.GetPropertyOrEmpty(NuGetRestore.TargetFrameworksProperty),
                 new TargetFrameworks(new[] { frameworkInfo }),
-                ToReferenceItems(update[DotNetCliToolReference.SchemaName].Items));
+                ToReferenceItems(toolReferences.Items));
         }
 
         private static IVsProjectProperties ToProjectProperties(IImmutableDictionary<string, string> properties)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ProjectRuleSnapshotExtensions.EmptyProjectRuleSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ProjectRuleSnapshotExtensions.EmptyProjectRuleSnapshot.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties
+{
+    internal static partial class ProjectRuleSnapshotExtensions
+    {
+        private class EmptyProjectRuleSnapshot : IProjectRuleSnapshot
+        {
+            public static readonly EmptyProjectRuleSnapshot Instance = new EmptyProjectRuleSnapshot();
+
+            public string RuleName
+            {
+                get { throw new NotSupportedException(); }
+            }
+
+            public IImmutableDictionary<string, IImmutableDictionary<string, string>> Items
+            {
+                get { return ImmutableDictionary<string, IImmutableDictionary<string, string>>.Empty; }
+            }
+
+            public IImmutableDictionary<string, string> Properties
+            {
+                get { return ImmutableDictionary<string, string>.Empty; }
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ProjectRuleSnapshotExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ProjectRuleSnapshotExtensions.cs
@@ -7,8 +7,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     /// <summary>
     ///     Contains common extensions for <see cref="IProjectRuleSnapshot"/> instances.
     /// </summary>
-    internal static class ProjectRuleSnapshotExtensions
+    internal static partial class ProjectRuleSnapshotExtensions
     {
+        /// <summary>
+        ///     Gets the value that is associated with specified name, or an empty string ("") if it does not exist.
+        /// </summary>
+        public static string GetPropertyOrEmpty(this IImmutableDictionary<string, string> properties, string name)
+        {
+            Requires.NotNull(properties, nameof(properties));
+            Requires.NotNullOrEmpty(name, nameof(name));
+
+            return properties.GetValueOrDefault(name, string.Empty);
+        }
+
         /// <summary>
         ///     Gets the value that is associated with the specified rule and property.
         /// </summary>
@@ -17,6 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             Requires.NotNull(snapshots, nameof(snapshots));
             Requires.NotNullOrEmpty(ruleName, nameof(ruleName));
             Requires.NotNullOrEmpty(propertyName, nameof(propertyName));
+
             if (snapshots.TryGetValue(ruleName, out IProjectRuleSnapshot snapshot) && snapshot.Properties.TryGetValue(propertyName, out string value))
             {
                 // Similar to MSBuild, we treat the absence of a property the same as an empty property
@@ -35,6 +47,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             string value = snapshots.GetPropertyOrDefault(ruleName, propertyName, defaultValue ? "true" : "false");
 
             return StringComparers.PropertyLiteralValues.Equals(value, "true");
+        }
+
+        /// <summary>
+        ///     Gets the snapshot associated with the specified rule, or an empty snapshot if it does not exist.
+        /// </summary>
+        public static IProjectRuleSnapshot GetSnapshotOrEmpty(this IImmutableDictionary<string, IProjectRuleSnapshot> snapshots, string ruleName)
+        {
+            Requires.NotNull(snapshots, nameof(snapshots));
+
+            if (snapshots.TryGetValue(ruleName, out IProjectRuleSnapshot result))
+            {
+                return result;
+            }
+
+            return EmptyProjectRuleSnapshot.Instance;
         }
     }
 }


### PR DESCRIPTION
Other teams have copied our rules to enable package reference support. These rules will become out-of-date with our built-in rules so handle missing rules. Also makes unit testing easier.