### PR TITLE
Enable WinForms designer to open

### DIFF
--- a/build/Packages.targets
+++ b/build/Packages.targets
@@ -93,8 +93,8 @@
     <PackageReference Update="Microsoft.Test.Apex.VisualStudio" Version="16.0.28117-pre" />
 
     <!-- CPS -->
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK" Version="16.1.163-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers" Version="16.1.163-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK" Version="16.2.133-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers" Version="16.2.133-pre" />
 
     <!-- Roslyn -->
     <PackageReference Update="Microsoft.VisualStudio.LanguageServices" Version="3.0.0" />
@@ -115,10 +115,10 @@
     <PackageReference Update="NuGet.VisualStudio" Version="5.1.0-rtm.5921" />
 
     <!-- MSBuild -->
-    <PackageReference Update="Microsoft.Build" Version="16.0.452"/>
-    <PackageReference Update="Microsoft.Build.Utilities.Core" Version="16.0.452"/>
-    <PackageReference Update="Microsoft.Build.Engine" Version="16.0.452"/>
-    <PackageReference Update="Microsoft.Build.Tasks.Core" Version="16.0.452"/>
+    <PackageReference Update="Microsoft.Build" Version="16.0.461"/>
+    <PackageReference Update="Microsoft.Build.Utilities.Core" Version="16.0.461"/>
+    <PackageReference Update="Microsoft.Build.Engine" Version="16.0.461"/>
+    <PackageReference Update="Microsoft.Build.Tasks.Core" Version="16.0.461"/>
 
     <!-- Libraries -->
     <PackageReference Update="Newtonsoft.Json" Version="9.0.1"/>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/OrderPrecedenceImportCollectionExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/OrderPrecedenceImportCollectionExtensions.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class OrderPrecedenceImportCollectionExtensions
