### PR TITLE
Remove unused resource strings

### DIFF
--- a/ProjectSystem.sln
+++ b/ProjectSystem.sln
@@ -33,6 +33,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DeployIntegrationDependenci
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{DD7EF107-AAD4-4C43-8A58-0DC1BC614ADE}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		build\Packages.targets = build\Packages.targets
 		build\SignToolData.json = build\SignToolData.json
 		build\Versions.props = build\Versions.props

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VisualBasic/VisualBasicVSImports.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VisualBasic/VisualBasicVSImports.cs
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
                         else
                         {
                             // Cannot reach this point, since index has to be Int or String
-                            System.Diagnostics.Debug.Assert(false, $"Parameter {nameof(index)} is niether an int nor a string");
+                            System.Diagnostics.Debug.Assert(false, $"Parameter {nameof(index)} is neither an int nor a string");
                         }
 
                         if (importProjectItem.IsImported)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
@@ -70,30 +70,6 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The project &apos;{0}&apos; has been modified outside the environment, and there are unsaved changes to the project.
-        ///
-        ///Press Save As to save the unsaved changes and load the updated project from disk.
-        ///Press Discard to discard the unsaved changes and load the updated project from disk.
-        ///Press Overwrite to overwrite the external changes with your changes.
-        ///Press Ignore to ignore the external changes. Your changes may be lost if you close and reopen the project.
-        ///    .
-        /// </summary>
-        internal static string ConflictingModificationsPrompt {
-            get {
-                return ResourceManager.GetString("ConflictingModificationsPrompt", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Conflicting Project Modification Detected.
-        /// </summary>
-        internal static string ConflictingProjectModificationTitle {
-            get {
-                return ResourceManager.GetString("ConflictingProjectModificationTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The debug executable &apos;{0}&apos; specified in the &apos;{1}&apos; debug profile does not exist..
         /// </summary>
         internal static string DebugExecutableNotFound {
@@ -108,15 +84,6 @@ namespace Microsoft.VisualStudio {
         internal static string DebugFrameworkMenuText {
             get {
                 return ResourceManager.GetString("DebugFrameworkMenuText", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to _Discard.
-        /// </summary>
-        internal static string Discard {
-            get {
-                return ResourceManager.GetString("Discard", resourceCulture);
             }
         }
         
@@ -139,24 +106,6 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .NET Core projects are not supported in this release of Visual Studio. Support will be available in a later update..
-        /// </summary>
-        internal static string DotNetCoreProjectsNotSupported {
-            get {
-                return ResourceManager.GetString("DotNetCoreProjectsNotSupported", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Edit {0}.
-        /// </summary>
-        internal static string EditProjectFileCommand {
-            get {
-                return ResourceManager.GetString("EditProjectFileCommand", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to An error in the launch settings file needs to be corrected before you can run the &apos;{0}&apos; project . Please see the error list for details..
         /// </summary>
         internal static string ErrorInProfilesFile {
@@ -175,15 +124,6 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An unexpected error occurred attempting to watch project file &apos;{0}&apos;.
-        /// </summary>
-        internal static string FailedToWatchProject {
-            get {
-                return ResourceManager.GetString("FailedToWatchProject", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Dependency.
         /// </summary>
         internal static string GraphNodeCategoryDependency {
@@ -193,38 +133,11 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to _Ignore.
-        /// </summary>
-        internal static string Ignore {
-            get {
-                return ResourceManager.GetString("Ignore", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Ignore A_ll.
-        /// </summary>
-        internal static string IgnoreAll {
-            get {
-                return ResourceManager.GetString("IgnoreAll", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to {0} - Import comes fom target file. This import cannot be removed..
         /// </summary>
         internal static string ImportsFromTargetCannotBeDeleted {
             get {
                 return ResourceManager.GetString("ImportsFromTargetCannotBeDeleted", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The debug profile &apos;{0}&apos; has requested a web browser be launched, but the URL specified is not a valid absolute URL.  {1}.
-        /// </summary>
-        internal static string InvalidAbsoluteUrlSpecified {
-            get {
-                return ResourceManager.GetString("InvalidAbsoluteUrlSpecified", resourceCulture);
             }
         }
         
@@ -265,24 +178,6 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Expected to find item type for rule {0}. The rule file is either missing or malformed..
-        /// </summary>
-        internal static string NoItemTypeForRule {
-            get {
-                return ResourceManager.GetString("NoItemTypeForRule", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Expected to find migrated cpsroj in {0}, but did not find any..
-        /// </summary>
-        internal static string NoMigratedCSProjFound {
-            get {
-                return ResourceManager.GetString("NoMigratedCSProjFound", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Unable to run your project. The &quot;RunCommand&quot; property is not defined..
         /// </summary>
         internal static string NoRunCommandSpecifiedInProject {
@@ -301,15 +196,6 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The debug profile &apos;{0}&apos; has requested a web browser be launched, but a URL was not specified..
-        /// </summary>
-        internal static string NoUrlSpecified {
-            get {
-                return ResourceManager.GetString("NoUrlSpecified", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to OK.
         /// </summary>
         internal static string OKButtonText {
@@ -324,15 +210,6 @@ namespace Microsoft.VisualStudio {
         internal static string OutputWindowPaneTitle {
             get {
                 return ResourceManager.GetString("OutputWindowPaneTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to _Overwrite.
-        /// </summary>
-        internal static string Overwrite {
-            get {
-                return ResourceManager.GetString("Overwrite", resourceCulture);
             }
         }
         
@@ -364,28 +241,6 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Project Modification Detected.
-        /// </summary>
-        internal static string ProjectModificationDlgTitle {
-            get {
-                return ResourceManager.GetString("ProjectModificationDlgTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The project &apos;{0}&apos; has been modified outside the environment.
-        ///
-        ///Press Reload to load the updated project from disk.
-        ///Press Ignore to ignore the external changes. The changes will be used the next time you open the project.
-        ///    .
-        /// </summary>
-        internal static string ProjectModificationsPrompt {
-            get {
-                return ResourceManager.GetString("ProjectModificationsPrompt", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to A project with an Output Type of Class Library cannot be started directly.
         ///
         ///In order to debug this project, add an executable project to this solution which references the library project. Set the executable project as the startup project..
@@ -393,24 +248,6 @@ namespace Microsoft.VisualStudio {
         internal static string ProjectNotRunnableDirectly {
             get {
                 return ResourceManager.GetString("ProjectNotRunnableDirectly", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to _Reload.
-        /// </summary>
-        internal static string Reload {
-            get {
-                return ResourceManager.GetString("Reload", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Reload A_ll.
-        /// </summary>
-        internal static string ReloadAll {
-            get {
-                return ResourceManager.GetString("ReloadAll", resourceCulture);
             }
         }
         
@@ -456,15 +293,6 @@ namespace Microsoft.VisualStudio {
         internal static string Restore_PropertyWithInconsistentValues {
             get {
                 return ResourceManager.GetString("Restore_PropertyWithInconsistentValues", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to _Save As.
-        /// </summary>
-        internal static string SaveAs {
-            get {
-                return ResourceManager.GetString("SaveAs", resourceCulture);
             }
         }
         

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
@@ -117,66 +117,14 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ProjectModificationsPrompt" xml:space="preserve">
-    <value>The project '{0}' has been modified outside the environment.
-
-Press Reload to load the updated project from disk.
-Press Ignore to ignore the external changes. The changes will be used the next time you open the project.
-    </value>
-  </data>
-  <data name="ConflictingModificationsPrompt" xml:space="preserve">
-    <value>The project '{0}' has been modified outside the environment, and there are unsaved changes to the project.
-
-Press Save As to save the unsaved changes and load the updated project from disk.
-Press Discard to discard the unsaved changes and load the updated project from disk.
-Press Overwrite to overwrite the external changes with your changes.
-Press Ignore to ignore the external changes. Your changes may be lost if you close and reopen the project.
-    </value>
-  </data>
-  <data name="ConflictingProjectModificationTitle" xml:space="preserve">
-    <value>Conflicting Project Modification Detected</value>
-  </data>
-  <data name="Discard" xml:space="preserve">
-    <value>_Discard</value>
-  </data>
-  <data name="Ignore" xml:space="preserve">
-    <value>_Ignore</value>
-  </data>
-  <data name="IgnoreAll" xml:space="preserve">
-    <value>Ignore A_ll</value>
-  </data>
-  <data name="Overwrite" xml:space="preserve">
-    <value>_Overwrite</value>
-  </data>
-  <data name="ProjectModificationDlgTitle" xml:space="preserve">
-    <value>Project Modification Detected</value>
-  </data>
-  <data name="Reload" xml:space="preserve">
-    <value>_Reload</value>
-  </data>
-  <data name="ReloadAll" xml:space="preserve">
-    <value>Reload A_ll</value>
-  </data>
   <data name="RenameSymbolFailed" xml:space="preserve">
     <value>Renaming the code element '{0}' failed.</value>
   </data>
   <data name="RenameSymbolPrompt" xml:space="preserve">
     <value>You are renaming a file. Would you also like to perform a rename in this project of all references to the code element '{0}'?</value>
   </data>
-  <data name="SaveAs" xml:space="preserve">
-    <value>_Save As</value>
-  </data>
-  <data name="FailedToWatchProject" xml:space="preserve">
-    <value>An unexpected error occurred attempting to watch project file '{0}'</value>
-  </data>
   <data name="GraphNodeCategoryDependency" xml:space="preserve">
     <value>Dependency</value>
-  </data>
-  <data name="NoItemTypeForRule" xml:space="preserve">
-    <value>Expected to find item type for rule {0}. The rule file is either missing or malformed.</value>
-  </data>
-  <data name="DotNetCoreProjectsNotSupported" xml:space="preserve">
-    <value>.NET Core projects are not supported in this release of Visual Studio. Support will be available in a later update.</value>
   </data>
   <data name="ActiveLaunchProfileNotFound" xml:space="preserve">
     <value>There aren't any active launch profiles configured for this project.</value>
@@ -194,12 +142,6 @@ Press Ignore to ignore the external changes. Your changes may be lost if you clo
     <value>A project with an Output Type of Class Library cannot be started directly.
 
 In order to debug this project, add an executable project to this solution which references the library project. Set the executable project as the startup project.</value>
-  </data>
-  <data name="NoUrlSpecified" xml:space="preserve">
-    <value>The debug profile '{0}' has requested a web browser be launched, but a URL was not specified.</value>
-  </data>
-  <data name="InvalidAbsoluteUrlSpecified" xml:space="preserve">
-    <value>The debug profile '{0}' has requested a web browser be launched, but the URL specified is not a valid absolute URL.  {1}</value>
   </data>
   <data name="NoDebugExecutableSpecified" xml:space="preserve">
     <value>The debug profile '{0}' is missing the path to the executable to debug.</value>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
@@ -7,76 +7,6 @@
         <target state="translated">{0} – import pochází z cílového souboru. Tento import nelze odebrat.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectModificationsPrompt">
-        <source>The project '{0}' has been modified outside the environment.
-
-Press Reload to load the updated project from disk.
-Press Ignore to ignore the external changes. The changes will be used the next time you open the project.
-    </source>
-        <target state="translated">Projekt {0} byl upravený mimo prostředí.
-
-Pokud chcete načíst aktualizovaný projekt z disku, stiskněte Načíst znovu.
-Pokud chcete ignorovat externí změny, stiskněte Ignorovat. Změny se použijí při příštím otevření projektu.
-    </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ConflictingModificationsPrompt">
-        <source>The project '{0}' has been modified outside the environment, and there are unsaved changes to the project.
-
-Press Save As to save the unsaved changes and load the updated project from disk.
-Press Discard to discard the unsaved changes and load the updated project from disk.
-Press Overwrite to overwrite the external changes with your changes.
-Press Ignore to ignore the external changes. Your changes may be lost if you close and reopen the project.
-    </source>
-        <target state="translated">Projekt {0} byl změněn mimo toto prostředí, takže obsahuje neuložené změny.
-
-Pokud chcete neuložené změny uložit a načíst aktualizovaný projekt z disku, stiskněte Uložit jako.
-Pokud chcete neuložené změny zahodit a načíst aktualizovaný projekt z disku, stiskněte Zahodit.
-Pokud chcete externí změny přepsat svými změnami, stiskněte Přepsat.
-Pokud chcete ignorovat externí změny, stiskněte Ignorovat. Pokud projekt zavřete a znovu ho otevřete, můžete o změny přijít.
-    </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ConflictingProjectModificationTitle">
-        <source>Conflicting Project Modification Detected</source>
-        <target state="translated">Byly zjištěny konfliktní změny projektu</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Discard">
-        <source>_Discard</source>
-        <target state="translated">_Zahodit</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Ignore">
-        <source>_Ignore</source>
-        <target state="translated">_Ignorovat</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IgnoreAll">
-        <source>Ignore A_ll</source>
-        <target state="translated">Ignorovat V_še</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Overwrite">
-        <source>_Overwrite</source>
-        <target state="translated">_Přepsat</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectModificationDlgTitle">
-        <source>Project Modification Detected</source>
-        <target state="translated">Byly zjištěny změny projektu</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Reload">
-        <source>_Reload</source>
-        <target state="translated">_Znovu načíst</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ReloadAll">
-        <source>Reload A_ll</source>
-        <target state="translated">Znovu načíst V_še</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RenameSymbolFailed">
         <source>Renaming the code element '{0}' failed.</source>
         <target state="translated">Přejmenování prvku kódu {0} nebylo úspěšné.</target>
@@ -87,29 +17,9 @@ Pokud chcete ignorovat externí změny, stiskněte Ignorovat. Pokud projekt zav�
         <target state="translated">Přejmenováváte soubor. Chcete také v tomto projektu přejmenovat všechny odkazy na prvek kódu {0}?</target>
         <note />
       </trans-unit>
-      <trans-unit id="SaveAs">
-        <source>_Save As</source>
-        <target state="translated">_Uložit jako</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToWatchProject">
-        <source>An unexpected error occurred attempting to watch project file '{0}'</source>
-        <target state="translated">Při pokusu o sledování souboru projektu {0} došlo k nečekané chybě</target>
-        <note />
-      </trans-unit>
       <trans-unit id="GraphNodeCategoryDependency">
         <source>Dependency</source>
         <target state="translated">Závislost</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoItemTypeForRule">
-        <source>Expected to find item type for rule {0}. The rule file is either missing or malformed.</source>
-        <target state="translated">Očekává se pro nalezení typu položky pro pravidlo {0}. Soubor pravidla chybí nebo nemá správný formát.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DotNetCoreProjectsNotSupported">
-        <source>.NET Core projects are not supported in this release of Visual Studio. Support will be available in a later update.</source>
-        <target state="translated">Projekty .NET Core nejsou v této verzi sady Visual Studio podporované. Podpora bude k dispozici v další aktualizaci.</target>
         <note />
       </trans-unit>
       <trans-unit id="ActiveLaunchProfileNotFound">
@@ -139,16 +49,6 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">Projekt s typem výstupu Knihovna tříd se nedá spustit přímo.
 
 Pokud chcete projekt ladit, přidejte do řešení spustitelný projekt, který odkazuje na projekt knihovny. Spustitelný projekt nastavte jako úvodní projekt.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoUrlSpecified">
-        <source>The debug profile '{0}' has requested a web browser be launched, but a URL was not specified.</source>
-        <target state="translated">Ladicí profil {0} vyžaduje spuštění webového prohlížeče, ale není zadaná adresa URL.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidAbsoluteUrlSpecified">
-        <source>The debug profile '{0}' has requested a web browser be launched, but the URL specified is not a valid absolute URL.  {1}</source>
-        <target state="translated">Ladicí profil {0} vyžaduje spuštění webového prohlížeče, ale zadaná adresa URL není platná absolutní adresa URL. {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="NoDebugExecutableSpecified">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
@@ -7,76 +7,6 @@
         <target state="translated">{0} – Import kommt von der Zieldatei. Dieser Import kann nicht entfernt werden.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectModificationsPrompt">
-        <source>The project '{0}' has been modified outside the environment.
-
-Press Reload to load the updated project from disk.
-Press Ignore to ignore the external changes. The changes will be used the next time you open the project.
-    </source>
-        <target state="translated">Das Projekt "{0}" wurde außerhalb der Umgebung geändert.
-
-Klicken Sie auf "Erneut laden", um das aktualisierte Projekt vom Datenträger zu laden.
-Klicken Sie auf "Ignorieren", um die externen Änderungen zu ignorieren. Die Änderungen werden verwendet, wenn Sie das Projekt das nächste Mal öffnen.
-    </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ConflictingModificationsPrompt">
-        <source>The project '{0}' has been modified outside the environment, and there are unsaved changes to the project.
-
-Press Save As to save the unsaved changes and load the updated project from disk.
-Press Discard to discard the unsaved changes and load the updated project from disk.
-Press Overwrite to overwrite the external changes with your changes.
-Press Ignore to ignore the external changes. Your changes may be lost if you close and reopen the project.
-    </source>
-        <target state="translated">Das Projekt "{0}" wurde außerhalb der Umgebung geändert, und es sind ungespeicherte Projektänderungen vorhanden.
-
-Klicken Sie auf "Speichern unter", um die ungespeicherten Änderungen zu speichern und das aktualisierte Projekt vom Datenträger zu laden.
-Klicken Sie auf "Verwerfen", um die ungespeicherten Änderungen zu verwerfen und das aktualisierte Projekt vom Datenträger zu laden.
-Klicken Sie auf "Überschreiben", um die externen Änderungen mit Ihren Änderungen zu überschreiben.
-Klicken Sie auf "Ignorieren", um die externen Änderungen zu ignorieren. Wenn Sie das Projekt schließen und erneut öffnen, gehen Ihre Änderungen möglicherweise verloren.
-    </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ConflictingProjectModificationTitle">
-        <source>Conflicting Project Modification Detected</source>
-        <target state="translated">Projektänderungskonflikt erkannt</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Discard">
-        <source>_Discard</source>
-        <target state="translated">_Verwerfen</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Ignore">
-        <source>_Ignore</source>
-        <target state="translated">_Ignorieren</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IgnoreAll">
-        <source>Ignore A_ll</source>
-        <target state="translated">A_lles ignorieren</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Overwrite">
-        <source>_Overwrite</source>
-        <target state="translated">_Überschreiben</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectModificationDlgTitle">
-        <source>Project Modification Detected</source>
-        <target state="translated">Projektänderung erkannt</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Reload">
-        <source>_Reload</source>
-        <target state="translated">_Erneut laden</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ReloadAll">
-        <source>Reload A_ll</source>
-        <target state="translated">A_lles erneut laden</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RenameSymbolFailed">
         <source>Renaming the code element '{0}' failed.</source>
         <target state="translated">Fehler beim Umbenennen des Codeelements "{0}".</target>
@@ -87,29 +17,9 @@ Klicken Sie auf "Ignorieren", um die externen Änderungen zu ignorieren. Wenn Si
         <target state="translated">Sie benennen eine Datei um. Möchten Sie in diesem Projekt auch alle Verweise auf das Codeelement "{0}" umbenennen?</target>
         <note />
       </trans-unit>
-      <trans-unit id="SaveAs">
-        <source>_Save As</source>
-        <target state="translated">_Speichern unter</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToWatchProject">
-        <source>An unexpected error occurred attempting to watch project file '{0}'</source>
-        <target state="translated">Unerwarteter Fehler beim Überwachen der Projektdatei "{0}".</target>
-        <note />
-      </trans-unit>
       <trans-unit id="GraphNodeCategoryDependency">
         <source>Dependency</source>
         <target state="translated">Abhängigkeit</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoItemTypeForRule">
-        <source>Expected to find item type for rule {0}. The rule file is either missing or malformed.</source>
-        <target state="translated">Der Elementtyp für die Regel "{0}" wurde erwartet. Die Regeldatei fehlt oder ist falsch formatiert.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DotNetCoreProjectsNotSupported">
-        <source>.NET Core projects are not supported in this release of Visual Studio. Support will be available in a later update.</source>
-        <target state="translated">.NET Core-Projekte werden in dieser Version von Visual Studio nicht unterstützt. Die Unterstützung wird per Update nachgereicht.</target>
         <note />
       </trans-unit>
       <trans-unit id="ActiveLaunchProfileNotFound">
@@ -139,16 +49,6 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">Ein Projekt mit dem Ausgabetyp "Klassenbibliothek" kann nicht direkt gestartet werden.
 
 Um das Projekt zu debuggen, fügen Sie dieser Projektmappe ein ausführbares Projekt hinzu, das auf das Bibliotheksprojekt verweist. Legen Sie das ausführbare Projekt als Startprojekt fest.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoUrlSpecified">
-        <source>The debug profile '{0}' has requested a web browser be launched, but a URL was not specified.</source>
-        <target state="translated">Das Debugprofil "{0}" hat den Start eines Webbrowsers angefordert, es wurde jedoch keine URL angegeben.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidAbsoluteUrlSpecified">
-        <source>The debug profile '{0}' has requested a web browser be launched, but the URL specified is not a valid absolute URL.  {1}</source>
-        <target state="translated">Das Debugprofil "{0}" hat den Start eines Webbrowsers angefordert, die angegebene URL ist jedoch keine gültige absolute URL. {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="NoDebugExecutableSpecified">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
@@ -7,76 +7,6 @@
         <target state="translated">{0}: la importación procede del archivo de destino. Esta importación no se puede quitar.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectModificationsPrompt">
-        <source>The project '{0}' has been modified outside the environment.
-
-Press Reload to load the updated project from disk.
-Press Ignore to ignore the external changes. The changes will be used the next time you open the project.
-    </source>
-        <target state="translated">El proyecto '{0}' se ha modificado fuera del entorno.
-
-Presione Recargar para cargar el proyecto actualizado del disco.
-Presione Omitir para pasar por alto los cambios externos. Los cambios se usarán la próxima vez que abra el proyecto.
-    </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ConflictingModificationsPrompt">
-        <source>The project '{0}' has been modified outside the environment, and there are unsaved changes to the project.
-
-Press Save As to save the unsaved changes and load the updated project from disk.
-Press Discard to discard the unsaved changes and load the updated project from disk.
-Press Overwrite to overwrite the external changes with your changes.
-Press Ignore to ignore the external changes. Your changes may be lost if you close and reopen the project.
-    </source>
-        <target state="translated">El proyecto '{0}' se ha modificado fuera del entorno y hay cambios sin guardar en el proyecto.
-
-Presione Guardar como para guardar los cambios no guardados y cargar el proyecto actualizado del disco.
-Presione Descartar para descartar los cambios no guardados y cargar el proyecto del disco.
-Presione sobrescribir para sobrescribir los cambios externos con los suyos.
-Presione Omitir para pasar por alto los cambios externos. Sus cambios pueden perderse si cierra y vuelve a abrir el proyecto.
-    </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ConflictingProjectModificationTitle">
-        <source>Conflicting Project Modification Detected</source>
-        <target state="translated">Se ha detectado una modificación en el proyecto en conflicto</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Discard">
-        <source>_Discard</source>
-        <target state="translated">_Descartar</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Ignore">
-        <source>_Ignore</source>
-        <target state="translated">_Omitir</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IgnoreAll">
-        <source>Ignore A_ll</source>
-        <target state="translated">Omitir to_do</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Overwrite">
-        <source>_Overwrite</source>
-        <target state="translated">_Sobrescribir</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectModificationDlgTitle">
-        <source>Project Modification Detected</source>
-        <target state="translated">Modificación detectada en el proyecto</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Reload">
-        <source>_Reload</source>
-        <target state="translated">_Recargar</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ReloadAll">
-        <source>Reload A_ll</source>
-        <target state="translated">Recargar to_do</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RenameSymbolFailed">
         <source>Renaming the code element '{0}' failed.</source>
         <target state="translated">No se pudo cambiar el nombre del elemento de código '{0}'.</target>
@@ -87,29 +17,9 @@ Presione Omitir para pasar por alto los cambios externos. Sus cambios pueden per
         <target state="translated">Va a cambiar el nombre de un archivo. ¿Quiere cambiar también el nombre de todas las referencias al elemento de código '{0}' que hay en este proyecto?</target>
         <note />
       </trans-unit>
-      <trans-unit id="SaveAs">
-        <source>_Save As</source>
-        <target state="translated">_Guardar como</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToWatchProject">
-        <source>An unexpected error occurred attempting to watch project file '{0}'</source>
-        <target state="translated">Error inesperado al intentar inspeccionar el archivo del proyecto '{0}'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="GraphNodeCategoryDependency">
         <source>Dependency</source>
         <target state="translated">Dependencia</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoItemTypeForRule">
-        <source>Expected to find item type for rule {0}. The rule file is either missing or malformed.</source>
-        <target state="translated">Se esperaba encontrar un tipo de elemento para la regla {0}. Falta el archivo de regla o tiene un formato incorrecto.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DotNetCoreProjectsNotSupported">
-        <source>.NET Core projects are not supported in this release of Visual Studio. Support will be available in a later update.</source>
-        <target state="translated">En esta versión de Visual Studio, no se admiten proyectos de .NET Core. Se admitirán en una actualización posterior.</target>
         <note />
       </trans-unit>
       <trans-unit id="ActiveLaunchProfileNotFound">
@@ -139,16 +49,6 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">Un proyecto con un tipo de salida de biblioteca de clases no se puede iniciar directamente.
 
 Para depurar este proyecto, agregue un proyecto ejecutable a esta solución con referencias al proyecto de biblioteca. Establezca el proyecto ejecutable como proyecto de inicio.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoUrlSpecified">
-        <source>The debug profile '{0}' has requested a web browser be launched, but a URL was not specified.</source>
-        <target state="translated">El perfil de depuración '{0}' ha solicitado que se inicie un explorador web, pero no se ha especificado una dirección URL.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidAbsoluteUrlSpecified">
-        <source>The debug profile '{0}' has requested a web browser be launched, but the URL specified is not a valid absolute URL.  {1}</source>
-        <target state="translated">El perfil de depuración '{0}' ha solicitado que se inicie un explorador web, pero la dirección URL especificada no es una URL absoluta válida. {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="NoDebugExecutableSpecified">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
@@ -7,76 +7,6 @@
         <target state="translated">{0} - L'importation provient du fichier cible. Impossible de supprimer cette importation.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectModificationsPrompt">
-        <source>The project '{0}' has been modified outside the environment.
-
-Press Reload to load the updated project from disk.
-Press Ignore to ignore the external changes. The changes will be used the next time you open the project.
-    </source>
-        <target state="translated">Le projet '{0}' a été modifié en dehors de l'environnement.
-
-Appuyez sur Recharger pour charger le projet mis à jour à partir du disque.
-Appuyez sur Ignorer pour ignorer les modifications externes. Les modifications seront appliquées à la prochaine ouverture du projet.
-    </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ConflictingModificationsPrompt">
-        <source>The project '{0}' has been modified outside the environment, and there are unsaved changes to the project.
-
-Press Save As to save the unsaved changes and load the updated project from disk.
-Press Discard to discard the unsaved changes and load the updated project from disk.
-Press Overwrite to overwrite the external changes with your changes.
-Press Ignore to ignore the external changes. Your changes may be lost if you close and reopen the project.
-    </source>
-        <target state="translated">Le projet '{0}' a été modifié en dehors de l'environnement et des modifications non enregistrées existent.
-
-Appuyez sur Enregistrer sous pour enregistrer les modifications et charger le projet mis à jour à partir du disque.
-Appuyez sur Abandonner pour ignorer les modifications et charger le projet mis à jour à partir du disque.
-Appuyez sur Remplacer pour remplacer les modifications externes par vos modifications.
-Appuyez sur Ignorer pour ignorer les modifications externes. Vous risquez de perdre vos modifications si vous fermez et rouvrez le projet.
-    </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ConflictingProjectModificationTitle">
-        <source>Conflicting Project Modification Detected</source>
-        <target state="translated">Modification de projet en conflit détectée</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Discard">
-        <source>_Discard</source>
-        <target state="translated">Aban_donner</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Ignore">
-        <source>_Ignore</source>
-        <target state="translated">_Ignorer</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IgnoreAll">
-        <source>Ignore A_ll</source>
-        <target state="translated">Ignore t_out</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Overwrite">
-        <source>_Overwrite</source>
-        <target state="translated">_Remplacer</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectModificationDlgTitle">
-        <source>Project Modification Detected</source>
-        <target state="translated">Modification de projet détectée</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Reload">
-        <source>_Reload</source>
-        <target state="translated">_Recharger</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ReloadAll">
-        <source>Reload A_ll</source>
-        <target state="translated">Recharger t_out</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RenameSymbolFailed">
         <source>Renaming the code element '{0}' failed.</source>
         <target state="translated">Échec du changement de nom de l'élément de code en '{0}'.</target>
@@ -87,29 +17,9 @@ Appuyez sur Ignorer pour ignorer les modifications externes. Vous risquez de per
         <target state="translated">Vous renommez un fichier. Voulez-vous également renommer dans ce projet toutes les références à l'élément de code '{0}' ?</target>
         <note />
       </trans-unit>
-      <trans-unit id="SaveAs">
-        <source>_Save As</source>
-        <target state="translated">Enregistrer _sous</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToWatchProject">
-        <source>An unexpected error occurred attempting to watch project file '{0}'</source>
-        <target state="translated">Une erreur inattendue s'est produite durant une tentative de suivi du fichier projet '{0}'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="GraphNodeCategoryDependency">
         <source>Dependency</source>
         <target state="translated">Dépendance</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoItemTypeForRule">
-        <source>Expected to find item type for rule {0}. The rule file is either missing or malformed.</source>
-        <target state="translated">Le type d'élément de la règle {0} était attendu. Le fichier de règle est manquant ou incorrectement formé.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DotNetCoreProjectsNotSupported">
-        <source>.NET Core projects are not supported in this release of Visual Studio. Support will be available in a later update.</source>
-        <target state="translated">Les projets .NET Core ne sont pas pris en charge dans cette version de Visual Studio. Ils le seront dans une mise à jour ultérieure.</target>
         <note />
       </trans-unit>
       <trans-unit id="ActiveLaunchProfileNotFound">
@@ -139,16 +49,6 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">Impossible de démarrer directement un projet avec un type de sortie de bibliothèque de classes.
 
 Pour déboguer ce projet, ajoutez à cette solution un projet exécutable qui fait référence au projet de bibliothèque. Définissez le projet exécutable comme projet de démarrage.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoUrlSpecified">
-        <source>The debug profile '{0}' has requested a web browser be launched, but a URL was not specified.</source>
-        <target state="translated">Le profil de débogage '{0}' a demandé le lancement d'un navigateur web, mais aucune URL n'a été spécifiée.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidAbsoluteUrlSpecified">
-        <source>The debug profile '{0}' has requested a web browser be launched, but the URL specified is not a valid absolute URL.  {1}</source>
-        <target state="translated">Le profil de débogage '{0}' a demandé le lancement d'un navigateur web, mais l'URL spécifiée n'est pas une URL absolue valide. {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="NoDebugExecutableSpecified">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
@@ -7,76 +7,6 @@
         <target state="translated">{0} - L'importazione proviene dal file di destinazione e non può essere rimossa.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectModificationsPrompt">
-        <source>The project '{0}' has been modified outside the environment.
-
-Press Reload to load the updated project from disk.
-Press Ignore to ignore the external changes. The changes will be used the next time you open the project.
-    </source>
-        <target state="translated">Il progetto '{0}' non è stato modificato nell'ambiente.
-
-Fare clic su Ricarica per ricaricare il progetto aggiornato dal disco.
-Fare clic su Ignora per ignorare le modifiche esterne. Le modifiche verranno usate alla successiva apertura del progetto.
-    </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ConflictingModificationsPrompt">
-        <source>The project '{0}' has been modified outside the environment, and there are unsaved changes to the project.
-
-Press Save As to save the unsaved changes and load the updated project from disk.
-Press Discard to discard the unsaved changes and load the updated project from disk.
-Press Overwrite to overwrite the external changes with your changes.
-Press Ignore to ignore the external changes. Your changes may be lost if you close and reopen the project.
-    </source>
-        <target state="translated">Il progetto '{0}' non è stato modificato nell'ambiente e alcune modifiche non sono state salvate.
-
-Scegliere Salva con nome per salvare le modifiche e caricare il progetto aggiornato dal disco.
-Scegliere Rimuovi per eliminare le modifiche non salvate e caricare il progetto aggiornato dal disco.
-Scegliere Sovrascrivi per sovrascrivere le modifiche esterne con le proprie.
-Fare clic su Ignora per ignorare le modifiche esterne. Le modifiche potrebbero andare perse se si chiude e riapre il progetto.
-    </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ConflictingProjectModificationTitle">
-        <source>Conflicting Project Modification Detected</source>
-        <target state="translated">Rilevate modifiche al progetto in conflitto</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Discard">
-        <source>_Discard</source>
-        <target state="translated">_Rimuovi</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Ignore">
-        <source>_Ignore</source>
-        <target state="translated">_Ignora</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IgnoreAll">
-        <source>Ignore A_ll</source>
-        <target state="translated">Ignora _tutto</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Overwrite">
-        <source>_Overwrite</source>
-        <target state="translated">_Sovrascrivi</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectModificationDlgTitle">
-        <source>Project Modification Detected</source>
-        <target state="translated">Rilevate modifiche al progetto</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Reload">
-        <source>_Reload</source>
-        <target state="translated">_Ricarica</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ReloadAll">
-        <source>Reload A_ll</source>
-        <target state="translated">Ricarica t_utto</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RenameSymbolFailed">
         <source>Renaming the code element '{0}' failed.</source>
         <target state="translated">La ridenominazione dell'elemento di codice '{0}' non è riuscita.</target>
@@ -87,29 +17,9 @@ Fare clic su Ignora per ignorare le modifiche esterne. Le modifiche potrebbero a
         <target state="translated">Si sta rinominando un file. Rinominare anche tutti i riferimenti all'elemento di codice '{0}' di questo progetto?</target>
         <note />
       </trans-unit>
-      <trans-unit id="SaveAs">
-        <source>_Save As</source>
-        <target state="translated">_Salva con nome</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToWatchProject">
-        <source>An unexpected error occurred attempting to watch project file '{0}'</source>
-        <target state="translated">Si è verificato un errore imprevisto durante il tentativo di controllare il file di progetto '{0}'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="GraphNodeCategoryDependency">
         <source>Dependency</source>
         <target state="translated">Dipendenza</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoItemTypeForRule">
-        <source>Expected to find item type for rule {0}. The rule file is either missing or malformed.</source>
-        <target state="translated">È previsto un tipo di elemento per la regola {0}. Il file delle regole non è presente o non è valido.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DotNetCoreProjectsNotSupported">
-        <source>.NET Core projects are not supported in this release of Visual Studio. Support will be available in a later update.</source>
-        <target state="translated">I progetti .NET Core non sono supportati in questa versione di Visual Studio. Il supporto sarà disponibile in un aggiornamento successivo.</target>
         <note />
       </trans-unit>
       <trans-unit id="ActiveLaunchProfileNotFound">
@@ -139,16 +49,6 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">Non è possibile avviare direttamente un progetto con tipo di output della libreria di classi.
 
 Per eseguire il debug del progetto, aggiungere a questa soluzione un progetto eseguibile che fa riferimento al progetto di libreria. Impostare il progetto eseguibile come progetto di avvio.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoUrlSpecified">
-        <source>The debug profile '{0}' has requested a web browser be launched, but a URL was not specified.</source>
-        <target state="translated">Il profilo di debug '{0}' ha richiesto l'avvio di un Web browser, ma l'URL non è stato specificato.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidAbsoluteUrlSpecified">
-        <source>The debug profile '{0}' has requested a web browser be launched, but the URL specified is not a valid absolute URL.  {1}</source>
-        <target state="translated">Il profilo di debug '{0}' ha richiesto l'avvio di un Web browser, ma l'URL specificato non è un URL assoluto valido. {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="NoDebugExecutableSpecified">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
@@ -7,76 +7,6 @@
         <target state="translated">{0} - インポートは、ターゲット ファイルからのものです。このインポートは削除できません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectModificationsPrompt">
-        <source>The project '{0}' has been modified outside the environment.
-
-Press Reload to load the updated project from disk.
-Press Ignore to ignore the external changes. The changes will be used the next time you open the project.
-    </source>
-        <target state="translated">プロジェクト '{0}' は環境外で変更されています。
-
-更新されたプロジェクトをディスクから読み込むには [再読み込み] をクリックしてください。
-外部の変更を無視する場合は、[無視] をクリックしてください。この変更は、次にプロジェクトを開いたときに使われます。
-    </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ConflictingModificationsPrompt">
-        <source>The project '{0}' has been modified outside the environment, and there are unsaved changes to the project.
-
-Press Save As to save the unsaved changes and load the updated project from disk.
-Press Discard to discard the unsaved changes and load the updated project from disk.
-Press Overwrite to overwrite the external changes with your changes.
-Press Ignore to ignore the external changes. Your changes may be lost if you close and reopen the project.
-    </source>
-        <target state="translated">プロジェクト '{0}' は環境の外で変更されており、このプロジェクトへの変更は保存されていません。
-
-変更を保存して更新されたプロジェクトをディスクから読み込むには [名前を付けて保存] を選択してください。
-未保存の変更を破棄して更新されたプロジェクトをディスクから読み込むには [破棄] を選択してください。
-外部の変更を上書きする場合は [上書き] を選択してください。
-外部の変更を無視する場合は、[無視] をクリックしてください。変更点は、プロジェクトを閉じて再度開いたときに失われる可能性があります。
-    </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ConflictingProjectModificationTitle">
-        <source>Conflicting Project Modification Detected</source>
-        <target state="translated">競合するプロジェクト変更が検出されました</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Discard">
-        <source>_Discard</source>
-        <target state="translated">破棄(_D)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Ignore">
-        <source>_Ignore</source>
-        <target state="translated">無視(_I)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IgnoreAll">
-        <source>Ignore A_ll</source>
-        <target state="translated">すべて無視(_L)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Overwrite">
-        <source>_Overwrite</source>
-        <target state="translated">上書き(_O)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectModificationDlgTitle">
-        <source>Project Modification Detected</source>
-        <target state="translated">プロジェクト変更が検出されました</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Reload">
-        <source>_Reload</source>
-        <target state="translated">再読み込み(_R)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ReloadAll">
-        <source>Reload A_ll</source>
-        <target state="translated">すべて再読み込み(_L)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RenameSymbolFailed">
         <source>Renaming the code element '{0}' failed.</source>
         <target state="translated">コード要素 '{0}' の名前変更に失敗しました。</target>
@@ -87,29 +17,9 @@ Press Ignore to ignore the external changes. Your changes may be lost if you clo
         <target state="translated">ファイルの名前を変更しようとしています。このプロジェクトのすべての参照をコード要素 '{0}' に名前を変更しますか?</target>
         <note />
       </trans-unit>
-      <trans-unit id="SaveAs">
-        <source>_Save As</source>
-        <target state="translated">名前を付けて保存(_S)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToWatchProject">
-        <source>An unexpected error occurred attempting to watch project file '{0}'</source>
-        <target state="translated">プロジェクト ファイル '{0}' をウォッチしようとして予期しないエラーが発生しました</target>
-        <note />
-      </trans-unit>
       <trans-unit id="GraphNodeCategoryDependency">
         <source>Dependency</source>
         <target state="translated">依存関係</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoItemTypeForRule">
-        <source>Expected to find item type for rule {0}. The rule file is either missing or malformed.</source>
-        <target state="translated">規則 {0} の項目の種類が見つかる必要があります。規則ファイルがないか、形式が正しくありません。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DotNetCoreProjectsNotSupported">
-        <source>.NET Core projects are not supported in this release of Visual Studio. Support will be available in a later update.</source>
-        <target state="translated">Visual Studio のこのリリースでは、.NET Core プロジェクトはサポートされていません。サポートはこれ以降の更新プログラムで利用できるようになります。</target>
         <note />
       </trans-unit>
       <trans-unit id="ActiveLaunchProfileNotFound">
@@ -139,16 +49,6 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">クラス ライブラリの出力タイプを持つプロジェクトを直接起動することはできません。
 
 このプロジェクトをデバッグするには、ライブラリ プロジェクトを参照するこのソリューションに実行可能なプロジェクトを追加します。その実行可能なプロジェクトをスタートアップ プロジェクトとして設定してください。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoUrlSpecified">
-        <source>The debug profile '{0}' has requested a web browser be launched, but a URL was not specified.</source>
-        <target state="translated">デバッグ プロファイル '{0}' で Web ブラウザーの起動が要求されましたが、URL が指定されていませんでした。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidAbsoluteUrlSpecified">
-        <source>The debug profile '{0}' has requested a web browser be launched, but the URL specified is not a valid absolute URL.  {1}</source>
-        <target state="translated">デバッグ プロファイル '{0}' で Web ブラウザーの起動が要求されましたが、指定された URL は有効な絶対 URL ではありません。  {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="NoDebugExecutableSpecified">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
@@ -7,76 +7,6 @@
         <target state="translated">{0} - 대상 파일에서 가져옵니다. 이 가져오기는 제거할 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectModificationsPrompt">
-        <source>The project '{0}' has been modified outside the environment.
-
-Press Reload to load the updated project from disk.
-Press Ignore to ignore the external changes. The changes will be used the next time you open the project.
-    </source>
-        <target state="translated">'{0}' 프로젝트가 환경 외부에서 수정되었습니다.
-
-디스크에서 업데이트된 프로젝트를 로드하려면 [다시 로드]를 누르세요.
-외부 변경을 무시하려면 [무시]를 누르세요. 변경 내용은 다음에 프로젝트를 열 때 사용됩니다.
-    </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ConflictingModificationsPrompt">
-        <source>The project '{0}' has been modified outside the environment, and there are unsaved changes to the project.
-
-Press Save As to save the unsaved changes and load the updated project from disk.
-Press Discard to discard the unsaved changes and load the updated project from disk.
-Press Overwrite to overwrite the external changes with your changes.
-Press Ignore to ignore the external changes. Your changes may be lost if you close and reopen the project.
-    </source>
-        <target state="translated">'{0}' 프로젝트가 환경 외부에서 수정되었으며 프로젝트에 저장되지 않은 변경 내용이 있습니다.
-
-저장되지 않은 변경 내용을 저장하려면 [다른 이름으로 저장]을 눌러 디스크에서 업데이트된 프로젝트를 로드하세요.
-저장되지 않은 변경 내용을 버리려면 [버리기]를 누르고 디스크에서 업데이트된 프로젝트를 로드하세요.
-변경 내용으로 외부 변경 내용을 덮어쓰려면 [덮어쓰기]를 누르세요.
-외부 변경을 무시하려면 [무시]를 누르세요. 프로젝트를 닫고 다시 열면 변경 내용이 손실됩니다.
-    </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ConflictingProjectModificationTitle">
-        <source>Conflicting Project Modification Detected</source>
-        <target state="translated">충돌하는 프로젝트 수정 감지</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Discard">
-        <source>_Discard</source>
-        <target state="translated">삭제(_D)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Ignore">
-        <source>_Ignore</source>
-        <target state="translated">무시(_I)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IgnoreAll">
-        <source>Ignore A_ll</source>
-        <target state="translated">모두 무시(_L)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Overwrite">
-        <source>_Overwrite</source>
-        <target state="translated">덮어쓰기(_O)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectModificationDlgTitle">
-        <source>Project Modification Detected</source>
-        <target state="translated">프로젝트 수정 감지</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Reload">
-        <source>_Reload</source>
-        <target state="translated">다시 로드(_R)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ReloadAll">
-        <source>Reload A_ll</source>
-        <target state="translated">모두 다시 로드(_L)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RenameSymbolFailed">
         <source>Renaming the code element '{0}' failed.</source>
         <target state="translated">코드 포인트 '{0}'의 이름을 바꾸지 못했습니다.</target>
@@ -87,29 +17,9 @@ Press Ignore to ignore the external changes. Your changes may be lost if you clo
         <target state="translated">파일의 이름을 바꾸고 있습니다. 이 프로젝트에서 코드 포인트 '{0}'의 모든 참조 이름도 바꾸시겠습니까?</target>
         <note />
       </trans-unit>
-      <trans-unit id="SaveAs">
-        <source>_Save As</source>
-        <target state="translated">다른 이름으로 저장(_S)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToWatchProject">
-        <source>An unexpected error occurred attempting to watch project file '{0}'</source>
-        <target state="translated">프로젝트 파일 '{0}'을(를) 조사하는 동안 예기치 않은 오류가 발생했습니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="GraphNodeCategoryDependency">
         <source>Dependency</source>
         <target state="translated">종속성</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoItemTypeForRule">
-        <source>Expected to find item type for rule {0}. The rule file is either missing or malformed.</source>
-        <target state="translated">{0} 규칙의 항목 형식을 찾아야 합니다. 규칙 파일이 없거나 형식이 잘못되었습니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DotNetCoreProjectsNotSupported">
-        <source>.NET Core projects are not supported in this release of Visual Studio. Support will be available in a later update.</source>
-        <target state="translated">이번 Visual Studio 릴리스에서는 .NET Core 프로젝트가 지원되지 않습니다. 이후 업데이트에서 지원됩니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="ActiveLaunchProfileNotFound">
@@ -139,16 +49,6 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">출력 형식이 클래스 라이브러리인 프로젝트는 직접 시작할 수 없습니다.
 
 이 프로젝트를 디버그하려면 라이브러리 프로젝트를 참조하는 실행 가능 프로젝트를 이 솔루션에 추가하고 해당 실행 가능 프로젝트를 시작 프로젝트로 설정하세요.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoUrlSpecified">
-        <source>The debug profile '{0}' has requested a web browser be launched, but a URL was not specified.</source>
-        <target state="translated">디버그 프로필 '{0}'에서 웹 브라우저를 시작하도록 요청했지만 URL이 지정되지 않았습니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidAbsoluteUrlSpecified">
-        <source>The debug profile '{0}' has requested a web browser be launched, but the URL specified is not a valid absolute URL.  {1}</source>
-        <target state="translated">디버그 프로필 '{0}'에서 웹 브라우저를 시작하도록 요청했지만 지정된 URL이 올바른 절대 URL이 아닙니다. {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="NoDebugExecutableSpecified">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
@@ -7,76 +7,6 @@
         <target state="translated">{0} — import pochodzi z pliku docelowego. Nie można usunąć importu.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectModificationsPrompt">
-        <source>The project '{0}' has been modified outside the environment.
-
-Press Reload to load the updated project from disk.
-Press Ignore to ignore the external changes. The changes will be used the next time you open the project.
-    </source>
-        <target state="translated">Projekt „{0}” został zmodyfikowany poza środowiskiem.
-
-Naciśnij pozycję Załaduj ponownie, aby załadować zaktualizowany projekt z dysku.
-Naciśnij pozycję Ignoruj, aby zignorować zewnętrzne zmiany. Zmiany zostaną użyte podczas następnego otwarcia projektu.
-    </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ConflictingModificationsPrompt">
-        <source>The project '{0}' has been modified outside the environment, and there are unsaved changes to the project.
-
-Press Save As to save the unsaved changes and load the updated project from disk.
-Press Discard to discard the unsaved changes and load the updated project from disk.
-Press Overwrite to overwrite the external changes with your changes.
-Press Ignore to ignore the external changes. Your changes may be lost if you close and reopen the project.
-    </source>
-        <target state="translated">Projekt „{0}” został zmodyfikowany poza środowiskiem, a niektóre zmiany w projekcie nie zostały zapisane.
-
-Naciśnij pozycję Zapisz jako, aby zapisać niezapisane zmiany i załadować zaktualizowany projekt z dysku.
-Naciśnij pozycję Odrzuć, aby odrzucić niezapisane zmiany i załadować zaktualizowany projekt z dysku.
-Naciśnij pozycję Zastąp, aby zastąpić zewnętrzne zmiany Twoimi zmianami.
-Naciśnij pozycję Ignoruj, aby zignorować zewnętrzne zmiany. Twoje zmiany mogą zostać utracone, jeśli zamkniesz i ponownie otworzysz projekt.
-    </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ConflictingProjectModificationTitle">
-        <source>Conflicting Project Modification Detected</source>
-        <target state="translated">Wykryto sprzeczną modyfikację projektu</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Discard">
-        <source>_Discard</source>
-        <target state="translated">_Odrzuć</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Ignore">
-        <source>_Ignore</source>
-        <target state="translated">_Ignoruj</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IgnoreAll">
-        <source>Ignore A_ll</source>
-        <target state="translated">Ignoruj w_szystkie</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Overwrite">
-        <source>_Overwrite</source>
-        <target state="translated">_Zastąp</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectModificationDlgTitle">
-        <source>Project Modification Detected</source>
-        <target state="translated">Wykryto modyfikację projektu</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Reload">
-        <source>_Reload</source>
-        <target state="translated">Załaduj _ponownie</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ReloadAll">
-        <source>Reload A_ll</source>
-        <target state="translated">Załaduj ponownie w_szystkie</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RenameSymbolFailed">
         <source>Renaming the code element '{0}' failed.</source>
         <target state="translated">Zmiana nazwy elementu kodu „{0}” nie powiodła się.</target>
@@ -87,29 +17,9 @@ Naciśnij pozycję Ignoruj, aby zignorować zewnętrzne zmiany. Twoje zmiany mog
         <target state="translated">Zmieniasz nazwę pliku. Czy chcesz także zmienić nazwy w tym projekcie dla wszystkich odwołań do elementu kodu „{0}”?</target>
         <note />
       </trans-unit>
-      <trans-unit id="SaveAs">
-        <source>_Save As</source>
-        <target state="translated">_Zapisz jako</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToWatchProject">
-        <source>An unexpected error occurred attempting to watch project file '{0}'</source>
-        <target state="translated">Podczas próby obejrzenia pliku projektu „{0}” wystąpił nieoczekiwany błąd.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="GraphNodeCategoryDependency">
         <source>Dependency</source>
         <target state="translated">Zależność</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoItemTypeForRule">
-        <source>Expected to find item type for rule {0}. The rule file is either missing or malformed.</source>
-        <target state="translated">Oczekiwano znalezienia typu elementu dla reguły {0}. Brakuje pliku reguły lub jest on nieprawidłowy.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DotNetCoreProjectsNotSupported">
-        <source>.NET Core projects are not supported in this release of Visual Studio. Support will be available in a later update.</source>
-        <target state="translated">Projekty .NET Core nie są obsługiwane w tej wersji programu Visual Studio. Obsługa będzie dostępna w nowszej wersji.</target>
         <note />
       </trans-unit>
       <trans-unit id="ActiveLaunchProfileNotFound">
@@ -139,16 +49,6 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">Projekt z typem wyjściowym biblioteki klasy nie może być bezpośrednio uruchomiony.
 
 Aby debugować ten projekt, dodaj projekt wykonywalny do tego rozwiązania, które odwołuje się do projektu biblioteki. Ustaw projekt wykonywalny jako projekt startowy.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoUrlSpecified">
-        <source>The debug profile '{0}' has requested a web browser be launched, but a URL was not specified.</source>
-        <target state="translated">Profil debugowania „{0}” zażądał uruchomienia przeglądarki sieci Web, ale nie określono adresu URL.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidAbsoluteUrlSpecified">
-        <source>The debug profile '{0}' has requested a web browser be launched, but the URL specified is not a valid absolute URL.  {1}</source>
-        <target state="translated">Profil debugowania „{0}” zażądał uruchomienia przeglądarki sieci Web, ale określony adres URL nie jest prawidłowym bezwzględnym adresem URL. {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="NoDebugExecutableSpecified">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
@@ -7,76 +7,6 @@
         <target state="translated">{0} – a importação é proveniente do arquivo de destino. Essa importação não pode ser removida.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectModificationsPrompt">
-        <source>The project '{0}' has been modified outside the environment.
-
-Press Reload to load the updated project from disk.
-Press Ignore to ignore the external changes. The changes will be used the next time you open the project.
-    </source>
-        <target state="translated">O projeto '{0}' foi modificado fora do ambiente.
-
-Pressione Recarregar para carregar o projeto atualizado do disco.
-Pressione Ignorar para ignorar as alterações externas. As alterações serão usadas na próxima vez que o projeto for aberto.
-    </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ConflictingModificationsPrompt">
-        <source>The project '{0}' has been modified outside the environment, and there are unsaved changes to the project.
-
-Press Save As to save the unsaved changes and load the updated project from disk.
-Press Discard to discard the unsaved changes and load the updated project from disk.
-Press Overwrite to overwrite the external changes with your changes.
-Press Ignore to ignore the external changes. Your changes may be lost if you close and reopen the project.
-    </source>
-        <target state="translated">O projeto '{0}' foi modificado fora do ambiente e há alterações não salvas no projeto.
-
-Pressione Salvar Como para salvar as alterações não salvas e carregar o projeto atualizado do disco.
-Pressione Descartar para descartar as alterações não salvas e carregar o projeto atualizado do disco.
-Pressione Substituir para substituir as alterações externas por suas alterações.
-Pressione Ignorar para ignorar as alterações externas. Suas alterações talvez sejam perdidas se o projeto for fechado e reaberto.
-    </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ConflictingProjectModificationTitle">
-        <source>Conflicting Project Modification Detected</source>
-        <target state="translated">Modificação de Projeto Conflitante Detectada</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Discard">
-        <source>_Discard</source>
-        <target state="translated">_Descartar</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Ignore">
-        <source>_Ignore</source>
-        <target state="translated">_Ignorar</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IgnoreAll">
-        <source>Ignore A_ll</source>
-        <target state="translated">Ignorar T_udo</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Overwrite">
-        <source>_Overwrite</source>
-        <target state="translated">_Substituir</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectModificationDlgTitle">
-        <source>Project Modification Detected</source>
-        <target state="translated">Modificação de Projeto Detectada</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Reload">
-        <source>_Reload</source>
-        <target state="translated">_Recarregar</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ReloadAll">
-        <source>Reload A_ll</source>
-        <target state="translated">Recarregar T_udo</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RenameSymbolFailed">
         <source>Renaming the code element '{0}' failed.</source>
         <target state="translated">Falha ao renomear o elemento de código '{0}'.</target>
@@ -87,29 +17,9 @@ Pressione Ignorar para ignorar as alterações externas. Suas alterações talve
         <target state="translated">Você está renomeando um arquivo. Gostaria também de realizar a renomeação neste projeto de todas as referências para o elemento de código '{0}'?</target>
         <note />
       </trans-unit>
-      <trans-unit id="SaveAs">
-        <source>_Save As</source>
-        <target state="translated">_Salvar Como</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToWatchProject">
-        <source>An unexpected error occurred attempting to watch project file '{0}'</source>
-        <target state="translated">Ocorreu um erro inesperado ao tentar inspecionar o arquivo de projeto '{0}'</target>
-        <note />
-      </trans-unit>
       <trans-unit id="GraphNodeCategoryDependency">
         <source>Dependency</source>
         <target state="translated">Dependência</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoItemTypeForRule">
-        <source>Expected to find item type for rule {0}. The rule file is either missing or malformed.</source>
-        <target state="translated">Era esperado encontrar o tipo de item para a regra {0}. O arquivo de regra está ausente ou malformado.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DotNetCoreProjectsNotSupported">
-        <source>.NET Core projects are not supported in this release of Visual Studio. Support will be available in a later update.</source>
-        <target state="translated">Os projetos .NET Core não têm suporte nessa versão do Visual Studio. O suporte estará disponível em uma atualização posterior.</target>
         <note />
       </trans-unit>
       <trans-unit id="ActiveLaunchProfileNotFound">
@@ -139,16 +49,6 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">Um projeto com um Tipo de Saída de Biblioteca de Classes não pode ser iniciado diretamente.
 
 Para depurar esse projeto, adicione um projeto executável a essa solução que faz referência ao projeto da biblioteca. Defina o projeto executável como o projeto de inicialização.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoUrlSpecified">
-        <source>The debug profile '{0}' has requested a web browser be launched, but a URL was not specified.</source>
-        <target state="translated">O perfil de depuração '{0}' solicitou que um navegador da Web seja iniciado, mas uma URL não foi especificada.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidAbsoluteUrlSpecified">
-        <source>The debug profile '{0}' has requested a web browser be launched, but the URL specified is not a valid absolute URL.  {1}</source>
-        <target state="translated">O perfil de depuração '{0}' solicitou que um navegador da Web seja iniciado, mas a URL especificada não é uma URL absoluta válida. {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="NoDebugExecutableSpecified">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
@@ -7,76 +7,6 @@
         <target state="translated">{0} — источником импорта является целевой файл. Удалить этот импорт невозможно.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectModificationsPrompt">
-        <source>The project '{0}' has been modified outside the environment.
-
-Press Reload to load the updated project from disk.
-Press Ignore to ignore the external changes. The changes will be used the next time you open the project.
-    </source>
-        <target state="translated">Проект "{0}" изменен за пределами среды.
-
-Нажмите кнопку "Перезагрузить", чтобы загрузить обновленный проект с диска.
-Нажмите кнопку "Пропустить", чтобы игнорировать внешние изменения. Изменения будут применены при следующем открытии проекта.
-    </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ConflictingModificationsPrompt">
-        <source>The project '{0}' has been modified outside the environment, and there are unsaved changes to the project.
-
-Press Save As to save the unsaved changes and load the updated project from disk.
-Press Discard to discard the unsaved changes and load the updated project from disk.
-Press Overwrite to overwrite the external changes with your changes.
-Press Ignore to ignore the external changes. Your changes may be lost if you close and reopen the project.
-    </source>
-        <target state="translated">Проект "{0}" изменен за пределами среды, и в проекте есть несохраненные изменения.
-
-Нажмите кнопку "Сохранить как", чтобы сохранить несохраненные изменения и загрузить обновленный проект с диска.
-Нажмите кнопку "Отменить", чтобы отменить несохраненные изменения и загрузить обновленный проект с диска.
-Нажмите кнопку "Перезаписать", чтобы перезаписать внешние изменения вашими изменениями.
-Нажмите кнопку "Пропустить", чтобы игнорировать внешние изменения. Если вы закроете и снова откроете проект, изменения могут быть утрачены.
-    </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ConflictingProjectModificationTitle">
-        <source>Conflicting Project Modification Detected</source>
-        <target state="translated">Обнаружены конфликтующие изменения проекта</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Discard">
-        <source>_Discard</source>
-        <target state="translated">_Отменить</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Ignore">
-        <source>_Ignore</source>
-        <target state="translated">_Пропустить</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IgnoreAll">
-        <source>Ignore A_ll</source>
-        <target state="translated">Пропустить в_се</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Overwrite">
-        <source>_Overwrite</source>
-        <target state="translated">Пере_записать</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectModificationDlgTitle">
-        <source>Project Modification Detected</source>
-        <target state="translated">Обнаружено изменение проекта</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Reload">
-        <source>_Reload</source>
-        <target state="translated">Пере_загрузить</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ReloadAll">
-        <source>Reload A_ll</source>
-        <target state="translated">Перезагрузить в_се</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RenameSymbolFailed">
         <source>Renaming the code element '{0}' failed.</source>
         <target state="translated">Ошибка переименования элемента кода "{0}".</target>
@@ -87,29 +17,9 @@ Press Ignore to ignore the external changes. Your changes may be lost if you clo
         <target state="translated">Выполняется переименование файла. Требуется ли также переименовать все ссылки на элемент кода "{0}" в проекте?</target>
         <note />
       </trans-unit>
-      <trans-unit id="SaveAs">
-        <source>_Save As</source>
-        <target state="translated">_Сохранить как</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToWatchProject">
-        <source>An unexpected error occurred attempting to watch project file '{0}'</source>
-        <target state="translated">При попытке просмотреть файл проекта "{0}" произошла непредвиденная ошибка.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="GraphNodeCategoryDependency">
         <source>Dependency</source>
         <target state="translated">Зависимость</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoItemTypeForRule">
-        <source>Expected to find item type for rule {0}. The rule file is either missing or malformed.</source>
-        <target state="translated">Ожидался тип элемента для правила {0}. Файл правила отсутствует или имеет неправильный формат.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DotNetCoreProjectsNotSupported">
-        <source>.NET Core projects are not supported in this release of Visual Studio. Support will be available in a later update.</source>
-        <target state="translated">Проекты .NET Core не поддерживаются в этом выпуске Visual Studio. Поддержка будет доступна в следующем обновлении.</target>
         <note />
       </trans-unit>
       <trans-unit id="ActiveLaunchProfileNotFound">
@@ -139,16 +49,6 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">Проект, библиотека классов которого имеет тип "Тип выходных данных", нельзя запустить напрямую.
 
 Чтобы выполнить отладку этого проекта, добавьте проект исполняемого файла в это решение, ссылающееся на проект библиотеки. Задайте проект исполняемого файла в качестве запускаемого проекта.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoUrlSpecified">
-        <source>The debug profile '{0}' has requested a web browser be launched, but a URL was not specified.</source>
-        <target state="translated">Профиль отладки "{0}" запросил запуск веб-браузера, однако URL-адрес не указан.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidAbsoluteUrlSpecified">
-        <source>The debug profile '{0}' has requested a web browser be launched, but the URL specified is not a valid absolute URL.  {1}</source>
-        <target state="translated">Профиль отладки "{0}" запросил запуск веб-браузера, однако указанный URL-адрес не является допустимым абсолютным URL-адресом. {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="NoDebugExecutableSpecified">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
@@ -7,76 +7,6 @@
         <target state="translated">{0} - İçeri aktarım hedef dosyadan geliyor. Bu içeri aktarım kaldırılamaz.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectModificationsPrompt">
-        <source>The project '{0}' has been modified outside the environment.
-
-Press Reload to load the updated project from disk.
-Press Ignore to ignore the external changes. The changes will be used the next time you open the project.
-    </source>
-        <target state="translated">'{0}' projesi ortamın dışında değiştirildi.
-
-Güncelleştirilmiş projeyi diskten yüklemek için, Yeniden Yükle’ye basın.
-Harici değişiklikleri yoksaymak için, Yoksay’a basın. Değişiklikler, projeyi bir sonraki açışınızda kullanılacaktır.
-    </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ConflictingModificationsPrompt">
-        <source>The project '{0}' has been modified outside the environment, and there are unsaved changes to the project.
-
-Press Save As to save the unsaved changes and load the updated project from disk.
-Press Discard to discard the unsaved changes and load the updated project from disk.
-Press Overwrite to overwrite the external changes with your changes.
-Press Ignore to ignore the external changes. Your changes may be lost if you close and reopen the project.
-    </source>
-        <target state="translated">'{0}' projesi ortamın dışında değiştirildi ve projede kaydedilmemiş değişiklikler var.
-
-Kaydedilmemiş değişiklikleri kaydetmek ve güncelleştirilmiş projeyi diskten yüklemek için, Farklı Kaydet’e basın.
-Kaydedilmemiş değişiklikleri atmak ve güncelleştirilmiş projeyi diskten yüklemek için, At’a basın.
-Değişikliklerinizi harici değişikliklerin üzerine yazmak için, Üzerine Yaz’a basın.
-Harici değişiklikleri yoksaymak için, Yoksay’a basın. Projeyi kapatıp yeniden açarsanız değişiklikleriniz kaybolabilir.
-    </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ConflictingProjectModificationTitle">
-        <source>Conflicting Project Modification Detected</source>
-        <target state="translated">Çakışan Proje Değişikliği Algılandı</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Discard">
-        <source>_Discard</source>
-        <target state="translated">_At</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Ignore">
-        <source>_Ignore</source>
-        <target state="translated">_Yoksay</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IgnoreAll">
-        <source>Ignore A_ll</source>
-        <target state="translated">Tümünü Y_oksay</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Overwrite">
-        <source>_Overwrite</source>
-        <target state="translated">_Üzerine Yaz</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectModificationDlgTitle">
-        <source>Project Modification Detected</source>
-        <target state="translated">Proje Değişikliği Algılandı</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Reload">
-        <source>_Reload</source>
-        <target state="translated">_Yeniden Yükle</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ReloadAll">
-        <source>Reload A_ll</source>
-        <target state="translated">Tümünü Y_eniden Yükle</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RenameSymbolFailed">
         <source>Renaming the code element '{0}' failed.</source>
         <target state="translated">'{0}' kod öğesi yeniden adlandırılamadı.</target>
@@ -87,29 +17,9 @@ Harici değişiklikleri yoksaymak için, Yoksay’a basın. Projeyi kapatıp yen
         <target state="translated">Bir dosyayı yeniden adlandırıyorsunuz. Bu dosyadaki '{0}' kod öğesine yapılan tüm başvurularda yeniden adlandırma işlemi gerçekleştirmek ister misiniz?</target>
         <note />
       </trans-unit>
-      <trans-unit id="SaveAs">
-        <source>_Save As</source>
-        <target state="translated">_Farklı Kaydet</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToWatchProject">
-        <source>An unexpected error occurred attempting to watch project file '{0}'</source>
-        <target state="translated">'{0}' proje dosyası izlenmeye çalışılırken beklenmeyen bir hata oluştu</target>
-        <note />
-      </trans-unit>
       <trans-unit id="GraphNodeCategoryDependency">
         <source>Dependency</source>
         <target state="translated">Bağımlılık.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoItemTypeForRule">
-        <source>Expected to find item type for rule {0}. The rule file is either missing or malformed.</source>
-        <target state="translated">{0} kuralı için öğe türü bulunması bekleniyordu. Kural dosyası eksik veya hatalı biçimlendirilmiş.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DotNetCoreProjectsNotSupported">
-        <source>.NET Core projects are not supported in this release of Visual Studio. Support will be available in a later update.</source>
-        <target state="translated">.NET Core projeleri Visual Studio’nun bu sürümünde desteklenmez. Sonraki güncelleştirmelerde destek sunulacaktır.</target>
         <note />
       </trans-unit>
       <trans-unit id="ActiveLaunchProfileNotFound">
@@ -139,16 +49,6 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">Çıkış Türü Sınıf Kitaplığı olan bir proje doğrudan başlatılamaz.
 
 Bu projede hata ayıklamak için bu çözüme, kitaplık projesine başvuran bir yürütülebilir proje ekleyin. Yürütülebilir projeyi başlangıç projesi olarak ayarlayın.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoUrlSpecified">
-        <source>The debug profile '{0}' has requested a web browser be launched, but a URL was not specified.</source>
-        <target state="translated">'{0}' hata ayıklama profili bir web tarayıcısının başlatılmasını istedi, ancak bir URL belirtilmedi.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidAbsoluteUrlSpecified">
-        <source>The debug profile '{0}' has requested a web browser be launched, but the URL specified is not a valid absolute URL.  {1}</source>
-        <target state="translated">'{0}' hata ayıklama profili bir web tarayıcısının başlatılmasını istedi, ancak belirtilen URL geçerli bir mutlak URL değil. {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="NoDebugExecutableSpecified">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
@@ -7,76 +7,6 @@
         <target state="translated">{0} - 导入项来自目标文件。无法删除此导入。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectModificationsPrompt">
-        <source>The project '{0}' has been modified outside the environment.
-
-Press Reload to load the updated project from disk.
-Press Ignore to ignore the external changes. The changes will be used the next time you open the project.
-    </source>
-        <target state="translated">项目“{0}”已在环境外部修改。
-
-按“重载”，从磁盘加载更新的项目。
-按“忽略”，忽略外部更改。将在下次打开项目时使用此更改。
-    </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ConflictingModificationsPrompt">
-        <source>The project '{0}' has been modified outside the environment, and there are unsaved changes to the project.
-
-Press Save As to save the unsaved changes and load the updated project from disk.
-Press Discard to discard the unsaved changes and load the updated project from disk.
-Press Overwrite to overwrite the external changes with your changes.
-Press Ignore to ignore the external changes. Your changes may be lost if you close and reopen the project.
-    </source>
-        <target state="translated">项目“{0}”已在环境外部修改，并且该项目有未保存的更改。
-
-按“另存为”，保存未保存的更改并从磁盘加载更新的项目。
-按“放弃”，放弃未保存的更改并从磁盘加载更新的项目。
-按“覆盖”，可以用你的更改覆盖外部更改。
-按“忽略”，忽略外部更改。如果关闭并重新打开项目，所做更改可能会丢失。
-    </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ConflictingProjectModificationTitle">
-        <source>Conflicting Project Modification Detected</source>
-        <target state="translated">检测到冲突的项目修改</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Discard">
-        <source>_Discard</source>
-        <target state="translated">放弃(_D)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Ignore">
-        <source>_Ignore</source>
-        <target state="translated">忽略(_I)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IgnoreAll">
-        <source>Ignore A_ll</source>
-        <target state="translated">全部忽略(_L)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Overwrite">
-        <source>_Overwrite</source>
-        <target state="translated">覆盖(_O)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectModificationDlgTitle">
-        <source>Project Modification Detected</source>
-        <target state="translated">检测到项目修改</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Reload">
-        <source>_Reload</source>
-        <target state="translated">重载(_R)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ReloadAll">
-        <source>Reload A_ll</source>
-        <target state="translated">全部重载(_L)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RenameSymbolFailed">
         <source>Renaming the code element '{0}' failed.</source>
         <target state="translated">重命名代码元素“{0}”失败。</target>
@@ -87,29 +17,9 @@ Press Ignore to ignore the external changes. Your changes may be lost if you clo
         <target state="translated">你正在重命名文件。是否也对此项目中对代码元素“{0}”的所有引用执行重命名操作?</target>
         <note />
       </trans-unit>
-      <trans-unit id="SaveAs">
-        <source>_Save As</source>
-        <target state="translated">另存为(_S)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToWatchProject">
-        <source>An unexpected error occurred attempting to watch project file '{0}'</source>
-        <target state="translated">尝试监视项目文件“{0}”时发生意外错误</target>
-        <note />
-      </trans-unit>
       <trans-unit id="GraphNodeCategoryDependency">
         <source>Dependency</source>
         <target state="translated">依赖项</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoItemTypeForRule">
-        <source>Expected to find item type for rule {0}. The rule file is either missing or malformed.</source>
-        <target state="translated">预期查找规则 {0} 的项类型。规则文件丢失或格式不正确。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DotNetCoreProjectsNotSupported">
-        <source>.NET Core projects are not supported in this release of Visual Studio. Support will be available in a later update.</source>
-        <target state="translated">此版本的 Visual Studio 不支持 .NET Core 项目。将在以后的更新中提供支持。</target>
         <note />
       </trans-unit>
       <trans-unit id="ActiveLaunchProfileNotFound">
@@ -139,16 +49,6 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">无法直接启动带有“类库输出类型”的项目。
 
 若要调试此项目，请向引用库项目的此解决方案中添加可执行项目。将此可执行项目设置为启动项目。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoUrlSpecified">
-        <source>The debug profile '{0}' has requested a web browser be launched, but a URL was not specified.</source>
-        <target state="translated">调试配置文件“{0}”已请求启动 Web 浏览器，但未指定 URL。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidAbsoluteUrlSpecified">
-        <source>The debug profile '{0}' has requested a web browser be launched, but the URL specified is not a valid absolute URL.  {1}</source>
-        <target state="translated">调试配置文件“{0}”已请求启动 Web 浏览器，但指定的 URL 不是有效的绝对 URL。{1}</target>
         <note />
       </trans-unit>
       <trans-unit id="NoDebugExecutableSpecified">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
@@ -7,76 +7,6 @@
         <target state="translated">{0} - 匯入來自目標檔案。此項匯入無法移除。</target>
         <note />
       </trans-unit>
-      <trans-unit id="ProjectModificationsPrompt">
-        <source>The project '{0}' has been modified outside the environment.
-
-Press Reload to load the updated project from disk.
-Press Ignore to ignore the external changes. The changes will be used the next time you open the project.
-    </source>
-        <target state="translated">專案 '{0}' 已在環境外部修改。
-
-按 [重新載入] 從磁碟載入更新的專案。
-按 [略過] 以略過外部變更。所做的變更會在您下次開啟專案時使用。
-    </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ConflictingModificationsPrompt">
-        <source>The project '{0}' has been modified outside the environment, and there are unsaved changes to the project.
-
-Press Save As to save the unsaved changes and load the updated project from disk.
-Press Discard to discard the unsaved changes and load the updated project from disk.
-Press Overwrite to overwrite the external changes with your changes.
-Press Ignore to ignore the external changes. Your changes may be lost if you close and reopen the project.
-    </source>
-        <target state="translated">專案 '{0}' 已在環境外部修改，而專案有未儲存的變更。
-
-按 [另存新檔] 儲存未儲存的變更並從磁碟載入更新的專案。
-按 [捨棄] 以捨棄未儲存的變更並從磁碟載入更新的專案。
-按 [覆寫] 以您的變更來覆寫外部變更。
-按 [略過] 以略過外部變更。如果關閉並重新開啟專案，可能會遺失您所做的變更。
-    </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ConflictingProjectModificationTitle">
-        <source>Conflicting Project Modification Detected</source>
-        <target state="translated">偵測到衝突的專案修改</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Discard">
-        <source>_Discard</source>
-        <target state="translated">捨棄(_D)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Ignore">
-        <source>_Ignore</source>
-        <target state="translated">略過(_I)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="IgnoreAll">
-        <source>Ignore A_ll</source>
-        <target state="translated">全部略過(_L)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Overwrite">
-        <source>_Overwrite</source>
-        <target state="translated">覆寫(_O)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProjectModificationDlgTitle">
-        <source>Project Modification Detected</source>
-        <target state="translated">偵測到專案修改</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Reload">
-        <source>_Reload</source>
-        <target state="translated">重新載入(_R)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ReloadAll">
-        <source>Reload A_ll</source>
-        <target state="translated">全部重新載入(_L)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RenameSymbolFailed">
         <source>Renaming the code element '{0}' failed.</source>
         <target state="translated">重新命名程式碼項目 '{0}' 失敗。</target>
@@ -87,29 +17,9 @@ Press Ignore to ignore the external changes. Your changes may be lost if you clo
         <target state="translated">您正在重新命名檔案。您是否也要重新命名此專案中對於程式碼項目 '{0}' 的所有參考?</target>
         <note />
       </trans-unit>
-      <trans-unit id="SaveAs">
-        <source>_Save As</source>
-        <target state="translated">另存新檔(_S)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="FailedToWatchProject">
-        <source>An unexpected error occurred attempting to watch project file '{0}'</source>
-        <target state="translated">嘗試監看專案檔 '{0}' 時發生未預期的錯誤</target>
-        <note />
-      </trans-unit>
       <trans-unit id="GraphNodeCategoryDependency">
         <source>Dependency</source>
         <target state="translated">相依性</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoItemTypeForRule">
-        <source>Expected to find item type for rule {0}. The rule file is either missing or malformed.</source>
-        <target state="translated">必須找到規則 {0} 的項目類型。規則檔可能遺漏或格式錯誤。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DotNetCoreProjectsNotSupported">
-        <source>.NET Core projects are not supported in this release of Visual Studio. Support will be available in a later update.</source>
-        <target state="translated">這一版的 Visual Studio 不支援 .NET Core 專案。稍後的更新將提供支援。</target>
         <note />
       </trans-unit>
       <trans-unit id="ActiveLaunchProfileNotFound">
@@ -139,16 +49,6 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">無法直接啟動輸出類型為類別庫的專案。
 
 為了為此專案偵錯，請將可執行檔專案新增至參考程式庫專案的此項解決方案，然後將這個可執行檔專案設定為啟始專案。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="NoUrlSpecified">
-        <source>The debug profile '{0}' has requested a web browser be launched, but a URL was not specified.</source>
-        <target state="translated">偵錯設定檔 '{0}' 已要求啟動網頁瀏覽器，但未指定 URL。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="InvalidAbsoluteUrlSpecified">
-        <source>The debug profile '{0}' has requested a web browser be launched, but the URL specified is not a valid absolute URL.  {1}</source>
-        <target state="translated">偵錯設定檔 '{0}' 已要求啟動網頁瀏覽器，但指定的 URL 不是有效的絕對 URL。{1}</target>
         <note />
       </trans-unit>
       <trans-unit id="NoDebugExecutableSpecified">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.Designer.cs
@@ -88,56 +88,11 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The framework name &apos;{0}&apos; cannot be converted to a short framework name..
-        /// </summary>
-        internal static string CouldNotGetShortFrameworkName {
-            get {
-                return ResourceManager.GetString("CouldNotGetShortFrameworkName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to  (Loading...).
-        /// </summary>
-        internal static string DependenciesLoadingPostfix {
-            get {
-                return ResourceManager.GetString("DependenciesLoadingPostfix", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to (Errors - see Error List).
-        /// </summary>
-        internal static string DependenciesNodeErrorsSuffix {
-            get {
-                return ResourceManager.GetString("DependenciesNodeErrorsSuffix", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Dependencies.
         /// </summary>
         internal static string DependenciesNodeName {
             get {
                 return ResourceManager.GetString("DependenciesNodeName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The following error occurred when reading the launch settings file &apos;{0}&apos;. {1} .
-        /// </summary>
-        internal static string ErrorReadingLaunchSettings {
-            get {
-                return ResourceManager.GetString("ErrorReadingLaunchSettings", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The following error occurred when writing to the launch settings file &apos;{0}&apos;. {1} .
-        /// </summary>
-        internal static string ErrorWritingDebugSettings {
-            get {
-                return ResourceManager.GetString("ErrorWritingDebugSettings", resourceCulture);
             }
         }
         
@@ -151,29 +106,11 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The specified framework name &apos;{0}&apos; must be .NETStandard..
-        /// </summary>
-        internal static string InvalidNetStandardFramework {
-            get {
-                return ResourceManager.GetString("InvalidNetStandardFramework", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Errors in &apos;{0}&apos; need to be corrected before applying changes..
         /// </summary>
         internal static string JsonErrorNeedToBeCorrected {
             get {
                 return ResourceManager.GetString("JsonErrorNeedToBeCorrected", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Error reading the launch settings file. This error will need to be corrected in order to debug this project. &apos;{0}&apos; .
-        /// </summary>
-        internal static string JsonErrorReadingLaunchSettings {
-            get {
-                return ResourceManager.GetString("JsonErrorReadingLaunchSettings", resourceCulture);
             }
         }
         
@@ -210,15 +147,6 @@ namespace Microsoft.VisualStudio {
         internal static string NuGetPackagesNodeName {
             get {
                 return ResourceManager.GetString("NuGetPackagesNodeName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to At least one launch profile is missing the required name attribute. These profiles will be ignored.
-        /// </summary>
-        internal static string ProfileMissingName {
-            get {
-                return ResourceManager.GetString("ProfileMissingName", resourceCulture);
             }
         }
         

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.resx
@@ -117,18 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="JsonErrorReadingLaunchSettings" xml:space="preserve">
-    <value>Error reading the launch settings file. This error will need to be corrected in order to debug this project. '{0}' </value>
-  </data>
-  <data name="ErrorReadingLaunchSettings" xml:space="preserve">
-    <value>The following error occurred when reading the launch settings file '{0}'. {1} </value>
-  </data>
-  <data name="ErrorWritingDebugSettings" xml:space="preserve">
-    <value>The following error occurred when writing to the launch settings file '{0}'. {1} </value>
-  </data>
-  <data name="ProfileMissingName" xml:space="preserve">
-    <value>At least one launch profile is missing the required name attribute. These profiles will be ignored</value>
-  </data>
   <data name="NoActionProfileName" xml:space="preserve">
     <value>Start</value>
   </data>
@@ -152,12 +140,6 @@
   <data name="ComNodeName" xml:space="preserve">
     <value>COM</value>
   </data>
-  <data name="DependenciesLoadingPostfix" xml:space="preserve">
-    <value> (Loading...)</value>
-  </data>
-  <data name="DependenciesNodeErrorsSuffix" xml:space="preserve">
-    <value>(Errors - see Error List)</value>
-  </data>
   <data name="DependenciesNodeName" xml:space="preserve">
     <value>Dependencies</value>
   </data>
@@ -172,13 +154,5 @@
   </data>
   <data name="SdkNodeName" xml:space="preserve">
     <value>SDK</value>
-  </data>
-  <data name="CouldNotGetShortFrameworkName" xml:space="preserve">
-    <value>The framework name '{0}' cannot be converted to a short framework name.</value>
-    <comment>Arguments in order:
-The string representation of the user's input framework name.</comment>
-  </data>
-  <data name="InvalidNetStandardFramework" xml:space="preserve">
-    <value>The specified framework name '{0}' must be .NETStandard.</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
@@ -2,26 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Resources.resx">
     <body>
-      <trans-unit id="JsonErrorReadingLaunchSettings">
-        <source>Error reading the launch settings file. This error will need to be corrected in order to debug this project. '{0}' </source>
-        <target state="translated">Při čtení souboru nastavení spuštění došlo k chybě. Pokud chcete tento projekt ladit, musíte chybu opravit. {0} </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ErrorReadingLaunchSettings">
-        <source>The following error occurred when reading the launch settings file '{0}'. {1} </source>
-        <target state="translated">Při čtení souboru nastavení spuštění {0} došlo k následující chybě. {1} </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ErrorWritingDebugSettings">
-        <source>The following error occurred when writing to the launch settings file '{0}'. {1} </source>
-        <target state="translated">Při zápisu do souboru nastavení spuštění {0} došlo k následující chybě. {1} </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProfileMissingName">
-        <source>At least one launch profile is missing the required name attribute. These profiles will be ignored</source>
-        <target state="translated">Nejméně v jednom profilu spuštění chybí povinný atribut názvu. Tyto profily budou ignorovány</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoActionProfileName">
         <source>Start</source>
         <target state="translated">Spustit</target>
@@ -57,16 +37,6 @@
         <target state="new">COM</target>
         <note />
       </trans-unit>
-      <trans-unit id="DependenciesLoadingPostfix">
-        <source> (Loading...)</source>
-        <target state="new"> (Loading...)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DependenciesNodeErrorsSuffix">
-        <source>(Errors - see Error List)</source>
-        <target state="new">(Errors - see Error List)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DependenciesNodeName">
         <source>Dependencies</source>
         <target state="new">Dependencies</target>
@@ -90,17 +60,6 @@
       <trans-unit id="SdkNodeName">
         <source>SDK</source>
         <target state="new">SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CouldNotGetShortFrameworkName">
-        <source>The framework name '{0}' cannot be converted to a short framework name.</source>
-        <target state="new">The framework name '{0}' cannot be converted to a short framework name.</target>
-        <note>Arguments in order:
-The string representation of the user's input framework name.</note>
-      </trans-unit>
-      <trans-unit id="InvalidNetStandardFramework">
-        <source>The specified framework name '{0}' must be .NETStandard.</source>
-        <target state="new">The specified framework name '{0}' must be .NETStandard.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
@@ -2,26 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Resources.resx">
     <body>
-      <trans-unit id="JsonErrorReadingLaunchSettings">
-        <source>Error reading the launch settings file. This error will need to be corrected in order to debug this project. '{0}' </source>
-        <target state="translated">Fehler beim Lesen der Starteinstellungsdatei. Dieser Fehler muss behoben werden, um das Projekt zu debuggen. {0} </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ErrorReadingLaunchSettings">
-        <source>The following error occurred when reading the launch settings file '{0}'. {1} </source>
-        <target state="translated">Fehler beim Lesen der Starteinstellungsdatei "{0}": {1} </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ErrorWritingDebugSettings">
-        <source>The following error occurred when writing to the launch settings file '{0}'. {1} </source>
-        <target state="translated">Fehler beim Schreiben in die Starteinstellungsdatei "{0}": {1} </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProfileMissingName">
-        <source>At least one launch profile is missing the required name attribute. These profiles will be ignored</source>
-        <target state="translated">In mindestens einem Startprofil fehlt das erforderliche Namensattribut. Die entsprechenden Profile werden ignoriert.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoActionProfileName">
         <source>Start</source>
         <target state="translated">Starten</target>
@@ -57,16 +37,6 @@
         <target state="new">COM</target>
         <note />
       </trans-unit>
-      <trans-unit id="DependenciesLoadingPostfix">
-        <source> (Loading...)</source>
-        <target state="new"> (Loading...)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DependenciesNodeErrorsSuffix">
-        <source>(Errors - see Error List)</source>
-        <target state="new">(Errors - see Error List)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DependenciesNodeName">
         <source>Dependencies</source>
         <target state="new">Dependencies</target>
@@ -90,17 +60,6 @@
       <trans-unit id="SdkNodeName">
         <source>SDK</source>
         <target state="new">SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CouldNotGetShortFrameworkName">
-        <source>The framework name '{0}' cannot be converted to a short framework name.</source>
-        <target state="new">The framework name '{0}' cannot be converted to a short framework name.</target>
-        <note>Arguments in order:
-The string representation of the user's input framework name.</note>
-      </trans-unit>
-      <trans-unit id="InvalidNetStandardFramework">
-        <source>The specified framework name '{0}' must be .NETStandard.</source>
-        <target state="new">The specified framework name '{0}' must be .NETStandard.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
@@ -2,26 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Resources.resx">
     <body>
-      <trans-unit id="JsonErrorReadingLaunchSettings">
-        <source>Error reading the launch settings file. This error will need to be corrected in order to debug this project. '{0}' </source>
-        <target state="translated">Error al leer el archivo de configuración de inicio. Este error debe corregirse para depurar este proyecto. '{0}' </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ErrorReadingLaunchSettings">
-        <source>The following error occurred when reading the launch settings file '{0}'. {1} </source>
-        <target state="translated">Se ha producido el siguiente error al leer el archivo de configuración de inicio '{0}'. {1} </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ErrorWritingDebugSettings">
-        <source>The following error occurred when writing to the launch settings file '{0}'. {1} </source>
-        <target state="translated">Se ha producido el siguiente error al escribir en el archivo de configuración de inicio '{0}'. {1} </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProfileMissingName">
-        <source>At least one launch profile is missing the required name attribute. These profiles will be ignored</source>
-        <target state="translated">Falta el atributo de nombre necesario en, al menos, un perfil de inicio. Estos perfiles se omitirán</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoActionProfileName">
         <source>Start</source>
         <target state="translated">Inicio</target>
@@ -57,16 +37,6 @@
         <target state="new">COM</target>
         <note />
       </trans-unit>
-      <trans-unit id="DependenciesLoadingPostfix">
-        <source> (Loading...)</source>
-        <target state="new"> (Loading...)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DependenciesNodeErrorsSuffix">
-        <source>(Errors - see Error List)</source>
-        <target state="new">(Errors - see Error List)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DependenciesNodeName">
         <source>Dependencies</source>
         <target state="new">Dependencies</target>
@@ -90,17 +60,6 @@
       <trans-unit id="SdkNodeName">
         <source>SDK</source>
         <target state="new">SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CouldNotGetShortFrameworkName">
-        <source>The framework name '{0}' cannot be converted to a short framework name.</source>
-        <target state="new">The framework name '{0}' cannot be converted to a short framework name.</target>
-        <note>Arguments in order:
-The string representation of the user's input framework name.</note>
-      </trans-unit>
-      <trans-unit id="InvalidNetStandardFramework">
-        <source>The specified framework name '{0}' must be .NETStandard.</source>
-        <target state="new">The specified framework name '{0}' must be .NETStandard.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
@@ -2,26 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Resources.resx">
     <body>
-      <trans-unit id="JsonErrorReadingLaunchSettings">
-        <source>Error reading the launch settings file. This error will need to be corrected in order to debug this project. '{0}' </source>
-        <target state="translated">Erreur de lecture du fichier des paramètres de lancement. Vous devez corriger cette erreur pour déboguer ce projet. '{0}' </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ErrorReadingLaunchSettings">
-        <source>The following error occurred when reading the launch settings file '{0}'. {1} </source>
-        <target state="translated">L'erreur suivante s'est produite pendant la lecture du fichier des paramètres de lancement '{0}'. {1} </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ErrorWritingDebugSettings">
-        <source>The following error occurred when writing to the launch settings file '{0}'. {1} </source>
-        <target state="translated">L'erreur suivante s'est produite pendant l'écriture dans le fichier des paramètres de lancement '{0}'. {1} </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProfileMissingName">
-        <source>At least one launch profile is missing the required name attribute. These profiles will be ignored</source>
-        <target state="translated">Au moins un profil de lancement ne comprend pas l'attribut de nom exigé. Ces profils seront ignorés</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoActionProfileName">
         <source>Start</source>
         <target state="translated">Démarrer</target>
@@ -57,16 +37,6 @@
         <target state="new">COM</target>
         <note />
       </trans-unit>
-      <trans-unit id="DependenciesLoadingPostfix">
-        <source> (Loading...)</source>
-        <target state="new"> (Loading...)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DependenciesNodeErrorsSuffix">
-        <source>(Errors - see Error List)</source>
-        <target state="new">(Errors - see Error List)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DependenciesNodeName">
         <source>Dependencies</source>
         <target state="new">Dependencies</target>
@@ -90,17 +60,6 @@
       <trans-unit id="SdkNodeName">
         <source>SDK</source>
         <target state="new">SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CouldNotGetShortFrameworkName">
-        <source>The framework name '{0}' cannot be converted to a short framework name.</source>
-        <target state="new">The framework name '{0}' cannot be converted to a short framework name.</target>
-        <note>Arguments in order:
-The string representation of the user's input framework name.</note>
-      </trans-unit>
-      <trans-unit id="InvalidNetStandardFramework">
-        <source>The specified framework name '{0}' must be .NETStandard.</source>
-        <target state="new">The specified framework name '{0}' must be .NETStandard.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
@@ -2,26 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Resources.resx">
     <body>
-      <trans-unit id="JsonErrorReadingLaunchSettings">
-        <source>Error reading the launch settings file. This error will need to be corrected in order to debug this project. '{0}' </source>
-        <target state="translated">Si è verificato un errore durante la lettura del file di impostazioni di avvio. È necessario correggere questo errore per eseguire il debug del progetto. '{0}' </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ErrorReadingLaunchSettings">
-        <source>The following error occurred when reading the launch settings file '{0}'. {1} </source>
-        <target state="translated">Durante la lettura del file di impostazioni di avvio '{0}' si è verificato l'errore seguente. {1} </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ErrorWritingDebugSettings">
-        <source>The following error occurred when writing to the launch settings file '{0}'. {1} </source>
-        <target state="translated">Durante la scrittura nel file di impostazioni di avvio '{0}' si è verificato l'errore seguente. {1} </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProfileMissingName">
-        <source>At least one launch profile is missing the required name attribute. These profiles will be ignored</source>
-        <target state="translated">In almeno un profilo di avvio manca l'attributo name obbligatorio. Questi profili verranno ignorati</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoActionProfileName">
         <source>Start</source>
         <target state="translated">Avvia</target>
@@ -57,16 +37,6 @@
         <target state="new">COM</target>
         <note />
       </trans-unit>
-      <trans-unit id="DependenciesLoadingPostfix">
-        <source> (Loading...)</source>
-        <target state="new"> (Loading...)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DependenciesNodeErrorsSuffix">
-        <source>(Errors - see Error List)</source>
-        <target state="new">(Errors - see Error List)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DependenciesNodeName">
         <source>Dependencies</source>
         <target state="new">Dependencies</target>
@@ -90,17 +60,6 @@
       <trans-unit id="SdkNodeName">
         <source>SDK</source>
         <target state="new">SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CouldNotGetShortFrameworkName">
-        <source>The framework name '{0}' cannot be converted to a short framework name.</source>
-        <target state="new">The framework name '{0}' cannot be converted to a short framework name.</target>
-        <note>Arguments in order:
-The string representation of the user's input framework name.</note>
-      </trans-unit>
-      <trans-unit id="InvalidNetStandardFramework">
-        <source>The specified framework name '{0}' must be .NETStandard.</source>
-        <target state="new">The specified framework name '{0}' must be .NETStandard.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
@@ -2,26 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Resources.resx">
     <body>
-      <trans-unit id="JsonErrorReadingLaunchSettings">
-        <source>Error reading the launch settings file. This error will need to be corrected in order to debug this project. '{0}' </source>
-        <target state="translated">起動設定ファイルの読み取り中にエラーが発生しました。このプロジェクトをデバッグするには、このエラーを修正する必要があります。'{0}' </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ErrorReadingLaunchSettings">
-        <source>The following error occurred when reading the launch settings file '{0}'. {1} </source>
-        <target state="translated">起動設定ファイル '{0}' を読み取るときに次のエラーが発生しました。{1} </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ErrorWritingDebugSettings">
-        <source>The following error occurred when writing to the launch settings file '{0}'. {1} </source>
-        <target state="translated">起動設定ファイル '{0}' に書き込むときに次のエラーが発生しました。{1} </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProfileMissingName">
-        <source>At least one launch profile is missing the required name attribute. These profiles will be ignored</source>
-        <target state="translated">少なくとも 1 つの起動プロファイルに、必須の name 属性が不足しています。これらのプロファイルは無視されます</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoActionProfileName">
         <source>Start</source>
         <target state="translated">開始</target>
@@ -57,16 +37,6 @@
         <target state="new">COM</target>
         <note />
       </trans-unit>
-      <trans-unit id="DependenciesLoadingPostfix">
-        <source> (Loading...)</source>
-        <target state="new"> (Loading...)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DependenciesNodeErrorsSuffix">
-        <source>(Errors - see Error List)</source>
-        <target state="new">(Errors - see Error List)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DependenciesNodeName">
         <source>Dependencies</source>
         <target state="new">Dependencies</target>
@@ -90,17 +60,6 @@
       <trans-unit id="SdkNodeName">
         <source>SDK</source>
         <target state="new">SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CouldNotGetShortFrameworkName">
-        <source>The framework name '{0}' cannot be converted to a short framework name.</source>
-        <target state="new">The framework name '{0}' cannot be converted to a short framework name.</target>
-        <note>Arguments in order:
-The string representation of the user's input framework name.</note>
-      </trans-unit>
-      <trans-unit id="InvalidNetStandardFramework">
-        <source>The specified framework name '{0}' must be .NETStandard.</source>
-        <target state="new">The specified framework name '{0}' must be .NETStandard.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
@@ -2,26 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Resources.resx">
     <body>
-      <trans-unit id="JsonErrorReadingLaunchSettings">
-        <source>Error reading the launch settings file. This error will need to be corrected in order to debug this project. '{0}' </source>
-        <target state="translated">시작 설정 파일을 읽는 동안 오류가 발생했습니다. 이 프로젝트를 디버그하려면 이 오류를 수정해야 합니다. '{0}' </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ErrorReadingLaunchSettings">
-        <source>The following error occurred when reading the launch settings file '{0}'. {1} </source>
-        <target state="translated">시작 설정 파일 '{0}'을(를) 읽는 동안 다음과 같은 오류가 발생했습니다. {1} </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ErrorWritingDebugSettings">
-        <source>The following error occurred when writing to the launch settings file '{0}'. {1} </source>
-        <target state="translated">시작 설정 파일 '{0}'에 쓰는 동안 다음과 같은 오류가 발생했습니다. {1} </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProfileMissingName">
-        <source>At least one launch profile is missing the required name attribute. These profiles will be ignored</source>
-        <target state="translated">하나 이상의 시작 프로필에 필수 이름 특성이 없습니다. 이 프로필을 무시합니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoActionProfileName">
         <source>Start</source>
         <target state="translated">시작</target>
@@ -57,16 +37,6 @@
         <target state="new">COM</target>
         <note />
       </trans-unit>
-      <trans-unit id="DependenciesLoadingPostfix">
-        <source> (Loading...)</source>
-        <target state="new"> (Loading...)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DependenciesNodeErrorsSuffix">
-        <source>(Errors - see Error List)</source>
-        <target state="new">(Errors - see Error List)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DependenciesNodeName">
         <source>Dependencies</source>
         <target state="new">Dependencies</target>
@@ -90,17 +60,6 @@
       <trans-unit id="SdkNodeName">
         <source>SDK</source>
         <target state="new">SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CouldNotGetShortFrameworkName">
-        <source>The framework name '{0}' cannot be converted to a short framework name.</source>
-        <target state="new">The framework name '{0}' cannot be converted to a short framework name.</target>
-        <note>Arguments in order:
-The string representation of the user's input framework name.</note>
-      </trans-unit>
-      <trans-unit id="InvalidNetStandardFramework">
-        <source>The specified framework name '{0}' must be .NETStandard.</source>
-        <target state="new">The specified framework name '{0}' must be .NETStandard.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
@@ -2,26 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Resources.resx">
     <body>
-      <trans-unit id="JsonErrorReadingLaunchSettings">
-        <source>Error reading the launch settings file. This error will need to be corrected in order to debug this project. '{0}' </source>
-        <target state="translated">Błąd podczas odczytywania pliku ustawień uruchamiania. Należy poprawić ten błąd w celu przeprowadzenia debugowania tego projektu. „{0}” </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ErrorReadingLaunchSettings">
-        <source>The following error occurred when reading the launch settings file '{0}'. {1} </source>
-        <target state="translated">Następujący błąd wystąpił podczas odczytywania pliku ustawień uruchamiania „{0}”. {1} </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ErrorWritingDebugSettings">
-        <source>The following error occurred when writing to the launch settings file '{0}'. {1} </source>
-        <target state="translated">Następujący błąd wystąpił podczas zapisywania do pliku ustawień uruchamiania „{0}”. {1} </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProfileMissingName">
-        <source>At least one launch profile is missing the required name attribute. These profiles will be ignored</source>
-        <target state="translated">W co najmniej jednym profilu uruchomienia brakuje wymaganego atrybutu nazwy. Te profile będą ignorowane</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoActionProfileName">
         <source>Start</source>
         <target state="translated">Uruchom</target>
@@ -57,16 +37,6 @@
         <target state="new">COM</target>
         <note />
       </trans-unit>
-      <trans-unit id="DependenciesLoadingPostfix">
-        <source> (Loading...)</source>
-        <target state="new"> (Loading...)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DependenciesNodeErrorsSuffix">
-        <source>(Errors - see Error List)</source>
-        <target state="new">(Errors - see Error List)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DependenciesNodeName">
         <source>Dependencies</source>
         <target state="new">Dependencies</target>
@@ -90,17 +60,6 @@
       <trans-unit id="SdkNodeName">
         <source>SDK</source>
         <target state="new">SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CouldNotGetShortFrameworkName">
-        <source>The framework name '{0}' cannot be converted to a short framework name.</source>
-        <target state="new">The framework name '{0}' cannot be converted to a short framework name.</target>
-        <note>Arguments in order:
-The string representation of the user's input framework name.</note>
-      </trans-unit>
-      <trans-unit id="InvalidNetStandardFramework">
-        <source>The specified framework name '{0}' must be .NETStandard.</source>
-        <target state="new">The specified framework name '{0}' must be .NETStandard.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
@@ -2,26 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Resources.resx">
     <body>
-      <trans-unit id="JsonErrorReadingLaunchSettings">
-        <source>Error reading the launch settings file. This error will need to be corrected in order to debug this project. '{0}' </source>
-        <target state="translated">Erro ao ler o arquivo de configurações de inicialização. Este erro precisará ser corrigido para depurar este projeto. '{0}' </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ErrorReadingLaunchSettings">
-        <source>The following error occurred when reading the launch settings file '{0}'. {1} </source>
-        <target state="translated">O erro a seguir ocorreu ao ler o arquivo de configurações de inicialização '{0}'. {1} </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ErrorWritingDebugSettings">
-        <source>The following error occurred when writing to the launch settings file '{0}'. {1} </source>
-        <target state="translated">O erro a seguir ocorreu ao gravar o arquivo de configurações de inicialização '{0}'. {1} </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProfileMissingName">
-        <source>At least one launch profile is missing the required name attribute. These profiles will be ignored</source>
-        <target state="translated">Pelo menos um perfil de inicialização não tem o atributo de nome necessário. Esses perfis serão ignorados</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoActionProfileName">
         <source>Start</source>
         <target state="translated">Iniciar</target>
@@ -57,16 +37,6 @@
         <target state="new">COM</target>
         <note />
       </trans-unit>
-      <trans-unit id="DependenciesLoadingPostfix">
-        <source> (Loading...)</source>
-        <target state="new"> (Loading...)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DependenciesNodeErrorsSuffix">
-        <source>(Errors - see Error List)</source>
-        <target state="new">(Errors - see Error List)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DependenciesNodeName">
         <source>Dependencies</source>
         <target state="new">Dependencies</target>
@@ -90,17 +60,6 @@
       <trans-unit id="SdkNodeName">
         <source>SDK</source>
         <target state="new">SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CouldNotGetShortFrameworkName">
-        <source>The framework name '{0}' cannot be converted to a short framework name.</source>
-        <target state="new">The framework name '{0}' cannot be converted to a short framework name.</target>
-        <note>Arguments in order:
-The string representation of the user's input framework name.</note>
-      </trans-unit>
-      <trans-unit id="InvalidNetStandardFramework">
-        <source>The specified framework name '{0}' must be .NETStandard.</source>
-        <target state="new">The specified framework name '{0}' must be .NETStandard.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
@@ -2,26 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Resources.resx">
     <body>
-      <trans-unit id="JsonErrorReadingLaunchSettings">
-        <source>Error reading the launch settings file. This error will need to be corrected in order to debug this project. '{0}' </source>
-        <target state="translated">Ошибка при чтении файла параметров запуска. Чтобы выполнить отладку проекта, необходимо исправить эту ошибку. "{0}" </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ErrorReadingLaunchSettings">
-        <source>The following error occurred when reading the launch settings file '{0}'. {1} </source>
-        <target state="translated">При чтении файла параметров запуска "{0}" произошла следующая ошибка. {1} </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ErrorWritingDebugSettings">
-        <source>The following error occurred when writing to the launch settings file '{0}'. {1} </source>
-        <target state="translated">При записи в файл параметров запуска "{0}" произошла следующая ошибка. {1} </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProfileMissingName">
-        <source>At least one launch profile is missing the required name attribute. These profiles will be ignored</source>
-        <target state="translated">Как минимум в одном профиле запуска отсутствует обязательный атрибут имени. Эти профили будут пропущены.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoActionProfileName">
         <source>Start</source>
         <target state="translated">Запуск</target>
@@ -57,16 +37,6 @@
         <target state="new">COM</target>
         <note />
       </trans-unit>
-      <trans-unit id="DependenciesLoadingPostfix">
-        <source> (Loading...)</source>
-        <target state="new"> (Loading...)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DependenciesNodeErrorsSuffix">
-        <source>(Errors - see Error List)</source>
-        <target state="new">(Errors - see Error List)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DependenciesNodeName">
         <source>Dependencies</source>
         <target state="new">Dependencies</target>
@@ -90,17 +60,6 @@
       <trans-unit id="SdkNodeName">
         <source>SDK</source>
         <target state="new">SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CouldNotGetShortFrameworkName">
-        <source>The framework name '{0}' cannot be converted to a short framework name.</source>
-        <target state="new">The framework name '{0}' cannot be converted to a short framework name.</target>
-        <note>Arguments in order:
-The string representation of the user's input framework name.</note>
-      </trans-unit>
-      <trans-unit id="InvalidNetStandardFramework">
-        <source>The specified framework name '{0}' must be .NETStandard.</source>
-        <target state="new">The specified framework name '{0}' must be .NETStandard.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
@@ -2,26 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Resources.resx">
     <body>
-      <trans-unit id="JsonErrorReadingLaunchSettings">
-        <source>Error reading the launch settings file. This error will need to be corrected in order to debug this project. '{0}' </source>
-        <target state="translated">Başlatma ayarları dosyasını okuma hatası. Bu projenin hatalarını ayıklamak için bu hatanın düzeltilmesi gerekir. '{0}' </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ErrorReadingLaunchSettings">
-        <source>The following error occurred when reading the launch settings file '{0}'. {1} </source>
-        <target state="translated">'{0}' başlatma ayarları dosyası okunurken şu hata oluştu. {1} </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ErrorWritingDebugSettings">
-        <source>The following error occurred when writing to the launch settings file '{0}'. {1} </source>
-        <target state="translated">'{0}' başlatma ayarları dosyasına yazılırken şu hata oluştu. {1} </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProfileMissingName">
-        <source>At least one launch profile is missing the required name attribute. These profiles will be ignored</source>
-        <target state="translated">En az bir başlatma profilinde gerekli ad özniteliği yok. Bu profiller yoksayılacak</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoActionProfileName">
         <source>Start</source>
         <target state="translated">Başlat</target>
@@ -57,16 +37,6 @@
         <target state="new">COM</target>
         <note />
       </trans-unit>
-      <trans-unit id="DependenciesLoadingPostfix">
-        <source> (Loading...)</source>
-        <target state="new"> (Loading...)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DependenciesNodeErrorsSuffix">
-        <source>(Errors - see Error List)</source>
-        <target state="new">(Errors - see Error List)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DependenciesNodeName">
         <source>Dependencies</source>
         <target state="new">Dependencies</target>
@@ -90,17 +60,6 @@
       <trans-unit id="SdkNodeName">
         <source>SDK</source>
         <target state="new">SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CouldNotGetShortFrameworkName">
-        <source>The framework name '{0}' cannot be converted to a short framework name.</source>
-        <target state="new">The framework name '{0}' cannot be converted to a short framework name.</target>
-        <note>Arguments in order:
-The string representation of the user's input framework name.</note>
-      </trans-unit>
-      <trans-unit id="InvalidNetStandardFramework">
-        <source>The specified framework name '{0}' must be .NETStandard.</source>
-        <target state="new">The specified framework name '{0}' must be .NETStandard.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
@@ -2,26 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Resources.resx">
     <body>
-      <trans-unit id="JsonErrorReadingLaunchSettings">
-        <source>Error reading the launch settings file. This error will need to be corrected in order to debug this project. '{0}' </source>
-        <target state="translated">在读取启动设置文件时出错。需要更正此错误以调试此项目。“{0}” </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ErrorReadingLaunchSettings">
-        <source>The following error occurred when reading the launch settings file '{0}'. {1} </source>
-        <target state="translated">在读取启动设置文件“{0}”时，发生以下错误。{1} </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ErrorWritingDebugSettings">
-        <source>The following error occurred when writing to the launch settings file '{0}'. {1} </source>
-        <target state="translated">在写入启动设置文件“{0}”时，发生以下错误。{1} </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProfileMissingName">
-        <source>At least one launch profile is missing the required name attribute. These profiles will be ignored</source>
-        <target state="translated">至少一个启动配置文件丢失了所需的名称特性。这些配置文件将被忽略</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoActionProfileName">
         <source>Start</source>
         <target state="translated">启动</target>
@@ -57,16 +37,6 @@
         <target state="new">COM</target>
         <note />
       </trans-unit>
-      <trans-unit id="DependenciesLoadingPostfix">
-        <source> (Loading...)</source>
-        <target state="new"> (Loading...)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DependenciesNodeErrorsSuffix">
-        <source>(Errors - see Error List)</source>
-        <target state="new">(Errors - see Error List)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DependenciesNodeName">
         <source>Dependencies</source>
         <target state="new">Dependencies</target>
@@ -90,17 +60,6 @@
       <trans-unit id="SdkNodeName">
         <source>SDK</source>
         <target state="new">SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CouldNotGetShortFrameworkName">
-        <source>The framework name '{0}' cannot be converted to a short framework name.</source>
-        <target state="new">The framework name '{0}' cannot be converted to a short framework name.</target>
-        <note>Arguments in order:
-The string representation of the user's input framework name.</note>
-      </trans-unit>
-      <trans-unit id="InvalidNetStandardFramework">
-        <source>The specified framework name '{0}' must be .NETStandard.</source>
-        <target state="new">The specified framework name '{0}' must be .NETStandard.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
@@ -2,26 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Resources.resx">
     <body>
-      <trans-unit id="JsonErrorReadingLaunchSettings">
-        <source>Error reading the launch settings file. This error will need to be corrected in order to debug this project. '{0}' </source>
-        <target state="translated">讀取啟動設定檔時發生錯誤。必須修正此錯誤，才能對此專案偵錯。'{0}' </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ErrorReadingLaunchSettings">
-        <source>The following error occurred when reading the launch settings file '{0}'. {1} </source>
-        <target state="translated">讀取啟動設定檔 '{0}' 時發生下列錯誤。{1} </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ErrorWritingDebugSettings">
-        <source>The following error occurred when writing to the launch settings file '{0}'. {1} </source>
-        <target state="translated">寫入啟動設定檔 '{0}' 時發生下列錯誤。{1} </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="ProfileMissingName">
-        <source>At least one launch profile is missing the required name attribute. These profiles will be ignored</source>
-        <target state="translated">至少一個啟動設定檔遺漏必要的名稱屬性。將會略過這些設定檔</target>
-        <note />
-      </trans-unit>
       <trans-unit id="NoActionProfileName">
         <source>Start</source>
         <target state="translated">啟動</target>
@@ -57,16 +37,6 @@
         <target state="new">COM</target>
         <note />
       </trans-unit>
-      <trans-unit id="DependenciesLoadingPostfix">
-        <source> (Loading...)</source>
-        <target state="new"> (Loading...)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DependenciesNodeErrorsSuffix">
-        <source>(Errors - see Error List)</source>
-        <target state="new">(Errors - see Error List)</target>
-        <note />
-      </trans-unit>
       <trans-unit id="DependenciesNodeName">
         <source>Dependencies</source>
         <target state="new">Dependencies</target>
@@ -90,17 +60,6 @@
       <trans-unit id="SdkNodeName">
         <source>SDK</source>
         <target state="new">SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="CouldNotGetShortFrameworkName">
-        <source>The framework name '{0}' cannot be converted to a short framework name.</source>
-        <target state="new">The framework name '{0}' cannot be converted to a short framework name.</target>
-        <note>Arguments in order:
-The string representation of the user's input framework name.</note>
-      </trans-unit>
-      <trans-unit id="InvalidNetStandardFramework">
-        <source>The specified framework name '{0}' must be .NETStandard.</source>
-        <target state="new">The specified framework name '{0}' must be .NETStandard.</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
Removes 8 unused resource strings from `Resources.resx` and 18 from `VSResources.resx`.

Note: there is no overlap with resources removed as part of #4895.