### PR TITLE
Use JoinableTaskContext instead of ThreadHelper

### DIFF
--- a/src/BannedSymbols.txt
+++ b/src/BannedSymbols.txt
@@ -66,3 +66,5 @@ M:Microsoft.VisualStudio.VSConstants.E_NOINTERFACE;Use HResult.NoInterface
 M:Microsoft.VisualStudio.VSConstants.E_UNEXPECTED;Use HResult.Unexpected
 M:Microsoft.VisualStudio.OLE.Interop.Constants.OLECMDERR_E_NOTSUPPORTED;Use HResult.Ole.Cmd.NotSupported
 M:Microsoft.VisualStudio.OLE.Interop.Constants.OLECMDERR_E_UNKNOWNGROUP;Use HResult.Ole.Cmd.UnknownGroup
+
+T:Microsoft.VisualStudio.Shell.ThreadHelper;Import JoinableTaskContext if inside a MEF component for unit testing purposes

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksDynamicMenuCommandTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksDynamicMenuCommandTests.cs
@@ -3,13 +3,14 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Threading.Tasks;
 
 using Microsoft.VisualStudio.ProjectSystem.Debug;
-
+using Microsoft.VisualStudio.Threading;
 using Moq;
 
 using Xunit;
+
+#pragma warning disable VSSDK005 // Avoid instantiating JoinableTaskContext
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 {
@@ -22,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
             startupHelper.Setup(x => x.GetExportFromDotNetStartupProjects<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
                          .Returns(ImmutableArray<IActiveDebugFrameworkServices>.Empty);
 
-            var command = new TestDebugFrameworksDynamicMenuCommand(startupHelper.Object);
+            var command = CreateInstance(startupHelper.Object);
             Assert.False(command.ExecCommand(0, EventArgs.Empty));
             startupHelper.Verify();
         }
@@ -46,7 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
             startupHelper.Setup(x => x.GetExportFromDotNetStartupProjects<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
                          .Returns(ImmutableArray.Create(activeDebugFrameworkSvcs.Object));
 
-            var command = new TestDebugFrameworksDynamicMenuCommand(startupHelper.Object);
+            var command = CreateInstance(startupHelper.Object);
             Assert.Equal(expected, command.ExecCommand(cmdIndex, EventArgs.Empty));
 
             startupHelper.Verify();
@@ -78,7 +79,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
             startupHelper.Setup(x => x.GetExportFromDotNetStartupProjects<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
                          .Returns(ImmutableArray.Create(activeDebugFrameworkSvcs1.Object, activeDebugFrameworkSvcs2.Object));
 
-            var command = new TestDebugFrameworksDynamicMenuCommand(startupHelper.Object);
+            var command = CreateInstance(startupHelper.Object);
             Assert.Equal(expected, command.ExecCommand(cmdIndex, EventArgs.Empty));
 
             startupHelper.Verify();
@@ -93,7 +94,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
             startupHelper.Setup(x => x.GetExportFromDotNetStartupProjects<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
                          .Returns(ImmutableArray<IActiveDebugFrameworkServices>.Empty);
 
-            var command = new TestDebugFrameworksDynamicMenuCommand(startupHelper.Object);
+            var command = CreateInstance(startupHelper.Object);
             Assert.False(command.QueryStatusCommand(0, EventArgs.Empty));
             startupHelper.Verify();
         }
@@ -107,7 +108,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
             startupHelper.Setup(x => x.GetExportFromDotNetStartupProjects<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
                          .Returns(ImmutableArray.Create(activeDebugFrameworkSvcs.Object));
 
-            var command = new TestDebugFrameworksDynamicMenuCommand(startupHelper.Object);
+            var command = CreateInstance(startupHelper.Object);
             Assert.True(command.QueryStatusCommand(0, EventArgs.Empty));
             Assert.False(command.Visible);
             Assert.Equal("", command.Text);
@@ -129,7 +130,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
             startupHelper.Setup(x => x.GetExportFromDotNetStartupProjects<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
                          .Returns(ImmutableArray.Create(activeDebugFrameworkSvcs.Object));
 
-            var command = new TestDebugFrameworksDynamicMenuCommand(startupHelper.Object);
+            var command = CreateInstance(startupHelper.Object);
             Assert.True(command.QueryStatusCommand(0, EventArgs.Empty));
             Assert.False(command.Visible);
             Assert.Equal("", command.Text);
@@ -157,7 +158,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
             startupHelper.Setup(x => x.GetExportFromDotNetStartupProjects<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
                          .Returns(ImmutableArray.Create(activeDebugFrameworkSvcs.Object));
 
-            var command = new TestDebugFrameworksDynamicMenuCommand(startupHelper.Object);
+            var command = CreateInstance(startupHelper.Object);
             Assert.True(command.QueryStatusCommand(cmdIndex, EventArgs.Empty));
             Assert.True(command.Visible);
             Assert.Equal(frameworks[cmdIndex], command.Text);
@@ -181,7 +182,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
             startupHelper.Setup(x => x.GetExportFromDotNetStartupProjects<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
                          .Returns(ImmutableArray.Create(activeDebugFrameworkSvcs1.Object, activeDebugFrameworkSvcs2.Object));
 
-            var command = new TestDebugFrameworksDynamicMenuCommand(startupHelper.Object);
+            var command = CreateInstance(startupHelper.Object);
             Assert.True(command.QueryStatusCommand(0, EventArgs.Empty));
             Assert.False(command.Visible);
             Assert.Equal("", command.Text);
@@ -208,7 +209,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
             startupHelper.Setup(x => x.GetExportFromDotNetStartupProjects<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
                          .Returns(ImmutableArray.Create(activeDebugFrameworkSvcs1.Object, activeDebugFrameworkSvcs2.Object));
 
-            var command = new TestDebugFrameworksDynamicMenuCommand(startupHelper.Object);
+            var command = CreateInstance(startupHelper.Object);
             Assert.True(command.QueryStatusCommand(0, EventArgs.Empty));
             Assert.False(command.Visible);
             Assert.Equal("", command.Text);
@@ -235,7 +236,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
             startupHelper.Setup(x => x.GetExportFromDotNetStartupProjects<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
                          .Returns(ImmutableArray.Create(activeDebugFrameworkSvcs1.Object, activeDebugFrameworkSvcs2.Object));
 
-            var command = new TestDebugFrameworksDynamicMenuCommand(startupHelper.Object);
+            var command = CreateInstance(startupHelper.Object);
             Assert.True(command.QueryStatusCommand(0, EventArgs.Empty));
             Assert.False(command.Visible);
             Assert.Equal("", command.Text);
@@ -262,7 +263,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
             startupHelper.Setup(x => x.GetExportFromDotNetStartupProjects<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
                          .Returns(ImmutableArray.Create(activeDebugFrameworkSvcs1.Object, activeDebugFrameworkSvcs2.Object));
 
-            var command = new TestDebugFrameworksDynamicMenuCommand(startupHelper.Object);
+            var command = CreateInstance(startupHelper.Object);
             Assert.True(command.QueryStatusCommand(0, EventArgs.Empty));
             Assert.False(command.Visible);
             Assert.Equal("", command.Text);
@@ -293,7 +294,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
             startupHelper.Setup(x => x.GetExportFromDotNetStartupProjects<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
                          .Returns(ImmutableArray.Create(activeDebugFrameworkSvcs1.Object, activeDebugFrameworkSvcs2.Object, activeDebugFrameworkSvcs3.Object));
 
-            var command = new TestDebugFrameworksDynamicMenuCommand(startupHelper.Object);
+            var command = CreateInstance(startupHelper.Object);
             Assert.True(command.QueryStatusCommand(0, EventArgs.Empty));
             Assert.False(command.Visible);
             Assert.Equal("", command.Text);
@@ -329,7 +330,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
             startupHelper.Setup(x => x.GetExportFromDotNetStartupProjects<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
                          .Returns(ImmutableArray.Create(activeDebugFrameworkSvcs1.Object, activeDebugFrameworkSvcs2.Object));
 
-            var command = new TestDebugFrameworksDynamicMenuCommand(startupHelper.Object);
+            var command = CreateInstance(startupHelper.Object);
             Assert.True(command.QueryStatusCommand(cmdIndex, EventArgs.Empty));
             Assert.True(command.Visible);
             Assert.Equal(frameworks1[cmdIndex], command.Text);
@@ -343,16 +344,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
             activeDebugFrameworkSvcs2.Verify();
         }
 
+        private static DebugFrameworksDynamicMenuCommand CreateInstance(IStartupProjectHelper startupProjectHelper)
+        {
+
+            return new DebugFrameworksDynamicMenuCommand(startupProjectHelper, new JoinableTaskContext());
+#pragma warning restore VSSDK005 // Avoid instantiating JoinableTaskContext
+        }
+
         private class TestDebugFrameworksDynamicMenuCommand : DebugFrameworksDynamicMenuCommand
         {
-            public TestDebugFrameworksDynamicMenuCommand(IStartupProjectHelper startupHelper)
-                : base(startupHelper)
+            public TestDebugFrameworksDynamicMenuCommand(IStartupProjectHelper startupHelper, JoinableTaskContext joinableTaskContext)
+                : base(startupHelper, joinableTaskContext)
             {
-            }
-
-            protected override void ExecuteSynchronously(Func<Task> asyncFunction)
-            {
-                asyncFunction.Invoke().Wait();
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
@@ -54,9 +54,9 @@ namespace Microsoft.VisualStudio.Packaging
 
         protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
+#pragma warning disable RS0030 // Do not used banned APIs
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
-#pragma warning disable RS0030 // Do not used banned APIs
             _projectSelectorService = await this.GetServiceAsync<SVsRegisterProjectTypes, IVsRegisterProjectSelector>();
 #pragma warning restore RS0030 // Do not used banned APIs
             Guid selectorGuid = typeof(FSharpProjectSelector).GUID;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/DebugFrameworksMenuTextUpdater.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/DebugFrameworksMenuTextUpdater.cs
@@ -120,7 +120,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         protected virtual void ExecuteSynchronously(Func<Task> asyncFunction)
         {
 #pragma warning disable VSTHRD102 // Only wrapped for test purposes
+#pragma warning disable RS0030 // Do not used banned APIs
             ThreadHelper.JoinableTaskFactory.Run(asyncFunction);
+#pragma warning restore RS0030 // Do not used banned APIs
 #pragma warning restore VSTHRD102
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphProvider.cs
@@ -15,7 +15,6 @@ using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.Actions;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
-using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
 
@@ -90,7 +89,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
         /// </summary>
         public void BeginGetGraphData(IGraphContext context)
         {
-            ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
+            JoinableFactory.RunAsync(async () =>
             {
                 try
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/UIThreadHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/UIThreadHelper.cs
@@ -22,7 +22,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
             {
                 try
                 {
+#pragma warning disable RS0030 // Do not used banned APIs
                     ThreadHelper.ThrowIfNotOnUIThread(memberName);
+#pragma warning restore RS0030 // Do not used banned APIs
                 }
                 catch
                 {


### PR DESCRIPTION
ThreadHelper is only initialized inside Visual Studio, move over to JoinableTaskContext which is its replacement for MEF components and is unit testable.