### PR TITLE
Pass MaxSupportedLangVersion to the Language Service

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/LanguageService.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/LanguageService.xaml
@@ -17,4 +17,7 @@
                   ReadOnly="True"
                   Visible="False" />
 
+  <StringProperty Name="MaxSupportedLangVersion"
+                  ReadOnly="True"
+                  Visible="False" />
 </Rule>


### PR DESCRIPTION
If a developer attempts to use a language feature not supported by the
version of C# currently in use by a project, the Language Service can
offer a fix to upgrade the user to a newer version. In order to do this
correctly in all scenarios, the Language Service needs to know the
maximum supported language version available to the project.

Here we obtain the value from MSBuild and pass it unchanged to the
Language Service. Typically the value will be a version like "7.3" or
"8.0", but the LS will also need to handle (in some manner) the empty
string, values that _may_ make sense to the compiler but are
questionable for LS purposes (e.g., "current", "preview"), and outright
garbage values.