### PR TITLE
Upgrade Moq to 4.12.0

### DIFF
--- a/build/Packages.targets
+++ b/build/Packages.targets
@@ -125,7 +125,7 @@
     <PackageReference Update="Newtonsoft.Json" Version="9.0.1"/>
 
     <!-- Tests -->
-    <PackageReference Update="Moq" Version="4.9.0"/>
+    <PackageReference Update="Moq" Version="4.12.0"/>
     <PackageReference Update="xunit" Version="$(XUnitVersion)" />
     <PackageReference Update="xunit.assert" Version="$(XunitVersion)" />
     <PackageReference Update="xunit.extensibility.core" Version="$(XunitVersion)" />


### PR DESCRIPTION
Moq 4.11 contains some breaking changes and wanted to test to make sure we're not affected by it. We're not, so just upgrade so others don't need to do same testing.