### PR TITLE
Remove unneeded <SubType> and <DependentUpon>

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
+++ b/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
@@ -21,92 +21,17 @@
     <Compile Include="..\Common\ManagedCodeMarkers.vb">
       <Link>ManagedCodeMarkers.vb</Link>
     </Compile>
-    <Compile Update="ApplicationDesigner\ApplicationDesignerPanel.vb">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="ApplicationDesigner\ApplicationDesignerRootComponent.vb">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="ApplicationDesigner\ApplicationDesignerView.vb">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="ApplicationDesigner\ApplicationDesignerWindowPaneControl.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="ApplicationDesigner\DesignerTabButton.vb">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="ApplicationDesigner\DesignerTabControl.vb">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="ApplicationDesigner\SpecialFileCustomView.Designer.vb">
-      <DependentUpon>SpecialFileCustomView.vb</DependentUpon>
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="ApplicationDesigner\SpecialFileCustomView.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="DesignerFramework\BaseDialog.vb">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Update="DesignerFramework\ErrorControl.Designer.vb">
-      <DependentUpon>ErrorControl.vb</DependentUpon>    
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="DesignerFramework\ErrorControl.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="PropPageDesigner\PropPageDesignerRootComponent.vb">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="PropPageDesigner\PropPageDesignerView.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="PropPages\PropPageHostDialog.vb">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Update="PropPages\PropPageUserControlBase.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="PropPages\VSThemedLinkLabel.vb">
-      <SubType>Component</SubType>
-    </Compile>  
-    <Compile Update="Resources\Designer.Designer.vb">
+   <Compile Update="Resources\Designer.Designer.vb">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
-      <DependentUpon>Designer.resx</DependentUpon>
     </Compile>    
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Update="ApplicationDesigner\ApplicationDesignerView.resx">
-      <DependentUpon>ApplicationDesignerView.vb</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Update="ApplicationDesigner\SpecialFileCustomView.resx">
-      <DependentUpon>SpecialFileCustomView.vb</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Update="PropPageDesigner\PropPageDesignerView.resx">
-      <DependentUpon>PropPageDesignerView.vb</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Update="PropPages\PropPageHostDialog.resx">
-      <DependentUpon>PropPageHostDialog.vb</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Update="PropPages\PropPageUserControlBase.resx">
-      <DependentUpon>PropPageUserControlBase.vb</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
     <EmbeddedResource Update="Resources\Designer.resx">
       <LogicalName>Microsoft.VisualStudio.AppDesigner.Designer.resources</LogicalName>
       <CustomToolNamespace>My.Resources</CustomToolNamespace>
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Designer.Designer.vb</LastGenOutput>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Update="DesignerFramework\ErrorControl.resx">
-      <DependentUpon>ErrorControl.vb</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Resources\ApplicationDesigner\OverflowImage.png">
       <LogicalName>Microsoft.VisualStudio.Editors.ApplicationDesigner.OverflowImage</LogicalName>

--- a/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
+++ b/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
@@ -24,165 +24,77 @@
     <RCResourceFile Include="native.rc" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Update="AddImportsDialogs\AddImports.resx">
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Update="AddImportsDialogs\AutoAddImportsCollisionDialog.resx">
-      <DependentUpon>AutoAddImportsCollisionDialog.vb</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Update="AddImportsDialogs\AutoAddImportsExtensionCollisionDialog.resx">
-      <DependentUpon>AutoAddImportsExtensionCollisionDialog.vb</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Update="DesignerFramework\ErrorControl.resx">
-      <DependentUpon>ErrorControl.vb</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Update="MyExtensibility\AddMyExtensionsDialog.resx">
-      <DependentUpon>AddMyExtensionsDialog.vb</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Update="MyExtensibility\AssemblyOptionDialog.resx">
-      <DependentUpon>AssemblyOptionDialog.vb</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Update="MyExtensibility\MyExtensibilityPropPage.resx">
-      <DependentUpon>MyExtensibilityPropPage.vb</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
     <EmbeddedResource Update="OptionPages\GeneralOptionPageResources.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <CustomToolNamespace>My.Resources</CustomToolNamespace>
       <LastGenOutput>GeneralOptionPageResources.Designer.vb</LastGenOutput>
     </EmbeddedResource>
     <EmbeddedResource Update="PropPages\AdvancedServicesDialog.resx">