+    {
+        public static void Add<T>(this OrderPrecedenceImportCollection<T, INamedExportMetadataView> collection, string name, T item)
+        {
+            var mock = new Mock<INamedExportMetadataView>();
+            mock.Setup(v => v.Name)
+                .Returns(name);
+
+            var result = new Lazy<T, INamedExportMetadataView>(() => item, mock.Object);
+
+            collection.Add(result);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IPhysicalProjectTreeFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IPhysicalProjectTreeFactory.cs
@@ -11,15 +11,18 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public static IPhysicalProjectTree Create(IProjectTreeProvider provider = null, IProjectTree currentTree = null, IProjectTreeService service = null)
         {
+            currentTree ??= ProjectTreeParser.Parse("Project");
+            provider ??= new ProjectTreeProvider();
+
             var mock = new Mock<IPhysicalProjectTree>();
             mock.Setup(t => t.TreeProvider)
-                .Returns(provider ?? IProjectTreeProviderFactory.Create());
+                .Returns(provider);
 
             mock.Setup(t => t.CurrentTree)
-                .Returns(currentTree ?? ProjectTreeParser.Parse("Project"));
+                .Returns(currentTree);
 
             mock.Setup(t => t.TreeService)
-                .Returns(service ?? IProjectTreeServiceFactory.Create());
+                .Returns(service ?? IProjectTreeServiceFactory.Create(currentTree, provider));
 
             return mock.Object;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectSystemOptionsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectSystemOptionsFactory.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 using Moq;
 
@@ -18,6 +20,24 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var mock = new Mock<IProjectSystemOptions>();
             mock.SetupGet(o => o.IsProjectOutputPaneEnabled)
                 .Returns(action);
+
+            return mock.Object;
+        }
+
+        public static IProjectSystemOptions ImplementGetUseDesignerByDefaultAsync(Func<string, bool, CancellationToken, bool> result)
+        {
+            var mock = new Mock<IProjectSystemOptions>();
+            mock.Setup(o => o.GetUseDesignerByDefaultAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(result);
+
+            return mock.Object;
+        }
+
+        public static IProjectSystemOptions ImplementSetUseDesignerByDefaultAsync(Func<string, bool, CancellationToken, Task> result)
+        {
+            var mock = new Mock<IProjectSystemOptions>();
+            mock.Setup(o => o.SetUseDesignerByDefaultAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .Returns(result);
 
             return mock.Object;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectTreeServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectTreeServiceFactory.cs
@@ -1,18 +1,24 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-
+using System.Threading;
 using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal static class IProjectTreeServiceFactory
     {
-        public static IProjectTreeService Create(IProjectTree tree)
+        public static IProjectTreeService Create(IProjectTree tree, IProjectTreeProvider treeProvider = null)
         {
             var mock = new Mock<IProjectTreeService>();
 
-            var treeState = IProjectTreeServiceStateFactory.ImplementTree(() => tree, () => IProjectTreeProviderFactory.Create());
+            var treeState = IProjectTreeServiceStateFactory.ImplementTree(() => tree, () => treeProvider ?? IProjectTreeProviderFactory.Create());
+
+            mock.Setup(s => s.PublishAnyNonLoadingTreeAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(treeState);
+
+            mock.Setup(s => s.PublishAnyNonNullTreeAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(treeState);
 
             mock.SetupGet(s => s.CurrentTree)
                 .Returns(treeState);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectSpecificEditorProviderFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectSpecificEditorProviderFactory.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Moq;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal static class IProjectSpecificEditorProviderFactory
+    {
+        public static IProjectSpecificEditorProvider ImplementGetSpecificEditorAsync(Guid editorFactory = default)
+        {
+            var mock = new Mock<IProjectSpecificEditorInfo>();
+            mock.Setup(i => i.EditorFactory)
+                .Returns(editorFactory);
+
+            return ImplementGetSpecificEditorAsync(mock.Object);
+        }
+
+        public static IProjectSpecificEditorProvider ImplementGetSpecificEditorAsync(IProjectSpecificEditorInfo projectSpecificEditorInfo)
+        {
+            var mock = new Mock<IProjectSpecificEditorProvider>();
+            mock.Setup(p => p.GetSpecificEditorAsync(It.IsAny<string>()))
+                .ReturnsAsync(projectSpecificEditorInfo);
+
+            return mock.Object;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProviderTests.cs
@@ -177,6 +177,35 @@ Project
             Assert.False(result);
         }
 
+        [Fact]
+        public async Task GetSpecificEditorAsync_WhenParentIsSourceFile_ReturnsNull()
+        {   // Let's folks double-click the designer file to open it as text
+
+            var provider = CreateInstanceWithDefaultEditorProvider(@"
+Project
+    Foo.cs (flags: {SourceFile})
+        Foo.Designer.cs, FilePath: ""C:\Foo.Designer.cs"", ItemType: Compile, SubType: Designer
+");
+
+            var result = await provider.GetSpecificEditorAsync(@"C:\Foo.Designer.cs");
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task SetUseGlobalEditorAsync_WhenParentIsSourceFile_ReturnsFalse()
+        {   
+            var provider = CreateInstanceWithDefaultEditorProvider(@"
+Project
+    Foo.cs (flags: {SourceFile})
+        Foo.Designer.cs, FilePath: ""C:\Foo.Designer.cs"", ItemType: Compile, SubType: Designer
+");
+
+            var result = await provider.SetUseGlobalEditorAsync(@"C:\Foo.Designer.cs", false);
+
+            Assert.False(result);
+        }
+
         [Theory]
         [InlineData(@"
 Project

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProviderTests.cs
@@ -1,0 +1,271 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
+{
+    public class WindowsFormsEditorProviderTests
+    {
+        [Fact]
+        public async Task GetSpecificEditorAsync_NullAsDocumentMoniker_ThrowsArgumentNull()
+        {
+            var provider = CreateInstance();
+
+            await Assert.ThrowsAsync<ArgumentNullException>("documentMoniker", () =>
+            {
+                return provider.GetSpecificEditorAsync((string)null);
+            });
+        }
+
+        [Fact]
+        public async Task SetUseGlobalEditorAsync_NullAsDocumentMoniker_ThrowsArgumentNull()
+        {
+            var provider = CreateInstance();
+
+            await Assert.ThrowsAsync<ArgumentNullException>("documentMoniker", () =>
+            {
+                return provider.SetUseGlobalEditorAsync((string)null, false);
+            });
+        }
+
+        [Fact]
+        public async Task GetSpecificEditorAsync_EmptyAsDocumentMoniker_ThrowsArgument()
+        {
+            var provider = CreateInstance();
+
+            await Assert.ThrowsAsync<ArgumentException>("documentMoniker", () =>
+            {
+                return provider.GetSpecificEditorAsync(string.Empty);
+            });
+        }
+
+        [Fact]
+        public async Task SetUseGlobalEditorAsync_EmptyAsDocumentMoniker_ThrowsArgument()
+        {
+            var provider = CreateInstance();
+
+            await Assert.ThrowsAsync<ArgumentException>("documentMoniker", () =>
+            {
+                return provider.SetUseGlobalEditorAsync(string.Empty, false);
+            });
+        }
+
+        [Fact]
+        public async Task GetSpecificEditorAsync_WhenNoProjectSpecificEditorProviders_ReturnsNull()
+        {
+            var provider = CreateInstance();
+
+            var result = await provider.GetSpecificEditorAsync(@"C:\Foo.cs");
+
+            Assert.Null(result);
+        }
+
+
+        [Fact]
+        public async Task GetSpecificEditorAsync_WhenNoDefaultProjectSpecificEditorProviders_ReturnsNull()
+        {
+            var editorProvider = IProjectSpecificEditorProviderFactory.ImplementGetSpecificEditorAsync();
+            var provider = CreateInstance();
+
+            provider.ProjectSpecificEditorProviders.Add("NotDefault", editorProvider);
+
+            var result = await provider.GetSpecificEditorAsync(@"C:\Foo.cs");
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task GetSpecificEditorAsync_WhenFileNotInProject_ReturnsNull()
+        {
+            var provider = CreateInstanceWithDefaultEditorProvider(@"
+Project
+");
+            var result = await provider.GetSpecificEditorAsync(@"C:\Foo.cs");
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task SetUseGlobalEditorAsync_WhenFileNotInProject_ReturnsFalse()
+        {
+            var provider = CreateInstanceWithDefaultEditorProvider(@"
+Project
+");
+            var result = await provider.SetUseGlobalEditorAsync(@"C:\Foo.cs", true);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task GetSpecificEditorAsync_WhenFileNotCompileItem_ReturnsNull()
+        {
+            var provider = CreateInstanceWithDefaultEditorProvider(@"
+Project
+    Foo.cs, FilePath: ""C:\Foo.cs"", ItemType: None
+");
+
+            var result = await provider.GetSpecificEditorAsync(@"C:\Foo.cs");
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task SetUseGlobalEditorAsync_WhenFileNotCompileItem_ReturnsFalse()
+        {
+            var provider = CreateInstanceWithDefaultEditorProvider(@"
+Project
+    Foo.cs, FilePath: ""C:\Foo.cs"", ItemType: None
+");
+
+            var result = await provider.SetUseGlobalEditorAsync(@"C:\Foo.cs", false);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task GetSpecificEditorAsync_WhenCompileItemWithNoSubType_ReturnsNull()
+        {
+            var provider = CreateInstanceWithDefaultEditorProvider(@"
+Project
+    Foo.cs, FilePath: ""C:\Foo.cs"", ItemType: Compile
+");
+
+            var result = await provider.GetSpecificEditorAsync(@"C:\Foo.cs");
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task SetUseGlobalEditorAsync_WhenCompileItemWithNoSubType_ReturnsFalse()
+        {
+            var provider = CreateInstanceWithDefaultEditorProvider(@"
+Project
+    Foo.cs, FilePath: ""C:\Foo.cs"", ItemType: Compile
+");
+
+            var result = await provider.SetUseGlobalEditorAsync(@"C:\Foo.cs", false);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task GetSpecificEditorAsync_WhenCompileItemWithUnrecognizedSubType_ReturnsNull()
+        {
+            var provider = CreateInstanceWithDefaultEditorProvider(@"
+Project
+    Foo.cs, FilePath: ""C:\Foo.cs"", ItemType: Compile, SubType: Code
+");
+
+            var result = await provider.GetSpecificEditorAsync(@"C:\Foo.cs");
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task SetUseGlobalEditorAsync_WhenCompileItemWithUnrecognizedSubType_ReturnsFalse()
+        {
+            var provider = CreateInstanceWithDefaultEditorProvider(@"
+Project
+    Foo.cs, FilePath: ""C:\Foo.cs"", ItemType: Compile, SubType: Code
+");
+
+            var result = await provider.SetUseGlobalEditorAsync(@"C:\Foo.cs", false);
+
+            Assert.False(result);
+        }
+
+        [Theory]
+        [InlineData(@"
+Project
+    Foo.txt, FilePath: ""C:\Foo.cs"", ItemType: Compile, SubType: Form
+", true)]
+        [InlineData(@"
+Project
+    Foo.txt, FilePath: ""C:\Foo.cs"", ItemType: Compile, SubType: Designer
+", true)]
+        [InlineData(@"
+Project
+    Foo.txt, FilePath: ""C:\Foo.cs"", ItemType: Compile, SubType: UserControl
+", true)]
+        [InlineData(@"
+Project
+    Foo.txt, FilePath: ""C:\Foo.cs"", ItemType: Compile, SubType: Component
+", false)]
+        public async Task GetSpecificEditorAsync_WhenMarkedWithRecognizedSubType_ReturnsResult(string tree, bool useDesignerByDefault)
+        {
+            var defaultEditorFactory = Guid.NewGuid();
+
+            var options = IProjectSystemOptionsFactory.ImplementGetUseDesignerByDefaultAsync((_, defaultValue, __) => defaultValue);
+            var provider = CreateInstanceWithDefaultEditorProvider(tree, options, defaultEditorFactory);
+
+            var result = await provider.GetSpecificEditorAsync(@"C:\Foo.cs");
+
+            Assert.NotEmpty(result.DisplayName);
+            Assert.Equal(VSConstants.LOGVIEWID.Designer_guid, result.DefaultView);
+            Assert.Equal(useDesignerByDefault, result.IsDefaultEditor);
+            Assert.Equal(defaultEditorFactory, result.EditorFactory);
+        }
+
+        [Theory]
+        [InlineData(@"
+Project
+    Foo.txt, FilePath: ""C:\Foo.cs"", ItemType: Compile, SubType: Form
+", "Form")]
+        [InlineData(@"
+Project
+    Foo.txt, FilePath: ""C:\Foo.cs"", ItemType: Compile, SubType: Designer
+", "Designer")]
+        [InlineData(@"
+Project
+    Foo.txt, FilePath: ""C:\Foo.cs"", ItemType: Compile, SubType: UserControl
+", "UserControl")]
+        [InlineData(@"
+Project
+    Foo.txt, FilePath: ""C:\Foo.cs"", ItemType: Compile, SubType: Component
+", "Component")]
+        public async Task SetUseGlobalEditorAsync_WhenMarkedWithRecognizedSubType_ReturnsTrue(string tree, string expectedCategory)
+        {
+            string categoryResult = null;
+            bool? valueResult = null;
+            var options = IProjectSystemOptionsFactory.ImplementSetUseDesignerByDefaultAsync((category, value, __) => { categoryResult = category; valueResult = value; return Task.CompletedTask; });
+            var provider = CreateInstanceWithDefaultEditorProvider(tree, options);
+
+            var result = await provider.SetUseGlobalEditorAsync(@"C:\Foo.cs", useGlobalEditor: true);
+
+            Assert.True(result);
+            Assert.False(valueResult);
+            Assert.Equal(expectedCategory, categoryResult);
+        }
+
+        private static WindowsFormsEditorProvider CreateInstanceWithDefaultEditorProvider(string projectTree, IProjectSystemOptions options = null, Guid defaultEditorFactory = default)
+        {
+            var tree = ProjectTreeParser.Parse(projectTree);
+
+            var defaultEditorProvider = IProjectSpecificEditorProviderFactory.ImplementGetSpecificEditorAsync(defaultEditorFactory);
+
+            var provider = CreateInstance(projectTree: IPhysicalProjectTreeFactory.Create(currentTree: tree), options: options);
+            provider.ProjectSpecificEditorProviders.Add("Default", defaultEditorProvider);
+
+            return provider;
+        }
+
+        private static WindowsFormsEditorProvider CreateInstance(string projectTree)
+        {
+            var tree = ProjectTreeParser.Parse(projectTree);
+
+            return CreateInstance(projectTree: IPhysicalProjectTreeFactory.Create(currentTree: tree));
+        }
+
+        private static WindowsFormsEditorProvider CreateInstance(UnconfiguredProject unconfiguredProject = null, IPhysicalProjectTree projectTree = null, IProjectSystemOptions options = null)
+        {
+            unconfiguredProject ??= UnconfiguredProjectFactory.Create();
+            projectTree ??= IPhysicalProjectTreeFactory.Create();
+            options ??= IProjectSystemOptionsFactory.Create();
+
+            return new WindowsFormsEditorProvider(unconfiguredProject, projectTree.AsLazy(), options.AsLazy());
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectSystemOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectSystemOptions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     {
         private const string FastUpToDateEnabledSettingKey = @"ManagedProjectSystem\FastUpToDateCheckEnabled";
         private const string FastUpToDateLogLevelSettingKey = @"ManagedProjectSystem\FastUpToDateLogLevel";
-
+        
         private readonly IEnvironmentHelper _environment;
         private readonly IVsUIService<ISettingsManager> _settingsManager;
         private readonly JoinableTaskContext _joinableTaskContext;
@@ -32,10 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         public bool IsProjectOutputPaneEnabled
         {
-            get
-            {
-                return IsEnabled("PROJECTSYSTEM_PROJECTOUTPUTPANEENABLED", ref _isProjectOutputPaneEnabled);
-            }
+            get { return IsEnvironmentVariableEnabled("PROJECTSYSTEM_PROJECTOUTPUTPANEENABLED", ref _isProjectOutputPaneEnabled); }
         }
 
         public async Task<bool> GetIsFastUpToDateCheckEnabledAsync(CancellationToken cancellationToken = default)
@@ -47,10 +44,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         public async Task<LogLevel> GetFastUpToDateLoggingLevelAsync(CancellationToken cancellationToken = default)
         {
             await _joinableTaskContext.Factory.SwitchToMainThreadAsync(cancellationToken);
+
             return _settingsManager.Value?.GetValueOrDefault(FastUpToDateLogLevelSettingKey, LogLevel.None) ?? LogLevel.None;
         }
 
-        private bool IsEnabled(string variable, ref bool? result)
+        private bool IsEnvironmentVariableEnabled(string variable, ref bool? result)
         {
             if (result == null)
             {
@@ -61,5 +59,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             return result.Value;
         }
+
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.EditorInfo.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.EditorInfo.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
+{
+    internal partial class WindowsFormEditorProvider
+    {
+        private class EditorInfo : IProjectSpecificEditorInfo
+        {
+            public EditorInfo(Guid editor, string displayName, bool isDefaultEditor)
+            {
+                Requires.NotEmpty(editor, nameof(editor));
+                Requires.NotNullOrEmpty(displayName, nameof(displayName));
+
+                EditorFactory = editor;
+                DisplayName = displayName;
+                IsDefaultEditor = isDefaultEditor;
+            }
+
+            public Guid EditorFactory { get; }
+
+            public bool IsDefaultEditor { get; }
+
+            public string DisplayName { get; }
+
+            public Guid DefaultView => VSConstants.LOGVIEWID.Designer_guid;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.EditorInfo.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.EditorInfo.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
 {
-    internal partial class WindowsFormEditorProvider
+    internal partial class WindowsFormsEditorProvider
     {
         private class EditorInfo : IProjectSpecificEditorInfo
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.EditorInfo.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.EditorInfo.cs
@@ -2,6 +2,8 @@
 
 using System;
 
+#nullable enable
+
 namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
 {
     internal partial class WindowsFormEditorProvider

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.SubTypeDescriptor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.SubTypeDescriptor.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#nullable enable
+
 namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
 {
     internal partial class WindowsFormEditorProvider

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.SubTypeDescriptor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.SubTypeDescriptor.cs
@@ -12,15 +12,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
 
             public readonly string DisplayName;
 
-            public readonly string DesignerCategoryForPersistence;
-
             public readonly bool UseDesignerByDefault;
 
-            public SubTypeDescriptor(string subType, string displayName, string designerCategoryForPersistence, bool useDesignerByDefault)
+            public SubTypeDescriptor(string subType, string displayName, bool useDesignerByDefault)
             {
                 SubType = subType;
                 DisplayName = displayName;
-                DesignerCategoryForPersistence = designerCategoryForPersistence;
                 UseDesignerByDefault = useDesignerByDefault;
             }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.SubTypeDescriptor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.SubTypeDescriptor.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
 {
-    internal partial class WindowsFormEditorProvider
+    internal partial class WindowsFormsEditorProvider
     {
         private class SubTypeDescriptor
         { 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.SubTypeDescriptor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.SubTypeDescriptor.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
+{
+    internal partial class WindowsFormEditorProvider
+    {
+        private class SubTypeDescriptor
+        { 
+            public readonly string SubType;
+
+            public readonly string DisplayName;
+
+            public readonly string DesignerCategoryForPersistence;
+
+            public readonly bool UseDesignerByDefault;
+
+            public SubTypeDescriptor(string subType, string displayName, string designerCategoryForPersistence, bool useDesignerByDefault)
+            {
+                SubType = subType;
+                DisplayName = displayName;
+                DesignerCategoryForPersistence = designerCategoryForPersistence;
+                UseDesignerByDefault = useDesignerByDefault;
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.cs
@@ -106,17 +106,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
         private async Task<string?> GetSubTypeAsync(string documentMoniker)
         {
             IProjectItemTree? item = await FindCompileItemByMonikerAsync(documentMoniker);
-            if (item == null)
-                return null;
 
-            IRule browseObject = item.BrowseObjectProperties;
-            if (browseObject == null)
-                return null;
+            IRule? browseObject = item?.BrowseObjectProperties;
 
-            if (!(browseObject.GetProperty(Compile.SubTypeProperty) is IEvaluatedProperty property))
-                return null;
+            if (browseObject?.GetProperty(Compile.SubTypeProperty) is IEvaluatedProperty property)
+                return await property.GetEvaluatedValueAtEndAsync();
 
-            return await property.GetEvaluatedValueAtEndAsync();
+            return null;
         }
 
         private async Task<IProjectItemTree?> FindCompileItemByMonikerAsync(string documentMoniker)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.cs
@@ -23,12 +23,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
     [Order(Order.BeforeDefault)] // Need to run before CPS's version before its deleted
     internal partial class WindowsFormsEditorProvider : IProjectSpecificEditorProvider
     {
-        private readonly static SubTypeDescriptor[] SubTypeDescriptors = new[]
+        private static readonly SubTypeDescriptor[] s_subTypeDescriptors = new[]
         {
-            new SubTypeDescriptor("Form",           VSResources.WindowsFormEditor_DisplayName, "Form",         useDesignerByDefault: true), // "Form" and "Designer" represent the same thing
-            new SubTypeDescriptor("Designer",       VSResources.WindowsFormEditor_DisplayName, "Form",         useDesignerByDefault: true),
-            new SubTypeDescriptor("UserControl",    VSResources.UserControlEditor_DisplayName, "UserControl",  useDesignerByDefault: true),
-            new SubTypeDescriptor("Component",      VSResources.ComponentEditor_DisplayName,   "Component",    useDesignerByDefault: false)
+            new SubTypeDescriptor("Form",           VSResources.WindowsFormEditor_DisplayName, useDesignerByDefault: true),
+            new SubTypeDescriptor("Designer",       VSResources.WindowsFormEditor_DisplayName, useDesignerByDefault: true),
+            new SubTypeDescriptor("UserControl",    VSResources.UserControlEditor_DisplayName, useDesignerByDefault: true),
+            new SubTypeDescriptor("Component",      VSResources.ComponentEditor_DisplayName,   useDesignerByDefault: false)
         };
 
         private readonly Lazy<IPhysicalProjectTree> _projectTree;
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
             if (descriptor == null)
                 return null;
 
-            bool isDefaultEditor = await _options.Value.GetUseDesignerByDefaultAsync(descriptor.DesignerCategoryForPersistence, descriptor.UseDesignerByDefault);
+            bool isDefaultEditor = await _options.Value.GetUseDesignerByDefaultAsync(descriptor.SubType, descriptor.UseDesignerByDefault);
 
             return new EditorInfo(editor.EditorFactory, descriptor.DisplayName, isDefaultEditor);
         }
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
                 return false;
 
             // 'useGlobalEditor' means use the default editor that is registered for source files
-            await _options.Value.SetUseDesignerByDefaultAsync(editorInfo.DesignerCategoryForPersistence, !useGlobalEditor);
+            await _options.Value.SetUseDesignerByDefaultAsync(editorInfo.SubType, !useGlobalEditor);
             return true;
         }
 
@@ -93,7 +93,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
             string? subType = await GetSubTypeAsync(documentMoniker);
             if (subType != null)
             {
-                foreach (SubTypeDescriptor descriptor in SubTypeDescriptors)
+                foreach (SubTypeDescriptor descriptor in s_subTypeDescriptors)
                 {
                     if (StringComparers.PropertyLiteralValues.Equals(subType, descriptor.SubType))
                         return descriptor;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.cs
@@ -119,6 +119,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
             IProjectTreeServiceState result = await _projectTree.Value.TreeService.PublishAnyNonLoadingTreeAsync();
 
             if (result.TreeProvider.FindByPath(result.Tree, documentMoniker) is IProjectItemTree treeItem &&
+                !treeItem.Parent.Flags.Contains(ProjectTreeFlags.SourceFile) &&
                 StringComparers.ItemTypes.Equals(treeItem.Item.ItemType, Compile.SchemaName))
             {
                 return treeItem;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.cs
@@ -108,11 +108,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
             IProjectItemTree? item = await FindCompileItemByMonikerAsync(documentMoniker);
 
             IRule? browseObject = item?.BrowseObjectProperties;
+            if (browseObject == null)
+                return null;
 
-            if (browseObject?.GetProperty(Compile.SubTypeProperty) is IEvaluatedProperty property)
-                return await property.GetEvaluatedValueAtEndAsync();
-
-            return null;
+            return await browseObject.GetPropertyValueAsync(Compile.SubTypeProperty);
         }
 
         private async Task<IProjectItemTree?> FindCompileItemByMonikerAsync(string documentMoniker)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
     [Export(typeof(IProjectSpecificEditorProvider))]
     [AppliesTo(ProjectCapability.DotNet)]
     [Order(Order.BeforeDefault)] // Need to run before CPS's version before its deleted
-    internal partial class WindowsFormEditorProvider : IProjectSpecificEditorProvider
+    internal partial class WindowsFormsEditorProvider : IProjectSpecificEditorProvider
     {
         private readonly static SubTypeDescriptor[] SubTypeDescriptors = new[]
         {
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
         private readonly Lazy<IProjectSystemOptions> _options;
 
         [ImportingConstructor]
-        public WindowsFormEditorProvider(UnconfiguredProject unconfiguredProject, Lazy<IPhysicalProjectTree> projectTree, Lazy<IProjectSystemOptions> options)
+        public WindowsFormsEditorProvider(UnconfiguredProject unconfiguredProject, Lazy<IPhysicalProjectTree> projectTree, Lazy<IProjectSystemOptions> options)
         {
             _projectTree = projectTree;
             _options = options;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.cs
@@ -6,6 +6,8 @@ using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading.Tasks;
 
+#nullable enable
+
 namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
 {
     /// <summary>
@@ -47,15 +49,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
             get;
         }
 
-        public async Task<IProjectSpecificEditorInfo> GetSpecificEditorAsync(string documentMoniker)
+        public async Task<IProjectSpecificEditorInfo?> GetSpecificEditorAsync(string documentMoniker)
         {
             Requires.NotNullOrEmpty(documentMoniker, nameof(documentMoniker));
 
-            IProjectSpecificEditorInfo editor = await GetDefaultEditorAsync(documentMoniker);
+            IProjectSpecificEditorInfo? editor = await GetDefaultEditorAsync(documentMoniker);
             if (editor == null)
                 return null;
 
-            SubTypeDescriptor descriptor = await GetSubTypeDescriptorAsync(documentMoniker);
+            SubTypeDescriptor? descriptor = await GetSubTypeDescriptorAsync(documentMoniker);
             if (descriptor == null)
                 return null;
 
@@ -68,7 +70,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
         {
             Requires.NotNullOrEmpty(documentMoniker, nameof(documentMoniker));
 
-            SubTypeDescriptor editorInfo = await GetSubTypeDescriptorAsync(documentMoniker);
+            SubTypeDescriptor? editorInfo = await GetSubTypeDescriptorAsync(documentMoniker);
             if (editorInfo == null)
                 return false;
 
@@ -77,31 +79,33 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
             return true;
         }
 
-        private async Task<IProjectSpecificEditorInfo> GetDefaultEditorAsync(string documentMoniker)
+        private async Task<IProjectSpecificEditorInfo?> GetDefaultEditorAsync(string documentMoniker)
         {
-            IProjectSpecificEditorProvider defaultProvider = GetDefaultEditorProvider();
+            IProjectSpecificEditorProvider? defaultProvider = GetDefaultEditorProvider();
             if (defaultProvider == null)
                 return null;
 
             return await defaultProvider.GetSpecificEditorAsync(documentMoniker);
         }
 
-        private async Task<SubTypeDescriptor> GetSubTypeDescriptorAsync(string documentMoniker)
+        private async Task<SubTypeDescriptor?> GetSubTypeDescriptorAsync(string documentMoniker)
         {
-            string subType = await GetSubTypeAsync(documentMoniker);
-
-            foreach (SubTypeDescriptor descriptor in SubTypeDescriptors)
+            string? subType = await GetSubTypeAsync(documentMoniker);
+            if (subType != null)
             {
-                if (StringComparers.PropertyLiteralValues.Equals(subType, descriptor.SubType))
-                    return descriptor;
+                foreach (SubTypeDescriptor descriptor in SubTypeDescriptors)
+                {
+                    if (StringComparers.PropertyLiteralValues.Equals(subType, descriptor.SubType))
+                        return descriptor;
+                }
             }
 
             return null;
         }
 
-        private async Task<string> GetSubTypeAsync(string documentMoniker)
+        private async Task<string?> GetSubTypeAsync(string documentMoniker)
         {
-            IProjectItemTree item = await FindCompileItemByMonikerAsync(documentMoniker);
+            IProjectItemTree? item = await FindCompileItemByMonikerAsync(documentMoniker);
             if (item == null)
                 return null;
 
@@ -115,7 +119,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
             return await property.GetEvaluatedValueAtEndAsync();
         }
 
-        private async Task<IProjectItemTree> FindCompileItemByMonikerAsync(string documentMoniker)
+        private async Task<IProjectItemTree?> FindCompileItemByMonikerAsync(string documentMoniker)
         {
             IProjectTreeServiceState result = await _projectTree.Value.TreeService.PublishAnyNonNullTreeAsync();
 
@@ -128,7 +132,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
             return null;
         }
 
-        private IProjectSpecificEditorProvider GetDefaultEditorProvider()
+        private IProjectSpecificEditorProvider? GetDefaultEditorProvider()
         {
             Lazy<IProjectSpecificEditorProvider> editorProvider = ProjectSpecificEditorProviders.FirstOrDefault(p => string.Equals(p.Metadata.Name, "Default", StringComparison.OrdinalIgnoreCase));
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.cs
@@ -116,7 +116,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
 
         private async Task<IProjectItemTree?> FindCompileItemByMonikerAsync(string documentMoniker)
         {
-            IProjectTreeServiceState result = await _projectTree.Value.TreeService.PublishAnyNonNullTreeAsync();
+            IProjectTreeServiceState result = await _projectTree.Value.TreeService.PublishAnyNonLoadingTreeAsync();
 
             if (result.TreeProvider.FindByPath(result.Tree, documentMoniker) is IProjectItemTree treeItem &&
                 StringComparers.ItemTypes.Equals(treeItem.Item.ItemType, Compile.SchemaName))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.cs
@@ -1,0 +1,138 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using System;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
+{
+    /// <summary>
+    ///     A project-specific editor provider that is responsible for handling two things;
+    ///     
+    ///     1) Add the Windows Forms designer to the list of editor factories for a "designable" source file, and 
+    ///        determines whether it opens by default.
+    ///     
+    ///     2) Persists whether the designer opens by default when the user uses Open With -> Set As Default.
+    /// </summary>
+    [Export(typeof(IProjectSpecificEditorProvider))]
+    [AppliesTo(ProjectCapability.DotNet)]
+    [Order(Order.BeforeDefault)] // Need to run before CPS's version before its deleted
+    internal partial class WindowsFormEditorProvider : IProjectSpecificEditorProvider
+    {
+        private readonly static SubTypeDescriptor[] SubTypeDescriptors = new[]
+        {
+            new SubTypeDescriptor("Form",           VSResources.WindowsFormEditor_DisplayName, "Form",         useDesignerByDefault: true), // "Form" and "Designer" represent the same thing
+            new SubTypeDescriptor("Designer",       VSResources.WindowsFormEditor_DisplayName, "Form",         useDesignerByDefault: true),
+            new SubTypeDescriptor("UserControl",    VSResources.UserControlEditor_DisplayName, "UserControl",  useDesignerByDefault: true),
+            new SubTypeDescriptor("Component",      VSResources.ComponentEditor_DisplayName,   "Component",    useDesignerByDefault: false)
+        };
+
+        private readonly Lazy<IPhysicalProjectTree> _projectTree;
+        private readonly Lazy<IProjectSystemOptions> _options;
+
+        [ImportingConstructor]
+        public WindowsFormEditorProvider(UnconfiguredProject unconfiguredProject, Lazy<IPhysicalProjectTree> projectTree, Lazy<IProjectSystemOptions> options)
+        {
+            _projectTree = projectTree;
+            _options = options;
+
+            ProjectSpecificEditorProviders = new OrderPrecedenceImportCollection<IProjectSpecificEditorProvider, INamedExportMetadataView>(projectCapabilityCheckProvider: unconfiguredProject);
+        }
+
+        [ImportMany]
+        public OrderPrecedenceImportCollection<IProjectSpecificEditorProvider, INamedExportMetadataView> ProjectSpecificEditorProviders
+        {
+            get;
+        }
+
+        public async Task<IProjectSpecificEditorInfo> GetSpecificEditorAsync(string documentMoniker)
+        {
+            Requires.NotNullOrEmpty(documentMoniker, nameof(documentMoniker));
+
+            IProjectSpecificEditorInfo editor = await GetDefaultEditorAsync(documentMoniker);
+            if (editor == null)
+                return null;
+
+            SubTypeDescriptor descriptor = await GetSubTypeDescriptorAsync(documentMoniker);
+            if (descriptor == null)
+                return null;
+
+            bool isDefaultEditor = await _options.Value.GetUseDesignerByDefaultAsync(descriptor.DesignerCategoryForPersistence, descriptor.UseDesignerByDefault);
+
+            return new EditorInfo(editor.EditorFactory, descriptor.DisplayName, isDefaultEditor);
+        }
+
+        public async Task<bool> SetUseGlobalEditorAsync(string documentMoniker, bool useGlobalEditor)
+        {
+            Requires.NotNullOrEmpty(documentMoniker, nameof(documentMoniker));
+
+            SubTypeDescriptor editorInfo = await GetSubTypeDescriptorAsync(documentMoniker);
+            if (editorInfo == null)
+                return false;
+
+            // 'useGlobalEditor' means use the default editor that is registered for source files
+            await _options.Value.SetUseDesignerByDefaultAsync(editorInfo.DesignerCategoryForPersistence, !useGlobalEditor);
+            return true;
+        }
+
+        private async Task<IProjectSpecificEditorInfo> GetDefaultEditorAsync(string documentMoniker)
+        {
+            IProjectSpecificEditorProvider defaultProvider = GetDefaultEditorProvider();
+            if (defaultProvider == null)
+                return null;
+
+            return await defaultProvider.GetSpecificEditorAsync(documentMoniker);
+        }
+
+        private async Task<SubTypeDescriptor> GetSubTypeDescriptorAsync(string documentMoniker)
+        {
+            string subType = await GetSubTypeAsync(documentMoniker);
+
+            foreach (SubTypeDescriptor descriptor in SubTypeDescriptors)
+            {
+                if (StringComparers.PropertyLiteralValues.Equals(subType, descriptor.SubType))
+                    return descriptor;
+            }
+
+            return null;
+        }
+
+        private async Task<string> GetSubTypeAsync(string documentMoniker)
+        {
+            IProjectItemTree item = await FindCompileItemByMonikerAsync(documentMoniker);
+            if (item == null)
+                return null;
+
+            IRule browseObject = item.BrowseObjectProperties;
+            if (browseObject == null)
+                return null;
+
+            if (!(browseObject.GetProperty(Compile.SubTypeProperty) is IEvaluatedProperty property))
+                return null;
+
+            return await property.GetEvaluatedValueAtEndAsync();
+        }
+
+        private async Task<IProjectItemTree> FindCompileItemByMonikerAsync(string documentMoniker)
+        {
+            IProjectTreeServiceState result = await _projectTree.Value.TreeService.PublishAnyNonNullTreeAsync();
+
+            if (result.TreeProvider.FindByPath(result.Tree, documentMoniker) is IProjectItemTree treeItem &&
+                StringComparers.ItemTypes.Equals(treeItem.Item.ItemType, Compile.SchemaName))
+            {
+                return treeItem;
+            }
+
+            return null;
+        }
+
+        private IProjectSpecificEditorProvider GetDefaultEditorProvider()
+        {
+            Lazy<IProjectSpecificEditorProvider> editorProvider = ProjectSpecificEditorProviders.FirstOrDefault(p => string.Equals(p.Metadata.Name, "Default", StringComparison.OrdinalIgnoreCase));
+
+            return editorProvider?.Value;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
@@ -70,6 +70,15 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Component Designer (Windows Forms).
+        /// </summary>
+        internal static string ComponentEditor_DisplayName {
+            get {
+                return ResourceManager.GetString("ComponentEditor_DisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The debug executable &apos;{0}&apos; specified in the &apos;{1}&apos; debug profile does not exist..
         /// </summary>
         internal static string DebugExecutableNotFound {
@@ -102,6 +111,15 @@ namespace Microsoft.VisualStudio {
         internal static string DontShowAgain {
             get {
                 return ResourceManager.GetString("DontShowAgain", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Edit {0}.
+        /// </summary>
+        internal static string EditProjectFileCommand {
+            get {
+                return ResourceManager.GetString("EditProjectFileCommand", resourceCulture);
             }
         }
         
@@ -174,6 +192,15 @@ namespace Microsoft.VisualStudio {
         internal static string NoDebugExecutableSpecified {
             get {
                 return ResourceManager.GetString("NoDebugExecutableSpecified", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Expected to find migrated cpsroj in {0}, but did not find any..
+        /// </summary>
+        internal static string NoMigratedCSProjFound {
+            get {
+                return ResourceManager.GetString("NoMigratedCSProjFound", resourceCulture);
             }
         }
         
@@ -293,6 +320,24 @@ namespace Microsoft.VisualStudio {
         internal static string Restore_PropertyWithInconsistentValues {
             get {
                 return ResourceManager.GetString("Restore_PropertyWithInconsistentValues", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to User Control Designer (Windows Forms).
+        /// </summary>
+        internal static string UserControlEditor_DisplayName {
+            get {
+                return ResourceManager.GetString("UserControlEditor_DisplayName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Form Designer (Windows Forms).
+        /// </summary>
+        internal static string WindowsFormEditor_DisplayName {
+            get {
+                return ResourceManager.GetString("WindowsFormEditor_DisplayName", resourceCulture);
             }
         }
         

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Component Designer (Windows Forms).
+        ///   Looks up a localized string similar to Component (Windows Forms) Designer.
         /// </summary>
         internal static string ComponentEditor_DisplayName {
             get {
@@ -324,7 +324,7 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to User Control Designer (Windows Forms).
+        ///   Looks up a localized string similar to User Control (Windows Forms) Designer.
         /// </summary>
         internal static string UserControlEditor_DisplayName {
             get {
@@ -333,7 +333,7 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Form Designer (Windows Forms).
+        ///   Looks up a localized string similar to Form (Windows Forms) Designer.
         /// </summary>
         internal static string WindowsFormEditor_DisplayName {
             get {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
@@ -219,12 +219,12 @@ In order to debug this project, add an executable project to this solution which
     <value>The value of the 'TargetFrameworkMoniker' and 'NuGetTargetMoniker' properties in the '{0}' configuration are both empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</value>
   </data>
   <data name="WindowsFormEditor_DisplayName" xml:space="preserve">
-    <value>Form Designer (Windows Forms)</value>
+    <value>Form (Windows Forms) Designer</value>
   </data>
   <data name="ComponentEditor_DisplayName" xml:space="preserve">
-    <value>Component Designer (Windows Forms)</value>
+    <value>Component (Windows Forms) Designer</value>
   </data>
   <data name="UserControlEditor_DisplayName" xml:space="preserve">
-    <value>User Control Designer (Windows Forms)</value>
+    <value>User Control (Windows Forms) Designer</value>
   </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
@@ -218,4 +218,13 @@ In order to debug this project, add an executable project to this solution which
   <data name="Restore_EmptyTargetFrameworkMoniker" xml:space="preserve">
     <value>The value of the 'TargetFrameworkMoniker' and 'NuGetTargetMoniker' properties in the '{0}' configuration are both empty. This configuration will not contribute to NuGet restore, which may result in restore and build errors.</value>
   </data>
+  <data name="WindowsFormEditor_DisplayName" xml:space="preserve">
+    <value>Form Designer (Windows Forms)</value>
+  </data>
+  <data name="ComponentEditor_DisplayName" xml:space="preserve">
+    <value>Component Designer (Windows Forms)</value>
+  </data>
+  <data name="UserControlEditor_DisplayName" xml:space="preserve">
+    <value>User Control Designer (Windows Forms)</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
@@ -171,6 +171,21 @@ Pokud chcete projekt ladit, přidejte do řešení spustitelný projekt, který 
         <target state="translated">Hodnoty vlastností TargetFrameworkMoniker a NuGetTargetMoniker v konfiguraci {0} jsou obě prázdné. Tato konfigurace se nebude podílet na obnovení přes NuGet, což může mít za následek chyby při obnovení a sestavení.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WindowsFormEditor_DisplayName">
+        <source>Form Designer (Windows Forms)</source>
+        <target state="new">Form Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComponentEditor_DisplayName">
+        <source>Component Designer (Windows Forms)</source>
+        <target state="new">Component Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UserControlEditor_DisplayName">
+        <source>User Control Designer (Windows Forms)</source>
+        <target state="new">User Control Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
@@ -172,18 +172,18 @@ Pokud chcete projekt ladit, přidejte do řešení spustitelný projekt, který 
         <note />
       </trans-unit>
       <trans-unit id="WindowsFormEditor_DisplayName">
-        <source>Form Designer (Windows Forms)</source>
-        <target state="new">Form Designer (Windows Forms)</target>
+        <source>Form (Windows Forms) Designer</source>
+        <target state="new">Form (Windows Forms) Designer</target>
         <note />
       </trans-unit>
       <trans-unit id="ComponentEditor_DisplayName">
-        <source>Component Designer (Windows Forms)</source>
-        <target state="new">Component Designer (Windows Forms)</target>
+        <source>Component (Windows Forms) Designer</source>
+        <target state="new">Component (Windows Forms) Designer</target>
         <note />
       </trans-unit>
       <trans-unit id="UserControlEditor_DisplayName">
-        <source>User Control Designer (Windows Forms)</source>
-        <target state="new">User Control Designer (Windows Forms)</target>
+        <source>User Control (Windows Forms) Designer</source>
+        <target state="new">User Control (Windows Forms) Designer</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
@@ -171,6 +171,21 @@ Um das Projekt zu debuggen, fügen Sie dieser Projektmappe ein ausführbares Pro
         <target state="translated">Die Werte der Eigenschaften "TargetFrameworkMoniker" und "NuGetTargetMoniker" in der Konfiguration "{0}" sind beide leer. Diese Konfiguration wird bei der NuGet-Wiederherstellung nicht berücksichtigt, was zu Wiederherstellungs- und Buildfehlern führen kann.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WindowsFormEditor_DisplayName">
+        <source>Form Designer (Windows Forms)</source>
+        <target state="new">Form Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComponentEditor_DisplayName">
+        <source>Component Designer (Windows Forms)</source>
+        <target state="new">Component Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UserControlEditor_DisplayName">
+        <source>User Control Designer (Windows Forms)</source>
+        <target state="new">User Control Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
@@ -172,18 +172,18 @@ Um das Projekt zu debuggen, fügen Sie dieser Projektmappe ein ausführbares Pro
         <note />
       </trans-unit>
       <trans-unit id="WindowsFormEditor_DisplayName">
-        <source>Form Designer (Windows Forms)</source>
-        <target state="new">Form Designer (Windows Forms)</target>
+        <source>Form (Windows Forms) Designer</source>
+        <target state="new">Form (Windows Forms) Designer</target>
         <note />
       </trans-unit>
       <trans-unit id="ComponentEditor_DisplayName">
-        <source>Component Designer (Windows Forms)</source>
-        <target state="new">Component Designer (Windows Forms)</target>
+        <source>Component (Windows Forms) Designer</source>
+        <target state="new">Component (Windows Forms) Designer</target>
         <note />
       </trans-unit>
       <trans-unit id="UserControlEditor_DisplayName">
-        <source>User Control Designer (Windows Forms)</source>
-        <target state="new">User Control Designer (Windows Forms)</target>
+        <source>User Control (Windows Forms) Designer</source>
+        <target state="new">User Control (Windows Forms) Designer</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
@@ -172,18 +172,18 @@ Para depurar este proyecto, agregue un proyecto ejecutable a esta solución con 
         <note />
       </trans-unit>
       <trans-unit id="WindowsFormEditor_DisplayName">
-        <source>Form Designer (Windows Forms)</source>
-        <target state="new">Form Designer (Windows Forms)</target>
+        <source>Form (Windows Forms) Designer</source>
+        <target state="new">Form (Windows Forms) Designer</target>
         <note />
       </trans-unit>
       <trans-unit id="ComponentEditor_DisplayName">
-        <source>Component Designer (Windows Forms)</source>
-        <target state="new">Component Designer (Windows Forms)</target>
+        <source>Component (Windows Forms) Designer</source>
+        <target state="new">Component (Windows Forms) Designer</target>
         <note />
       </trans-unit>
       <trans-unit id="UserControlEditor_DisplayName">
-        <source>User Control Designer (Windows Forms)</source>
-        <target state="new">User Control Designer (Windows Forms)</target>
+        <source>User Control (Windows Forms) Designer</source>
+        <target state="new">User Control (Windows Forms) Designer</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
@@ -171,6 +171,21 @@ Para depurar este proyecto, agregue un proyecto ejecutable a esta solución con 
         <target state="translated">Los valores de las propiedades "TargetFrameworkMoniker" y "NuGetTargetMoniker" en la configuración de "{0}" están vacíos. Esta configuración no contribuirá a la restauración de NuGet, lo que puede dar lugar a errores de restauración y compilación.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WindowsFormEditor_DisplayName">
+        <source>Form Designer (Windows Forms)</source>
+        <target state="new">Form Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComponentEditor_DisplayName">
+        <source>Component Designer (Windows Forms)</source>
+        <target state="new">Component Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UserControlEditor_DisplayName">
+        <source>User Control Designer (Windows Forms)</source>
+        <target state="new">User Control Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
@@ -172,18 +172,18 @@ Pour déboguer ce projet, ajoutez à cette solution un projet exécutable qui fa
         <note />
       </trans-unit>
       <trans-unit id="WindowsFormEditor_DisplayName">
-        <source>Form Designer (Windows Forms)</source>
-        <target state="new">Form Designer (Windows Forms)</target>
+        <source>Form (Windows Forms) Designer</source>
+        <target state="new">Form (Windows Forms) Designer</target>
         <note />
       </trans-unit>
       <trans-unit id="ComponentEditor_DisplayName">
-        <source>Component Designer (Windows Forms)</source>
-        <target state="new">Component Designer (Windows Forms)</target>
+        <source>Component (Windows Forms) Designer</source>
+        <target state="new">Component (Windows Forms) Designer</target>
         <note />
       </trans-unit>
       <trans-unit id="UserControlEditor_DisplayName">
-        <source>User Control Designer (Windows Forms)</source>
-        <target state="new">User Control Designer (Windows Forms)</target>
+        <source>User Control (Windows Forms) Designer</source>
+        <target state="new">User Control (Windows Forms) Designer</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
@@ -171,6 +171,21 @@ Pour déboguer ce projet, ajoutez à cette solution un projet exécutable qui fa
         <target state="translated">Les valeurs des propriétés 'TargetFrameworkMoniker' et 'NuGetTargetMoniker' dans la configuration '{0}' sont vides. Cette configuration ne contribue pas à la restauration NuGet, ce qui peut entraîner des erreurs de restauration et des erreurs de build.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WindowsFormEditor_DisplayName">
+        <source>Form Designer (Windows Forms)</source>
+        <target state="new">Form Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComponentEditor_DisplayName">
+        <source>Component Designer (Windows Forms)</source>
+        <target state="new">Component Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UserControlEditor_DisplayName">
+        <source>User Control Designer (Windows Forms)</source>
+        <target state="new">User Control Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
@@ -172,18 +172,18 @@ Per eseguire il debug del progetto, aggiungere a questa soluzione un progetto es
         <note />
       </trans-unit>
       <trans-unit id="WindowsFormEditor_DisplayName">
-        <source>Form Designer (Windows Forms)</source>
-        <target state="new">Form Designer (Windows Forms)</target>
+        <source>Form (Windows Forms) Designer</source>
+        <target state="new">Form (Windows Forms) Designer</target>
         <note />
       </trans-unit>
       <trans-unit id="ComponentEditor_DisplayName">
-        <source>Component Designer (Windows Forms)</source>
-        <target state="new">Component Designer (Windows Forms)</target>
+        <source>Component (Windows Forms) Designer</source>
+        <target state="new">Component (Windows Forms) Designer</target>
         <note />
       </trans-unit>
       <trans-unit id="UserControlEditor_DisplayName">
-        <source>User Control Designer (Windows Forms)</source>
-        <target state="new">User Control Designer (Windows Forms)</target>
+        <source>User Control (Windows Forms) Designer</source>
+        <target state="new">User Control (Windows Forms) Designer</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
@@ -171,6 +171,21 @@ Per eseguire il debug del progetto, aggiungere a questa soluzione un progetto es
         <target state="translated">I valori delle proprietà 'TargetFrameworkMoniker' e 'NuGetTargetMoniker' nella configurazione '{0}' sono vuoti. Questa configurazione non contribuisce al ripristino di NuGet e questo può comportare errori di ripristino e di compilazione.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WindowsFormEditor_DisplayName">
+        <source>Form Designer (Windows Forms)</source>
+        <target state="new">Form Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComponentEditor_DisplayName">
+        <source>Component Designer (Windows Forms)</source>
+        <target state="new">Component Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UserControlEditor_DisplayName">
+        <source>User Control Designer (Windows Forms)</source>
+        <target state="new">User Control Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
@@ -172,18 +172,18 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="WindowsFormEditor_DisplayName">
-        <source>Form Designer (Windows Forms)</source>
-        <target state="new">Form Designer (Windows Forms)</target>
+        <source>Form (Windows Forms) Designer</source>
+        <target state="new">Form (Windows Forms) Designer</target>
         <note />
       </trans-unit>
       <trans-unit id="ComponentEditor_DisplayName">
-        <source>Component Designer (Windows Forms)</source>
-        <target state="new">Component Designer (Windows Forms)</target>
+        <source>Component (Windows Forms) Designer</source>
+        <target state="new">Component (Windows Forms) Designer</target>
         <note />
       </trans-unit>
       <trans-unit id="UserControlEditor_DisplayName">
-        <source>User Control Designer (Windows Forms)</source>
-        <target state="new">User Control Designer (Windows Forms)</target>
+        <source>User Control (Windows Forms) Designer</source>
+        <target state="new">User Control (Windows Forms) Designer</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
@@ -171,6 +171,21 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">'{0}' 構成の 'TargetFrameworkMoniker' プロパティおよび 'NuGetTargetMoniker' プロパティの値が両方とも空です。この構成は NuGet の復元には影響しませんが、復元およびビルドのエラーが発生する可能性があります。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WindowsFormEditor_DisplayName">
+        <source>Form Designer (Windows Forms)</source>
+        <target state="new">Form Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComponentEditor_DisplayName">
+        <source>Component Designer (Windows Forms)</source>
+        <target state="new">Component Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UserControlEditor_DisplayName">
+        <source>User Control Designer (Windows Forms)</source>
+        <target state="new">User Control Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
@@ -172,18 +172,18 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="WindowsFormEditor_DisplayName">
-        <source>Form Designer (Windows Forms)</source>
-        <target state="new">Form Designer (Windows Forms)</target>
+        <source>Form (Windows Forms) Designer</source>
+        <target state="new">Form (Windows Forms) Designer</target>
         <note />
       </trans-unit>
       <trans-unit id="ComponentEditor_DisplayName">
-        <source>Component Designer (Windows Forms)</source>
-        <target state="new">Component Designer (Windows Forms)</target>
+        <source>Component (Windows Forms) Designer</source>
+        <target state="new">Component (Windows Forms) Designer</target>
         <note />
       </trans-unit>
       <trans-unit id="UserControlEditor_DisplayName">
-        <source>User Control Designer (Windows Forms)</source>
-        <target state="new">User Control Designer (Windows Forms)</target>
+        <source>User Control (Windows Forms) Designer</source>
+        <target state="new">User Control (Windows Forms) Designer</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
@@ -171,6 +171,21 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">'{0}' 구성의 'TargetFrameworkMoniker' 및 'NuGetTargetMoniker' 속성 값이 둘 다 비어 있습니다. 이 구성은 NuGet 복원에 영향을 주지 않아 복원 및 빌드 오류가 발생할 수 있습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WindowsFormEditor_DisplayName">
+        <source>Form Designer (Windows Forms)</source>
+        <target state="new">Form Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComponentEditor_DisplayName">
+        <source>Component Designer (Windows Forms)</source>
+        <target state="new">Component Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UserControlEditor_DisplayName">
+        <source>User Control Designer (Windows Forms)</source>
+        <target state="new">User Control Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
@@ -171,6 +171,21 @@ Aby debugować ten projekt, dodaj projekt wykonywalny do tego rozwiązania, któ
         <target state="translated">Wartości właściwości „TargetFrameworkMoniker” i „NuGetTargetMoniker” w konfiguracji „{0}” są puste. Ta konfiguracja nie zostanie uwzględniona przy przywracaniu pakietów NuGet, co może skutkować błędami przywracania i kompilacji.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WindowsFormEditor_DisplayName">
+        <source>Form Designer (Windows Forms)</source>
+        <target state="new">Form Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComponentEditor_DisplayName">
+        <source>Component Designer (Windows Forms)</source>
+        <target state="new">Component Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UserControlEditor_DisplayName">
+        <source>User Control Designer (Windows Forms)</source>
+        <target state="new">User Control Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
@@ -172,18 +172,18 @@ Aby debugować ten projekt, dodaj projekt wykonywalny do tego rozwiązania, któ
         <note />
       </trans-unit>
       <trans-unit id="WindowsFormEditor_DisplayName">
-        <source>Form Designer (Windows Forms)</source>
-        <target state="new">Form Designer (Windows Forms)</target>
+        <source>Form (Windows Forms) Designer</source>
+        <target state="new">Form (Windows Forms) Designer</target>
         <note />
       </trans-unit>
       <trans-unit id="ComponentEditor_DisplayName">
-        <source>Component Designer (Windows Forms)</source>
-        <target state="new">Component Designer (Windows Forms)</target>
+        <source>Component (Windows Forms) Designer</source>
+        <target state="new">Component (Windows Forms) Designer</target>
         <note />
       </trans-unit>
       <trans-unit id="UserControlEditor_DisplayName">
-        <source>User Control Designer (Windows Forms)</source>
-        <target state="new">User Control Designer (Windows Forms)</target>
+        <source>User Control (Windows Forms) Designer</source>
+        <target state="new">User Control (Windows Forms) Designer</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
@@ -172,18 +172,18 @@ Para depurar esse projeto, adicione um projeto executável a essa solução que 
         <note />
       </trans-unit>
       <trans-unit id="WindowsFormEditor_DisplayName">
-        <source>Form Designer (Windows Forms)</source>
-        <target state="new">Form Designer (Windows Forms)</target>
+        <source>Form (Windows Forms) Designer</source>
+        <target state="new">Form (Windows Forms) Designer</target>
         <note />
       </trans-unit>
       <trans-unit id="ComponentEditor_DisplayName">
-        <source>Component Designer (Windows Forms)</source>
-        <target state="new">Component Designer (Windows Forms)</target>
+        <source>Component (Windows Forms) Designer</source>
+        <target state="new">Component (Windows Forms) Designer</target>
         <note />
       </trans-unit>
       <trans-unit id="UserControlEditor_DisplayName">
-        <source>User Control Designer (Windows Forms)</source>
-        <target state="new">User Control Designer (Windows Forms)</target>
+        <source>User Control (Windows Forms) Designer</source>
+        <target state="new">User Control (Windows Forms) Designer</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
@@ -171,6 +171,21 @@ Para depurar esse projeto, adicione um projeto executável a essa solução que 
         <target state="translated">Os valores das propriedades 'TargetFrameworkMoniker' e 'NuGetTargetMoniker' na configuração '{0}' estão vazios. Essa configuração não contribuirá para a restauração do NuGet, o que poderá resultar em erros de restauração e de build.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WindowsFormEditor_DisplayName">
+        <source>Form Designer (Windows Forms)</source>
+        <target state="new">Form Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComponentEditor_DisplayName">
+        <source>Component Designer (Windows Forms)</source>
+        <target state="new">Component Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UserControlEditor_DisplayName">
+        <source>User Control Designer (Windows Forms)</source>
+        <target state="new">User Control Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
@@ -172,18 +172,18 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="WindowsFormEditor_DisplayName">
-        <source>Form Designer (Windows Forms)</source>
-        <target state="new">Form Designer (Windows Forms)</target>
+        <source>Form (Windows Forms) Designer</source>
+        <target state="new">Form (Windows Forms) Designer</target>
         <note />
       </trans-unit>
       <trans-unit id="ComponentEditor_DisplayName">
-        <source>Component Designer (Windows Forms)</source>
-        <target state="new">Component Designer (Windows Forms)</target>
+        <source>Component (Windows Forms) Designer</source>
+        <target state="new">Component (Windows Forms) Designer</target>
         <note />
       </trans-unit>
       <trans-unit id="UserControlEditor_DisplayName">
-        <source>User Control Designer (Windows Forms)</source>
-        <target state="new">User Control Designer (Windows Forms)</target>
+        <source>User Control (Windows Forms) Designer</source>
+        <target state="new">User Control (Windows Forms) Designer</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
@@ -171,6 +171,21 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">Значения свойств "TargetFrameworkMoniker" и "NuGetTargetMoniker" в конфигурации "{0}" являются пустыми. Эта конфигурация не будет задействована в восстановлении NuGet, что может привести к ошибкам при восстановлении и сборке.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WindowsFormEditor_DisplayName">
+        <source>Form Designer (Windows Forms)</source>
+        <target state="new">Form Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComponentEditor_DisplayName">
+        <source>Component Designer (Windows Forms)</source>
+        <target state="new">Component Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UserControlEditor_DisplayName">
+        <source>User Control Designer (Windows Forms)</source>
+        <target state="new">User Control Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
@@ -171,6 +171,21 @@ Bu projede hata ayıklamak için bu çözüme, kitaplık projesine başvuran bir
         <target state="translated">'{0}' yapılandırmasındaki 'TargetFrameworkMoniker' ve 'NuGetTargetMoniker' özelliklerinin değeri boş. Bu yapılandırma NuGet geri yüklemesine katkıda bulunmaz, bu da geri yükleme ve derleme hatalarına neden olabilir.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WindowsFormEditor_DisplayName">
+        <source>Form Designer (Windows Forms)</source>
+        <target state="new">Form Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComponentEditor_DisplayName">
+        <source>Component Designer (Windows Forms)</source>
+        <target state="new">Component Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UserControlEditor_DisplayName">
+        <source>User Control Designer (Windows Forms)</source>
+        <target state="new">User Control Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
@@ -172,18 +172,18 @@ Bu projede hata ayıklamak için bu çözüme, kitaplık projesine başvuran bir
         <note />
       </trans-unit>
       <trans-unit id="WindowsFormEditor_DisplayName">
-        <source>Form Designer (Windows Forms)</source>
-        <target state="new">Form Designer (Windows Forms)</target>
+        <source>Form (Windows Forms) Designer</source>
+        <target state="new">Form (Windows Forms) Designer</target>
         <note />
       </trans-unit>
       <trans-unit id="ComponentEditor_DisplayName">
-        <source>Component Designer (Windows Forms)</source>
-        <target state="new">Component Designer (Windows Forms)</target>
+        <source>Component (Windows Forms) Designer</source>
+        <target state="new">Component (Windows Forms) Designer</target>
         <note />
       </trans-unit>
       <trans-unit id="UserControlEditor_DisplayName">
-        <source>User Control Designer (Windows Forms)</source>
-        <target state="new">User Control Designer (Windows Forms)</target>
+        <source>User Control (Windows Forms) Designer</source>
+        <target state="new">User Control (Windows Forms) Designer</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
@@ -171,6 +171,21 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">“{0}”配置中 "TargetFrameworkMoniker" 和 "NuGetTargetMoniker" 属性的值均为空。此配置将影响 NuGet 还原，这可能导致还原和生成错误。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WindowsFormEditor_DisplayName">
+        <source>Form Designer (Windows Forms)</source>
+        <target state="new">Form Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComponentEditor_DisplayName">
+        <source>Component Designer (Windows Forms)</source>
+        <target state="new">Component Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UserControlEditor_DisplayName">
+        <source>User Control Designer (Windows Forms)</source>
+        <target state="new">User Control Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
@@ -172,18 +172,18 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="WindowsFormEditor_DisplayName">
-        <source>Form Designer (Windows Forms)</source>
-        <target state="new">Form Designer (Windows Forms)</target>
+        <source>Form (Windows Forms) Designer</source>
+        <target state="new">Form (Windows Forms) Designer</target>
         <note />
       </trans-unit>
       <trans-unit id="ComponentEditor_DisplayName">
-        <source>Component Designer (Windows Forms)</source>
-        <target state="new">Component Designer (Windows Forms)</target>
+        <source>Component (Windows Forms) Designer</source>
+        <target state="new">Component (Windows Forms) Designer</target>
         <note />
       </trans-unit>
       <trans-unit id="UserControlEditor_DisplayName">
-        <source>User Control Designer (Windows Forms)</source>
-        <target state="new">User Control Designer (Windows Forms)</target>
+        <source>User Control (Windows Forms) Designer</source>
+        <target state="new">User Control (Windows Forms) Designer</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
@@ -171,6 +171,21 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">'{0}' 組態中 'TargetFrameworkMoniker' 和 'NuGetTargetMoniker' 屬性的值皆為空白。此組態無助於 NuGet 還原，可能導致還原及建置錯誤。</target>
         <note />
       </trans-unit>
+      <trans-unit id="WindowsFormEditor_DisplayName">
+        <source>Form Designer (Windows Forms)</source>
+        <target state="new">Form Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ComponentEditor_DisplayName">
+        <source>Component Designer (Windows Forms)</source>
+        <target state="new">Component Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UserControlEditor_DisplayName">
+        <source>User Control Designer (Windows Forms)</source>
+        <target state="new">User Control Designer (Windows Forms)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
@@ -172,18 +172,18 @@ In order to debug this project, add an executable project to this solution which
         <note />
       </trans-unit>
       <trans-unit id="WindowsFormEditor_DisplayName">
-        <source>Form Designer (Windows Forms)</source>
-        <target state="new">Form Designer (Windows Forms)</target>
+        <source>Form (Windows Forms) Designer</source>
+        <target state="new">Form (Windows Forms) Designer</target>
         <note />
       </trans-unit>
       <trans-unit id="ComponentEditor_DisplayName">
-        <source>Component Designer (Windows Forms)</source>
-        <target state="new">Component Designer (Windows Forms)</target>
+        <source>Component (Windows Forms) Designer</source>
+        <target state="new">Component (Windows Forms) Designer</target>
         <note />
       </trans-unit>
       <trans-unit id="UserControlEditor_DisplayName">
-        <source>User Control Designer (Windows Forms)</source>
-        <target state="new">User Control Designer (Windows Forms)</target>
+        <source>User Control (Windows Forms) Designer</source>
+        <target state="new">User Control (Windows Forms) Designer</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectSystemOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectSystemOptions.cs
@@ -44,5 +44,15 @@ namespace Microsoft.VisualStudio.ProjectSystem
         ///     The level of fast up to date check logging.
         /// </value>
         Task<LogLevel> GetFastUpToDateLoggingLevelAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Gets a value indicating whether the designer view is the default editor for the specified designer category.
+        /// </summary>
+        Task<bool> GetUseDesignerByDefaultAsync(string designerCategory, bool defaultValue, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Sets a value indicating whether the designer view is the default editor for the specified designer category.
+        /// </summary>
+        Task SetUseDesignerByDefaultAsync(string designerCategory, bool value, CancellationToken cancellationToken = default);
     }
 }


### PR DESCRIPTION
Enable WinForms designer to open

Fixes: #3823, #4804

This ports WinFormEditorProvider from CPS, and changes behavior from it and legacy:

- Users can now control (using Open With... -> Set As Default) whether the designer opens by default for Forms, User Controls and Components separately from each other. Legacy/CPS have a single setting that controls this. This is helpful because the Component designer is less useful than the Form designer, so you might want the latter to open but not the former.

- This new setting roams and is shared across all languages. Legacy/CPS is per language per VS install.

- Component Designer is turned off by default. Users can open it via the View Designer command, or use above Open With to set it to open by default.

- The name of the designer editor has changed from "CSharp/Visual Basic Form Editor" for Forms, User Controls and Components in legacy to:

Type|Name
---|---
Form|Form (Windows Forms) Designer 
Component|Component (Windows Forms) Designer
UserControl|User Control (Windows Forms) Designer

I feel these names are better descriptions of what they open and are consistent with the "XAML Designer".

This is a draft PR because we're blocked on CPS producing a package with an updated `IProjectSpecificEditorProvider` implementation. tag @adrianvmsft.