### PR TITLE
Update LogicalToDeviceUnits calls with DpiAwareness 

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerView.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerView.vb
@@ -17,6 +17,7 @@ Imports Microsoft.VisualStudio.Editors.PropertyPages
 Imports Microsoft.VisualStudio.ManagedInterfaces.ProjectDesigner
 Imports Microsoft.VisualStudio.PlatformUI
 Imports Microsoft.VisualStudio.Shell.Interop
+Imports Microsoft.VisualStudio.Utilities
 
 Imports OleInterop = Microsoft.VisualStudio.OLE.Interop
 Imports VSITEMID = Microsoft.VisualStudio.Editors.VSITEMIDAPPDES
@@ -54,8 +55,8 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             'Add any initialization after the InitializeComponent() call
 
             ' Scale the width of the Configuration/Platform combo boxes
-            ConfigurationComboBox.Width = DpiHelper.LogicalToDeviceUnitsX(ConfigurationComboBox.Width)
-            PlatformComboBox.Width = DpiHelper.LogicalToDeviceUnitsX(PlatformComboBox.Width)
+            ConfigurationComboBox.Width = DpiAwareness.LogicalToDeviceUnits(Handle, ConfigurationComboBox.Width)
+            PlatformComboBox.Width = DpiAwareness.LogicalToDeviceUnits(Handle, PlatformComboBox.Width)
 
             'Start out with the assumption that the configuration/platform comboboxes
             '  are invisible, otherwise they will flicker visible before being turned off.

--- a/src/Microsoft.VisualStudio.Editors/Common/SplitButton.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/SplitButton.vb
@@ -5,7 +5,7 @@ Imports System.Drawing
 Imports System.Windows.Forms
 Imports System.Windows.Forms.VisualStyles
 
-Imports Microsoft.VisualStudio.PlatformUI
+Imports Microsoft.VisualStudio.Utilities
 
 Namespace Microsoft.VisualStudio.Editors.Common
 
@@ -29,7 +29,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
             MyBase.New()
 
             AccessibleRole = AccessibleRole.SplitButton
-            _pushButtonWidth = DpiHelper.LogicalToDeviceUnitsX(_pushButtonWidth)
+            _pushButtonWidth = DpiAwareness.LogicalToDeviceUnits(Handle, _pushButtonWidth)
         End Sub
 
         Protected Overrides Sub OnPaint(pevent As PaintEventArgs)
@@ -42,8 +42,8 @@ Namespace Microsoft.VisualStudio.Editors.Common
 
             ButtonRenderer.DrawButton(g, bounds, State)
 
-            Dim singlePixelWidth = DpiHelper.LogicalToDeviceUnitsX(1)
-            Dim dividerLineVerticalPadding = DpiHelper.LogicalToDeviceUnitsY(4)
+            Dim singlePixelWidth = DpiAwareness.LogicalToDeviceUnits(Handle, 1)
+            Dim dividerLineVerticalPadding = DpiAwareness.LogicalToDeviceUnits(Handle, 4)
 
             _dropDownRectangle = New Rectangle(
                 x:=bounds.Right - _pushButtonWidth - singlePixelWidth,
@@ -108,8 +108,8 @@ Namespace Microsoft.VisualStudio.Editors.Common
 
             If Focused Then
                 bounds.Inflate(
-                    width:=DpiHelper.LogicalToDeviceUnitsX(-4),
-                    height:=DpiHelper.LogicalToDeviceUnitsY(-4))
+                    width:=DpiAwareness.LogicalToDeviceUnits(Handle, -4),
+                    height:=DpiAwareness.LogicalToDeviceUnits(Handle, -4))
 
                 ControlPaint.DrawFocusRectangle(g, bounds)
             End If
@@ -243,16 +243,16 @@ Namespace Microsoft.VisualStudio.Editors.Common
             End Set
         End Property
 
-        Private Shared Sub PaintArrow(g As Graphics, dropDownRect As Rectangle)
+        Private Sub PaintArrow(g As Graphics, dropDownRect As Rectangle)
             Dim middle = New Point(Convert.ToInt32(dropDownRect.Left + dropDownRect.Width / 2), Convert.ToInt32(dropDownRect.Top + dropDownRect.Height / 2))
 
             ' if the width is odd - favor pushing it over one pixel right.
             middle.X += (dropDownRect.Width Mod 2)
 
