### PR TITLE
Fix naming violations

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
@@ -2804,9 +2804,9 @@ NextControl:
         '''   uses the information already in the PropertyControlData for the page.
         ''' </summary>
         ''' <remarks></remarks>
-        Protected Overridable Sub EnableAllControls(_enabled As Boolean)
+        Protected Overridable Sub EnableAllControls(enabled As Boolean)
             For Each _controlData As PropertyControlData In ControlData
-                _controlData.EnableControls(_enabled)
+                _controlData.EnableControls(enabled)
             Next _controlData
         End Sub
 

--- a/src/Microsoft.VisualStudio.AppDesigner/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.AppDesigner/PublicAPI.Shipped.txt
@@ -851,7 +851,7 @@ Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.DisableOnDebug() -> Boolean
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.DisableWhenDebugMode(mode As Microsoft.VisualStudio.Shell.Interop.DBGMODE) -> Boolean
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.EditProperty(dispid As Integer) -> Void
-Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.EnableAllControls(_enabled As Boolean) -> Void
+Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.EnableAllControls(enabled As Boolean) -> Void
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.GetF1HelpKeyword() -> String
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.GetProperty(dispid As Integer, ByRef obj As Object) -> Boolean
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.GetPropertyControl(PropertyId As Integer) -> System.Windows.Forms.Control

--- a/src/Microsoft.VisualStudio.Editors/My Project/AssemblyInfo.vb
+++ b/src/Microsoft.VisualStudio.Editors/My Project/AssemblyInfo.vb
@@ -84,10 +84,7 @@ Imports System.Runtime.InteropServices
 <Assembly: TypeForwardedTo(GetType(Microsoft.VisualStudio.Editors.PropertyPages.ControlDataFlags))>
 <Assembly: TypeForwardedTo(GetType(Microsoft.VisualStudio.Editors.PropertyPages.IPropertyPageInternal))>
 <Assembly: TypeForwardedTo(GetType(Microsoft.VisualStudio.Editors.PropertyPages.IPropertyPageSiteInternal))>
-' TODO why is the analyzer giving a diagnostic here?
-#Disable Warning RS0016 ' Symbol 'New' is not part of the declared API
 <Assembly: TypeForwardedTo(GetType(Microsoft.VisualStudio.Editors.PropertyPages.ProjectReloadedException))>
-#Enable Warning RS0016 ' Symbol 'New' is not part of the declared API
 <Assembly: TypeForwardedTo(GetType(Microsoft.VisualStudio.Editors.PropertyPages.PropertyControlData))>
 <Assembly: TypeForwardedTo(GetType(Microsoft.VisualStudio.Editors.PropertyPages.PropertyListener))>
 <Assembly: TypeForwardedTo(GetType(Microsoft.VisualStudio.Editors.PropertyPages.PropertyPageException))>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
@@ -55,8 +55,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             WARNINGS_NONE
         End Enum
 
-        Protected Overrides Sub EnableAllControls(_enabled As Boolean)
-            MyBase.EnableAllControls(_enabled)
+        Protected Overrides Sub EnableAllControls(enabled As Boolean)
+            MyBase.EnableAllControls(enabled)
         End Sub
 
         Protected Overrides ReadOnly Property ControlData() As PropertyControlData()

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CompilePropPage2.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CompilePropPage2.vb
@@ -164,34 +164,34 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Function
 
 #Region "Enable / disable controls helpers"
-        Protected Overrides Sub EnableAllControls(_enabled As Boolean)
-            MyBase.EnableAllControls(_enabled)
+        Protected Overrides Sub EnableAllControls(enabled As Boolean)
+            MyBase.EnableAllControls(enabled)
 
-            GetPropertyControlData(VsProjPropId.VBPROJPROPID_DocumentationFile).EnableControls(_enabled)
-            AdvancedOptionsButton.Enabled = _enabled
-            GetPropertyControlData(VsProjPropId.VBPROJPROPID_OutputPath).EnableControls(_enabled)
-            GetPropertyControlData(VsProjPropId.VBPROJPROPID_RegisterForComInterop).EnableControls(_enabled AndAlso RegisterForComInteropSupported())
+            GetPropertyControlData(VsProjPropId.VBPROJPROPID_DocumentationFile).EnableControls(enabled)
+            AdvancedOptionsButton.Enabled = enabled
+            GetPropertyControlData(VsProjPropId.VBPROJPROPID_OutputPath).EnableControls(enabled)
+            GetPropertyControlData(VsProjPropId.VBPROJPROPID_RegisterForComInterop).EnableControls(enabled AndAlso RegisterForComInteropSupported())
 
-            EnableDisableWarningControls(_enabled)
+            EnableDisableWarningControls(enabled)
         End Sub
 
-        Private Sub EnableDisableWarningControls(_enabled As Boolean)
-            GetPropertyControlData(VsProjPropId.VBPROJPROPID_WarningLevel).EnableControls(_enabled) 'DisableAllWarningsCheckBox
-            GetPropertyControlData(VsProjPropId.VBPROJPROPID_TreatWarningsAsErrors).EnableControls(_enabled AndAlso Not DisableAllWarnings())
+        Private Sub EnableDisableWarningControls(enabled As Boolean)
+            GetPropertyControlData(VsProjPropId.VBPROJPROPID_WarningLevel).EnableControls(enabled) 'DisableAllWarningsCheckBox
+            GetPropertyControlData(VsProjPropId.VBPROJPROPID_TreatWarningsAsErrors).EnableControls(enabled AndAlso Not DisableAllWarnings())
 
-            EnableDisableGridView(_enabled)
+            EnableDisableGridView(enabled)
         End Sub
 
-        Private Sub EnableDisableGridView(_enabled As Boolean)
+        Private Sub EnableDisableGridView(enabled As Boolean)
 
             If GetPropertyControlData(VsProjPropId2.VBPROJPROPID_NoWarn).IsMissing _
             OrElse GetPropertyControlData(VsProjPropId80.VBPROJPROPID_TreatSpecificWarningsAsErrors).IsMissing Then
                 'Not much sense in having the grid enabled if these properties aren't supported by the flavor
-                _enabled = False
+                enabled = False
             End If
 
             Dim NotifyColumn As DataGridViewComboBoxColumn = CType(WarningsGridView.Columns.Item(NotifyColumnIndex), DataGridViewComboBoxColumn)
-            If _enabled AndAlso DisableAllWarningsCheckBox.CheckState = CheckState.Unchecked AndAlso WarningsAsErrorCheckBox.CheckState = CheckState.Unchecked Then
+            If enabled AndAlso DisableAllWarningsCheckBox.CheckState = CheckState.Unchecked AndAlso WarningsAsErrorCheckBox.CheckState = CheckState.Unchecked Then
                 For Each column As DataGridViewColumn In WarningsGridView.Columns
                     column.DefaultCellStyle.BackColor = WarningsGridView.DefaultCellStyle.BackColor
                 Next

--- a/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/DebugPropPage.vb
@@ -163,12 +163,12 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Return True
         End Function
 
-        Protected Overrides Sub EnableAllControls(_enabled As Boolean)
-            MyBase.EnableAllControls(_enabled)
+        Protected Overrides Sub EnableAllControls(enabled As Boolean)
+            MyBase.EnableAllControls(enabled)
 
-            GetPropertyControlData(VsProjPropId.VBPROJPROPID_StartAction).EnableControls(_enabled)
-            GetPropertyControlData(VsProjPropId.VBPROJPROPID_StartProgram).EnableControls(_enabled)
-            GetPropertyControlData(VsProjPropId.VBPROJPROPID_StartURL).EnableControls(_enabled)
+            GetPropertyControlData(VsProjPropId.VBPROJPROPID_StartAction).EnableControls(enabled)
+            GetPropertyControlData(VsProjPropId.VBPROJPROPID_StartProgram).EnableControls(enabled)
+            GetPropertyControlData(VsProjPropId.VBPROJPROPID_StartURL).EnableControls(enabled)
         End Sub
 
         ''' <summary>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePropPage.vb
