### PR TITLE
Use canonical names for tree flags & documentation

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyModelFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyModelFactory.cs
@@ -92,8 +92,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             }
 
             data.Flags += data.Resolved
-                ? DependencyTreeFlags.ResolvedFlags
-                : DependencyTreeFlags.UnresolvedFlags;
+                ? DependencyTreeFlags.Resolved
+                : DependencyTreeFlags.Unresolved;
 
             if (icon.HasValue)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/TestDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/TestDependencyModel.cs
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                    && (OriginalItemSpec == null || OriginalItemSpec == dependency.OriginalItemSpec)
                    && (Path == null || OriginalItemSpec == dependency.Path)
                    && (SchemaName == null || SchemaName == dependency.SchemaName)
-                   && (SchemaItemType == null || !Flags.Contains(DependencyTreeFlags.GenericDependencyFlags) || SchemaItemType == dependency.SchemaItemType)
+                   && (SchemaItemType == null || !Flags.Contains(DependencyTreeFlags.GenericDependency) || SchemaItemType == dependency.SchemaItemType)
                    && Resolved == dependency.Resolved
                    && TopLevel == dependency.TopLevel
                    && Implicit == dependency.Implicit

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/AnalyzerDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/AnalyzerDependencyModelTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.CodeInformationWarning, model.UnresolvedIcon);
             Assert.Equal(ManagedImageMonikers.CodeInformationWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
-                DependencyTreeFlags.AnalyzerSubTreeNodeFlags +
+                DependencyTreeFlags.AnalyzerDependency +
                 DependencyTreeFlags.GenericResolvedDependencyFlags,
                 model.Flags);
         }
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.CodeInformationWarning, model.UnresolvedIcon);
             Assert.Equal(ManagedImageMonikers.CodeInformationWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
-                DependencyTreeFlags.AnalyzerSubTreeNodeFlags +
+                DependencyTreeFlags.AnalyzerDependency +
                 DependencyTreeFlags.GenericUnresolvedDependencyFlags,
                 model.Flags);
         }
@@ -104,7 +104,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.CodeInformationWarning, model.UnresolvedIcon);
             Assert.Equal(ManagedImageMonikers.CodeInformationWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
-                DependencyTreeFlags.AnalyzerSubTreeNodeFlags +
+                DependencyTreeFlags.AnalyzerDependency +
                 DependencyTreeFlags.GenericResolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRemove,
                 model.Flags);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/AssemblyDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/AssemblyDependencyModelTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(KnownMonikers.ReferenceWarning, model.UnresolvedIcon);
             Assert.Equal(KnownMonikers.ReferenceWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
-                DependencyTreeFlags.AssemblySubTreeNodeFlags +
+                DependencyTreeFlags.AssemblyDependency +
                 DependencyTreeFlags.GenericResolvedDependencyFlags,
                 model.Flags);
         }
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(KnownMonikers.ReferenceWarning, model.UnresolvedIcon);
             Assert.Equal(KnownMonikers.ReferenceWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
-                DependencyTreeFlags.AssemblySubTreeNodeFlags +
+                DependencyTreeFlags.AssemblyDependency +
                 DependencyTreeFlags.GenericResolvedDependencyFlags,
                 model.Flags);
         }
@@ -104,7 +104,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(KnownMonikers.ReferenceWarning, model.UnresolvedIcon);
             Assert.Equal(KnownMonikers.ReferenceWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
-                DependencyTreeFlags.AssemblySubTreeNodeFlags +
+                DependencyTreeFlags.AssemblyDependency +
                 DependencyTreeFlags.GenericUnresolvedDependencyFlags,
                 model.Flags);
         }
@@ -136,7 +136,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(KnownMonikers.ReferenceWarning, model.UnresolvedIcon);
             Assert.Equal(KnownMonikers.ReferenceWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
-                DependencyTreeFlags.AssemblySubTreeNodeFlags +
+                DependencyTreeFlags.AssemblyDependency +
                 DependencyTreeFlags.GenericResolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRemove,
                 model.Flags);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/ComDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/ComDependencyModelTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.ComponentWarning, model.UnresolvedIcon);
             Assert.Equal(ManagedImageMonikers.ComponentWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
-                DependencyTreeFlags.ComSubTreeNodeFlags +
+                DependencyTreeFlags.ComDependency +
                 DependencyTreeFlags.GenericResolvedDependencyFlags,
                 model.Flags);
         }
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.ComponentWarning, model.UnresolvedIcon);
             Assert.Equal(ManagedImageMonikers.ComponentWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
-                DependencyTreeFlags.ComSubTreeNodeFlags +
+                DependencyTreeFlags.ComDependency +
                 DependencyTreeFlags.GenericUnresolvedDependencyFlags,
                 model.Flags);
         }
@@ -103,7 +103,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.ComponentWarning, model.UnresolvedIcon);
             Assert.Equal(ManagedImageMonikers.ComponentWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
-                DependencyTreeFlags.ComSubTreeNodeFlags +
+                DependencyTreeFlags.ComDependency +
                 DependencyTreeFlags.GenericResolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRemove,
                 model.Flags);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DependenciesViewModelFactoryTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DependenciesViewModelFactoryTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(targetFramework.FullName, result.Caption);
             Assert.Equal(KnownMonikers.Library, result.Icon);
             Assert.Equal(KnownMonikers.Library, result.ExpandedIcon);
-            Assert.True(result.Flags.Contains(DependencyTreeFlags.TargetNodeFlags));
+            Assert.True(result.Flags.Contains(DependencyTreeFlags.TargetNode));
             Assert.True(result.Flags.Contains("$TFM:tFm1"));
         }
 
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(targetFramework.FullName, result.Caption);
             Assert.Equal(ManagedImageMonikers.LibraryWarning, result.Icon);
             Assert.Equal(ManagedImageMonikers.LibraryWarning, result.ExpandedIcon);
-            Assert.True(result.Flags.Contains(DependencyTreeFlags.TargetNodeFlags));
+            Assert.True(result.Flags.Contains(DependencyTreeFlags.TargetNode));
             Assert.True(result.Flags.Contains("$TFM:tFm1"));
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DiagnosticDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DiagnosticDependencyModelTests.cs
@@ -43,9 +43,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.ErrorSmall, model.UnresolvedIcon);
             Assert.Equal(ManagedImageMonikers.ErrorSmall, model.UnresolvedExpandedIcon);
             Assert.Equal(
-                DependencyTreeFlags.NuGetSubTreeNodeFlags +
-                DependencyTreeFlags.DiagnosticNodeFlags +
-                DependencyTreeFlags.DiagnosticErrorNodeFlags +
+                DependencyTreeFlags.NuGetDependency +
+                DependencyTreeFlags.Diagnostic +
+                DependencyTreeFlags.ErrorDiagnostic +
                 DependencyTreeFlags.GenericUnresolvedDependencyFlags,
                 model.Flags);
         }
