### PR TITLE
Fix NRE due to dataflow race

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PotentialEditorConfigDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PotentialEditorConfigDataSource.cs
@@ -58,6 +58,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             base.Initialize();
 
+            _broadcastBlock = DataflowBlockSlim.CreateBroadcastBlock<IProjectVersionedValue<FileWatchData>>(nameFormat: nameof(PotentialEditorConfigDataSource) + "Broadcast {1}");
+
             IDisposable projectRuleSourceLink = _project.Services.ProjectSubscription.ProjectRuleSource.SourceBlock.LinkToAsyncAction(ProcessProjectChanged, ruleNames: PotentialEditorConfigFiles.SchemaName);
 
             IDisposable join = JoinUpstreamDataSources(_project.Services.ProjectSubscription.ProjectRuleSource);
@@ -66,7 +68,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             _disposables.AddDisposable(projectRuleSourceLink);
             _disposables.AddDisposable(join);
 
-            _broadcastBlock = DataflowBlockSlim.CreateBroadcastBlock<IProjectVersionedValue<FileWatchData>>(nameFormat: nameof(PotentialEditorConfigDataSource) + "Broadcast {1}");
             _publicBlock = _broadcastBlock.SafePublicize();
         }
 


### PR DESCRIPTION
Fixes a NRE due to a dataflow race condition in `PotentialEditorConfigDataSource`. 

It was possible for `ProcessProjectChanged` to be called before `_broadcastBlock` was assigned, leading to a NRE when it was dereferenced.

This exception has been fixed indirectly in `master` via 2894df437536832d27c2c9e125180fcebc2f7a8b so does not need to be integrated forward. This PR prevents it happening in 16.3 preview 1.

@tmeschter @jmarolf @jjmew 