### PR TITLE
Pass RuntimeIdentifierGraphPath during nomination

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -89,6 +89,10 @@
                   ReadOnly="True"
                   Visible="False" />
 
+  <StringProperty Name="RuntimeIdentifierGraphPath"
+                  ReadOnly="True"
+                  Visible="False" />
+
   <StringProperty Name="RuntimeIdentifiers"
                   ReadOnly="True"
                   Visible="False" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/project-system/issues/4951

Original ask [here](https://github.com/NuGet/Home/issues/7351).
Spec at https://github.com/NuGet/Client.Engineering/blob/master/Specs/RuntimeJsonFromProject.md. 

The SDK will provide the RuntimeIdentifierGraphPath, that NuGet will treat that as the project provided runtime identifier graph.
This will effectively replace the platforms package.

cc @davkean @jjmew 

