### PR TITLE
Connection point debug assert removed

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropertyListener.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropertyListener.vb
@@ -82,7 +82,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                             Debug.Assert(ConfigProperties IsNot Nothing OrElse CpsPropertyDescriptorWrapper.IsCpsComponent(Dispatch), "Couldn't get ProjectConfigurationProperties from config")
                             If ConfigProperties IsNot Nothing Then
                                 EventSource = ConfigProperties
-                                Debug.Assert(SupportsConnectionPointContainer(EventSource), "Unable to get connection point container from configuration")
                             End If
                         End If
                     End If


### PR DESCRIPTION
Fixes: https://github.com/dotnet/project-system/issues/4746 

As Dave said, our configuration properties do not implement `ConnectionPointContainer` like `DynamicTypeBrowseObject` does, for example. This will always be hit for configured property pages and should be removed. 