### PR TITLE
Add SubType/ItemType support to project tree parser

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/ProjectSystem/ProjectTreeParserTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/ProjectSystem/ProjectTreeParserTests.cs
@@ -209,62 +209,62 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         // Input                                                                                    // Expected
         [Theory]
-        [InlineData(@"R(visibility: visible)",                                                      @"R[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]""")]
-        [InlineData(@"Ro(visibility: visible)",                                                     @"Ro[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]""")]
-        [InlineData(@"Root(visibility: visible)",                                                   @"Root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]""")]
-        [InlineData(@"Project Root(visibility: visible)",                                           @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]""")]
-        [InlineData(@"This is the project root(visibility: visible)",                               @"This is the project root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]""")]
-        [InlineData(@"R (visibility: visible)",                                                     @"R[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]""")]
-        [InlineData(@"Ro (visibility: visible)",                                                    @"Ro[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]""")]
-        [InlineData(@"Root (visibility: visible)",                                                  @"Root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]""")]
-        [InlineData(@"Project Root (visibility: visible)",                                          @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]""")]
-        [InlineData(@"This is the project root (visibility: visible)",                              @"This is the project root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]""")]
-        [InlineData(@"R(visibility: invisible)",                                                    @"R[caption] (visibility: invisible, flags: {}), FilePath: ""[filepath]""")]
-        [InlineData(@"Ro(visibility: invisible)",                                                   @"Ro[caption] (visibility: invisible, flags: {}), FilePath: ""[filepath]""")]
-        [InlineData(@"Root(visibility: invisible)",                                                 @"Root[caption] (visibility: invisible, flags: {}), FilePath: ""[filepath]""")]
-        [InlineData(@"Project Root(visibility: invisible)",                                         @"Project Root[caption] (visibility: invisible, flags: {}), FilePath: ""[filepath]""")]
-        [InlineData(@"This is the project root(visibility: invisible)",                             @"This is the project root[caption] (visibility: invisible, flags: {}), FilePath: ""[filepath]""")]
-        [InlineData(@"R (visibility: invisible)",                                                   @"R[caption] (visibility: invisible, flags: {}), FilePath: ""[filepath]""")]
-        [InlineData(@"Ro (visibility: invisible)",                                                  @"Ro[caption] (visibility: invisible, flags: {}), FilePath: ""[filepath]""")]
-        [InlineData(@"Root (visibility: invisible)",                                                @"Root[caption] (visibility: invisible, flags: {}), FilePath: ""[filepath]""")]
-        [InlineData(@"Project Root (visibility: invisible)",                                        @"Project Root[caption] (visibility: invisible, flags: {}), FilePath: ""[filepath]""")]
-        [InlineData(@"This is the project root (visibility: invisible)",                            @"This is the project root[caption] (visibility: invisible, flags: {}), FilePath: ""[filepath]""")]
+        [InlineData(@"R(visibility: visible)",                                                      @"R[caption] (visibility: visible)")]
+        [InlineData(@"Ro(visibility: visible)",                                                     @"Ro[caption] (visibility: visible)")]
+        [InlineData(@"Root(visibility: visible)",                                                   @"Root[caption] (visibility: visible)")]
+        [InlineData(@"Project Root(visibility: visible)",                                           @"Project Root[caption] (visibility: visible)")]
+        [InlineData(@"This is the project root(visibility: visible)",                               @"This is the project root[caption] (visibility: visible)")]
+        [InlineData(@"R (visibility: visible)",                                                     @"R[caption] (visibility: visible)")]
+        [InlineData(@"Ro (visibility: visible)",                                                    @"Ro[caption] (visibility: visible)")]
+        [InlineData(@"Root (visibility: visible)",                                                  @"Root[caption] (visibility: visible)")]
+        [InlineData(@"Project Root (visibility: visible)",                                          @"Project Root[caption] (visibility: visible)")]
+        [InlineData(@"This is the project root (visibility: visible)",                              @"This is the project root[caption] (visibility: visible)")]
+        [InlineData(@"R(visibility: invisible)",                                                    @"R[caption] (visibility: invisible)")]
+        [InlineData(@"Ro(visibility: invisible)",                                                   @"Ro[caption] (visibility: invisible)")]
+        [InlineData(@"Root(visibility: invisible)",                                                 @"Root[caption] (visibility: invisible)")]
+        [InlineData(@"Project Root(visibility: invisible)",                                         @"Project Root[caption] (visibility: invisible)")]
+        [InlineData(@"This is the project root(visibility: invisible)",                             @"This is the project root[caption] (visibility: invisible)")]
+        [InlineData(@"R (visibility: invisible)",                                                   @"R[caption] (visibility: invisible)")]
+        [InlineData(@"Ro (visibility: invisible)",                                                  @"Ro[caption] (visibility: invisible)")]
+        [InlineData(@"Root (visibility: invisible)",                                                @"Root[caption] (visibility: invisible)")]
+        [InlineData(@"Project Root (visibility: invisible)",                                        @"Project Root[caption] (visibility: invisible)")]
+        [InlineData(@"This is the project root (visibility: invisible)",                            @"This is the project root[caption] (visibility: invisible)")]
         public void Parse_RootWithVisibility_CanParse(string input, string expected)
         {
-            AssertProjectTree(input, expected);
+            AssertProjectTree(input, expected, ProjectTreeWriterOptions.Visibility);
         }
 
         // Input                                                                                    // Expected
         [Theory]