@@ -81,9 +81,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.WarningSmall, model.UnresolvedIcon);
             Assert.Equal(ManagedImageMonikers.WarningSmall, model.UnresolvedExpandedIcon);
             Assert.Equal(
-                DependencyTreeFlags.NuGetSubTreeNodeFlags +
-                DependencyTreeFlags.DiagnosticNodeFlags +
-                DependencyTreeFlags.DiagnosticWarningNodeFlags +
+                DependencyTreeFlags.NuGetDependency +
+                DependencyTreeFlags.Diagnostic +
+                DependencyTreeFlags.WarningDiagnostic +
                 DependencyTreeFlags.GenericUnresolvedDependencyFlags,
                 model.Flags);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageAnalyzerAssemblyDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageAnalyzerAssemblyDependencyModelTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.CodeInformationWarning, model.UnresolvedExpandedIcon);
             AssertEx.CollectionLength(model.DependencyIDs, 2);
             Assert.Equal(
-                DependencyTreeFlags.NuGetSubTreeNodeFlags +
+                DependencyTreeFlags.NuGetDependency +
                 DependencyTreeFlags.GenericResolvedDependencyFlags,
                 model.Flags);
         }
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.CodeInformationWarning, model.UnresolvedExpandedIcon);
             AssertEx.CollectionLength(model.DependencyIDs, 2);
             Assert.Equal(
-                DependencyTreeFlags.NuGetSubTreeNodeFlags +
+                DependencyTreeFlags.NuGetDependency +
                 DependencyTreeFlags.GenericUnresolvedDependencyFlags,
                 model.Flags);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageAssemblyDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageAssemblyDependencyModelTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(KnownMonikers.ReferenceWarning, model.UnresolvedExpandedIcon);
             AssertEx.CollectionLength(model.DependencyIDs, 2);
             Assert.Equal(
-                DependencyTreeFlags.NuGetSubTreeNodeFlags +
+                DependencyTreeFlags.NuGetDependency +
                 DependencyTreeFlags.GenericResolvedDependencyFlags,
                 model.Flags);
         }
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(KnownMonikers.ReferenceWarning, model.UnresolvedExpandedIcon);
             AssertEx.CollectionLength(model.DependencyIDs, 2);
             Assert.Equal(
-                DependencyTreeFlags.NuGetSubTreeNodeFlags +
+                DependencyTreeFlags.NuGetDependency +
                 DependencyTreeFlags.GenericUnresolvedDependencyFlags,
                 model.Flags);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageDependencyModelTests.cs
@@ -50,8 +50,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.NuGetGreyWarning, model.UnresolvedExpandedIcon);
             AssertEx.CollectionLength(model.DependencyIDs, 2);
             Assert.Equal(
-                DependencyTreeFlags.NuGetSubTreeNodeFlags +
-                DependencyTreeFlags.PackageNodeFlags +
+                DependencyTreeFlags.NuGetDependency +
+                DependencyTreeFlags.NuGetPackageDependency +
                 DependencyTreeFlags.SupportsHierarchy +
                 DependencyTreeFlags.GenericResolvedDependencyFlags,
                 model.Flags);
@@ -95,8 +95,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.NuGetGreyWarning, model.UnresolvedExpandedIcon);
             AssertEx.CollectionLength(model.DependencyIDs, 2);
             Assert.Equal(
-                DependencyTreeFlags.NuGetSubTreeNodeFlags +
-                DependencyTreeFlags.PackageNodeFlags +
+                DependencyTreeFlags.NuGetDependency +
+                DependencyTreeFlags.NuGetPackageDependency +
                 DependencyTreeFlags.SupportsHierarchy +
                 DependencyTreeFlags.GenericUnresolvedDependencyFlags,
                 model.Flags);
@@ -140,8 +140,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.NuGetGreyWarning, model.UnresolvedExpandedIcon);
             AssertEx.CollectionLength(model.DependencyIDs, 2);
             Assert.Equal(
-                DependencyTreeFlags.NuGetSubTreeNodeFlags +
-                DependencyTreeFlags.PackageNodeFlags +
+                DependencyTreeFlags.NuGetDependency +
+                DependencyTreeFlags.NuGetPackageDependency +
                 DependencyTreeFlags.SupportsHierarchy +
                 DependencyTreeFlags.GenericResolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRemove,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageFrameworkAssembliesViewModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageFrameworkAssembliesViewModelTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(Dependency.FrameworkAssemblyNodePriority, model.Priority);
             Assert.Equal(KnownMonikers.Library, model.Icon);
             Assert.Equal(KnownMonikers.Library, model.ExpandedIcon);
-            Assert.Equal(DependencyTreeFlags.FrameworkAssembliesNodeFlags, model.Flags);
+            Assert.Equal(DependencyTreeFlags.FrameworkAssembliesNode, model.Flags);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageUnknownDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/PackageUnknownDependencyModelTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(KnownMonikers.QuestionMark, model.UnresolvedExpandedIcon);
             AssertEx.CollectionLength(model.DependencyIDs, 2);
             Assert.Equal(
-                DependencyTreeFlags.NuGetSubTreeNodeFlags +
+                DependencyTreeFlags.NuGetDependency +
                 DependencyTreeFlags.GenericResolvedDependencyFlags,
                 model.Flags);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/ProjectDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/ProjectDependencyModelTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.ApplicationWarning, model.UnresolvedExpandedIcon);
             Assert.True(model.Flags.Contains(DependencyTreeFlags.SupportsHierarchy));
             Assert.Equal(
-                DependencyTreeFlags.ProjectNodeFlags +
+                DependencyTreeFlags.ProjectDependency +
                 DependencyTreeFlags.SupportsHierarchy +
                 DependencyTreeFlags.GenericResolvedDependencyFlags,
                 model.Flags);
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.ApplicationWarning, model.UnresolvedExpandedIcon);
             Assert.True(model.Flags.Contains(DependencyTreeFlags.SupportsHierarchy));
             Assert.Equal(
-                DependencyTreeFlags.ProjectNodeFlags +
+                DependencyTreeFlags.ProjectDependency +
                 DependencyTreeFlags.SupportsHierarchy +
                 DependencyTreeFlags.GenericUnresolvedDependencyFlags,
                 model.Flags);