-      <DependentUpon>AdvancedServicesDialog.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.AdvancedServicesDialog.resources</LogicalName>
-      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Update="PropPages\AdvBuildSettingsPropPage.resx">
-      <DependentUpon>AdvBuildSettingsPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.AdvBuildSettingsPropPage.resources</LogicalName>
-      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Update="PropPages\AdvCompilerSettingsPropPage.resx">
-      <DependentUpon>AdvCompilerSettingsPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.AdvCompilerSettingsPropPage.resources</LogicalName>
-      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Update="PropPages\ApplicationPropPage.resx">
-      <DependentUpon>ApplicationPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.ApplicationPropPage.resources</LogicalName>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Update="PropPages\ApplicationPropPageBase.resx">
-      <DependentUpon>ApplicationPropPageBase.vb</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Update="PropPages\ApplicationPropPageVBBase.resx">
-      <DependentUpon>ApplicationPropPageVBBase.vb</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Update="PropPages\ApplicationPropPageVBWinForms.resx">
-      <DependentUpon>ApplicationPropPageVBWinForms.vb</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Update="PropPages\PackagePropPage.resx">
-      <DependentUpon>PackagePropPage.vb</DependentUpon>
-      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Update="PropPages\AssemblyInfoPropPage.resx">
-      <DependentUpon>AssemblyInfoPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.AssemblyInfoPropPage.resources</LogicalName>
-      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Update="PropPages\BuildEventCommandLineDialog.resx">
-      <DependentUpon>BuildEventCommandLineDialog.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.BuildEventCommandLineDialog.resources</LogicalName>
-      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Update="PropPages\BuildEventsPropPage.resx">
-      <DependentUpon>BuildEventsPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.BuildEventsPropPage.resources</LogicalName>
-      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Update="PropPages\BuildPropPage.resx">
-      <DependentUpon>BuildPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.BuildPropPage.resources</LogicalName>
-      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Update="PropPages\CompilePropPage2.resx">
       <DependentUpon>CompilePropPage2.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.CompilePropPage2.resources</LogicalName>
-      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Update="PropPages\CSharpApplicationPropPage.resx">
-      <DependentUpon>CSharpApplicationPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.CSharpApplicationPropPage.resources</LogicalName>
-      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Update="PropPages\DebugPropPage.resx">
-      <DependentUpon>DebugPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.DebugPropPage.resources</LogicalName>
-      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Update="PropPages\ReferencePathsPropPage.resx">
-      <DependentUpon>ReferencePathsPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.ReferencePathsPropPage.resources</LogicalName>
-      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Update="PropPages\ReferencePropPage.resx">
-      <DependentUpon>ReferencePropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.ReferencePropPage.resources</LogicalName>
-      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Update="PropPages\ServicesAuthenticationForm.resx">
-      <DependentUpon>ServicesAuthenticationForm.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.ServicesAuthenticationForm.resources</LogicalName>
-      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Update="PropPages\ServicesPropPage.resx">
-      <DependentUpon>ServicesPropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.ServicesPropPage.resources</LogicalName>
-      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Update="PropPages\Strings.resx">
-      <SubType>Designer</SubType>
       <CustomToolNamespace>My.Resources</CustomToolNamespace>
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Strings.Designer.vb</LastGenOutput>
     </EmbeddedResource>
     <EmbeddedResource Update="PropPages\UnusedReferencePropPage.resx">
