### PR TITLE
Rename "SouceItemHandler" -> "CompileItemHandler"

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/CompileItemHandler_CommandLineTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/CompileItemHandler_CommandLineTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
-    public class SourceItemHandler_CommandTests : CommandLineHandlerTestBase
+    public class CompileItemHandler_CommandTests : CommandLineHandlerTestBase
     {
         [Fact]
         public void Constructor_NullAsProject_ThrowsArgumentNull()
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             Assert.Throws<ArgumentNullException>("project", () =>
             {
-                new SourceItemHandler((UnconfiguredProject)null);
+                new CompileItemHandler((UnconfiguredProject)null);
             });
         }
 
@@ -83,11 +83,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             return CreateInstance(null, null);
         }
 
-        private SourceItemHandler CreateInstance(UnconfiguredProject project = null, IWorkspaceProjectContext context = null)
+        private CompileItemHandler CreateInstance(UnconfiguredProject project = null, IWorkspaceProjectContext context = null)
         {
             project = project ?? UnconfiguredProjectFactory.Create();
 
-            var handler = new SourceItemHandler(project);
+            var handler = new CompileItemHandler(project);
             if (context != null)
                 handler.Initialize(context);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/CompileItemHandler_EvaluationTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/CompileItemHandler_EvaluationTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
-    public class SourceItemHandler_EvaluationTests : EvaluationHandlerTestBase
+    public class CompileItemHandler_EvaluationTests : EvaluationHandlerTestBase
     {
         [Fact]
         public void Constructor_NullAsProject_ThrowsArgumentNull()
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             Assert.Throws<ArgumentNullException>("project", () =>
             {
-                new SourceItemHandler((UnconfiguredProject)null);
+                new CompileItemHandler((UnconfiguredProject)null);
             });
         }
 
@@ -26,11 +26,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             return CreateInstance(null, null);
         }
 
-        private SourceItemHandler CreateInstance(UnconfiguredProject project = null, IWorkspaceProjectContext context = null)
+        private CompileItemHandler CreateInstance(UnconfiguredProject project = null, IWorkspaceProjectContext context = null)
         {
             project = project ?? UnconfiguredProjectFactory.Create();
 
-            var handler = new SourceItemHandler(project);
+            var handler = new CompileItemHandler(project);
             if (context != null)
                 handler.Initialize(context);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CompileItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CompileItemHandler.cs
@@ -12,16 +12,16 @@ using Microsoft.VisualStudio.ProjectSystem.Logging;
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 {
     /// <summary>
-    ///     Handles changes to sources files during project evaluations and sources files that are passed
+    ///     Handles changes to Compile items during project evaluations and items that are passed
     ///     to the compiler during design-time builds.
     /// </summary>
     [Export(typeof(IWorkspaceContextHandler))]
-    internal partial class SourceItemHandler : AbstractEvaluationCommandLineHandler, IProjectEvaluationHandler, ICommandLineHandler
+    internal partial class CompileItemHandler : AbstractEvaluationCommandLineHandler, IProjectEvaluationHandler, ICommandLineHandler
     {
         private readonly UnconfiguredProject _project;
 
         [ImportingConstructor]
-        public SourceItemHandler(UnconfiguredProject project)
+        public CompileItemHandler(UnconfiguredProject project)
             : base(project)
         {
             _project = project;


### PR DESCRIPTION
To match the naming of the other handlers that are named after their equivalent item.