### PR TITLE
Persist SubType to the .user file instead of the project file

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -95,7 +95,8 @@
                           SingleFileGenerators;
                           DeclaredSourceItems;
                           UserSourceItems;
-                          SupportAvailableItemName;" />
+                          SupportAvailableItemName;
+                          PersistDesignTimeDataOutOfProject;" />
 
     <!-- Reference Manager capabilities -->
     <ProjectCapability Include="ReferenceManagerAssemblies" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/AdditionalFiles.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/AdditionalFiles.BrowseObject.xaml
@@ -132,6 +132,12 @@
 
   <EnumProperty Name="SubType"
                 Visible="false">
+    <EnumProperty.DataSource>
+      <DataSource Persistence="DesignTimeItemPropertiesStorage"
+                  ItemType="AdditionalFiles"
+                  PersistedName="SubType"
+                  HasConfigurationCondition="false"/>
+    </EnumProperty.DataSource>
     <EnumValue Name="Designer" />
     <EnumValue Name="Component" />
     <EnumValue Name="Control" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/AdditionalFiles.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/AdditionalFiles.xaml
@@ -79,7 +79,14 @@
   </StringProperty>
 
   <StringProperty Name="SubType"
-                  Visible="false" />
+                  Visible="false">
+    <StringProperty.DataSource>
+      <DataSource Persistence="DesignTimeItemPropertiesStorage"
+                  ItemType="AdditionalFiles"
+                  PersistedName="SubType"
+                  HasConfigurationCondition="false"/>
+    </StringProperty.DataSource>
+  </StringProperty>
 
   <BoolProperty Name="Visible"
                 Visible="false" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/ApplicationDefinition.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/ApplicationDefinition.BrowseObject.xaml
@@ -132,6 +132,12 @@
 
   <EnumProperty Name="SubType"
                 Visible="false">
+    <EnumProperty.DataSource>
+      <DataSource Persistence="DesignTimeItemPropertiesStorage"
+                  ItemType="ApplicationDefinition"
+                  PersistedName="SubType"
+                  HasConfigurationCondition="false"/>
+    </EnumProperty.DataSource>
     <EnumValue Name="Designer" />
     <EnumValue Name="Component" />
     <EnumValue Name="Control" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/ApplicationDefinition.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/ApplicationDefinition.xaml
@@ -79,7 +79,14 @@
   </StringProperty>
 
   <StringProperty Name="SubType"
-                  Visible="false" />
+                  Visible="false">
+    <StringProperty.DataSource>
+      <DataSource Persistence="DesignTimeItemPropertiesStorage"
+                  ItemType="ApplicationDefinition"
+                  PersistedName="SubType"
+                  HasConfigurationCondition="false"/>
+    </StringProperty.DataSource>
+  </StringProperty>
 
   <BoolProperty Name="Visible"
                 Visible="false" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.BrowseObject.xaml
@@ -132,6 +132,12 @@
 
   <EnumProperty Name="SubType"
                 Visible="false">
+    <EnumProperty.DataSource>
+      <DataSource Persistence="DesignTimeItemPropertiesStorage"
+                  ItemType="Compile"
+                  PersistedName="SubType"
+                  HasConfigurationCondition="false"/>
+    </EnumProperty.DataSource>
     <EnumValue Name="Designer" />
     <EnumValue Name="Component" />
     <EnumValue Name="Control" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.xaml
@@ -79,7 +79,14 @@
   </StringProperty>
 
   <StringProperty Name="SubType"
-                  Visible="false" />
+                  Visible="false">
+    <StringProperty.DataSource>
+      <DataSource Persistence="DesignTimeItemPropertiesStorage"
+                  ItemType="Compile"
+                  PersistedName="SubType"
+                  HasConfigurationCondition="false"/>
+    </StringProperty.DataSource>
+  </StringProperty>
 
   <BoolProperty Name="Visible"
                 Visible="false" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.BrowseObject.xaml
@@ -132,6 +132,12 @@
 
   <EnumProperty Name="SubType"
                 Visible="false">
+    <EnumProperty.DataSource>
+      <DataSource Persistence="DesignTimeItemPropertiesStorage"
+                  ItemType="Content"
+                  PersistedName="SubType"
+                  HasConfigurationCondition="false"/>
+    </EnumProperty.DataSource>
     <EnumValue Name="Designer" />
     <EnumValue Name="Component" />
     <EnumValue Name="Control" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.xaml
@@ -79,7 +79,14 @@
   </StringProperty>
 
   <StringProperty Name="SubType"
-                  Visible="false" />
+                  Visible="false">
+    <StringProperty.DataSource>
+      <DataSource Persistence="DesignTimeItemPropertiesStorage"
+                  ItemType="Content"
+                  PersistedName="SubType"
+                  HasConfigurationCondition="false"/>
+    </StringProperty.DataSource>
+  </StringProperty>
 
   <BoolProperty Name="Visible"
                 Visible="false" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.BrowseObject.xaml
@@ -132,6 +132,12 @@
 
   <EnumProperty Name="SubType"
                 Visible="false">
+    <EnumProperty.DataSource>
+      <DataSource Persistence="DesignTimeItemPropertiesStorage"
+                  ItemType="EmbeddedResource"
+                  PersistedName="SubType"
+                  HasConfigurationCondition="false"/>
+    </EnumProperty.DataSource>
     <EnumValue Name="Designer" />
     <EnumValue Name="Component" />
     <EnumValue Name="Control" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.xaml
