### PR TITLE
Force .cs and .vb to use crlf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,8 +12,8 @@
 # default for csharp files.
 # Note: This is only used by command line
 ###############################################################################
-*.cs     diff=csharp text 
-*.vb     text
+*.cs     text eol=crlf diff=csharp
+*.vb     text eol=crlf
 
 ###############################################################################
 # Set the merge driver for project and solution files


### PR DESCRIPTION
Several unit tests include string literals for expected values. Without this setting, a repo checked out with alternative line ending settings will have failing tests. This can occur, for example, if you clone the repo using WSL.