-      <DependentUpon>UnusedReferencePropPage.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.UnusedReferencePropPage.resources</LogicalName>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Update="PropPages\WPF\AppDotXamlErrorControl.resx">
-      <DependentUpon>AppDotXamlErrorControl.vb</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Update="PropPages\WPF\ApplicationPropPageVBWPF.resx">
-      <DependentUpon>ApplicationPropPageVBWPF.vb</DependentUpon>
-      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Update="ResourceEditor\DialogQueryName.resx">
-      <DependentUpon>DialogQueryName.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.ResourceEditor.DialogQueryName.resources</LogicalName>
-      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Update="ResourceEditor\OpenFileWarningDialog.resx">
-      <DependentUpon>OpenFileWarningDialog.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.ResourceEditor.OpenFileWarningDialog.resources</LogicalName>
-      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Update="Resources\Microsoft.VisualStudio.Editors.Designer.resx">
-      <SubType>Designer</SubType>
       <CustomToolNamespace>My.Resources</CustomToolNamespace>
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Microsoft.VisualStudio.Editors.Designer.Designer.vb</LastGenOutput>
     </EmbeddedResource>
     <EmbeddedResource Update="Resources\MyExtensibilityRes.resx">
-      <SubType>Designer</SubType>
       <CustomToolNamespace>My.Resources</CustomToolNamespace>
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>MyExtensibilityRes.Designer.vb</LastGenOutput>
@@ -212,359 +124,41 @@
     <EmbeddedResource Include="Resources\SettingsDesigner\namespace.bmp" />
     <EmbeddedResource Include="Resources\SettingsDesigner\object.bmp" />
     <EmbeddedResource Update="SettingsDesigner\SettingsDesignerView.resx">
-      <DependentUpon>SettingsDesignerView.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsDesignerView.resources</LogicalName>
-      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Update="SettingsDesigner\TypeEditorHostControl.resx">
-      <DependentUpon>TypeEditorHostControl.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.SettingsDesigner.TypeEditorHostControl.resources</LogicalName>
-      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Update="SettingsDesigner\TypePickerDialog.resx">
-      <DependentUpon>TypePickerDialog.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.SettingsDesigner.TypePickerDialog.resources</LogicalName>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Update="VSPackage.resx">
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Update="XmlToSchema\InputXmlForm.resx">
-      <DependentUpon>InputXmlForm.vb</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Update="XmlToSchema\PasteXmlDialog.resx">
-      <DependentUpon>PasteXmlDialog.vb</DependentUpon>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-    <EmbeddedResource Update="XmlToSchema\WebUrlDialog.resx">
-      <DependentUpon>WebUrlDialog.vb</DependentUpon>
-      <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <Compile Update="OptionPages\GeneralOptionPageControl.xaml.vb">
-      <DependentUpon>GeneralOptionPageControl.xaml</DependentUpon>
-    </Compile>
     <Compile Update="OptionPages\GeneralOptionPageResources.Designer.vb">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