@@ -79,7 +79,14 @@
   </StringProperty>
 
   <StringProperty Name="SubType"
-                  Visible="false" />
+                  Visible="false">
+    <StringProperty.DataSource>
+      <DataSource Persistence="DesignTimeItemPropertiesStorage"
+                  ItemType="EmbeddedResource"
+                  PersistedName="SubType"
+                  HasConfigurationCondition="false"/>
+    </StringProperty.DataSource>
+  </StringProperty>
 
   <BoolProperty Name="Visible"
                 Visible="false" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.BrowseObject.xaml
@@ -132,6 +132,12 @@
 
   <EnumProperty Name="SubType"
                 Visible="false">
+    <EnumProperty.DataSource>
+      <DataSource Persistence="DesignTimeItemPropertiesStorage"
+                  ItemType="None"
+                  PersistedName="SubType"
+                  HasConfigurationCondition="false"/>
+    </EnumProperty.DataSource>
     <EnumValue Name="Designer" />
     <EnumValue Name="Component" />
     <EnumValue Name="Control" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.xaml
@@ -79,7 +79,14 @@
   </StringProperty>
 
   <StringProperty Name="SubType"
-                  Visible="false" />
+                  Visible="false">
+    <StringProperty.DataSource>
+      <DataSource Persistence="DesignTimeItemPropertiesStorage"
+                  ItemType="None"
+                  PersistedName="SubType"
+                  HasConfigurationCondition="false"/>
+    </StringProperty.DataSource>
+  </StringProperty>
 
   <BoolProperty Name="Visible"
                 Visible="false" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Page.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Page.BrowseObject.xaml
@@ -132,6 +132,12 @@
 
   <EnumProperty Name="SubType"
                 Visible="false">
+    <EnumProperty.DataSource>
+      <DataSource Persistence="DesignTimeItemPropertiesStorage"
+                  ItemType="Page"
+                  PersistedName="SubType"
+                  HasConfigurationCondition="false"/>
+    </EnumProperty.DataSource>
     <EnumValue Name="Designer" />
     <EnumValue Name="Component" />
     <EnumValue Name="Control" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Page.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Page.xaml
@@ -79,7 +79,14 @@
   </StringProperty>
 
   <StringProperty Name="SubType"
-                  Visible="false" />
+                  Visible="false">
+    <StringProperty.DataSource>
+      <DataSource Persistence="DesignTimeItemPropertiesStorage"
+                  ItemType="Page"
+                  PersistedName="SubType"
+                  HasConfigurationCondition="false"/>
+    </StringProperty.DataSource>
+  </StringProperty>
 
   <BoolProperty Name="Visible"
                 Visible="false" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Resource.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Resource.BrowseObject.xaml
@@ -132,6 +132,12 @@
 
   <EnumProperty Name="SubType"
                 Visible="false">
+    <EnumProperty.DataSource>
+      <DataSource Persistence="DesignTimeItemPropertiesStorage"
+                  ItemType="Resource"
+                  PersistedName="SubType"
+                  HasConfigurationCondition="false"/>
+    </EnumProperty.DataSource>
     <EnumValue Name="Designer" />
     <EnumValue Name="Component" />
     <EnumValue Name="Control" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Resource.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Resource.xaml
@@ -79,7 +79,14 @@
   </StringProperty>
 
   <StringProperty Name="SubType"
-                  Visible="false" />
+                  Visible="false">
+    <StringProperty.DataSource>
+      <DataSource Persistence="DesignTimeItemPropertiesStorage"
+                  ItemType="Resource"
+                  PersistedName="SubType"
+                  HasConfigurationCondition="false"/>
+    </StringProperty.DataSource>
+  </StringProperty>
 
   <BoolProperty Name="Visible"
                 Visible="false" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/XamlAppDef.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/XamlAppDef.BrowseObject.xaml
@@ -132,6 +132,12 @@
 
   <EnumProperty Name="SubType"
                 Visible="false">
+    <EnumProperty.DataSource>
+      <DataSource Persistence="DesignTimeItemPropertiesStorage"
+                  ItemType="XamlAppDef"
+                  PersistedName="SubType"
+                  HasConfigurationCondition="false"/>
+    </EnumProperty.DataSource>
     <EnumValue Name="Designer" />
     <EnumValue Name="Component" />
     <EnumValue Name="Control" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/XamlAppDef.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/XamlAppDef.xaml
@@ -79,7 +79,14 @@
   </StringProperty>
 
   <StringProperty Name="SubType"
-                  Visible="false" />
+                  Visible="false">
+    <StringProperty.DataSource>
+      <DataSource Persistence="DesignTimeItemPropertiesStorage"
+                  ItemType="XamlAppDef"
+                  PersistedName="SubType"
+                  HasConfigurationCondition="false"/>
+    </StringProperty.DataSource>
+  </StringProperty>
 
   <BoolProperty Name="Visible"
                 Visible="false" />


### PR DESCRIPTION
Roslyn.sln has started to get a bunch of modifications with SubType being filled in, even though ProjectSystem.sln doesn't. Maybe something to do with Arcade? Either way this was always coming, now it just came quicker.

This means as the compiler pushes SubType information to CPS, it gets stored in the <project>.user file instead of the project file itself.

Fixes #182 

cc @jasonmalinowski 