### PR TITLE
Don't hide/remove empty TFMs from the Dependencies node

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependenciesSnapshotFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependenciesSnapshotFactory.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             if (activeTarget != null)
             {
-                mock.Setup(x => x.ActiveTarget).Returns(activeTarget);
+                mock.Setup(x => x.ActiveTargetFramework).Returns(activeTarget);
             }
 
             return mock.Object;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependenciesSnapshotFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependenciesSnapshotFactory.cs
@@ -16,16 +16,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         }
 
         public static IDependenciesSnapshot Implement(
-            Dictionary<ITargetFramework, ITargetedDependenciesSnapshot> targets = null,
+            Dictionary<ITargetFramework, ITargetedDependenciesSnapshot> dependenciesByTarget = null,
             bool? hasUnresolvedDependency = null,
             ITargetFramework activeTarget = null,
             MockBehavior mockBehavior = MockBehavior.Default)
         {
             var mock = new Mock<IDependenciesSnapshot>(mockBehavior);
 
-            if (targets != null)
+            if (dependenciesByTarget != null)
             {
-                mock.Setup(x => x.Targets).Returns(targets.ToImmutableDictionary());
+                mock.Setup(x => x.DependenciesByTargetFramework).Returns(dependenciesByTarget.ToImmutableDictionary());
             }
 
             if (hasUnresolvedDependency.HasValue)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependenciesSnapshotTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependenciesSnapshotTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         {
             Assert.Throws<ArgumentNullException>("projectPath", () => new DependenciesSnapshot(projectPath: null, null, null));
             Assert.Throws<ArgumentNullException>("activeTarget", () => new DependenciesSnapshot("path", activeTarget: null, null));
-            Assert.Throws<ArgumentNullException>("targets", () => new DependenciesSnapshot("path", TargetFramework.Any, null));
+            Assert.Throws<ArgumentNullException>("dependenciesByTargetFramework", () => new DependenciesSnapshot("path", TargetFramework.Any, null));
         }
 
         [Fact]
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
             Assert.Same(projectPath, snapshot.ProjectPath);
             Assert.Same(activeTarget, snapshot.ActiveTarget);
-            Assert.Empty(snapshot.Targets);
+            Assert.Empty(snapshot.DependenciesByTargetFramework);
             Assert.False(snapshot.HasUnresolvedDependency);
             Assert.Null(snapshot.FindDependency("foo"));
         }
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
             Assert.Same(projectPath, snapshot.ProjectPath);
             Assert.Same(TargetFramework.Empty, snapshot.ActiveTarget);
-            Assert.Empty(snapshot.Targets);
+            Assert.Empty(snapshot.DependenciesByTargetFramework);
             Assert.False(snapshot.HasUnresolvedDependency);
             Assert.Null(snapshot.FindDependency("foo"));
         }
@@ -112,7 +112,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             Assert.NotSame(previousSnapshot, snapshot);
             Assert.Same(newProjectPath, snapshot.ProjectPath);
             Assert.Same(activeTarget, snapshot.ActiveTarget);
-            Assert.Same(previousSnapshot.Targets, snapshot.Targets);
+            Assert.Same(previousSnapshot.DependenciesByTargetFramework, snapshot.DependenciesByTargetFramework);
         }
 
         [Fact]
@@ -150,7 +150,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             Assert.NotSame(previousSnapshot, snapshot);
             Assert.Same(newProjectPath, snapshot.ProjectPath);
             Assert.Same(newActiveTarget, snapshot.ActiveTarget);
-            Assert.Same(previousSnapshot.Targets, snapshot.Targets);
+            Assert.Same(previousSnapshot.DependenciesByTargetFramework, snapshot.DependenciesByTargetFramework);
         }
 
         [Fact]
@@ -189,8 +189,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             Assert.NotSame(previousSnapshot, snapshot);
             Assert.Same(newProjectPath, snapshot.ProjectPath);
             Assert.Same(activeTarget, snapshot.ActiveTarget);
