### PR TITLE
Add telemetry for advanced build settings dialog

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
@@ -1759,6 +1759,17 @@ Namespace Microsoft.VisualStudio.Editors.Common
                 TelemetryService.DefaultSession.PostFault(InputXmlFormEventName, "Exception encountered during Xml Schema Inference", ex)
             End Sub
 
+            Private Const AdvBuildSettingsPropPageEventName As String = "vs/projectsystem/appdesigner/advbuildsettingsproppage"
+            Public Enum AdvBuildSettingsPropPageEvent
+                FormOpened = 0
+            End Enum
+
+            Public Shared Sub LogAdvBuildSettingsPropPageEvent(eventValue As AdvBuildSettingsPropPageEvent)
+                Dim userTask = New UserTaskEvent(AdvBuildSettingsPropPageEventName, TelemetryResult.Success)
+                userTask.Properties("vs.projectsystem.appdesigner.advbuildsettingsproppage") = eventValue
+                TelemetryService.DefaultSession.PostEvent(userTask)
+            End Sub
+
         End Class
 #End Region
     End Module

--- a/src/Microsoft.VisualStudio.Editors/PropPages/AdvBuildSettingsPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AdvBuildSettingsPropPage.vb
@@ -44,6 +44,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
             AutoScaleMode = AutoScaleMode.Font
             PageRequiresScaling = False
+
+            TelemetryLogger.LogAdvBuildSettingsPropPageEvent(TelemetryLogger.AdvBuildSettingsPropPageEvent.FormOpened)
         End Sub
 
         Protected Overrides ReadOnly Property ControlData() As PropertyControlData()


### PR DESCRIPTION
Fire a telemetry every time the C# Advanced Build Settings dialog is opened. We want to get some idea of how many people actually use this dialog.