-      <DependentUpon>GeneralOptionPageResources.resx</DependentUpon>
-    </Compile>
-    <Compile Update="PropPages\AdvancedServicesDialog.Designer.vb">
-      <DependentUpon>AdvancedServicesDialog.vb</DependentUpon>
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="PropPages\AdvBuildSettingsPropPage.Designer.vb">
-      <DependentUpon>AdvBuildSettingsPropPage.vb</DependentUpon>
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="PropPages\AdvCompilerSettingsPropPage.Designer.vb">
-      <DependentUpon>AdvCompilerSettingsPropPage.vb</DependentUpon>
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="PropPages\ApplicationPropPageVBBase.Designer.vb">
-      <DependentUpon>ApplicationPropPageVBBase.vb</DependentUpon>
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="PropPages\ApplicationPropPageVBWinForms.Designer.vb">
-      <DependentUpon>ApplicationPropPageVBWinForms.vb</DependentUpon>
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="PropPages\PackagePropPage.Designer.vb">
-      <DependentUpon>PackagePropPage.vb</DependentUpon>
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="PropPages\PackagePropPage.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="PropPages\AssemblyInfoPropPage.Designer.vb">
-      <DependentUpon>AssemblyInfoPropPage.vb</DependentUpon>
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="PropPages\BuildEventCommandLineDialog.Designer.vb">
-      <DependentUpon>BuildEventCommandLineDialog.vb</DependentUpon>
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Update="PropPages\BuildEventsPropPage.Designer.vb">
-      <DependentUpon>BuildEventsPropPage.vb</DependentUpon>
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="PropPages\BuildPropPage.Designer.vb">
-      <DependentUpon>BuildPropPage.vb</DependentUpon>
-      <SubType>UserControl</SubType>
     </Compile>
     <Compile Update="PropPages\CompilePropPage2.Designer.vb">
       <DependentUpon>CompilePropPage2.vb</DependentUpon>
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="PropPages\CSharpApplicationPropPage.Designer.vb">
-      <DependentUpon>CSharpApplicationPropPage.vb</DependentUpon>
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="PropPages\DebugPropPage.Designer.vb">
-      <DependentUpon>DebugPropPage.vb</DependentUpon>
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="PropPages\ReferencePathsPropPage.Designer.vb">
-      <DependentUpon>ReferencePathsPropPage.vb</DependentUpon>
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="PropPages\ReferencePropPage.Designer.vb">
-      <DependentUpon>ReferencePropPage.vb</DependentUpon>
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="PropPages\ServicesAuthenticationForm.Designer.vb">
-      <DependentUpon>ServicesAuthenticationForm.vb</DependentUpon>
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Update="PropPages\ServicesPropPage.Designer.vb">
-      <DependentUpon>ServicesPropPage.vb</DependentUpon>
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="PropPages\TextBoxWithWorkaroundForAutoCompleteAppend.vb">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="PropPages\UnusedReferencePropPage.Designer.vb">
-      <DependentUpon>UnusedReferencePropPage.vb</DependentUpon>
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="PropPages\WPF\ApplicationPropPageVBWPF.Designer.vb">
-      <DependentUpon>ApplicationPropPageVBWPF.vb</DependentUpon>
-      <SubType>UserControl</SubType>
     </Compile>
     <Compile Include="..\Common\ManagedCodeMarkers.vb">
       <Link>ManagedCodeMarkers.vb</Link>
     </Compile>
-    <Compile Update="AddImportsDialogs\AddImportDialogBase.vb">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Update="AddImportsDialogs\AddImports.Designer.vb">
-      <DependentUpon>AddImports.resx</DependentUpon>
-    </Compile>
-    <Compile Update="AddImportsDialogs\AutoAddImportsCollisionDialog.Designer.vb">
-      <DependentUpon>AutoAddImportsCollisionDialog.vb</DependentUpon>
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Update="AddImportsDialogs\AutoAddImportsCollisionDialog.vb">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Update="AddImportsDialogs\AutoAddImportsExtensionCollisionDialog.Designer.vb">
-      <DependentUpon>AutoAddImportsExtensionCollisionDialog.vb</DependentUpon>
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Update="AddImportsDialogs\AutoAddImportsExtensionCollisionDialog.vb">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Update="DesignerFramework\BaseDesignerView.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="DesignerFramework\BaseDialog.vb">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Update="DesignerFramework\DesignerDataGridView.vb">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="DesignerFramework\DesignerListView.vb">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="DesignerFramework\DesignerToolbarPanel.vb">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="DesignerFramework\ErrorControl.Designer.vb">
-      <DependentUpon>ErrorControl.vb</DependentUpon>
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="DesignerFramework\ErrorControl.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="DesignerFramework\ThemedBorderUserControl.Designer.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="DesignerFramework\ThemedBorderUserControl.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="DesignerFramework\WrapCheckBox.vb">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="MyExtensibility\AddMyExtensionsDialog.vb">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Update="MyExtensibility\AssemblyOptionDialog.vb">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Update="MyExtensibility\MyExtensibilityPropPage.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="MyExtensibility\MyExtensionDataGridView.vb">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="PropPages\AdvancedServicesDialog.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="proppages\AdvBuildSettingsPropPage.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="proppages\AdvCompilerSettingsPropPage.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="proppages\ApplicationPropPage.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="PropPages\ApplicationPropPage.Designer.vb">
-      <DependentUpon>ApplicationPropPage.vb</DependentUpon>
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="proppages\ApplicationPropPageBase.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="proppages\ApplicationPropPageInternalBase.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="PropPages\ApplicationPropPageVBBase.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="PropPages\ApplicationPropPageVBWinForms.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="proppages\AssemblyInfoPropPage.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="proppages\BuildEventCommandLineDialog.vb">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Update="proppages\BuildEventsPropPage.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="proppages\BuildPropPage.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="proppages\BuildPropPageBase.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
     <Compile Update="proppages\CompilePropPage2.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="proppages\ComponentWrapper.vb">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="proppages\CSharpApplicationPropPage.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="proppages\DebugPropPage.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="proppages\ReferenceComponent.vb">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="proppages\ReferencePathsPropPage.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="proppages\ReferencePropPage.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="proppages\ServiceReferenceComponent.vb">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="proppages\ServicesAuthenticationForm.vb">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Update="proppages\ServicesPropPage.vb">