-            Assert.NotSame(previousSnapshot.Targets, snapshot.Targets);
-            Assert.Equal(@"tfm1\Xxx\dependency1", snapshot.Targets[activeTarget].DependenciesWorld.First().Value.Id);
+            Assert.NotSame(previousSnapshot.DependenciesByTargetFramework, snapshot.DependenciesByTargetFramework);
+            Assert.Equal(@"tfm1\Xxx\dependency1", snapshot.DependenciesByTargetFramework[activeTarget].DependenciesWorld.First().Value.Id);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependenciesSnapshotTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependenciesSnapshotTests.cs
@@ -26,16 +26,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         public void Constructor()
         {
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
-            var activeTarget = new TargetFramework("tfm1");
+            var targetFramework = new TargetFramework("tfm1");
 
             var snapshot = new DependenciesSnapshot(
                 projectPath,
-                activeTarget,
+                activeTargetFramework: targetFramework,
                 ImmutableDictionary<ITargetFramework, ITargetedDependenciesSnapshot>.Empty);
 
             Assert.Same(projectPath, snapshot.ProjectPath);
-            Assert.Same(activeTarget, snapshot.ActiveTargetFramework);
             Assert.Empty(snapshot.DependenciesByTargetFramework);
+            Assert.Same(targetFramework, snapshot.ActiveTargetFramework);
             Assert.False(snapshot.HasUnresolvedDependency);
             Assert.Null(snapshot.FindDependency("foo"));
         }
@@ -59,22 +59,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         {
             const string projectPath = @"c:\somefolder\someproject\a.csproj";
             var catalogs = IProjectCatalogSnapshotFactory.Create();
-            var activeTarget = new TargetFramework("tfm1");
+            var targetFramework = new TargetFramework("tfm1");
 
             var previousSnapshot = new DependenciesSnapshot(
                 projectPath,
-                activeTarget,
+                activeTargetFramework: targetFramework,
                 ImmutableDictionary<ITargetFramework, ITargetedDependenciesSnapshot>.Empty);
 
             var targetChanges = new DependenciesChangesBuilder();
-            var changes = new Dictionary<ITargetFramework, IDependenciesChanges> { [activeTarget] = targetChanges.Build() };
+            var changes = new Dictionary<ITargetFramework, IDependenciesChanges> { [targetFramework] = targetChanges.Build() };
 
             var snapshot = DependenciesSnapshot.FromChanges(
                 projectPath,
                 previousSnapshot,
                 changes.ToImmutableDictionary(),
                 catalogs,
-                activeTarget,
+                targetFramework,
                 ImmutableArray<IDependenciesSnapshotFilter>.Empty,
                 new Dictionary<string, IProjectDependenciesSubTreeProvider>(),
                 null);
@@ -89,29 +89,29 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             const string newProjectPath = @"c:\somefolder\someproject\b.csproj";
 
             var catalogs = IProjectCatalogSnapshotFactory.Create();
-            var activeTarget = new TargetFramework("tfm1");
+            var targetFramework = new TargetFramework("tfm1");
 
             var previousSnapshot = new DependenciesSnapshot(
                 previousProjectPath,
-                activeTarget,
+                activeTargetFramework: targetFramework,
                 ImmutableDictionary<ITargetFramework, ITargetedDependenciesSnapshot>.Empty);
 
             var targetChanges = new DependenciesChangesBuilder();
-            var changes = new Dictionary<ITargetFramework, IDependenciesChanges> { [activeTarget] = targetChanges.Build() };
+            var changes = new Dictionary<ITargetFramework, IDependenciesChanges> { [targetFramework] = targetChanges.Build() };
 
             var snapshot = DependenciesSnapshot.FromChanges(
                 newProjectPath,
                 previousSnapshot,
                 changes.ToImmutableDictionary(),
                 catalogs,
-                activeTarget,
+                targetFramework,
                 ImmutableArray<IDependenciesSnapshotFilter>.Empty,
                 new Dictionary<string, IProjectDependenciesSubTreeProvider>(),
                 null);
 
             Assert.NotSame(previousSnapshot, snapshot);
             Assert.Same(newProjectPath, snapshot.ProjectPath);
-            Assert.Same(activeTarget, snapshot.ActiveTargetFramework);
+            Assert.Same(targetFramework, snapshot.ActiveTargetFramework);
             Assert.Same(previousSnapshot.DependenciesByTargetFramework, snapshot.DependenciesByTargetFramework);
         }
 
@@ -122,19 +122,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             const string newProjectPath = @"c:\somefolder\someproject\b.csproj";
 
             var catalogs = IProjectCatalogSnapshotFactory.Create();
