### PR TITLE
Design time inputs file watcher

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ConfiguredProjectServicesFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ConfiguredProjectServicesFactory.cs
@@ -14,13 +14,15 @@ namespace Microsoft.VisualStudio.ProjectSystem
                                                        IAdditionalRuleDefinitionsService ruleService = null,
                                                        IProjectSubscriptionService projectSubscriptionService = null,
                                                        IProjectPropertiesProvider projectPropertiesProvider = null,
-                                                       IProjectService projectService = null)
+                                                       IProjectService projectService = null,
+                                                       IProjectThreadingService threadingService = null)
         {
             var mock = new Mock<ConfiguredProjectServices>();
             mock.Setup(c => c.PropertyPagesCatalog).Returns(propertyPagesCatalogProvider);
             mock.Setup(c => c.AdditionalRuleDefinitions).Returns(ruleService);
             mock.Setup(c => c.ProjectSubscription).Returns(projectSubscriptionService);
             mock.Setup(c => c.ProjectPropertiesProvider).Returns(projectPropertiesProvider);
+            mock.Setup(c => c.ThreadingPolicy).Returns(threadingService);
             mock.SetupGet(s => s.ProjectService).Returns(projectService);
             return mock.Object;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsAsyncFileChangeExMock.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsAsyncFileChangeExMock.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.Shell
 {
-    public class TestIVsAsyncFileChangeEx : IVsAsyncFileChangeEx
+    public class IVsAsyncFileChangeExMock : IVsAsyncFileChangeEx
     {
         private uint _lastCookie;
         private readonly Dictionary<uint, string> _watchedFiles = new Dictionary<uint, string>();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         [MemberData(nameof(GetTestCases))]
         internal async Task VerifyDesignTimeInputsWatched(string[] designTimeInputs, string[] sharedDesignTimeInputs, string[] watchedFiles, string[] fileChangeNotificationsToSend, string[] fileChangeNotificationsExpected)
         {
-            var fileChangeService = new TestIVsAsyncFileChangeEx();
+            var fileChangeService = new IVsAsyncFileChangeExMock();
 
             using DesignTimeInputsFileWatcher watcher = CreateDesignTimeInputsFileWatcher(fileChangeService, out ProjectValueDataSource<DesignTimeInputs> source);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
@@ -91,9 +91,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 
             int notificationCount = 0;
             // Create a block to receive the output
-            var receiver = DataflowBlockSlim.CreateActionBlock<IProjectVersionedValue<string>>(val =>
+            var receiver = DataflowBlockSlim.CreateActionBlock<IProjectVersionedValue<string[]>>(val =>
             {
-                Assert.Equal(fileChangeNotificationsExpected[notificationCount++], val.Value);
+                foreach (string file in val.Value)
+                {
+                    Assert.Equal(fileChangeNotificationsExpected[notificationCount++], file);
+                }
 
                 // if we've seen every file, we're done
                 if (notificationCount == fileChangeNotificationsExpected.Length)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
@@ -1,0 +1,152 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+using Moq;
+
+using Xunit;
+using Xunit.Sdk;
+
+using Task = System.Threading.Tasks.Task;
+
+#nullable disable
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
+{
+    public class DesignTimeInputsFileWatcherTests
+    {
+        public static IEnumerable<object[]> GetTestCases()
+        {
+            return new[]
+            {
+                // A single design time input
+                new object[]
+                {
+                    new string[] { "File1.cs" },              // design time inputs
+                    new string[] { },                         // shared design time inputs
+                    new string[] { "File1.cs" },              // expected watched files
+                    new string[] { },                         // file change notifications to send
+                    new string[] { "File1.cs" }               // file change notifications expected
+                },
+
+                // A design time input and a shared design time input
+                new object[]
+                {
+                    new string[] { "File1.cs" },
+                    new string[] { "File2.cs" },
+                    new string[] { "File1.cs", "File2.cs" },
+                    new string[] { },
+                    new string[] { "File1.cs", "File2.cs" }
+                },
+
+                // A file that is both design time and shared, should only be watched once
+                new object[]
+                {
+                    new string[] { "File1.cs" },
+                    new string[] { "File2.cs", "File1.cs" },
+                    new string[] { "File1.cs", "File2.cs" },
+                    new string[] { },
+                    new string[] { "File1.cs", "File2.cs" }
+                },
+
+                // A design time input that gets modified
+                 new object[]
+                {
+                    new string[] { "File1.cs" },
+                    new string[] { },
+                    new string[] { "File1.cs" },
+                    new string[] { "File1.cs", "File1.cs", "File1.cs" },
+                    new string[] { "File1.cs", "File1.cs", "File1.cs", "File1.cs" }
+                },
+
+                // A design time input and a shared design time input, that both change, to ensure ordering is correct
+                new object[]
+                {
+                    new string[] { "File1.cs" },
+                    new string[] { "File2.cs" },
+                    new string[] { "File1.cs", "File2.cs" },
+                    new string[] { "File1.cs", "File2.cs" },
+                    new string[] { "File1.cs", "File2.cs", "File1.cs", "File2.cs" }
+                },
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestCases))]
+        internal async Task VerifyDesignTimeInputsWatched(string[] designTimeInputs, string[] sharedDesignTimeInputs, string[] watchedFiles, string[] fileChangeNotificationsToSend, string[] fileChangeNotificationsExpected)
+        {
+            var fileChangeService = new TestIVsAsyncFileChangeEx();
+
+            using DesignTimeInputsFileWatcher watcher = CreateDesignTimeInputsFileWatcher(fileChangeService, out ProjectValueDataSource<DesignTimeInputs> source);
+
+            // Send our input
+            await source.SendAsync(new DesignTimeInputs(designTimeInputs, sharedDesignTimeInputs));
+
+            // The TaskCompletionSource is the thing we use to wait for the test to finish
+            var finished = new TaskCompletionSource<bool>();
+
+            int notificationCount = 0;
+            // Create a block to receive the output
+            var receiver = DataflowBlockSlim.CreateActionBlock<IProjectVersionedValue<string>>(val =>
+            {
+                Assert.Equal(fileChangeNotificationsExpected[notificationCount++], val.Value);
+
+                // if we've seen every file, we're done
+                if (notificationCount == fileChangeNotificationsExpected.Length)
+                {
+                    finished.SetResult(true);
+                }
+            });
+            watcher.SourceBlock.LinkTo(receiver, DataflowOption.PropagateCompletion);
+
+            // Send down our fake file changes
+            watcher.FilesChanged((uint)fileChangeNotificationsToSend.Length, fileChangeNotificationsToSend, null);
+
+            // The timeout here is annoying, but even though our test is "smart" and waits for data, unfortunately if the code breaks the test is more likely to hang than fail
+            if (await Task.WhenAny(finished.Task, Task.Delay(500)) != finished.Task)
+            {
+                throw new AssertActualExpectedException(fileChangeNotificationsExpected.Length, notificationCount, "Timed out after 500ms");
+            }
+
+            // Observe the task in case of exceptions
+            await finished.Task;
+
+            // Make sure we watched all of the files we should
+            Assert.Equal(watchedFiles, fileChangeService.WatchedFiles);
+
+            watcher.Dispose();
+
+            // Should clean up and unwatch everything
+            Assert.Empty(fileChangeService.WatchedFiles);
+        }
+
+        private static DesignTimeInputsFileWatcher CreateDesignTimeInputsFileWatcher(IVsAsyncFileChangeEx fileChangeService, out ProjectValueDataSource<DesignTimeInputs> source)
+        {
+            // Create our mock design time inputs data source, but with a source we can actually use
+            var services = IProjectCommonServicesFactory.CreateWithDefaultThreadingPolicy();
+            source = ProjectValueDataSourceFactory.Create<DesignTimeInputs>(services);
+
+            var mock = new Mock<IDesignTimeInputsDataSource>();
+            mock.SetupGet(s => s.SourceBlock)
+                .Returns(source.SourceBlock);
+
+            var dataSource = mock.Object;
+
+            // Set up all of the mocks in the world
+            var threadingService = IProjectThreadingServiceFactory.Create();
+            var projectServices = ProjectServicesFactory.Create(threadingService: threadingService, projectLockService: IProjectLockServiceFactory.Create());
+            var projectService = IProjectServiceFactory.Create(projectServices);
+
+            var configuredProject = ConfiguredProjectFactory.Create(
+                services: ConfiguredProjectServicesFactory.Create(projectService: projectService, threadingService: threadingService),
+                unconfiguredProject: UnconfiguredProjectFactory.Create());
+
+            // Create our class under test
+            return new DesignTimeInputsFileWatcher(configuredProject, dataSource, IVsServiceFactory.Create<SVsFileChangeEx, Shell.IVsAsyncFileChangeEx>(fileChangeService));
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/TestHelpers/TestIVsAsyncFileChangeEx.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/TestHelpers/TestIVsAsyncFileChangeEx.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.VisualStudio.Shell
+{
+    public class TestIVsAsyncFileChangeEx : IVsAsyncFileChangeEx
+    {
+        private uint _lastCookie;
+        private readonly Dictionary<uint, string> _watchedFiles = new Dictionary<uint, string>();
+
+        public IEnumerable<string> WatchedFiles => _watchedFiles.Values;
+
+        public Task<uint> AdviseFileChangeAsync(string filename, _VSFILECHANGEFLAGS filter, IVsFreeThreadedFileChangeEvents2 sink, CancellationToken cancellationToken = default)
+        {
+            uint cookie = _lastCookie++;
+            _watchedFiles.Add(cookie, filename);
+            return System.Threading.Tasks.Task.FromResult(cookie);
+        }
+
+        public Task<string> UnadviseFileChangeAsync(uint cookie, CancellationToken cancellationToken = default)
+        {
+            string file = _watchedFiles[cookie];
+            _watchedFiles.Remove(cookie);
+            return System.Threading.Tasks.Task.FromResult(file);
+        }
+
+        public Task<uint> AdviseDirChangeAsync(string directory, bool watchSubdirectories, IVsFreeThreadedFileChangeEvents2 sink, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public System.Threading.Tasks.Task IgnoreDirAsync(string directory, bool ignore, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public System.Threading.Tasks.Task IgnoreFileAsync(uint cookie, string filename, bool ignore, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public System.Threading.Tasks.Task SyncFileAsync(string filename, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<string> UnadviseDirChangeAsync(uint cookie, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         private readonly IProjectThreadingService _threadingService;
         private readonly IDesignTimeInputsDataSource _designTimeInputsDataSource;
         private readonly IVsService<IVsAsyncFileChangeEx> _fileChangeService;
-        private ImmutableDictionary<string, uint> _fileWatcherCookies = ImmutableDictionary<string, uint>.Empty.WithComparers(StringComparers.Paths);
+        private readonly Dictionary<string, uint> _fileWatcherCookies = new Dictionary<string, uint>(StringComparers.Paths);
 
         private int _version;
         private IDisposable? _dataSourceLink;
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                 if (!allFiles.Contains(file))
                 {
                     await vsAsyncFileChangeEx.UnadviseFileChangeAsync(cookie);
-                    _fileWatcherCookies = _fileWatcherCookies.Remove(file);
+                    _fileWatcherCookies.Remove(file);
                 }
             }
 
@@ -113,7 +113,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                     // We don't care about delete and add here, as they come through data flow, plus they are really bouncy - every file change is a Time, Del and Add event)
                     uint cookie = await vsAsyncFileChangeEx.AdviseFileChangeAsync(file, _VSFILECHANGEFLAGS.VSFILECHG_Time | _VSFILECHANGEFLAGS.VSFILECHG_Size, sink: this);
 
-                    _fileWatcherCookies = _fileWatcherCookies.Add(file, cookie);
+                    _fileWatcherCookies.Add(file, cookie);
 
                     // Advise of an addition now
                     newFiles.Add(file);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
@@ -1,0 +1,180 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Threading.Tasks.Dataflow;
+
+using Microsoft.VisualStudio.ProjectSystem.Utilities;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
+{
+    /// <summary>
+    /// Produces output whenever a design time input changes
+    /// </summary>
+    [Export(typeof(IDesignTimeInputsFileWatcher))]
+    [AppliesTo(ProjectCapability.CSharpOrVisualBasicLanguageService)]
+    internal class DesignTimeInputsFileWatcher : ProjectValueDataSourceBase<string>, IVsFreeThreadedFileChangeEvents2, IDesignTimeInputsFileWatcher
+    {
+        private readonly IProjectThreadingService _threadingService;
+        private readonly IDesignTimeInputsDataSource _designTimeInputsDataSource;
+        private readonly IVsService<IVsAsyncFileChangeEx> _fileChangeService;
+        private ImmutableDictionary<string, uint> _fileWatcherCookies = ImmutableDictionary<string, uint>.Empty.WithComparers(StringComparers.Paths);
+
+        private int _version;
+        private readonly DisposableBag _disposables = new DisposableBag();
+
+        /// <summary>
+        /// The block that receives updates from the active tree provider.
+        /// </summary>
+        private IBroadcastBlock<IProjectVersionedValue<string>>? _broadcastBlock;
+
+        /// <summary>
+        /// The public facade for the broadcast block.
+        /// </summary>
+        private IReceivableSourceBlock<IProjectVersionedValue<string>>? _publicBlock;
+
+        [ImportingConstructor]
+        public DesignTimeInputsFileWatcher(ConfiguredProject project,
+                                           IDesignTimeInputsDataSource designTimeInputsDataSource,
+                                           IVsService<SVsFileChangeEx, IVsAsyncFileChangeEx> fileChangeService)
+             : base(project.Services, synchronousDisposal: true, registerDataSource: false)
+        {
+            _threadingService = project.Services.ThreadingPolicy;
+            _designTimeInputsDataSource = designTimeInputsDataSource;
+            _fileChangeService = fileChangeService;
+        }
+
+        public override NamedIdentity DataSourceKey { get; } = new NamedIdentity(nameof(DesignTimeInputsFileWatcher));
+
+        public override IComparable DataSourceVersion => _version;
+
+        public override IReceivableSourceBlock<IProjectVersionedValue<string>> SourceBlock
+        {
+            get
+            {
+                EnsureInitialized();
+
+                return _publicBlock!;
+            }
+        }
+
+        protected override void Initialize()
+        {
+            base.Initialize();
+
+            IDisposable dataSourceLink = _designTimeInputsDataSource.SourceBlock.LinkToAsyncAction(ProcessDesignTimeInputs);
+
+            IDisposable join = JoinUpstreamDataSources(_designTimeInputsDataSource);
+
+            _disposables.AddDisposable(dataSourceLink);
+            _disposables.AddDisposable(join);
+
+            _broadcastBlock = DataflowBlockSlim.CreateBroadcastBlock<IProjectVersionedValue<string>>(nameFormat: nameof(DesignTimeInputsFileWatcher) + "Broadcast {1}");
+            _publicBlock = _broadcastBlock.SafePublicize();
+        }
+
+        private async Task ProcessDesignTimeInputs(IProjectVersionedValue<DesignTimeInputs> input)
+        {
+            // We don't want to watch any new files while we're disposing
+            if (IsDisposing)
+            {
+                return;
+            }
+
+            DesignTimeInputs designTimeInputs = input.Value;
+
+            IVsAsyncFileChangeEx vsAsyncFileChangeEx = await _fileChangeService.GetValueAsync();
+
+            // we don't care about the difference between types of inputs, so we just construct one hashset for fast comparisons later
+            var allFiles = new HashSet<string>(StringComparers.Paths);
+            allFiles.AddRange(designTimeInputs.Inputs);
+            allFiles.AddRange(designTimeInputs.SharedInputs);
+
+            // Remove any files we're watching that we don't care about any more
+            foreach (string file in _fileWatcherCookies.Keys.ToArray())
+            {
+                if (!allFiles.Contains(file))
+                {
+                    ImmutableInterlocked.TryRemove(ref _fileWatcherCookies, file, out uint cookie);
+                    await vsAsyncFileChangeEx.UnadviseFileChangeAsync(cookie);
+                }
+            }
+
+            // Now watch and output files that are new
+            foreach (string file in allFiles)
+            {
+                if (!_fileWatcherCookies.ContainsKey(file))
+                {
+                    // We don't care about delete and add here, as they come through data flow, plus they are really bouncy - every file change is a Time, Del and Add event)
+                    uint cookie = await vsAsyncFileChangeEx.AdviseFileChangeAsync(file, _VSFILECHANGEFLAGS.VSFILECHG_Time | _VSFILECHANGEFLAGS.VSFILECHG_Size, sink: this);
+
+                    ImmutableInterlocked.TryAdd(ref _fileWatcherCookies, file, cookie);
+
+                    // Advise of an addition now
+                    PostToOutput(file);
+                }
+            }
+        }
+
+        private void PostToOutput(string file)
+        {
+            _version++;
+            ImmutableDictionary<NamedIdentity, IComparable> dataSources = ImmutableDictionary<NamedIdentity, IComparable>.Empty.Add(DataSourceKey, DataSourceVersion);
+
+            _broadcastBlock.Post(new ProjectVersionedValue<string>(file, dataSources));
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _broadcastBlock?.Complete();
+                _disposables.Dispose();
+
+                _threadingService.ExecuteSynchronously(async () =>
+                {
+                    IVsAsyncFileChangeEx vsAsyncFileChangeEx = await _fileChangeService.GetValueAsync();
+
+                    foreach (uint cookie in _fileWatcherCookies.Values)
+                    {
+                        await vsAsyncFileChangeEx.UnadviseFileChangeAsync(cookie);
+                    }
+                });
+            }
+
+            base.Dispose(disposing);
+        }
+
+        public int FilesChanged(uint cChanges, string[] rgpszFile, uint[] rggrfChange)
+        {
+            for (int i = 0; i < cChanges; i++)
+            {
+                PostToOutput(rgpszFile[i]);
+            }
+
+            return HResult.OK;
+        }
+
+        public int DirectoryChanged(string pszDirectory)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int DirectoryChangedEx(string pszDirectory, string pszFile)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int DirectoryChangedEx2(string pszDirectory, uint cChanges, string[] rgpszFile, uint[] rggrfChange)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;
@@ -164,17 +164,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 
         public int DirectoryChanged(string pszDirectory)
         {
-            throw new NotImplementedException();
+            return HResult.NotImplemented;
         }
 
         public int DirectoryChangedEx(string pszDirectory, string pszFile)
         {
-            throw new NotImplementedException();
+            return HResult.NotImplemented;
         }
 
         public int DirectoryChangedEx2(string pszDirectory, uint cChanges, string[] rgpszFile, uint[] rggrfChange)
         {
-            throw new NotImplementedException();
+            return HResult.NotImplemented;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/IDesignTimeInputsFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/IDesignTimeInputsFileWatcher.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
     /// Represents a data source that produces output whenever a design time input changes
     /// </summary>
     [ProjectSystemContract(ProjectSystemContractScope.ConfiguredProject, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
-    internal interface IDesignTimeInputsFileWatcher : IProjectValueDataSource<string>
+    internal interface IDesignTimeInputsFileWatcher : IProjectValueDataSource<string[]>
     {
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/IDesignTimeInputsFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/IDesignTimeInputsFileWatcher.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.Composition;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
+{
+    /// <summary>
+    /// Represents a data source that produces output whenever a design time input changes
+    /// </summary>
+    [ProjectSystemContract(ProjectSystemContractScope.ConfiguredProject, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
+    internal interface IDesignTimeInputsFileWatcher : IProjectValueDataSource<string>
+    {
+    }
+}


### PR DESCRIPTION
A dataflow block that listens for design time inputs and shared inputs, and watches those files, and then sends output whenever a file is changed.