### PR TITLE
Wrap dialog creation in SystemAware DpiScope

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/BaseDialog.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/BaseDialog.vb
@@ -4,6 +4,7 @@ Imports System.ComponentModel
 Imports System.ComponentModel.Design
 Imports System.Windows.Forms
 Imports System.Windows.Forms.Design
+Imports Microsoft.VisualStudio.Utilities
 
 Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
 
@@ -89,11 +90,13 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
                 _uiService = CType(GetService(GetType(IUIService)), IUIService)
             End If
 
-            If Not (_uiService Is Nothing) Then
-                Return _uiService.ShowDialog(Me)
-            Else
-                Return MyBase.ShowDialog()
-            End If
+            Using (DpiAwareness.EnterDpiScope(DpiAwarenessContext.SystemAware))
+                If Not (_uiService Is Nothing) Then
+                    Return _uiService.ShowDialog(Me)
+                Else
+                    Return MyBase.ShowDialog()
+                End If
+            End Using
         End Function 'ShowDialog
 
         '= Public =============================================================

--- a/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/AddImportsDialogService.vb
+++ b/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/AddImportsDialogService.vb
@@ -1,6 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Windows.Forms
+Imports Microsoft.VisualStudio.Utilities
 
 Namespace Microsoft.VisualStudio.Editors.AddImports
     Friend Class AddImportsDialogService
@@ -24,26 +25,30 @@ Namespace Microsoft.VisualStudio.Editors.AddImports
         Public Function ShowDialog([namespace] As String, identifier As String, minimallyQualifiedName As String, dialogType As AddImportsDialogType, helpCallBack As IVBAddImportsDialogHelpCallback) As AddImportsResult Implements IVBAddImportsDialogService.ShowDialog
             Select Case dialogType
                 Case AddImportsDialogType.AddImportsCollisionDialog
-                    Using d As New AutoAddImportsCollisionDialog([namespace], identifier, minimallyQualifiedName, helpCallBack, _serviceProvider)
-                        Dim result As DialogResult = d.ShowDialog
+                    Using (DpiAwareness.EnterDpiScope(DpiAwarenessContext.SystemAware))
+                        Using d As New AutoAddImportsCollisionDialog([namespace], identifier, minimallyQualifiedName, helpCallBack, _serviceProvider)
+                            Dim result As DialogResult = d.ShowDialog
 
-                        If (result = DialogResult.Cancel) Then
-                            Return AddImportsResult.AddImports_Cancel
-                        ElseIf (d.ShouldImportAnyways) Then
-                            Return AddImportsResult.AddImports_ImportsAnyways
-                        Else
-                            Return AddImportsResult.AddImports_QualifyCurrentLine
-                        End If
+                            If (result = DialogResult.Cancel) Then
+                                Return AddImportsResult.AddImports_Cancel
+                            ElseIf (d.ShouldImportAnyways) Then
+                                Return AddImportsResult.AddImports_ImportsAnyways
+                            Else
+                                Return AddImportsResult.AddImports_QualifyCurrentLine
+                            End If
+                        End Using
                     End Using
                 Case AddImportsDialogType.AddImportsExtensionCollisionDialog
-                    Using d As New AutoAddImportsExtensionCollisionDialog([namespace], identifier, minimallyQualifiedName, helpCallBack, _serviceProvider)
-                        Dim result As DialogResult = d.ShowDialog
+                    Using (DpiAwareness.EnterDpiScope(DpiAwarenessContext.SystemAware))
+                        Using d As New AutoAddImportsExtensionCollisionDialog([namespace], identifier, minimallyQualifiedName, helpCallBack, _serviceProvider)
+                            Dim result As DialogResult = d.ShowDialog
 
