### PR TITLE
Snapshot tracks only visible unresolved items

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependenciesSnapshotFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IDependenciesSnapshotFactory.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             if (hasUnresolvedDependency.HasValue)
             {
-                mock.Setup(x => x.HasUnresolvedDependency).Returns(hasUnresolvedDependency.Value);
+                mock.Setup(x => x.HasVisibleUnresolvedDependency).Returns(hasUnresolvedDependency.Value);
             }
 
             if (activeTarget != null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITargetedDependenciesSnapshotFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ITargetedDependenciesSnapshotFactory.cs
@@ -74,7 +74,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             if (hasUnresolvedDependency.HasValue)
             {
-                mock.Setup(x => x.HasUnresolvedDependency).Returns(hasUnresolvedDependency.Value);
+                mock.Setup(x => x.HasVisibleUnresolvedDependency).Returns(hasUnresolvedDependency.Value);
             }
 
             if (catalogs != null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependenciesSnapshotTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependenciesSnapshotTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             Assert.Same(projectPath, snapshot.ProjectPath);
             Assert.Same(targetFramework, snapshot.ActiveTargetFramework);
             Assert.Same(dependenciesByTargetFramework, snapshot.DependenciesByTargetFramework);
-            Assert.False(snapshot.HasUnresolvedDependency);
+            Assert.False(snapshot.HasVisibleUnresolvedDependency);
             Assert.Null(snapshot.FindDependency("foo"));
         }
 
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             Assert.Same(projectPath, snapshot.ProjectPath);
             Assert.Same(TargetFramework.Empty, snapshot.ActiveTargetFramework);
             Assert.Empty(snapshot.DependenciesByTargetFramework);
-            Assert.False(snapshot.HasUnresolvedDependency);
+            Assert.False(snapshot.HasVisibleUnresolvedDependency);
             Assert.Null(snapshot.FindDependency("foo"));
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyExtensionsTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyExtensionsTests.cs
@@ -50,31 +50,31 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 KnownMonikers.AboutBox,
                 KnownMonikers.Abbreviation);
 
-            var dependencyResolved = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Yyy"",
-    ""Id"": ""tfm1\\yyy\\dependencyExisting"",
-    ""Name"":""dependencyExisting"",
-    ""Caption"":""DependencyExisting"",
-    ""HasUnresolvedDependency"":""false"",
-    ""SchemaName"":""MySchema"",
-    ""SchemaItemType"":""MySchemaItemType"",
-    ""Priority"":""1"",
-    ""Resolved"":""true""
-}", iconSet: iconSet);
+            var dependencyResolved = new TestDependency
+            {
+                ProviderType = "Yyy",
+                Id = "tfm1\\yyy\\dependencyExisting",
+                Name = "dependencyExisting",
+                Caption = "DependencyExisting",
+                SchemaName = "MySchema",
+                SchemaItemType = "MySchemaItemType",
+                Priority = 1,
+                Resolved = true,
+                IconSet = iconSet
+            };
 
