### PR TITLE
Revert change to make rows autosize

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
@@ -85,7 +85,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             AllowUserToDeleteRows = False
             EditMode = DataGridViewEditMode.EditOnKeystrokeOrF2
             AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill
-            AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.AllCells
             DefaultCellStyle.WrapMode = DataGridViewTriState.True
 
             ' when the NullValue set to empty string, DataGridView will compare input string with it by using String.Compare.


### PR DESCRIPTION
Reverts this commit: https://github.com/dotnet/project-system/pull/3786/commits/c30f4626d9a1e176492d1b279b3d45aa42fd5ae6

Fixes [AB#936285](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/936285)

When rows are set to autosize the DataGridView ignores any manual change of Height, which means rows can expand to larger than the visible area on the screen. This makes the editing a very poor experience when using very long resource strings.

This also fixes a perf regression mentioned in the bug, and in the code here:
https://github.com/dotnet/project-system/blob/master/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb#L606-L608