-      <SubType>UserControl</SubType>
     </Compile>
     <Compile Update="PropPages\Strings.Designer.vb">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
-      <DependentUpon>Strings.resx</DependentUpon>
-    </Compile>
-    <Compile Update="proppages\UnusedReferencePropPage.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="proppages\WebReferenceComponent.vb">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="PropPages\WPF\AppDotXamlErrorControl.Designer.vb">
-      <DependentUpon>AppDotXamlErrorControl.vb</DependentUpon>
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="PropPages\WPF\AppDotXamlErrorControl.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="PropPages\WPF\ApplicationPropPageVBWPF.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="ResourceEditor\DialogQueryName.vb">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Update="ResourceEditor\OpenFileWarningDialog.vb">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Update="ResourceEditor\ResourceEditorRootComponent.vb">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="ResourceEditor\ResourceEditorView.vb">
-      <SubType>UserControl</SubType>
     </Compile>
     <Compile Update="ResourceEditor\ResourceEditorView_EditorState.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="ResourceEditor\ResourceListView.vb">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="ResourceEditor\ResourceStringTable.vb">
-      <SubType>Component</SubType>
     </Compile>
     <Compile Update="Resources\Microsoft.VisualStudio.Editors.Designer.Designer.vb">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
-      <DependentUpon>Microsoft.VisualStudio.Editors.Designer.resx</DependentUpon>
     </Compile>
     <Compile Update="Resources\MyExtensibilityRes.Designer.vb">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
-      <DependentUpon>MyExtensibilityRes.resx</DependentUpon>
-    </Compile>
-    <Compile Update="SettingsDesigner\DataGridViewUITypeEditorEditingControl.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="SettingsDesigner\DesignTimeSettingInstance.vb">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="SettingsDesigner\DesignTimeSettings.vb">
-      <SubType>Designer</SubType>
-    </Compile>
-    <Compile Update="SettingsDesigner\SettingsDesignerView.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="SettingsDesigner\TypeEditorHostControl.vb">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="SettingsDesigner\TypePickerDialog.vb">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Update="XmlToSchema\InputXmlForm.Designer.vb">
-      <DependentUpon>InputXmlForm.vb</DependentUpon>
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Update="XmlToSchema\InputXmlForm.vb">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Update="XmlToSchema\PasteXmlDialog.Designer.vb">
-      <DependentUpon>PasteXmlDialog.vb</DependentUpon>
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Update="XmlToSchema\PasteXmlDialog.vb">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Update="XmlToSchema\Utilities.vb">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Update="XmlToSchema\WebUrlDialog.Designer.vb">
-      <DependentUpon>WebUrlDialog.vb</DependentUpon>
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Update="XmlToSchema\WebUrlDialog.vb">
-      <SubType>Form</SubType>
     </Compile>
     <Compile Update="XmlToSchema\Wizard.vb" />
   </ItemGroup>
@@ -590,7 +184,6 @@
   <ItemGroup>
     <Page Include="OptionPages\GeneralOptionPageControl.xaml">
       <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
     </Page>
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -29,44 +29,13 @@
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Update="ProjectSystem\VS\LanguageServices\CSharp\CSharpCodeDomProvider.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="ProjectSystem\VS\LanguageServices\VisualBasic\VisualBasicCodeDomProvider.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Update="ProjectSystem\VS\PropertyPages\DebugPageControl.xaml.cs">
-      <DependentUpon>DebugPageControl.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\VS\PropertyPages\GetProfileNameDialog.xaml.cs">
-      <DependentUpon>GetProfileNameDialog.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\VS\PropertyPages\PropertyPage.cs">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="ProjectSystem\VS\PropertyPages\PropertyPage.Designer.cs">
-      <DependentUpon>PropertyPage.cs</DependentUpon>
-      <SubType>UserControl</SubType>
-    </Compile>
     <Compile Update="ProjectSystem\VS\PropertyPages\PropertyPageResources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