-        [InlineData(@"Project Root (flags: {})",                                                    @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]""")]
-        [InlineData(@"Project Root (flags: {A})",                                                   @"Project Root[caption] (visibility: visible, flags: {A[capability]}), FilePath: ""[filepath]""")]
-        [InlineData(@"Project Root (flags: {A B})",                                                 @"Project Root[caption] (visibility: visible, flags: {A[capability] B[capability]}), FilePath: ""[filepath]""")]
-        [InlineData(@"Project Root (flags: {A B C})",                                               @"Project Root[caption] (visibility: visible, flags: {A[capability] B[capability] C[capability]}), FilePath: ""[filepath]""")]
-        [InlineData(@"Project Root (flags: {Folder})",                                              @"Project Root[caption] (visibility: visible, flags: {Folder[capability]}), FilePath: ""[filepath]""")]
-        [InlineData(@"Project Root (flags: {Folder IncludeInProjectCandidate})",                    @"Project Root[caption] (visibility: visible, flags: {Folder[capability] IncludeInProjectCandidate[capability]}), FilePath: ""[filepath]""")]
-        [InlineData(@"Project Root (flags: {AppDesigner Folder IncludeInProjectCandidate})",        @"Project Root[caption] (visibility: visible, flags: {AppDesigner[capability] Folder[capability] IncludeInProjectCandidate[capability]}), FilePath: ""[filepath]""")]
-        [InlineData(@"Project Root (flags: {App:Designer})",                                        @"Project Root[caption] (visibility: visible, flags: {App:Designer[capability]}), FilePath: ""[filepath]""")]
-        [InlineData(@"Project Root (visibility: visible, flags: {App:Designer})",                   @"Project Root[caption] (visibility: visible, flags: {App:Designer[capability]}), FilePath: ""[filepath]""")]
-        [InlineData(@"Project Root (flags: {App:Designer}, visibility: visible)",                   @"Project Root[caption] (visibility: visible, flags: {App:Designer[capability]}), FilePath: ""[filepath]""")]
+        [InlineData(@"Project Root (flags: {})",                                                    @"Project Root[caption] (flags: {})")]
+        [InlineData(@"Project Root (flags: {A})",                                                   @"Project Root[caption] (flags: {A[capability]})")]
+        [InlineData(@"Project Root (flags: {A B})",                                                 @"Project Root[caption] (flags: {A[capability] B[capability]})")]
+        [InlineData(@"Project Root (flags: {A B C})",                                               @"Project Root[caption] (flags: {A[capability] B[capability] C[capability]})")]
+        [InlineData(@"Project Root (flags: {Folder})",                                              @"Project Root[caption] (flags: {Folder[capability]})")]
+        [InlineData(@"Project Root (flags: {Folder IncludeInProjectCandidate})",                    @"Project Root[caption] (flags: {Folder[capability] IncludeInProjectCandidate[capability]})")]
+        [InlineData(@"Project Root (flags: {AppDesigner Folder IncludeInProjectCandidate})",        @"Project Root[caption] (flags: {AppDesigner[capability] Folder[capability] IncludeInProjectCandidate[capability]})")]
+        [InlineData(@"Project Root (flags: {App:Designer})",                                        @"Project Root[caption] (flags: {App:Designer[capability]})")]
+        [InlineData(@"Project Root (visibility: visible, flags: {App:Designer})",                   @"Project Root[caption] (flags: {App:Designer[capability]})")]
+        [InlineData(@"Project Root (flags: {App:Designer}, visibility: visible)",                   @"Project Root[caption] (flags: {App:Designer[capability]})")]
         public void Parse_RootWithCapabilities_CanParse(string input, string expected)
         {
-            AssertProjectTree(input, expected);
+            AssertProjectTree(input, expected, ProjectTreeWriterOptions.Capabilities);
         }
 
         // Input                                                                                    // Expected
         [Theory]