@@ -108,7 +108,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.ApplicationWarning, model.UnresolvedIcon);
             Assert.Equal(ManagedImageMonikers.ApplicationWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
-                DependencyTreeFlags.ProjectNodeFlags +
+                DependencyTreeFlags.ProjectDependency +
                 DependencyTreeFlags.SupportsHierarchy +
                 DependencyTreeFlags.GenericResolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRemove,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SdkDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SdkDependencyModelTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.SdkWarning, model.UnresolvedIcon);
             Assert.Equal(ManagedImageMonikers.SdkWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
-                DependencyTreeFlags.SdkSubTreeNodeFlags +
+                DependencyTreeFlags.SdkDependency +
                 DependencyTreeFlags.SupportsHierarchy +
                 DependencyTreeFlags.GenericResolvedDependencyFlags,
                 model.Flags);
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.SdkWarning, model.UnresolvedIcon);
             Assert.Equal(ManagedImageMonikers.SdkWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
-                DependencyTreeFlags.SdkSubTreeNodeFlags +
+                DependencyTreeFlags.SdkDependency +
                 DependencyTreeFlags.SupportsHierarchy +
                 DependencyTreeFlags.GenericUnresolvedDependencyFlags,
                 model.Flags);
@@ -105,7 +105,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.SdkWarning, model.UnresolvedIcon);
             Assert.Equal(ManagedImageMonikers.SdkWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
-                DependencyTreeFlags.SdkSubTreeNodeFlags +
+                DependencyTreeFlags.SdkDependency +
                 DependencyTreeFlags.SupportsHierarchy +
                 DependencyTreeFlags.GenericResolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRemove,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SharedProjectDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SharedProjectDependencyModelTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.True(model.Flags.Contains(DependencyTreeFlags.SharedProjectFlags));
             Assert.False(model.Flags.Contains(DependencyTreeFlags.SupportsRuleProperties));
             Assert.Equal(
-                DependencyTreeFlags.ProjectNodeFlags +
+                DependencyTreeFlags.ProjectDependency +
                 DependencyTreeFlags.SharedProjectFlags +
                 DependencyTreeFlags.GenericResolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRuleProperties,
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.SharedProjectWarning, model.UnresolvedIcon);
             Assert.Equal(ManagedImageMonikers.SharedProjectWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
-                DependencyTreeFlags.ProjectNodeFlags +
+                DependencyTreeFlags.ProjectDependency +
                 DependencyTreeFlags.SharedProjectFlags +
                 DependencyTreeFlags.GenericUnresolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRuleProperties,
@@ -110,7 +110,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.Equal(ManagedImageMonikers.SharedProjectWarning, model.UnresolvedIcon);
             Assert.Equal(ManagedImageMonikers.SharedProjectWarning, model.UnresolvedExpandedIcon);
             Assert.Equal(
-                DependencyTreeFlags.ProjectNodeFlags +
+                DependencyTreeFlags.ProjectDependency +
                 DependencyTreeFlags.SharedProjectFlags +
                 DependencyTreeFlags.GenericResolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRuleProperties -

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SubTreeRootDependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/SubTreeRootDependencyModelTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 flag + 
                 DependencyTreeFlags.GenericResolvedDependencyFlags + 
                 DependencyTreeFlags.DependencyFlags +
-                DependencyTreeFlags.SubTreeRootNodeFlags -
+                DependencyTreeFlags.SubTreeRootNode -
                 DependencyTreeFlags.SupportsRuleProperties -
                 DependencyTreeFlags.SupportsRemove,
                 model.Flags);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyTests.cs
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                     ""Visible"": ""true"",
                     ""Priority"": ""3""
                 }",
-                flags: DependencyTreeFlags.DependencyFlags.Union(DependencyTreeFlags.GenericDependencyFlags),
+                flags: DependencyTreeFlags.DependencyFlags.Union(DependencyTreeFlags.GenericDependency),
                 icon: KnownMonikers.Path,
                 expandedIcon: KnownMonikers.PathIcon,
                 unresolvedIcon: KnownMonikers.PathListBox,
@@ -119,7 +119,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             Assert.True(dependency.Properties.ContainsKey("prop1"));
             Assert.Single(dependency.DependencyIDs);
             Assert.Equal("Tfm1\\xxx\\otherid", dependency.DependencyIDs[0]);
-            Assert.True(dependency.Flags.Contains(DependencyTreeFlags.ResolvedFlags));
+            Assert.True(dependency.Flags.Contains(DependencyTreeFlags.Resolved));
             Assert.True(dependency.Flags.Contains(DependencyTreeFlags.DependencyFlags));
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/ImplicitTopLevelDependenciesSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/ImplicitTopLevelDependenciesSnapshotFilterTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             TopLevel = true,
             Implicit = false,
             Resolved = true,
-            Flags = DependencyTreeFlags.GenericDependencyFlags,
+            Flags = DependencyTreeFlags.GenericDependency,
             OriginalItemSpec = ProjectItemSpec
         };
 
@@ -120,7 +120,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 TopLevel = true,
                 Implicit = false,
                 Resolved = true,
-                Flags = DependencyTreeFlags.GenericDependencyFlags,
+                Flags = DependencyTreeFlags.GenericDependency,
                 OriginalItemSpec = projectItemSpec,
                 IconSet = new DependencyIconSet(KnownMonikers.Reference, KnownMonikers.Reference, KnownMonikers.Reference, KnownMonikers.Reference)
             };

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/SdkAndPackagesDependenciesSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/SdkAndPackagesDependenciesSnapshotFilterTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             {
                 Id = "dependency1",
                 TopLevel = false,
-                Flags = DependencyTreeFlags.SdkSubTreeNodeFlags
+                Flags = DependencyTreeFlags.SdkDependency
             });
         }
 
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 Name = sdkName,
                 TopLevel = true,
                 Resolved = false,
-                Flags = DependencyTreeFlags.SdkSubTreeNodeFlags
+                Flags = DependencyTreeFlags.SdkDependency
             };
 
             var packageDependency = new TestDependency
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 Id = Dependency.GetID(targetFramework, PackageRuleHandler.ProviderTypeString, sdkName),
                 Resolved = true,
                 DependencyIDs = dependencyIDs,
-                Flags = DependencyTreeFlags.PackageNodeFlags
+                Flags = DependencyTreeFlags.NuGetPackageDependency
             };
 
             var worldBuilder = new IDependency[] { sdkDependency, packageDependency }.ToImmutableDictionary(d => d.Id).ToBuilder();
@@ -91,14 +91,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 Name = sdkName,
                 TopLevel = false,
                 Resolved = true,
-                Flags = DependencyTreeFlags.SdkSubTreeNodeFlags
+                Flags = DependencyTreeFlags.SdkDependency
             };
 
             var packageDependency = new TestDependency
             {
                 Id = Dependency.GetID(targetFramework, PackageRuleHandler.ProviderTypeString, sdkName),
                 Resolved = false,
-                Flags = DependencyTreeFlags.PackageNodeFlags
+                Flags = DependencyTreeFlags.NuGetPackageDependency
             };
 
             var worldBuilder = new IDependency[] { sdkDependency, packageDependency }.ToImmutableDictionary(d => d.Id).ToBuilder();
