### PR TITLE
Revert "use VS2019 on the official build"

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -2,7 +2,7 @@ resources:
 - repo: self
   clean: true
 queue:
-  name: VSEng-MicroBuildVS2019
+  name: VSEng-MicroBuildVS2017
   demands: Cmd
 variables:
   BuildConfiguration: Release


### PR DESCRIPTION
Reverts dotnet/project-system#4878

Our sign target bakes in the 15.0 path to MSBuild so we cannot use 2019 machines for official builds

```xml
  <Import Project="BuildStep.props" />

  <Target Name="Sign">
    <Exec Command='"$(MSBuildProjectDirectory)\vswhere.exe" -latest -prerelease -property installationPath -requires Microsoft.Component.MSBuild'
          Condition="'$(RealSign)' == 'true'"
          ConsoleToMsBuild="true"
          StandardErrorImportance="high">
      <Output TaskParameter="ConsoleOutput" PropertyName="_VsInstallDir" />
    </Exec>

    <ItemGroup>
      <SignToolArgs Include='-outputconfig "$(OutputConfigFile)"' Condition="'$(OutputConfigFile)' != ''" />      
      <SignToolArgs Include='-nugetPackagesPath "$(NuGetPackageRoot)\"' />
      <SignToolArgs Include='-intermediateOutputPath "$(ArtifactsObjDir)\"' />
      <SignToolArgs Include='-config "$(ConfigFile)"' />
      <SignToolArgs Include='-test' Condition="'$(RealSign)' != 'true'" />
      <SignToolArgs Include='-msbuildpath "$(_VsInstallDir)\MSBuild\15.0\Bin\msbuild.exe"' Condition="'$(RealSign)' == 'true'"/>
      <SignToolArgs Include='"$(ArtifactsConfigurationDir)\"' />
    </ItemGroup>
    
    <Exec Command="$(NuGetPackageRoot)roslyntools.signtool\$(RoslynToolsSignToolVersion)\tools\SignTool.exe @(SignToolArgs, ' ')" />
  </Target>

</Project>

```