-                        If result = DialogResult.Cancel Then
-                            Return AddImportsResult.AddImports_Cancel
-                        Else
-                            Return AddImportsResult.AddImports_QualifyCurrentLine
-                        End If
+                            If result = DialogResult.Cancel Then
+                                Return AddImportsResult.AddImports_Cancel
+                            Else
+                                Return AddImportsResult.AddImports_QualifyCurrentLine
+                            End If
+                        End Using
                     End Using
                 Case Else
                     Throw New InvalidOperationException("Unexpected Dialog Type")

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDialog.vb
@@ -4,6 +4,7 @@ Imports System.ComponentModel
 Imports System.ComponentModel.Design
 Imports System.Windows.Forms
 Imports System.Windows.Forms.Design
+Imports Microsoft.VisualStudio.Utilities
 
 Namespace Microsoft.VisualStudio.Editors.DesignerFramework
 
@@ -86,11 +87,13 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                 _uiService = CType(GetService(GetType(IUIService)), IUIService)
             End If
 
-            If Not (_uiService Is Nothing) Then
-                Return _uiService.ShowDialog(Me)
-            Else
-                Return MyBase.ShowDialog()
-            End If
+            Using (DpiAwareness.EnterDpiScope(DpiAwarenessContext.SystemAware))
+                If Not (_uiService Is Nothing) Then
+                    Return _uiService.ShowDialog(Me)
+                Else
+                    Return MyBase.ShowDialog()
+                End If
+            End Using
         End Function 'ShowDialog
 
         '= FRIEND =============================================================

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventCommandLineDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventCommandLineDialog.vb
@@ -3,6 +3,7 @@
 Imports System.Text
 Imports System.Windows.Forms
 Imports System.Windows.Forms.Design
+Imports Microsoft.VisualStudio.Utilities
 
 Namespace Microsoft.VisualStudio.Editors.PropertyPages
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventCommandLineDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventCommandLineDialog.vb
@@ -264,14 +264,15 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             If sp IsNot Nothing Then
                 ServiceProvider = sp
             End If
-
-            If ServiceProvider IsNot Nothing Then
-                Dim uiService As IUIService = CType(ServiceProvider.GetService(GetType(IUIService)), IUIService)
-                If uiService IsNot Nothing Then
-                    Return uiService.ShowDialog(Me)
+            Using (DpiAwareness.EnterDpiScope(DpiAwarenessContext.SystemAware))
+                If ServiceProvider IsNot Nothing Then
+                    Dim uiService As IUIService = CType(ServiceProvider.GetService(GetType(IUIService)), IUIService)
+                    If uiService IsNot Nothing Then
+                        Return uiService.ShowDialog(Me)
+                    End If
                 End If
-            End If
-            Return MyBase.ShowDialog()
+                Return MyBase.ShowDialog()
+            End Using
         End Function
     End Class
 End Namespace

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
@@ -4605,22 +4605,24 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <returns>The selected folder, or Nothing if the user canceled.</returns>
         ''' <remarks></remarks>
         Public Function ShowFolderBrowserDialog(ByRef UserCanceled As Boolean, Title As String, ShowNewFolderButton As Boolean, Optional DefaultPath As String = Nothing) As String
-            UserCanceled = False
-            Dim Dialog As New FolderBrowserDialog
-            With Dialog
-                .Description = Title
-                .ShowNewFolderButton = ShowNewFolderButton
-                If DefaultPath <> "" Then
-                    .SelectedPath = DefaultPath
-                End If
+            Using (DpiAwareness.EnterDpiScope(DpiAwarenessContext.SystemAware))
+                UserCanceled = False
+                Dim Dialog As New FolderBrowserDialog
+                With Dialog
+                    .Description = Title
+                    .ShowNewFolderButton = ShowNewFolderButton
+                    If DefaultPath <> "" Then
+                        .SelectedPath = DefaultPath
+                    End If
 
-                If .ShowDialog(GetDialogOwnerWindow()) = DialogResult.Cancel Then
-                    UserCanceled = True
-                    Return Nothing
-                End If
+                    If .ShowDialog(GetDialogOwnerWindow()) = DialogResult.Cancel Then
+                        UserCanceled = True
+                        Return Nothing
+                    End If
 
-                Return .SelectedPath
-            End With
+                    Return .SelectedPath
+                End With
+            End Using
         End Function
 
 

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ConnectionStringUITypeEditor.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ConnectionStringUITypeEditor.vb
@@ -6,6 +6,7 @@ Imports Microsoft.VisualStudio.Data.Core
 Imports Microsoft.VisualStudio.Data.Services
 Imports Microsoft.VisualStudio.Data.Services.SupportEntities
 Imports Microsoft.VisualStudio.DataTools.Interop
+Imports Microsoft.VisualStudio.Utilities
 Imports Microsoft.VSDesigner.Data.Local
 Imports Microsoft.VSDesigner.VSDesignerPackage
 

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ConnectionStringUITypeEditor.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ConnectionStringUITypeEditor.vb
@@ -44,130 +44,132 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <returns></returns>
         ''' <remarks>Does not use the IWindowsFormsEditorService service to show it's dialog...</remarks>
         Public Overrides Function EditValue(context As ComponentModel.ITypeDescriptorContext, ServiceProvider As IServiceProvider, oValue As Object) As Object
