### PR TITLE
Use NuGetTargetMoniker instead of TFM if its exists

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PackageRestore/Snapshots/RestoreBuilderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PackageRestore/Snapshots/RestoreBuilderTests.cs
@@ -63,6 +63,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
         }
 
         [Fact]
+        public void ToProjectRestoreInfo_RespectsNuGetTargetMonikerIfPresent()
+        {
+            var update = IProjectSubscriptionUpdateFactory.FromJson(@"
+{
+    ""CurrentState"": {
+        ""NuGetRestore"": {
+            ""Properties"": {
+                ""NuGetTargetMoniker"": ""UWP, Version=v10"",
+                ""TargetFrameworkMoniker"": "".NETFramework, Version=v4.5""
+            },
+        }
+    }
+}
+");
+            var result = RestoreBuilder.ToProjectRestoreInfo(update.CurrentState);
+            var targetFramework = result.TargetFrameworks.Item(0);
+
+            Assert.Equal("UWP, Version=v10", targetFramework.TargetFrameworkMoniker);
+        }
+
+        [Fact]
         public void ToProjectRestoreInfo_SetsCoreProperties()
         {
             var update = IProjectSubscriptionUpdateFactory.FromJson(@"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/RestoreBuilder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/RestoreBuilder.cs
@@ -28,8 +28,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
             IProjectRuleSnapshot packageReferences = update.GetSnapshotOrEmpty(PackageReference.SchemaName);
             IProjectRuleSnapshot toolReferences = update.GetSnapshotOrEmpty(DotNetCliToolReference.SchemaName);
 
+            // For certain project types such as UWP, "TargetFrameworkMoniker" != the moniker that restore uses
+            string targetMoniker = properties.GetPropertyOrEmpty(NuGetRestore.NuGetTargetMonikerProperty);
+            if (targetMoniker.Length == 0)
+                targetMoniker = properties.GetPropertyOrEmpty(NuGetRestore.TargetFrameworkMonikerProperty);
+
             IVsTargetFrameworkInfo2 frameworkInfo = new TargetFrameworkInfo(
-                properties.GetPropertyOrEmpty(NuGetRestore.TargetFrameworkMonikerProperty),
+                targetMoniker,
                 ToReferenceItems(frameworkReferences.Items),
                 ToReferenceItems(packageDownloads.Items),
                 ToReferenceItems(projectReferences.Items),

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
@@ -523,7 +523,7 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The value of the &apos;TargetFrameworkMoniker&apos; property in the &apos;{0}&apos; configuration is empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors..
+        ///   Looks up a localized string similar to The value of the &apos;TargetFrameworkMoniker&apos; and &apos;NuGetTargetMoniker&apos; properties in the &apos;{0}&apos; configuration are both empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors..
         /// </summary>
         internal static string Restore_EmptyTargetFrameworkMoniker {
             get {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
@@ -304,6 +304,6 @@ In order to debug this project, add an executable project to this solution which
     <value>The metadata on 'DotNetCliToolReference' item '{0}' is inconsistent between target frameworks. Only the first one will be restored.</value>
   </data>
   <data name="Restore_EmptyTargetFrameworkMoniker" xml:space="preserve">
-    <value>The value of the 'TargetFrameworkMoniker' property in the '{0}' configuration is empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</value>
+    <value>The value of the 'TargetFrameworkMoniker' and 'NuGetTargetMoniker' properties in the '{0}' configuration are both empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
@@ -317,8 +317,8 @@ Pokud chcete projekt ladit, přidejte do řešení spustitelný projekt, který 
         <note />
       </trans-unit>
       <trans-unit id="Restore_EmptyTargetFrameworkMoniker">
-        <source>The value of the 'TargetFrameworkMoniker' property in the '{0}' configuration is empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</source>
-        <target state="translated">Hodnota vlastnosti TargetFrameworkMoniker v konfiguraci {0} je prázdná. Tato konfigurace se nebude podílet na obnovení přes NuGet, což může mít za následek chyby při obnovení a sestavení.</target>
+        <source>The value of the 'TargetFrameworkMoniker' and 'NuGetTargetMoniker' properties in the '{0}' configuration are both empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</source>
+        <target state="needs-review-translation">Hodnota vlastnosti TargetFrameworkMoniker v konfiguraci {0} je prázdná. Tato konfigurace se nebude podílet na obnovení přes NuGet, což může mít za následek chyby při obnovení a sestavení.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
@@ -317,8 +317,8 @@ Um das Projekt zu debuggen, fügen Sie dieser Projektmappe ein ausführbares Pro
         <note />
       </trans-unit>
       <trans-unit id="Restore_EmptyTargetFrameworkMoniker">
-        <source>The value of the 'TargetFrameworkMoniker' property in the '{0}' configuration is empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</source>
-        <target state="translated">Der Wert der Eigenschaft "TargetFrameworkMoniker" in der "{0}"-Konfiguration ist leer. Diese Konfiguration wird bei der NuGet-Wiederherstellung nicht berücksichtigt, was zu Wiederherstellungs- und Buildfehlern führen kann.</target>
+        <source>The value of the 'TargetFrameworkMoniker' and 'NuGetTargetMoniker' properties in the '{0}' configuration are both empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</source>
+        <target state="needs-review-translation">Der Wert der Eigenschaft "TargetFrameworkMoniker" in der "{0}"-Konfiguration ist leer. Diese Konfiguration wird bei der NuGet-Wiederherstellung nicht berücksichtigt, was zu Wiederherstellungs- und Buildfehlern führen kann.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
@@ -317,8 +317,8 @@ Para depurar este proyecto, agregue un proyecto ejecutable a esta solución con 
         <note />
       </trans-unit>
       <trans-unit id="Restore_EmptyTargetFrameworkMoniker">
-        <source>The value of the 'TargetFrameworkMoniker' property in the '{0}' configuration is empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</source>
-        <target state="translated">El valor de la propiedad "TargetFrameworkMoniker" en la configuración de "{0}" está vacía. Esta configuración no contribuirá a la restauración de NuGet, lo que puede dar lugar a errores de restauración y compilación.</target>
+        <source>The value of the 'TargetFrameworkMoniker' and 'NuGetTargetMoniker' properties in the '{0}' configuration are both empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</source>
+        <target state="needs-review-translation">El valor de la propiedad "TargetFrameworkMoniker" en la configuración de "{0}" está vacía. Esta configuración no contribuirá a la restauración de NuGet, lo que puede dar lugar a errores de restauración y compilación.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
@@ -317,8 +317,8 @@ Pour déboguer ce projet, ajoutez à cette solution un projet exécutable qui fa
         <note />
       </trans-unit>
       <trans-unit id="Restore_EmptyTargetFrameworkMoniker">
-        <source>The value of the 'TargetFrameworkMoniker' property in the '{0}' configuration is empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</source>
-        <target state="translated">La valeur de la propriété TargetFrameworkMoniker dans la configuration « {0} » est vide. Cette configuration ne contribue pas à la restauration NuGet, ce qui peut entraîner des erreurs de restauration et de build.</target>
+        <source>The value of the 'TargetFrameworkMoniker' and 'NuGetTargetMoniker' properties in the '{0}' configuration are both empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</source>
+        <target state="needs-review-translation">La valeur de la propriété TargetFrameworkMoniker dans la configuration « {0} » est vide. Cette configuration ne contribue pas à la restauration NuGet, ce qui peut entraîner des erreurs de restauration et de build.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
@@ -317,8 +317,8 @@ Per eseguire il debug del progetto, aggiungere a questa soluzione un progetto es
         <note />
       </trans-unit>
       <trans-unit id="Restore_EmptyTargetFrameworkMoniker">
-        <source>The value of the 'TargetFrameworkMoniker' property in the '{0}' configuration is empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</source>
-        <target state="translated">Il valore della proprietà 'TargetFrameworkMoniker' nella configurazione '{0}' è vuoto. Questa configurazione non contribuisce al ripristino di NuGet e questo può comportare errori di ripristino e di compilazione.</target>
+        <source>The value of the 'TargetFrameworkMoniker' and 'NuGetTargetMoniker' properties in the '{0}' configuration are both empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</source>
+        <target state="needs-review-translation">Il valore della proprietà 'TargetFrameworkMoniker' nella configurazione '{0}' è vuoto. Questa configurazione non contribuisce al ripristino di NuGet e questo può comportare errori di ripristino e di compilazione.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
@@ -317,8 +317,8 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="Restore_EmptyTargetFrameworkMoniker">
-        <source>The value of the 'TargetFrameworkMoniker' property in the '{0}' configuration is empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</source>
-        <target state="translated">'{0}' 構成の 'TargetFrameworkMoniker' プロパティの値が空です。この構成は NuGet の復元には影響しませんが、復元およびビルドのエラーが発生する可能性があります。</target>
+        <source>The value of the 'TargetFrameworkMoniker' and 'NuGetTargetMoniker' properties in the '{0}' configuration are both empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</source>
+        <target state="needs-review-translation">'{0}' 構成の 'TargetFrameworkMoniker' プロパティの値が空です。この構成は NuGet の復元には影響しませんが、復元およびビルドのエラーが発生する可能性があります。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
@@ -317,8 +317,8 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="Restore_EmptyTargetFrameworkMoniker">
-        <source>The value of the 'TargetFrameworkMoniker' property in the '{0}' configuration is empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</source>
-        <target state="translated">'{0}' 구성의 'TargetFrameworkMoniker' 속성 값이 비어 있습니다. 이 구성은 NuGet 복원에 기여하지 않아 복원 및 빌드 오류가 발생할 수 있습니다.</target>
+        <source>The value of the 'TargetFrameworkMoniker' and 'NuGetTargetMoniker' properties in the '{0}' configuration are both empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</source>
+        <target state="needs-review-translation">'{0}' 구성의 'TargetFrameworkMoniker' 속성 값이 비어 있습니다. 이 구성은 NuGet 복원에 기여하지 않아 복원 및 빌드 오류가 발생할 수 있습니다.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
@@ -317,8 +317,8 @@ Aby debugować ten projekt, dodaj projekt wykonywalny do tego rozwiązania, któ
         <note />
       </trans-unit>
       <trans-unit id="Restore_EmptyTargetFrameworkMoniker">
-        <source>The value of the 'TargetFrameworkMoniker' property in the '{0}' configuration is empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</source>
-        <target state="translated">Wartość właściwości „TargetFrameworkMoniker” w konfiguracji „{0}” jest pusta. Ta konfiguracja nie przyczyni się do przywracania pakietów NuGet, co może skutkować błędami przywracania i kompilacji.</target>
+        <source>The value of the 'TargetFrameworkMoniker' and 'NuGetTargetMoniker' properties in the '{0}' configuration are both empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</source>
+        <target state="needs-review-translation">Wartość właściwości „TargetFrameworkMoniker” w konfiguracji „{0}” jest pusta. Ta konfiguracja nie przyczyni się do przywracania pakietów NuGet, co może skutkować błędami przywracania i kompilacji.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
@@ -317,8 +317,8 @@ Para depurar esse projeto, adicione um projeto executável a essa solução que 
         <note />
       </trans-unit>
       <trans-unit id="Restore_EmptyTargetFrameworkMoniker">
-        <source>The value of the 'TargetFrameworkMoniker' property in the '{0}' configuration is empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</source>
-        <target state="translated">O valor da propriedade 'TargetFrameworkMoniker' na configuração '{0}' está vazio. Essa configuração não contribuirá para a restauração do NuGet, o que pode resultar em erros de restauração e de build.</target>
+        <source>The value of the 'TargetFrameworkMoniker' and 'NuGetTargetMoniker' properties in the '{0}' configuration are both empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</source>
+        <target state="needs-review-translation">O valor da propriedade 'TargetFrameworkMoniker' na configuração '{0}' está vazio. Essa configuração não contribuirá para a restauração do NuGet, o que pode resultar em erros de restauração e de build.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
@@ -317,8 +317,8 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="Restore_EmptyTargetFrameworkMoniker">
-        <source>The value of the 'TargetFrameworkMoniker' property in the '{0}' configuration is empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</source>
-        <target state="translated">Значение свойства "TargetFrameworkMoniker" в конфигурации "{0}" является пустым. Эта конфигурация не будет задействована в восстановлении NuGet, что может привести к ошибкам при восстановлении и сборке.</target>
+        <source>The value of the 'TargetFrameworkMoniker' and 'NuGetTargetMoniker' properties in the '{0}' configuration are both empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</source>
+        <target state="needs-review-translation">Значение свойства "TargetFrameworkMoniker" в конфигурации "{0}" является пустым. Эта конфигурация не будет задействована в восстановлении NuGet, что может привести к ошибкам при восстановлении и сборке.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
@@ -317,8 +317,8 @@ Bu projede hata ayıklamak için bu çözüme, kitaplık projesine başvuran bir
         <note />
       </trans-unit>
       <trans-unit id="Restore_EmptyTargetFrameworkMoniker">
-        <source>The value of the 'TargetFrameworkMoniker' property in the '{0}' configuration is empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</source>
-        <target state="translated">'{0}' yapılandırmasındaki 'TargetFrameworkMoniker' özelliğinin değeri boş. Bu yapılandırma NuGet geri yüklemeye katkıda bulunmaz, bu da geri yükleme ve derleme hatalarına neden olabilir.</target>
+        <source>The value of the 'TargetFrameworkMoniker' and 'NuGetTargetMoniker' properties in the '{0}' configuration are both empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</source>
+        <target state="needs-review-translation">'{0}' yapılandırmasındaki 'TargetFrameworkMoniker' özelliğinin değeri boş. Bu yapılandırma NuGet geri yüklemeye katkıda bulunmaz, bu da geri yükleme ve derleme hatalarına neden olabilir.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
@@ -317,8 +317,8 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="Restore_EmptyTargetFrameworkMoniker">
-        <source>The value of the 'TargetFrameworkMoniker' property in the '{0}' configuration is empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</source>
-        <target state="translated">“{0}”配置中的 TargetFrameworkMoniker 属性的值为空。此配置将影响 NuGet 还原，这可能导致还原并生成错误。</target>
+        <source>The value of the 'TargetFrameworkMoniker' and 'NuGetTargetMoniker' properties in the '{0}' configuration are both empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</source>
+        <target state="needs-review-translation">“{0}”配置中的 TargetFrameworkMoniker 属性的值为空。此配置将影响 NuGet 还原，这可能导致还原并生成错误。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
@@ -317,8 +317,8 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="Restore_EmptyTargetFrameworkMoniker">
-        <source>The value of the 'TargetFrameworkMoniker' property in the '{0}' configuration is empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</source>
-        <target state="translated">'{0}' 組態中的 'TargetFrameworkMoniker' 屬性值是空的。這樣的組態不會對 NuGet 還原生效，而可能導致還原及建置錯誤。</target>
+        <source>The value of the 'TargetFrameworkMoniker' and 'NuGetTargetMoniker' properties in the '{0}' configuration are both empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</source>
+        <target state="needs-review-translation">'{0}' 組態中的 'TargetFrameworkMoniker' 屬性值是空的。這樣的組態不會對 NuGet 還原生效，而可能導致還原及建置錯誤。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -93,6 +93,10 @@
                   ReadOnly="True"
                   Visible="False" />
 
+  <StringProperty Name="NuGetTargetMoniker"
+                  ReadOnly="True"
+                  Visible="False" />
+
   <StringProperty Name="TargetFramework"
                   DisplayName="Target Framework">
     <StringProperty.DataSource>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/project-system/issues/4854.

Note: This has localization impact that I believe is okay; if we do not ship localized values - then the user will continue to get the old string.