### PR TITLE
DesignTimeInputs data source and tests

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -6,6 +6,7 @@ trigger:
 - dev16.0.x
 - dev16.1.x
 - dev16.2.x
+- feature/*
 
 # Branches that trigger builds on PR
 pr:
@@ -15,6 +16,7 @@ pr:
 - dev16.0.x
 - dev16.1.x
 - dev16.2.x
+- feature/*
 
 jobs:
 - job: Windows

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ConfiguredProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ConfiguredProjectFactory.cs
@@ -8,12 +8,13 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal static class ConfiguredProjectFactory
     {
-        public static ConfiguredProject Create(IProjectCapabilitiesScope capabilities = null, ProjectConfiguration projectConfiguration = null, ConfiguredProjectServices services = null)
+        public static ConfiguredProject Create(IProjectCapabilitiesScope capabilities = null, ProjectConfiguration projectConfiguration = null, ConfiguredProjectServices services = null, UnconfiguredProject unconfiguredProject = null)
         {
             var mock = new Mock<ConfiguredProject>();
             mock.Setup(c => c.Capabilities).Returns(capabilities);
             mock.Setup(c => c.ProjectConfiguration).Returns(projectConfiguration);
             mock.Setup(c => c.Services).Returns(services);
+            mock.SetupGet(c => c.UnconfiguredProject).Returns(unconfiguredProject);
             return mock.Object;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ConfiguredProjectServicesFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ConfiguredProjectServicesFactory.cs
@@ -13,13 +13,15 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public static ConfiguredProjectServices Create(IPropertyPagesCatalogProvider propertyPagesCatalogProvider = null,
                                                        IAdditionalRuleDefinitionsService ruleService = null,
                                                        IProjectSubscriptionService projectSubscriptionService = null,
-                                                       IProjectPropertiesProvider projectPropertiesProvider = null)
+                                                       IProjectPropertiesProvider projectPropertiesProvider = null,
+                                                       IProjectService projectService = null)
         {
             var mock = new Mock<ConfiguredProjectServices>();
             mock.Setup(c => c.PropertyPagesCatalog).Returns(propertyPagesCatalogProvider);
             mock.Setup(c => c.AdditionalRuleDefinitions).Returns(ruleService);
             mock.Setup(c => c.ProjectSubscription).Returns(projectSubscriptionService);
             mock.Setup(c => c.ProjectPropertiesProvider).Returns(projectPropertiesProvider);
+            mock.SetupGet(s => s.ProjectService).Returns(projectService);
             return mock.Object;
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectSubscriptionServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectSubscriptionServiceFactory.cs
@@ -20,6 +20,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
             mock.SetupGet(s => s.ProjectBuildRuleSource)
                 .Returns(source);
 
+            mock.SetupGet(s => s.SourceItemsRuleSource)
+                .Returns(source);
+
             return mock.Object;
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectServicesFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectServicesFactory.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal static class ProjectServicesFactory
     {
-        public static ProjectServices Create(IProjectThreadingService threadingService = null, IProjectFaultHandlerService faultHandlerService = null, IProjectService projectService = null)
+        public static ProjectServices Create(IProjectThreadingService threadingService = null, IProjectFaultHandlerService faultHandlerService = null, IProjectService projectService = null, IProjectLockService projectLockService = null)
         {
             threadingService ??= IProjectThreadingServiceFactory.Create();
             faultHandlerService ??= IProjectFaultHandlerServiceFactory.Create();
@@ -22,6 +22,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             projectServices.Setup(u => u.ProjectService)
                 .Returns(projectService);
+
+            projectServices.Setup(u => u.ProjectLockService)
+                .Returns(projectLockService);
 
             return projectServices.Object;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectValueDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectValueDataSource.cs
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             _broadcastBlock = DataflowBlockSlim.CreateBroadcastBlock<IProjectVersionedValue<T>>(null);
         }
 
-        public async Task SendAndCompleteAsync(T value, ITargetBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>> targetBlock)
+        public async Task SendAndCompleteAsync(T value, IDataflowBlock targetBlock)
         {
             await SendAsync(value);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsDataSourceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsDataSourceTests.cs
@@ -1,0 +1,155 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.ProjectSystem.VS.TempPE;
+using Xunit;
+
+// Nullable annotations don't add a lot of value to this class, and until https://github.com/dotnet/roslyn/issues/33199 is fixed
+// MemberData doesn't work anyway
+#nullable disable
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    public class DesignTimeInputsDataSourceTests
+    {
+        public static IEnumerable<object[]> GetTestCases()
+        {
+            return new[]
+            {
+                // A single design time input
+                new object[]
+                {
+                    @"""CurrentState"": {
+                        ""Compile"": {
+                            ""Items"": { 
+                                ""File1.cs"": {
+                                    ""DesignTime"": true
+                                }
+                            }
+                        }
+                    }",
+                    new string[] { "File1.cs" },
+                    new string[] { }
+                },
+
+                // A single design time input, and a normal file
+                new object[]
+                {
+                    @"""CurrentState"": {
+                        ""Compile"": {
+                            ""Items"": { 
+                                ""File1.cs"": {
+                                    ""DesignTime"": true
+                                },
+                                ""File2.cs"": { }
+                            }
+                        }
+                    }",
+                    new string[] { "File1.cs" },
+                    new string[] { }
+                },
+
+                // A single design time input, and a single shared design time input
+                new object[]
+                {
+                    @"""CurrentState"": {
+                        ""Compile"": {
+                            ""Items"": { 
+                                ""File1.cs"": {
+                                    ""DesignTime"": true
+                                },
+                                ""File2.cs"": {
+                                    ""DesignTimeSharedInput"": true
+                                }
+                            }
+                        }
+                    }",
+                    new string[] { "File1.cs" },
+                    new string[] { "File2.cs" }
+                },
+
+                // A file that is both a design time and shared design time input
+                new object[]
+                {
+                    @"""CurrentState"": {
+                        ""Compile"": {
+                            ""Items"": { 
+                                ""File1.cs"": {
+                                    ""DesignTime"": true,
+                                    ""DesignTimeSharedInput"": true
+                                }
+                            }
+                        }
+                    }",
+                    new string[] { "File1.cs" },
+                    new string[] { "File1.cs" }
+                },
+
+                // A design time input that is a linked file, and hence ignored
+                new object[]
+                {
+                    @"""CurrentState"": {
+                        ""Compile"": {
+                            ""Items"": { 
+                                ""File1.cs"": {
+                                    ""DesignTime"": true,
+                                    ""Link"": ""foo""
+                                }
+                            }
+                        }
+                    }",
+                    new string[] { },
+                    new string[] { }
+                },
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestCases))]
+        public async Task VerifyDesignTimeInputsProcessed(string projectState, string[] designTimeInputs, string[] sharedDesignTimeInputs)
+        {
+            var projectServices = ProjectServicesFactory.Create(threadingService: IProjectThreadingServiceFactory.Create(), projectLockService: IProjectLockServiceFactory.Create());
+            var projectService = IProjectServiceFactory.Create(projectServices);
+            var projectSubscriptionService = IProjectSubscriptionServiceFactory.Create();
+
+            var configuredProject = ConfiguredProjectFactory.Create(
+                services: ConfiguredProjectServicesFactory.Create(projectService: projectService),
+                unconfiguredProject: UnconfiguredProjectFactory.Create());
+
+            // Construct and initialize an instance to test
+            using var dataSource = new DesignTimeInputsDataSource(configuredProject, projectSubscriptionService);
+
+            dataSource.Test_Initialize();
+
+            const string defaultProjectConfig = @"""ProjectConfiguration"": {
+                                                    ""Name"": ""Debug|AnyCPU"",
+                                                    ""Dimensions"": {
+                                                        ""Configuration"": ""Debug"",
+                                                        ""Platform"": ""AnyCPU""
+                                                    }
+                                                }";
+
+            // Create a block to receive the results of the block under test
+            DesignTimeInputs inputs = null;
+            var receiver = DataflowBlockSlim.CreateActionBlock<IProjectVersionedValue<DesignTimeInputs>>(val =>
+            {
+                inputs = val.Value;
+            });
+            dataSource.SourceBlock.LinkTo(receiver, DataflowOption.PropagateCompletion);
+
+            // Construct our input value, including a default project config
+            var configUpdate = IProjectSubscriptionUpdateFactory.FromJson("{ " + projectState + "," + defaultProjectConfig + " }");
+
+            // Send our input, and wait for our receiver to complete
+            var sourceItems = (ProjectValueDataSource<IProjectSubscriptionUpdate>)projectSubscriptionService.SourceItemsRuleSource;
+            await sourceItems.SendAndCompleteAsync(configUpdate, receiver);
+
+            // Assert
+            Assert.NotNull(inputs);
+            Assert.Equal(designTimeInputs, inputs.Inputs);
+            Assert.Equal(sharedDesignTimeInputs, inputs.SharedInputs);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputs.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputs.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputs.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputs.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
+{
+    internal class DesignTimeInputs
+    {
+        public string[] Inputs = Array.Empty<string>();
+        public string[] SharedInputs = Array.Empty<string>();
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputs.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputs.cs
@@ -1,12 +1,19 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 {
     internal class DesignTimeInputs
     {
-        public string[] Inputs = Array.Empty<string>();
-        public string[] SharedInputs = Array.Empty<string>();
+        public readonly ImmutableArray<string> Inputs;
+        public readonly ImmutableArray<string> SharedInputs;
+
+        public DesignTimeInputs(IEnumerable<string> inputs, IEnumerable<string> sharedInputs)
+        {
+            Inputs = ImmutableArray<string>.Empty.AddRange(inputs);
+            SharedInputs = ImmutableArray<string>.Empty.AddRange(sharedInputs);
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsDataSource.cs
@@ -35,14 +35,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             get { return _project; }
         }
 
-        /// <summary>
-        /// Allow unit tests to initialize this class. May be removed in future
-        /// </summary>
-        internal void Test_Initialize()
-        {
-            EnsureInitialized();
-        }
-
         protected override IDisposable LinkExternalInput(ITargetBlock<IProjectVersionedValue<DesignTimeInputs>> targetBlock)
         {
             IProjectValueDataSource<IProjectSubscriptionUpdate> source = _projectSubscriptionService.SourceItemsRuleSource;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsDataSource.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Threading.Tasks.Dataflow;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
+{
+    /// <summary>
+    /// Processes Compile source items into <see cref="DesignTimeInputs" /> that includes design time and shared design time inputs
+    /// only.
+    /// </summary>
+    [Export(typeof(IDesignTimeInputsDataSource))]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicLanguageService)]
+    internal class DesignTimeInputsDataSource : ChainedProjectValueDataSourceBase<DesignTimeInputs>, IDesignTimeInputsDataSource
+    {
+        private static readonly ImmutableHashSet<string> s_ruleNames = Empty.OrdinalIgnoreCaseStringSet.Add(Compile.SchemaName);
+
+        private readonly UnconfiguredProject _project;
+        private readonly IProjectSubscriptionService _projectSubscriptionService;
+
+        [ImportingConstructor]
+        public DesignTimeInputsDataSource(ConfiguredProject project, IProjectSubscriptionService projectSubscriptionService)
+            : base(project.Services, synchronousDisposal: true, registerDataSource: false)
+        {
+            _project = project.UnconfiguredProject;
+            _projectSubscriptionService = projectSubscriptionService;
+        }
+
+        protected override UnconfiguredProject ContainingProject
+        {
+            get { return _project; }
+        }
+
+        /// <summary>
+        /// Allow unit tests to initialize this class. May be removed in future
+        /// </summary>
+        internal void Test_Initialize()
+        {
+            EnsureInitialized();
+        }
+
+        protected override IDisposable LinkExternalInput(ITargetBlock<IProjectVersionedValue<DesignTimeInputs>> targetBlock)
+        {
+            IProjectValueDataSource<IProjectSubscriptionUpdate> source = _projectSubscriptionService.SourceItemsRuleSource;
+
+            // Transform the changes from evaluation/design-time build -> restore data
+            DisposableValue<ISourceBlock<IProjectVersionedValue<DesignTimeInputs>>> transformBlock = source.SourceBlock
+                                                                                .TransformWithNoDelta(update => update.Derive(u => GetDesignTimeInputs(u.CurrentState)),
+                                                                                                      suppressVersionOnlyUpdates: false,
+                                                                                                      ruleNames: s_ruleNames);
+
+            // Set the link up so that we publish changes to target block
+            transformBlock.Value.LinkTo(targetBlock, DataflowOption.PropagateCompletion);
+
+            // Join the source blocks, so if they need to switch to UI thread to complete 
+            // and someone is blocked on us on the same thread, the call proceeds
+            JoinUpstreamDataSources(source);
+
+            return transformBlock;
+        }
+
+        private DesignTimeInputs GetDesignTimeInputs(IImmutableDictionary<string, IProjectRuleSnapshot> currentState)
+        {
+            var designTimeInputs = new List<string>();
+            var designTimeSharedInputs = new List<string>();
+
+            foreach ((string itemName, IImmutableDictionary<string, string> metadata) in currentState["Compile"].Items)
+            {
+                (bool designTime, bool designTimeShared) = GetDesignTimePropsForItem(metadata);
+
+                if (designTime)
+                {
+                    designTimeInputs.Add(itemName);
+                }
+
+                // Legacy allows files to be DesignTime and DesignTimeShared
+                if (designTimeShared)
+                {
+                    designTimeSharedInputs.Add(itemName);
+
+                }
+            }
+
+            return new DesignTimeInputs
+            {
+                Inputs = designTimeInputs.ToArray(),
+                SharedInputs = designTimeSharedInputs.ToArray()
+            };
+        }
+
+        private static (bool designTime, bool designTimeShared) GetDesignTimePropsForItem(IImmutableDictionary<string, string> item)
+        {
+            item.TryGetValue(Compile.LinkProperty, out string linkString);
+            item.TryGetValue(Compile.DesignTimeProperty, out string designTimeString);
+            item.TryGetValue(Compile.DesignTimeSharedInputProperty, out string designTimeSharedString);
+
+            if (linkString != null && linkString.Length > 0)
+            {
+                // Linked files are never used as TempPE inputs
+                return (false, false);
+            }
+
+            return (StringComparers.PropertyLiteralValues.Equals(designTimeString, bool.TrueString), StringComparers.PropertyLiteralValues.Equals(designTimeSharedString, bool.TrueString));
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsDataSource.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsDataSource.cs
@@ -77,11 +77,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                 }
             }
 
-            return new DesignTimeInputs
-            {
-                Inputs = designTimeInputs.ToArray(),
-                SharedInputs = designTimeSharedInputs.ToArray()
-            };
+            return new DesignTimeInputs(designTimeInputs, designTimeSharedInputs);
         }
 
         private static (bool designTime, bool designTimeShared) GetDesignTimePropsForItem(IImmutableDictionary<string, string> item)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/IDesignTimeInputsDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/IDesignTimeInputsDataSource.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.VisualStudio.Composition;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
+{
+    /// <summary>
+    /// Represents the data source of source items that are design time inputs or shared design time inputs
+    /// </summary>
+    [ProjectSystemContract(ProjectSystemContractScope.ConfiguredProject, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
+    internal interface IDesignTimeInputsDataSource : IProjectValueDataSource<DesignTimeInputs>
+    {
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/IDesignTimeInputsDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/IDesignTimeInputsDataSource.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.VisualStudio.Composition;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Composition;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 {


### PR DESCRIPTION
This is the first little piece of the latest rewrite of TempPE, this time using data flow. I wouldn't be surprised if this changes (in particular the shape of `DesignTimeInputs`) but I'm putting it up early because it's my first ever use of data flow.

Also, excitingly, it's the first set of tests I've been able to write that isn't tied horribly to the internal implementation details of the class under test! Well except all of those mocks that are used by it and its base classes, and the specific parts of the project changes that I specified in JSON, but it's close to good at least! 😛

Also note this is going into a feature branch.