-            Dim dataConnectionDialogFactory As IVsDataConnectionDialogFactory = DirectCast(ServiceProvider.GetService(GetType(IVsDataConnectionDialogFactory)), IVsDataConnectionDialogFactory)
+            Using (DpiAwareness.EnterDpiScope(DpiAwarenessContext.SystemAware))
+                Dim dataConnectionDialogFactory As IVsDataConnectionDialogFactory = DirectCast(ServiceProvider.GetService(GetType(IVsDataConnectionDialogFactory)), IVsDataConnectionDialogFactory)
 
-            If dataConnectionDialogFactory Is Nothing Then
-                Debug.Fail("Couldn't get the IVsDataConnectionDialogFactory service from our provider...")
-                Return oValue
-            End If
+                If dataConnectionDialogFactory Is Nothing Then
+                    Debug.Fail("Couldn't get the IVsDataConnectionDialogFactory service from our provider...")
+                    Return oValue
+                End If
 
-            Dim providerManager As IVsDataProviderManager = DirectCast(ServiceProvider.GetService(GetType(IVsDataProviderManager)), IVsDataProviderManager)
-            If providerManager Is Nothing Then
-                Debug.Fail("Couldn't get the IVsProviderManager service from our provider")
-                Return oValue
-            End If
+                Dim providerManager As IVsDataProviderManager = DirectCast(ServiceProvider.GetService(GetType(IVsDataProviderManager)), IVsDataProviderManager)
+                If providerManager Is Nothing Then
+                    Debug.Fail("Couldn't get the IVsProviderManager service from our provider")
+                    Return oValue
+                End If
 
-            Dim providerMapper As IDTAdoDotNetProviderMapper = DirectCast(ServiceProvider.GetService(GetType(IDTAdoDotNetProviderMapper)), IDTAdoDotNetProviderMapper)
-            If providerMapper Is Nothing Then
-                Debug.Fail("Couldn't get the IDTAdoDotNetProviderMapper service from our provider")
-                Return oValue
-            End If
+                Dim providerMapper As IDTAdoDotNetProviderMapper = DirectCast(ServiceProvider.GetService(GetType(IDTAdoDotNetProviderMapper)), IDTAdoDotNetProviderMapper)
+                If providerMapper Is Nothing Then
+                    Debug.Fail("Couldn't get the IDTAdoDotNetProviderMapper service from our provider")
+                    Return oValue
+                End If
 
-            Dim dataConnectionDialog As IVsDataConnectionDialog = dataConnectionDialogFactory.CreateConnectionDialog()
+                Dim dataConnectionDialog As IVsDataConnectionDialog = dataConnectionDialogFactory.CreateConnectionDialog()
 