@@ -135,14 +135,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 Id = Dependency.GetID(targetFramework, SdkRuleHandler.ProviderTypeString, packageName),
                 TopLevel = false,
                 Resolved = true,
-                Flags = DependencyTreeFlags.PackageNodeFlags.Union(DependencyTreeFlags.UnresolvedFlags) // to see if unresolved is fixed
+                Flags = DependencyTreeFlags.NuGetPackageDependency.Union(DependencyTreeFlags.Unresolved) // to see if unresolved is fixed
             };
 
             var packageDependency = new TestDependency
             {
                 Id = "packageId",
                 Name = packageName,
-                Flags = DependencyTreeFlags.PackageNodeFlags,
+                Flags = DependencyTreeFlags.NuGetPackageDependency,
                 TopLevel = true,
                 Resolved = true,
                 DependencyIDs = dependencyIDs
@@ -186,14 +186,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 Id = Dependency.GetID(targetFramework, SdkRuleHandler.ProviderTypeString, packageName),
                 TopLevel = false,
                 Resolved = true,
-                Flags = DependencyTreeFlags.SdkSubTreeNodeFlags.Union(DependencyTreeFlags.ResolvedFlags)
+                Flags = DependencyTreeFlags.SdkDependency.Union(DependencyTreeFlags.Resolved)
             };
 
             var packageDependency = new TestDependency
             {
                 Id = "packageId",
                 Name = packageName,
-                Flags = DependencyTreeFlags.PackageNodeFlags,
+                Flags = DependencyTreeFlags.NuGetPackageDependency,
                 TopLevel = true,
                 Resolved = true
             };

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnsupportedProjectsSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnsupportedProjectsSnapshotFilterTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 Id = "dependency1",
                 TopLevel = true,
                 Resolved = true,
-                Flags = DependencyTreeFlags.ProjectNodeFlags
+                Flags = DependencyTreeFlags.ProjectDependency
             };
 
             AssertNoChange(new TestDependency
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             AssertNoChange(new TestDependency
             {
                 ClonePropertiesFrom = acceptable,
-                Flags = DependencyTreeFlags.ProjectNodeFlags.Union(DependencyTreeFlags.SharedProjectFlags)
+                Flags = DependencyTreeFlags.ProjectDependency.Union(DependencyTreeFlags.SharedProjectFlags)
             });
 
             return;
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 Id = "dependency1",
                 TopLevel = true,
                 Resolved = true,
-                Flags = DependencyTreeFlags.ProjectNodeFlags.Union(DependencyTreeFlags.ResolvedFlags),
+                Flags = DependencyTreeFlags.ProjectDependency.Union(DependencyTreeFlags.Resolved),
                 TargetFramework = targetFramework,
                 FullPath = projectPath
             };
@@ -129,7 +129,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 Id = "dependency1",
                 TopLevel = true,
                 Resolved = true,
-                Flags = DependencyTreeFlags.ProjectNodeFlags.Union(DependencyTreeFlags.ResolvedFlags),
+                Flags = DependencyTreeFlags.ProjectDependency.Union(DependencyTreeFlags.Resolved),
                 FullPath = projectPath
             };
 
@@ -171,7 +171,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 Id = "dependency1",
                 TopLevel = true,
                 Resolved = true,
-                Flags = DependencyTreeFlags.ProjectNodeFlags.Union(DependencyTreeFlags.ResolvedFlags),
+                Flags = DependencyTreeFlags.ProjectDependency.Union(DependencyTreeFlags.Resolved),
                 FullPath = projectPath,
                 TargetFramework = targetFramework
             };

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/DependenciesTreeViewProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/DependenciesTreeViewProviderTests.cs
@@ -181,7 +181,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.TreeView
                                 Caption = "DependencyExisting",
                                 FilePath = "tfm1\\yyy\\dependencyExisting",
                                 CustomTag = "ShouldBeCleanedSinceNodeWillBeRecreated",
-                                Flags = DependencyTreeFlags.UnresolvedFlags
+                                Flags = DependencyTreeFlags.Unresolved
                             }
                         }
                     }
@@ -242,7 +242,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.TreeView
                                 Caption = "DependencyExisting",
                                 FilePath = "tfm1\\yyy\\dependencyExisting",
                                 CustomTag = "ShouldBeCleanedSinceNodeWillBeRecreated",
-                                Flags = DependencyTreeFlags.ResolvedFlags
+                                Flags = DependencyTreeFlags.Resolved
                             }
                         }
                     }
@@ -302,7 +302,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.TreeView
                             {
                                 Caption = "DependencyExisting",
                                 FilePath = "tfm1\\yyy\\dependencyExisting",
-                                Flags = DependencyTreeFlags.ResolvedFlags
+                                Flags = DependencyTreeFlags.Resolved
                             }
                         }
                     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
@@ -28,9 +28,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
 {
     /// <summary>
     /// Provides actual dependencies nodes under Dependencies\[DependencyType]\[TopLevel]\[....] sub nodes. 
-    /// Note: when dependency has <see cref="ProjectTreeFlags.Common.BrokenReference"/> flag,
-    /// <see cref="IGraphProvider"/> API are not called for that node.
     /// </summary>
+    /// <remarks>
+    /// When a dependency has flag <see cref="ProjectTreeFlags.Common.BrokenReference"/>,
+    /// <see cref="IGraphProvider"/> APIs are not called for that node.
+    /// </remarks>
     [Export(typeof(DependenciesGraphProvider))]
     [Export(typeof(IDependenciesGraphBuilder))]
     [AppliesTo(ProjectCapability.DependenciesTree)]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/PackageGraphViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/PackageGraphViewProvider.cs
@@ -57,7 +57,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
                     continue;
                 }
 
