### PR TITLE
XAML Rule review

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/XamlRuleTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/XamlRuleTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml;
+using System.Xml.Linq;
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Rules
@@ -77,6 +78,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
                     Assert.False(element.HasAttribute("Category"));
                 }
             }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetAllRules))]
+        public void RuleMustHaveAName(string ruleName, string fullPath)
+        {
+            XElement rule = LoadXamlRuleX(fullPath).Root;
+
+            // Ignore XAML documents for other types such as ProjectSchemaDefinitions
+            if (rule.Name.LocalName != "Rule")
+                return;
+
+            string name = rule.Attribute("Name")?.Value;
+
+            Assert.NotNull(name);
+            Assert.NotEqual("", name);
         }
 
         [Theory]
@@ -243,6 +260,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
             }
 
             return rule;
+        }
+
+        private static XDocument LoadXamlRuleX(string fullPath)
+        {
+            var settings = new XmlReaderSettings { XmlResolver = null };
+            using var fileStream = File.OpenRead(fullPath);
+            using var reader = XmlReader.Create(fileStream, settings);
+            return XDocument.Load(reader);
         }
 
         private void AssertXmlEqual(XmlDocument left, XmlDocument right)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/XamlRuleTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/XamlRuleTests.cs
@@ -1,9 +1,12 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml;
 using System.Xml.Linq;
+
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Rules

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/XamlRuleTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/XamlRuleTests.cs
@@ -85,6 +85,36 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
 
         [Theory]
         [MemberData(nameof(GetAllRules))]