@@ -101,15 +101,15 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             MyBase.CleanupCOMReferences()
         End Sub
 
-        Protected Overrides Sub EnableAllControls(_enabled As Boolean)
-            MyBase.EnableAllControls(_enabled)
+        Protected Overrides Sub EnableAllControls(enabled As Boolean)
+            MyBase.EnableAllControls(enabled)
 
-            ReferenceList.Enabled = _enabled
-            addSplitButton.Enabled = _enabled
-            RemoveReference.Enabled = _enabled
-            UpdateReferences.Enabled = _enabled
-            UnusedReferences.Enabled = _enabled
-            GetPropertyControlData("ImportList").EnableControls(_enabled)
+            ReferenceList.Enabled = enabled
+            addSplitButton.Enabled = enabled
+            RemoveReference.Enabled = enabled
+            UpdateReferences.Enabled = enabled
+            UnusedReferences.Enabled = enabled
+            GetPropertyControlData("ImportList").EnableControls(enabled)
         End Sub
 
         Protected Overrides ReadOnly Property ControlData() As PropertyControlData()
@@ -713,9 +713,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             EnableImportGroup()
         End Sub
 
-        Private Sub AddNamespaceToImportList(_namespace As String)
-            If ImportList.Items.IndexOf(_namespace) = -1 Then
-                ImportList.Items.Add(_namespace)
+        Private Sub AddNamespaceToImportList(ns As String)
+            If ImportList.Items.IndexOf(ns) = -1 Then
+                ImportList.Items.Add(ns)
             End If
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/UnusedReferencePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/UnusedReferencePropPage.vb
@@ -178,9 +178,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' Enable/disable remove button and set whether there 
         ''' are changes to apply (IsDirty).
         ''' </summary>
