### PR TITLE
Validate top level rule DataSource properties

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AnalyzerReference.xaml
@@ -7,7 +7,6 @@
       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
-                ItemType="Analyzer"
                 MSBuildTarget="CollectAnalyzersDesignTime"
                 Persistence="ProjectFile"
                 SourceOfDefaultValue="AfterContext"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CollectedFrameworkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CollectedFrameworkReference.xaml
@@ -8,7 +8,6 @@
   
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
-                ItemType="FrameworkReference"
                 MSBuildTarget="CollectFrameworkReferences"
                 Persistence="ProjectFile"
                 SourceOfDefaultValue="AfterContext"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CollectedPackageDownload.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CollectedPackageDownload.xaml
@@ -8,7 +8,6 @@
   
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
-                ItemType="PackageDownload"
                 MSBuildTarget="CollectPackageDownloads"
                 Persistence="ProjectFile"
                 SourceOfDefaultValue="AfterContext"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CompilerCommandLineArgs.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CompilerCommandLineArgs.xaml
@@ -5,7 +5,6 @@
       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
-                ItemType="CompilerCommandLineArgs "
                 MSBuildTarget="CompileDesignTime"
                 Persistence="CompilerCommandLineArgs "
                 SourceOfDefaultValue="AfterContext"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PackageReference.xaml
@@ -7,7 +7,6 @@
       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
-                ItemType="PackageReference"
                 MSBuildTarget="CollectPackageReferences"
                 Persistence="ProjectFile"
                 SourceOfDefaultValue="AfterContext"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAnalyzerReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAnalyzerReference.xaml
@@ -7,7 +7,6 @@
       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
-                ItemType="Analyzer"
                 MSBuildTarget="CollectAnalyzersDesignTime"
                 Persistence="ResolvedReference"
                 SourceOfDefaultValue="AfterContext"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedAssemblyReference.xaml
@@ -7,7 +7,6 @@
       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
-                ItemType="Reference"
                 MSBuildTarget="ResolveAssemblyReferencesDesignTime"
                 Persistence="ResolvedReference"
                 SourceOfDefaultValue="AfterContext"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedCOMReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedCOMReference.xaml
@@ -7,7 +7,6 @@
       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
-                ItemType="COMReference"
                 MSBuildTarget="ResolveComReferencesDesignTime"
                 Persistence="ResolvedReference"
                 SourceOfDefaultValue="AfterContext"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedCompilationReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedCompilationReference.xaml
@@ -5,7 +5,6 @@
       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
-                ItemType="ReferencePathWithRefAssemblies"
                 MSBuildTarget="CollectResolvedCompilationReferencesDesignTime"
                 Persistence="ResolvedReference"
                 SourceOfDefaultValue="AfterContext"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedFrameworkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedFrameworkReference.xaml
@@ -8,7 +8,6 @@
   
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
-                ItemType="_ResolvedFrameworkReference"
                 MSBuildTarget="ResolveFrameworkReferencesDesignTime"
                 Persistence="ResolvedReference"
                 SourceOfDefaultValue="AfterContext"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedPackageReference.xaml
@@ -7,7 +7,6 @@
       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
-                ItemType="PackageReference"
                 MSBuildTarget="ResolvePackageDependenciesDesignTime"
                 Persistence="ResolvedReference"
                 SourceOfDefaultValue="AfterContext"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedProjectReference.xaml
@@ -7,7 +7,6 @@
       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
-                ItemType="ProjectReference"
                 MSBuildTarget="ResolveProjectReferencesDesignTime"
                 Persistence="ResolvedReference"
                 SourceOfDefaultValue="AfterContext"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedSdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedSdkReference.xaml
@@ -7,7 +7,6 @@
       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
-                ItemType="SDKReference"
                 MSBuildTarget="CollectResolvedSDKReferencesDesignTime"
                 Persistence="ResolvedReference"
                 SourceOfDefaultValue="AfterContext"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SdkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/SdkReference.xaml
@@ -7,7 +7,6 @@
       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
-                ItemType="SDKReference"
                 MSBuildTarget="CollectSDKReferencesDesignTime"
                 Persistence="ProjectFile"
                 SourceOfDefaultValue="AfterContext"


### PR DESCRIPTION
Validates:

1. When `SourceType` is `TargetResults` that `MSBuildTarget` is present
1. That `MSBuildTarget` is only present when `SourceType` is `TargetResults`
1. When `SourceType` is `Item` that `ItemType` is present
1. That `ItemType` is only present when `SourceType` is `Item`

This resulted in removing a bunch of redundant `ItemType` attributes from rule data sources.