+        public void VisiblePropertiesMustHaveDisplayName(string ruleName, string fullPath)
+        {
+            // The "DisplayName" property is localised, while "Name" is not.
+            // Visible properties without a "DisplayName" will appear in English in all locales.
+
+            XElement rule = LoadXamlRuleX(fullPath).Root;
+
+            // Ignore XAML documents for other types such as ProjectSchemaDefinitions
+            if (rule.Name.LocalName != "Rule")
+                return;
+
+            foreach (var property in GetProperties(rule))
+            {
+                // Properties are visible by default
+                string visibleValue = property.Attribute("Visible")?.Value ?? "true";
+
+                Assert.True(bool.TryParse(visibleValue, out bool visible));
+
+                if (!visible)
+                    continue;
+
+                string displayName = property.Attribute("DisplayName")?.Value;
+
+                Assert.NotNull(displayName);
+                Assert.NotEqual("", displayName);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetAllRules))]
         public void PropertyDescriptionMustEndWithFullStop(string ruleName, string fullPath)
         {
             XElement rule = LoadXamlRuleX(fullPath).Root;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/COMReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/COMReference.xaml
@@ -20,20 +20,24 @@
                   ReadOnly="True"
                   Visible="False" />
 
-  <BoolProperty Name="Isolated" />
+  <BoolProperty Name="Isolated"
+                DisplayName="Isolated" />
 
   <StringProperty Name="Lcid"
                   Description="The LCID of the COM server."
                   DisplayName="Locale" />
 
-  <IntProperty Name="VersionMajor" />
+  <IntProperty Name="VersionMajor"
+               DisplayName="Major Version" />
 
-  <IntProperty Name="VersionMinor" />
+  <IntProperty Name="VersionMinor"
+               DisplayName="Minor Version" />
 
   <BoolProperty Name="Visible"
                 ReadOnly="True"
                 Visible="False" />
 
-  <StringProperty Name="WrapperTool" />
+  <StringProperty Name="WrapperTool"
+                  DisplayName="Wrapper Tool" />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CollectedFrameworkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CollectedFrameworkReference.xaml
@@ -15,6 +15,7 @@
                 SourceType="TargetResults" />
   </Rule.DataSource>
 
-  <StringProperty Name="PrivateAssets" />
+  <StringProperty Name="PrivateAssets"
+                  DisplayName="Private Assets" />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CollectedPackageDownload.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CollectedPackageDownload.xaml
@@ -15,6 +15,7 @@
                 SourceType="TargetResults" />
   </Rule.DataSource>
 
-  <StringProperty Name="Version" />
+  <StringProperty Name="Version"
+                  DisplayName="Version" />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -110,7 +110,7 @@
                   Visible="False" />
 
   <BoolProperty Name="Optimize"
-                Description="Should compiler optimize output?" />
+                Description="Whether the compiler should optimize output." />
 
   <StringProperty Name="OutputName" />
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -27,7 +27,8 @@
   <StringProperty Name="ApplicationIcon"
                   DisplayName="Application Icon" />
 
-  <StringProperty Name="AssemblyName" />
+  <StringProperty Name="AssemblyName"
+                  DisplayName="Assembly Name" />
 
   <StringProperty Name="AssemblyReferenceTabs"
                   Visible="false" />
@@ -45,9 +46,11 @@
   </BoolProperty>
 
   <StringListProperty Name="AvailablePlatforms"
-                      Separator="," />
+                      Separator=","
+                      DisplayName="Available Platforms" />
 
-  <StringProperty Name="BaseIntermediateOutputPath" />
+  <StringProperty Name="BaseIntermediateOutputPath"
+                  DisplayName="Base Intermediate Output Path" />
 
   <StringProperty Name="Configuration"
                   Visible="false" />
@@ -100,7 +103,8 @@
   <StringProperty Name="MSBuildProjectFullPath"
                   Visible="false" />
 
-  <StringProperty Name="Name" />
+  <StringProperty Name="Name"
+                  DisplayName="Name" />
 
   <StringProperty Name="NETCoreSdkVersion"
                   ReadOnly="True"
@@ -110,13 +114,17 @@
                   Visible="False" />
 
   <BoolProperty Name="Optimize"
-                Description="Whether the compiler should optimize output." />
+                Description="Whether the compiler should optimize output."
+                DisplayName="Optimize" />
 
-  <StringProperty Name="OutputName" />
+  <StringProperty Name="OutputName"
+                  DisplayName="Output Name" />
 
-  <StringProperty Name="OutputPath" />
+  <StringProperty Name="OutputPath"
+                  DisplayName="Output Path" />
 
-  <EnumProperty Name="OutputType">
+  <EnumProperty Name="OutputType"
+                DisplayName="Output Type" >
     <EnumValue Name="Library"
                DisplayName="Class Library" />
     <EnumValue Name="Exe"
@@ -270,7 +278,8 @@
     </StringProperty.DataSource>
   </StringProperty>
 
-  <StringProperty Name="TargetPath" />
+  <StringProperty Name="TargetPath"
+                  DisplayName="Target Path" />
 
   <StringProperty Name="TargetPlatformIdentifier"
                   Visible="false" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DotNetCliToolReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DotNetCliToolReference.xaml
@@ -19,7 +19,7 @@
                   Visible="True" />
 
   <StringProperty Name="ExcludeAssets"
-                  Description="Assets to exclude from this reference"
+                  Description="Assets to exclude from this reference."
                   DisplayName="ExcludeAssets"
                   Visible="True" />
 
@@ -32,7 +32,7 @@
                   Visible="False" />
 
   <StringProperty Name="IncludeAssets"
-                  Description="Assets to include from this reference"
+                  Description="Assets to include from this reference."
                   DisplayName="IncludeAssets"
                   Visible="True" />
 
@@ -49,7 +49,7 @@
                   Visible="False" />
 
   <StringProperty Name="PrivateAssets"
-                  Description="Assets that are private in this reference"
+                  Description="Assets that are private in this reference."
                   DisplayName="PrivateAssets"
                   Visible="True" />
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DotNetCliToolReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DotNetCliToolReference.xaml
@@ -15,13 +15,11 @@
   <StringProperty Name="Description"
                   Description="Dependency description."
                   DisplayName="Description"
-                  ReadOnly="True"
-                  Visible="True" />
+                  ReadOnly="True" />
 
   <StringProperty Name="ExcludeAssets"
                   Description="Assets to exclude from this reference."
-                  DisplayName="ExcludeAssets"
-                  Visible="True" />
+                  DisplayName="ExcludeAssets" />
 
   <StringProperty Name="FrameworkName"
                   ReadOnly="True"
@@ -33,12 +31,10 @@
 
   <StringProperty Name="IncludeAssets"
                   Description="Assets to include from this reference."
-                  DisplayName="IncludeAssets"
-                  Visible="True" />
+                  DisplayName="IncludeAssets" />
 
   <StringProperty Name="Name"
-                  ReadOnly="True"
-                  Visible="True" />
+                  ReadOnly="True" />
 
   <StringProperty Name="OriginalItemSpec"
                   ReadOnly="True"
@@ -50,8 +46,7 @@
 
   <StringProperty Name="PrivateAssets"
                   Description="Assets that are private in this reference."
-                  DisplayName="PrivateAssets"
-                  Visible="True" />
+                  DisplayName="PrivateAssets" />
 
   <StringProperty Name="RuntimeIdentifier"
                   ReadOnly="True"
@@ -67,7 +62,6 @@
 
   <StringProperty Name="Version"
                   Description="Version of dependency."
-                  DisplayName="Version"
-                  ReadOnly="True" />
+                  DisplayName="Version" />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DotNetCliToolReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/DotNetCliToolReference.xaml
@@ -34,7 +34,8 @@
                   DisplayName="IncludeAssets" />
 
   <StringProperty Name="Name"
-                  ReadOnly="True" />
+                  ReadOnly="True"
+                  DisplayName="Name" />
 
   <StringProperty Name="OriginalItemSpec"
                   ReadOnly="True"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
@@ -17,13 +17,11 @@
   <StringProperty Name="Description"
                   Description="Dependency description."
                   DisplayName="Description"
-                  ReadOnly="True"
-                  Visible="True" />
+                  ReadOnly="True" />
 
   <StringProperty Name="ExcludeAssets"
                   Description="Assets to exclude from this reference."
-                  DisplayName="Excluded assets"
-                  Visible="True" />
+                  DisplayName="Excluded assets" />
 
   <StringProperty Name="FrameworkName"
                   ReadOnly="True"
@@ -35,26 +33,22 @@
 
   <BoolProperty Name="GeneratePathProperty"
                 Description="Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'."
-                DisplayName="Generate path property"
-                Visible="True" />
+                DisplayName="Generate path property" />
 
   <StringProperty Name="IncludeAssets"
                   Description="Assets to include from this reference."
-                  DisplayName="Included assets"
-                  Visible="True" />
+                  DisplayName="Included assets" />
 
   <StringProperty Name="IsImplicitlyDefined"
                   ReadOnly="True"
                   Visible="False" />
 
   <StringProperty Name="Name"
-                  ReadOnly="True"
-                  Visible="True" />
+                  ReadOnly="True" />
 
   <StringProperty Name="NoWarn"
                   Description="Comma-delimited list of warnings that should be suppressed for this package."
-                  DisplayName="Suppress warnings"
-                  Visible="True" />
+                  DisplayName="Suppress warnings" />
 
   <StringProperty Name="OriginalItemSpec"
                   ReadOnly="True"
@@ -62,13 +56,11 @@
 
   <StringProperty Name="Path"
                   Description="Location of the package being referenced."
-                  ReadOnly="True"
-                  Visible="True" />
+                  ReadOnly="True" />
 
   <StringProperty Name="PrivateAssets"
                   Description="Assets that are private in this reference."
-                  DisplayName="Private assets"
-                  Visible="True" />
+                  DisplayName="Private assets" />
 
   <StringProperty Name="RuntimeIdentifier"
                   ReadOnly="True"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
@@ -44,7 +44,8 @@
                   Visible="False" />
 
   <StringProperty Name="Name"
-                  ReadOnly="True" />
+                  ReadOnly="True"
+                  DisplayName="Name" />
 
   <StringProperty Name="NoWarn"
                   Description="Comma-delimited list of warnings that should be suppressed for this package."
@@ -56,7 +57,8 @@
 
   <StringProperty Name="Path"
                   Description="Location of the package being referenced."
-                  ReadOnly="True" />
+                  ReadOnly="True"
+                  DisplayName="Path" />
 
   <StringProperty Name="PrivateAssets"
                   Description="Assets that are private in this reference."

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
@@ -21,7 +21,7 @@
                   Visible="True" />
 
   <StringProperty Name="ExcludeAssets"
-                  Description="Assets to exclude from this reference"
+                  Description="Assets to exclude from this reference."
                   DisplayName="Excluded assets"
                   Visible="True" />
 
@@ -39,7 +39,7 @@
                 Visible="True" />
 
   <StringProperty Name="IncludeAssets"
-                  Description="Assets to include from this reference"
+                  Description="Assets to include from this reference."
                   DisplayName="Included assets"
                   Visible="True" />
 
@@ -52,7 +52,7 @@
                   Visible="True" />
 
   <StringProperty Name="NoWarn"
-                  Description="Comma-delimited list of warnings that should be suppressed for this package"
+                  Description="Comma-delimited list of warnings that should be suppressed for this package."
                   DisplayName="Suppress warnings"
                   Visible="True" />
 
@@ -66,7 +66,7 @@
                   Visible="True" />
 
   <StringProperty Name="PrivateAssets"
-                  Description="Assets that are private in this reference"
+                  Description="Assets that are private in this reference."
                   DisplayName="Private assets"
                   Visible="True" />
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectDebugger.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectDebugger.xaml
@@ -10,7 +10,9 @@
       xmlns="http://schemas.microsoft.com/build/2009/properties">
 
   <Rule.DataSource>
-    <DataSource Persistence="ProjectFile"  HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+    <DataSource Persistence="ProjectFile"
+                HasConfigurationCondition="False"
+                SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
   <!-- the command which appears in the debugger dropdown -->
@@ -20,22 +22,30 @@
     <sys:String x:Key="DebugTargetDropdownEnum">ActiveDebugProfile</sys:String>
   </Rule.Metadata>
 
-  <DynamicEnumProperty Name="ActiveDebugProfile" DisplayName="Debug Target" EnumProvider="DebugProfileProvider"
+  <DynamicEnumProperty Name="ActiveDebugProfile"
+                       DisplayName="Debug Target"
+                       EnumProvider="DebugProfileProvider"
                        Description="Specifies the profile to use for debugging">
     <DynamicEnumProperty.DataSource>
-      <DataSource Persistence="UserFile" HasConfigurationCondition="False" SourceOfDefaultValue="AfterContext" />
+      <DataSource Persistence="UserFile"
+                  HasConfigurationCondition="False"
+                  SourceOfDefaultValue="AfterContext" />
     </DynamicEnumProperty.DataSource>
   </DynamicEnumProperty>
 
   <StringProperty Name="ActiveDebugFramework" ReadOnly="False" Visible="False">
     <StringProperty.DataSource>
-      <DataSource Persistence="UserFile" HasConfigurationCondition="false" SourceOfDefaultValue="AfterContext" />
+      <DataSource Persistence="UserFile"
+                  HasConfigurationCondition="false"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 
   <StringProperty Name="ActiveDebugRuntime" ReadOnly="False" Visible="False">
     <StringProperty.DataSource>
-      <DataSource Persistence="UserFile" HasConfigurationCondition="false" SourceOfDefaultValue="AfterContext" />
+      <DataSource Persistence="UserFile"
+                  HasConfigurationCondition="false"
+                  SourceOfDefaultValue="AfterContext" />
     </StringProperty.DataSource>
   </StringProperty>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectDebugger.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectDebugger.xaml
@@ -25,7 +25,7 @@
   <DynamicEnumProperty Name="ActiveDebugProfile"
                        DisplayName="Debug Target"
                        EnumProvider="DebugProfileProvider"
-                       Description="Specifies the profile to use for debugging">
+                       Description="Specifies the profile to use for debugging.">
     <DynamicEnumProperty.DataSource>
       <DataSource Persistence="UserFile"
                   HasConfigurationCondition="False"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectReference.xaml
@@ -62,7 +62,7 @@
   </BoolProperty>
 
   <StringProperty Name="ExcludeAssets"
-                  Description="Assets to exclude from this reference"
+                  Description="Assets to exclude from this reference."
                   DisplayName="Exclude Assets"
                   Visible="True" />
 
@@ -77,7 +77,7 @@
   </StringProperty>
 
   <StringProperty Name="IncludeAssets"
-                  Description="Assets to include from this reference"
+                  Description="Assets to include from this reference."
                   DisplayName="Include Assets"
                   Visible="True" />
 
@@ -85,7 +85,7 @@
                 Visible="False" />
 
   <StringProperty Name="PrivateAssets"
-                  Description="Assets that are private in this reference"
+                  Description="Assets that are private in this reference."
                   DisplayName="Private Assets"
                   Visible="True" />
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedCompilationReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedCompilationReference.xaml
@@ -21,7 +21,8 @@
                   Visible="False" />
 
   <StringProperty Name="ResolvedPath"
-                  ReadOnly="True">
+                  ReadOnly="True"
+                  DisplayName="Resolved Path">
     <StringProperty.DataSource>
       <DataSource PersistedName="Identity"
                   SourceOfDefaultValue="AfterContext" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedPackageReference.xaml
@@ -28,13 +28,11 @@
   <StringProperty Name="Description"
                   Description="Dependency description."
                   DisplayName="Description"
-                  ReadOnly="True"
-                  Visible="True" />
+                  ReadOnly="True" />
 
   <StringProperty Name="ExcludeAssets"
                   Description="Assets to exclude from this reference."
-                  DisplayName="ExcludeAssets"
-                  Visible="True">
+                  DisplayName="ExcludeAssets">
     <StringProperty.DataSource>
       <DataSource HasConfigurationCondition="False"
                   ItemType="PackageReference"
@@ -53,8 +51,7 @@
 
   <StringProperty Name="IncludeAssets"
                   Description="Assets to include from this reference."
-                  DisplayName="IncludeAssets"
-                  Visible="True">
+                  DisplayName="IncludeAssets">
     <StringProperty.DataSource>
       <DataSource HasConfigurationCondition="False"
                   ItemType="PackageReference"
@@ -72,8 +69,7 @@
                 Visible="False" />
 
   <StringProperty Name="Name"
-                  ReadOnly="True"
-                  Visible="True" />
+                  ReadOnly="True" />
 
   <StringProperty Name="NoWarn"
                   Description="Comma-delimited list of warnings that should be suppressed for this package."
@@ -92,13 +88,11 @@
 
   <StringProperty Name="Path"
                   Description="Location of the package being referenced."
-                  ReadOnly="True"
-                  Visible="True" />
+                  ReadOnly="True" />
 
   <StringProperty Name="PrivateAssets"
                   Description="Assets that are private in this reference."
-                  DisplayName="PrivateAssets"
-                  Visible="True">
+                  DisplayName="PrivateAssets">
     <StringProperty.DataSource>
       <DataSource HasConfigurationCondition="False"
                   ItemType="PackageReference"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedPackageReference.xaml
@@ -69,7 +69,8 @@
                 Visible="False" />
 
   <StringProperty Name="Name"
-                  ReadOnly="True" />
+                  ReadOnly="True"
+                  DisplayName="Name" />
 
   <StringProperty Name="NoWarn"
                   Description="Comma-delimited list of warnings that should be suppressed for this package."
@@ -88,7 +89,8 @@
 
   <StringProperty Name="Path"
                   Description="Location of the package being referenced."
-                  ReadOnly="True" />
+                  ReadOnly="True"
+                  DisplayName="Path" />
 
   <StringProperty Name="PrivateAssets"
                   Description="Assets that are private in this reference."

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedPackageReference.xaml
@@ -32,7 +32,7 @@
                   Visible="True" />
 
   <StringProperty Name="ExcludeAssets"
-                  Description="Assets to exclude from this reference"
+                  Description="Assets to exclude from this reference."
                   DisplayName="ExcludeAssets"
                   Visible="True">
     <StringProperty.DataSource>
@@ -52,7 +52,7 @@
                   Visible="False" />
 
   <StringProperty Name="IncludeAssets"
-                  Description="Assets to include from this reference"
+                  Description="Assets to include from this reference."
                   DisplayName="IncludeAssets"
                   Visible="True">
     <StringProperty.DataSource>
@@ -76,7 +76,7 @@
                   Visible="True" />
 
   <StringProperty Name="NoWarn"
-                  Description="Comma-delimited list of warnings that should be suppressed for this package"
+                  Description="Comma-delimited list of warnings that should be suppressed for this package."
                   DisplayName="NoWarn"
                   Visible="True">
     <StringProperty.DataSource>
@@ -96,7 +96,7 @@
                   Visible="True" />
 
   <StringProperty Name="PrivateAssets"
-                  Description="Assets that are private in this reference"
+                  Description="Assets that are private in this reference."
                   DisplayName="PrivateAssets"
                   Visible="True">
     <StringProperty.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedProjectReference.xaml
@@ -64,7 +64,7 @@
   </BoolProperty>
 
   <StringProperty Name="ExcludeAssets"
-                  Description="Assets to exclude from this reference"
+                  Description="Assets to exclude from this reference."
                   DisplayName="Exclude Assets"
                   Visible="True" />
 
@@ -94,7 +94,7 @@
   </StringProperty>
 
   <StringProperty Name="IncludeAssets"
-                  Description="Assets to include from this reference"
+                  Description="Assets to include from this reference."
                   DisplayName="Include Assets"
                   Visible="True" />
 
@@ -110,7 +110,7 @@
                   Visible="False" />
 
   <StringProperty Name="PrivateAssets"
-                  Description="Assets that are private in this reference"
+                  Description="Assets that are private in this reference."
                   DisplayName="Private Assets"
                   Visible="True" />
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SourceControl.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SourceControl.xaml
@@ -12,12 +12,16 @@
                 SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
-  <StringProperty Name="SccAuxPath" />
+  <StringProperty Name="SccAuxPath"
+                  DisplayName="SccAuxPath" />
 
-  <StringProperty Name="SccLocalPath" />
+  <StringProperty Name="SccLocalPath"
+                  DisplayName="SccLocalPath" />
 
-  <StringProperty Name="SccProjectName" />
+  <StringProperty Name="SccProjectName"
+                  DisplayName="SccProjectName" />
 
-  <StringProperty Name="SccProvider" />
+  <StringProperty Name="SccProvider"
+                  DisplayName="SccProvider" />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckBuilt.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/UpToDateCheckBuilt.xaml
@@ -10,7 +10,8 @@
                 SourceType="TargetResults" />
   </Rule.DataSource>
 
-  <StringProperty Name="Original" />
+  <StringProperty Name="Original"
+                  DisplayName="Original" />
 
   <BoolProperty Name="Visible"
                 ReadOnly="True"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ComReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ComReference.xaml.cs.xlf
@@ -32,6 +32,26 @@
         <target state="translated">Identifikátor LCID serveru COM</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntProperty|VersionMajor|DisplayName">
+        <source>Major Version</source>
+        <target state="new">Major Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMinor|DisplayName">
+        <source>Minor Version</source>
+        <target state="new">Minor Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WrapperTool|DisplayName">
+        <source>Wrapper Tool</source>
+        <target state="new">Wrapper Tool</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Isolated|DisplayName">
+        <source>Isolated</source>
+        <target state="new">Isolated</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ComReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ComReference.xaml.de.xlf
@@ -32,6 +32,26 @@
         <target state="translated">Die LCID des COM-Servers.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntProperty|VersionMajor|DisplayName">
+        <source>Major Version</source>
+        <target state="new">Major Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMinor|DisplayName">
+        <source>Minor Version</source>
+        <target state="new">Minor Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WrapperTool|DisplayName">
+        <source>Wrapper Tool</source>
+        <target state="new">Wrapper Tool</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Isolated|DisplayName">
+        <source>Isolated</source>
+        <target state="new">Isolated</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ComReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ComReference.xaml.es.xlf
@@ -32,6 +32,26 @@
         <target state="translated">LCID del servidor COM.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntProperty|VersionMajor|DisplayName">
+        <source>Major Version</source>
+        <target state="new">Major Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMinor|DisplayName">
+        <source>Minor Version</source>
+        <target state="new">Minor Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WrapperTool|DisplayName">
+        <source>Wrapper Tool</source>
+        <target state="new">Wrapper Tool</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Isolated|DisplayName">
+        <source>Isolated</source>
+        <target state="new">Isolated</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ComReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ComReference.xaml.fr.xlf
@@ -32,6 +32,26 @@
         <target state="translated">LCID du serveur COM.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntProperty|VersionMajor|DisplayName">
+        <source>Major Version</source>
+        <target state="new">Major Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMinor|DisplayName">
+        <source>Minor Version</source>
+        <target state="new">Minor Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WrapperTool|DisplayName">
+        <source>Wrapper Tool</source>
+        <target state="new">Wrapper Tool</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Isolated|DisplayName">
+        <source>Isolated</source>
+        <target state="new">Isolated</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ComReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ComReference.xaml.it.xlf
@@ -32,6 +32,26 @@
         <target state="translated">LCID del server COM.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntProperty|VersionMajor|DisplayName">
+        <source>Major Version</source>
+        <target state="new">Major Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMinor|DisplayName">
+        <source>Minor Version</source>
+        <target state="new">Minor Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WrapperTool|DisplayName">
+        <source>Wrapper Tool</source>
+        <target state="new">Wrapper Tool</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Isolated|DisplayName">
+        <source>Isolated</source>
+        <target state="new">Isolated</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ComReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ComReference.xaml.ja.xlf
@@ -32,6 +32,26 @@
         <target state="translated">COM サーバーの LCID です。</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntProperty|VersionMajor|DisplayName">
+        <source>Major Version</source>
+        <target state="new">Major Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMinor|DisplayName">
+        <source>Minor Version</source>
+        <target state="new">Minor Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WrapperTool|DisplayName">
+        <source>Wrapper Tool</source>
+        <target state="new">Wrapper Tool</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Isolated|DisplayName">
+        <source>Isolated</source>
+        <target state="new">Isolated</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ComReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ComReference.xaml.ko.xlf
@@ -32,6 +32,26 @@
         <target state="translated">COM 서버의 LCID입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntProperty|VersionMajor|DisplayName">
+        <source>Major Version</source>
+        <target state="new">Major Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMinor|DisplayName">
+        <source>Minor Version</source>
+        <target state="new">Minor Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WrapperTool|DisplayName">
+        <source>Wrapper Tool</source>
+        <target state="new">Wrapper Tool</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Isolated|DisplayName">
+        <source>Isolated</source>
+        <target state="new">Isolated</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ComReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ComReference.xaml.pl.xlf
@@ -32,6 +32,26 @@
         <target state="translated">Identyfikator LCID serwera COM.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntProperty|VersionMajor|DisplayName">
+        <source>Major Version</source>
+        <target state="new">Major Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMinor|DisplayName">
+        <source>Minor Version</source>
+        <target state="new">Minor Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WrapperTool|DisplayName">
+        <source>Wrapper Tool</source>
+        <target state="new">Wrapper Tool</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Isolated|DisplayName">
+        <source>Isolated</source>
+        <target state="new">Isolated</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ComReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ComReference.xaml.pt-BR.xlf
@@ -32,6 +32,26 @@
         <target state="translated">O LCID do servidor COM.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntProperty|VersionMajor|DisplayName">
+        <source>Major Version</source>
+        <target state="new">Major Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMinor|DisplayName">
+        <source>Minor Version</source>
+        <target state="new">Minor Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WrapperTool|DisplayName">
+        <source>Wrapper Tool</source>
+        <target state="new">Wrapper Tool</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Isolated|DisplayName">
+        <source>Isolated</source>
+        <target state="new">Isolated</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ComReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ComReference.xaml.ru.xlf
@@ -32,6 +32,26 @@
         <target state="translated">Код языка COM-сервера.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntProperty|VersionMajor|DisplayName">
+        <source>Major Version</source>
+        <target state="new">Major Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMinor|DisplayName">
+        <source>Minor Version</source>
+        <target state="new">Minor Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WrapperTool|DisplayName">
+        <source>Wrapper Tool</source>
+        <target state="new">Wrapper Tool</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Isolated|DisplayName">
+        <source>Isolated</source>
+        <target state="new">Isolated</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ComReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ComReference.xaml.tr.xlf
@@ -32,6 +32,26 @@
         <target state="translated">COM sunucusunun LCID'i.</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntProperty|VersionMajor|DisplayName">
+        <source>Major Version</source>
+        <target state="new">Major Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMinor|DisplayName">
+        <source>Minor Version</source>
+        <target state="new">Minor Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WrapperTool|DisplayName">
+        <source>Wrapper Tool</source>
+        <target state="new">Wrapper Tool</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Isolated|DisplayName">
+        <source>Isolated</source>
+        <target state="new">Isolated</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ComReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ComReference.xaml.zh-Hans.xlf
@@ -32,6 +32,26 @@
         <target state="translated">COM 服务器的 LCID。</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntProperty|VersionMajor|DisplayName">
+        <source>Major Version</source>
+        <target state="new">Major Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMinor|DisplayName">
+        <source>Minor Version</source>
+        <target state="new">Minor Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WrapperTool|DisplayName">
+        <source>Wrapper Tool</source>
+        <target state="new">Wrapper Tool</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Isolated|DisplayName">
+        <source>Isolated</source>
+        <target state="new">Isolated</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ComReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ComReference.xaml.zh-Hant.xlf
@@ -32,6 +32,26 @@
         <target state="translated">COM 伺服器的 LCID。</target>
         <note />
       </trans-unit>
+      <trans-unit id="IntProperty|VersionMajor|DisplayName">
+        <source>Major Version</source>
+        <target state="new">Major Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="IntProperty|VersionMinor|DisplayName">
+        <source>Minor Version</source>
+        <target state="new">Minor Version</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|WrapperTool|DisplayName">
+        <source>Wrapper Tool</source>
+        <target state="new">Wrapper Tool</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Isolated|DisplayName">
+        <source>Isolated</source>
+        <target state="new">Isolated</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.cs.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
-        <source>Should compiler optimize output?</source>
-        <target state="translated">Má kompilátor optimalizovat výstup?</target>
+        <source>Whether the compiler should optimize output.</source>
+        <target state="needs-review-translation">Má kompilátor optimalizovat výstup?</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|TargetRuntime.AppHost|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.cs.xlf
@@ -112,6 +112,51 @@
         <target state="translated">Zakázat rychlou kontrolu aktuálnosti</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|AvailablePlatforms|DisplayName">
+        <source>Available Platforms</source>
+        <target state="new">Available Platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|BaseIntermediateOutputPath|DisplayName">
+        <source>Base Intermediate Output Path</source>
+        <target state="new">Base Intermediate Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|DisplayName">
+        <source>Optimize</source>
+        <target state="new">Optimize</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OutputName|DisplayName">
+        <source>Output Name</source>
+        <target state="new">Output Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OutputPath|DisplayName">
+        <source>Output Path</source>
+        <target state="new">Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OutputType|DisplayName">
+        <source>Output Type</source>
+        <target state="new">Output Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetPath|DisplayName">
+        <source>Target Path</source>
+        <target state="new">Target Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyName|DisplayName">
+        <source>Assembly Name</source>
+        <target state="new">Assembly Name</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.de.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
-        <source>Should compiler optimize output?</source>
-        <target state="translated">Soll die Ausgabe vom Compiler optimiert werden?</target>
+        <source>Whether the compiler should optimize output.</source>
+        <target state="needs-review-translation">Soll die Ausgabe vom Compiler optimiert werden?</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|TargetRuntime.AppHost|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.de.xlf
@@ -112,6 +112,51 @@
         <target state="translated">Schnelle Aktualitätsprüfung deaktivieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|AvailablePlatforms|DisplayName">
+        <source>Available Platforms</source>
+        <target state="new">Available Platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|BaseIntermediateOutputPath|DisplayName">
+        <source>Base Intermediate Output Path</source>
+        <target state="new">Base Intermediate Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|DisplayName">
+        <source>Optimize</source>
+        <target state="new">Optimize</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OutputName|DisplayName">
+        <source>Output Name</source>
+        <target state="new">Output Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OutputPath|DisplayName">
+        <source>Output Path</source>
+        <target state="new">Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OutputType|DisplayName">
+        <source>Output Type</source>
+        <target state="new">Output Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetPath|DisplayName">
+        <source>Target Path</source>
+        <target state="new">Target Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyName|DisplayName">
+        <source>Assembly Name</source>
+        <target state="new">Assembly Name</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.es.xlf
@@ -112,6 +112,51 @@
         <target state="translated">Deshabilitar la comprobación rápida de actualizaciones</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|AvailablePlatforms|DisplayName">
+        <source>Available Platforms</source>
+        <target state="new">Available Platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|BaseIntermediateOutputPath|DisplayName">
+        <source>Base Intermediate Output Path</source>
+        <target state="new">Base Intermediate Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|DisplayName">
+        <source>Optimize</source>
+        <target state="new">Optimize</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OutputName|DisplayName">
+        <source>Output Name</source>
+        <target state="new">Output Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OutputPath|DisplayName">
+        <source>Output Path</source>
+        <target state="new">Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OutputType|DisplayName">
+        <source>Output Type</source>
+        <target state="new">Output Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetPath|DisplayName">
+        <source>Target Path</source>
+        <target state="new">Target Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyName|DisplayName">
+        <source>Assembly Name</source>
+        <target state="new">Assembly Name</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.es.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
-        <source>Should compiler optimize output?</source>
-        <target state="translated">¿Debe el compilador optimizar los resultados?</target>
+        <source>Whether the compiler should optimize output.</source>
+        <target state="needs-review-translation">¿Debe el compilador optimizar los resultados?</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|TargetRuntime.AppHost|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.fr.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
-        <source>Should compiler optimize output?</source>
-        <target state="translated">Le compilateur doit-il optimiser la sortie ?</target>
+        <source>Whether the compiler should optimize output.</source>
+        <target state="needs-review-translation">Le compilateur doit-il optimiser la sortie ?</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|TargetRuntime.AppHost|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.fr.xlf
@@ -112,6 +112,51 @@
         <target state="translated">Désactiver le contrôle de mise à jour rapide</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|AvailablePlatforms|DisplayName">
+        <source>Available Platforms</source>
+        <target state="new">Available Platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|BaseIntermediateOutputPath|DisplayName">
+        <source>Base Intermediate Output Path</source>
+        <target state="new">Base Intermediate Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|DisplayName">
+        <source>Optimize</source>
+        <target state="new">Optimize</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OutputName|DisplayName">
+        <source>Output Name</source>
+        <target state="new">Output Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OutputPath|DisplayName">
+        <source>Output Path</source>
+        <target state="new">Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OutputType|DisplayName">
+        <source>Output Type</source>
+        <target state="new">Output Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetPath|DisplayName">
+        <source>Target Path</source>
+        <target state="new">Target Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyName|DisplayName">
+        <source>Assembly Name</source>
+        <target state="new">Assembly Name</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.it.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
-        <source>Should compiler optimize output?</source>
-        <target state="translated">Indicare se il compilatore deve ottimizzare l'output.</target>
+        <source>Whether the compiler should optimize output.</source>
+        <target state="needs-review-translation">Indicare se il compilatore deve ottimizzare l'output.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|TargetRuntime.AppHost|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.it.xlf
@@ -112,6 +112,51 @@
         <target state="translated">Disabilita controllo aggiornamenti rapido</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|AvailablePlatforms|DisplayName">
+        <source>Available Platforms</source>
+        <target state="new">Available Platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|BaseIntermediateOutputPath|DisplayName">
+        <source>Base Intermediate Output Path</source>
+        <target state="new">Base Intermediate Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|DisplayName">
+        <source>Optimize</source>
+        <target state="new">Optimize</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OutputName|DisplayName">
+        <source>Output Name</source>
+        <target state="new">Output Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OutputPath|DisplayName">
+        <source>Output Path</source>
+        <target state="new">Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OutputType|DisplayName">
+        <source>Output Type</source>
+        <target state="new">Output Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetPath|DisplayName">
+        <source>Target Path</source>
+        <target state="new">Target Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyName|DisplayName">
+        <source>Assembly Name</source>
+        <target state="new">Assembly Name</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.ja.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
-        <source>Should compiler optimize output?</source>
-        <target state="translated">コンパイラが出力を最適化するかどうかを示します。</target>
+        <source>Whether the compiler should optimize output.</source>
+        <target state="needs-review-translation">コンパイラが出力を最適化するかどうかを示します。</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|TargetRuntime.AppHost|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.ja.xlf
@@ -112,6 +112,51 @@
         <target state="translated">最新状態の高速チェックの無効化</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|AvailablePlatforms|DisplayName">
+        <source>Available Platforms</source>
+        <target state="new">Available Platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|BaseIntermediateOutputPath|DisplayName">
+        <source>Base Intermediate Output Path</source>
+        <target state="new">Base Intermediate Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|DisplayName">
+        <source>Optimize</source>
+        <target state="new">Optimize</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OutputName|DisplayName">
+        <source>Output Name</source>
+        <target state="new">Output Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OutputPath|DisplayName">
+        <source>Output Path</source>
+        <target state="new">Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OutputType|DisplayName">
+        <source>Output Type</source>
+        <target state="new">Output Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetPath|DisplayName">
+        <source>Target Path</source>
+        <target state="new">Target Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyName|DisplayName">
+        <source>Assembly Name</source>
+        <target state="new">Assembly Name</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.ko.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
-        <source>Should compiler optimize output?</source>
-        <target state="translated">컴파일러가 출력을 최적화해야 합니까?</target>
+        <source>Whether the compiler should optimize output.</source>
+        <target state="needs-review-translation">컴파일러가 출력을 최적화해야 합니까?</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|TargetRuntime.AppHost|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.ko.xlf
@@ -112,6 +112,51 @@
         <target state="translated">빠른 최신 검사 사용 안 함</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|AvailablePlatforms|DisplayName">
+        <source>Available Platforms</source>
+        <target state="new">Available Platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|BaseIntermediateOutputPath|DisplayName">
+        <source>Base Intermediate Output Path</source>
+        <target state="new">Base Intermediate Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|DisplayName">
+        <source>Optimize</source>
+        <target state="new">Optimize</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OutputName|DisplayName">
+        <source>Output Name</source>
+        <target state="new">Output Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OutputPath|DisplayName">
+        <source>Output Path</source>
+        <target state="new">Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OutputType|DisplayName">
+        <source>Output Type</source>
+        <target state="new">Output Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetPath|DisplayName">
+        <source>Target Path</source>
+        <target state="new">Target Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyName|DisplayName">
+        <source>Assembly Name</source>
+        <target state="new">Assembly Name</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.pl.xlf
@@ -112,6 +112,51 @@
         <target state="translated">Wyłącz szybkie testy aktualności</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|AvailablePlatforms|DisplayName">
+        <source>Available Platforms</source>
+        <target state="new">Available Platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|BaseIntermediateOutputPath|DisplayName">
+        <source>Base Intermediate Output Path</source>
+        <target state="new">Base Intermediate Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|DisplayName">
+        <source>Optimize</source>
+        <target state="new">Optimize</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OutputName|DisplayName">
+        <source>Output Name</source>
+        <target state="new">Output Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OutputPath|DisplayName">
+        <source>Output Path</source>
+        <target state="new">Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OutputType|DisplayName">
+        <source>Output Type</source>
+        <target state="new">Output Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetPath|DisplayName">
+        <source>Target Path</source>
+        <target state="new">Target Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyName|DisplayName">
+        <source>Assembly Name</source>
+        <target state="new">Assembly Name</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.pl.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
-        <source>Should compiler optimize output?</source>
-        <target state="translated">Czy kompilator powinien optymalizować dane wyjściowe?</target>
+        <source>Whether the compiler should optimize output.</source>
+        <target state="needs-review-translation">Czy kompilator powinien optymalizować dane wyjściowe?</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|TargetRuntime.AppHost|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.pt-BR.xlf
@@ -112,6 +112,51 @@
         <target state="translated">Desabilitar verificação atualizada rápida</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|AvailablePlatforms|DisplayName">
+        <source>Available Platforms</source>
+        <target state="new">Available Platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|BaseIntermediateOutputPath|DisplayName">
+        <source>Base Intermediate Output Path</source>
+        <target state="new">Base Intermediate Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|DisplayName">
+        <source>Optimize</source>
+        <target state="new">Optimize</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OutputName|DisplayName">
+        <source>Output Name</source>
+        <target state="new">Output Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OutputPath|DisplayName">
+        <source>Output Path</source>
+        <target state="new">Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OutputType|DisplayName">
+        <source>Output Type</source>
+        <target state="new">Output Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetPath|DisplayName">
+        <source>Target Path</source>
+        <target state="new">Target Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyName|DisplayName">
+        <source>Assembly Name</source>
+        <target state="new">Assembly Name</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.pt-BR.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
-        <source>Should compiler optimize output?</source>
-        <target state="translated">O compilador deve otimizar o resultado?</target>
+        <source>Whether the compiler should optimize output.</source>
+        <target state="needs-review-translation">O compilador deve otimizar o resultado?</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|TargetRuntime.AppHost|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.ru.xlf
@@ -112,6 +112,51 @@
         <target state="translated">Отключить быструю проверку на актуальность</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|AvailablePlatforms|DisplayName">
+        <source>Available Platforms</source>
+        <target state="new">Available Platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|BaseIntermediateOutputPath|DisplayName">
+        <source>Base Intermediate Output Path</source>
+        <target state="new">Base Intermediate Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|DisplayName">
+        <source>Optimize</source>
+        <target state="new">Optimize</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OutputName|DisplayName">
+        <source>Output Name</source>
+        <target state="new">Output Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OutputPath|DisplayName">
+        <source>Output Path</source>
+        <target state="new">Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OutputType|DisplayName">
+        <source>Output Type</source>
+        <target state="new">Output Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetPath|DisplayName">
+        <source>Target Path</source>
+        <target state="new">Target Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyName|DisplayName">
+        <source>Assembly Name</source>
+        <target state="new">Assembly Name</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.ru.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
-        <source>Should compiler optimize output?</source>
-        <target state="translated">Должен ли компилятор оптимизировать выходные файлы?</target>
+        <source>Whether the compiler should optimize output.</source>
+        <target state="needs-review-translation">Должен ли компилятор оптимизировать выходные файлы?</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|TargetRuntime.AppHost|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.tr.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
-        <source>Should compiler optimize output?</source>
-        <target state="translated">Derleyici çıkışı en iyi duruma getirmeli midir?</target>
+        <source>Whether the compiler should optimize output.</source>
+        <target state="needs-review-translation">Derleyici çıkışı en iyi duruma getirmeli midir?</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|TargetRuntime.AppHost|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.tr.xlf
@@ -112,6 +112,51 @@
         <target state="translated">Hızlı Güncellik Denetimini Devre Dışı Bırak</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|AvailablePlatforms|DisplayName">
+        <source>Available Platforms</source>
+        <target state="new">Available Platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|BaseIntermediateOutputPath|DisplayName">
+        <source>Base Intermediate Output Path</source>
+        <target state="new">Base Intermediate Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|DisplayName">
+        <source>Optimize</source>
+        <target state="new">Optimize</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OutputName|DisplayName">
+        <source>Output Name</source>
+        <target state="new">Output Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OutputPath|DisplayName">
+        <source>Output Path</source>
+        <target state="new">Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OutputType|DisplayName">
+        <source>Output Type</source>
+        <target state="new">Output Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetPath|DisplayName">
+        <source>Target Path</source>
+        <target state="new">Target Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyName|DisplayName">
+        <source>Assembly Name</source>
+        <target state="new">Assembly Name</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.zh-Hans.xlf
@@ -112,6 +112,51 @@
         <target state="translated">禁用快速最新检查</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|AvailablePlatforms|DisplayName">
+        <source>Available Platforms</source>
+        <target state="new">Available Platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|BaseIntermediateOutputPath|DisplayName">
+        <source>Base Intermediate Output Path</source>
+        <target state="new">Base Intermediate Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|DisplayName">
+        <source>Optimize</source>
+        <target state="new">Optimize</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OutputName|DisplayName">
+        <source>Output Name</source>
+        <target state="new">Output Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OutputPath|DisplayName">
+        <source>Output Path</source>
+        <target state="new">Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OutputType|DisplayName">
+        <source>Output Type</source>
+        <target state="new">Output Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetPath|DisplayName">
+        <source>Target Path</source>
+        <target state="new">Target Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyName|DisplayName">
+        <source>Assembly Name</source>
+        <target state="new">Assembly Name</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.zh-Hans.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
-        <source>Should compiler optimize output?</source>
-        <target state="translated">编译器是否应优化输出?</target>
+        <source>Whether the compiler should optimize output.</source>
+        <target state="needs-review-translation">编译器是否应优化输出?</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|TargetRuntime.AppHost|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.zh-Hant.xlf
@@ -112,6 +112,51 @@
         <target state="translated">停用快速最新版檢查</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringListProperty|AvailablePlatforms|DisplayName">
+        <source>Available Platforms</source>
+        <target state="new">Available Platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|BaseIntermediateOutputPath|DisplayName">
+        <source>Base Intermediate Output Path</source>
+        <target state="new">Base Intermediate Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|DisplayName">
+        <source>Optimize</source>
+        <target state="new">Optimize</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OutputName|DisplayName">
+        <source>Output Name</source>
+        <target state="new">Output Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|OutputPath|DisplayName">
+        <source>Output Path</source>
+        <target state="new">Output Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OutputType|DisplayName">
+        <source>Output Type</source>
+        <target state="new">Output Type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|TargetPath|DisplayName">
+        <source>Target Path</source>
+        <target state="new">Target Path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyName|DisplayName">
+        <source>Assembly Name</source>
+        <target state="new">Assembly Name</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ConfigurationGeneral.xaml.zh-Hant.xlf
@@ -83,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
-        <source>Should compiler optimize output?</source>
-        <target state="translated">編譯器是否應將輸出最佳化?</target>
+        <source>Whether the compiler should optimize output.</source>
+        <target state="needs-review-translation">編譯器是否應將輸出最佳化?</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|TargetRuntime.AppHost|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.cs.xlf
@@ -62,6 +62,11 @@
         <target state="needs-review-translation">Soukromé prostředky v tomto odkazu</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.cs.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Prostředky zahrnuté z tohoto odkazu</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Prostředky zahrnuté z tohoto odkazu</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Prostředky vyloučené z tohoto odkazu</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Prostředky vyloučené z tohoto odkazu</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Soukromé prostředky v tomto odkazu</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Soukromé prostředky v tomto odkazu</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.de.xlf
@@ -62,6 +62,11 @@
         <target state="needs-review-translation">Private Ressourcen in diesem Verweis</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.de.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Einzuschließende Ressourcen aus diesem Verweis</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Einzuschließende Ressourcen aus diesem Verweis</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Auszuschließende Ressourcen aus diesem Verweis</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Auszuschließende Ressourcen aus diesem Verweis</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Private Ressourcen in diesem Verweis</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Private Ressourcen in diesem Verweis</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.es.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Recursos de esta referencia que se deben incluir</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Recursos de esta referencia que se deben incluir</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Recursos de esta referencia que se deben excluir</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Recursos de esta referencia que se deben excluir</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Recursos que son privados en esta referencia</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Recursos que son privados en esta referencia</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.es.xlf
@@ -62,6 +62,11 @@
         <target state="needs-review-translation">Recursos que son privados en esta referencia</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.fr.xlf
@@ -62,6 +62,11 @@
         <target state="needs-review-translation">Composants privés dans cette référence</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.fr.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Composants à inclure à partir de cette référence</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Composants à inclure à partir de cette référence</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Composants à exclure à partir de cette référence</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Composants à exclure à partir de cette référence</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Composants privés dans cette référence</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Composants privés dans cette référence</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.it.xlf
@@ -62,6 +62,11 @@
         <target state="needs-review-translation">Risorse private in questo riferimento</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.it.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Risorse da includere da questo riferimento</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Risorse da includere da questo riferimento</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Risorse da escludere da questo riferimento</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Risorse da escludere da questo riferimento</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Risorse private in questo riferimento</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Risorse private in questo riferimento</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.ja.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">この参照から含める資産</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">この参照から含める資産</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">この参照から除外する資産</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">この参照から除外する資産</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">この参照で非公開のアセット</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">この参照で非公開のアセット</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.ja.xlf
@@ -62,6 +62,11 @@
         <target state="needs-review-translation">この参照で非公開のアセット</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.ko.xlf
@@ -62,6 +62,11 @@
         <target state="needs-review-translation">이 참조에서 private인 자산입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.ko.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">이 참조에서 포함할 자산입니다.</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">이 참조에서 포함할 자산입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">이 참조에서 제외할 자산입니다.</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">이 참조에서 제외할 자산입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">이 참조에서 private인 자산입니다.</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">이 참조에서 private인 자산입니다.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.pl.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Zasoby do uwzględnienia z tego odwołania</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Zasoby do uwzględnienia z tego odwołania</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Zasoby do wykluczenia z tego odwołania</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Zasoby do wykluczenia z tego odwołania</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Prywatne zasoby w tym odwołaniu</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Prywatne zasoby w tym odwołaniu</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.pl.xlf
@@ -62,6 +62,11 @@
         <target state="needs-review-translation">Prywatne zasoby w tym odwołaniu</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.pt-BR.xlf
@@ -62,6 +62,11 @@
         <target state="needs-review-translation">Ativos que são privados nessa referência</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.pt-BR.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Ativos a serem incluídos dessa referência</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Ativos a serem incluídos dessa referência</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Ativos a serem excluídos dessa referência</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Ativos a serem excluídos dessa referência</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Ativos que são privados nessa referência</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Ativos que são privados nessa referência</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.ru.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Ресурсы, включаемые из этой ссылки</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Ресурсы, включаемые из этой ссылки</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Ресурсы, исключаемые из этой ссылки</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Ресурсы, исключаемые из этой ссылки</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Ресурсы, являющиеся закрытыми в этой ссылке</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Ресурсы, являющиеся закрытыми в этой ссылке</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.ru.xlf
@@ -62,6 +62,11 @@
         <target state="needs-review-translation">Ресурсы, являющиеся закрытыми в этой ссылке</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.tr.xlf
@@ -62,6 +62,11 @@
         <target state="needs-review-translation">Bu başvuruda özel olan varlıklar</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.tr.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Bu başvurudan eklenecek varlıklar</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Bu başvurudan eklenecek varlıklar</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Bu başvurudan dışlanacak varlıklar</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Bu başvurudan dışlanacak varlıklar</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Bu başvuruda özel olan varlıklar</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Bu başvuruda özel olan varlıklar</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.zh-Hans.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">要从此引用中包括的资产</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">要从此引用中包括的资产</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">要从此引用中排除的资产</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">要从此引用中排除的资产</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">此引用中的私有资产</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">此引用中的私有资产</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.zh-Hans.xlf
@@ -62,6 +62,11 @@
         <target state="needs-review-translation">此引用中的私有资产</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.zh-Hant.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">要從此參考包含的資產</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">要從此參考包含的資產</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">要從此參考排除的資產</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">要從此參考排除的資產</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">此參考中的私用資產</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">此參考中的私用資產</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/DotNetCliToolReference.xaml.zh-Hant.xlf
@@ -62,6 +62,11 @@
         <target state="needs-review-translation">此參考中的私用資產</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.cs.xlf
@@ -87,6 +87,16 @@
         <target state="translated">Určuje, jestli se má generovat vlastnost MSBuildu s umístěním kořenového adresáře balíčku. Název generované vlastnosti je ve formátu Pkg[ID_balíčku], kde [ID_balíčku] je ID balíčku, ve kterém jsou tečky nahrazené podtržítky.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.cs.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Prostředky zahrnuté z tohoto odkazu</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Prostředky zahrnuté z tohoto odkazu</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Prostředky vyloučené z tohoto odkazu</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Prostředky vyloučené z tohoto odkazu</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Soukromé prostředky v tomto odkazu</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Soukromé prostředky v tomto odkazu</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
-        <target state="translated">Seznam upozornění oddělených čárkou, která by se měla u tohoto balíčku potlačit</target>
+        <source>Comma-delimited list of warnings that should be suppressed for this package.</source>
+        <target state="needs-review-translation">Seznam upozornění oddělených čárkou, která by se měla u tohoto balíčku potlačit</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.de.xlf
@@ -87,6 +87,16 @@
         <target state="translated">Gibt an, ob eine MSBuild-Eigenschaft mit dem Speicherort des Stammverzeichnisses des Pakets generiert werden soll. Der Name der generierten Eigenschaft weist das Format "Pkg[Paket-ID]" auf, wobei "[Paket-ID]" der ID des Pakets entspricht. Hierbei müssen Punkte (.) jedoch durch Unterstriche (_) ersetzt werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.de.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Einzuschließende Ressourcen aus diesem Verweis</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Einzuschließende Ressourcen aus diesem Verweis</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Auszuschließende Ressourcen aus diesem Verweis</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Auszuschließende Ressourcen aus diesem Verweis</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Private Ressourcen in diesem Verweis</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Private Ressourcen in diesem Verweis</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
-        <target state="translated">Durch Trennzeichen getrennte Liste von Warnungen, die für dieses Paket unterdrückt werden sollen</target>
+        <source>Comma-delimited list of warnings that should be suppressed for this package.</source>
+        <target state="needs-review-translation">Durch Trennzeichen getrennte Liste von Warnungen, die für dieses Paket unterdrückt werden sollen</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.es.xlf
@@ -87,6 +87,16 @@
         <target state="translated">Indica si se va a generar una propiedad de MSBuild con la ubicación del directorio raíz del paquete. El nombre de la propiedad generada tiene el formato "pkg [PackageID]", donde "[PackageID]" es el ID del paquete con cualquier punto "." reemplazado por guiones bajos " _ ".</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.es.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Recursos de esta referencia que se deben incluir</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Recursos de esta referencia que se deben incluir</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Recursos de esta referencia que se deben excluir</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Recursos de esta referencia que se deben excluir</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Recursos que son privados en esta referencia</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Recursos que son privados en esta referencia</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
-        <target state="translated">Lista de advertencias delimitada por comas que se deben suprimir en este paquete</target>
+        <source>Comma-delimited list of warnings that should be suppressed for this package.</source>
+        <target state="needs-review-translation">Lista de advertencias delimitada por comas que se deben suprimir en este paquete</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.fr.xlf
@@ -87,6 +87,16 @@
         <target state="translated">Indique s'il faut générer une propriété MSBuild avec l'emplacement du répertoire racine du package. Le nom de la propriété générée est au format 'Pkg[PackageID]', où '[PackageID]' est l'ID du package avec tous les points '.' remplacés par des traits de soulignement '_'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.fr.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Composants à inclure à partir de cette référence</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Composants à inclure à partir de cette référence</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Composants à exclure à partir de cette référence</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Composants à exclure à partir de cette référence</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Composants privés dans cette référence</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Composants privés dans cette référence</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
-        <target state="translated">Liste délimitée par des virgules, qui répertorie les avertissements à supprimer pour ce package</target>
+        <source>Comma-delimited list of warnings that should be suppressed for this package.</source>
+        <target state="needs-review-translation">Liste délimitée par des virgules, qui répertorie les avertissements à supprimer pour ce package</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.it.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Risorse da includere da questo riferimento</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Risorse da includere da questo riferimento</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Risorse da escludere da questo riferimento</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Risorse da escludere da questo riferimento</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Risorse private in questo riferimento</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Risorse private in questo riferimento</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
-        <target state="translated">Elenco di avvisi delimitati da virgole che non devono essere visualizzati per questo pacchetto</target>
+        <source>Comma-delimited list of warnings that should be suppressed for this package.</source>
+        <target state="needs-review-translation">Elenco di avvisi delimitati da virgole che non devono essere visualizzati per questo pacchetto</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.it.xlf
@@ -87,6 +87,16 @@
         <target state="translated">Indica se generare una proprietà MSBuild con il percorso della directory radice del pacchetto. Il nome di proprietà generato è in formato 'Pkg[IDpacchetto]', dove '[IDpacchetto]' è l'ID del pacchetto in cui gli eventuali punti ('.') sono stati sostituiti da caratteri di sottolineatura ('_').</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ja.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">この参照から含める資産</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">この参照から含める資産</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">この参照から除外する資産</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">この参照から除外する資産</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">この参照で非公開のアセット</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">この参照で非公開のアセット</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
-        <target state="translated">このパッケージで非表示にする必要がある警告のコンマ区切りリスト</target>
+        <source>Comma-delimited list of warnings that should be suppressed for this package.</source>
+        <target state="needs-review-translation">このパッケージで非表示にする必要がある警告のコンマ区切りリスト</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ja.xlf
@@ -87,6 +87,16 @@
         <target state="translated">MSBuild プロパティをパッケージのルート ディレクトリーの場所に生成するかどうかを示します。生成されるプロパティ名は 'Pkg[PackageID]' という形式になります。'[PackageID]' はパッケージの ID で、ピリオド (.) はアンダースコア (_) に置き換えられます。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ko.xlf
@@ -87,6 +87,16 @@
         <target state="translated">패키지의 루트 디렉터리 위치를 사용하여 MSBuild 속성을 생성할지 여부를 제어합니다. 생성된 속성 이름은 'Pkg[PackageID]' 형식입니다. 여기서 '[PackageID]'는 패키지의 ID이고 마침표 '.'는 밑줄 '_'로 바뀝니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ko.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">이 참조에서 포함할 자산입니다.</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">이 참조에서 포함할 자산입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">이 참조에서 제외할 자산입니다.</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">이 참조에서 제외할 자산입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">이 참조에서 private인 자산입니다.</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">이 참조에서 private인 자산입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
-        <target state="translated">이 패키지에 대해 표시하지 않는, 쉼표로 구분된 경고 목록</target>
+        <source>Comma-delimited list of warnings that should be suppressed for this package.</source>
+        <target state="needs-review-translation">이 패키지에 대해 표시하지 않는, 쉼표로 구분된 경고 목록</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.pl.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Zasoby do uwzględnienia z tego odwołania</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Zasoby do uwzględnienia z tego odwołania</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Zasoby do wykluczenia z tego odwołania</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Zasoby do wykluczenia z tego odwołania</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Prywatne zasoby w tym odwołaniu</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Prywatne zasoby w tym odwołaniu</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
-        <target state="translated">Rozdzielona przecinkami lista ostrzeżeń, które mają zostać pominięte dla tego pakietu</target>
+        <source>Comma-delimited list of warnings that should be suppressed for this package.</source>
+        <target state="needs-review-translation">Rozdzielona przecinkami lista ostrzeżeń, które mają zostać pominięte dla tego pakietu</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.pl.xlf
@@ -87,6 +87,16 @@
         <target state="translated">Wskazuje, czy należy generowania właściwość MSBuild z lokalizacją katalogu głównego pakietu. Nazwa właściwości generowane jest w formie 'Pkg [PackageID]', gdzie '[PackageID] 'jest identyfikator pakietu z okresów'.' zastąpione znakami podkreślenia '_'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.pt-BR.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Ativos a serem incluídos dessa referência</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Ativos a serem incluídos dessa referência</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Ativos a serem excluídos dessa referência</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Ativos a serem excluídos dessa referência</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Ativos que são privados nessa referência</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Ativos que são privados nessa referência</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
-        <target state="translated">Lista de avisos delimitada por vírgulas que deve ser suprimida para este pacote</target>
+        <source>Comma-delimited list of warnings that should be suppressed for this package.</source>
+        <target state="needs-review-translation">Lista de avisos delimitada por vírgulas que deve ser suprimida para este pacote</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.pt-BR.xlf
@@ -87,6 +87,16 @@
         <target state="translated">Indica se é necessário gerar uma propriedade do MSBuild com a localização do diretório de raiz do pacote. O nome da propriedade gerado é em forma de 'Pkg [PackageID]', onde '[PackageID] 'é o ID do pacote com quaisquer períodos'.' substituído com caracteres de sublinhado '_'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ru.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Ресурсы, включаемые из этой ссылки</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Ресурсы, включаемые из этой ссылки</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Ресурсы, исключаемые из этой ссылки</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Ресурсы, исключаемые из этой ссылки</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Ресурсы, являющиеся закрытыми в этой ссылке</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Ресурсы, являющиеся закрытыми в этой ссылке</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
-        <target state="translated">Разделенный запятыми список предупреждений, которые должны быть подавлены для этого пакета.</target>
+        <source>Comma-delimited list of warnings that should be suppressed for this package.</source>
+        <target state="needs-review-translation">Разделенный запятыми список предупреждений, которые должны быть подавлены для этого пакета.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.ru.xlf
@@ -87,6 +87,16 @@
         <target state="translated">Указывает, необходимо ли создать свойство MSBuild, содержащее расположение корневого каталог пакета. Имя созданного свойства имеет вид 'Pkg[PackageID]', где '[PackageID]' — идентификатор пакета, в котором точки ('.') заменены на нижние подчеркивания ('_').</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.tr.xlf
@@ -87,6 +87,16 @@
         <target state="translated">Paket kök dizini konumuyla bir MSBuild özelliği oluşturulup oluşturulmayacağını belirtir. Oluşturulan özellik adı 'Pkg[PackageID]' biçimindedir. Burada '[PackageID]', noktalar '.' alt çizgi '_' ile değiştirilmiş olarak paketin adıdır.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.tr.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Bu başvurudan eklenecek varlıklar</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Bu başvurudan eklenecek varlıklar</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Bu başvurudan dışlanacak varlıklar</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Bu başvurudan dışlanacak varlıklar</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Bu başvuruda özel olan varlıklar</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Bu başvuruda özel olan varlıklar</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
-        <target state="translated">Bu paket için gizlenmesi gereken virgülle ayrılmış uyarı listesi</target>
+        <source>Comma-delimited list of warnings that should be suppressed for this package.</source>
+        <target state="needs-review-translation">Bu paket için gizlenmesi gereken virgülle ayrılmış uyarı listesi</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.zh-Hans.xlf
@@ -87,6 +87,16 @@
         <target state="translated">指示是否要使用包的根目录的位置生成 MSBuild 属性。所生成的属性名称采用 "Pkg[PackageID]" 的形式，其中 "[PackageID]" 是包的 ID，且所有句点 "." 均替换为下划线 "_"。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.zh-Hans.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">要从此引用中包括的资产</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">要从此引用中包括的资产</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">要从此引用中排除的资产</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">要从此引用中排除的资产</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">此引用中的私有资产</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">此引用中的私有资产</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
-        <target state="translated">应为此包取消的警告逗号分隔列表</target>
+        <source>Comma-delimited list of warnings that should be suppressed for this package.</source>
+        <target state="needs-review-translation">应为此包取消的警告逗号分隔列表</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.zh-Hant.xlf
@@ -87,6 +87,16 @@
         <target state="translated">表示是否要以套件根目錄的位置產生 MSBuild 屬性。產生屬性的名稱格式為 'Pkg[PackageID]'，其中 '[PackageID]' 是套件的識別碼，所有句點 '.' 均會替換為底線 '_'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/PackageReference.xaml.zh-Hant.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">要從此參考包含的資產</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">要從此參考包含的資產</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">要從此參考排除的資產</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">要從此參考排除的資產</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">此參考中的私用資產</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">此參考中的私用資產</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
-        <target state="translated">不應對此套件顯示的警告清單 (以逗點分隔)</target>
+        <source>Comma-delimited list of warnings that should be suppressed for this package.</source>
+        <target state="needs-review-translation">不應對此套件顯示的警告清單 (以逗點分隔)</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectDebugger.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectDebugger.xaml.cs.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|ActiveDebugProfile|Description">
-        <source>Specifies the profile to use for debugging</source>
-        <target state="translated">Určuje profil používaný k ladění</target>
+        <source>Specifies the profile to use for debugging.</source>
+        <target state="needs-review-translation">Určuje profil používaný k ladění</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectDebugger.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectDebugger.xaml.de.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|ActiveDebugProfile|Description">
-        <source>Specifies the profile to use for debugging</source>
-        <target state="translated">Gibt das Profil an, das zum Debuggen verwendet werden soll.</target>
+        <source>Specifies the profile to use for debugging.</source>
+        <target state="needs-review-translation">Gibt das Profil an, das zum Debuggen verwendet werden soll.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectDebugger.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectDebugger.xaml.es.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|ActiveDebugProfile|Description">
-        <source>Specifies the profile to use for debugging</source>
-        <target state="translated">Especifica el perfil que debe usarse para la depuración</target>
+        <source>Specifies the profile to use for debugging.</source>
+        <target state="needs-review-translation">Especifica el perfil que debe usarse para la depuración</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectDebugger.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectDebugger.xaml.fr.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|ActiveDebugProfile|Description">
-        <source>Specifies the profile to use for debugging</source>
-        <target state="translated">Spécifie le profil à utiliser pour le débogage</target>
+        <source>Specifies the profile to use for debugging.</source>
+        <target state="needs-review-translation">Spécifie le profil à utiliser pour le débogage</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectDebugger.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectDebugger.xaml.it.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|ActiveDebugProfile|Description">
-        <source>Specifies the profile to use for debugging</source>
-        <target state="translated">Consente di specificare il profilo da usare per il debug</target>
+        <source>Specifies the profile to use for debugging.</source>
+        <target state="needs-review-translation">Consente di specificare il profilo da usare per il debug</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectDebugger.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectDebugger.xaml.ja.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|ActiveDebugProfile|Description">
-        <source>Specifies the profile to use for debugging</source>
-        <target state="translated">デバッグに使用するプロファイルを指定する</target>
+        <source>Specifies the profile to use for debugging.</source>
+        <target state="needs-review-translation">デバッグに使用するプロファイルを指定する</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectDebugger.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectDebugger.xaml.ko.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|ActiveDebugProfile|Description">
-        <source>Specifies the profile to use for debugging</source>
-        <target state="translated">디버깅에 사용할 프로필을 지정합니다.</target>
+        <source>Specifies the profile to use for debugging.</source>
+        <target state="needs-review-translation">디버깅에 사용할 프로필을 지정합니다.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectDebugger.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectDebugger.xaml.pl.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|ActiveDebugProfile|Description">
-        <source>Specifies the profile to use for debugging</source>
-        <target state="translated">Określa profil do użycia podczas debugowania</target>
+        <source>Specifies the profile to use for debugging.</source>
+        <target state="needs-review-translation">Określa profil do użycia podczas debugowania</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectDebugger.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectDebugger.xaml.pt-BR.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|ActiveDebugProfile|Description">
-        <source>Specifies the profile to use for debugging</source>
-        <target state="translated">Especifica o perfil a ser usado para a depuração</target>
+        <source>Specifies the profile to use for debugging.</source>
+        <target state="needs-review-translation">Especifica o perfil a ser usado para a depuração</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectDebugger.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectDebugger.xaml.ru.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|ActiveDebugProfile|Description">
-        <source>Specifies the profile to use for debugging</source>
-        <target state="translated">Указывает профиль, используемый для отладки</target>
+        <source>Specifies the profile to use for debugging.</source>
+        <target state="needs-review-translation">Указывает профиль, используемый для отладки</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectDebugger.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectDebugger.xaml.tr.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|ActiveDebugProfile|Description">
-        <source>Specifies the profile to use for debugging</source>
-        <target state="translated">Hata ayıklama için kullanılacak profili belirtir</target>
+        <source>Specifies the profile to use for debugging.</source>
+        <target state="needs-review-translation">Hata ayıklama için kullanılacak profili belirtir</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectDebugger.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectDebugger.xaml.zh-Hans.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|ActiveDebugProfile|Description">
-        <source>Specifies the profile to use for debugging</source>
-        <target state="translated">指定用于调试的配置文件</target>
+        <source>Specifies the profile to use for debugging.</source>
+        <target state="needs-review-translation">指定用于调试的配置文件</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectDebugger.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectDebugger.xaml.zh-Hant.xlf
@@ -18,8 +18,8 @@
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|ActiveDebugProfile|Description">
-        <source>Specifies the profile to use for debugging</source>
-        <target state="translated">指定要使用於偵錯的設定檔</target>
+        <source>Specifies the profile to use for debugging.</source>
+        <target state="needs-review-translation">指定要使用於偵錯的設定檔</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectReference.xaml.cs.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Prostředky zahrnuté z tohoto odkazu</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Prostředky zahrnuté z tohoto odkazu</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Prostředky vyloučené z tohoto odkazu</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Prostředky vyloučené z tohoto odkazu</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Soukromé prostředky v tomto odkazu</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Soukromé prostředky v tomto odkazu</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectReference.xaml.de.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Einzuschließende Ressourcen aus diesem Verweis</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Einzuschließende Ressourcen aus diesem Verweis</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Auszuschließende Ressourcen aus diesem Verweis</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Auszuschließende Ressourcen aus diesem Verweis</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Private Ressourcen in diesem Verweis</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Private Ressourcen in diesem Verweis</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectReference.xaml.es.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Recursos de esta referencia que se deben incluir</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Recursos de esta referencia que se deben incluir</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Recursos de esta referencia que se deben excluir</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Recursos de esta referencia que se deben excluir</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Recursos que son privados en esta referencia</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Recursos que son privados en esta referencia</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectReference.xaml.fr.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Composants à inclure à partir de cette référence</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Composants à inclure à partir de cette référence</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Composants à exclure à partir de cette référence</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Composants à exclure à partir de cette référence</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Composants privés dans cette référence</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Composants privés dans cette référence</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectReference.xaml.it.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Risorse da includere da questo riferimento</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Risorse da includere da questo riferimento</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Risorse da escludere da questo riferimento</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Risorse da escludere da questo riferimento</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Risorse private in questo riferimento</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Risorse private in questo riferimento</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectReference.xaml.ja.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">この参照から含める資産</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">この参照から含める資産</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">この参照から除外する資産</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">この参照から除外する資産</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">この参照で非公開のアセット</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">この参照で非公開のアセット</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectReference.xaml.ko.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">이 참조에서 포함할 자산입니다.</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">이 참조에서 포함할 자산입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">이 참조에서 제외할 자산입니다.</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">이 참조에서 제외할 자산입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">이 참조에서 private인 자산입니다.</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">이 참조에서 private인 자산입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectReference.xaml.pl.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Zasoby do uwzględnienia z tego odwołania</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Zasoby do uwzględnienia z tego odwołania</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Zasoby do wykluczenia z tego odwołania</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Zasoby do wykluczenia z tego odwołania</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Prywatne zasoby w tym odwołaniu</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Prywatne zasoby w tym odwołaniu</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectReference.xaml.pt-BR.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Ativos a serem incluídos dessa referência</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Ativos a serem incluídos dessa referência</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Ativos a serem excluídos dessa referência</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Ativos a serem excluídos dessa referência</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Ativos que são privados nessa referência</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Ativos que são privados nessa referência</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectReference.xaml.ru.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Ресурсы, включаемые из этой ссылки</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Ресурсы, включаемые из этой ссылки</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Ресурсы, исключаемые из этой ссылки</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Ресурсы, исключаемые из этой ссылки</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Ресурсы, являющиеся закрытыми в этой ссылке</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Ресурсы, являющиеся закрытыми в этой ссылке</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectReference.xaml.tr.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Bu başvurudan eklenecek varlıklar</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Bu başvurudan eklenecek varlıklar</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Bu başvurudan dışlanacak varlıklar</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Bu başvurudan dışlanacak varlıklar</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Bu başvuruda özel olan varlıklar</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Bu başvuruda özel olan varlıklar</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectReference.xaml.zh-Hans.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">要从此引用中包括的资产</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">要从此引用中包括的资产</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">要从此引用中排除的资产</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">要从此引用中排除的资产</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">此引用中的私有资产</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">此引用中的私有资产</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ProjectReference.xaml.zh-Hant.xlf
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">要從此參考包含的資產</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">要從此參考包含的資產</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">要從此參考排除的資產</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">要從此參考排除的資產</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">此參考中的私用資產</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">此參考中的私用資產</target>
         <note />
       </trans-unit>
       <trans-unit id="StringListProperty|Aliases|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.cs.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
-        <target state="translated">Seznam upozornění oddělených čárkou, která by se měla u tohoto balíčku potlačit</target>
+        <source>Comma-delimited list of warnings that should be suppressed for this package.</source>
+        <target state="needs-review-translation">Seznam upozornění oddělených čárkou, která by se měla u tohoto balíčku potlačit</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Prostředky zahrnuté z tohoto odkazu</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Prostředky zahrnuté z tohoto odkazu</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Prostředky vyloučené z tohoto odkazu</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Prostředky vyloučené z tohoto odkazu</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Soukromé prostředky v tomto odkazu</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Soukromé prostředky v tomto odkazu</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.cs.xlf
@@ -77,6 +77,16 @@
         <target state="translated">Umístění odkazovaného balíčku</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.de.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
-        <target state="translated">Durch Trennzeichen getrennte Liste von Warnungen, die für dieses Paket unterdrückt werden sollen</target>
+        <source>Comma-delimited list of warnings that should be suppressed for this package.</source>
+        <target state="needs-review-translation">Durch Trennzeichen getrennte Liste von Warnungen, die für dieses Paket unterdrückt werden sollen</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Einzuschließende Ressourcen aus diesem Verweis</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Einzuschließende Ressourcen aus diesem Verweis</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Auszuschließende Ressourcen aus diesem Verweis</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Auszuschließende Ressourcen aus diesem Verweis</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Private Ressourcen in diesem Verweis</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Private Ressourcen in diesem Verweis</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.de.xlf
@@ -77,6 +77,16 @@
         <target state="translated">Speicherort des Pakets, auf das verwiesen wird.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.es.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
-        <target state="translated">Lista de advertencias delimitada por comas que se deben suprimir en este paquete</target>
+        <source>Comma-delimited list of warnings that should be suppressed for this package.</source>
+        <target state="needs-review-translation">Lista de advertencias delimitada por comas que se deben suprimir en este paquete</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Recursos de esta referencia que se deben incluir</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Recursos de esta referencia que se deben incluir</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Recursos de esta referencia que se deben excluir</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Recursos de esta referencia que se deben excluir</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Recursos que son privados en esta referencia</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Recursos que son privados en esta referencia</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.es.xlf
@@ -77,6 +77,16 @@
         <target state="translated">Ubicación del paquete al que se hace referencia.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.fr.xlf
@@ -77,6 +77,16 @@
         <target state="translated">Emplacement du package actuellement référencé.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.fr.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
-        <target state="translated">Liste délimitée par des virgules, qui répertorie les avertissements à supprimer pour ce package</target>
+        <source>Comma-delimited list of warnings that should be suppressed for this package.</source>
+        <target state="needs-review-translation">Liste délimitée par des virgules, qui répertorie les avertissements à supprimer pour ce package</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Composants à inclure à partir de cette référence</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Composants à inclure à partir de cette référence</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Composants à exclure à partir de cette référence</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Composants à exclure à partir de cette référence</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Composants privés dans cette référence</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Composants privés dans cette référence</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.it.xlf
@@ -77,6 +77,16 @@
         <target state="translated">Percorso del pacchetto a cui viene fatto riferimento.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.it.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
-        <target state="translated">Elenco di avvisi delimitati da virgole che non devono essere visualizzati per questo pacchetto</target>
+        <source>Comma-delimited list of warnings that should be suppressed for this package.</source>
+        <target state="needs-review-translation">Elenco di avvisi delimitati da virgole che non devono essere visualizzati per questo pacchetto</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Risorse da includere da questo riferimento</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Risorse da includere da questo riferimento</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Risorse da escludere da questo riferimento</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Risorse da escludere da questo riferimento</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Risorse private in questo riferimento</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Risorse private in questo riferimento</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.ja.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
-        <target state="translated">このパッケージで非表示にする必要がある警告のコンマ区切りリスト</target>
+        <source>Comma-delimited list of warnings that should be suppressed for this package.</source>
+        <target state="needs-review-translation">このパッケージで非表示にする必要がある警告のコンマ区切りリスト</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">この参照から含める資産</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">この参照から含める資産</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">この参照から除外する資産</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">この参照から除外する資産</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">この参照で非公開のアセット</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">この参照で非公開のアセット</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.ja.xlf
@@ -77,6 +77,16 @@
         <target state="translated">参照されているパッケージの場所。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.ko.xlf
@@ -77,6 +77,16 @@
         <target state="translated">참조되는 패키지의 위치입니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.ko.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
-        <target state="translated">이 패키지에 대해 표시하지 않는, 쉼표로 구분된 경고 목록</target>
+        <source>Comma-delimited list of warnings that should be suppressed for this package.</source>
+        <target state="needs-review-translation">이 패키지에 대해 표시하지 않는, 쉼표로 구분된 경고 목록</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">이 참조에서 포함할 자산입니다.</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">이 참조에서 포함할 자산입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">이 참조에서 제외할 자산입니다.</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">이 참조에서 제외할 자산입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">이 참조에서 private인 자산입니다.</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">이 참조에서 private인 자산입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.pl.xlf
@@ -77,6 +77,16 @@
         <target state="translated">Lokalizacja pakietu, którego dotyczy odwołanie.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.pl.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
-        <target state="translated">Rozdzielona przecinkami lista ostrzeżeń, które mają zostać pominięte dla tego pakietu</target>
+        <source>Comma-delimited list of warnings that should be suppressed for this package.</source>
+        <target state="needs-review-translation">Rozdzielona przecinkami lista ostrzeżeń, które mają zostać pominięte dla tego pakietu</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Zasoby do uwzględnienia z tego odwołania</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Zasoby do uwzględnienia z tego odwołania</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Zasoby do wykluczenia z tego odwołania</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Zasoby do wykluczenia z tego odwołania</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Prywatne zasoby w tym odwołaniu</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Prywatne zasoby w tym odwołaniu</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.pt-BR.xlf
@@ -77,6 +77,16 @@
         <target state="translated">Localização do pacote que está sendo referenciado.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.pt-BR.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
-        <target state="translated">Lista de avisos delimitada por vírgulas que deve ser suprimida para este pacote</target>
+        <source>Comma-delimited list of warnings that should be suppressed for this package.</source>
+        <target state="needs-review-translation">Lista de avisos delimitada por vírgulas que deve ser suprimida para este pacote</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Ativos a serem incluídos dessa referência</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Ativos a serem incluídos dessa referência</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Ativos a serem excluídos dessa referência</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Ativos a serem excluídos dessa referência</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Ativos que são privados nessa referência</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Ativos que são privados nessa referência</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.ru.xlf
@@ -77,6 +77,16 @@
         <target state="translated">Расположение пакета, на который указывает ссылка.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.ru.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
-        <target state="translated">Разделенный запятыми список предупреждений, которые должны быть подавлены для этого пакета.</target>
+        <source>Comma-delimited list of warnings that should be suppressed for this package.</source>
+        <target state="needs-review-translation">Разделенный запятыми список предупреждений, которые должны быть подавлены для этого пакета.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Ресурсы, включаемые из этой ссылки</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Ресурсы, включаемые из этой ссылки</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Ресурсы, исключаемые из этой ссылки</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Ресурсы, исключаемые из этой ссылки</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Ресурсы, являющиеся закрытыми в этой ссылке</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Ресурсы, являющиеся закрытыми в этой ссылке</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.tr.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
-        <target state="translated">Bu paket için gizlenmesi gereken virgülle ayrılmış uyarı listesi</target>
+        <source>Comma-delimited list of warnings that should be suppressed for this package.</source>
+        <target state="needs-review-translation">Bu paket için gizlenmesi gereken virgülle ayrılmış uyarı listesi</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Bu başvurudan eklenecek varlıklar</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Bu başvurudan eklenecek varlıklar</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Bu başvurudan dışlanacak varlıklar</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Bu başvurudan dışlanacak varlıklar</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Bu başvuruda özel olan varlıklar</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Bu başvuruda özel olan varlıklar</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.tr.xlf
@@ -77,6 +77,16 @@
         <target state="translated">Başvurulan paketin konumu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.zh-Hans.xlf
@@ -77,6 +77,16 @@
         <target state="translated">所引用的包的位置。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.zh-Hans.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
-        <target state="translated">应为此包取消的警告逗号分隔列表</target>
+        <source>Comma-delimited list of warnings that should be suppressed for this package.</source>
+        <target state="needs-review-translation">应为此包取消的警告逗号分隔列表</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">要从此引用中包括的资产</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">要从此引用中包括的资产</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">要从此引用中排除的资产</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">要从此引用中排除的资产</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">此引用中的私有资产</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">此引用中的私有资产</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.zh-Hant.xlf
@@ -77,6 +77,16 @@
         <target state="translated">目前參考的套件位置。</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|Name|DisplayName">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Path|DisplayName">
+        <source>Path</source>
+        <target state="new">Path</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedPackageReference.xaml.zh-Hant.xlf
@@ -38,8 +38,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|NoWarn|Description">
-        <source>Comma-delimited list of warnings that should be suppressed for this package</source>
-        <target state="translated">不應對此套件顯示的警告清單 (以逗點分隔)</target>
+        <source>Comma-delimited list of warnings that should be suppressed for this package.</source>
+        <target state="needs-review-translation">不應對此套件顯示的警告清單 (以逗點分隔)</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
@@ -48,8 +48,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">要從此參考包含的資產</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">要從此參考包含的資產</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|DisplayName">
@@ -58,8 +58,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">要從此參考排除的資產</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">要從此參考排除的資產</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|DisplayName">
@@ -68,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">此參考中的私用資產</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">此參考中的私用資產</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedProjectReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedProjectReference.xaml.cs.xlf
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Prostředky vyloučené z tohoto odkazu</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Prostředky vyloučené z tohoto odkazu</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Prostředky zahrnuté z tohoto odkazu</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Prostředky zahrnuté z tohoto odkazu</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ReferenceOutputAssembly|DisplayName">
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Soukromé prostředky v tomto odkazu</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Soukromé prostředky v tomto odkazu</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedProjectReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedProjectReference.xaml.de.xlf
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Auszuschließende Ressourcen aus diesem Verweis</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Auszuschließende Ressourcen aus diesem Verweis</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Einzuschließende Ressourcen aus diesem Verweis</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Einzuschließende Ressourcen aus diesem Verweis</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ReferenceOutputAssembly|DisplayName">
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Private Ressourcen in diesem Verweis</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Private Ressourcen in diesem Verweis</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedProjectReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedProjectReference.xaml.es.xlf
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Recursos de esta referencia que se deben excluir</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Recursos de esta referencia que se deben excluir</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Recursos de esta referencia que se deben incluir</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Recursos de esta referencia que se deben incluir</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ReferenceOutputAssembly|DisplayName">
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Recursos que son privados en esta referencia</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Recursos que son privados en esta referencia</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedProjectReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedProjectReference.xaml.fr.xlf
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Composants à exclure à partir de cette référence</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Composants à exclure à partir de cette référence</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Composants à inclure à partir de cette référence</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Composants à inclure à partir de cette référence</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ReferenceOutputAssembly|DisplayName">
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Composants privés dans cette référence</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Composants privés dans cette référence</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedProjectReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedProjectReference.xaml.it.xlf
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Risorse da escludere da questo riferimento</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Risorse da escludere da questo riferimento</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Risorse da includere da questo riferimento</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Risorse da includere da questo riferimento</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ReferenceOutputAssembly|DisplayName">
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Risorse private in questo riferimento</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Risorse private in questo riferimento</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedProjectReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedProjectReference.xaml.ja.xlf
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">この参照から除外する資産</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">この参照から除外する資産</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">この参照から含める資産</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">この参照から含める資産</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ReferenceOutputAssembly|DisplayName">
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">この参照で非公開のアセット</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">この参照で非公開のアセット</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedProjectReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedProjectReference.xaml.ko.xlf
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">이 참조에서 제외할 자산입니다.</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">이 참조에서 제외할 자산입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">이 참조에서 포함할 자산입니다.</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">이 참조에서 포함할 자산입니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ReferenceOutputAssembly|DisplayName">
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">이 참조에서 private인 자산입니다.</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">이 참조에서 private인 자산입니다.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedProjectReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedProjectReference.xaml.pl.xlf
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Zasoby do wykluczenia z tego odwołania</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Zasoby do wykluczenia z tego odwołania</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Zasoby do uwzględnienia z tego odwołania</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Zasoby do uwzględnienia z tego odwołania</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ReferenceOutputAssembly|DisplayName">
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Prywatne zasoby w tym odwołaniu</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Prywatne zasoby w tym odwołaniu</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedProjectReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedProjectReference.xaml.pt-BR.xlf
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Ativos a serem excluídos dessa referência</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Ativos a serem excluídos dessa referência</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Ativos a serem incluídos dessa referência</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Ativos a serem incluídos dessa referência</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ReferenceOutputAssembly|DisplayName">
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Ativos que são privados nessa referência</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Ativos que são privados nessa referência</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedProjectReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedProjectReference.xaml.ru.xlf
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Ресурсы, исключаемые из этой ссылки</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Ресурсы, исключаемые из этой ссылки</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Ресурсы, включаемые из этой ссылки</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Ресурсы, включаемые из этой ссылки</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ReferenceOutputAssembly|DisplayName">
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Ресурсы, являющиеся закрытыми в этой ссылке</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Ресурсы, являющиеся закрытыми в этой ссылке</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedProjectReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedProjectReference.xaml.tr.xlf
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">Bu başvurudan dışlanacak varlıklar</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">Bu başvurudan dışlanacak varlıklar</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">Bu başvurudan eklenecek varlıklar</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">Bu başvurudan eklenecek varlıklar</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ReferenceOutputAssembly|DisplayName">
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">Bu başvuruda özel olan varlıklar</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">Bu başvuruda özel olan varlıklar</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedProjectReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedProjectReference.xaml.zh-Hans.xlf
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">要从此引用中排除的资产</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">要从此引用中排除的资产</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">要从此引用中包括的资产</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">要从此引用中包括的资产</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ReferenceOutputAssembly|DisplayName">
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">此引用中的私有资产</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">此引用中的私有资产</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedProjectReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedProjectReference.xaml.zh-Hant.xlf
@@ -108,8 +108,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|ExcludeAssets|Description">
-        <source>Assets to exclude from this reference</source>
-        <target state="translated">要從此參考排除的資產</target>
+        <source>Assets to exclude from this reference.</source>
+        <target state="needs-review-translation">要從此參考排除的資產</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|DisplayName">
@@ -118,8 +118,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|IncludeAssets|Description">
-        <source>Assets to include from this reference</source>
-        <target state="translated">要從此參考包含的資產</target>
+        <source>Assets to include from this reference.</source>
+        <target state="needs-review-translation">要從此參考包含的資產</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|ReferenceOutputAssembly|DisplayName">
@@ -138,8 +138,8 @@
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference</source>
-        <target state="translated">此參考中的私用資產</target>
+        <source>Assets that are private in this reference.</source>
+        <target state="needs-review-translation">此參考中的私用資產</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SourceControl.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SourceControl.xaml.cs.xlf
@@ -12,6 +12,26 @@
         <target state="translated">Obecné</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|SccAuxPath|DisplayName">
+        <source>SccAuxPath</source>
+        <target state="new">SccAuxPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccLocalPath|DisplayName">
+        <source>SccLocalPath</source>
+        <target state="new">SccLocalPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccProjectName|DisplayName">
+        <source>SccProjectName</source>
+        <target state="new">SccProjectName</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccProvider|DisplayName">
+        <source>SccProvider</source>
+        <target state="new">SccProvider</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SourceControl.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SourceControl.xaml.de.xlf
@@ -12,6 +12,26 @@
         <target state="translated">Allgemein</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|SccAuxPath|DisplayName">
+        <source>SccAuxPath</source>
+        <target state="new">SccAuxPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccLocalPath|DisplayName">
+        <source>SccLocalPath</source>
+        <target state="new">SccLocalPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccProjectName|DisplayName">
+        <source>SccProjectName</source>
+        <target state="new">SccProjectName</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccProvider|DisplayName">
+        <source>SccProvider</source>
+        <target state="new">SccProvider</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SourceControl.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SourceControl.xaml.es.xlf
@@ -12,6 +12,26 @@
         <target state="translated">General</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|SccAuxPath|DisplayName">
+        <source>SccAuxPath</source>
+        <target state="new">SccAuxPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccLocalPath|DisplayName">
+        <source>SccLocalPath</source>
+        <target state="new">SccLocalPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccProjectName|DisplayName">
+        <source>SccProjectName</source>
+        <target state="new">SccProjectName</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccProvider|DisplayName">
+        <source>SccProvider</source>
+        <target state="new">SccProvider</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SourceControl.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SourceControl.xaml.fr.xlf
@@ -12,6 +12,26 @@
         <target state="translated">Général</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|SccAuxPath|DisplayName">
+        <source>SccAuxPath</source>
+        <target state="new">SccAuxPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccLocalPath|DisplayName">
+        <source>SccLocalPath</source>
+        <target state="new">SccLocalPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccProjectName|DisplayName">
+        <source>SccProjectName</source>
+        <target state="new">SccProjectName</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccProvider|DisplayName">
+        <source>SccProvider</source>
+        <target state="new">SccProvider</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SourceControl.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SourceControl.xaml.it.xlf
@@ -12,6 +12,26 @@
         <target state="translated">Generale</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|SccAuxPath|DisplayName">
+        <source>SccAuxPath</source>
+        <target state="new">SccAuxPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccLocalPath|DisplayName">
+        <source>SccLocalPath</source>
+        <target state="new">SccLocalPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccProjectName|DisplayName">
+        <source>SccProjectName</source>
+        <target state="new">SccProjectName</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccProvider|DisplayName">
+        <source>SccProvider</source>
+        <target state="new">SccProvider</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SourceControl.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SourceControl.xaml.ja.xlf
@@ -12,6 +12,26 @@
         <target state="translated">全般</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|SccAuxPath|DisplayName">
+        <source>SccAuxPath</source>
+        <target state="new">SccAuxPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccLocalPath|DisplayName">
+        <source>SccLocalPath</source>
+        <target state="new">SccLocalPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccProjectName|DisplayName">
+        <source>SccProjectName</source>
+        <target state="new">SccProjectName</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccProvider|DisplayName">
+        <source>SccProvider</source>
+        <target state="new">SccProvider</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SourceControl.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SourceControl.xaml.ko.xlf
@@ -12,6 +12,26 @@
         <target state="translated">일반</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|SccAuxPath|DisplayName">
+        <source>SccAuxPath</source>
+        <target state="new">SccAuxPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccLocalPath|DisplayName">
+        <source>SccLocalPath</source>
+        <target state="new">SccLocalPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccProjectName|DisplayName">
+        <source>SccProjectName</source>
+        <target state="new">SccProjectName</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccProvider|DisplayName">
+        <source>SccProvider</source>
+        <target state="new">SccProvider</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SourceControl.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SourceControl.xaml.pl.xlf
@@ -12,6 +12,26 @@
         <target state="translated">Ogólne</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|SccAuxPath|DisplayName">
+        <source>SccAuxPath</source>
+        <target state="new">SccAuxPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccLocalPath|DisplayName">
+        <source>SccLocalPath</source>
+        <target state="new">SccLocalPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccProjectName|DisplayName">
+        <source>SccProjectName</source>
+        <target state="new">SccProjectName</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccProvider|DisplayName">
+        <source>SccProvider</source>
+        <target state="new">SccProvider</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SourceControl.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SourceControl.xaml.pt-BR.xlf
@@ -12,6 +12,26 @@
         <target state="translated">Geral</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|SccAuxPath|DisplayName">
+        <source>SccAuxPath</source>
+        <target state="new">SccAuxPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccLocalPath|DisplayName">
+        <source>SccLocalPath</source>
+        <target state="new">SccLocalPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccProjectName|DisplayName">
+        <source>SccProjectName</source>
+        <target state="new">SccProjectName</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccProvider|DisplayName">
+        <source>SccProvider</source>
+        <target state="new">SccProvider</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SourceControl.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SourceControl.xaml.ru.xlf
@@ -12,6 +12,26 @@
         <target state="translated">Общие</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|SccAuxPath|DisplayName">
+        <source>SccAuxPath</source>
+        <target state="new">SccAuxPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccLocalPath|DisplayName">
+        <source>SccLocalPath</source>
+        <target state="new">SccLocalPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccProjectName|DisplayName">
+        <source>SccProjectName</source>
+        <target state="new">SccProjectName</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccProvider|DisplayName">
+        <source>SccProvider</source>
+        <target state="new">SccProvider</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SourceControl.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SourceControl.xaml.tr.xlf
@@ -12,6 +12,26 @@
         <target state="translated">Genel</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|SccAuxPath|DisplayName">
+        <source>SccAuxPath</source>
+        <target state="new">SccAuxPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccLocalPath|DisplayName">
+        <source>SccLocalPath</source>
+        <target state="new">SccLocalPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccProjectName|DisplayName">
+        <source>SccProjectName</source>
+        <target state="new">SccProjectName</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccProvider|DisplayName">
+        <source>SccProvider</source>
+        <target state="new">SccProvider</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SourceControl.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SourceControl.xaml.zh-Hans.xlf
@@ -12,6 +12,26 @@
         <target state="translated">常规</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|SccAuxPath|DisplayName">
+        <source>SccAuxPath</source>
+        <target state="new">SccAuxPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccLocalPath|DisplayName">
+        <source>SccLocalPath</source>
+        <target state="new">SccLocalPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccProjectName|DisplayName">
+        <source>SccProjectName</source>
+        <target state="new">SccProjectName</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccProvider|DisplayName">
+        <source>SccProvider</source>
+        <target state="new">SccProvider</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SourceControl.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/SourceControl.xaml.zh-Hant.xlf
@@ -12,6 +12,26 @@
         <target state="translated">一般</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|SccAuxPath|DisplayName">
+        <source>SccAuxPath</source>
+        <target state="new">SccAuxPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccLocalPath|DisplayName">
+        <source>SccLocalPath</source>
+        <target state="new">SccLocalPath</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccProjectName|DisplayName">
+        <source>SccProjectName</source>
+        <target state="new">SccProjectName</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|SccProvider|DisplayName">
+        <source>SccProvider</source>
+        <target state="new">SccProvider</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
`Rule` has both [`Name`](https://github.com/microsoft/msbuild/blob/f65f3e1e6ccd33284a7dba489914048292ff02a3/src/Framework/XamlTypes/Rule.cs#L96) and [`DisplayName`](https://github.com/microsoft/msbuild/blob/f65f3e1e6ccd33284a7dba489914048292ff02a3/src/Framework/XamlTypes/Rule.cs#L110) properties. Only `DisplayName` is localised. Therefore, rule properties that are visible but do not have a `DisplayName` specified will never be localised in the UI.

This PR adds a unit test to ensure visible properties have a display name. It also adds several missing display names.

It also ensures property `Description` text ends with a full stop, which seems to be convention in the UI.

@tmeschter please review this from a loc perspective. It may not be something we want to merge until later, or perhaps not at all.

Related to #4105.