-        ''' <param name="_enabled">Enable or disable</param>
+        ''' <param name="enabled">Enable or disable</param>
         ''' <remarks>Use when proppage is on a PropPageHostDialog</remarks>
-        Private Sub EnableRemoveRefs(_enabled As Boolean)
+        Private Sub EnableRemoveRefs(enabled As Boolean)
 
             If ParentForm IsNot Nothing Then
                 Debug.Assert(TypeOf ParentForm Is PropPageHostDialog, "Unused references list should be on host dialog")
@@ -188,10 +188,10 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 Dim RemoveButton As Button = CType(ParentForm, PropPageHostDialog).OK
 
                 ' Enable/Disable group
-                RemoveButton.Enabled = _enabled
+                RemoveButton.Enabled = enabled
 
                 ' indicate if we have references to remove on apply()
-                If (_enabled) Then
+                If (enabled) Then
                     SetDirty(Me)
                     RemoveButton.DialogResult = DialogResult.OK
                 Else

--- a/src/Microsoft.VisualStudio.Editors/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.Editors/PublicAPI.Shipped.txt
@@ -868,7 +868,7 @@ Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.DisableOnDebug() -> Boolean (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.DisableWhenDebugMode(mode As Microsoft.VisualStudio.Shell.Interop.DBGMODE) -> Boolean (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.EditProperty(dispid As Integer) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
-Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.EnableAllControls(_enabled As Boolean) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
+Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.EnableAllControls(enabled As Boolean) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.GetF1HelpKeyword() -> String (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.GetProperty(dispid As Integer, ByRef obj As Object) -> Boolean (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Overridable Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase.GetPropertyControl(PropertyId As Integer) -> System.Windows.Forms.Control (forwarded, contained in Microsoft.VisualStudio.AppDesigner)

--- a/src/Microsoft.VisualStudio.Editors/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.Editors/PublicAPI.Shipped.txt
@@ -496,6 +496,7 @@ Microsoft.VisualStudio.Editors.PropertyPages.PackagePropPageComClass
 Microsoft.VisualStudio.Editors.PropertyPages.PackagePropPageComClass.New() -> Void
 Microsoft.VisualStudio.Editors.PropertyPages.ProjectReloadedException (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.PropertyPages.ProjectReloadedException.New() -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
+Microsoft.VisualStudio.Editors.PropertyPages.ProjectReloadedException.New(Info As System.Runtime.Serialization.SerializationInfo, Context As System.Runtime.Serialization.StreamingContext) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.FinishPendingValidations() -> Boolean (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.PropertyPages.PropPageBase.GetLocaleID() -> Integer (forwarded, contained in Microsoft.VisualStudio.AppDesigner)


### PR DESCRIPTION
Fix naming violations in parameters, which theoretically can break usage, but is doubtful.