### PR TITLE
Remove the Debug.Fail for already having the hierarchy

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerView.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerView.vb
@@ -193,14 +193,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                         'This is the project we want
                         Hierarchy = TryCast(Marshal.GetObjectForIUnknown(NestedHierarchy), IVsHierarchy)
                         Marshal.Release(NestedHierarchy)
-                    Else
-                        'If GetNestedHierarchy failed, we must already have the hierarchy for the
-                        '  project.
-
-                        '(Note: we don't expect this code path anymore, as I believe the project designer 
-                        '  is always set up using the solution hierarchy because of the fact that it's
-                        '  an editor on the project file.)
-                        Debug.Fail("GetNestedHierarchy failed")
                     End If
 
                     Debug.Assert(TypeOf Hierarchy Is IVsProject, "We didn't get a hierarchy to a project?")


### PR DESCRIPTION
Fix for https://github.com/dotnet/project-system/issues/4745

Currently, this seems to be *always* failing when opening the property pages. 

At least one of the reasons `GetNestedHierarchy` is failing here is because the `ItemID` is `VSConstants.VSITEMID_ROOT` and it will always fail if that is the case.

I don't believe this is valuable to have, especially if we hit it every time with no issues with the `Hierarchy`