-            If dataConnectionDialog Is Nothing Then
-                Debug.Fail("Failed to get a IVsDataConnectionDialog from the IVsDataConnectionDialogFactory!?")
-                Return oValue
-            End If
+                If dataConnectionDialog Is Nothing Then
+                    Debug.Fail("Failed to get a IVsDataConnectionDialog from the IVsDataConnectionDialogFactory!?")
+                    Return oValue
+                End If
 
-            ' If this is a local data file, we've gotta let the connectionstringconverter service
-            ' do it's magic to convert the path. Trying to convert a non-local data connection string
-            ' should be a no-op, so we should be safe if we just try to get hold of the required services
-            ' and give it a try...
-            Dim dteProj As EnvDTE.Project = Nothing
-            Dim connectionStringConverter As IConnectionStringConverterService =
+                ' If this is a local data file, we've gotta let the connectionstringconverter service
+                ' do it's magic to convert the path. Trying to convert a non-local data connection string
+                ' should be a no-op, so we should be safe if we just try to get hold of the required services
+                ' and give it a try...
+                Dim dteProj As EnvDTE.Project = Nothing
+                Dim connectionStringConverter As IConnectionStringConverterService =
                 DirectCast(ServiceProvider.GetService(GetType(IConnectionStringConverterService)), IConnectionStringConverterService)
-            If connectionStringConverter IsNot Nothing Then
-                ' The SettingsDesignerLoader should have added the project item as a service in case someone needs to 
-                ' get hold of it....
-                Dim dteProjItem As EnvDTE.ProjectItem = Nothing
-                dteProjItem = DirectCast(ServiceProvider.GetService(GetType(EnvDTE.ProjectItem)), EnvDTE.ProjectItem)
-                If dteProjItem IsNot Nothing Then
-                    dteProj = dteProjItem.ContainingProject
-                Else
-                    Debug.Fail("We failed to get the EnvDTE.ProjectItem service from our service provider. The settings designer loader should have added it...")
-                End If
-            End If
-
-            dataConnectionDialog.AddSources(AddressOf New DataConnectionDialogFilterer(dteProj).IsCombinationSupported)
-            dataConnectionDialog.LoadSourceSelection()
-            dataConnectionDialog.LoadProviderSelections()
-
-            Dim value As SerializableConnectionString
-            Try
-                value = TryCast(oValue, SerializableConnectionString)
-
-                ' We keep track of if there was sensitive data in the string when we were called - if not, we've gotta prompt the user
-                ' about the potential security implications if (s)he adds sensitive data
-                Dim containedSensitiveData As Boolean = False
-
-                ' If we have a value coming in, we should feed the dialog with this value
-                If value IsNot Nothing Then
-                    ' The normalized connection string contains the connection string after the connection string converter is done
-                    ' munching it.
-                    Dim normalizedConnectionString As String = Nothing
-                    Try
-                        If connectionStringConverter IsNot Nothing AndAlso dteProj IsNot Nothing AndAlso value.ProviderName <> "" Then
-                            normalizedConnectionString = connectionStringConverter.ToDesignTime(dteProj, value.ConnectionString, value.ProviderName)
-                        End If
-                    Catch ex As ArgumentException
-                    Catch ex As ConnectionStringConverterServiceException
-                        ' Well, the user may very well type garbage into the connection string text box
-                    Finally
-                        ' If we couldn't find the service, or if something else went wrong, we fall back 
-                        ' to the connection string as it is showing in the designer...
-                        If normalizedConnectionString Is Nothing Then
-                            normalizedConnectionString = value.ConnectionString
-                        End If
-                    End Try
-
-                    Dim providerGuid As Guid = Guid.Empty
-                    If value.ProviderName <> "" Then
-                        ' Get the provider GUID (if any)
-                        providerGuid = GetGuidFromInvariantProviderName(providerMapper, value.ProviderName, normalizedConnectionString, False)
-                    End If
-
-                    ' If we have a provider, we can feed the dialog with the initial values. 
-                    If Not providerGuid.Equals(Guid.Empty) Then
-                        dataConnectionDialog.LoadExistingConfiguration(providerGuid, normalizedConnectionString, False)
-
-                        Dim oldConnectionStringProperties As IVsDataConnectionProperties = GetConnectionStringProperties(providerManager, providerGuid, normalizedConnectionString)
-                        If oldConnectionStringProperties IsNot Nothing AndAlso ContainsSensitiveData(oldConnectionStringProperties) Then
-                            ' If we already had sensitive data in the string coming in to this function, we don't have to prompt again...
-                            containedSensitiveData = True
-                        End If
-                    ElseIf normalizedConnectionString <> "" Then
-                        dataConnectionDialog.SafeConnectionString = normalizedConnectionString
+                If connectionStringConverter IsNot Nothing Then
+                    ' The SettingsDesignerLoader should have added the project item as a service in case someone needs to 
+                    ' get hold of it....
+                    Dim dteProjItem As EnvDTE.ProjectItem = Nothing
+                    dteProjItem = DirectCast(ServiceProvider.GetService(GetType(EnvDTE.ProjectItem)), EnvDTE.ProjectItem)
+                    If dteProjItem IsNot Nothing Then
+                        dteProj = dteProjItem.ContainingProject
+                    Else
+                        Debug.Fail("We failed to get the EnvDTE.ProjectItem service from our service provider. The settings designer loader should have added it...")
                     End If
                 End If
 