-        [InlineData(@"Project Root (), FilePath: """"",                                             @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]""")]
-        [InlineData(@"Project Root (), FilePath: ""C""",                                            @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""C[filepath]""")]
-        [InlineData(@"Project Root (), FilePath: ""C:""",                                           @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""C:[filepath]""")]
-        [InlineData(@"Project Root (), FilePath: ""C:\""",                                          @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""C:\[filepath]""")]
-        [InlineData(@"Project Root (), FilePath: ""C:\Project""",                                   @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""C:\Project[filepath]""")]
-        [InlineData(@"Project Root (), FilePath: ""C:\Project Root""",                              @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""C:\Project Root[filepath]""")]
-        [InlineData(@"Project Root (), FilePath: ""Project Root""",                                 @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""Project Root[filepath]""")]
-        [InlineData(@"Project Root (), FilePath: ""Project Root.csproj""",                          @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""Project Root.csproj[filepath]""")]
-        [InlineData(@"Project Root (), FilePath: ""Folder\Project Root.csproj""",                   @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""Folder\Project Root.csproj[filepath]""")]
+        [InlineData(@"Project Root (), FilePath: """"",                                             @"Project Root[caption], FilePath: ""[filepath]""")]
+        [InlineData(@"Project Root (), FilePath: ""C""",                                            @"Project Root[caption], FilePath: ""C[filepath]""")]
+        [InlineData(@"Project Root (), FilePath: ""C:""",                                           @"Project Root[caption], FilePath: ""C:[filepath]""")]
+        [InlineData(@"Project Root (), FilePath: ""C:\""",                                          @"Project Root[caption], FilePath: ""C:\[filepath]""")]
+        [InlineData(@"Project Root (), FilePath: ""C:\Project""",                                   @"Project Root[caption], FilePath: ""C:\Project[filepath]""")]
+        [InlineData(@"Project Root (), FilePath: ""C:\Project Root""",                              @"Project Root[caption], FilePath: ""C:\Project Root[filepath]""")]
+        [InlineData(@"Project Root (), FilePath: ""Project Root""",                                 @"Project Root[caption], FilePath: ""Project Root[filepath]""")]
+        [InlineData(@"Project Root (), FilePath: ""Project Root.csproj""",                          @"Project Root[caption], FilePath: ""Project Root.csproj[filepath]""")]
+        [InlineData(@"Project Root (), FilePath: ""Folder\Project Root.csproj""",                   @"Project Root[caption], FilePath: ""Folder\Project Root.csproj[filepath]""")]
         public void Parse_RootWithFilePath_CanParse(string input, string expected)
         {
-            AssertProjectTree(input, expected);
+            AssertProjectTree(input, expected, ProjectTreeWriterOptions.FilePath);
         }
 
         // Input                                                                                    // Expected
@@ -278,19 +278,19 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         // Input                                                                                                                                    // Expected
         [Theory]
