### PR TITLE
 Use Microsoft.Build.NoTargets SDK for documentation project

### DIFF
--- a/docs/Documentation.csproj
+++ b/docs/Documentation.csproj
@@ -1,7 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project>
 
+  <!-- See https://github.com/microsoft/MSBuildSdks/tree/master/src/NoTargets -->
+  <Sdk Name="Microsoft.Build.NoTargets" Version="1.0.73" />
+  
   <ItemGroup>
     <None Include="**/*.md" />
+    <PackageReference Remove="@(PackageReference)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This dogfoods a custom MSBuild SDK project in our solution ([`Microsoft.Build.NoTargets`](https://github.com/microsoft/MSBuildSdks/tree/master/src/NoTargets)).

> The `Microsoft.Build.NoTargets` MSBuild project SDK allows project tree owners the ability to define projects that do not compile an assembly. This can be useful for utility projects that just copy files, build packages, or any other function where an assembly is not compiled.