-                if (childDependency.Flags.Contains(DependencyTreeFlags.FxAssemblyProjectFlags))
+                if (childDependency.Flags.Contains(DependencyTreeFlags.FxAssemblyDependency))
                 {
                     fxAssembliesChildren.Add(childDependency);
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/ProjectGraphViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/ViewProviders/ProjectGraphViewProvider.cs
@@ -126,7 +126,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.V
         {
             topLevelDependencyMatches = new HashSet<IDependency>();
 
-            if (!topLevelDependency.Flags.Contains(DependencyTreeFlags.ProjectNodeFlags))
+            if (!topLevelDependency.Flags.Contains(DependencyTreeFlags.ProjectDependency))
             {
                 return false;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
@@ -258,8 +258,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 if (dependencyNode != null
                     && dependency.Flags.Contains(DependencyTreeFlags.SupportsHierarchy))
                 {
-                    if ((dependency.Resolved && dependencyNode.Flags.Contains(DependencyTreeFlags.UnresolvedFlags))
-                        || (!dependency.Resolved && dependencyNode.Flags.Contains(DependencyTreeFlags.ResolvedFlags)))
+                    if ((dependency.Resolved && dependencyNode.Flags.Contains(DependencyTreeFlags.Unresolved))
+                        || (!dependency.Resolved && dependencyNode.Flags.Contains(DependencyTreeFlags.Resolved)))
                     {
                         // when transition from unresolved to resolved or vise versa - remove old node
                         // and re-add new  one to allow GraphProvider to recalculate children

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
@@ -269,7 +269,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     }
                 }
 
-                dependencyNode = await CreateOrUpdateNodeAsync(dependencyNode, dependency, targetedSnapshot, isActiveTarget);
+                // NOTE this project system supports multiple implicit configuration dimensions (such as target framework)
+                // which is a concept not modelled by DTE/VSLangProj. In order to produce a sensible view of the project
+                // via automation, we expose only the active target framework at any given time.
+                //
+                // This is achieved by using IProjectItemTree for active target framework items, and IProjectTree for inactive
+                // target frameworks. CPS only creates automation objects for items with "Reference" flag if they implement
+                // IProjectItemTree. See SimpleItemNode.Initialize (in CPS) for details.
+
+                dependencyNode = await CreateOrUpdateNodeAsync(
+                    dependencyNode,
+                    dependency,
+                    targetedSnapshot,
+                    isProjectItem: isActiveTarget);
 
                 currentNodes?.Add(dependencyNode);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependencyTreeFlags.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependencyTreeFlags.cs
@@ -7,6 +7,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     /// <summary>
     /// Cached immutable instances of <see cref="ProjectTreeFlags"/> used by nodes in the dependencies tree.
     /// </summary>
+    /// <remarks>
+    /// Members having names ending in <c>Flags</c> are aggregates, containing multiple flags. All others are singular.
+    /// </remarks>
     public static class DependencyTreeFlags
     {
         internal static readonly ProjectTreeFlags DependenciesRootNodeFlags
@@ -36,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         internal static readonly ProjectTreeFlags ResolvedReferenceFlags
                 = BaseReferenceFlags.Add(ProjectTreeFlags.Common.ResolvedReference);
 
-        internal static readonly ProjectTreeFlags GenericDependencyFlags = ProjectTreeFlags.Create("GenericDependency");
+        internal static readonly ProjectTreeFlags GenericDependency = ProjectTreeFlags.Create("GenericDependency");
 
         public static readonly ProjectTreeFlags SupportsRemove = ProjectTreeFlags.Create("SupportsRemove");
 
@@ -61,49 +64,50 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                                   .Union(SupportsRuleProperties)
                                   .Union(SupportsRemove);
 
-        internal static readonly ProjectTreeFlags UnresolvedFlags = ProjectTreeFlags.Create("Unresolved");
-        internal static readonly ProjectTreeFlags ResolvedFlags = ProjectTreeFlags.Create("Resolved");
+        internal static readonly ProjectTreeFlags Unresolved = ProjectTreeFlags.Create("Unresolved");
+        internal static readonly ProjectTreeFlags Resolved = ProjectTreeFlags.Create("Resolved");
 
-        public static readonly ProjectTreeFlags UnresolvedDependencyFlags = UnresolvedFlags.Union(DependencyFlags);
-        public static readonly ProjectTreeFlags ResolvedDependencyFlags = ResolvedFlags.Union(DependencyFlags);
+        public static readonly ProjectTreeFlags UnresolvedDependencyFlags = Unresolved.Union(DependencyFlags);
+        public static readonly ProjectTreeFlags ResolvedDependencyFlags = Resolved.Union(DependencyFlags);
 
         internal static readonly ProjectTreeFlags GenericUnresolvedDependencyFlags
                 = UnresolvedDependencyFlags.Union(UnresolvedReferenceFlags)
-                                           .Union(GenericDependencyFlags);
+                                           .Union(GenericDependency);
 
         internal static readonly ProjectTreeFlags GenericResolvedDependencyFlags
                 = ResolvedDependencyFlags.Union(ResolvedReferenceFlags)
-                                         .Union(GenericDependencyFlags);
+                                         .Union(GenericDependency);
 
-        internal static readonly ProjectTreeFlags TargetNodeFlags = ProjectTreeFlags.Create("TargetNode");
-        internal static readonly ProjectTreeFlags SubTreeRootNodeFlags = ProjectTreeFlags.Create("SubTreeRootNode");
+        internal static readonly ProjectTreeFlags TargetNode = ProjectTreeFlags.Create("TargetNode");
+        internal static readonly ProjectTreeFlags SubTreeRootNode = ProjectTreeFlags.Create("SubTreeRootNode");
 
-        internal static readonly ProjectTreeFlags AnalyzerSubTreeRootNodeFlags = ProjectTreeFlags.Create("AnalyzerSubTreeRootNode");
-        internal static readonly ProjectTreeFlags AnalyzerSubTreeNodeFlags = ProjectTreeFlags.Create("AnalyzerDependency");
+        internal static readonly ProjectTreeFlags AnalyzerSubTreeRootNode = ProjectTreeFlags.Create("AnalyzerSubTreeRootNode");
+        internal static readonly ProjectTreeFlags AnalyzerDependency = ProjectTreeFlags.Create("AnalyzerDependency");
 
-        internal static readonly ProjectTreeFlags AssemblySubTreeRootNodeFlags = ProjectTreeFlags.Create("AssemblySubTreeRootNode");
-        internal static readonly ProjectTreeFlags AssemblySubTreeNodeFlags = ProjectTreeFlags.Create("AssemblyDependency");
+        internal static readonly ProjectTreeFlags AssemblySubTreeRootNode = ProjectTreeFlags.Create("AssemblySubTreeRootNode");
+        internal static readonly ProjectTreeFlags AssemblyDependency = ProjectTreeFlags.Create("AssemblyDependency");
 
-        internal static readonly ProjectTreeFlags ComSubTreeRootNodeFlags = ProjectTreeFlags.Create("ComSubTreeRootNode");
-        internal static readonly ProjectTreeFlags ComSubTreeNodeFlags = ProjectTreeFlags.Create("ComDependency");
+        internal static readonly ProjectTreeFlags ComSubTreeRootNode = ProjectTreeFlags.Create("ComSubTreeRootNode");
+        internal static readonly ProjectTreeFlags ComDependency = ProjectTreeFlags.Create("ComDependency");
 
-        internal static readonly ProjectTreeFlags NuGetSubTreeRootNodeFlags = ProjectTreeFlags.Create("NuGetSubTreeRootNode");
-        internal static readonly ProjectTreeFlags NuGetSubTreeNodeFlags = ProjectTreeFlags.Create("NuGetDependency");
-        internal static readonly ProjectTreeFlags PackageNodeFlags = ProjectTreeFlags.Create("NuGetPackageDependency");
-        internal static readonly ProjectTreeFlags FrameworkAssembliesNodeFlags = ProjectTreeFlags.Create("FrameworkAssembliesNode");
-        internal static readonly ProjectTreeFlags FxAssemblyProjectFlags = ProjectTreeFlags.Create("FxAssemblyDependency");
+        internal static readonly ProjectTreeFlags NuGetSubTreeRootNode = ProjectTreeFlags.Create("NuGetSubTreeRootNode");
+        internal static readonly ProjectTreeFlags NuGetDependency = ProjectTreeFlags.Create("NuGetDependency");
+        internal static readonly ProjectTreeFlags NuGetPackageDependency = ProjectTreeFlags.Create("NuGetPackageDependency");
+        internal static readonly ProjectTreeFlags FrameworkAssembliesNode = ProjectTreeFlags.Create("FrameworkAssembliesNode");
+        internal static readonly ProjectTreeFlags FxAssemblyDependency = ProjectTreeFlags.Create("FxAssemblyDependency");
 
-        internal static readonly ProjectTreeFlags ProjectSubTreeRootNodeFlags = ProjectTreeFlags.Create("ProjectSubTreeRootNode");
-        internal static readonly ProjectTreeFlags ProjectNodeFlags = ProjectTreeFlags.Create("ProjectDependency");
+        internal static readonly ProjectTreeFlags ProjectSubTreeRootNode = ProjectTreeFlags.Create("ProjectSubTreeRootNode");
+        internal static readonly ProjectTreeFlags ProjectDependency = ProjectTreeFlags.Create("ProjectDependency");
+
         internal static readonly ProjectTreeFlags SharedProjectFlags
             = ProjectTreeFlags.Create("SharedProjectDependency")
                               .Add(ProjectTreeFlags.Common.SharedProjectImportReference);
 
-        internal static readonly ProjectTreeFlags DiagnosticNodeFlags = ProjectTreeFlags.Create("Diagnostic");
-        internal static readonly ProjectTreeFlags DiagnosticErrorNodeFlags = ProjectTreeFlags.Create("ErrorDiagnostic");
-        internal static readonly ProjectTreeFlags DiagnosticWarningNodeFlags = ProjectTreeFlags.Create("WarningDiagnostic");
+        internal static readonly ProjectTreeFlags Diagnostic = ProjectTreeFlags.Create("Diagnostic");
+        internal static readonly ProjectTreeFlags ErrorDiagnostic = ProjectTreeFlags.Create("ErrorDiagnostic");
+        internal static readonly ProjectTreeFlags WarningDiagnostic = ProjectTreeFlags.Create("WarningDiagnostic");
 
-        internal static readonly ProjectTreeFlags SdkSubTreeRootNodeFlags = ProjectTreeFlags.Create("SdkSubTreeRootNode");
-        internal static readonly ProjectTreeFlags SdkSubTreeNodeFlags = ProjectTreeFlags.Create("SdkDependency");
+        internal static readonly ProjectTreeFlags SdkSubTreeRootNode = ProjectTreeFlags.Create("SdkSubTreeRootNode");
+        internal static readonly ProjectTreeFlags SdkDependency = ProjectTreeFlags.Create("SdkDependency");
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependencyTreeFlags.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependencyTreeFlags.cs
@@ -4,6 +4,9 @@
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
+    /// <summary>
+    /// Cached immutable instances of <see cref="ProjectTreeFlags"/> used by nodes in the dependencies tree.
+    /// </summary>
     public static class DependencyTreeFlags
     {
         internal static readonly ProjectTreeFlags DependenciesRootNodeFlags
@@ -18,10 +21,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 = ProjectTreeFlags.Create(ProjectTreeFlags.Common.Reference);
 
         /// <summary>
-        /// The set of flags to assign to unresolvable Reference nodes.
-        /// Note: when dependency has ProjectTreeFlags.Common.BrokenReference flag, GraphProvider API are not 
-        /// called for that node.
+        /// The set of flags to assign to unresolved Reference nodes.
         /// </summary>
+        /// <remarks>
+        /// Contains <see cref="ProjectTreeFlags.Common.BrokenReference"/> which stops
+        /// <c>IGraphProvider</c> APIs from being called for that node.
+        /// </remarks>
         internal static readonly ProjectTreeFlags UnresolvedReferenceFlags
                 = BaseReferenceFlags.Add(ProjectTreeFlags.Common.BrokenReference);
 
@@ -46,7 +51,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
         /// <summary>
         /// These public flags below are to be used with all nodes: default project item
-        /// nodes and all custom nodes provided by third party IProjectDependenciesSubTreeProvider
+        /// nodes and all custom nodes provided by third party <see cref="IProjectDependenciesSubTreeProvider"/>
         /// implementations. This is to have a way to distinguish dependency nodes in general.
         /// </summary>
         public static readonly ProjectTreeFlags DependencyFlags

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/AnalyzerDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/AnalyzerDependencyModel.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
     internal class AnalyzerDependencyModel : DependencyModel
     {
-        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(add: DependencyTreeFlags.AnalyzerSubTreeNodeFlags);
+        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(add: DependencyTreeFlags.AnalyzerDependency);
 
         private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
             icon: KnownMonikers.CodeInformation,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/AssemblyDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/AssemblyDependencyModel.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
     internal class AssemblyDependencyModel : DependencyModel
     {
-        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(add: DependencyTreeFlags.AssemblySubTreeNodeFlags);
+        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(add: DependencyTreeFlags.AssemblyDependency);
 
         private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
             icon: KnownMonikers.Reference,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/ComDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/ComDependencyModel.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
     internal class ComDependencyModel : DependencyModel
     {
-        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(add: DependencyTreeFlags.ComSubTreeNodeFlags);
+        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(add: DependencyTreeFlags.ComDependency);
 
         private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
             icon: ManagedImageMonikers.Component,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/DiagnosticDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/DiagnosticDependencyModel.cs
@@ -19,14 +19,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
     internal class DiagnosticDependencyModel : DependencyModel
     {
         private static readonly ProjectTreeFlags s_errorFlags = new DependencyFlagCache(
-            add: DependencyTreeFlags.NuGetSubTreeNodeFlags +
-                 DependencyTreeFlags.DiagnosticNodeFlags +
-                 DependencyTreeFlags.DiagnosticErrorNodeFlags).Get(isResolved: false, isImplicit: false);
+            add: DependencyTreeFlags.NuGetDependency +
+                 DependencyTreeFlags.Diagnostic +
+                 DependencyTreeFlags.ErrorDiagnostic).Get(isResolved: false, isImplicit: false);
 
         private static readonly ProjectTreeFlags s_warningFlags = new DependencyFlagCache(
-            add: DependencyTreeFlags.NuGetSubTreeNodeFlags +
-                 DependencyTreeFlags.DiagnosticNodeFlags +
-                 DependencyTreeFlags.DiagnosticWarningNodeFlags).Get(isResolved: false, isImplicit: false);
+            add: DependencyTreeFlags.NuGetDependency +
+                 DependencyTreeFlags.Diagnostic +
+                 DependencyTreeFlags.WarningDiagnostic).Get(isResolved: false, isImplicit: false);
 
         private static readonly DependencyIconSet s_errorIconSet = new DependencyIconSet(
             icon: ManagedImageMonikers.ErrorSmall,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageAnalyzerAssemblyDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageAnalyzerAssemblyDependencyModel.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
     internal class PackageAnalyzerAssemblyDependencyModel : DependencyModel
     {
-        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(add: DependencyTreeFlags.NuGetSubTreeNodeFlags);
+        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(add: DependencyTreeFlags.NuGetDependency);
 
         private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
             icon: KnownMonikers.CodeInformation,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageAssemblyDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageAssemblyDependencyModel.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
     internal class PackageAssemblyDependencyModel : DependencyModel
     {
-        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(add: DependencyTreeFlags.NuGetSubTreeNodeFlags);
+        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(add: DependencyTreeFlags.NuGetDependency);
 
         private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
             icon: KnownMonikers.Reference,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageDependencyModel.cs
@@ -13,8 +13,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
     internal class PackageDependencyModel : DependencyModel
     {
         private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(
-            add: DependencyTreeFlags.NuGetSubTreeNodeFlags +
-                 DependencyTreeFlags.PackageNodeFlags +
+            add: DependencyTreeFlags.NuGetDependency +
+                 DependencyTreeFlags.NuGetPackageDependency +
                  DependencyTreeFlags.SupportsHierarchy);
 
         private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageFrameworkAssembliesViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageFrameworkAssembliesViewModel.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         public int Priority => Dependency.FrameworkAssemblyNodePriority;
         public ImageMoniker Icon => RegularIcon;
         public ImageMoniker ExpandedIcon => RegularIcon;
-        public ProjectTreeFlags Flags => DependencyTreeFlags.FrameworkAssembliesNodeFlags;
+        public ProjectTreeFlags Flags => DependencyTreeFlags.FrameworkAssembliesNode;
         public IDependency? OriginalModel => null;
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageUnknownDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/PackageUnknownDependencyModel.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 {
     internal class PackageUnknownDependencyModel : DependencyModel
     {
-        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(add: DependencyTreeFlags.NuGetSubTreeNodeFlags);
+        private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(add: DependencyTreeFlags.NuGetDependency);
 
         private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(
             icon: KnownMonikers.QuestionMark,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/ProjectDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/ProjectDependencyModel.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
     internal class ProjectDependencyModel : DependencyModel
     {
         private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(
-            add: DependencyTreeFlags.ProjectNodeFlags +
+            add: DependencyTreeFlags.ProjectDependency +
                  DependencyTreeFlags.SupportsHierarchy);
 
         private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/SdkDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/SdkDependencyModel.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
     internal class SdkDependencyModel : DependencyModel
     {
         private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(
-            add: DependencyTreeFlags.SdkSubTreeNodeFlags +
+            add: DependencyTreeFlags.SdkDependency +
                  DependencyTreeFlags.SupportsHierarchy);
 
         private static readonly DependencyIconSet s_iconSet = new DependencyIconSet(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/SharedProjectDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/SharedProjectDependencyModel.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
     internal class SharedProjectDependencyModel : DependencyModel
     {
         private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(
-            add: DependencyTreeFlags.ProjectNodeFlags +
+            add: DependencyTreeFlags.ProjectDependency +
                  DependencyTreeFlags.SharedProjectFlags,
             remove: DependencyTreeFlags.SupportsRuleProperties);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/SubTreeRootDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/SubTreeRootDependencyModel.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
     {
         private static readonly DependencyFlagCache s_flagCache = new DependencyFlagCache(
             add: DependencyTreeFlags.DependencyFlags +
-                 DependencyTreeFlags.SubTreeRootNodeFlags,
+                 DependencyTreeFlags.SubTreeRootNode,
             remove: DependencyTreeFlags.SupportsRuleProperties +
                     DependencyTreeFlags.SupportsRemove);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/TargetDependencyViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/TargetDependencyViewModel.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
         public TargetDependencyViewModel(ITargetedDependenciesSnapshot snapshot)
         {
             Caption = snapshot.TargetFramework.FriendlyName;
-            Flags = DependencyTreeFlags.TargetNodeFlags.Add($"$TFM:{snapshot.TargetFramework.FullName}");
+            Flags = DependencyTreeFlags.TargetNode.Add($"$TFM:{snapshot.TargetFramework.FullName}");
             _hasUnresolvedDependency = snapshot.HasUnresolvedDependency;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -82,23 +82,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
             targetChanged |= RemoveTargetFrameworksWithNoDependencies();
 
-            ITargetFramework activeTarget = activeTargetFramework ?? previousSnapshot.ActiveTarget;
+            activeTargetFramework ??= previousSnapshot.ActiveTarget;
 
             if (targetChanged)
             {
                 // Targets have changed
                 return new DependenciesSnapshot(
                     previousSnapshot.ProjectPath,
-                    activeTarget,
+                    activeTargetFramework,
                     builder.ToImmutable());
             }
 
-            if (!activeTarget.Equals(previousSnapshot.ActiveTarget))
+            if (!activeTargetFramework.Equals(previousSnapshot.ActiveTarget))
             {
                 // The active target changed
                 return new DependenciesSnapshot(
                     previousSnapshot.ProjectPath,
-                    activeTarget,
+                    activeTargetFramework,
                     previousSnapshot.Targets);
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Dependency.cs
@@ -61,16 +61,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             // in the tree to avoid flicks).
             if (Resolved)
             {
-                if (!Flags.Contains(DependencyTreeFlags.ResolvedFlags))
+                if (!Flags.Contains(DependencyTreeFlags.Resolved))
                 {
-                    Flags += DependencyTreeFlags.ResolvedFlags;
+                    Flags += DependencyTreeFlags.Resolved;
                 }
             }
             else
             {
-                if (!Flags.Contains(DependencyTreeFlags.UnresolvedFlags))
+                if (!Flags.Contains(DependencyTreeFlags.Unresolved))
                 {
-                    Flags += DependencyTreeFlags.UnresolvedFlags;
+                    Flags += DependencyTreeFlags.Unresolved;
                 }
             }
 
@@ -206,7 +206,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 // Thus always set predefined itemType for all custom nodes.
                 // TODO: generate specific xaml rule for generic Dependency nodes
                 // tracking issue: https://github.com/dotnet/project-system/issues/1102
-                bool isGenericNodeType = Flags.Contains(DependencyTreeFlags.GenericDependencyFlags);
+                bool isGenericNodeType = Flags.Contains(DependencyTreeFlags.GenericDependency);
                 return isGenericNodeType ? _schemaItemType : Folder.PrimaryDataSourceItemType;
             }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/ImplicitTopLevelDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/ImplicitTopLevelDependenciesSnapshotFilter.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             if (!dependency.TopLevel
                 || dependency.Implicit
                 || !dependency.Resolved
-                || !dependency.Flags.Contains(DependencyTreeFlags.GenericDependencyFlags)
+                || !dependency.Flags.Contains(DependencyTreeFlags.GenericDependency)
                 || dependency.Flags.Contains(DependencyTreeFlags.SharedProjectFlags))
             {
                 context.Accept(dependency);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/SdkAndPackagesDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/SdkAndPackagesDependenciesSnapshotFilter.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
                 return;
             }
 
-            if (dependency.Flags.Contains(DependencyTreeFlags.SdkSubTreeNodeFlags))
+            if (dependency.Flags.Contains(DependencyTreeFlags.SdkDependency))
             {
                 // This is an SDK dependency.
                 //
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
                     return;
                 }
             }
-            else if (dependency.Flags.Contains(DependencyTreeFlags.PackageNodeFlags) && dependency.Resolved)
+            else if (dependency.Flags.Contains(DependencyTreeFlags.NuGetPackageDependency) && dependency.Resolved)
             {
                 // This is a resolved package dependency.
                 //
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
         {
             if (dependency.TopLevel &&
                 dependency.Resolved &&
-                dependency.Flags.Contains(DependencyTreeFlags.PackageNodeFlags))
+                dependency.Flags.Contains(DependencyTreeFlags.NuGetPackageDependency))
             {
                 // This is a package dependency.
                 //

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/UnsupportedProjectsSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/UnsupportedProjectsSnapshotFilter.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
         {
             if (dependency.TopLevel
                 && dependency.Resolved
-                && dependency.Flags.Contains(DependencyTreeFlags.ProjectNodeFlags)
+                && dependency.Flags.Contains(DependencyTreeFlags.ProjectDependency)
                 && !dependency.Flags.Contains(DependencyTreeFlags.SharedProjectFlags))
             {
                 ITargetedDependenciesSnapshot? snapshot = _aggregateSnapshotProvider.GetSnapshot(dependency);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/IDependencyExtensions.cs
@@ -134,15 +134,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         public static ProjectTreeFlags GetResolvedFlags(this IDependency dependency)
         {
             return dependency.Flags
-                .Union(DependencyTreeFlags.ResolvedFlags)
-                .Except(DependencyTreeFlags.UnresolvedFlags);
+                .Union(DependencyTreeFlags.Resolved)
+                .Except(DependencyTreeFlags.Unresolved);
         }
 
         public static ProjectTreeFlags GetUnresolvedFlags(this IDependency dependency)
         {
             return dependency.Flags
-                .Union(DependencyTreeFlags.UnresolvedFlags)
-                .Except(DependencyTreeFlags.ResolvedFlags);
+                .Union(DependencyTreeFlags.Unresolved)
+                .Except(DependencyTreeFlags.Resolved);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/AnalyzerRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/AnalyzerRuleHandler.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             ProviderTypeString,
             Resources.AnalyzersNodeName,
             s_iconSet,
-            DependencyTreeFlags.AnalyzerSubTreeRootNodeFlags);
+            DependencyTreeFlags.AnalyzerSubTreeRootNode);
 
         public AnalyzerRuleHandler()
             : base(AnalyzerReference.SchemaName, ResolvedAnalyzerReference.SchemaName)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/AssemblyRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/AssemblyRuleHandler.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             ProviderTypeString,
             Resources.AssembliesNodeName,
             s_iconSet,
-            DependencyTreeFlags.AssemblySubTreeRootNodeFlags);
+            DependencyTreeFlags.AssemblySubTreeRootNode);
 
         public AssemblyRuleHandler()
             : base(AssemblyReference.SchemaName, ResolvedAssemblyReference.SchemaName)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/ComRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/ComRuleHandler.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             ProviderTypeString,
             Resources.ComNodeName,
             s_iconSet,
-            DependencyTreeFlags.ComSubTreeRootNodeFlags);
+            DependencyTreeFlags.ComSubTreeRootNode);
 
         public ComRuleHandler()
             : base(ComReference.SchemaName, ResolvedCOMReference.SchemaName)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             ProviderTypeString,
             Resources.NuGetPackagesNodeName,
             s_iconSet,
-            DependencyTreeFlags.NuGetSubTreeRootNodeFlags);
+            DependencyTreeFlags.NuGetSubTreeRootNode);
 
         [ImportingConstructor]
         public PackageRuleHandler(ITargetFrameworkProvider targetFrameworkProvider)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/ProjectRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/ProjectRuleHandler.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             ProviderTypeString,
             Resources.ProjectsNodeName,
             s_iconSet,
-            DependencyTreeFlags.ProjectSubTreeRootNodeFlags);
+            DependencyTreeFlags.ProjectSubTreeRootNode);
 
         public override string ProviderType => ProviderTypeString;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/SdkRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/SdkRuleHandler.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             ProviderTypeString,
             Resources.SdkNodeName,
             s_iconSet,
-            DependencyTreeFlags.SdkSubTreeRootNodeFlags);
+            DependencyTreeFlags.SdkSubTreeRootNode);
 
         public SdkRuleHandler()
             : base(SdkReference.SchemaName, ResolvedSdkReference.SchemaName)


### PR DESCRIPTION
Makes singular member names match the actual flag value. This makes it easier to debug and learn the actual flags used in the system.

Leaves aggregate members ending with "Flags".

I've been confused by this a few times now while debugging so wanted to fix it. There's no public API change here.

Also add some documentation around the use of tree flags.

Probably easiest to review a84607dff9de5d7b1c1e25a6de9901911b0a0626, ce5e48b215caa7b52eb00fd2942bd2944d791fea and f38732c1612e690c5a69e8d755eb75b9776d03aa separately. I would have made this two small PRs but for a conflict.