-            var previousActiveTarget = new TargetFramework("tfm1");
-            var newActiveTarget = new TargetFramework("tfm2");
+            var targetFramework1 = new TargetFramework("tfm1");
+            var targetFramework2 = new TargetFramework("tfm2");
 
             var previousSnapshot = new DependenciesSnapshot(
                 previousProjectPath,
-                previousActiveTarget,
+                activeTargetFramework: targetFramework1,
                 ImmutableDictionary<ITargetFramework, ITargetedDependenciesSnapshot>.Empty);
 
             var targetChanges = new DependenciesChangesBuilder();
             var changes = new Dictionary<ITargetFramework, IDependenciesChanges>
             {
-                [previousActiveTarget] = targetChanges.Build(),
-                [newActiveTarget] = targetChanges.Build()
+                [targetFramework1] = targetChanges.Build(),
+                [targetFramework2] = targetChanges.Build()
             };
 
             var snapshot = DependenciesSnapshot.FromChanges(
@@ -142,14 +142,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 previousSnapshot,
                 changes.ToImmutableDictionary(),
                 catalogs,
-                newActiveTarget,
+                activeTargetFramework: targetFramework2,
                 ImmutableArray<IDependenciesSnapshotFilter>.Empty,
                 new Dictionary<string, IProjectDependenciesSubTreeProvider>(),
                 null);
 
             Assert.NotSame(previousSnapshot, snapshot);
             Assert.Same(newProjectPath, snapshot.ProjectPath);
-            Assert.Same(newActiveTarget, snapshot.ActiveTargetFramework);
+            Assert.Same(targetFramework2, snapshot.ActiveTargetFramework);
             Assert.Same(previousSnapshot.DependenciesByTargetFramework, snapshot.DependenciesByTargetFramework);
         }
 
@@ -160,11 +160,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             const string newProjectPath = @"c:\somefolder\someproject\b.csproj";
 
             var catalogs = IProjectCatalogSnapshotFactory.Create();
-            var activeTarget = new TargetFramework("tfm1");
+            var targetFramework = new TargetFramework("tfm1");
 
             var previousSnapshot = new DependenciesSnapshot(
                 previousProjectPath,
-                activeTarget,
+                activeTargetFramework: targetFramework,
                 ImmutableDictionary<ITargetFramework, ITargetedDependenciesSnapshot>.Empty);
 
             var targetChanges = new DependenciesChangesBuilder();
@@ -174,23 +174,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 Id = "dependency1"
             };
             targetChanges.Added(model);
-            var changes = new Dictionary<ITargetFramework, IDependenciesChanges> { [activeTarget] = targetChanges.Build() };
+            var changes = new Dictionary<ITargetFramework, IDependenciesChanges> { [targetFramework] = targetChanges.Build() };
 
             var snapshot = DependenciesSnapshot.FromChanges(
                 newProjectPath,
                 previousSnapshot,
                 changes.ToImmutableDictionary(),
                 catalogs,
-                activeTarget,
+                activeTargetFramework: targetFramework,
                 ImmutableArray<IDependenciesSnapshotFilter>.Empty,
                 new Dictionary<string, IProjectDependenciesSubTreeProvider>(),
                 null);
 
             Assert.NotSame(previousSnapshot, snapshot);
             Assert.Same(newProjectPath, snapshot.ProjectPath);
-            Assert.Same(activeTarget, snapshot.ActiveTargetFramework);
+            Assert.Same(targetFramework, snapshot.ActiveTargetFramework);
             Assert.NotSame(previousSnapshot.DependenciesByTargetFramework, snapshot.DependenciesByTargetFramework);
-            Assert.Equal(@"tfm1\Xxx\dependency1", snapshot.DependenciesByTargetFramework[activeTarget].DependenciesWorld.First().Value.Id);
+            Assert.Equal(@"tfm1\Xxx\dependency1", snapshot.DependenciesByTargetFramework[targetFramework].DependenciesWorld.First().Value.Id);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependenciesSnapshotTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependenciesSnapshotTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         public void Constructor_WhenRequiredParamsNotProvided_ShouldThrow()
         {
             Assert.Throws<ArgumentNullException>("projectPath", () => new DependenciesSnapshot(projectPath: null, null, null));
-            Assert.Throws<ArgumentNullException>("activeTarget", () => new DependenciesSnapshot("path", activeTarget: null, null));
+            Assert.Throws<ArgumentNullException>("activeTargetFramework", () => new DependenciesSnapshot("path", activeTargetFramework: null, null));
             Assert.Throws<ArgumentNullException>("dependenciesByTargetFramework", () => new DependenciesSnapshot("path", TargetFramework.Any, null));
         }
 
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 ImmutableDictionary<ITargetFramework, ITargetedDependenciesSnapshot>.Empty);
 
             Assert.Same(projectPath, snapshot.ProjectPath);
