### PR TITLE
Remove the need for .NET Core 2.1 to be installed

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -5,8 +5,6 @@
     "Microsoft.Net.Component.4.7.2.SDK",
     "Microsoft.Net.Component.4.7.2.TargetingPack",
     "Microsoft.Net.ComponentGroup.DevelopmentPrerequisites",
-    "Microsoft.Net.Core.Component.SDK.2.1",
-    "Microsoft.NetCore.ComponentGroup.DevelopmentTools.2.1",
     "Microsoft.VisualStudio.Component.CoreEditor",
     "Microsoft.VisualStudio.Component.ManagedDesktop.Core",
     "Microsoft.VisualStudio.Component.ManagedDesktop.Prerequisites",


### PR DESCRIPTION
16.3 includes 3.0 by default which we automatically work against, but there's no 'Or' concept in .vsconfig so we cannot represent that.