-      <DependentUpon>PropertyPageResources.resx</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\VS\PropertyPages\WpfBasedPropertyPage.cs">
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="ProjectSystem\VS\PropertyPages\WpfBasedPropertyPage.Designer.cs">
-      <DependentUpon>WpfBasedPropertyPage.cs</DependentUpon>
-      <SubType>UserControl</SubType>
-    </Compile>
-    <Compile Update="ProjectSystem\VS\UI\DontShowAgainMessageBox.xaml.cs">
-      <DependentUpon>DontShowAgainMessageBox.xaml</DependentUpon>
     </Compile>
     <Compile Update="VSResources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
-      <DependentUpon>VSResources.resx</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>
@@ -76,107 +45,82 @@
   </ItemGroup>
   <ItemGroup>
     <Page Include="ProjectSystem\VS\PropertyPages\DebugPageControl.xaml">
-      <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="ProjectSystem\VS\PropertyPages\GetProfileNameDialog.xaml">
       <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
     </Page>
     <Page Include="ProjectSystem\VS\PropertyPages\WatermarkStyle.xaml">
       <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
     </Page>
     <Page Include="ProjectSystem\VS\UI\DontShowAgainMessageBox.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Resource Include="Resources\Icons\LibraryWarning_16x.xaml">
       <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
     </Resource>
     <Resource Include="Resources\Icons\NuGetGrey_16x.xaml">
       <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
     </Resource>
     <Resource Include="Resources\Icons\NuGetGreyWarning_16x.xaml">
       <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
     </Resource>
     <Resource Include="Resources\Icons\NuGetGreyPrivate_16x.xaml">
       <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
     </Resource>
     <Resource Include="Resources\Icons\ReferenceGroupWarning_16x.xaml">
       <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
     </Resource>
     <Resource Include="Resources\Icons\ReferenceGroup_16x.xaml">
       <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
     </Resource>
     <Resource Include="Resources\Icons\ApplicationPrivate_16x.xaml">
       <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
     </Resource>
     <Resource Include="Resources\Icons\ApplicationWarning_16x.xaml">
       <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
     </Resource>
     <Resource Include="Resources\Icons\CodeInformationPrivate_16x.xaml">
       <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
     </Resource>
     <Resource Include="Resources\Icons\CodeInformationWarning_16x.xaml">
       <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
     </Resource>
     <Resource Include="Resources\Icons\ComponentPrivate_16x.xaml">
       <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
     </Resource>
     <Resource Include="Resources\Icons\ComponentWarning_16x.xaml">
       <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
     </Resource>
     <Resource Include="Resources\Icons\Component_16x.xaml">
       <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
     </Resource>
     <Resource Include="Resources\Icons\ErrorSmall_16x.xaml">
       <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
     </Resource>
     <Resource Include="Resources\Icons\ReferencePrivate_16x.xaml">
       <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
     </Resource>
     <Resource Include="Resources\Icons\SDKPrivate_16x.xaml">
       <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
     </Resource>
     <Resource Include="Resources\Icons\SDKWarning_16x.xaml">
       <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
     </Resource>
     <Resource Include="Resources\Icons\SDK_16x.xaml">
       <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
     </Resource>
     <Resource Include="Resources\Icons\SharedProjectPrivate_16x.xaml">
       <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
     </Resource>
     <Resource Include="Resources\Icons\SharedProjectWarning_16x.xaml">
       <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
     </Resource>
     <Resource Include="Resources\Icons\SharedProject_16x.xaml">
       <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
     </Resource>
     <Resource Include="Resources\Icons\WarningSmall_16x.xaml">
       <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
     </Resource>
     <Resource Include="Resources\Icons\ApplicationPrivate_16x.png" />
     <Resource Include="Resources\Icons\ApplicationWarning_16x.png" />
