### PR TITLE
Small dependency node fixes

### DIFF
--- a/ProjectSystem.sln
+++ b/ProjectSystem.sln
@@ -37,6 +37,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{DD7EF107
 		build\Packages.targets = build\Packages.targets
 		build\SignToolData.json = build\SignToolData.json
 		build\Versions.props = build\Versions.props
+		build\VisualStudio.XamlRules.props = build\VisualStudio.XamlRules.props
+		build\VisualStudio.XamlRules.targets = build\VisualStudio.XamlRules.targets
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Rulesets", "Rulesets", "{E09AD054-22FC-4E70-8889-0F3DCF1267C7}"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependenciesSnapshotFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependenciesSnapshotFactory.cs
@@ -2,8 +2,6 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
-
-using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 
 using Moq;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependencyFactory.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
-using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 
 using Moq;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITargetFrameworkFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITargetFrameworkFactory.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
-
 using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITargetedDependenciesSnapshotFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITargetedDependenciesSnapshotFactory.cs
@@ -6,7 +6,6 @@ using System.Collections.Immutable;
 using System.Linq;
 
 using Microsoft.VisualStudio.ProjectSystem.Properties;
-using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 
 using Moq;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/MockIDependenciesTreeServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/MockIDependenciesTreeServices.cs
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             };
         }
 
