### PR TITLE
Ignore test deployment & coverage files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ x64/
 
 # MSTest test Results
 [Tt]est[Rr]esult*/
+[Dd]eploy*/[Oo]ut
+*.coverage
 [Bb]uild[Ll]og.*
 UnitTestResults.html
 


### PR DESCRIPTION
In 16.2, deployments & coverage files are no longer deployed to TestResults - ignore their new locations.