@@ -207,19 +151,16 @@
     <EmbeddedResource Update="ProjectSystem\VS\PropertyPages\PropertyPageResources.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>PropertyPageResources.Designer.cs</LastGenOutput>
-      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Update="VSResources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>VSResources.Designer.cs</LastGenOutput>
-      <SubType>Designer</SubType>
       <MergeWithCTO>true</MergeWithCTO>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <VSCTCompile Include="Menus.vsct">
       <ResourceName>Menus.ctmenu</ResourceName>
-      <SubType>Designer</SubType>
     </VSCTCompile>
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -26,341 +26,164 @@
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Update="ProjectSystem\Rules\AnalyzerReference.xaml.cs">
-      <DependentUpon>AnalyzerReference.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\Items\AdditionalFiles.cs">
-      <DependentUpon>AdditionalFiles.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\Items\ApplicationDefinition.cs">
-      <DependentUpon>ApplicationDefinition.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\Items\Page.cs">
-      <DependentUpon>Page.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\CollectedFrameworkReference.cs">
-      <DependentUpon>CollectedFrameworkReference.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\ProjectDebugger.xaml.cs">
-      <DependentUpon>ProjectDebugger.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\CollectedPackageDownload.cs">
-      <DependentUpon>CollectedPackageDownload.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\ResolvedAnalyzerReference.xaml.cs">
-      <DependentUpon>ResolvedAnalyzerReference.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\ResolvedCompilationReference.cs">
-      <DependentUpon>ResolvedCompilationReference.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\ResolvedPackageReference.cs">
-      <DependentUpon>ResolvedPackageReference.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\ResolvedSdkReference.cs">
-      <DependentUpon>ResolvedSdkReference.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\SdkReference.xaml.cs">
-      <DependentUpon>SdkReference.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\PackageReference.cs">
-      <DependentUpon>PackageReference.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\CompilerCommandLineArgs.cs">
-      <DependentUpon>CompilerCommandLineArgs.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\AppDesigner.xaml.cs">
-      <DependentUpon>AppDesigner.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\Items\Compile.cs">
-      <DependentUpon>Compile.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\AssemblyReference.cs">
-      <DependentUpon>AssemblyReference.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\COMReference.cs">
-      <DependentUpon>COMReference.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\Items\Content.cs">
-      <DependentUpon>Content.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\DebuggerGeneral.cs">
-      <DependentUpon>DebuggerGeneral.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\DotNetCliToolReference.cs">
-      <DependentUpon>DotNetCliToolReference.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\Items\EmbeddedResource.cs">
-      <DependentUpon>EmbeddedResource.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\UpToDateCheckInput.cs">
-      <DependentUpon>UpToDateCheckInput.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\UpToDateCheckOutput.cs">
-      <DependentUpon>UpToDateCheckOutput.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\UpToDateCheckBuilt.cs">
-      <DependentUpon>UpToDateCheckBuilt.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\CopyUpToDateMarker.cs">
-      <DependentUpon>CopyUpToDateMarker.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\Items\Folder.cs">
-      <DependentUpon>Folder.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\SourceControl.cs">
-      <DependentUpon>SourceControl.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\SpecialFolder.cs">
-      <DependentUpon>SpecialFolder.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\SubProject.cs">
-      <DependentUpon>SubProject.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\ConfigurationGeneral.xaml.cs">
-      <DependentUpon>ConfigurationGeneral.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\ProjectReference.cs">
-      <DependentUpon>ProjectReference.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\ResolvedAssemblyReference.cs">
-      <DependentUpon>ResolvedAssemblyReference.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\ResolvedCOMReference.cs">
-      <DependentUpon>ResolvedCOMReference.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\ResolvedProjectReference.cs">
-      <DependentUpon>ResolvedProjectReference.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\GeneralBrowseObject.cs">
-      <DependentUpon>GeneralBrowseObject.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\ConfiguredBrowseObject.cs">
-      <DependentUpon>GeneralConfiguredBrowseObject.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\Items\None.cs">
-      <DependentUpon>None.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\NuGetRestore.cs">
-      <DependentUpon>NuGetRestore.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\LanguageService.cs">
-      <DependentUpon>LanguageService.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\Items\XamlAppDef.cs">
-      <DependentUpon>XamlAppDef.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\VisualBasic.NamespaceImport.cs">
-      <DependentUpon>VisualBasic.NamespaceImport.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\Items\Resource.cs">
-      <DependentUpon>Resource.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="ProjectSystem\Rules\PotentialEditorConfigFiles.cs">
-      <DependentUpon>PotentialEditorConfigFiles.xaml</DependentUpon>
-    </Compile>
     <Compile Update="Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
