### PR TITLE
Add a stub for target ResolveFrameworkReferences

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -382,6 +382,7 @@
   <Target Name="ResolvePackageDependenciesDesignTime" />
   <Target Name="CollectSDKReferencesDesignTime" />
   <Target Name="CollectResolvedSDKReferencesDesignTime" />
+  <Target Name="ResolveFrameworkReferences" />
 
   <Target
     Name="ResolveFrameworkReferencesDesignTime"


### PR DESCRIPTION
The stub immediately below this declares it depends upon `ResolveFrameworkReferences` yet that target may not exist.