### PR TITLE
Add waiter service

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsThreadedWaitDialogFactoryFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsThreadedWaitDialogFactoryFactory.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+using Microsoft.VisualStudio.ProjectSystem.VS;
+using Microsoft.VisualStudio.Shell.Interop;
+
+using Moq;
+
+using Xunit;
+
+namespace Microsoft.VisualStudio.Mocks
+{
+    internal static class IVsThreadedWaitDialogFactoryFactory
+    {
+        private delegate void CreateInstanceCallback(out IVsThreadedWaitDialog2 ppIVsThreadedWaitDialog);
+
+        public static (IVsThreadedWaitDialogFactory dialogFactory, Action cancel) Create(string title = "", string message = "", bool isCancelable = false)
+        {
+            IVsThreadedWaitDialogCallback callback = null;
+            var threadedWaitDialogFactoryMock = new Mock<IVsThreadedWaitDialogFactory>();
+            var threadedWaitDialogMock = new Mock<IVsThreadedWaitDialog3>();
+            threadedWaitDialogMock.Setup(m => m.StartWaitDialogWithCallback(
+                It.IsNotNull<string>(),
+                It.IsNotNull<string>(),
+                It.Is<string>(s => s == null),
+                It.Is<object>(s => s == null),
+                It.Is<string>(s => s == null),
+                It.IsAny<bool>(),
+                It.IsInRange(0, int.MaxValue, Range.Inclusive),
+                It.Is<bool>(v => v == false),
+                It.Is<int>(i => i == 0),
+                It.Is<int>(i => i == 0),
+                It.IsNotNull<IVsThreadedWaitDialogCallback>()))
+                .Callback((string szWaitCaption,
+                           string szWaitMessage,
+                           string szProgressText,
+                           object varStatusBmpAnim,
+                           string szStatusBarText,
+                           bool fIsCancelable,
+                           int iDelayToShowDialog,
+                           bool fShowProgress,
+                           int iTotalSteps,
+                           int iCurrentStep,
+                           IVsThreadedWaitDialogCallback pCallback) =>
+                {
+                    Assert.Equal(title, szWaitCaption);
+                    Assert.Equal(message, szWaitMessage);
+                    Assert.Equal(isCancelable, fIsCancelable);
+                    callback = pCallback;
+                });
+            threadedWaitDialogMock.Setup(m => m.EndWaitDialog(out It.Ref<int>.IsAny));
+            var threadedWaitDialog = threadedWaitDialogMock.Object;
+            threadedWaitDialogFactoryMock
+                .Setup(m => m.CreateInstance(out It.Ref<IVsThreadedWaitDialog2>.IsAny))
+                .Callback(new CreateInstanceCallback((out IVsThreadedWaitDialog2 ppIVsThreadedWaitDialog) =>
+                {
+                    ppIVsThreadedWaitDialog = threadedWaitDialog;
+                }))
+                .Returns(HResult.OK);
+
+            Action cancel = () =>
+            {
+                callback?.OnCanceled();
+            };
+
+            return (threadedWaitDialogFactoryMock.Object, cancel);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsThreadedWaitDialogFactoryFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsThreadedWaitDialogFactoryFactory.cs
@@ -3,13 +3,12 @@
 using System;
 
 using Microsoft.VisualStudio.ProjectSystem.VS;
-using Microsoft.VisualStudio.Shell.Interop;
 
 using Moq;
 
 using Xunit;
 
-namespace Microsoft.VisualStudio.Mocks
+namespace Microsoft.VisualStudio.Shell.Interop
 {
     internal static class IVsThreadedWaitDialogFactoryFactory
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/CSharp/RenamerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/CSharp/RenamerTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis;
@@ -32,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.CSharp
             await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, LanguageNames.CSharp);
 
             Mock.Get(userNotificationServices).Verify(h => h.Confirm(It.IsAny<string>()), Times.Once);
-            Mock.Get(roslynServices).Verify(h => h.RenameSymbolAsync(It.IsAny<Solution>(), It.IsAny<ISymbol>(), It.IsAny<string>()), Times.Never);
+            Mock.Get(roslynServices).Verify(h => h.RenameSymbolAsync(It.IsAny<Solution>(), It.IsAny<ISymbol>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 
         [Theory]
@@ -55,7 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.CSharp
             await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, LanguageNames.CSharp).TimeoutAfter(TimeSpan.FromSeconds(1));
 
             Mock.Get(userNotificationServices).Verify(h => h.Confirm(It.IsAny<string>()), Times.Never);
-            Mock.Get(roslynServices).Verify(h => h.RenameSymbolAsync(It.IsAny<Solution>(), It.IsAny<ISymbol>(), It.IsAny<string>()), Times.Never);
+            Mock.Get(roslynServices).Verify(h => h.RenameSymbolAsync(It.IsAny<Solution>(), It.IsAny<ISymbol>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
             Mock.Get(roslynServices).Verify(h => h.ApplyChangesToSolution(It.IsAny<Workspace>(), It.IsAny<Solution>()), Times.Never);
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/RenamerTestsBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/RenamerTestsBase.cs
@@ -3,8 +3,12 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.ProjectSystem.Waiting;
+
+using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
 {
@@ -53,8 +57,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
                     unconfiguredProjectCreator: () => unconfiguredProject);
             var unconfiguredProjectTasksService = IUnconfiguredProjectTasksServiceFactory.Create();
             var environmentOptionsFactory = IEnvironmentOptionsFactory.Implement((string category, string page, string property, bool defaultValue) => { return true; });
+            var waitIndicator = (new Mock<IWaitIndicator>()).Object;
 
-            var renamer = new Renamer(projectServices, unconfiguredProjectTasksService, ws, environmentOptionsFactory, userNotificationServices, roslynServices);
+            var renamer = new Renamer(projectServices, unconfiguredProjectTasksService, ws, environmentOptionsFactory, userNotificationServices, roslynServices, waitIndicator);
             await renamer.HandleRenameAsync(oldFilePath, newFilePath)
                          .TimeoutAfter(TimeSpan.FromSeconds(1));
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/VisualBasic/RenamerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/VisualBasic/RenamerTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis;
@@ -74,7 +75,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.VisualBasic
             await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, LanguageNames.VisualBasic);
 
             Mock.Get(userNotificationServices).Verify(h => h.Confirm(It.IsAny<string>()), Times.Never);
-            Mock.Get(roslynServices).Verify(h => h.RenameSymbolAsync(It.IsAny<Solution>(), It.IsAny<ISymbol>(), It.IsAny<string>()), Times.Never);
+            Mock.Get(roslynServices).Verify(h => h.RenameSymbolAsync(It.IsAny<Solution>(), It.IsAny<ISymbol>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
             Mock.Get(roslynServices).Verify(h => h.ApplyChangesToSolution(It.IsAny<Workspace>(), It.IsAny<Solution>()), Times.Never);
         }
 
@@ -120,7 +121,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.VisualBasic
             await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, LanguageNames.VisualBasic);
 
             Mock.Get(userNotificationServices).Verify(h => h.Confirm(It.IsAny<string>()), Times.Once);
-            Mock.Get(roslynServices).Verify(h => h.RenameSymbolAsync(It.IsAny<Solution>(), It.IsAny<ISymbol>(), It.IsAny<string>()), Times.Never);
+            Mock.Get(roslynServices).Verify(h => h.RenameSymbolAsync(It.IsAny<Solution>(), It.IsAny<ISymbol>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Waiting/VisualStudioWaitContextTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Waiting/VisualStudioWaitContextTests.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Shell.Interop;
+
+using Moq;
+
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
+{
+    public class VisualStudioWaitContextTests
+    {
+        [Fact]
+        public static void SetPropertyAllowCancel_Test()
+        {
+            string title = "Test001";
+            string message = "Testing001";
+            bool isCancelable = true;
+            var context = Create(title, message, isCancelable);
+            Assert.True(context.AllowCancel);
+            context.AllowCancel = false;
+            Assert.False(context.AllowCancel);
+        }
+
+        [Fact]
+        public static void SetPropertyMessage_Test()
+        {
+            string title = "Test001";
+            string message = "Testing001";
+            bool isCancelable = true;
+            var context = Create(title, message, isCancelable);
+            Assert.Equal(message, context.Message);
+            var message2 = "Testing002";
+            context.Message = message2;
+            Assert.Equal(message2, context.Message);
+        }
+
+        [Fact]
+        public static void CreateWrongType_Test()
+        {
+            Assert.Throws<ArgumentNullException>(() => _ = CreateWrongType(string.Empty, string.Empty, false));
+        }
+
+        private delegate void CreateInstanceCallback(out IVsThreadedWaitDialog2 ppIVsThreadedWaitDialog);
+
+        private static VisualStudioWaitContext Create(string title, string message, bool allowCancel)
+        {
+            var threadedWaitDialogFactoryMock = new Mock<IVsThreadedWaitDialogFactory>();
+            var threadedWaitDialogMock = new Mock<IVsThreadedWaitDialog3>();
+            threadedWaitDialogMock.Setup(m => m.StartWaitDialogWithCallback(
+                It.IsNotNull<string>(),
+                It.IsNotNull<string>(),
+                It.Is<string>(s => s == null),
+                It.Is<object>(s => s == null),
+                It.Is<string>(s => s == null),
+                It.IsAny<bool>(),
+                It.IsInRange(0, int.MaxValue, Range.Inclusive),
+                It.Is<bool>(v => v == false),
+                It.Is<int>(i => i == 0),
+                It.Is<int>(i => i == 0),
+                It.IsNotNull<IVsThreadedWaitDialogCallback>()))
+                .Callback((string szWaitCaption,
+                           string szWaitMessage,
+                           string szProgressText,
+                           object varStatusBmpAnim,
+                           string szStatusBarText,
+                           bool fIsCancelable,
+                           int iDelayToShowDialog,
+                           bool fShowProgress,
+                           int iTotalSteps,
+                           int iCurrentStep,
+                           IVsThreadedWaitDialogCallback pCallback) =>
+                {
+                    Assert.Equal(title, szWaitCaption);
+                    Assert.Equal(message, szWaitMessage);
+                    Assert.Equal(allowCancel, fIsCancelable);
+                });
+            threadedWaitDialogMock.Setup(m => m.EndWaitDialog(out It.Ref<int>.IsAny));
+            var threadedWaitDialog = threadedWaitDialogMock.Object;
+
+            threadedWaitDialogFactoryMock
+                .Setup(m => m.CreateInstance(out It.Ref<IVsThreadedWaitDialog2>.IsAny))
+                .Callback(new CreateInstanceCallback((out IVsThreadedWaitDialog2 ppIVsThreadedWaitDialog) =>
+                {
+                    ppIVsThreadedWaitDialog = threadedWaitDialog;
+                }))
+                .Returns(HResult.OK);
+            return new VisualStudioWaitContext(threadedWaitDialogFactoryMock.Object, title, message, allowCancel);
+        }
+
+        private static VisualStudioWaitContext CreateWrongType(string title, string message, bool allowCancel)
+        {
+            var threadedWaitDialogFactoryMock = new Mock<IVsThreadedWaitDialogFactory>();
+            var threadedWaitDialog = new Mock<IVsThreadedWaitDialog2>().Object;
+            threadedWaitDialogFactoryMock
+                .Setup(m => m.CreateInstance(out It.Ref<IVsThreadedWaitDialog2>.IsAny))
+                .Callback(new CreateInstanceCallback((out IVsThreadedWaitDialog2 ppIVsThreadedWaitDialog) =>
+                {
+                    ppIVsThreadedWaitDialog = null;
+                }))
+                .Returns(HResult.OK);
+            return new VisualStudioWaitContext(threadedWaitDialogFactoryMock.Object, title, message, allowCancel);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Waiting/VisualStudioWaitIndicatorInstanceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Waiting/VisualStudioWaitIndicatorInstanceTests.cs
@@ -1,0 +1,439 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.Mocks;
+using Microsoft.VisualStudio.ProjectSystem.Waiting;
+using Microsoft.VisualStudio.Shell.Interop;
+
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
+{
+    public class VisualStudioWaitIndicatorInstanceTests
+    {
+        [Fact]
+        public static async Task Dispose_Test()
+        {
+            var (instance, _) = await CreateAsync();
+            instance.Dispose();
+            Assert.True(instance.IsDisposed);
+        }
+
+        [Fact]
+        public static async Task DisposeAsync_Test()
+        {
+            var (instance, _) = await CreateAsync();
+            await instance.DisposeAsync();
+            Assert.True(instance.IsDisposed);
+        }
+
+        [Fact]
+        public static async Task UsingBlock_Test()
+        {
+            var (instance, _) = await CreateAsync();
+            using (instance)
+            {
+                Assert.True(!instance.IsDisposed);
+            }
+        }
+
+        [Fact]
+        public static async Task Wait_Exception_Test()
+        {
+            var (instance, _) = await CreateAsync();
+            using (instance)
+            {
+                Assert.Throws<Exception>(() =>
+                {
+                    instance.Wait("", "", false, _
+                        => throw new Exception());
+                });
+
+                Assert.True(!instance.IsDisposed);
+            }
+        }
+
+        [Fact]
+        public static async Task WaitForAsyncFunction_Wrapped_Exception_Test()
+        {
+            var (instance, _) = await CreateAsync();
+            using (instance)
+            {
+                Assert.Throws<Exception>(() =>
+                {
+                    instance.WaitForAsyncFunction("", "", false, async _
+                        => await Task.FromException(new Exception()));
+                });
+
+                Assert.True(!instance.IsDisposed);
+            }
+        }
+
+        [Fact]
+        public static async Task WaitForAsyncFunction_Wrapped_Canceled_Test()
+        {
+            var (instance, _) = await CreateAsync();
+            using (instance)
+            {
+                instance.WaitForAsyncFunction("", "", false, async _
+                    => await Task.FromException(new OperationCanceledException()));
+
+                Assert.True(!instance.IsDisposed);
+            }
+        }
+
+
+        [Fact]
+        public static async Task Wait_DoNotReturnTask_Test()
+        {
+            var (instance, _) = await CreateAsync();
+            using (instance)
+            {
+                Assert.Throws<ArgumentException>(() =>
+                {
+                    instance.Wait("", "", false, async _ =>
+                    {
+                        await Task.FromException(new OperationCanceledException());
+                    });
+                });
+            }
+        }
+
+        [Fact]
+        public static async Task WaitForAsyncFunction_Wrapped_Canceled_Test2()
+        {
+            var (instance, _) = await CreateAsync();
+            using (instance)
+            {
+                instance.WaitForAsyncFunction("", "", false, async _ =>
+                {
+                    await Task.WhenAll(
+                        Task.Run(() => throw new OperationCanceledException()),
+                        Task.Run(() => throw new OperationCanceledException()));
+                });
+                Assert.True(!instance.IsDisposed);
+            }
+        }
+
+        [Fact]
+        public static async Task WaitForAsyncFunction_Wrapped_Canceled_Test3()
+        {
+            var (instance, _) = await CreateAsync();
+            using (instance)
+            {
+                instance.WaitForAsyncFunction("", "", false, _ =>
+                {
+                    throw new AggregateException(new[] { new OperationCanceledException(), new OperationCanceledException() });
+                });
+                Assert.True(!instance.IsDisposed);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static async Task WaitForAsyncFunction_Test(bool isCancelable)
+        {
+            bool wasCalled = false;
+            string title = "Test01";
+            string message = "Testing01";
+            var (instance, _) = await CreateAsync(title, message, isCancelable);
+            instance.WaitForAsyncFunction(title, message, isCancelable, _ =>
+            {
+                wasCalled = true;
+                return Task.CompletedTask;
+            });
+            Assert.True(wasCalled);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static async Task Wait_Test(bool isCancelable)
+        {
+            bool wasCalled = false;
+            string title = "Test01";
+            string message = "Testing01";
+            var (instance, _) = await CreateAsync(title, message, isCancelable);
+            instance.Wait(title, message, isCancelable, _ =>
+            {
+                wasCalled = true;
+                throw new OperationCanceledException();
+            });
+
+            Assert.True(wasCalled);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static async Task WaitWithResult_Test(bool isCancelable)
+        {
+            bool wasCalled = false;
+            string title = "Test02";
+            string message = "Testing02";
+            var (instance, _) = await CreateAsync(title, message, isCancelable);
+            instance.WaitWithResult(title, message, isCancelable, _ =>
+            {
+                wasCalled = true;
+            });
+            Assert.True(wasCalled);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static async Task WaitWithResult_Canceled_Test(bool isCancelable)
+        {
+            bool wasCalled = false;
+            string title = "Test02";
+            string message = "Testing02";
+            var (instance, _) = await CreateAsync(title, message, isCancelable);
+            instance.WaitWithResult(title, message, isCancelable, _ =>
+            {
+                wasCalled = true;
+                throw new OperationCanceledException();
+            });
+            Assert.True(wasCalled);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static async Task WaitForAsyncFunction_Test2(bool isCancelable)
+        {
+            bool wasCalled = false;
+            string title = "Test03";
+            string message = "Testing03";
+            var (instance, _) = await CreateAsync(title, message, isCancelable);
+            instance.WaitForAsyncFunction(title, message, isCancelable, _ =>
+            {
+                wasCalled = true;
+                return Task.CompletedTask;
+            });
+            Assert.True(wasCalled);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static async Task WaitForAsyncFunction_Canceled_Test(bool isCancelable)
+        {
+            bool wasCalled = false;
+            string title = "Test03";
+            string message = "Testing03";
+            var (instance, _) = await CreateAsync(title, message, isCancelable);
+            instance.WaitForAsyncFunction(title, message, isCancelable, _ =>
+            {
+                wasCalled = true;
+                throw new OperationCanceledException();
+            });
+            Assert.True(wasCalled);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static async Task WaitForAsyncFunctionWithResult_Test(bool isCancelable)
+        {
+            bool wasCalled = false;
+            string title = "Test04";
+            string message = "Testing04";
+            var (instance, _) = await CreateAsync(title, message, isCancelable);
+            var result = instance.WaitForAsyncFunctionWithResult(title, message, isCancelable, _ =>
+            {
+                wasCalled = true;
+                return Task.CompletedTask;
+            });
+            Assert.True(wasCalled);
+            Assert.Equal(WaitIndicatorResult.Completed, result);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static async Task WaitForAsyncFunctionWithResult_Canceled_Test(bool isCancelable)
+        {
+            bool wasCalled = false;
+            string title = "Test04";
+            string message = "Testing04";
+            var (instance, _) = await CreateAsync(title, message, isCancelable);
+            var result = instance.WaitForAsyncFunctionWithResult(title, message, isCancelable, _ =>
+            {
+                wasCalled = true;
+                throw new OperationCanceledException();
+            });
+            Assert.True(wasCalled);
+            Assert.Equal(WaitIndicatorResult.Canceled, result);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static async Task Wait_Returns_Test(bool isCancelable)
+        {
+            string title = "Test05";
+            string message = "Testing05";
+            var (instance, _) = await CreateAsync(title, message, isCancelable);
+            var result = instance.Wait(title, message, isCancelable, _ =>
+            {
+                return 42;
+            });
+            Assert.Equal(42, result);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        public static async Task WaitReturns_Canceled_Test(bool isCancelable)
+        {
+            string title = "Test05";
+            string message = "Testing05";
+            var (instance, _) = await CreateAsync(title, message, isCancelable);
+            var result = instance.Wait(title, message, isCancelable, _ =>
+            {
+                if (isCancelable)
+                {
+                    throw new OperationCanceledException();
+                }
+
+                return 42;
+            });
+            Assert.Equal(0, result);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static async Task WaitWithResult_Returns_Test(bool isCancelable)
+        {
+            string title = "Test06";
+            string message = "Testing06";
+            var (instance, _) = await CreateAsync(title, message, isCancelable);
+            var (cancelled, result) = instance.WaitWithResult(title, message, isCancelable, _ =>
+            {
+                return 42;
+            });
+            Assert.Equal(42, result);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        public static async Task WaitWithResult_Canceled_Test2(bool isCancelable)
+        {
+            string title = "Test06";
+            string message = "Testing06";
+            var (instance, _) = await CreateAsync(title, message, isCancelable);
+            var (cancelled, result) = instance.WaitWithResult(title, message, isCancelable, _ =>
+            {
+                if (isCancelable)
+                {
+                    throw new OperationCanceledException();
+                }
+
+                return 42;
+            });
+            Assert.Equal(0, result);
+            Assert.Equal(WaitIndicatorResult.Canceled, cancelled);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static async Task WaitForAsyncOperation_Returns_Test(bool isCancelable)
+        {
+            string title = "Test07";
+            string message = "Testing07";
+            var (instance, _) = await CreateAsync(title, message, isCancelable);
+            var result = instance.WaitForAsyncFunction(title, message, isCancelable, _ =>
+            {
+                return Task.FromResult(42);
+            });
+            Assert.Equal(42, result);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        public static async Task WaitForAsyncFunctionReturns_Canceled_Test(bool isCancelable)
+        {
+            string title = "Test07";
+            string message = "Testing07";
+            var (instance, _) = await CreateAsync(title, message, isCancelable);
+            object result = instance.WaitForAsyncFunction(title, message, isCancelable, _ =>
+            {
+                if (isCancelable)
+                {
+                    throw new OperationCanceledException();
+                }
+
+                return Task.FromResult(default(object));
+            });
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static async Task WaitForAsyncFunctionWithResult_Returns_Test(bool isCancelable)
+        {
+            string title = "Test08";
+            string message = "Testing08";
+            var (instance, _) = await CreateAsync(title, message, isCancelable);
+            var (_, result) = instance.WaitForAsyncFunctionWithResult(title, message, isCancelable, _ =>
+            {
+                return Task.FromResult(42);
+            });
+            Assert.Equal(42, result);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        public static async Task WaitForAsyncFunctionWithResult_Returns_Canceled_Test(bool isCancelable)
+        {
+            string title = "Test08";
+            string message = "Testing08";
+            var (instance, _) = await CreateAsync(title, message, isCancelable);
+            var (canceled, result) = instance.WaitForAsyncFunctionWithResult(title, message, isCancelable, _ =>
+            {
+                if (isCancelable)
+                {
+                    throw new OperationCanceledException();
+                }
+
+                return Task.FromResult(42);
+            });
+            Assert.Equal(0, result);
+            Assert.Equal(WaitIndicatorResult.Canceled, canceled);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static async Task Wait_Cancellation_Test(bool isCancelable)
+        {
+            bool wasCalled = false;
+            string title = "Test01";
+            string message = "Testing01";
+            var (instance, cancel) = await CreateAsync(title, message, isCancelable);
+            instance.Wait(title, message, isCancelable, token =>
+            {
+                cancel();
+                Assert.Equal(isCancelable, token.IsCancellationRequested);
+                wasCalled = true;
+            });
+            Assert.True(wasCalled);
+        }
+
+        private static async Task<(VisualStudioWaitIndicator.Instance, Action cancel)> CreateAsync(string title = "", string message = "", bool isCancelable = false)
+        {
+            var threadingService = IProjectThreadingServiceFactory.Create();
+            var (threadedWaitDialogFactory, cancel) = IVsThreadedWaitDialogFactoryFactory.Create(title, message, isCancelable);
+            var threadedWaitDialogFactoryService = IVsServiceFactory.Create<SVsThreadedWaitDialogFactory, IVsThreadedWaitDialogFactory>(threadedWaitDialogFactory);
+
+            var instance = new VisualStudioWaitIndicator.Instance(threadingService, threadedWaitDialogFactoryService);
+            await instance.InitializeAsync();
+            return (instance, cancel);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Waiting/VisualStudioWaitIndicatorInstanceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Waiting/VisualStudioWaitIndicatorInstanceTests.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Threading.Tasks;
 
-using Microsoft.VisualStudio.Mocks;
 using Microsoft.VisualStudio.ProjectSystem.Waiting;
 using Microsoft.VisualStudio.Shell.Interop;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Waiting/VisualStudioWaitIndicatorTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Waiting/VisualStudioWaitIndicatorTests.cs
@@ -1,0 +1,807 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.Mocks;
+
+using Microsoft.VisualStudio.ProjectSystem.Waiting;
+using Microsoft.VisualStudio.Shell.Interop;
+
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
+{
+    public class VisualStudioWaitIndicatorTests
+    {
+        [Fact]
+        public static async Task Dispose_Test()
+        {
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator();
+            await waitIndicator.ActivateAsync();
+            Assert.False(waitIndicator.IsDisposed);
+            waitIndicator.Dispose();
+            Assert.True(waitIndicator.IsDisposed);
+        }
+
+        [Fact]
+        public static async Task DisposeAsync_Test()
+        {
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator();
+            await waitIndicator.ActivateAsync();
+            Assert.False(waitIndicator.IsDisposed);
+            await waitIndicator.DisposeAsync();
+            Assert.True(waitIndicator.IsDisposed);
+        }
+
+        [Fact]
+        public static async Task DisposeBlock_Test()
+        {
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator();
+            await waitIndicator.ActivateAsync();
+            using (waitIndicator)
+            {
+                Assert.False(waitIndicator.IsDisposed);
+            }
+            Assert.True(waitIndicator.IsDisposed);
+        }
+
+        [Fact]
+        public static async Task DeactivateAsync_Test()
+        {
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator();
+            await waitIndicator.ActivateAsync();
+            await waitIndicator.DeactivateAsync();
+            Assert.False(waitIndicator.IsDisposed);
+        }
+
+        [Fact]
+        public static async Task ActivateAsyncTwice_Test()
+        {
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator();
+            await waitIndicator.ActivateAsync();
+            await waitIndicator.ActivateAsync();
+            Assert.False(waitIndicator.IsDisposed);
+        }
+
+        [Fact]
+        public static async Task DeactivateTwiceAsync_Test()
+        {
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator();
+            await waitIndicator.DeactivateAsync();
+            await waitIndicator.DeactivateAsync();
+            Assert.False(waitIndicator.IsDisposed);
+        }
+
+        [Fact]
+        public static async Task LoadAsyncAndUnloadAsync_Test()
+        {
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator();
+            await waitIndicator.LoadAsync();
+            await waitIndicator.UnloadAsync();
+            Assert.False(waitIndicator.IsDisposed);
+        }
+
+        [Fact]
+        public static async Task LoadAsyncTwice_Test()
+        {
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator();
+            await waitIndicator.LoadAsync();
+            await waitIndicator.LoadAsync();
+            Assert.False(waitIndicator.IsDisposed);
+        }
+
+        [Fact]
+        public static async Task UnloadAsyncTwice_Test()
+        {
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator();
+            await waitIndicator.UnloadAsync();
+            await waitIndicator.UnloadAsync();
+            Assert.False(waitIndicator.IsDisposed);
+        }
+
+        [Theory]
+        [InlineData("", null)]
+        [InlineData(null, "")]
+        public static async Task Wait_ArgumentNullException_Test(string title, string message)
+        {
+            bool isCancelable = false;
+            var (waitIndicator, cancel) = CreateVisualStudioWaitIndicator(title, message, isCancelable);
+            await waitIndicator.LoadAsync();
+
+            using (waitIndicator)
+            {
+                Assert.Throws<ArgumentNullException>(() =>
+                {
+                    waitIndicator.Wait(title, message, isCancelable, _ =>
+                    {
+                        throw new Exception();
+                    });
+                });
+
+                Assert.False(waitIndicator.IsDisposed);
+            }
+        }
+
+        [Fact]
+        public static async Task Wait_ArgumentNullException_Delegate_Test()
+        {
+            var (waitIndicator, cancel) = CreateVisualStudioWaitIndicator();
+            await waitIndicator.LoadAsync();
+
+            using (waitIndicator)
+            {
+                Assert.Throws<ArgumentNullException>(() =>
+                {
+                    waitIndicator.Wait("", "", false, null);
+                });
+
+                Assert.False(waitIndicator.IsDisposed);
+            }
+        }
+
+        [Fact]
+        public static async Task Wait_Exception_Test()
+        {
+            var (waitIndicator, cancel) = CreateVisualStudioWaitIndicator();
+            await waitIndicator.LoadAsync();
+
+            using (waitIndicator)
+            {
+                Assert.Throws<Exception>(() =>
+                {
+                    waitIndicator.Wait("", "", false, _ =>
+                    {
+                        throw new Exception();
+                    });
+                });
+
+                Assert.False(waitIndicator.IsDisposed);
+            }
+        }
+
+        [Fact]
+        public static async Task WaitForAsyncFunction_Wrapped_Exception_Test()
+        {
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator();
+            await waitIndicator.LoadAsync();
+
+            using (waitIndicator)
+            {
+                Assert.Throws<Exception>(() =>
+                {
+                    waitIndicator.WaitForAsyncFunction("", "", false, async _ =>
+                    {
+                        await Task.FromException(new Exception());
+                    });
+                });
+
+                Assert.False(waitIndicator.IsDisposed);
+            }
+        }
+
+        [Fact]
+        public static async Task Wait_Wrapped_Canceled_Test()
+        {
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator();
+            await waitIndicator.LoadAsync();
+
+            using (waitIndicator)
+            {
+                waitIndicator.Wait("", "", false, _ =>
+                {
+                    Task.FromException(new OperationCanceledException());
+                });
+
+                Assert.False(waitIndicator.IsDisposed);
+            }
+        }
+
+        [Fact]
+        public static async Task WaitForAsyncFunction_Wrapped_Canceled_Test2Async()
+        {
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator();
+            await waitIndicator.LoadAsync();
+
+            using (waitIndicator)
+            {
+                waitIndicator.WaitForAsyncFunction("", "", false, async _ =>
+                {
+                    await Task.WhenAll(
+                        Task.Run(() => throw new OperationCanceledException()),
+                        Task.Run(() => throw new OperationCanceledException()));
+                });
+
+                Assert.False(waitIndicator.IsDisposed);
+            }
+        }
+
+        [Fact]
+        public static async Task Wait_Wrapped_Canceled_Test3Async()
+        {
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator();
+            await waitIndicator.LoadAsync();
+
+            using (waitIndicator)
+            {
+                waitIndicator.Wait("", "", false, _ =>
+                {
+                    throw new AggregateException(new[] { new OperationCanceledException(), new OperationCanceledException() });
+                });
+
+                Assert.False(waitIndicator.IsDisposed);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static async Task Wait_Test(bool isCancelable)
+        {
+            bool wasCalled = false;
+            string title = "Test01";
+            string message = "Testing01";
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator(title, message, isCancelable);
+            await waitIndicator.LoadAsync();
+
+            waitIndicator.Wait(title, message, isCancelable, _ =>
+            {
+                wasCalled = true;
+            });
+            Assert.True(wasCalled);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static async Task Wait_Canceled_Test(bool isCancelable)
+        {
+            bool wasCalled = false;
+            string title = "Test01";
+            string message = "Testing01";
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator(title, message, isCancelable);
+            await waitIndicator.LoadAsync();
+
+            waitIndicator.Wait(title, message, isCancelable, _ =>
+            {
+                wasCalled = true;
+                throw new OperationCanceledException();
+            });
+
+            Assert.True(wasCalled);
+        }
+
+        [Theory]
+        [InlineData("", null)]
+        [InlineData(null, "")]
+        public static async Task WaitWithResult_ArgumentNullException_Test(string title, string message)
+        {
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator(title, message);
+            await waitIndicator.LoadAsync();
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                waitIndicator.WaitWithResult(title, message, false, _ =>
+                {
+                    throw new Exception();
+                });
+            });
+
+            Assert.False(waitIndicator.IsDisposed);
+        }
+
+        [Fact]
+        public static async Task WaitWithResult_ArgumentNullException_Delegate_Test()
+        {
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator();
+            await waitIndicator.LoadAsync();
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                waitIndicator.WaitWithResult("", "", false, null);
+            });
+
+            Assert.False(waitIndicator.IsDisposed);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static async Task WaitWithResult_Test(bool isCancelable)
+        {
+            bool wasCalled = false;
+            string title = "Test02";
+            string message = "Testing02";
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator(title, message, isCancelable);
+            await waitIndicator.LoadAsync();
+
+            waitIndicator.WaitWithResult(title, message, isCancelable, _ =>
+            {
+                wasCalled = true;
+            });
+            Assert.True(wasCalled);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static async Task WaitWithResult_Canceled_Test(bool isCancelable)
+        {
+            bool wasCalled = false;
+            string title = "Test02";
+            string message = "Testing02";
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator(title, message, isCancelable);
+            await waitIndicator.LoadAsync();
+
+            waitIndicator.WaitWithResult(title, message, isCancelable, _ =>
+            {
+                wasCalled = true;
+                throw new OperationCanceledException();
+            });
+            Assert.True(wasCalled);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static async Task WaitForAsyncFunction_Test(bool isCancelable)
+        {
+            bool wasCalled = false;
+            string title = "Test03";
+            string message = "Testing03";
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator(title, message, isCancelable);
+            await waitIndicator.LoadAsync();
+
+            waitIndicator.WaitForAsyncFunction(title, message, isCancelable, _ =>
+            {
+                wasCalled = true;
+                return Task.CompletedTask;
+            });
+            Assert.True(wasCalled);
+        }
+
+        [Theory]
+        [InlineData("", null)]
+        [InlineData(null, "")]
+        public static async Task WaitForAsyncFunction_ArgumentNullException_Test(string title, string message)
+        {
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator(title, message);
+            await waitIndicator.LoadAsync();
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                waitIndicator.WaitForAsyncFunction(title, message, false, _ =>
+                {
+                    throw new Exception();
+                });
+            });
+
+            Assert.False(waitIndicator.IsDisposed);
+        }
+
+        [Fact]
+        public static async Task WaitForAsyncFunction_ArgumentNullException_Delegate_Test()
+        {
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator();
+            await waitIndicator.LoadAsync();
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                waitIndicator.WaitForAsyncFunction("", "", false, null);
+            });
+
+            Assert.False(waitIndicator.IsDisposed);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static async Task WaitForAsyncFunction_Canceled_Test(bool isCancelable)
+        {
+            bool wasCalled = false;
+            string title = "Test03";
+            string message = "Testing03";
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator(title, message, isCancelable);
+            await waitIndicator.LoadAsync();
+
+            waitIndicator.WaitForAsyncFunction(title, message, isCancelable, _ =>
+            {
+                wasCalled = true;
+                throw new OperationCanceledException();
+            });
+            Assert.True(wasCalled);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static async Task WaitForAsyncFunctionWithResult_Test(bool isCancelable)
+        {
+            bool wasCalled = false;
+            string title = "Test04";
+            string message = "Testing04";
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator(title, message, isCancelable);
+            await waitIndicator.LoadAsync();
+
+            var result = waitIndicator.WaitForAsyncFunctionWithResult(title, message, isCancelable, _ =>
+            {
+                wasCalled = true;
+                return Task.CompletedTask;
+            });
+            Assert.True(wasCalled);
+            Assert.Equal(WaitIndicatorResult.Completed, result);
+        }
+
+
+        [Theory]
+        [InlineData("", null)]
+        [InlineData(null, "")]
+        public static async Task WaitForAsyncFunctionWithResult_ArgumentNullException_Test(string title, string message)
+        {
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator(title, message);
+            await waitIndicator.LoadAsync();
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var result = waitIndicator.WaitForAsyncFunctionWithResult(title, message, false, _ =>
+                {
+                    throw new Exception();
+                });
+            });
+
+            Assert.False(waitIndicator.IsDisposed);
+        }
+
+        [Fact]
+        public static async Task WaitForAsyncFunctionWithResult_ArgumentNullException_Delegate_Test()
+        {
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator();
+            await waitIndicator.LoadAsync();
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var result = waitIndicator.WaitForAsyncFunctionWithResult("", "", false, null);
+            });
+
+            Assert.False(waitIndicator.IsDisposed);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static async Task WaitForAsyncFunctionWithResult_Canceled_Test(bool isCancelable)
+        {
+            bool wasCalled = false;
+            string title = "Test04";
+            string message = "Testing04";
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator(title, message, isCancelable);
+            await waitIndicator.LoadAsync();
+
+            var result = waitIndicator.WaitForAsyncFunctionWithResult(title, message, isCancelable, _ =>
+            {
+                wasCalled = true;
+                throw new OperationCanceledException();
+            });
+            Assert.True(wasCalled);
+            Assert.Equal(WaitIndicatorResult.Canceled, result);
+        }
+
+        [Theory]
+        [InlineData("", null)]
+        [InlineData(null, "")]
+        public static async Task Wait_Returns_ArgumentNullException_Test(string title, string message)
+        {
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator(title, message);
+            await waitIndicator.LoadAsync();
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var result = waitIndicator.Wait(title, message, false, _ =>
+                {
+                    return 42;
+                });
+            });
+
+            Assert.False(waitIndicator.IsDisposed);
+        }
+
+        [Fact]
+        public static async Task WaitForOperationReturns_ArgumentNullException_Delegate_Test()
+        {
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator();
+            await waitIndicator.LoadAsync();
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var result = waitIndicator.Wait("", "", false, (Func<CancellationToken, int>)null);
+            });
+
+            Assert.False(waitIndicator.IsDisposed);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static async Task Wait_Returns_Test(bool isCancelable)
+        {
+            string title = "Test05";
+            string message = "Testing05";
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator(title, message, isCancelable);
+            await waitIndicator.LoadAsync();
+
+            var result = waitIndicator.Wait(title, message, isCancelable, _ =>
+            {
+                return 42;
+            });
+            Assert.Equal(42, result);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        public static async Task Wait_Canceled_Test2(bool isCancelable)
+        {
+            string title = "Test05";
+            string message = "Testing05";
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator(title, message, isCancelable);
+            await waitIndicator.LoadAsync();
+
+            var result = waitIndicator.Wait(title, message, isCancelable, _ =>
+            {
+                if (isCancelable)
+                {
+                    throw new OperationCanceledException();
+                }
+
+                return 42;
+            });
+            Assert.Equal(0, result);
+        }
+
+        [Theory]
+        [InlineData("", null)]
+        [InlineData(null, "")]
+        public static async Task WaitWithResult_Returns_ArgumentNullException_Test(string title, string message)
+        {
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator(title, message);
+            await waitIndicator.LoadAsync();
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var (canceled, result) = waitIndicator.WaitWithResult(title, message, false, _ =>
+                {
+                    return 42;
+                });
+            });
+
+            Assert.False(waitIndicator.IsDisposed);
+        }
+
+        [Fact]
+        public static async Task WaitWithResult_ResultReturns_ArgumentNullException_Delegate_Test()
+        {
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator();
+            await waitIndicator.LoadAsync();
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var (canceled, result) = waitIndicator.WaitWithResult("", "", false, (Func<CancellationToken, int>)null);
+            });
+
+            Assert.False(waitIndicator.IsDisposed);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static async Task WaitWithResult_Returns_Test(bool isCancelable)
+        {
+            string title = "Test06";
+            string message = "Testing06";
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator(title, message, isCancelable);
+            await waitIndicator.LoadAsync();
+
+            var (canceled, result) = waitIndicator.WaitWithResult(title, message, isCancelable, _ =>
+            {
+                return 42;
+            });
+            Assert.Equal(42, result);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        public static async Task WaitWithResult_ReturnsCanceled_Test(bool isCancelable)
+        {
+            string title = "Test06";
+            string message = "Testing06";
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator(title, message, isCancelable);
+            await waitIndicator.LoadAsync();
+
+            var (canceled, result) = waitIndicator.WaitWithResult(title, message, isCancelable, _ =>
+            {
+                if (isCancelable)
+                {
+                    throw new OperationCanceledException();
+                }
+
+                return 42;
+            });
+            Assert.Equal(0, result);
+            Assert.Equal(WaitIndicatorResult.Canceled, canceled);
+        }
+
+        [Theory]
+        [InlineData("", null)]
+        [InlineData(null, "")]
+        public static async Task WaitForAsyncFunction_Returns_ArgumentNullException_Test(string title, string message)
+        {
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator(title, message);
+            await waitIndicator.LoadAsync();
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var result = waitIndicator.WaitForAsyncFunction(title, message, false, _ =>
+                {
+                    return Task.FromResult(42);
+                });
+            });
+
+            Assert.False(waitIndicator.IsDisposed);
+        }
+
+        [Fact]
+        public static async Task WaitForAsyncFunction_Returns_ArgumentNullException_Delegate_Test()
+        {
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator();
+            await waitIndicator.LoadAsync();
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var result = waitIndicator.WaitForAsyncFunction("", "", false, (Func<CancellationToken, Task<int>>)null);
+            });
+
+            Assert.False(waitIndicator.IsDisposed);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static async Task WaitForAsyncFunction_Returns_Test(bool isCancelable)
+        {
+            string title = "Test07";
+            string message = "Testing07";
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator(title, message, isCancelable);
+            await waitIndicator.LoadAsync();
+
+            var result = waitIndicator.WaitForAsyncFunction(title, message, isCancelable, _ =>
+            {
+                return Task.FromResult(42);
+            });
+            Assert.Equal(42, result);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        public static async Task WaitForAsyncFunction_Returns_Canceled_Test(bool isCancelable)
+        {
+            string title = "Test07";
+            string message = "Testing07";
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator(title, message, isCancelable);
+            await waitIndicator.LoadAsync();
+
+            object result = waitIndicator.WaitForAsyncFunction(title, message, isCancelable, _ =>
+            {
+                if (isCancelable)
+                {
+                    throw new OperationCanceledException();
+                }
+
+                return Task.FromResult(default(object));
+            });
+            Assert.Null(result);
+        }
+
+        [Theory]
+        [InlineData("", null)]
+        [InlineData(null, "")]
+        public static async Task WaitForAsyncFunctionWithResult_Returns_ArgumentNullException_Test(string title, string message)
+        {
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator(title, message);
+            await waitIndicator.LoadAsync();
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var (_, result) = waitIndicator.WaitForAsyncFunctionWithResult(title, message, false, _ =>
+                {
+                    return Task.FromResult(42);
+                });
+            });
+
+            Assert.False(waitIndicator.IsDisposed);
+        }
+
+        [Fact]
+        public static async Task WaitForAsyncFunctionWithResult_Returns_ArgumentNullException_Delegate_Test()
+        {
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator();
+            await waitIndicator.LoadAsync();
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var (_, result) = waitIndicator.WaitForAsyncFunctionWithResult("", "", false, (Func<CancellationToken, Task<int>>)null);
+            });
+
+            Assert.False(waitIndicator.IsDisposed);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static async Task WaitForAsyncOperationWithResultReturns_Test(bool isCancelable)
+        {
+            string title = "Test08";
+            string message = "Testing08";
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator(title, message, isCancelable);
+            await waitIndicator.LoadAsync();
+
+            var (_, result) = waitIndicator.WaitForAsyncFunctionWithResult(title, message, isCancelable, _ =>
+            {
+                return Task.FromResult(42);
+            });
+            Assert.Equal(42, result);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        public static async Task WaitForAsyncFunctionWithResult_Returns_Canceled_Test(bool isCancelable)
+        {
+            string title = "Test08";
+            string message = "Testing08";
+            var (waitIndicator, _) = CreateVisualStudioWaitIndicator(title, message, isCancelable);
+            await waitIndicator.LoadAsync();
+
+            var (canceled, result) = waitIndicator.WaitForAsyncFunctionWithResult(title, message, isCancelable, _ =>
+            {
+                if (isCancelable)
+                {
+                    throw new OperationCanceledException();
+                }
+
+                return Task.FromResult(42);
+            });
+            Assert.Equal(0, result);
+            Assert.Equal(WaitIndicatorResult.Canceled, canceled);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public static async Task WaitForOperation_Cancellation_Test(bool isCancelable)
+        {
+            bool wasCalled = false;
+            string title = "Test01";
+            string message = "Testing01";
+            var (waitIndicator, cancel) = CreateVisualStudioWaitIndicator(title, message, isCancelable);
+            await waitIndicator.LoadAsync();
+
+            waitIndicator.Wait(title, message, isCancelable, token =>
+            {
+                cancel();
+                Assert.Equal(isCancelable, token.IsCancellationRequested);
+                wasCalled = true;
+            });
+            Assert.True(wasCalled);
+        }
+
+        private static (VisualStudioWaitIndicator, Action cancel) CreateVisualStudioWaitIndicator(string title = "", string message = "", bool isCancelable = false)
+        {
+            var threadingService = IProjectThreadingServiceFactory.Create();
+            var (threadedWaitDialogFactory, cancel) = IVsThreadedWaitDialogFactoryFactory.Create(title, message, isCancelable);
+            var threadedWaitDialogFactoryService = IVsServiceFactory.Create<SVsThreadedWaitDialogFactory, IVsThreadedWaitDialogFactory>(threadedWaitDialogFactory);
+            var unconfiguredProject = UnconfiguredProjectFactory.Create();
+
+            var waitIndicator = new VisualStudioWaitIndicator(unconfiguredProject, threadingService, threadedWaitDialogFactoryService);
+            return (waitIndicator, cancel);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Waiting/VisualStudioWaitIndicatorTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Waiting/VisualStudioWaitIndicatorTests.cs
@@ -4,8 +4,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Microsoft.VisualStudio.Mocks;
-
 using Microsoft.VisualStudio.ProjectSystem.Waiting;
 using Microsoft.VisualStudio.Shell.Interop;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IRoslynServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IRoslynServices.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis;
@@ -10,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
     internal interface IRoslynServices
     {
-        Task<Solution> RenameSymbolAsync(Solution solution, ISymbol symbol, string newName);
+        Task<Solution> RenameSymbolAsync(Solution solution, ISymbol symbol, string newName, CancellationToken token = default);
         bool ApplyChangesToSolution(Workspace ws, Solution renamedSolution);
         bool IsValidIdentifier(string identifierName);
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/RoslynServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/RoslynServices.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.ComponentModel.Composition;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis;
@@ -35,9 +36,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             }
         }
 
-        public Task<Solution> RenameSymbolAsync(Solution solution, ISymbol symbol, string newName)
+        public Task<Solution> RenameSymbolAsync(Solution solution, ISymbol symbol, string newName, CancellationToken token = default)
         {
-            return RoslynRenamer.Renamer.RenameSymbolAsync(solution, symbol, newName, solution.Workspace.Options);
+            return RoslynRenamer.Renamer.RenameSymbolAsync(solution, symbol, newName, solution.Workspace.Options, token);
         }
 
         public bool ApplyChangesToSolution(Workspace ws, Solution renamedSolution)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Waiting/VisualStudioWaitContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Waiting/VisualStudioWaitContext.cs
@@ -1,0 +1,124 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+using Microsoft.VisualStudio.ProjectSystem.Waiting;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
+{
+    internal class VisualStudioWaitContext : IWaitContext
+    {
+        private const int DelayToShowDialogSecs = 2;
+
+        private readonly string _title;
+        private string _message;
+        private bool _allowCancel;
+        private readonly CancellationTokenSource _cancellationTokenSource;
+        private readonly IVsThreadedWaitDialog3 _dialog;
+
+        public VisualStudioWaitContext(IVsThreadedWaitDialogFactory waitDialogFactory,
+                                       string title,
+                                       string message,
+                                       bool allowCancel)
+        {
+            _title = title;
+            _message = message;
+            _allowCancel = allowCancel;
+            if (_allowCancel)
+            {
+                _cancellationTokenSource = new CancellationTokenSource();
+            }
+
+            _dialog = CreateDialog(waitDialogFactory);
+        }
+
+        private IVsThreadedWaitDialog3 CreateDialog(IVsThreadedWaitDialogFactory dialogFactory)
+        {
+            Marshal.ThrowExceptionForHR(dialogFactory.CreateInstance(out var dialog2));
+            if (dialog2 == null)
+                throw new ArgumentNullException(nameof(dialog2));
+
+            var dialog3 = (IVsThreadedWaitDialog3)dialog2;
+            var callback = new Callback(this);
+
+            dialog3.StartWaitDialogWithCallback(
+                szWaitCaption: _title,
+                szWaitMessage: _message,
+                szProgressText: null,
+                varStatusBmpAnim: null,
+                szStatusBarText: null,
+                fIsCancelable: _allowCancel,
+                iDelayToShowDialog: DelayToShowDialogSecs,
+                fShowProgress: false,
+                iTotalSteps: 0,
+                iCurrentStep: 0,
+                pCallback: callback);
+
+            return dialog3;
+        }
+
+        private class Callback : IVsThreadedWaitDialogCallback
+        {
+            private readonly VisualStudioWaitContext _waitContext;
+
+            public Callback(VisualStudioWaitContext waitContext)
+            {
+                _waitContext = waitContext;
+            }
+
+            public void OnCanceled()
+            {
+                _waitContext.OnCanceled();
+            }
+        }
+
+        public CancellationToken CancellationToken => _allowCancel
+                                                    ? _cancellationTokenSource.Token
+                                                    : CancellationToken.None;
+
+        public bool AllowCancel
+        {
+            get => _allowCancel;
+            set
+            {
+                _allowCancel = value;
+                UpdateDialog();
+            }
+        }
+
+        public string Message
+        {
+            get => _message;
+            set
+            {
+                _message = value;
+                UpdateDialog();
+            }
+        }
+
+        private void UpdateDialog()
+        {
+            _dialog.UpdateProgress(
+                _message,
+                szProgressText: null,
+                szStatusBarText: null,
+                iCurrentStep: 0,
+                iTotalSteps: 0,
+                fDisableCancel: !_allowCancel,
+                pfCanceled: out _);
+        }
+
+        public void Dispose() => _dialog.EndWaitDialog(out _);
+
+        private void OnCanceled()
+        {
+            if (_allowCancel)
+            {
+                _cancellationTokenSource.Cancel();
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Waiting/VisualStudioWaitIndicator.Instance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Waiting/VisualStudioWaitIndicator.Instance.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.ProjectSystem.Waiting;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
+{
+    internal partial class VisualStudioWaitIndicator
+    {
+        internal class Instance : OnceInitializedOnceDisposedAsync, IMultiLifetimeInstance, IWaitIndicator
+        {
+            private readonly IProjectThreadingService _threadingService;
+            private readonly IVsService<SVsThreadedWaitDialogFactory, IVsThreadedWaitDialogFactory> _threadedWaitDialogFactoryService;
+            private IVsThreadedWaitDialogFactory _threadedWaitDialogFactory;
+
+            public Instance(IProjectThreadingService threadingService, IVsService<SVsThreadedWaitDialogFactory, IVsThreadedWaitDialogFactory> threadedWaitDialogFactoryService)
+                : base(threadingService.JoinableTaskContext)
+            {
+                _threadingService = threadingService;
+                _threadedWaitDialogFactoryService = threadedWaitDialogFactoryService;
+            }
+
+            public void Wait(string title, string message, bool allowCancel, Action<CancellationToken> action)
+            {
+                _ = WaitWithResult(title, message, allowCancel, action);
+            }
+
+            public T Wait<T>(string title, string message, bool allowCancel, Func<CancellationToken, T> action)
+            {
+                if (typeof(T) == typeof(Task))
+                    throw new ArgumentException(nameof(T));
+
+                (_, T result) = WaitWithResult(title, message, allowCancel, action);
+                return result;
+            }
+
+            public void WaitForAsyncFunction(string title, string message, bool allowCancel, Func<CancellationToken, Task> asyncFunction)
+            {
+                _ = WaitForAsyncFunctionWithResult(title, message, allowCancel, asyncFunction);
+            }
+
+            public T WaitForAsyncFunction<T>(string title, string message, bool allowCancel, Func<CancellationToken, Task<T>> asyncFunction)
+            {
+                (_, T result) = WaitForAsyncFunctionWithResult(title, message, allowCancel, asyncFunction);
+                return result;
+            }
+
+            public WaitIndicatorResult WaitForAsyncFunctionWithResult(string title, string message, bool allowCancel, Func<CancellationToken, Task> asyncFunction)
+            {
+                (WaitIndicatorResult waitResult, _) = WaitForOperationImpl(title, message, allowCancel, token =>
+                {
+                    JoinableFactory.Run(() => asyncFunction(token));
+                    return true;
+                });
+
+                return waitResult;
+            }
+
+            public WaitIndicatorResult WaitWithResult(string title, string message, bool allowCancel, Action<CancellationToken> action)
+            {
+                (WaitIndicatorResult waitResult, _) = WaitForOperationImpl(title, message, allowCancel, token =>
+                {
+                    action(token);
+                    return true;
+                });
+
+                return waitResult;
+            }
+
+            public (WaitIndicatorResult, T) WaitForAsyncFunctionWithResult<T>(string title, string message, bool allowCancel, Func<CancellationToken, Task<T>> asyncFunction)
+            {
+                return WaitForOperationImpl(title, message, allowCancel, token => JoinableFactory.Run(() => asyncFunction(token)));
+            }
+
+            public (WaitIndicatorResult, T) WaitWithResult<T>(string title, string message, bool allowCancel, Func<CancellationToken, T> function)
+            {
+                return WaitForOperationImpl(title, message, allowCancel, function);
+            }
+
+            private (WaitIndicatorResult, T) WaitForOperationImpl<T>(string title, string message, bool allowCancel, Func<CancellationToken, T> function)
+            {
+                _threadingService.VerifyOnUIThread();
+                using (IWaitContext waitContext = StartWait(title, message, allowCancel))
+                {
+                    try
+                    {
+                        T result = function(waitContext.CancellationToken);
+
+                        return (WaitIndicatorResult.Completed, result);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        return (WaitIndicatorResult.Canceled, default);
+                    }
+                    catch (AggregateException aggregate) when (aggregate.InnerExceptions.All(e => e is OperationCanceledException))
+                    {
+                        return (WaitIndicatorResult.Canceled, default);
+                    }
+                }
+            }
+
+            private IWaitContext StartWait(string title, string message, bool allowCancel)
+                => new VisualStudioWaitContext(_threadedWaitDialogFactory, title, message, allowCancel);
+
+            protected override Task DisposeCoreAsync(bool initialized) => Task.CompletedTask;
+            protected override Task InitializeCoreAsync(CancellationToken cancellationToken) => InitializeAsync();
+
+            public async Task InitializeAsync()
+            {
+                await _threadingService.SwitchToUIThread();
+                _threadedWaitDialogFactory = await _threadedWaitDialogFactoryService.GetValueAsync();
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Waiting/VisualStudioWaitIndicator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Waiting/VisualStudioWaitIndicator.cs
@@ -1,0 +1,116 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.ProjectSystem.Waiting;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
+{
+    [Export(typeof(IImplicitlyActiveService))]
+    [Export(typeof(IWaitIndicator))]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasic)]
+    internal partial class VisualStudioWaitIndicator : AbstractMultiLifetimeComponent<VisualStudioWaitIndicator.Instance>, IImplicitlyActiveService, IWaitIndicator
+    {
+        private readonly IProjectThreadingService _threadingService;
+        private readonly IVsService<SVsThreadedWaitDialogFactory, IVsThreadedWaitDialogFactory> _waitDialogFactoryService;
+
+        [ImportingConstructor]
+        public VisualStudioWaitIndicator(UnconfiguredProject unconfiguredProject,
+                                         IProjectThreadingService threadingService,
+                                         IVsService<SVsThreadedWaitDialogFactory, IVsThreadedWaitDialogFactory> waitDialogFactoryService)
+            : base(threadingService.JoinableTaskContext)
+        {
+            _threadingService = threadingService;
+            _waitDialogFactoryService = waitDialogFactoryService;
+        }
+
+        public Task ActivateAsync() => LoadAsync();
+        public Task DeactivateAsync() => UnloadAsync();
+
+        protected override Instance CreateInstance() => new Instance(_threadingService, _waitDialogFactoryService);
+
+        public void Wait(string title, string message, bool allowCancel, Action<CancellationToken> action)
+        {
+            Requires.NotNull(title, nameof(title));
+            Requires.NotNull(message, nameof(message));
+            Requires.NotNull(action, nameof(action));
+
+            Instance instance = _threadingService.ExecuteSynchronously(() => WaitForLoadedAsync());
+            instance.Wait(title, message, allowCancel, action);
+        }
+
+        public T Wait<T>(string title, string message, bool allowCancel, Func<CancellationToken, T> action)
+        {
+            Requires.NotNull(title, nameof(title));
+            Requires.NotNull(message, nameof(message));
+            Requires.NotNull(action, nameof(action));
+
+            Instance instance = _threadingService.ExecuteSynchronously(() => WaitForLoadedAsync());
+            return instance.Wait(title, message, allowCancel, action);
+        }
+
+        public void WaitForAsyncFunction(string title, string message, bool allowCancel, Func<CancellationToken, Task> asyncFunction)
+        {
+            Requires.NotNull(title, nameof(title));
+            Requires.NotNull(message, nameof(message));
+            Requires.NotNull(asyncFunction, nameof(asyncFunction));
+
+            Instance instance = _threadingService.ExecuteSynchronously(() => WaitForLoadedAsync());
+            instance.WaitForAsyncFunction(title, message, allowCancel, asyncFunction);
+        }
+
+        public T WaitForAsyncFunction<T>(string title, string message, bool allowCancel, Func<CancellationToken, Task<T>> asyncFunction)
+        {
+            Requires.NotNull(title, nameof(title));
+            Requires.NotNull(message, nameof(message));
+            Requires.NotNull(asyncFunction, nameof(asyncFunction));
+
+            Instance instance = _threadingService.ExecuteSynchronously(() => WaitForLoadedAsync());
+            return instance.WaitForAsyncFunction(title, message, allowCancel, asyncFunction);
+        }
+
+        public WaitIndicatorResult WaitWithResult(string title, string message, bool allowCancel, Action<CancellationToken> action)
+        {
+            Requires.NotNull(title, nameof(title));
+            Requires.NotNull(message, nameof(message));
+            Requires.NotNull(action, nameof(action));
+
+            Instance instance = _threadingService.ExecuteSynchronously(() => WaitForLoadedAsync());
+            return instance.WaitWithResult(title, message, allowCancel, action);
+        }
+
+        public (WaitIndicatorResult, T) WaitWithResult<T>(string title, string message, bool allowCancel, Func<CancellationToken, T> function)
+        {
+            Requires.NotNull(title, nameof(title));
+            Requires.NotNull(message, nameof(message));
+            Requires.NotNull(function, nameof(function));
+
+            Instance instance = _threadingService.ExecuteSynchronously(() => WaitForLoadedAsync());
+            return instance.WaitWithResult(title, message, allowCancel, function);
+        }
+
+        public WaitIndicatorResult WaitForAsyncFunctionWithResult(string title, string message, bool allowCancel, Func<CancellationToken, Task> asyncFunction)
+        {
+            Requires.NotNull(title, nameof(title));
+            Requires.NotNull(message, nameof(message));
+            Requires.NotNull(asyncFunction, nameof(asyncFunction));
+
+            Instance instance = _threadingService.ExecuteSynchronously(() => WaitForLoadedAsync());
+            return instance.WaitForAsyncFunctionWithResult(title, message, allowCancel, asyncFunction);
+        }
+
+        public (WaitIndicatorResult, T) WaitForAsyncFunctionWithResult<T>(string title, string message, bool allowCancel, Func<CancellationToken, Task<T>> asyncFunction)
+        {
+            Requires.NotNull(title, nameof(title));
+            Requires.NotNull(message, nameof(message));
+            Requires.NotNull(asyncFunction, nameof(asyncFunction));
+
+            Instance instance = _threadingService.ExecuteSynchronously(() => WaitForLoadedAsync());
+            return instance.WaitForAsyncFunctionWithResult(title, message, allowCancel, asyncFunction);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/IWaitContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/IWaitContext.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Waiting
+{
+    internal interface IWaitContext : IDisposable
+    {
+        CancellationToken CancellationToken { get; }
+        bool AllowCancel { get; set; }
+        string Message { get; set; }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/IWaitIndicator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/IWaitIndicator.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Waiting
+{
+    internal interface IWaitIndicator
+    {
+        void Wait(string title, string message, bool allowCancel, Action<CancellationToken> action);
+        T Wait<T>(string title, string message, bool allowCancel, Func<CancellationToken, T> action);
+        void WaitForAsyncFunction(string title, string message, bool allowCancel, Func<CancellationToken, Task> asyncFunction);
+        T WaitForAsyncFunction<T>(string title, string message, bool allowCancel, Func<CancellationToken, Task<T>> asyncFunction);
+        WaitIndicatorResult WaitWithResult(string title, string message, bool allowCancel, Action<CancellationToken> action);
+        (WaitIndicatorResult, T) WaitWithResult<T>(string title, string message, bool allowCancel, Func<CancellationToken, T> function);
+        WaitIndicatorResult WaitForAsyncFunctionWithResult(string title, string message, bool allowCancel, Func<CancellationToken, Task> asyncFunction);
+        (WaitIndicatorResult, T) WaitForAsyncFunctionWithResult<T>(string title, string message, bool allowCancel, Func<CancellationToken, Task<T>> asyncFunction);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/WaitIndicatorResult.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/WaitIndicatorResult.cs
@@ -7,4 +7,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Waiting
         Completed,
         Canceled,
     }
+
+    internal static class WaitIndicatorResultExtensions
+    {
+        public static bool WasCanceled(this WaitIndicatorResult result) => result == WaitIndicatorResult.Canceled;
+    }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/WaitIndicatorResult.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/WaitIndicatorResult.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.Waiting
+{
+    internal enum WaitIndicatorResult
+    {
+        Completed,
+        Canceled,
+    }
+}


### PR DESCRIPTION
allows the user to cancel a long running rename operation