-      <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>
     <XamlPropertyRule Include="ProjectSystem\Rules\Items\Compile.xaml">
       <XlfInput>false</XlfInput>
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\AssemblyReference.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\COMReference.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\Items\Content.xaml">
       <XlfInput>false</XlfInput>
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\Items\ApplicationDefinition.xaml">
       <XlfInput>false</XlfInput>
-      <SubType>Designer</SubType>
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\Items\Page.xaml">
       <XlfInput>false</XlfInput>
-      <SubType>Designer</SubType>
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\Items\EmbeddedResource.xaml">
       <XlfInput>false</XlfInput>
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\CollectedFrameworkReference.xaml">
       <XlfInput>false</XlfInput>
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\CollectedPackageDownload.xaml">
       <XlfInput>false</XlfInput>
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\UpToDateCheckInput.xaml">
       <XlfInput>false</XlfInput>
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\UpToDateCheckOutput.xaml">
       <XlfInput>false</XlfInput>
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\UpToDateCheckBuilt.xaml">
       <XlfInput>false</XlfInput>
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\CopyUpToDateMarker.xaml">
       <XlfInput>false</XlfInput>
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\Items\Folder.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\SourceControl.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\SpecialFolder.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\SubProject.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\ConfigurationGeneral.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\DebuggerGeneral.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\DotNetCliToolReference.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\GeneralBrowseObject.xaml">
-      <SubType>Designer</SubType>
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\GeneralConfiguredBrowseObject.xaml">
-      <SubType>Designer</SubType>
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\Items\None.xaml">
       <XlfInput>false</XlfInput>
-      <SubType>Designer</SubType>
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\NuGetRestore.xaml">
       <XlfInput>false</XlfInput>
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\LanguageService.xaml">
       <XlfInput>false</XlfInput>
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\ProjectReference.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\VisualBasic.NamespaceImport.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\ResolvedAssemblyReference.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\ResolvedCOMReference.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\ResolvedProjectReference.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\Items\Resource.xaml">
       <XlfInput>false</XlfInput>
-      <SubType>Designer</SubType>
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\AppDesigner.xaml">
       <XlfInput>false</XlfInput>
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\CompilerCommandLineArgs.xaml">
       <XlfInput>false</XlfInput>
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\PackageReference.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\SdkReference.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\ResolvedSdkReference.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\ResolvedPackageReference.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\AnalyzerReference.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\ResolvedAnalyzerReference.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\ResolvedCompilationReference.xaml">
       <XlfInput>false</XlfInput>
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\ProjectDebugger.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\Items\AdditionalFiles.xaml">
       <XlfInput>false</XlfInput>
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\Items\XamlAppDef.xaml">
       <XlfInput>false</XlfInput>
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\PotentialEditorConfigFiles.xaml">
       <XlfInput>false</XlfInput>
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
-      <SubType>Designer</SubType>
     </XamlPropertyRule>
     <XamlPropertyRuleNoCodeBehind Include="ProjectSystem\Rules\Items\AdditionalFiles.BrowseObject.xaml" />
     <XamlPropertyRuleNoCodeBehind Include="ProjectSystem\Rules\Items\ApplicationDefinition.BrowseObject.xaml" />
@@ -381,7 +204,6 @@
     <EmbeddedResource Update="Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-      <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
`<SubType>` is now stored in the user file, `<DependentUpon>` is now implicitly determined.