-        public Task<IRule> GetRuleAsync(IDependency dependency, IProjectCatalogSnapshot catalogs)
+        public Task<IRule> GetBrowseObjectRuleAsync(IDependency dependency, IProjectCatalogSnapshot catalogs)
         {
             var mockRule = new Mock<IRule>(MockBehavior.Strict);
             mockRule.Setup(x => x.Name).Returns(dependency.SchemaItemType);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/TestDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/TestDependencyModel.cs
@@ -7,7 +7,6 @@ using System.Linq;
 
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
-using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependenciesSnapshotTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependenciesSnapshotTests.cs
@@ -1,0 +1,196 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Filters;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions;
+
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
+{
+    public sealed class DependenciesSnapshotTests
+    {
+        [Fact]
+        public void Constructor_WhenRequiredParamsNotProvided_ShouldThrow()
+        {
+            Assert.Throws<ArgumentNullException>("projectPath", () => new DependenciesSnapshot(projectPath: null, null, null));
+            Assert.Throws<ArgumentNullException>("activeTarget", () => new DependenciesSnapshot("path", activeTarget: null, null));
+            Assert.Throws<ArgumentNullException>("targets", () => new DependenciesSnapshot("path", TargetFramework.Any, null));
+        }
+
+        [Fact]
+        public void Constructor()
+        {
+            const string projectPath = @"c:\somefolder\someproject\a.csproj";
+            var activeTarget = new TargetFramework("tfm1");
+
+            var snapshot = new DependenciesSnapshot(
+                projectPath,
+                activeTarget,
+                ImmutableDictionary<ITargetFramework, ITargetedDependenciesSnapshot>.Empty);
+
+            Assert.Same(projectPath, snapshot.ProjectPath);
+            Assert.Same(activeTarget, snapshot.ActiveTarget);
+            Assert.Empty(snapshot.Targets);
+            Assert.False(snapshot.HasUnresolvedDependency);
+            Assert.Null(snapshot.FindDependency("foo"));
+        }
+
+        [Fact]
+        public void CreateEmpty()
+        {
+            const string projectPath = @"c:\somefolder\someproject\a.csproj";
+
+            var snapshot = DependenciesSnapshot.CreateEmpty(projectPath);
+
+            Assert.Same(projectPath, snapshot.ProjectPath);
+            Assert.Same(TargetFramework.Empty, snapshot.ActiveTarget);
+            Assert.Empty(snapshot.Targets);
+            Assert.False(snapshot.HasUnresolvedDependency);
+            Assert.Null(snapshot.FindDependency("foo"));
+        }
+
+        [Fact]
+        public void FromChanges_Empty_NoChange()
+        {
+            const string projectPath = @"c:\somefolder\someproject\a.csproj";
+            var catalogs = IProjectCatalogSnapshotFactory.Create();
+            var activeTarget = new TargetFramework("tfm1");
+
+            var previousSnapshot = new DependenciesSnapshot(
+                projectPath,
+                activeTarget,
+                ImmutableDictionary<ITargetFramework, ITargetedDependenciesSnapshot>.Empty);
+
+            var targetChanges = new DependenciesChangesBuilder();
+            var changes = new Dictionary<ITargetFramework, IDependenciesChanges> { [activeTarget] = targetChanges.Build() };
+
+            var snapshot = DependenciesSnapshot.FromChanges(
+                projectPath,
+                previousSnapshot,
+                changes.ToImmutableDictionary(),
+                catalogs,
+                activeTarget,
+                ImmutableArray<IDependenciesSnapshotFilter>.Empty,
+                new Dictionary<string, IProjectDependenciesSubTreeProvider>(),
+                null);
+
+            Assert.Same(previousSnapshot, snapshot);
+        }
+
+        [Fact]
+        public void FromChanges_Empty_ProjectPathChange()
+        {
+            const string previousProjectPath = @"c:\somefolder\someproject\a.csproj";
+            const string newProjectPath = @"c:\somefolder\someproject\b.csproj";
+
+            var catalogs = IProjectCatalogSnapshotFactory.Create();
+            var activeTarget = new TargetFramework("tfm1");
+
+            var previousSnapshot = new DependenciesSnapshot(
+                previousProjectPath,
+                activeTarget,
+                ImmutableDictionary<ITargetFramework, ITargetedDependenciesSnapshot>.Empty);
+
+            var targetChanges = new DependenciesChangesBuilder();
+            var changes = new Dictionary<ITargetFramework, IDependenciesChanges> { [activeTarget] = targetChanges.Build() };
+
+            var snapshot = DependenciesSnapshot.FromChanges(
+                newProjectPath,
+                previousSnapshot,
+                changes.ToImmutableDictionary(),
+                catalogs,
+                activeTarget,
+                ImmutableArray<IDependenciesSnapshotFilter>.Empty,
+                new Dictionary<string, IProjectDependenciesSubTreeProvider>(),
+                null);
+
+            Assert.NotSame(previousSnapshot, snapshot);
+            Assert.Same(newProjectPath, snapshot.ProjectPath);
+            Assert.Same(activeTarget, snapshot.ActiveTarget);
+            Assert.Same(previousSnapshot.Targets, snapshot.Targets);
+        }
+
+        [Fact]
+        public void FromChanges_Empty_ProjectPathAndActiveTargetChange()
+        {
+            const string previousProjectPath = @"c:\somefolder\someproject\a.csproj";
+            const string newProjectPath = @"c:\somefolder\someproject\b.csproj";
+
+            var catalogs = IProjectCatalogSnapshotFactory.Create();
+            var previousActiveTarget = new TargetFramework("tfm1");
+            var newActiveTarget = new TargetFramework("tfm2");
+
+            var previousSnapshot = new DependenciesSnapshot(
+                previousProjectPath,
+                previousActiveTarget,
+                ImmutableDictionary<ITargetFramework, ITargetedDependenciesSnapshot>.Empty);
+
+            var targetChanges = new DependenciesChangesBuilder();
+            var changes = new Dictionary<ITargetFramework, IDependenciesChanges>
+            {
+                [previousActiveTarget] = targetChanges.Build(),
+                [newActiveTarget] = targetChanges.Build()
+            };
+
+            var snapshot = DependenciesSnapshot.FromChanges(
+                newProjectPath,
+                previousSnapshot,
+                changes.ToImmutableDictionary(),
+                catalogs,
+                newActiveTarget,
+                ImmutableArray<IDependenciesSnapshotFilter>.Empty,
+                new Dictionary<string, IProjectDependenciesSubTreeProvider>(),
+                null);
+
+            Assert.NotSame(previousSnapshot, snapshot);
+            Assert.Same(newProjectPath, snapshot.ProjectPath);
+            Assert.Same(newActiveTarget, snapshot.ActiveTarget);
+            Assert.Same(previousSnapshot.Targets, snapshot.Targets);
+        }
+
+        [Fact]
+        public void FromChanges_Empty_ProjectPathAndTargetChange()
+        {
+            const string previousProjectPath = @"c:\somefolder\someproject\a.csproj";
+            const string newProjectPath = @"c:\somefolder\someproject\b.csproj";
+
+            var catalogs = IProjectCatalogSnapshotFactory.Create();
+            var activeTarget = new TargetFramework("tfm1");
+
+            var previousSnapshot = new DependenciesSnapshot(
+                previousProjectPath,
+                activeTarget,
+                ImmutableDictionary<ITargetFramework, ITargetedDependenciesSnapshot>.Empty);
+
+            var targetChanges = new DependenciesChangesBuilder();
+            var model = new TestDependencyModel
+            {
+                ProviderType = "Xxx",
+                Id = "dependency1"
+            };
+            targetChanges.Added(model);
+            var changes = new Dictionary<ITargetFramework, IDependenciesChanges> { [activeTarget] = targetChanges.Build() };
+
+            var snapshot = DependenciesSnapshot.FromChanges(
+                newProjectPath,
+                previousSnapshot,
+                changes.ToImmutableDictionary(),
+                catalogs,
+                activeTarget,
+                ImmutableArray<IDependenciesSnapshotFilter>.Empty,
+                new Dictionary<string, IProjectDependenciesSubTreeProvider>(),
+                null);
+
+            Assert.NotSame(previousSnapshot, snapshot);
+            Assert.Same(newProjectPath, snapshot.ProjectPath);
+            Assert.Same(activeTarget, snapshot.ActiveTarget);
+            Assert.NotSame(previousSnapshot.Targets, snapshot.Targets);
+            Assert.Equal(@"tfm1\Xxx\dependency1", snapshot.Targets[activeTarget].DependenciesWorld.First().Value.Id);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyTests.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 
 using Microsoft.VisualStudio.Imaging;
-using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models;
 
 using Xunit;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/SdkAndPackagesDependenciesSnapshotFilterTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/SdkAndPackagesDependenciesSnapshotFilterTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-
-using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Filters;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions.RuleHandlers;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
@@ -6,7 +6,6 @@ using System.Collections.Immutable;
 using System.Linq;
 
 using Microsoft.VisualStudio.Imaging;
-using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Filters;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
     public sealed class TargetedDependenciesSnapshotTests
     {
         [Fact]
-        public void TConstructor_WhenRequiredParamsNotProvided_ShouldThrow()
+        public void Constructor_WhenRequiredParamsNotProvided_ShouldThrow()
         {
             Assert.Throws<ArgumentNullException>("projectPath", () => new TargetedDependenciesSnapshot(projectPath: null, null, null, null));
             Assert.Throws<ArgumentNullException>("targetFramework", () => new TargetedDependenciesSnapshot("path", targetFramework: null, null, null));
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         }
 
         [Fact]
-        public void TConstructor()
+        public void Constructor()
         {
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var targetFramework = new TargetFramework("tfm1");
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         }
 
         [Fact]
-        public void TCreateEmpty()
+        public void CreateEmpty()
         {
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var targetFramework = new TargetFramework("tfm1");
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         }
 
         [Fact]
-        public void TFromChanges_Empty()
+        public void FromChanges_Empty()
         {
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var targetFramework = new TargetFramework("tfm1");
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         }
 
         [Fact]
-        public void TFromChanges_NoChanges()
+        public void FromChanges_NoChanges()
         {
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var targetFramework = new TargetFramework("tfm1");
@@ -122,7 +122,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         }
 
         [Fact]
-        public void TFromChanges_AddingToEmpty()
+        public void FromChanges_AddingToEmpty()
         {
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var targetFramework = new TargetFramework("tfm1");
@@ -181,7 +181,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         }
 
         [Fact]
-        public void TFromChanges_NoChangesAfterBeforeRemoveFilterDeclinedChange()
+        public void FromChanges_NoChangesAfterBeforeRemoveFilterDeclinedChange()
         {
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
 
@@ -235,7 +235,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         }
 
         [Fact]
-        public void TFromChanges_ReportedChangesAfterBeforeRemoveFilterDeclinedChange()
+        public void FromChanges_ReportedChangesAfterBeforeRemoveFilterDeclinedChange()
         {
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var targetFramework = new TargetFramework("tfm1");
@@ -298,7 +298,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         }
 
         [Fact]
-        public void TFromChanges_NoChangesAfterBeforeAddFilterDeclinedChange()
+        public void FromChanges_NoChangesAfterBeforeAddFilterDeclinedChange()
         {
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var targetFramework = new TargetFramework("tfm1");
@@ -364,7 +364,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         }
 
         [Fact]
-        public void TFromChanges_ReportedChangesAfterBeforeAddFilterDeclinedChange()
+        public void FromChanges_ReportedChangesAfterBeforeAddFilterDeclinedChange()
         {
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var targetFramework = new TargetFramework("tfm1");
@@ -445,7 +445,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         }
 
         [Fact]
-        public void TFromChanges_RemovedAndAddedChanges()
+        public void FromChanges_RemovedAndAddedChanges()
         {
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var targetFramework = new TargetFramework("tfm1");
@@ -594,7 +594,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         }
 
         [Fact]
-        public void TFromChanges_UpdatesTopLevelDependencies()
+        public void FromChanges_UpdatesTopLevelDependencies()
         {
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var targetFramework = new TargetFramework("tfm1");
@@ -663,7 +663,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         /// https://github.com/dotnet/project-system/issues/3374
         /// </summary>
         [Fact]
-        public void TCheckForUnresolvedDependencies_CircularDependency_DoesNotRecurseInfinitely()
+        public void CheckForUnresolvedDependencies_CircularDependency_DoesNotRecurseInfinitely()
         {
             const string id1 = @"tfm1\xxx\dependency1";
             const string id2 = @"tfm1\xxx\dependency2";

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
@@ -36,12 +36,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 catalogs,
                 ImmutableDictionary<string, IDependency>.Empty);
 
-            Assert.NotNull(snapshot.TargetFramework);
-            Assert.Equal("tfm1", snapshot.TargetFramework.FullName);
-            Assert.Equal(projectPath, snapshot.ProjectPath);
-            Assert.Equal(catalogs, snapshot.Catalogs);
+            Assert.Same(projectPath, snapshot.ProjectPath);
+            Assert.Same(targetFramework, snapshot.TargetFramework);
+            Assert.Same(catalogs, snapshot.Catalogs);
+            Assert.False(snapshot.HasUnresolvedDependency);
             Assert.Empty(snapshot.TopLevelDependencies);
             Assert.Empty(snapshot.DependenciesWorld);
+            Assert.False(snapshot.CheckForUnresolvedDependencies("foo"));
+            Assert.Empty(snapshot.GetDependencyChildren(new TestDependency()));
         }
 
         [Fact]
@@ -54,17 +56,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             var snapshot = TargetedDependenciesSnapshot.CreateEmpty(projectPath, targetFramework, catalogs);
 
             Assert.Same(projectPath, snapshot.ProjectPath);
-            Assert.Same(catalogs, snapshot.Catalogs);
             Assert.Same(targetFramework, snapshot.TargetFramework);
+            Assert.Same(catalogs, snapshot.Catalogs);
             Assert.False(snapshot.HasUnresolvedDependency);
-            Assert.Empty(snapshot.DependenciesWorld);
             Assert.Empty(snapshot.TopLevelDependencies);
+            Assert.Empty(snapshot.DependenciesWorld);
             Assert.False(snapshot.CheckForUnresolvedDependencies("foo"));
             Assert.Empty(snapshot.GetDependencyChildren(new TestDependency()));
         }
 
         [Fact]
-        public void FromChanges_Empty()
+        public void FromChanges_Empty_NoChanges()
         {
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var targetFramework = new TargetFramework("tfm1");
@@ -86,7 +88,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         }
 
         [Fact]
-        public void FromChanges_NoChanges()
+        public void FromChanges_NotEmpty_NoChanges()
         {
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var targetFramework = new TargetFramework("tfm1");

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependency.cs
@@ -5,7 +5,6 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 
 using Microsoft.VisualStudio.Imaging;
-using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/DependenciesTreeViewProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/DependenciesTreeViewProviderTests.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
-using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 
 using Xunit;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -576,7 +576,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     // Thus, just in case, explicitly request it here (GetCatalogsAsync will acquire a project read lock)
                     _namedCatalogs = await ActiveConfiguredProject.Services
                         .PropertyPagesCatalog
-                        .GetCatalogsAsync(CancellationToken.None);
+                        .GetCatalogsAsync();
                 }
 
                 return _namedCatalogs;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -513,7 +513,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 flags: flags);
         }
 
-        public async Task<IRule?> GetRuleAsync(IDependency dependency, IProjectCatalogSnapshot? catalogs)
+        public async Task<IRule?> GetBrowseObjectRuleAsync(IDependency dependency, IProjectCatalogSnapshot? catalogs)
         {
             Requires.NotNull(dependency, nameof(dependency));
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -517,10 +517,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         {
             Requires.NotNull(dependency, nameof(dependency));
 
-            ConfiguredProject project = dependency.TargetFramework.Equals(TargetFramework.Any)
-                ? ActiveConfiguredProject
-                : _dependenciesHost.GetConfiguredProject(dependency.TargetFramework) ?? ActiveConfiguredProject;
-
             IImmutableDictionary<string, IPropertyPagesCatalog> namedCatalogs = await GetNamedCatalogsAsync();
             Requires.NotNull(namedCatalogs, nameof(namedCatalogs));
 
@@ -543,7 +539,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 // Since we have no browse object, we still need to create *something* so
                 // that standard property pages can pop up.
                 Rule emptyRule = RuleExtensions.SynthesizeEmptyRule(context.ItemType);
-                return GetActiveConfiguredProjectExports(project).PropertyPagesDataModelProvider.GetRule(
+                return GetConfiguredProjectExports().PropertyPagesDataModelProvider.GetRule(
                     emptyRule,
                     context.File,
                     context.ItemType,
@@ -552,7 +548,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             if (dependency.Resolved)
             {
-                return GetActiveConfiguredProjectExports(project).RuleFactory.CreateResolvedReferencePageRule(
+                return GetConfiguredProjectExports().RuleFactory.CreateResolvedReferencePageRule(
                     schema,
                     context,
                     dependency.Name,
@@ -580,6 +576,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 }
 
                 return _namedCatalogs;
+            }
+
+            ConfiguredProjectExports GetConfiguredProjectExports()
+            {
+                ConfiguredProject project = dependency.TargetFramework.Equals(TargetFramework.Any)
+                    ? ActiveConfiguredProject
+                    : _dependenciesHost.GetConfiguredProject(dependency.TargetFramework) ?? ActiveConfiguredProject;
+
+                return GetActiveConfiguredProjectExports(project);
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
@@ -199,7 +199,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             foreach ((string providerType, List<IDependency> dependencies) in groupedByProviderType)
             {
                 IDependencyViewModel? subTreeViewModel = _viewModelFactory.CreateRootViewModel(
-                    providerType, targetedSnapshot.CheckForUnresolvedDependencies(providerType));
+                    providerType,
+                    targetedSnapshot.CheckForUnresolvedDependencies(providerType));
 
                 if (subTreeViewModel == null)
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
@@ -171,14 +171,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             {
                 if (!dependency.Visible)
                 {
-                    if (dependency.Flags.Contains(DependencyTreeFlags.ShowEmptyProviderRootNode))
+                    // If a dependency is not visible we will still register a top-level group if it
+                    // has the ShowEmptyProviderRootNode flag.
+                    if (!dependency.Flags.Contains(DependencyTreeFlags.ShowEmptyProviderRootNode))
                     {
-                        // if provider sends special invisible node with flag ShowEmptyProviderRootNode, we 
-                        // need to show provider node even if it does not have any dependencies.
-                        groupedByProviderType.Add(dependency.ProviderType, new List<IDependency>());
+                        // No such flag, so skip it completely.
+                        continue;
                     }
-
-                    continue;
                 }
 
                 if (!groupedByProviderType.TryGetValue(dependency.ProviderType, out List<IDependency> dependencies))
@@ -187,7 +186,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     groupedByProviderType.Add(dependency.ProviderType, dependencies);
                 }
 
-                dependencies.Add(dependency);
+                // Only add visible dependencies. See note above.
+                if (dependency.Visible)
+                {
+                    dependencies.Add(dependency);
+                }
             }
 
             var currentNodes = new List<IProjectTree>(capacity: groupedByProviderType.Count);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
@@ -319,7 +319,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             IRule? rule = null;
             if (dependency.Flags.Contains(DependencyTreeFlags.SupportsRuleProperties))
             {
-                rule = await _treeServices.GetRuleAsync(dependency, targetedSnapshot.Catalogs);
+                rule = await _treeServices.GetBrowseObjectRuleAsync(dependency, targetedSnapshot.Catalogs);
             }
 
             return CreateOrUpdateNode(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/IDependenciesChanges.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/IDependenciesChanges.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// </summary>
         /// <remarks>
         /// Consumers must only use the <see cref="IDependencyModel.Id"/> and
-        /// <see cref="IDependencyModel.ProviderType"/> properties of returns items.
+        /// <see cref="IDependencyModel.ProviderType"/> properties of returned items.
         /// </remarks>
         IImmutableList<IDependencyModel> RemovedNodes { get; }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/IDependenciesTreeServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/IDependenciesTreeServices.cs
@@ -64,6 +64,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// <param name="dependency"></param>
         /// <param name="catalogs"></param>
         /// <returns></returns>
-        Task<IRule?> GetRuleAsync(IDependency dependency, IProjectCatalogSnapshot? catalogs);
+        Task<IRule?> GetBrowseObjectRuleAsync(IDependency dependency, IProjectCatalogSnapshot? catalogs);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/IDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/IDependencyModel.cs
@@ -56,13 +56,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         string Caption { get; }
 
         /// <summary>
-        /// Used in <see cref="IDependenciesTreeServices.GetRuleAsync"/> to determine the browse
+        /// Used in <see cref="IDependenciesTreeServices.GetBrowseObjectRuleAsync"/> to determine the browse
         /// object rule for this dependency.
         /// </summary>
         string? SchemaName { get; }
 
         /// <summary>
-        /// Used in <see cref="IDependenciesTreeServices.GetRuleAsync"/> to determine the browse
+        /// Used in <see cref="IDependenciesTreeServices.GetBrowseObjectRuleAsync"/> to determine the browse
         /// object rule for this dependency.
         /// </summary>
         string? SchemaItemType { get; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/DependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/DependencyModel.cs
@@ -98,6 +98,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
                    StringComparers.DependencyProviderTypes.Equals(other.ProviderType, ProviderType);
         }
 
-        public override string ToString() => Id;
+        public override string ToString() => $"{ProviderType}-{Id}";
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -130,10 +130,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
                 if (emptyFrameworks != null)
                 {
-                    foreach (ITargetFramework framework in emptyFrameworks)
-                    {
-                        builder.Remove(framework);
-                    }
+                    builder.RemoveRange(emptyFrameworks);
                 }
 
                 return anythingRemoved;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             {
                 // Targets have changed
                 return new DependenciesSnapshot(
-                    previousSnapshot.ProjectPath,
+                    projectPath,
                     activeTargetFramework,
                     builder.ToImmutable());
             }
@@ -97,7 +97,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             {
                 // The active target changed
                 return new DependenciesSnapshot(
-                    previousSnapshot.ProjectPath,
+                    projectPath,
+                    activeTargetFramework,
+                    previousSnapshot.Targets);
+            }
+
+            if (projectPath != previousSnapshot.ProjectPath)
+            {
+                // The project path changed
+                return new DependenciesSnapshot(
+                    projectPath,
                     activeTargetFramework,
                     previousSnapshot.Targets);
             }
@@ -147,7 +156,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 : new DependenciesSnapshot(ProjectPath, ActiveTarget, newTargets);
         }
 
-        private DependenciesSnapshot(
+        // Internal, for test use -- normal code should use the factory methods
+        internal DependenciesSnapshot(
             string projectPath,
             ITargetFramework activeTarget,
             ImmutableDictionary<ITargetFramework, ITargetedDependenciesSnapshot> targets)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
             var builder = previousSnapshot.Targets.ToBuilder();
 
-            bool targetChanged = false;
+            bool builderChanged = false;
 
             foreach ((ITargetFramework targetFramework, IDependenciesChanges dependenciesChanges) in changes)
             {
@@ -76,15 +76,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 if (!ReferenceEquals(previousTargetedSnapshot, newTargetedSnapshot))
                 {
                     builder[targetFramework] = newTargetedSnapshot;
-                    targetChanged = true;
+                    builderChanged = true;
                 }
             }
 
-            targetChanged |= RemoveTargetFrameworksWithNoDependencies();
+            builderChanged |= RemoveTargetFrameworksWithNoDependencies();
 
             activeTargetFramework ??= previousSnapshot.ActiveTarget;
 
-            if (targetChanged)
+            if (builderChanged)
             {
                 // Targets have changed
                 return new DependenciesSnapshot(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Dependency.cs
@@ -119,6 +119,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         {
             // Copy values as necessary to create a clone with any properties overridden
 
+            _id = dependency._id;
             _modelId = dependency._modelId;
             _fullPath = dependency._fullPath;
             TargetFramework = dependency.TargetFramework;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/IAddDependencyContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/IAddDependencyContext.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
         void Reject();
 
         /// <summary>
-        /// Adds a new, or replaces an existing dependency (keyed on <see cref="IDependencyModel.Id"/>).
+        /// Adds a new, or replaces an existing dependency (keyed on <see cref="IDependency.Id"/>).
         /// </summary>
         /// <remarks>
         /// In the course of filtering one dependency, the filter may wish to modify or add other

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/IRemoveDependencyContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/IRemoveDependencyContext.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
         void Reject();
 
         /// <summary>
-        /// Adds a new, or replaces an existing dependency (keyed on <see cref="IDependencyModel.Id"/>).
+        /// Adds a new, or replaces an existing dependency (keyed on <see cref="IDependency.Id"/>).
         /// </summary>
         /// <remarks>
         /// In the course of filtering one dependency, the filter may wish to modify or add other

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/IDependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/IDependency.cs
@@ -92,13 +92,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         string Caption { get; }
 
         /// <summary>
-        /// Used in <see cref="IDependenciesTreeServices.GetRuleAsync"/> to determine the browse
+        /// Used in <see cref="IDependenciesTreeServices.GetBrowseObjectRuleAsync"/> to determine the browse
         /// object rule for this dependency.
         /// </summary>
         string SchemaName { get; }
 
         /// <summary>
-        /// Used in <see cref="IDependenciesTreeServices.GetRuleAsync"/> to determine the browse
+        /// Used in <see cref="IDependenciesTreeServices.GetBrowseObjectRuleAsync"/> to determine the browse
         /// object rule for this dependency.
         /// </summary>
         string SchemaItemType { get; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependenciesChangesBuilder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependenciesChangesBuilder.cs
@@ -45,6 +45,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 _removed == null ? (IImmutableList<IDependencyModel>)ImmutableList<IDependencyModel>.Empty : ImmutableArray.CreateRange(_removed));
         }
 
+        public override string ToString() => ToString(_added, _removed);
+
         private sealed class DependenciesChanges : IDependenciesChanges
         {
             public IImmutableList<IDependencyModel> AddedNodes { get; }
@@ -57,6 +59,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 AddedNodes = addedNodes;
                 RemovedNodes = removedNodes;
             }
+
+            public override string ToString() => DependenciesChangesBuilder.ToString(AddedNodes, RemovedNodes);
+        }
+
+        private static string ToString(IReadOnlyCollection<IDependencyModel>? added, IReadOnlyCollection<IDependencyModel>? removed)
+        {
+            int addedCount = added?.Count ?? 0;
+            int removedCount = removed?.Count ?? 0;
+
+            return (addedCount, removedCount) switch
+            {
+                (0, 0) => "No changes",
+                (0, _) => $"{removedCount} removed",
+                (_, 0) => $"{addedCount} added",
+                (_, _) => $"{addedCount} added, {removedCount} removed"
+            };
         }
 
         private sealed class RemovedDependencyModel : IDependencyModel
@@ -105,6 +123,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             public override int GetHashCode()
                 => unchecked(StringComparer.OrdinalIgnoreCase.GetHashCode(Id) * 397 ^
                              StringComparer.OrdinalIgnoreCase.GetHashCode(ProviderType));
+
+            public override string ToString() => $"{ProviderType}-{Id}";
         }
     }
 }


### PR DESCRIPTION
Small bits while working on `FrameworkReference` support.

Of note:

- 1c04eb30c0db798afde6e8b9c34df86fbde90f3a fixes a bug where a change to the project's path (e.g. via rename) wouldn't be propagated to the snapshot.
- 93787d340d063af979f3872ed58944c9989904cb fixes an exception that could occur in rare circumstances.
- b6a1b30f4fd36f765c65540fb0bdc51d217f4a72 helps reduce string allocations.