### PR TITLE
Always persist ResX files in ordinal order

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceFile.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceFile.vb
@@ -1014,9 +1014,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
                     Dim comparer As IComparer
                     If _alphabetizedOrder Then
-                        comparer = New AlphabetizedOrderComparer()
+                        comparer = AlphabetizedOrderComparer.Instance
                     Else
-                        comparer = New OriginalOrderComparer()
+                        comparer = OriginalOrderComparer.Instance
                     End If
 
                     Array.Sort(resourceList, comparer)
@@ -1610,6 +1610,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Private Class AlphabetizedOrderComparer
             Implements IComparer
 
+            Public Shared ReadOnly Instance As New AlphabetizedOrderComparer
+
             Public Function Compare(x As Object, y As Object) As Integer Implements IComparer.Compare
                 Dim r1 As Resource = CType(x, Resource)
                 Dim r2 As Resource = CType(y, Resource)
@@ -1623,6 +1625,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         Private Class OriginalOrderComparer
             Implements IComparer
+
+            Public Shared ReadOnly Instance As New OriginalOrderComparer
 
             Public Function Compare(x As Object, y As Object) As Integer Implements IComparer.Compare
                 Dim r1 As Resource = CType(x, Resource)

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceFile.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceFile.vb
@@ -956,7 +956,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
                             ' we check whether the resource item in the original file was alphabetized, we keep the style when we save it...
                             If _alphabetizedOrder Then
-                                If String.Compare(lastName, Resource.Name, StringComparison.Ordinal) > 0 Then
+                                If StringComparers.ResourceNames.Compare(lastName, Resource.Name) > 0 Then
                                     _alphabetizedOrder = False
                                 Else
                                     lastName = Resource.Name
@@ -1616,7 +1616,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 Dim r1 As Resource = CType(x, Resource)
                 Dim r2 As Resource = CType(y, Resource)
 
-                Return String.Compare(r1.Name, r2.Name, StringComparison.OrdinalIgnoreCase)
+                Return StringComparers.ResourceNames.Compare(r1.Name, r2.Name)
             End Function
         End Class
 
@@ -1633,7 +1633,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 Dim r2 As Resource = CType(y, Resource)
 
                 If r1.OrderID = r2.OrderID Then
-                    Return String.Compare(r1.Name, r2.Name, StringComparison.OrdinalIgnoreCase)
+                    Return StringComparers.ResourceNames.Compare(r1.Name, r2.Name)
                 Else
                     Return r1.OrderID - r2.OrderID
                 End If

--- a/src/Microsoft.VisualStudio.Editors/StringComparers.vb
+++ b/src/Microsoft.VisualStudio.Editors/StringComparers.vb
@@ -13,6 +13,12 @@ Namespace Microsoft.VisualStudio
             End Get
         End Property
 
+        Public Shared ReadOnly Property ResourceNames As StringComparer
+            Get
+                Return StringComparer.OrdinalIgnoreCase
+            End Get
+        End Property
+
     End Class
 
 End Namespace


### PR DESCRIPTION
Fixes: #3575

ResX's files are persisted as "alphabetized" if they were determined to be "alphabetized" when opened. However, the persistence and determination use different comparisons, resulting in a file that was persisted as "alphabetized" to be opened as "non-alphabetized". Make them the same ("ordinal ignore case") .

The determination check was changed to match the persistence format to reduce the churn when editing the ResX in a new version of VS.