-                If (dataConnectionDialog.ShowDialog() AndAlso dataConnectionDialog.DisplayConnectionString <> "") Then
-                    ' If the user press OK and we have a connection string, lets return this new value!
-                    dataConnectionDialog.SaveProviderSelections()
-                    If (dataConnectionDialog.SaveSelection) Then
-                        dataConnectionDialog.SaveSourceSelection()
+                dataConnectionDialog.AddSources(AddressOf New DataConnectionDialogFilterer(dteProj).IsCombinationSupported)
+                dataConnectionDialog.LoadSourceSelection()
+                dataConnectionDialog.LoadProviderSelections()
+
+                Dim value As SerializableConnectionString
+                Try
+                    value = TryCast(oValue, SerializableConnectionString)
+
+                    ' We keep track of if there was sensitive data in the string when we were called - if not, we've gotta prompt the user
+                    ' about the potential security implications if (s)he adds sensitive data
+                    Dim containedSensitiveData As Boolean = False
+
+                    ' If we have a value coming in, we should feed the dialog with this value
+                    If value IsNot Nothing Then
+                        ' The normalized connection string contains the connection string after the connection string converter is done
+                        ' munching it.
+                        Dim normalizedConnectionString As String = Nothing
+                        Try
+                            If connectionStringConverter IsNot Nothing AndAlso dteProj IsNot Nothing AndAlso value.ProviderName <> "" Then
+                                normalizedConnectionString = connectionStringConverter.ToDesignTime(dteProj, value.ConnectionString, value.ProviderName)
+                            End If
+                        Catch ex As ArgumentException
+                        Catch ex As ConnectionStringConverterServiceException
+                            ' Well, the user may very well type garbage into the connection string text box
+                        Finally
+                            ' If we couldn't find the service, or if something else went wrong, we fall back 
+                            ' to the connection string as it is showing in the designer...
+                            If normalizedConnectionString Is Nothing Then
+                                normalizedConnectionString = value.ConnectionString
+                            End If
+                        End Try
+
+                        Dim providerGuid As Guid = Guid.Empty
+                        If value.ProviderName <> "" Then
+                            ' Get the provider GUID (if any)
+                            providerGuid = GetGuidFromInvariantProviderName(providerMapper, value.ProviderName, normalizedConnectionString, False)
+                        End If
+
+                        ' If we have a provider, we can feed the dialog with the initial values. 
+                        If Not providerGuid.Equals(Guid.Empty) Then
+                            dataConnectionDialog.LoadExistingConfiguration(providerGuid, normalizedConnectionString, False)
+
+                            Dim oldConnectionStringProperties As IVsDataConnectionProperties = GetConnectionStringProperties(providerManager, providerGuid, normalizedConnectionString)
+                            If oldConnectionStringProperties IsNot Nothing AndAlso ContainsSensitiveData(oldConnectionStringProperties) Then
+                                ' If we already had sensitive data in the string coming in to this function, we don't have to prompt again...
+                                containedSensitiveData = True
+                            End If
+                        ElseIf normalizedConnectionString <> "" Then
+                            dataConnectionDialog.SafeConnectionString = normalizedConnectionString
+                        End If
                     End If
 