-            Dim leftOffset = DpiHelper.LogicalToDeviceUnitsX(3)
-            Dim rightOffset = DpiHelper.LogicalToDeviceUnitsX(3)
-            Dim topOffset = DpiHelper.LogicalToDeviceUnitsY(1)
-            Dim bottomOffset = DpiHelper.LogicalToDeviceUnitsY(2)
+            Dim leftOffset = DpiAwareness.LogicalToDeviceUnits(Handle, 3)
+            Dim rightOffset = DpiAwareness.LogicalToDeviceUnits(Handle, 3)
+            Dim topOffset = DpiAwareness.LogicalToDeviceUnits(Handle, 1)
+            Dim bottomOffset = DpiAwareness.LogicalToDeviceUnits(Handle, 2)
 
             Dim arrow = New Point(2) {
                 New Point(

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerDataGridView.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerDataGridView.vb
@@ -6,7 +6,7 @@ Imports System.Drawing
 Imports System.Windows.Forms
 
 Imports Microsoft.VisualStudio.Editors.Common
-Imports Microsoft.VisualStudio.PlatformUI
+Imports Microsoft.VisualStudio.Utilities
 
 Namespace Microsoft.VisualStudio.Editors.DesignerFramework
 
@@ -43,7 +43,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             BackColor = SystemColors.Window
             ForeColor = SystemColors.WindowText
             ' Make sure the row headers have enough space to display the glyphs in HDPI
-            RowHeadersWidth = DpiHelper.LogicalToDeviceUnitsX(RowHeadersWidth)
+            RowHeadersWidth = DpiAwareness.LogicalToDeviceUnits(Handle, RowHeadersWidth)
         End Sub
 
         ''' <summary>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/AdvBuildSettingsPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AdvBuildSettingsPropPage.vb
@@ -6,7 +6,7 @@ Imports System.Reflection
 Imports System.Runtime.Versioning
 Imports System.Windows.Forms
 
-Imports Microsoft.VisualStudio.PlatformUI
+Imports Microsoft.VisualStudio.Utilities
 Imports Microsoft.VisualStudio.Shell.Interop
 Imports Microsoft.VisualStudio.Editors.Common
 Imports VSLangProj80
@@ -36,7 +36,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             cboDebugInfo.Items.AddRange(New Object() {New ComboItem("none", My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_AdvancedBuildSettings_DebugInfo_None), New ComboItem("full", My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_AdvancedBuildSettings_DebugInfo_Full), New ComboItem("pdbonly", My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_AdvancedBuildSettings_DebugInfo_PdbOnly), New ComboItem("portable", My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_AdvancedBuildSettings_DebugInfo_Portable), New ComboItem("embedded", My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_AdvancedBuildSettings_DebugInfo_Embedded)})
 
             ' Scale the width of the overarching table layout panel
-            overarchingTableLayoutPanel.Width = DpiHelper.LogicalToDeviceUnitsX(overarchingTableLayoutPanel.Width)
+            overarchingTableLayoutPanel.Width = DpiAwareness.LogicalToDeviceUnits(Handle, overarchingTableLayoutPanel.Width)
 
             MinimumSize = PreferredSize()
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
@@ -21,7 +21,7 @@ Imports Microsoft.VisualStudio.Editors.Common.DTEUtils
 Imports Microsoft.VisualStudio.Editors.DesignerFramework
 Imports Microsoft.VisualStudio.Editors.Interop
 Imports Microsoft.VisualStudio.Imaging
-Imports Microsoft.VisualStudio.PlatformUI
+Imports Microsoft.VisualStudio.Utilities
 Imports Microsoft.VisualStudio.Shell.Design
 Imports Microsoft.VisualStudio.Shell.Interop
 Imports Microsoft.Win32
@@ -597,7 +597,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <remarks></remarks>
         Private Sub InitializeUI()
             AllowDrop = True
-            StringTable.RowHeadersWidth = DpiHelper.LogicalToDeviceUnitsX(35)
+            StringTable.RowHeadersWidth = DpiAwareness.LogicalToDeviceUnits(Handle, 35)
         End Sub
 
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceListView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceListView.vb
@@ -8,7 +8,7 @@ Imports System.Runtime.InteropServices
 Imports System.Windows.Forms
 
 Imports Microsoft.VisualStudio.Editors.Common.Utils
-Imports Microsoft.VisualStudio.PlatformUI
+Imports Microsoft.VisualStudio.Utilities
 
 Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
@@ -57,10 +57,10 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Private Const DefaultSmallImageWidthHeight As Integer = 20
 
         ' The above settings scaled up for High DPI
-        Private ReadOnly _selectionBorderWidth As Integer = DpiHelper.LogicalToDeviceUnitsX(DefaultSelectionBorderWidth)
-        Private ReadOnly _borderWidth As Integer = DpiHelper.LogicalToDeviceUnitsX(DefaultBorderWidth)
-        Private ReadOnly _largeImageWidthHeight As Integer = DpiHelper.LogicalToDeviceUnitsX(DefaultLargeImageWidthHeight)
-        Private ReadOnly _smallImageWidthHeight As Integer = DpiHelper.LogicalToDeviceUnitsX(DefaultSmallImageWidthHeight)
+        Private ReadOnly _selectionBorderWidth As Integer = DpiAwareness.LogicalToDeviceUnits(Handle, DefaultSelectionBorderWidth)
+        Private ReadOnly _borderWidth As Integer = DpiAwareness.LogicalToDeviceUnits(Handle, DefaultBorderWidth)
+        Private ReadOnly _largeImageWidthHeight As Integer = DpiAwareness.LogicalToDeviceUnits(Handle, DefaultLargeImageWidthHeight)
+        Private ReadOnly _smallImageWidthHeight As Integer = DpiAwareness.LogicalToDeviceUnits(Handle, DefaultSmallImageWidthHeight)
 
         'The default column width for the "Name" column in "Details" view
         Private Const DefaultColumnWidthName As Integer = 150 'Includes the size of the thumbnail icon
@@ -330,11 +330,11 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
             If Not _columnInitialized Then
 
-                Columns.Add(My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_DetailsCol_Name, DpiHelper.LogicalToDeviceUnitsX(DefaultColumnWidthName), HorizontalAlignment.Left)
-                Columns.Add(My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_DetailsCol_Filename, DpiHelper.LogicalToDeviceUnitsX(DefaultColumnWidthFilename), HorizontalAlignment.Left)
-                Columns.Add(My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_DetailsCol_ImageType, DpiHelper.LogicalToDeviceUnitsX(DefaultColumnWidthImageType), HorizontalAlignment.Left)
-                Columns.Add(My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_DetailsCol_Size, DpiHelper.LogicalToDeviceUnitsX(DefaultColumnWidthSize), HorizontalAlignment.Left)
-                Columns.Add(My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_DetailsCol_Comment, DpiHelper.LogicalToDeviceUnitsX(DefaultColumnWidthComment), HorizontalAlignment.Left)
+                Columns.Add(My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_DetailsCol_Name, DpiAwareness.LogicalToDeviceUnits(Handle, DefaultColumnWidthName), HorizontalAlignment.Left)
+                Columns.Add(My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_DetailsCol_Filename, DpiAwareness.LogicalToDeviceUnits(Handle, DefaultColumnWidthFilename), HorizontalAlignment.Left)
+                Columns.Add(My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_DetailsCol_ImageType, DpiAwareness.LogicalToDeviceUnits(Handle, DefaultColumnWidthImageType), HorizontalAlignment.Left)
+                Columns.Add(My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_DetailsCol_Size, DpiAwareness.LogicalToDeviceUnits(Handle, DefaultColumnWidthSize), HorizontalAlignment.Left)
+                Columns.Add(My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_DetailsCol_Comment, DpiAwareness.LogicalToDeviceUnits(Handle, DefaultColumnWidthComment), HorizontalAlignment.Left)
 
                 _columnInitialized = True
             End If

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
@@ -8,7 +8,7 @@ Imports System.Security.Permissions
 Imports System.Windows.Forms
 
 Imports Microsoft.VisualStudio.Editors.Common
-Imports Microsoft.VisualStudio.PlatformUI
+Imports Microsoft.VisualStudio.Utilities
 
 Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
@@ -217,7 +217,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ' ==== Name Column
 
             Dim ColumnWidth As Integer
-            ColumnWidth = DpiHelper.LogicalToDeviceUnitsX(ColumnMinScrollingWidth_Name)
+            ColumnWidth = DpiAwareness.LogicalToDeviceUnits(Handle, ColumnMinScrollingWidth_Name)
             Dim NameColumn As New DataGridViewTextBoxColumn
             With NameColumn
                 .AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill
@@ -233,7 +233,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
             ' ==== Type Column
 
-            ColumnWidth = DpiHelper.LogicalToDeviceUnitsX(ColumnMinScrollingWidth_Type)
+            ColumnWidth = DpiAwareness.LogicalToDeviceUnits(Handle, ColumnMinScrollingWidth_Type)
             Dim TypeColumn As New DataGridViewTextBoxColumn
             With TypeColumn
                 .AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill
@@ -253,7 +253,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             '... By specifying DataGridViewTextBoxColumn here, we're indicating that user-added rows
             '      (i.e., through the "new row" at the bottom of the DataGridView) will be of type
             '      ResourceStringTextBoxCell.
-            ColumnWidth = DpiHelper.LogicalToDeviceUnitsX(ColumnMinScrollingWidth_Value)
+            ColumnWidth = DpiAwareness.LogicalToDeviceUnits(Handle, ColumnMinScrollingWidth_Value)
             Dim ValueColumn As New DataGridViewTextBoxColumn
             With ValueColumn
                 .AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill
@@ -268,7 +268,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Columns.Add(ValueColumn)
 
             ' ==== Comment Column
-            ColumnWidth = DpiHelper.LogicalToDeviceUnitsX(ColumnMinScrollingWidth_Comment)
+            ColumnWidth = DpiAwareness.LogicalToDeviceUnits(Handle, ColumnMinScrollingWidth_Comment)
             Dim CommentColumn As New DataGridViewTextBoxColumn
             With CommentColumn
                 .AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill
@@ -366,7 +366,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             'The error glyphs don't show up if the row height is below the glyph size.  We don't want that
             '  to happen, so restrict the minimum height.
             Dim NewRow As New DataGridViewRow With {
-                .MinimumHeight = Math.Max(DpiHelper.LogicalToDeviceUnitsY(RowMinimumHeight), Font.Height + DpiHelper.LogicalToDeviceUnitsY(ROW_BORDER_HEIGHT))
+                .MinimumHeight = Math.Max(DpiAwareness.LogicalToDeviceUnits(Handle, RowMinimumHeight), Font.Height + DpiAwareness.LogicalToDeviceUnits(Handle, ROW_BORDER_HEIGHT))
             }
 
             'Build up the new row (with blank values) cell by cell
@@ -1166,7 +1166,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             '  show up at all.
             'See CreateNewResourceRow().  Currently you can't create a row for OnNewRowNeeded, there's
             '  supposed to be a template row to be able to use for this later in m3, if needed.
-            e.Row.MinimumHeight = Math.Max(DpiHelper.LogicalToDeviceUnitsY(RowMinimumHeight), Font.Height + DpiHelper.LogicalToDeviceUnitsY(ROW_BORDER_HEIGHT))
+            e.Row.MinimumHeight = Math.Max(DpiAwareness.LogicalToDeviceUnits(Handle, RowMinimumHeight), Font.Height + DpiAwareness.LogicalToDeviceUnits(Handle, ROW_BORDER_HEIGHT))
 
             If ResourceFile Is Nothing Then
                 Debug.Fail("No resource file")

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
@@ -15,7 +15,7 @@ Imports Microsoft.VisualStudio.Editors.Common
 Imports Microsoft.VisualStudio.Editors.DesignerFramework
 Imports Microsoft.VisualStudio.Editors.Interop
 Imports Microsoft.VisualStudio.Editors.PropertyPages
-Imports Microsoft.VisualStudio.PlatformUI
+Imports Microsoft.VisualStudio.Utilities
 Imports Microsoft.VisualStudio.Shell.Interop
 Imports Microsoft.VSDesigner.VSDesignerPackage
 
@@ -170,10 +170,10 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 .AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill,
                 .FillWeight = 100.0!,
                 .HeaderText = My.Resources.Microsoft_VisualStudio_Editors_Designer.SD_GridViewValueColumnHeaderText,
-                .MinimumWidth = DpiHelper.LogicalToDeviceUnitsX(SystemInformation.VerticalScrollBarWidth + 2), ' Add 2 for left/right borders...
+                .MinimumWidth = DpiAwareness.LogicalToDeviceUnits(Handle, SystemInformation.VerticalScrollBarWidth + 2), ' Add 2 for left/right borders...
                 .Resizable = DataGridViewTriState.True,
                 .SortMode = DataGridViewColumnSortMode.Automatic,
-                .Width = DpiHelper.LogicalToDeviceUnitsX(200)
+                .Width = DpiAwareness.LogicalToDeviceUnits(Handle, 200)
             }
             _settingsGridView.Columns.Add(TypeEditorCol)
 
@@ -268,29 +268,29 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             '
             resources.ApplyResources(_dataGridViewTextBoxColumn1, "DataGridViewTextBoxColumn1")
             _dataGridViewTextBoxColumn1.AutoSizeMode = DataGridViewAutoSizeColumnMode.None
-            _dataGridViewTextBoxColumn1.MinimumWidth = DpiHelper.LogicalToDeviceUnitsX(100)
+            _dataGridViewTextBoxColumn1.MinimumWidth = DpiAwareness.LogicalToDeviceUnits(Handle, 100)
             _dataGridViewTextBoxColumn1.Name = "GridViewNameTextBoxColumn"
-            _dataGridViewComboBoxColumn1.Width = DpiHelper.LogicalToDeviceUnitsX(100)
+            _dataGridViewComboBoxColumn1.Width = DpiAwareness.LogicalToDeviceUnits(Handle, 100)
             '
             'DataGridViewComboBoxColumn1
             '
             resources.ApplyResources(_dataGridViewComboBoxColumn1, "DataGridViewComboBoxColumn1")
             _dataGridViewComboBoxColumn1.AutoSizeMode = DataGridViewAutoSizeColumnMode.None
-            _dataGridViewComboBoxColumn1.MinimumWidth = DpiHelper.LogicalToDeviceUnitsX(100)
+            _dataGridViewComboBoxColumn1.MinimumWidth = DpiAwareness.LogicalToDeviceUnits(Handle, 100)
             _dataGridViewComboBoxColumn1.Name = "GridViewTypeComboBoxColumn"
             _dataGridViewComboBoxColumn1.SortMode = DataGridViewColumnSortMode.Automatic
-            _dataGridViewComboBoxColumn1.Width = DpiHelper.LogicalToDeviceUnitsX(100)
+            _dataGridViewComboBoxColumn1.Width = DpiAwareness.LogicalToDeviceUnits(Handle, 100)
             '
             'DataGridViewComboBoxColumn2
             '
             _dataGridViewComboBoxColumn2.AutoSizeMode = DataGridViewAutoSizeColumnMode.None
             resources.ApplyResources(_dataGridViewComboBoxColumn2, "DataGridViewComboBoxColumn2")
             _dataGridViewComboBoxColumn2.MaxDropDownItems = 2
-            _dataGridViewComboBoxColumn2.MinimumWidth = DpiHelper.LogicalToDeviceUnitsX(100)
+            _dataGridViewComboBoxColumn2.MinimumWidth = DpiAwareness.LogicalToDeviceUnits(Handle, 100)
             _dataGridViewComboBoxColumn2.Name = "GridViewScopeComboBoxColumn"
             _dataGridViewComboBoxColumn2.SortMode = DataGridViewColumnSortMode.Automatic
             _dataGridViewComboBoxColumn2.ValueType = GetType(DesignTimeSettingInstance.SettingScope)
-            _dataGridViewComboBoxColumn2.Width = DpiHelper.LogicalToDeviceUnitsX(100)
+            _dataGridViewComboBoxColumn2.Width = DpiAwareness.LogicalToDeviceUnits(Handle, 100)
             '
             'DescriptionLinkLabel
             '
@@ -396,10 +396,10 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             TypeColumn.Items.Add(_typeNameResolver.PersistedSettingTypeNameToTypeDisplayName(SettingsSerializer.CultureInvariantVirtualTypeNameWebReference))
             TypeColumn.Items.Add(_typeNameResolver.PersistedSettingTypeNameToTypeDisplayName(SettingsSerializer.CultureInvariantVirtualTypeNameConnectionString))
             TypeColumn.Items.Add(My.Resources.Microsoft_VisualStudio_Editors_Designer.SD_ComboBoxItem_BrowseType)
-            TypeColumn.Width = DpiHelper.LogicalToDeviceUnitsX(TypeColumn.GetPreferredWidth(DataGridViewAutoSizeColumnMode.AllCells, False) + SystemInformation.VerticalScrollBarWidth + InternalComboBoxPadding)
+            TypeColumn.Width = DpiAwareness.LogicalToDeviceUnits(Handle, TypeColumn.GetPreferredWidth(DataGridViewAutoSizeColumnMode.AllCells, False) + SystemInformation.VerticalScrollBarWidth + InternalComboBoxPadding)
 
 
-            ScopeColumn.Width = DpiHelper.LogicalToDeviceUnitsX(ScopeColumn.GetPreferredWidth(DataGridViewAutoSizeColumnMode.AllCells, False) + SystemInformation.VerticalScrollBarWidth + InternalComboBoxPadding)
+            ScopeColumn.Width = DpiAwareness.LogicalToDeviceUnits(Handle, ScopeColumn.GetPreferredWidth(DataGridViewAutoSizeColumnMode.AllCells, False) + SystemInformation.VerticalScrollBarWidth + InternalComboBoxPadding)
 
             'Hook up for broadcast messages
             If _cookieBroadcastMessages = 0 Then


### PR DESCRIPTION
Splitting https://github.com/dotnet/project-system/pull/4766 into separate parts. This PR will update the LogicalToDeviceUnits calls with the corresponding DpiAwareness method, except those regarding images.