### PR TITLE
Remove property page control size asserts

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerPanel.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerPanel.vb
@@ -384,7 +384,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                             'Since the ApplicationDesignerPanel starts out intentionally hidden, PerformLayout()
                             '  will not dock it to its parent size.  So we do that manually here to minimize
                             '  size changes.
-                            Debug.Assert(Parent.Size.Width <> 0 AndAlso Parent.Size.Height <> 0)
                             Size = Parent.Size
                             _pageHostingPanel.ResumeLayout(False)
                             ResumeLayout(True) 'Must give the PageHostingPanel a chance to dock properly to its parent

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerView.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerView.vb
@@ -1051,7 +1051,6 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                                 Else
                                     Common.Switches.TracePDFocus(TraceLevel.Info, "  ... Calling CreateDesigner")
                                     HostingPanel.SuspendLayout()
-                                    Debug.Assert(HostingPanel.Size.Width <> 0 AndAlso HostingPanel.Size.Height <> 0)
                                     Try
                                         .CreateDesigner()
                                     Finally


### PR DESCRIPTION
More useless asserts that are always hit on the property pages. Seemingly they are hit because of some race condition because when debugging the panels always have a non-zero size. 