-                    Dim newValue As New SerializableConnectionString With {
+                    If (dataConnectionDialog.ShowDialog() AndAlso dataConnectionDialog.DisplayConnectionString <> "") Then
+                        ' If the user press OK and we have a connection string, lets return this new value!
+                        dataConnectionDialog.SaveProviderSelections()
+                        If (dataConnectionDialog.SaveSelection) Then
+                            dataConnectionDialog.SaveSourceSelection()
+                        End If
+
+                        Dim newValue As New SerializableConnectionString With {
                         .ProviderName = GetInvariantProviderNameFromGuid(providerMapper, dataConnectionDialog.SelectedProvider),
                         .ConnectionString = GetConnectionString(ServiceProvider, dataConnectionDialog, Not containedSensitiveData)
                     }
-                    If dteProj IsNot Nothing AndAlso connectionStringConverter IsNot Nothing Then
-                        ' Go back to the runtime representation of the string...
-                        newValue.ConnectionString = connectionStringConverter.ToRunTime(dteProj, newValue.ConnectionString, newValue.ProviderName)
-                    End If
+                        If dteProj IsNot Nothing AndAlso connectionStringConverter IsNot Nothing Then
+                            ' Go back to the runtime representation of the string...
+                            newValue.ConnectionString = connectionStringConverter.ToRunTime(dteProj, newValue.ConnectionString, newValue.ProviderName)
+                        End If
 
-                    Return newValue
-                Else
-                    ' Well, we better return the old value...
-                    Return oValue
-                End If
-            Finally
-                If dataConnectionDialog IsNot Nothing Then
-                    dataConnectionDialog.Dispose()
-                End If
-            End Try
-            Return oValue
+                        Return newValue
+                    Else
+                        ' Well, we better return the old value...
+                        Return oValue
+                    End If
+                Finally
+                    If dataConnectionDialog IsNot Nothing Then
+                        dataConnectionDialog.Dispose()
+                    End If
+                End Try
+                Return oValue
+            End Using
         End Function
 
         ''' <summary>

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
@@ -1834,8 +1834,10 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                                     'to the Auth Service
                                     servicesAuthForm.LoadAnonymously = True
                                 Else
-                                    Dim result As DialogResult = servicesAuthForm.ShowDialog()
-                                    If result = DialogResult.Cancel Then Exit Sub
+                                    Using (DpiAwareness.EnterDpiScope(DpiAwarenessContext.SystemAware))
+                                        Dim result As DialogResult = servicesAuthForm.ShowDialog()
+                                        If result = DialogResult.Cancel Then Exit Sub
+                                    End Using
                                     'TODO: What exceptions do we need to catch?
                                 End If
                                 If servicesAuthForm.LoadAnonymously OrElse
@@ -2061,16 +2063,18 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             Try
                 _isShowingTypePicker = True
                 If Not DBNull.Value.Equals(_settingsGridView.CurrentCell.Value) Then
-                    Dim TypePickerDlg As New TypePickerDialog(Settings.Site, DesignerLoader.VsHierarchy, DesignerLoader.ProjectItemid)
+                    Using (DpiAwareness.EnterDpiScope(DpiAwarenessContext.SystemAware))
+                        Dim TypePickerDlg As New TypePickerDialog(Settings.Site, DesignerLoader.VsHierarchy, DesignerLoader.ProjectItemid)
 
-                    TypePickerDlg.SetProjectReferencedAssemblies()
+                        TypePickerDlg.SetProjectReferencedAssemblies()
 
-                    If UIService.ShowDialog(TypePickerDlg) = DialogResult.OK Then
-                        ChangeSettingType(_settingsGridView.Rows(ptCurrent.Y), TypePickerDlg.TypeName)
-                    Else
-                        ' The user clicked cancel in the dialog - let's cancel this edit
-                        _settingsGridView.CancelEdit()
-                    End If
+                        If UIService.ShowDialog(TypePickerDlg) = DialogResult.OK Then
+                            ChangeSettingType(_settingsGridView.Rows(ptCurrent.Y), TypePickerDlg.TypeName)
+                        Else
+                            ' The user clicked cancel in the dialog - let's cancel this edit
+                            _settingsGridView.CancelEdit()
+                        End If
+                    End Using
                 End If
             Finally
                 _isShowingTypePicker = False

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypeEditorHostControl.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/TypeEditorHostControl.vb
@@ -7,6 +7,7 @@ Imports System.Windows.Forms
 Imports System.Windows.Forms.Design
 
 Imports Microsoft.VisualStudio.Editors.Common
+Imports Microsoft.VisualStudio.Utilities
 
 Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
@@ -511,11 +512,13 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
         Public Function ShowDialog(dialog As Form) As DialogResult Implements IWindowsFormsEditorService.ShowDialog
             Dim UiSvc As IUIService = DirectCast(GetService(GetType(IUIService)), IUIService)
-            If Not UiSvc Is Nothing Then
-                Return UiSvc.ShowDialog(dialog)
-            Else
-                Return dialog.ShowDialog(_showEditorButton)
-            End If
+            Using (DpiAwareness.EnterDpiScope(DpiAwarenessContext.SystemAware))
+                If Not UiSvc Is Nothing Then
+                    Return UiSvc.ShowDialog(dialog)
+                Else
+                    Return dialog.ShowDialog(_showEditorButton)
+                End If
+            End Using
         End Function
 
 #End Region

--- a/src/Microsoft.VisualStudio.Editors/XmlToSchema/Wizard.vb
+++ b/src/Microsoft.VisualStudio.Editors/XmlToSchema/Wizard.vb
@@ -7,6 +7,7 @@ Imports System.Windows.Forms.Design
 Imports EnvDTE
 
 Imports Microsoft.VisualStudio.TemplateWizard
+Imports Microsoft.VisualStudio.Utilities
 
 Namespace Microsoft.VisualStudio.Editors.XmlToSchema
     Public NotInheritable Class Wizard
@@ -73,7 +74,9 @@ Namespace Microsoft.VisualStudio.Editors.XmlToSchema
                     .ServiceProvider = Common.ShellUtil.GetServiceProvider(dte)
                 }
                 Dim uiService As IUIService = CType(inputForm.ServiceProvider.GetService(GetType(IUIService)), IUIService)
-                uiService.ShowDialog(inputForm)
+                Using (DpiAwareness.EnterDpiScope(DpiAwarenessContext.SystemAware))
+                    uiService.ShowDialog(inputForm)
+                End Using
 
             Catch ex As Exception
                 If FilterException(ex) Then


### PR DESCRIPTION
Fixes https://github.com/dotnet/project-system/issues/4769

This wraps all of the WinForms ShowDialog calls with `DpiAwareness.EnterDpiScope(DpiAwarenessContext.SystemAware)` . It was a little tedious and some of the Using's scopes were purposely trying to maintain the format of large functions/blocks of code. Also, the guidance was to wrap everything from the instantiation of the dialog to the `ShowDialog`, not just the call.