-        [InlineData(@"Project Root (), Icon: {}",                                                                                                   @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]"", Icon: {[icon]}, ExpandedIcon: {[icon]}")]
-        [InlineData(@"Project Root (), Icon: {}, ExpandedIcon: {}",                                                                                 @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]"", Icon: {[icon]}, ExpandedIcon: {[icon]}")]
-        [InlineData(@"Project Root (), ExpandedIcon: {}",                                                                                           @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]"", Icon: {[icon]}, ExpandedIcon: {[icon]}")]
-        [InlineData(@"Project Root (), ExpandedIcon: {}, Icon: {}",                                                                                 @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]"", Icon: {[icon]}, ExpandedIcon: {[icon]}")]
-        [InlineData(@"Project Root (), Icon: {41F80260-959C-4556-852C-F7D1B31DD201 0}",                                                             @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]"", Icon: {41F80260-959C-4556-852C-F7D1B31DD201 0[icon]}, ExpandedIcon: {[icon]}")]
-        [InlineData(@"Project Root (), Icon: {41F80260-959C-4556-852C-F7D1B31DD201 1}",                                                             @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]"", Icon: {41F80260-959C-4556-852C-F7D1B31DD201 1[icon]}, ExpandedIcon: {[icon]}")]
-        [InlineData(@"Project Root (), Icon: {41F80260-959C-4556-852C-F7D1B31DD201 2}",                                                             @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]"", Icon: {41F80260-959C-4556-852C-F7D1B31DD201 2[icon]}, ExpandedIcon: {[icon]}")]
-        [InlineData(@"Project Root (), Icon: {41F80260-959C-4556-852C-F7D1B31DD201 10}",                                                            @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]"", Icon: {41F80260-959C-4556-852C-F7D1B31DD201 10[icon]}, ExpandedIcon: {[icon]}")]
-        [InlineData(@"Project Root (), Icon: {41F80260-959C-4556-852C-F7D1B31DD201 10}, ExpandedIcon: {41F80260-959C-4556-852C-F7D1B31DD201 0}",    @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]"", Icon: {41F80260-959C-4556-852C-F7D1B31DD201 10[icon]}, ExpandedIcon: {41F80260-959C-4556-852C-F7D1B31DD201 0[icon]}")]
-        [InlineData(@"Project Root (), Icon: {41F80260-959C-4556-852C-F7D1B31DD201 10}, ExpandedIcon: {F88CB78E-D07D-4131-8E53-B601CEB30517 0}",    @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]"", Icon: {41F80260-959C-4556-852C-F7D1B31DD201 10[icon]}, ExpandedIcon: {F88CB78E-D07D-4131-8E53-B601CEB30517 0[icon]}")]
+        [InlineData(@"Project Root (), Icon: {}",                                                                                                   @"Project Root[caption], Icon: {[icon]}, ExpandedIcon: {[icon]}")]
+        [InlineData(@"Project Root (), Icon: {}, ExpandedIcon: {}",                                                                                 @"Project Root[caption], Icon: {[icon]}, ExpandedIcon: {[icon]}")]
+        [InlineData(@"Project Root (), ExpandedIcon: {}",                                                                                           @"Project Root[caption], Icon: {[icon]}, ExpandedIcon: {[icon]}")]
+        [InlineData(@"Project Root (), ExpandedIcon: {}, Icon: {}",                                                                                 @"Project Root[caption], Icon: {[icon]}, ExpandedIcon: {[icon]}")]
+        [InlineData(@"Project Root (), Icon: {41F80260-959C-4556-852C-F7D1B31DD201 0}",                                                             @"Project Root[caption], Icon: {41F80260-959C-4556-852C-F7D1B31DD201 0[icon]}, ExpandedIcon: {[icon]}")]
+        [InlineData(@"Project Root (), Icon: {41F80260-959C-4556-852C-F7D1B31DD201 1}",                                                             @"Project Root[caption], Icon: {41F80260-959C-4556-852C-F7D1B31DD201 1[icon]}, ExpandedIcon: {[icon]}")]
+        [InlineData(@"Project Root (), Icon: {41F80260-959C-4556-852C-F7D1B31DD201 2}",                                                             @"Project Root[caption], Icon: {41F80260-959C-4556-852C-F7D1B31DD201 2[icon]}, ExpandedIcon: {[icon]}")]
+        [InlineData(@"Project Root (), Icon: {41F80260-959C-4556-852C-F7D1B31DD201 10}",                                                            @"Project Root[caption], Icon: {41F80260-959C-4556-852C-F7D1B31DD201 10[icon]}, ExpandedIcon: {[icon]}")]
+        [InlineData(@"Project Root (), Icon: {41F80260-959C-4556-852C-F7D1B31DD201 10}, ExpandedIcon: {41F80260-959C-4556-852C-F7D1B31DD201 0}",    @"Project Root[caption], Icon: {41F80260-959C-4556-852C-F7D1B31DD201 10[icon]}, ExpandedIcon: {41F80260-959C-4556-852C-F7D1B31DD201 0[icon]}")]
+        [InlineData(@"Project Root (), Icon: {41F80260-959C-4556-852C-F7D1B31DD201 10}, ExpandedIcon: {F88CB78E-D07D-4131-8E53-B601CEB30517 0}",    @"Project Root[caption], Icon: {41F80260-959C-4556-852C-F7D1B31DD201 10[icon]}, ExpandedIcon: {F88CB78E-D07D-4131-8E53-B601CEB30517 0[icon]}")]
         public void Parse_RootWithIcons_CanParse(string input, string expected)
         {
-            AssertProjectTree(input, expected, ProjectTreeWriterOptions.AllProperties);
+            AssertProjectTree(input, expected, ProjectTreeWriterOptions.Icons);
         }
 
         [Theory]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/ProjectSystem/ProjectTreeParserTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/ProjectSystem/ProjectTreeParserTests.cs
@@ -248,7 +248,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         [InlineData(@"Project Root (flags: {App:Designer}, visibility: visible)",                   @"Project Root[caption] (flags: {App:Designer[capability]})")]
         public void Parse_RootWithCapabilities_CanParse(string input, string expected)
         {
-            AssertProjectTree(input, expected, ProjectTreeWriterOptions.Capabilities);
+            AssertProjectTree(input, expected, ProjectTreeWriterOptions.Flags);
         }
 
         // Input                                                                                    // Expected
@@ -405,7 +405,7 @@ Root
             AssertThrows(input, ProjectTreeFormatError.IndentTooManyLevels);
         }
 
-        private void AssertProjectTree(string input, string expected, ProjectTreeWriterOptions options = ProjectTreeWriterOptions.Capabilities | ProjectTreeWriterOptions.FilePath | ProjectTreeWriterOptions.Visibility)
+        private void AssertProjectTree(string input, string expected, ProjectTreeWriterOptions options = ProjectTreeWriterOptions.Flags | ProjectTreeWriterOptions.FilePath | ProjectTreeWriterOptions.Visibility)
         {
             // Remove the newlines from the start and end of input and expected so that 
             // it makes it easier inside the test to layout the repro.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/ProjectSystem/ProjectTreeParserTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/ProjectSystem/ProjectTreeParserTests.cs
@@ -276,6 +276,15 @@ namespace Microsoft.VisualStudio.ProjectSystem
             AssertProjectTree(input, expected, ProjectTreeWriterOptions.ItemType);
         }
 
+        // Input                                                                                    // Expected
+        [Theory]
+        [InlineData(@"Project Root, SubType: Designer",                                             @"Project Root[caption], SubType: Designer[subtype]")]
+        [InlineData(@"Project Root, SubType: Form",                                                 @"Project Root[caption], SubType: Form[subtype]")]
+        public void Parse_RootWithSubType_CanParse(string input, string expected)
+        {
+            AssertProjectTree(input, expected, ProjectTreeWriterOptions.SubType);
+        }
+
         // Input                                                                                                                                    // Expected
         [Theory]
         [InlineData(@"Project Root (), Icon: {}",                                                                                                   @"Project Root[caption], Icon: {[icon]}, ExpandedIcon: {[icon]}")]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/ProjectSystem/ProjectTreeParserTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/ProjectSystem/ProjectTreeParserTests.cs
@@ -267,6 +267,15 @@ namespace Microsoft.VisualStudio.ProjectSystem
             AssertProjectTree(input, expected);
         }
 
+        // Input                                                                                    // Expected
+        [Theory]
+        [InlineData(@"Project Root, ItemType: Compile",                                             @"Project Root[caption], ItemType: Compile[itemtype]")]
+        [InlineData(@"Project Root, ItemType: None",                                                @"Project Root[caption], ItemType: None[itemtype]")]
+        public void Parse_RootWithItemType_CanParse(string input, string expected)
+        {
+            AssertProjectTree(input, expected, ProjectTreeWriterOptions.ItemType);
+        }
+
         // Input                                                                                                                                    // Expected
         [Theory]
         [InlineData(@"Project Root (), Icon: {}",                                                                                                   @"Project Root[caption] (visibility: visible, flags: {}), FilePath: ""[filepath]"", Icon: {[icon]}, ExpandedIcon: {[icon]}")]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectItemTree.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectItemTree.cs
@@ -113,6 +113,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 tree.Visible = Visible;
                 tree.Parent = Parent;
                 tree.Icon = Icon;
+                tree.SubType = SubType;
                 tree.ExpandedIcon = ExpandedIcon;
                 tree.DisplayOrder = DisplayOrder;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectItemTree.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectItemTree.cs
@@ -10,9 +10,17 @@ namespace Microsoft.VisualStudio.ProjectSystem
     {
         private class MutableProjectItemTree : MutableProjectTree, IProjectItemTree2
         {
-            public bool IsLinked => throw new NotImplementedException();
+            public MutableProjectItemTree()
+            {
+                Item = new MutableProjectPropertiesContext();
+            }
 
-            public IProjectPropertiesContext Item { get; set; }
+            public MutableProjectPropertiesContext Item
+            {
+                get;
+            }
+
+            public bool IsLinked => throw new NotImplementedException();
 
             public IPropertySheet PropertySheet => throw new NotImplementedException();
 
@@ -66,6 +74,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 throw new NotImplementedException();
             }
 
+            IProjectPropertiesContext IProjectItemTree.Item
+            {
+                get { return Item; }
+            }
+
             IProjectItemTree2 IProjectItemTree2.SetProperties(string caption, string filePath, IRule browseObjectProperties, ProjectImageMoniker icon, ProjectImageMoniker expandedIcon, bool? visible, ProjectTreeFlags? flags, IProjectPropertiesContext context, IPropertySheet propertySheet, bool? isLinked, bool resetFilePath, bool resetBrowseObjectProperties, bool resetIcon, bool resetExpandedIcon, int? displayOrder)
             {
                 throw new NotImplementedException();
@@ -74,6 +87,36 @@ namespace Microsoft.VisualStudio.ProjectSystem
             IProjectItemTree IProjectItemTree.SetProperties(string caption, string filePath, IRule browseObjectProperties, ProjectImageMoniker icon, ProjectImageMoniker expandedIcon, bool? visible, ProjectTreeFlags? flags, IProjectPropertiesContext context, IPropertySheet propertySheet, bool? isLinked, bool resetFilePath, bool resetBrowseObjectProperties, bool resetIcon, bool resetExpandedIcon)
             {
                 throw new NotImplementedException();
+            }
+
+            public MutableProjectTree BuildProjectTree()
+            {
+                // MutableProjectItemTree acts as a builder for both MutableProjectItemTree and MutableProjectTree
+                // 
+                // Once we've finished building, return either ourselves if we are already are a MutableProjectItemTree
+                // otherwise, copy ourselves to a MutableProjectTree.
+
+                if (!string.IsNullOrEmpty(Item.ItemName) || !string.IsNullOrEmpty(Item.ItemType))
+                {
+                    return this;
+                }
+
+                var tree = new MutableProjectTree();
+                foreach (MutableProjectTree child in Children)
+                {
+                    tree.Children.Add(child);
+                }
+
+                tree.Caption = Caption;
+                tree.Flags = Flags;
+                tree.FilePath = FilePath;
+                tree.Visible = Visible;
+                tree.Parent = Parent;
+                tree.Icon = Icon;
+                tree.ExpandedIcon = ExpandedIcon;
+                tree.DisplayOrder = DisplayOrder;
+
+                return tree;
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectPropertiesContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectPropertiesContext.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             public string File => throw new NotImplementedException();
 
-            public string ItemType => throw new NotImplementedException();
+            public string ItemType { get; set; }
 
             public string ItemName { get; set; }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectTree.SubTypeRule.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectTree.SubTypeRule.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal partial class ProjectTreeParser
+    {
+        private partial class MutableProjectTree
+        {
+            // Does nothing other than return the "SubType" property
+            private class SubTypeRule : IRule
+            {
+                private readonly MutableProjectTree _tree;
+
+                public SubTypeRule(MutableProjectTree tree)
+                {
+                    _tree = tree;
+                }
+
+                public IPropertyGroup this[string categoryName] => throw new NotImplementedException();
+
+                public string Name => throw new NotImplementedException();
+                public string DisplayName => throw new NotImplementedException();
+                public string Description => throw new NotImplementedException();
+                public string HelpString => throw new NotImplementedException();
+                public string PageTemplate => throw new NotImplementedException();
+                public string SwitchPrefix => throw new NotImplementedException();
+                public string Separator => throw new NotImplementedException();
+                public IReadOnlyList<ICategory> Categories => throw new NotImplementedException();
+                public Rule Schema => throw new NotImplementedException();
+                public int Order => throw new NotImplementedException();
+                public string File => throw new NotImplementedException();
+                public string ItemType => throw new NotImplementedException();
+                public string ItemName => throw new NotImplementedException();
+                public IReadOnlyList<IPropertyGroup> PropertyGroups => throw new NotImplementedException();
+                public IEnumerable<IProperty> Properties => throw new NotImplementedException();
+                public IProjectPropertiesContext Context => throw new NotImplementedException();
+                public bool PropertyPagesHidden => throw new NotImplementedException();
+
+                public IProperty GetProperty(string propertyName)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public Task<string> GetPropertyValueAsync(string propertyName)
+                {
+                    if (propertyName == "SubType")
+                    {
+                        return Task.FromResult(_tree.SubType);
+                    }
+
+                    throw new NotImplementedException();
+                }
+            }
+        }
+    }
+}
+

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectTree.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectTree.cs
@@ -274,38 +274,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
                 return this;
             }
-
-            public string ItemName { get; set; }
-
-            public string ItemType { get; set; }
-
-            public MutableProjectItemTree ToMutableProjectItemTree()
-            {
-                var newItemTree = new MutableProjectItemTree();
-                var newTree = newItemTree as MutableProjectTree;
-
-                newTree.Children = new Collection<MutableProjectTree>(Children);
-                newTree.Caption = Caption;
-                newTree.Flags = Flags;
-                newTree.FilePath = FilePath;
-                newTree.Visible = Visible;
-                newTree.Parent = Parent;
-                newTree.Icon = Icon;
-                newTree.ExpandedIcon = ExpandedIcon;
-                newTree.DisplayOrder = DisplayOrder;
-                newTree.ItemName = ItemName;
-                newTree.ItemType = ItemType;
-
-                var projectPropertiesContext = new MutableProjectPropertiesContext
-                {
-                    ItemName = ItemName,
-                    ItemType = ItemType
-                };
-
-                newItemTree.Item = projectPropertiesContext;
-
-                return newItemTree;
-            }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectTree.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectTree.cs
@@ -4,19 +4,19 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal partial class ProjectTreeParser
     {
-        private class MutableProjectTree : IProjectTree2
+        private partial class MutableProjectTree : IProjectTree2
         {
             public MutableProjectTree()
             {
                 Children = new Collection<MutableProjectTree>();
                 Visible = true;
+                BrowseObjectProperties = new SubTypeRule(this);
             }
 
             public Collection<MutableProjectTree> Children
@@ -32,6 +32,12 @@ namespace Microsoft.VisualStudio.ProjectSystem
             }
 
             public ProjectTreeFlags Flags
+            {
+                get;
+                set;
+            }
+
+            public string SubType
             {
                 get;
                 set;
@@ -65,12 +71,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 get { return Parent; }
             }
 
-            IRule IProjectTree.BrowseObjectProperties
+            public IRule BrowseObjectProperties
             {
-                get
-                {
-                    throw new NotImplementedException();
-                }
+                get;
             }
 
             IReadOnlyList<IProjectTree> IProjectTree.Children

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectTree.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectTree.cs
@@ -277,6 +277,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             public string ItemName { get; set; }
 
+            public string ItemType { get; set; }
+
             public MutableProjectItemTree ToMutableProjectItemTree()
             {
                 var newItemTree = new MutableProjectItemTree();
@@ -292,10 +294,12 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 newTree.ExpandedIcon = ExpandedIcon;
                 newTree.DisplayOrder = DisplayOrder;
                 newTree.ItemName = ItemName;
+                newTree.ItemType = ItemType;
 
                 var projectPropertiesContext = new MutableProjectPropertiesContext
                 {
-                    ItemName = ItemName
+                    ItemName = ItemName,
+                    ItemType = ItemType
                 };
 
                 newItemTree.Item = projectPropertiesContext;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.cs
@@ -261,6 +261,12 @@ namespace Microsoft.VisualStudio.ProjectSystem
                         ReadItemType(tree);
                         break;
 
+                    case "SubType":
+                        tokenizer.Skip(TokenType.Colon);
+                        tokenizer.Skip(TokenType.WhiteSpace);
+                        ReadSubType(tree);
+                        break;
+
                     case "Icon":
                         tokenizer.Skip(TokenType.Colon);
                         tokenizer.Skip(TokenType.WhiteSpace);
@@ -314,11 +320,20 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         private void ReadItemType(MutableProjectItemTree tree)
-        {   // Parses 'Compile'
+        {
+            tree.Item.ItemType = ReadPropertyValue();
+        }
 
+        private void ReadSubType(MutableProjectItemTree tree)
+        {
+            tree.SubType = ReadPropertyValue();
+        }
+
+        private string ReadPropertyValue()
+        {   
             Tokenizer tokenizer = Tokenizer(Delimiters.PropertyValue);
 
-            tree.Item.ItemType = tokenizer.ReadIdentifier(IdentifierParseOptions.None);
+            return tokenizer.ReadIdentifier(IdentifierParseOptions.None);
         }
 
         private string ReadQuotedPropertyValue()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.cs
@@ -122,13 +122,13 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var tree = new MutableProjectTree();
             ReadProjectItemProperties(tree);
 
-            if (string.IsNullOrWhiteSpace(tree.ItemName))
+            if (string.IsNullOrWhiteSpace(tree.ItemName) && string.IsNullOrWhiteSpace(tree.ItemType))
             {
                 return tree;
             }
             else
             {
-                // Because we have an evaluated include value (ItemName), this means we have a project item tree.
+                // Because we have an evaluated include value (ItemName or ItemType), this means we have a project item tree.
                 return tree.ToMutableProjectItemTree();
             }
         }
@@ -263,6 +263,12 @@ namespace Microsoft.VisualStudio.ProjectSystem
                         ReadFilePath(tree);
                         break;
 
+                    case "ItemType":
+                        tokenizer.Skip(TokenType.Colon);
+                        tokenizer.Skip(TokenType.WhiteSpace);
+                        ReadItemType(tree);
+                        break;
+
                     case "Icon":
                         tokenizer.Skip(TokenType.Colon);
                         tokenizer.Skip(TokenType.WhiteSpace);
@@ -294,7 +300,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         private void ReadDisplayOrder(MutableProjectTree tree)
-        {   // Parses ': 1`
+        {   // Parses '1`
 
             Tokenizer tokenizer = Tokenizer(Delimiters.PropertyValue);
 
@@ -304,15 +310,23 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         private void ReadItemName(MutableProjectTree tree)
-        {   // Parses ': "test.fs"'
+        {   // Parses '"test.fs"'
 
             tree.ItemName = ReadQuotedPropertyValue();
         }
 
         private void ReadFilePath(MutableProjectTree tree)
-        {   // Parses ': "C:\Temp\Foo"'
+        {   // Parses '"C:\Temp\Foo"'
 
             tree.FilePath = ReadQuotedPropertyValue();
+        }
+
+        private void ReadItemType(MutableProjectTree tree)
+        {   // Parses 'Compile'
+
+            Tokenizer tokenizer = Tokenizer(Delimiters.PropertyValue);
+
+            tree.ItemType = tokenizer.ReadIdentifier(IdentifierParseOptions.Required);
         }
 
         private string ReadQuotedPropertyValue()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeWriter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeWriter.cs
@@ -47,6 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             WriteProperties(tree);
             WriteFilePath(tree);
             WriteItemType(tree);
+            WriteSubType(tree);
             WriteIcons(tree);
             WriteChildren(tree, indentLevel);
         }
@@ -145,6 +146,20 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 {
                     _builder.Append("[itemtype]");
                 }
+            }
+        }
+
+        private void WriteSubType(IProjectTree tree)
+        {
+            if (!_options.HasFlag(ProjectTreeWriterOptions.SubType))
+                return;
+
+            _builder.Append(", SubType: ");
+            _builder.Append(tree.BrowseObjectProperties.GetPropertyValueAsync("SubType").Result);
+
+            if (TagElements)
+            {
+                _builder.Append("[subtype]");
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeWriter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeWriter.cs
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         private void WriteProperties(IProjectTree tree)
         {
             bool visibility = _options.HasFlag(ProjectTreeWriterOptions.Visibility);
-            bool flags = _options.HasFlag(ProjectTreeWriterOptions.Visibility);
+            bool flags = _options.HasFlag(ProjectTreeWriterOptions.Capabilities);
 
             if (!visibility && !flags)
                 return;
@@ -98,12 +98,18 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             if (visibility)
             {
-                WriteVisibility(tree);
-                _builder.Append(", ");
+                WriteVisibility(tree);                
             }
 
             if (flags)
+            {
+                if (visibility)
+                {
+                    _builder.Append(", ");
+                }
+
                 WriteFlags(tree);
+            }
 
             _builder.Append(')');
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeWriter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeWriter.cs
@@ -46,6 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             WriteCaption(tree);
             WriteProperties(tree);
             WriteFilePath(tree);
+            WriteItemType(tree);
             WriteIcons(tree);
             WriteChildren(tree, indentLevel);
         }
@@ -122,6 +123,23 @@ namespace Microsoft.VisualStudio.ProjectSystem
             }
 
             _builder.Append('"');
+        }
+
+        private void WriteItemType(IProjectTree tree)
+        {
+            if (!_options.HasFlag(ProjectTreeWriterOptions.ItemType))
+                return;
+
+            if (tree is IProjectItemTree item)
+            {
+                _builder.Append(", ItemType: ");
+                _builder.Append(item.Item.ItemType);
+
+                if (TagElements)
+                {
+                    _builder.Append("[itemtype]");
+                }
+            }
         }
 
         private void WriteVisibility(IProjectTree tree)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeWriter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeWriter.cs
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         private void WriteProperties(IProjectTree tree)
         {
             bool visibility = _options.HasFlag(ProjectTreeWriterOptions.Visibility);
-            bool flags = _options.HasFlag(ProjectTreeWriterOptions.Capabilities);
+            bool flags = _options.HasFlag(ProjectTreeWriterOptions.Flags);
 
             if (!visibility && !flags)
                 return;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeWriterOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeWriterOptions.cs
@@ -10,10 +10,10 @@ namespace Microsoft.VisualStudio.ProjectSystem
         None = 0,
         Tags = 1,
         FilePath = 2,
-        Capabilities = 4,
+        Flags = 4,
         Visibility = 8,
         Icons = 16,
         ItemType = 32,
-        AllProperties = FilePath | Visibility | Capabilities | Icons | ItemType
+        AllProperties = FilePath | Visibility | Flags | Icons | ItemType
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeWriterOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeWriterOptions.cs
@@ -14,6 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         Visibility = 8,
         Icons = 16,
         ItemType = 32,
+        SubType = 64,
         AllProperties = FilePath | Visibility | Flags | Icons | ItemType
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeWriterOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeWriterOptions.cs
@@ -13,6 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         Capabilities = 4,
         Visibility = 8,
         Icons = 16,
-        AllProperties = FilePath | Visibility | Capabilities | Icons
+        ItemType = 32,
+        AllProperties = FilePath | Visibility | Capabilities | Icons | ItemType
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeWriterOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeWriterOptions.cs
@@ -15,6 +15,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
         Icons = 16,
         ItemType = 32,
         SubType = 64,
-        AllProperties = FilePath | Visibility | Flags | Icons | ItemType
+        AllProperties = FilePath | Visibility | Flags | Icons | ItemType | SubType
     }
 }


### PR DESCRIPTION
Add SubType/ItemType support to project tree parser, and a few other changes.

Need this to test the WindowsFormsEditorProvider.