### PR TITLE
update queues used in the integration tests

### DIFF
--- a/build/azure-pipelines-integration.yml
+++ b/build/azure-pipelines-integration.yml
@@ -8,7 +8,9 @@ pr:
 
 jobs:
 - job: Visual_Studio
-  pool: dotnet-external-vs2019-preview
+  pool:
+    name: NetCorePublic-Pool
+    queue: buildpool.windows.10.amd64.vs2019.pre.open
   strategy:
     maxParallel: 2
     matrix:


### PR DESCRIPTION
dnceng has said they are turning these VMs off so I am moving us to another queue that hopefully won't get shutdown