-            Assert.Same(activeTarget, snapshot.ActiveTarget);
+            Assert.Same(activeTarget, snapshot.ActiveTargetFramework);
             Assert.Empty(snapshot.DependenciesByTargetFramework);
             Assert.False(snapshot.HasUnresolvedDependency);
             Assert.Null(snapshot.FindDependency("foo"));
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             var snapshot = DependenciesSnapshot.CreateEmpty(projectPath);
 
             Assert.Same(projectPath, snapshot.ProjectPath);
-            Assert.Same(TargetFramework.Empty, snapshot.ActiveTarget);
+            Assert.Same(TargetFramework.Empty, snapshot.ActiveTargetFramework);
             Assert.Empty(snapshot.DependenciesByTargetFramework);
             Assert.False(snapshot.HasUnresolvedDependency);
             Assert.Null(snapshot.FindDependency("foo"));
@@ -111,7 +111,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
             Assert.NotSame(previousSnapshot, snapshot);
             Assert.Same(newProjectPath, snapshot.ProjectPath);
-            Assert.Same(activeTarget, snapshot.ActiveTarget);
+            Assert.Same(activeTarget, snapshot.ActiveTargetFramework);
             Assert.Same(previousSnapshot.DependenciesByTargetFramework, snapshot.DependenciesByTargetFramework);
         }
 
@@ -149,7 +149,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
             Assert.NotSame(previousSnapshot, snapshot);
             Assert.Same(newProjectPath, snapshot.ProjectPath);
-            Assert.Same(newActiveTarget, snapshot.ActiveTarget);
+            Assert.Same(newActiveTarget, snapshot.ActiveTargetFramework);
             Assert.Same(previousSnapshot.DependenciesByTargetFramework, snapshot.DependenciesByTargetFramework);
         }
 
@@ -188,7 +188,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
             Assert.NotSame(previousSnapshot, snapshot);
             Assert.Same(newProjectPath, snapshot.ProjectPath);
-            Assert.Same(activeTarget, snapshot.ActiveTarget);
+            Assert.Same(activeTarget, snapshot.ActiveTargetFramework);
             Assert.NotSame(previousSnapshot.DependenciesByTargetFramework, snapshot.DependenciesByTargetFramework);
             Assert.Equal(@"tfm1\Xxx\dependency1", snapshot.DependenciesByTargetFramework[activeTarget].DependenciesWorld.First().Value.Id);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependenciesSnapshotTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependenciesSnapshotTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 activeTargetFramework: targetFramework,
                 ImmutableDictionary<ITargetFramework, ITargetedDependenciesSnapshot>.Empty));
 
-            Assert.Equal("activeTargetFramework must be present in dependenciesByTargetFramework.", ex.Message);
+            Assert.StartsWith("Must contain activeTargetFramework (tfm1).", ex.Message);
         }
 
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/DependenciesTreeViewProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/TreeView/DependenciesTreeViewProviderTests.cs
@@ -803,7 +803,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.TreeView
         private static IDependenciesSnapshot GetSnapshot(params (ITargetFramework tfm, IReadOnlyList<IDependency> dependencies)[] testData)
         {
             var catalogs = IProjectCatalogSnapshotFactory.Create();
-            var targets = new Dictionary<ITargetFramework, ITargetedDependenciesSnapshot>();
+            var dependenciesByTarget = new Dictionary<ITargetFramework, ITargetedDependenciesSnapshot>();
 
             foreach ((ITargetFramework tfm, IReadOnlyList<IDependency> dependencies) in testData)
             {
@@ -813,11 +813,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.TreeView
                     checkForUnresolvedDependencies: false,
                     targetFramework: tfm);
 
-                targets.Add(tfm, targetedSnapshot);
+                dependenciesByTarget.Add(tfm, targetedSnapshot);
             }
 
             return IDependenciesSnapshotFactory.Implement(
-                targets: targets,
+                dependenciesByTarget: dependenciesByTarget,
                 hasUnresolvedDependency: false,
                 activeTarget: testData[0].tfm);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/GetChildrenGraphActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/GetChildrenGraphActionHandler.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
                 projectPath,
                 dependency,
                 inputGraphNode,
