### PR TITLE
Remove deprecated analyzers

### DIFF
--- a/build/Default.ruleset
+++ b/build/Default.ruleset
@@ -29,6 +29,7 @@
     <Rule Id="CA1054" Action="None" />
     <Rule Id="CA1055" Action="None" />
     <Rule Id="CA1056" Action="None" />
+    <Rule Id="CA1062" Action="None" />
     <Rule Id="CA1063" Action="Warning" />
     <Rule Id="CA1064" Action="None" />
     <Rule Id="CA1065" Action="None" />
@@ -36,6 +37,7 @@
     <Rule Id="CA1067" Action="Warning" />
     <Rule Id="CA1068" Action="Warning" />
     <Rule Id="CA1031" Action="None" /> <!-- Do not catch general exception types -->
+    <Rule Id="CA1303" Action="None" />
     <Rule Id="CA1304" Action="None" />
     <Rule Id="CA1707" Action="None" />
     <Rule Id="CA1710" Action="None" />
@@ -58,11 +60,6 @@
     <Rule Id="CA2227" Action="None" />
     <Rule Id="CA2231" Action="None" />
     <Rule Id="CA2234" Action="None" />
-  </Rules>
-  <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers.Exp" RuleNamespace="Microsoft.CodeQuality.Analyzers.Exp">
-    <Rule Id="CA1062" Action="None" />
-    <Rule Id="CA1303" Action="None" />
-    <Rule Id="CA1508" Action="None" /> <!-- disable until 2.9.x per https://github.com/dotnet/roslyn-analyzers/issues/1921#issuecomment-446702992 -->
   </Rules>
   <Rules AnalyzerId="Microsoft.NetFramework.Analyzers" RuleNamespace="Microsoft.NetFramework.Analyzers">
     <Rule Id="CA2153" Action="None" /> <!-- TODO do not catch CorruptedStateExceptions -->

--- a/build/Packages.targets
+++ b/build/Packages.targets
@@ -109,7 +109,6 @@
     <PackageReference Update="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="$(RoslynAnalyzersPackagesVersion)" />
     <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="$(RoslynAnalyzersPackagesVersion)" />
     <PackageReference Update="Text.Analyzers" Version="$(RoslynAnalyzersOldPackagesVersion)" />
-    <PackageReference Update="Microsoft.CodeQuality.Analyzers.Exp" Version="$(RoslynAnalyzersOldPackagesVersion)" />
     <PackageReference Update="Roslyn.Diagnostics.Analyzers" Version="$(RoslynAnalyzersOldPackagesVersion)" />
 
     <!-- NuGet -->

--- a/src/HostAgnostic.props
+++ b/src/HostAgnostic.props
@@ -24,7 +24,6 @@
     
     <!-- Analyzers-->
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" />
-    <PackageReference Include="Microsoft.CodeQuality.Analyzers.Exp" />
     <PackageReference Include="Microsoft.CodeQuality.Analyzers" />
     <PackageReference Include="Microsoft.NetFramework.Analyzers" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" />


### PR DESCRIPTION
These analyzers are deprecated as per https://github.com/dotnet/roslyn-analyzers/issues/2664#issuecomment-509884741.