-            var dependencyUnresolved = IDependencyFactory.FromJson(@"
-{
-    ""ProviderType"": ""Yyy"",
-    ""Id"": ""tfm1\\yyy\\dependencyExisting"",
-    ""Name"":""dependencyExisting"",
-    ""Caption"":""DependencyExisting"",
-    ""HasUnresolvedDependency"":""false"",
-    ""SchemaName"":""MySchema"",
-    ""SchemaItemType"":""MySchemaItemType"",
-    ""Priority"":""1"",
-    ""Resolved"":""false""
-}", iconSet: iconSet);
+            var dependencyUnresolved = new TestDependency
+            {
+                ProviderType = "Yyy",
+                Id = "tfm1\\yyy\\dependencyExisting",
+                Name = "dependencyExisting",
+                Caption = "DependencyExisting",
+                SchemaName = "MySchema",
+                SchemaItemType = "MySchemaItemType",
+                Priority = 1,
+                Resolved = false,
+                IconSet = iconSet
+            };
 
             var mockSnapshot = ITargetedDependenciesSnapshotFactory.ImplementMock(checkForUnresolvedDependencies: false).Object;
             var mockSnapshotUnresolvedDependency = ITargetedDependenciesSnapshotFactory.ImplementMock(checkForUnresolvedDependencies: true).Object;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshotTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             Assert.Same(projectPath, snapshot.ProjectPath);
             Assert.Same(targetFramework, snapshot.TargetFramework);
             Assert.Same(catalogs, snapshot.Catalogs);
-            Assert.False(snapshot.HasUnresolvedDependency);
+            Assert.False(snapshot.HasVisibleUnresolvedDependency);
             Assert.Empty(snapshot.TopLevelDependencies);
             Assert.Empty(snapshot.DependenciesWorld);
             Assert.False(snapshot.CheckForUnresolvedDependencies("foo"));
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             Assert.Same(projectPath, snapshot.ProjectPath);
             Assert.Same(targetFramework, snapshot.TargetFramework);
             Assert.Same(catalogs, snapshot.Catalogs);
-            Assert.False(snapshot.HasUnresolvedDependency);
+            Assert.False(snapshot.HasVisibleUnresolvedDependency);
             Assert.Empty(snapshot.TopLevelDependencies);
             Assert.Empty(snapshot.DependenciesWorld);
             Assert.False(snapshot.CheckForUnresolvedDependencies("foo"));
@@ -176,7 +176,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             Assert.NotSame(previousSnapshot, snapshot);
             Assert.Same(updatedProjectPath, snapshot.ProjectPath);
             Assert.Same(catalogs, snapshot.Catalogs);
-            Assert.True(snapshot.HasUnresolvedDependency);
+            Assert.True(snapshot.HasVisibleUnresolvedDependency);
             AssertEx.CollectionLength(snapshot.DependenciesWorld, 2);
             AssertEx.CollectionLength(snapshot.TopLevelDependencies, 1);
             Assert.True(resolvedTop.Matches(snapshot.TopLevelDependencies.Single(), targetFramework));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -438,7 +438,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                         {
                             dependenciesNode = await viewProvider.BuildTreeAsync(dependenciesNode, snapshot, cancellationToken);
 
-                            await _treeTelemetryService.ObserveTreeUpdateCompletedAsync(snapshot.HasUnresolvedDependency);
+                            await _treeTelemetryService.ObserveTreeUpdateCompletedAsync(snapshot.HasVisibleUnresolvedDependency);
                         }
 
                         // TODO We still are getting mismatched data sources and need to figure out better 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             dependenciesTree = CleanupOldNodes(dependenciesTree, currentTopLevelNodes);
 
-            ProjectImageMoniker rootIcon = _viewModelFactory.GetDependenciesRootIcon(snapshot.HasUnresolvedDependency).ToProjectSystemType();
+            ProjectImageMoniker rootIcon = _viewModelFactory.GetDependenciesRootIcon(snapshot.HasVisibleUnresolvedDependency).ToProjectSystemType();
 
             return dependenciesTree.SetProperties(icon: rootIcon, expandedIcon: rootIcon);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/TargetDependencyViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/TargetDependencyViewModel.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
         {
             Caption = snapshot.TargetFramework.FriendlyName;
             Flags = DependencyTreeFlags.TargetNode.Add($"$TFM:{snapshot.TargetFramework.FullName}");
-            _hasUnresolvedDependency = snapshot.HasUnresolvedDependency;
+            _hasUnresolvedDependency = snapshot.HasVisibleUnresolvedDependency;
         }
 
         public string Caption { get; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -203,7 +203,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         public ImmutableDictionary<ITargetFramework, ITargetedDependenciesSnapshot> DependenciesByTargetFramework { get; }
 
         /// <inheritdoc />
-        public bool HasUnresolvedDependency => DependenciesByTargetFramework.Any(x => x.Value.HasUnresolvedDependency);
+        public bool HasVisibleUnresolvedDependency => DependenciesByTargetFramework.Any(x => x.Value.HasVisibleUnresolvedDependency);
 
         /// <inheritdoc />
         public IDependency? FindDependency(string dependencyId, bool topLevel = false)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/UnsupportedProjectsSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/UnsupportedProjectsSnapshotFilter.cs
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             {
                 ITargetedDependenciesSnapshot? snapshot = _aggregateSnapshotProvider.GetSnapshot(dependency);
 
-                if (snapshot != null && snapshot.HasUnresolvedDependency)
+                if (snapshot != null && snapshot.HasVisibleUnresolvedDependency)
                 {
                     context.Accept(dependency.ToUnresolved(ProjectReference.SchemaName));
                     return;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/IDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/IDependenciesSnapshot.cs
@@ -30,9 +30,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
         /// <summary>
         /// Gets whether this snapshot contains at least one unresolved/broken dependency at any level
-        /// for any target framework.
+        /// for any target framework which is visible.
         /// </summary>
-        bool HasUnresolvedDependency { get; }
+        bool HasVisibleUnresolvedDependency { get; }
 
         /// <summary>
         /// Finds dependency for given id across all target frameworks.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/ITargetedDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/ITargetedDependenciesSnapshot.cs
@@ -39,9 +39,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         ImmutableDictionary<string, IDependency> DependenciesWorld { get; }
 
         /// <summary>
-        /// Specifies is this snapshot contains at least one unresolved/broken dependency at any level.
+        /// Specifies is this snapshot contains at least one unresolved/broken dependency at any level which is visible.
         /// </summary>
-        bool HasUnresolvedDependency { get; }
+        bool HasVisibleUnresolvedDependency { get; }
 
         /// <summary>
         /// Efficient API for checking if a given dependency has an unresolved child dependency at any level. 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
@@ -174,7 +174,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             Catalogs = catalogs;
             DependenciesWorld = dependenciesWorld;
 
-            bool hasUnresolvedDependency = false;
+            bool hasVisibleUnresolvedDependency = false;
             ImmutableArray<IDependency>.Builder topLevelDependencies = ImmutableArray.CreateBuilder<IDependency>();
 
             foreach ((string id, IDependency dependency) in dependenciesWorld)
@@ -183,9 +183,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                     string.Equals(id, dependency.Id),
                     "dependenciesWorld dictionary entry keys must match their value's ids.");
 
-                if (!dependency.Resolved)
+                if (!dependency.Resolved && dependency.Visible)
                 {
-                    hasUnresolvedDependency = true;
+                    hasVisibleUnresolvedDependency = true;
                 }
 
                 if (dependency.TopLevel)
@@ -201,7 +201,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 }
             }
 
-            HasUnresolvedDependency = hasUnresolvedDependency;
+            HasVisibleUnresolvedDependency = hasVisibleUnresolvedDependency;
             TopLevelDependencies = topLevelDependencies.ToImmutable();
         }
 
@@ -230,7 +230,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         private object SyncLock => _dependenciesChildrenMap;
 
         /// <inheritdoc />
-        public bool HasUnresolvedDependency { get; }
+        public bool HasVisibleUnresolvedDependency { get; }
 
         /// <inheritdoc />
         public bool CheckForUnresolvedDependencies(IDependency dependency)


### PR DESCRIPTION
Allowing non-visible items to turn this flag 'true' can produce a "Dependencies" node with a warning icon, but no children with a corresponding warning to drill into.

Relates to #4362.