-                snapshot.Targets[dependency.TargetFramework]);
+                snapshot.DependenciesByTargetFramework[dependency.TargetFramework]);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/SearchGraphActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/Actions/SearchGraphActionHandler.cs
@@ -81,7 +81,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
                 using var scope = new GraphTransactionScope();
                 foreach (IDependency topLevelDependency in allTopLevelDependencies)
                 {
-                    ITargetedDependenciesSnapshot targetedSnapshot = snapshot.Targets[topLevelDependency.TargetFramework];
+                    ITargetedDependenciesSnapshot targetedSnapshot = snapshot.DependenciesByTargetFramework[topLevelDependency.TargetFramework];
 
                     if (!cachedDependencyToMatchingResultsMap
                             .TryGetValue(topLevelDependency.Id, out HashSet<IDependency>? topLevelDependencyMatches))
@@ -156,7 +156,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes.A
         {
             var matchedDependencies = new HashSet<IDependency>();
 
-            foreach ((ITargetFramework _, ITargetedDependenciesSnapshot targetedSnapshot) in dependenciesSnapshot.Targets)
+            foreach ((ITargetFramework _, ITargetedDependenciesSnapshot targetedSnapshot) in dependenciesSnapshot.DependenciesByTargetFramework)
             {
                 foreach ((string _, IDependency dependency) in targetedSnapshot.DependenciesWorld)
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphChangeTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/GraphNodes/DependenciesGraphChangeTracker.cs
@@ -152,7 +152,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.GraphNodes
                         nodeProjectPath,
                         updatedDependency,
                         inputGraphNode,
-                        updatedSnapshot!.Targets[updatedDependency.TargetFramework]))
+                        updatedSnapshot!.DependenciesByTargetFramework[updatedDependency.TargetFramework]))
                     {
                         anyChanges = true;
                     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
@@ -61,9 +61,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             var currentTopLevelNodes = new List<IProjectTree>();
 
-            if (snapshot.Targets.Count(x => !x.Key.Equals(TargetFramework.Any)) == 1)
+            if (snapshot.DependenciesByTargetFramework.Count(x => !x.Key.Equals(TargetFramework.Any)) == 1)
             {
-                foreach ((ITargetFramework _, ITargetedDependenciesSnapshot targetedSnapshot) in snapshot.Targets)
+                foreach ((ITargetFramework _, ITargetedDependenciesSnapshot targetedSnapshot) in snapshot.DependenciesByTargetFramework)
                 {
                     if (cancellationToken.IsCancellationRequested)
                     {
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             }
             else
             {
-                foreach ((ITargetFramework targetFramework, ITargetedDependenciesSnapshot targetedSnapshot) in snapshot.Targets)
+                foreach ((ITargetFramework targetFramework, ITargetedDependenciesSnapshot targetedSnapshot) in snapshot.DependenciesByTargetFramework)
                 {
                     if (cancellationToken.IsCancellationRequested)
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
                     dependenciesTree = await BuildSubTreesAsync(
                         rootNode: dependenciesTree,
-                        snapshot.ActiveTarget,
+                        snapshot.ActiveTargetFramework,
                         targetedSnapshot,
                         RememberNewNodes);
                 }
@@ -90,7 +90,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                     {
                         dependenciesTree = await BuildSubTreesAsync(
                             rootNode: dependenciesTree,
-                            snapshot.ActiveTarget,
+                            snapshot.ActiveTargetFramework,
                             targetedSnapshot,
                             RememberNewNodes);
                     }
@@ -109,7 +109,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
                         node = await BuildSubTreesAsync(
                             rootNode: node,
-                            snapshot.ActiveTarget,
+                            snapshot.ActiveTargetFramework,
                             targetedSnapshot,
                             CleanupOldNodes);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/DependenciesViewModelFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/DependenciesViewModelFactory.cs
@@ -31,11 +31,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 
         public IDependencyViewModel? CreateRootViewModel(string providerType, bool hasUnresolvedDependency)
         {
-            IProjectDependenciesSubTreeProvider? provider = GetProvider(providerType);
+            IProjectDependenciesSubTreeProvider? provider = GetProvider();
 
             IDependencyModel? dependencyModel = provider?.CreateRootDependencyNode();
 
             return dependencyModel?.ToViewModel(hasUnresolvedDependency);
+
+            IProjectDependenciesSubTreeProvider? GetProvider()
+            {
+                return SubTreeProviders
+                    .FirstOrDefault((x, t) => StringComparers.DependencyProviderTypes.Equals(x.Value.ProviderType, t), providerType)
+                    ?.Value;
+            }
         }
 
         public ImageMoniker GetDependenciesRootIcon(bool hasUnresolvedDependencies)
@@ -43,13 +50,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
             return hasUnresolvedDependencies
                 ? ManagedImageMonikers.ReferenceGroupWarning
                 : ManagedImageMonikers.ReferenceGroup;
-        }
-
-        private IProjectDependenciesSubTreeProvider? GetProvider(string providerType)
-        {
-            return SubTreeProviders
-                .FirstOrDefault((x, t) => StringComparers.DependencyProviderTypes.Equals(x.Value.ProviderType, t), providerType)
-                ?.Value;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/AggregateDependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/AggregateDependenciesSnapshotProvider.cs
@@ -120,14 +120,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             }
 
             ITargetFramework? targetFramework = _targetFrameworkProvider.GetNearestFramework(
-                dependency.TargetFramework, snapshot.Targets.Keys);
+                dependency.TargetFramework, snapshot.DependenciesByTargetFramework.Keys);
 
             if (targetFramework == null)
             {
                 return null;
             }
 
-            return snapshot.Targets[targetFramework];
+            return snapshot.DependenciesByTargetFramework[targetFramework];
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -175,17 +175,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
             if (activeTargetFramework.Equals(TargetFramework.Empty))
             {
-                if (dependenciesByTargetFramework.Count != 0)
-                {
-                    Requires.Fail($"If {nameof(activeTargetFramework)} is empty, {nameof(dependenciesByTargetFramework)} must be empty.");
-                }
+                Requires.Argument(
+                    dependenciesByTargetFramework.Count == 0,
+                    nameof(dependenciesByTargetFramework),
+                    $"Must be empty when {nameof(activeTargetFramework)} is empty.");
             }
             else
             {
-                if (!dependenciesByTargetFramework.ContainsKey(activeTargetFramework))
-                {
-                    Requires.Fail($"{nameof(activeTargetFramework)} must be present in {nameof(dependenciesByTargetFramework)}.");
-                }
+                Requires.Argument(
+                    dependenciesByTargetFramework.ContainsKey(activeTargetFramework),
+                    nameof(dependenciesByTargetFramework),
+                    $"Must contain {nameof(activeTargetFramework)} ({activeTargetFramework.FullName}).");
             }
 
             ProjectPath = projectPath;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         {
             return new DependenciesSnapshot(
                 projectPath,
-                activeTarget: TargetFramework.Empty,
+                activeTargetFramework: TargetFramework.Empty,
                 dependenciesByTargetFramework: ImmutableDictionary<ITargetFramework, ITargetedDependenciesSnapshot>.Empty);
         }
 
@@ -80,7 +80,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
             builderChanged |= RemoveTargetFrameworksWithNoDependencies();
 
-            activeTargetFramework ??= previousSnapshot.ActiveTarget;
+            activeTargetFramework ??= previousSnapshot.ActiveTargetFramework;
 
             if (builderChanged)
             {
@@ -91,9 +91,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                     builder.ToImmutable());
             }
 
-            if (!activeTargetFramework.Equals(previousSnapshot.ActiveTarget))
+            if (!activeTargetFramework.Equals(previousSnapshot.ActiveTargetFramework))
             {
-                // The active target changed
+                // The active target framework changed
                 return new DependenciesSnapshot(
                     projectPath,
                     activeTargetFramework,
@@ -149,21 +149,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             // Return this if no targets changed
             return ReferenceEquals(newTargets, DependenciesByTargetFramework)
                 ? this
-                : new DependenciesSnapshot(ProjectPath, ActiveTarget, newTargets);
+                : new DependenciesSnapshot(ProjectPath, ActiveTargetFramework, newTargets);
         }
 
         // Internal, for test use -- normal code should use the factory methods
         internal DependenciesSnapshot(
             string projectPath,
-            ITargetFramework activeTarget,
+            ITargetFramework activeTargetFramework,
             ImmutableDictionary<ITargetFramework, ITargetedDependenciesSnapshot> dependenciesByTargetFramework)
         {
             Requires.NotNullOrEmpty(projectPath, nameof(projectPath));
-            Requires.NotNull(activeTarget, nameof(activeTarget));
+            Requires.NotNull(activeTargetFramework, nameof(activeTargetFramework));
             Requires.NotNull(dependenciesByTargetFramework, nameof(dependenciesByTargetFramework));
 
             ProjectPath = projectPath;
-            ActiveTarget = activeTarget;
+            ActiveTargetFramework = activeTargetFramework;
             DependenciesByTargetFramework = dependenciesByTargetFramework;
         }
 
@@ -173,7 +173,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         public string ProjectPath { get; }
 
         /// <inheritdoc />
-        public ITargetFramework ActiveTarget { get; }
+        public ITargetFramework ActiveTargetFramework { get; }
 
         /// <inheritdoc />
         public ImmutableDictionary<ITargetFramework, ITargetedDependenciesSnapshot> DependenciesByTargetFramework { get; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -114,8 +114,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             // Nothing has changed, so return the same snapshot
             return previousSnapshot;
 
-            // Active target differs
-
             bool RemoveTargetFrameworksWithNoDependencies()
             {
                 // This is a long-winded way of doing this that minimises allocations

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Filters;
@@ -13,7 +12,6 @@ using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Filters
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 {
     /// <inheritdoc />
-    [DebuggerDisplay("{" + nameof(DependenciesByTargetFramework) + ".Count} target frameworks - {ProjectPath}")]
     internal sealed class DependenciesSnapshot : IDependenciesSnapshot
     {
         #region Factories and private constructor
@@ -223,5 +221,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         {
             return other != null && other.ProjectPath.Equals(ProjectPath, StringComparison.OrdinalIgnoreCase);
         }
+
+        public override string ToString() => $"{DependenciesByTargetFramework.Count} target framework{(DependenciesByTargetFramework.Count == 1 ? "" : "s")} - {ProjectPath}";
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/IDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/IDependenciesSnapshot.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         /// <summary>
         /// Gets a dictionary of dependencies by target framework.
         /// </summary>
-        ImmutableDictionary<ITargetFramework, ITargetedDependenciesSnapshot> Targets { get; }
+        ImmutableDictionary<ITargetFramework, ITargetedDependenciesSnapshot> DependenciesByTargetFramework { get; }
 
         /// <summary>
         /// Gets whether this snapshot contains at least one unresolved/broken dependency at any level

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/IDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/IDependenciesSnapshot.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         string ProjectPath { get; }
 
         /// <summary>
-        /// Gets the active target framework for project (first in the <c>TargetFrameworks</c> property).
+        /// Gets the active target framework for project.
         /// </summary>
         ITargetFramework ActiveTarget { get; }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/IDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/IDependenciesSnapshot.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         /// <summary>
         /// Gets the active target framework for project.
         /// </summary>
-        ITargetFramework ActiveTarget { get; }
+        ITargetFramework ActiveTargetFramework { get; }
 
         /// <summary>
         /// Gets a dictionary of dependencies by target framework.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/IDependenciesSnapshotExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/IDependenciesSnapshotExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
     {
         public static IEnumerable<IDependency> GetFlatTopLevelDependencies(this IDependenciesSnapshot self)
         {
-            foreach ((ITargetFramework _, ITargetedDependenciesSnapshot targetedSnapshot) in self.Targets)
+            foreach ((ITargetFramework _, ITargetedDependenciesSnapshot targetedSnapshot) in self.DependenciesByTargetFramework)
             {
                 foreach (IDependency dependency in targetedSnapshot.TopLevelDependencies)
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Filters;
@@ -12,7 +11,6 @@ using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Filters
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 {
-    [DebuggerDisplay("{TargetFramework.FriendlyName} - {DependenciesWorld.Count} dependencies ({TopLevelDependencies} top level) - {ProjectPath}")]
     internal sealed class TargetedDependenciesSnapshot : ITargetedDependenciesSnapshot
     {
         #region Factories and internal constructor
@@ -345,5 +343,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                     : children.ToImmutable();
             }
         }
+
+        public override string ToString() => $"{TargetFramework.FriendlyName} - {DependenciesWorld.Count} dependencies ({TopLevelDependencies.Length} top level) - {ProjectPath}";
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
@@ -287,7 +287,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
         }
 
         private void UpdateDependenciesSnapshot(
-            ImmutableDictionary<ITargetFramework, IDependenciesChanges> changes,
+            ImmutableDictionary<ITargetFramework, IDependenciesChanges> changesByTargetFramework,
             IProjectCatalogSnapshot? catalogs,
             ITargetFramework? activeTargetFramework,
             CancellationToken token)
@@ -298,7 +298,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 snapshot => DependenciesSnapshot.FromChanges(
                     _commonServices.Project.FullPath,
                     snapshot,
-                    changes,
+                    changesByTargetFramework,
                     catalogs,
                     activeTargetFramework,
                     _snapshotFilters.ToImmutableValueArray(),

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
@@ -265,7 +265,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 return;
             }
 
-            UpdateDependenciesSnapshot(e.Changes, e.Catalogs, e.ActiveTarget, CancellationToken.None);
+            UpdateDependenciesSnapshot(e.Changes, e.Catalogs, e.TargetFrameworks, e.ActiveTarget, CancellationToken.None);
         }
 
         private void OnSubtreeProviderDependenciesChanged(object sender, DependenciesChangedEventArgs e)
@@ -283,12 +283,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
             ImmutableDictionary<ITargetFramework, IDependenciesChanges> changes = ImmutableDictionary<ITargetFramework, IDependenciesChanges>.Empty.Add(targetFramework, e.Changes);
 
-            UpdateDependenciesSnapshot(changes, catalogs: null, activeTargetFramework: null, e.Token);
+            UpdateDependenciesSnapshot(changes, catalogs: null, targetFrameworks: default, activeTargetFramework: null, e.Token);
         }
 
         private void UpdateDependenciesSnapshot(
             ImmutableDictionary<ITargetFramework, IDependenciesChanges> changesByTargetFramework,
             IProjectCatalogSnapshot? catalogs,
+            ImmutableArray<ITargetFramework> targetFrameworks,
             ITargetFramework? activeTargetFramework,
             CancellationToken token)
         {
@@ -300,6 +301,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                     snapshot,
                     changesByTargetFramework,
                     catalogs,
+                    targetFrameworks,
                     activeTargetFramework,
                     _snapshotFilters.ToImmutableValueArray(),
                     _subTreeProviders.ToValueDictionary(p => p.ProviderType, StringComparers.DependencyProviderTypes),

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
@@ -258,6 +258,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 DependenciesChanged?.Invoke(
                     this,
                     new DependencySubscriptionChangedEventArgs(
+                        currentAggregateContext.TargetFrameworks,
                         currentAggregateContext.ActiveTargetFramework,
                         catalogSnapshot,
                         changes));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
@@ -163,7 +163,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             Requires.NotNull(changesBuilder, nameof(changesBuilder));
 
             IDependenciesSnapshot snapshot = _dependenciesSnapshotProvider.CurrentSnapshot;
-            if (!snapshot.Targets.TryGetValue(targetFramework, out ITargetedDependenciesSnapshot targetedSnapshot))
+            if (!snapshot.DependenciesByTargetFramework.TryGetValue(targetFramework, out ITargetedDependenciesSnapshot targetedSnapshot))
             {
                 return;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
@@ -147,6 +147,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
                 DependenciesChanged?.Invoke(
                     this,
                     new DependencySubscriptionChangedEventArgs(
+                        currentAggregateContext.TargetFrameworks,
                         currentAggregateContext.ActiveTargetFramework,
                         catalogs,
                         changes));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/IDependencyCrossTargetSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/IDependencyCrossTargetSubscriber.cs
@@ -61,16 +61,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
     internal sealed class DependencySubscriptionChangedEventArgs
     {
         public DependencySubscriptionChangedEventArgs(
+            ImmutableArray<ITargetFramework> targetFrameworks,
             ITargetFramework activeTarget,
             IProjectCatalogSnapshot catalogs,
             ImmutableDictionary<ITargetFramework, IDependenciesChanges> changes)
         {
+            Requires.Argument(!targetFrameworks.IsDefaultOrEmpty, nameof(targetFrameworks), "Must not be default or empty.");
             Requires.Argument(changes.Count != 0, nameof(changes), "Must not be zero.");
 
+            TargetFrameworks = targetFrameworks;
             ActiveTarget = activeTarget;
             Catalogs = catalogs;
             Changes = changes;
         }
+
+        public ImmutableArray<ITargetFramework> TargetFrameworks { get; }
 
         public ITargetFramework ActiveTarget { get; }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/ProjectRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/ProjectRuleHandler.cs
@@ -121,7 +121,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
             string otherProjectPath = otherProjectSnapshot.ProjectPath;
 
-            foreach ((ITargetFramework _, ITargetedDependenciesSnapshot targetedDependencies) in thisProjectSnapshot.Targets)
+            foreach ((ITargetFramework _, ITargetedDependenciesSnapshot targetedDependencies) in thisProjectSnapshot.DependenciesByTargetFramework)
             {
                 foreach (IDependency dependency in targetedDependencies.TopLevelDependencies)
                 {


### PR DESCRIPTION
Fixes #4937.

This PR is basically all in 89b57bbcec0831652773484a8827c40ff79ac500.

Previously any target framework not containing a dependency was removed from the snapshot. This was presumably to clean up when a target framework was removed from the project.

This change passes an explicit list of target frameworks through for the snapshot update, so that the tree can always show all target frameworks in multi-targeting projects.

Without this change, it's possible to have a misleading presentation in the UI (see #4937). With SDK 3.0.100, the MSBuild SDK no longer appears as a dependency, so it's much more likely we'd have target frameworks with no dependencies at all.

This also adds validation that the active target framework is present in related collections.