### PR TITLE
Revert "Turn on discovery of .editorconfig files"

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -47,8 +47,8 @@ dotnet_separate_import_directive_groups = true
 # Suggest more modern language features when available
 dotnet_style_object_initializer = true:suggestion
 dotnet_style_collection_initializer = true:suggestion
-dotnet_style_coalesce_expression = true:error
-dotnet_style_null_propagation = true:error
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
 dotnet_style_explicit_tuple_names = true:suggestion
 dotnet_style_prefer_inferred_tuple_names = true:suggestion
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
@@ -58,14 +58,14 @@ dotnet_style_prefer_conditional_expression_over_assignment = false
 dotnet_style_prefer_auto_properties = false
 
 # Avoid "this." and "Me." if not necessary
-dotnet_style_qualification_for_field = false:error
-dotnet_style_qualification_for_property = false:error
-dotnet_style_qualification_for_method = false:error
-dotnet_style_qualification_for_event = false:error
+dotnet_style_qualification_for_field = false:warning
+dotnet_style_qualification_for_property = false:warning
+dotnet_style_qualification_for_method = false:warning
+dotnet_style_qualification_for_event = false:warning
 
 # Use language keywords instead of framework type names for type references
-dotnet_style_predefined_type_for_locals_parameters_members = true:error
-dotnet_style_predefined_type_for_member_access = true:error
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
 
 # Prefer read-only on fields
 dotnet_style_readonly_field = true:warning
@@ -149,9 +149,9 @@ csharp_style_expression_bodied_indexers = true:none
 csharp_style_expression_bodied_accessors = true:none
 
 # Suggest more modern language features when available
-csharp_style_pattern_matching_over_is_with_cast_check = true:error
-csharp_style_pattern_matching_over_as_with_null_check = true:error
-csharp_style_inlined_variable_declaration = true:error
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
 csharp_style_throw_expression = true:suggestion
 csharp_style_conditional_delegate_call = true:suggestion
 csharp_style_deconstructed_variable_declaration = true:suggestion
@@ -210,206 +210,3 @@ csharp_prefer_braces = false:none
 # We allow usage of "var" inside tests as it reduces churn as we remove/rename types
 csharp_style_var_for_built_in_types = true:none
 csharp_style_var_elsewhere = true:none
-
-# Dotnet code analysis settings:
-[*.{cs,vb}]
-# Microsoft.Analyzers.ManagedCodeAnalysis
-dotnet_diagnostic.CA1801.severity = none
-dotnet_diagnostic.CA1804.severity = none
-dotnet_diagnostic.CA1806.severity = none
-dotnet_diagnostic.CA1821.severity = none
-dotnet_diagnostic.CA1823.severity = none
-dotnet_diagnostic.CA1824.severity = none
-dotnet_diagnostic.CA2200.severity = none
-
-# Microsoft.CodeQuality.Analyzers
-dotnet_diagnostic.CA1000.severity = none
-dotnet_diagnostic.CA1001.severity = none
-dotnet_diagnostic.CA1010.severity = none
-dotnet_diagnostic.CA1016.severity = none
-dotnet_diagnostic.CA1018.severity = none
-dotnet_diagnostic.CA1028.severity = none
-dotnet_diagnostic.CA1030.severity = none
-dotnet_diagnostic.CA1032.severity = none
-dotnet_diagnostic.CA1034.severity = none
-dotnet_diagnostic.CA1036.severity = error
-dotnet_diagnostic.CA1040.severity = none
-dotnet_diagnostic.CA1041.severity = none
-dotnet_diagnostic.CA1043.severity = none
-dotnet_diagnostic.CA1051.severity = none
-dotnet_diagnostic.CA1052.severity = none
-dotnet_diagnostic.CA1054.severity = none
-dotnet_diagnostic.CA1055.severity = none
-dotnet_diagnostic.CA1056.severity = none
-dotnet_diagnostic.CA1062.severity = none
-dotnet_diagnostic.CA1063.severity = warning
-dotnet_diagnostic.CA1064.severity = none
-dotnet_diagnostic.CA1065.severity = none
-dotnet_diagnostic.CA1066.severity = none
-dotnet_diagnostic.CA1067.severity = warning
-dotnet_diagnostic.CA1068.severity = warning
-dotnet_diagnostic.CA1031.severity = none        # Do not catch general exception types
-dotnet_diagnostic.CA1303.severity = none
-dotnet_diagnostic.CA1304.severity = none
-dotnet_diagnostic.CA1707.severity = none
-dotnet_diagnostic.CA1710.severity = none
-dotnet_diagnostic.CA1714.severity = none
-dotnet_diagnostic.CA1715.severity = none
-dotnet_diagnostic.CA1716.severity = none
-dotnet_diagnostic.CA1717.severity = none
-dotnet_diagnostic.CA1720.severity = none
-dotnet_diagnostic.CA1721.severity = none
-dotnet_diagnostic.CA1724.severity = none
-dotnet_diagnostic.CA1815.severity = none
-dotnet_diagnostic.CA1820.severity = none
-dotnet_diagnostic.CA2007.severity = none
-dotnet_diagnostic.CA2211.severity = none
-dotnet_diagnostic.CA2213.severity = none        # https://github.com/dotnet/roslyn-analyzers/issues/1796
-dotnet_diagnostic.CA2218.severity = none
-dotnet_diagnostic.CA2222.severity = none
-dotnet_diagnostic.CA2224.severity = none
-dotnet_diagnostic.CA2225.severity = none
-dotnet_diagnostic.CA2227.severity = none
-dotnet_diagnostic.CA2231.severity = none
-dotnet_diagnostic.CA2234.severity = none
-
-# Microsoft.NetFramework.Analyzers
-dotnet_diagnostic.CA2153.severity = none        # TODO do not catch CorruptedStateExceptions
-dotnet_diagnostic.CA2235.severity = error
-dotnet_diagnostic.CA3075.severity = error
-
-# Microsoft.CodeAnalysis.Analyzers
-# These diagnostics apply to the source code of analyzers themselves.
-# We do not have any analyzers in this repository, so disable these.
-dotnet_diagnostic.RS1001.severity = none
-dotnet_diagnostic.RS1002.severity = none
-dotnet_diagnostic.RS1003.severity = none
-dotnet_diagnostic.RS1004.severity = none
-dotnet_diagnostic.RS1005.severity = none
-dotnet_diagnostic.RS1006.severity = none
-dotnet_diagnostic.RS1008.severity = none
-dotnet_diagnostic.RS1009.severity = none
-dotnet_diagnostic.RS1010.severity = none
-dotnet_diagnostic.RS1011.severity = none
-dotnet_diagnostic.RS1012.severity = none
-dotnet_diagnostic.RS1013.severity = none
-dotnet_diagnostic.RS1014.severity = warning         # DoNotIgnoreReturnValueOnImmutableObjectMethodInvocation
-dotnet_diagnostic.RS1015.severity = none
-dotnet_diagnostic.RS1016.severity = none
-dotnet_diagnostic.RS1017.severity = none
-dotnet_diagnostic.RS1018.severity = none
-dotnet_diagnostic.RS1019.severity = none
-dotnet_diagnostic.RS1020.severity = none
-dotnet_diagnostic.RS1021.severity = none
-dotnet_diagnostic.RS1022.severity = none
-dotnet_diagnostic.RS1023.severity = none
-
-# Microsoft.Composition.Analyzers
-dotnet_diagnostic.RS0006.severity = error
-dotnet_diagnostic.RS0023.severity = error
-
-# Roslyn.Core
-dotnet_diagnostic.AD0001.severity = error
-
-# Roslyn.Diagnostic.Analyzers
-dotnet_diagnostic.RS0001.severity = warning
-dotnet_diagnostic.RS0002.severity = warning
-dotnet_diagnostic.RS0005.severity = warning
-dotnet_diagnostic.RS0016.severity = error
-dotnet_diagnostic.RS0017.severity = error
-dotnet_diagnostic.RS0022.severity = error
-dotnet_diagnostic.RS0024.severity = error
-dotnet_diagnostic.RS0025.severity = error
-dotnet_diagnostic.RS0026.severity = error
-dotnet_diagnostic.RS0027.severity = error
-dotnet_diagnostic.RS0030.severity = error
-dotnet_diagnostic.RS0031.severity = error
-dotnet_diagnostic.RS0033.severity = none            # Importing constructor should be [Obsolete]
-dotnet_diagnostic.RS0034.severity = none            # Style rule that enforces public MEF constructor marked with [ImportingConstructor]
-
-# System.Collections.Immutable.Analyzers
-dotnet_diagnostic.RS0012.severity = warning
-
-# System.Runtime.Analyzers
-dotnet_diagnostic.CA1305.severity = none
-dotnet_diagnostic.CA1307.severity = none
-dotnet_diagnostic.CA1308.severity = none
-dotnet_diagnostic.CA1810.severity = none
-dotnet_diagnostic.CA1816.severity = none
-dotnet_diagnostic.CA1825.severity = warning
-dotnet_diagnostic.CA2002.severity = none
-dotnet_diagnostic.CA2207.severity = none
-dotnet_diagnostic.CA2208.severity = none
-dotnet_diagnostic.CA2216.severity = none
-dotnet_diagnostic.CA2219.severity = none
-dotnet_diagnostic.CA2241.severity = none
-dotnet_diagnostic.CA2242.severity = none
-dotnet_diagnostic.RS0014.severity = warning
-
-# System.Runtime.InteropServices.Analyzers
-dotnet_diagnostic.CA1401.severity = none
-dotnet_diagnostic.CA2101.severity = none
-dotnet_diagnostic.RS0015.severity = warning
-
-# System.Threading.Tasks.Analyzers
-dotnet_diagnostic.RS0018.severity = warning
-
-# XmlDocumentationComments.Analyzers
-dotnet_diagnostic.RS0010.severity = warning
-
-# Microsoft.VisualStudio.Threading.Analyzers
-dotnet_diagnostic.VSTHRD200.severity = none     # Naming styles:  Before: Task Open()  After: Task OpenAsync()
-dotnet_diagnostic.VSTHRD010.severity = none     # Visual Studio service should be used on main thread explicitly.
-dotnet_diagnostic.VSTHRD103.severity = none     # Call async methods when in an async method.
-dotnet_diagnostic.VSTHRD108.severity = none     # Thread affinity checks should be unconditional.
-dotnet_diagnostic.VSTHRD003.severity = none     # Avoid awaiting or returning a Task representing work that was not started within your context as that can lead to deadlocks
-
-# Microsoft.VisualStudio.SDK.Analyzers
-dotnet_diagnostic.VSSDK006.severity = none      # Check whether the result of GetService calls is null
-
-# Microsoft.CodeAnalysis.CSharp.Features            # Name:                                        Before:                                             After:
-dotnet_diagnostic.IDE0001.severity = error          # Simplify names                               System.Version version;                             Version version;
-dotnet_diagnostic.IDE0002.severity = error          # Simplify (member access)                     System.Version.Equals("1", "2");                    Version.Equals("1", "2");
-dotnet_diagnostic.IDE0005.severity = error          # Using directive is unnecessary               using System.Text;                                  <nothing>
-dotnet_diagnostic.IDE0030.severity = error          # Use coalesce expression (nullable)           int? y = x.HasValue ? x.Value : 0                   int? y = x ?? 0;
-dotnet_diagnostic.IDE0030WithoutSuggestion.severity = error
-dotnet_diagnostic.IDE1006.severity = error          # Naming styles                                Task Open()                                         Task OpenAsync()
-dotnet_diagnostic.IDE1006WithoutSuggestion.severity = suggestion
-
-# Dotnet code analysis settings for test projects:
-[src/*Tests/**/*.{cs,vb}]
-# Microsoft.CodeQuality.Analyzers
-# For tests, the ConfigureAwait(true) is good enough. Either they are already running on a thread pool
-# thread where ConfigureAwait(false) does nothing, or we're running the workload from an STA thread
-# where we want to marshal the continuations back to it.
-dotnet_diagnostic.CA2007.severity = none
-dotnet_diagnostic.CA1822.severity = none
-dotnet_diagnostic.CA2000.severity = none
-dotnet_diagnostic.CA2009.severity = none
-
-# System.Runtime.Analyzers
-dotnet_diagnostic.CA1825.severity = none        # Avoid zero length allocations - suppress for non-shipping/test projects (originally RS0007)
-
-# Microsoft.Composition.Analyzers
-dotnet_diagnostic.RS0006.severity = none
-dotnet_diagnostic.RS0023.severity = none
-
-# Microsoft.VisualStudio.Threading.Analyzers
-dotnet_diagnostic.VSTHRD001.severity = none     # Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.
-dotnet_diagnostic.VSTHRD002.severity = none     # Synchronously waiting on tasks or awaiters may cause deadlocks. Use JoinableTaskFactory.Run instead.
-dotnet_diagnostic.VSTHRD010.severity = none     # Visual Studio service should be used on main thread explicitly.
-dotnet_diagnostic.VSTHRD103.severity = none     # Synchronously blocks. Await ThrowsAsync instead.
-dotnet_diagnostic.VSTHRD110.severity = none     # Observe result of async calls 
-dotnet_diagnostic.VSTHRD200.severity = none     # Naming stylesNaming styles:  Before: Task Open()  After: Task OpenAsync()
-
-# xunit.analyzers
-dotnet_diagnostic.xUnit1026.severity = none     # Theory methods must use all parameters 
-dotnet_diagnostic.xUnit1004.severity = none     # Test methods should not be skipped
-
-# Microsoft.CodeAnalysis.CSharp.Features
-dotnet_diagnostic.IDE0001.severity = none       # Too noisy due to https://github.com/dotnet/roslyn/issues/27819
-dotnet_diagnostic.IDE1006.severity = none       # Naming styles is too noisy as it fires on all async tests
-dotnet_diagnostic.IDE1006WithoutSuggestion.severity = none
-dotnet_diagnostic.IDE0067.severity = none	    # Noisy in tests
-dotnet_diagnostic.IDE0068.severity = none       # Noisy in tests
-dotnet_diagnostic.IDE0068.severity = none       # Noisy in tests

--- a/ProjectSystem.sln
+++ b/ProjectSystem.sln
@@ -41,6 +41,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{DD7EF107
 		build\VisualStudio.XamlRules.targets = build\VisualStudio.XamlRules.targets
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Rulesets", "Rulesets", "{E09AD054-22FC-4E70-8889-0F3DCF1267C7}"
+	ProjectSection(SolutionItems) = preProject
+		build\Default.ruleset = build\Default.ruleset
+		build\Test.ruleset = build\Test.ruleset
+	EndProjectSection
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Dependencies", "Dependencies", "{6A95E22E-6D85-4494-AEB5-FCD60A8E88A3}"
 	ProjectSection(SolutionItems) = preProject
 		src\HostAgnostic.props = src\HostAgnostic.props
@@ -121,6 +127,7 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
+		{E09AD054-22FC-4E70-8889-0F3DCF1267C7} = {DD7EF107-AAD4-4C43-8A58-0DC1BC614ADE}
 		{6A95E22E-6D85-4494-AEB5-FCD60A8E88A3} = {DD7EF107-AAD4-4C43-8A58-0DC1BC614ADE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution

--- a/build/Default.ruleset
+++ b/build/Default.ruleset
@@ -1,0 +1,181 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Common diagnostic rules to run during build for all shipping Roslyn projects" Description="This file contains diagnostic settings used by all Roslyn projects. Projects that need specific settings should have their own rule set files that Include this one, and then make the neceessary adjustments." ToolsVersion="15.0">
+  <IncludeAll Action="Hidden" />
+  <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
+    <Rule Id="CA1801" Action="None" />
+    <Rule Id="CA1804" Action="None" />
+    <Rule Id="CA1806" Action="None" />
+    <Rule Id="CA1821" Action="None" />
+    <Rule Id="CA1823" Action="None" />
+    <Rule Id="CA1824" Action="None" />
+    <Rule Id="CA2200" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
+    <Rule Id="CA1000" Action="None" />
+    <Rule Id="CA1001" Action="None" />
+    <Rule Id="CA1010" Action="None" />
+    <Rule Id="CA1016" Action="None" />
+    <Rule Id="CA1018" Action="None" />
+    <Rule Id="CA1028" Action="None" />
+    <Rule Id="CA1030" Action="None" />
+    <Rule Id="CA1032" Action="None" />
+    <Rule Id="CA1034" Action="None" />
+    <Rule Id="CA1036" Action="Error" />
+    <Rule Id="CA1040" Action="None" />
+    <Rule Id="CA1041" Action="None" />
+    <Rule Id="CA1043" Action="None" />
+    <Rule Id="CA1051" Action="None" />
+    <Rule Id="CA1052" Action="None" />
+    <Rule Id="CA1054" Action="None" />
+    <Rule Id="CA1055" Action="None" />
+    <Rule Id="CA1056" Action="None" />
+    <Rule Id="CA1062" Action="None" />
+    <Rule Id="CA1063" Action="Warning" />
+    <Rule Id="CA1064" Action="None" />
+    <Rule Id="CA1065" Action="None" />
+    <Rule Id="CA1066" Action="None" />
+    <Rule Id="CA1067" Action="Warning" />
+    <Rule Id="CA1068" Action="Warning" />
+    <Rule Id="CA1031" Action="None" /> <!-- Do not catch general exception types -->
+    <Rule Id="CA1303" Action="None" />
+    <Rule Id="CA1304" Action="None" />
+    <Rule Id="CA1707" Action="None" />
+    <Rule Id="CA1710" Action="None" />
+    <Rule Id="CA1714" Action="None" />
+    <Rule Id="CA1715" Action="None" />
+    <Rule Id="CA1716" Action="None" />
+    <Rule Id="CA1717" Action="None" />
+    <Rule Id="CA1720" Action="None" />
+    <Rule Id="CA1721" Action="None" />
+    <Rule Id="CA1724" Action="None" />
+    <Rule Id="CA1815" Action="None" />
+    <Rule Id="CA1820" Action="None" />
+    <Rule Id="CA2007" Action="None" />
+    <Rule Id="CA2211" Action="None" />
+    <Rule Id="CA2213" Action="None" /> <!-- https://github.com/dotnet/roslyn-analyzers/issues/1796 -->
+    <Rule Id="CA2218" Action="None" />
+    <Rule Id="CA2222" Action="None" />
+    <Rule Id="CA2224" Action="None" />
+    <Rule Id="CA2225" Action="None" />
+    <Rule Id="CA2227" Action="None" />
+    <Rule Id="CA2231" Action="None" />
+    <Rule Id="CA2234" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.NetFramework.Analyzers" RuleNamespace="Microsoft.NetFramework.Analyzers">
+    <Rule Id="CA2153" Action="None" /> <!-- TODO do not catch CorruptedStateExceptions -->
+    <Rule Id="CA2235" Action="Error" />
+    <Rule Id="CA3075" Action="Error" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.Analyzers" RuleNamespace="Microsoft.CodeAnalysis.Analyzers">
+    <!-- These diagnostics apply to the source code of analyzers themselves. -->
+    <!-- We do not have any analyzers in this repository, so disable these. -->
+    <Rule Id="RS1001" Action="None" />
+    <Rule Id="RS1002" Action="None" />
+    <Rule Id="RS1003" Action="None" />
+    <Rule Id="RS1004" Action="None" />
+    <Rule Id="RS1005" Action="None" />
+    <Rule Id="RS1006" Action="None" />
+    <Rule Id="RS1008" Action="None" />
+    <Rule Id="RS1009" Action="None" />
+    <Rule Id="RS1010" Action="None" />
+    <Rule Id="RS1011" Action="None" />
+    <Rule Id="RS1012" Action="None" />
+    <Rule Id="RS1013" Action="None" />
+    <Rule Id="RS1014" Action="Warning" /> <!-- DoNotIgnoreReturnValueOnImmutableObjectMethodInvocation -->
+    <Rule Id="RS1015" Action="None" />
+    <Rule Id="RS1016" Action="None" />
+    <Rule Id="RS1017" Action="None" />
+    <Rule Id="RS1018" Action="None" />
+    <Rule Id="RS1019" Action="None" />
+    <Rule Id="RS1020" Action="None" />
+    <Rule Id="RS1021" Action="None" />
+    <Rule Id="RS1022" Action="None" />
+    <Rule Id="RS1023" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.Composition.Analyzers" RuleNamespace="Microsoft.Composition.Analyzers">
+    <Rule Id="RS0006" Action="Error" />
+    <Rule Id="RS0023" Action="Error" />
+  </Rules>
+  <Rules AnalyzerId="Roslyn.Core" RuleNamespace="Roslyn.Core">
+    <Rule Id="AD0001" Action="Error" />
+  </Rules>
+  <Rules AnalyzerId="Roslyn.Diagnostic.Analyzers" RuleNamespace="Roslyn.Diagnostics.Analyzers">
+    <Rule Id="RS0001" Action="Warning" />
+    <Rule Id="RS0002" Action="Warning" />
+    <Rule Id="RS0005" Action="Warning" />
+    <Rule Id="RS0016" Action="Error" />
+    <Rule Id="RS0017" Action="Error" />
+    <Rule Id="RS0022" Action="Error" />
+    <Rule Id="RS0024" Action="Error" />
+    <Rule Id="RS0025" Action="Error" />
+    <Rule Id="RS0026" Action="Error" />
+    <Rule Id="RS0027" Action="Error" />
+    <Rule Id="RS0030" Action="Error" />
+    <Rule Id="RS0031" Action="Error" />
+    <Rule Id="RS0033" Action="None" /> <!-- Importing constructor should be [Obsolete] -->
+    <Rule Id="RS0034" Action="None" /> <!-- Style rule that enforces public MEF constructor marked with [ImportingConstructor] -->
+  </Rules>
+  <Rules AnalyzerId="System.Collections.Immutable.Analyzers" RuleNamespace="System.Collections.Immutable.Analyzers">
+    <Rule Id="RS0012" Action="Warning" />
+  </Rules>
+  <Rules AnalyzerId="System.Runtime.Analyzers" RuleNamespace="System.Runtime.Analyzers">
+    <Rule Id="CA1305" Action="None" />
+    <Rule Id="CA1307" Action="None" />
+    <Rule Id="CA1308" Action="None" />
+    <Rule Id="CA1810" Action="None" />
+    <Rule Id="CA1816" Action="None" />
+    <Rule Id="CA1825" Action="Warning" />
+    <Rule Id="CA2002" Action="None" />
+    <Rule Id="CA2207" Action="None" />
+    <Rule Id="CA2208" Action="None" />
+    <Rule Id="CA2216" Action="None" />
+    <Rule Id="CA2219" Action="None" />
+    <Rule Id="CA2241" Action="None" />
+    <Rule Id="CA2242" Action="None" />
+    <Rule Id="RS0014" Action="Warning" />
+  </Rules>
+  <Rules AnalyzerId="System.Runtime.InteropServices.Analyzers" RuleNamespace="System.Runtime.InteropServices.Analyzers">
+    <Rule Id="CA1401" Action="None" />
+    <Rule Id="CA2101" Action="None" />
+    <Rule Id="RS0015" Action="Warning" />
+  </Rules>
+  <Rules AnalyzerId="System.Threading.Tasks.Analyzers" RuleNamespace="System.Threading.Tasks.Analyzers">
+    <Rule Id="RS0018" Action="Warning" />
+  </Rules>
+  <Rules AnalyzerId="XmlDocumentationComments.Analyzers" RuleNamespace="XmlDocumentationComments.Analyzers">
+    <Rule Id="RS0010" Action="Warning" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
+                                                              <!-- Name:                                        Before:                                             After:                                -->
+    <Rule Id="IDE0001" Action="Error" />                      <!-- Simplify names                               System.Version version;                             Version version;                      -->
+    <Rule Id="IDE0002" Action="Error" />                      <!-- Simplify (member access)                     System.Version.Equals("1", "2");                    Version.Equals("1", "2");             -->
+    <Rule Id="IDE0003" Action="Error" />                      <!-- Remove qualification                         this.X = x;                                         X = x;                                -->
+    <Rule Id="IDE0005" Action="Error" />                      <!-- Using directive is unnecessary               using System.Text;                                                                        -->
+    <Rule Id="IDE0012" Action="Error" />                      <!-- Simplify framework names                     System.Int32 value;                                 int value;                            -->
+    <Rule Id="IDE0013" Action="Error" />                      <!-- Simplify framework names (member access)     Int32.Parse("1");                                   int.Parse("1");                       -->
+    <Rule Id="IDE0018" Action="Error" />                      <!-- Inline variable declaration                  TryParse(value, out result)                         TryParse(value, out int result)       -->
+    <Rule Id="IDE0018WithoutSuggestion" Action="Error" />
+    <Rule Id="IDE0019" Action="Error" />                      <!-- Use pattern matching                         if (button != null)                                 if (control is Button button)         -->
+    <Rule Id="IDE0019WithoutSuggestion" Action="Error" />
+    <Rule Id="IDE0020" Action="Error" />                      <!-- Use pattern matching                         if (control is Button)                              if (control is Button button)         -->
+    <Rule Id="IDE0020WithoutSuggestion" Action="Error" />
+    <Rule Id="IDE0029" Action="Error" />                      <!-- Use coalesce expression                      string y = x == null ? string.Empty : x;            string y = x ?? string.Empty;         -->
+    <Rule Id="IDE0029WithoutSuggestion" Action="Error" />
+    <Rule Id="IDE0030" Action="Error" />                      <!-- Use coalesce expression (nullable)           int? y = x.HasValue ? x.Value : 0                   int? y = x ?? 0;                      -->
+    <Rule Id="IDE0030WithoutSuggestion" Action="Error" />
+    <Rule Id="IDE0031" Action="Error" />                      <!-- Use null propagation                         string y = x == null ? null : x.ToLower()           string y = x?.ToLower();              -->
+    <Rule Id="IDE0031WithoutSuggestion" Action="Error" />
+    <Rule Id="IDE1006" Action="Error" />                      <!-- Naming styles                                Task Open()                                         Task OpenAsync()                      -->
+    <Rule Id="IDE1006WithoutSuggestion" Action="Info" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.VisualStudio.Threading.Analyzers" RuleNamespace="Microsoft.VisualStudio.Threading.Analyzers">
+    <Rule Id="VSTHRD200" Action="None" />                       <!-- Naming styles                              Task Open()                                         Task OpenAsync()                      -->
+    <Rule Id="VSTHRD010" Action="None" />                       <!-- Visual Studio service should be used on main thread explicitly.-->
+    <Rule Id="VSTHRD103" Action="None" />                       <!-- Call async methods when in an async method.-->
+    <Rule Id="VSTHRD108" Action="None" />                       <!-- Thread affinity checks should be unconditional.-->
+    <Rule Id="VSTHRD003" Action="None" />                       <!-- Avoid awaiting or returning a Task representing work that was not started within your context as that can lead to deadlocks-->
+  </Rules>
+  <Rules AnalyzerId="Microsoft.VisualStudio.SDK.Analyzers" RuleNamespace="Microsoft.VisualStudio.SDK.Analyzers">
+    <Rule Id="VSSDK006" Action="None" />                        <!-- Check whether the result of GetService calls is null -->
+  </Rules>
+</RuleSet>

--- a/build/Packages.targets
+++ b/build/Packages.targets
@@ -109,6 +109,7 @@
     <PackageReference Update="Microsoft.NetFramework.Analyzers" Version="2.9.3" />
     <PackageReference Update="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="2.9.3" />
     <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="2.9.3" />
+    <PackageReference Update="Text.Analyzers" Version="2.6.4" />
     <PackageReference Update="Roslyn.Diagnostics.Analyzers" Version="2.9.4-beta1.final" />
 
     <!-- NuGet -->

--- a/build/Test.ruleset
+++ b/build/Test.ruleset
@@ -1,0 +1,46 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Common diagnostic rules for all non-shipping projects" Description="Enables/disable rules specific to all non-shipping projects." ToolsVersion="14.0">
+  <Include Path=".\Default.ruleset" Action="Default" />
+  <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
+    <!-- For tests, the ConfigureAwait(true) is good enough. Either they are already running on a thread pool
+         thread where ConfigureAwait(false) does nothing, or we're running the workload from an STA thread
+         where we want to marshal the continuations back to it. -->
+    <Rule Id="CA2007" Action="None" />
+    <Rule Id="CA1822" Action="None" />
+    <Rule Id="CA2000" Action="None" />
+    <Rule Id="CA2009" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="System.Runtime.Analyzers" RuleNamespace="System.Runtime.Analyzers">
+    <!-- Avoid zero length allocations - suppress for non-shipping/test projects (originally RS0007) -->
+    <Rule Id="CA1825" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.Composition.Analyzers" RuleNamespace="Microsoft.Composition.Analyzers">
+    <Rule Id="RS0006" Action="None" />
+    <Rule Id="RS0023" Action="None" />
+  </Rules>
+   <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
+    <!-- Too noisy due to https://github.com/dotnet/roslyn/issues/27819 -->
+    <Rule Id="IDE0001" Action="None" />                       <!-- Simplify names                               System.Version version;                             Version version;                      -->
+
+     <!-- Naming styles is too noisy as it fires on all async tests -->     
+    <Rule Id="IDE1006" Action="None" />                       <!-- Naming styles                                Task Open()                                         Task OpenAsync()                      -->
+    <Rule Id="IDE1006WithoutSuggestion" Action="None" />
+     
+     <!-- Dispose rules are too noisy for tests -->
+    <Rule Id="IDE0067" Action="None" />
+    <Rule Id="IDE0068" Action="None" />
+    <Rule Id="IDE0069" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.VisualStudio.Threading.Analyzers" RuleNamespace="Microsoft.VisualStudio.Threading.Analyzers">
+    <Rule Id="VSTHRD001" Action="None" />                     <!-- Await JoinableTaskFactory.SwitchToMainThreadAsync() to switch to the UI thread instead of APIs that can deadlock or require specifying a priority.-->
+    <Rule Id="VSTHRD002" Action="None" />                     <!-- Synchronously waiting on tasks or awaiters may cause deadlocks. Use JoinableTaskFactory.Run instead.-->
+    <Rule Id="VSTHRD010" Action="None" />                     <!-- Visual Studio service should be used on main thread explicitly.-->
+    <Rule Id="VSTHRD103" Action="None" />                     <!-- Synchronously blocks. Await ThrowsAsync instead.-->
+    <Rule Id="VSTHRD110" Action="None" />                     <!-- Observe result of async calls -->
+    <Rule Id="VSTHRD200" Action="None" />                     <!-- Naming styles                                Task Open()                                         Task OpenAsync()                      -->
+  </Rules>
+  <Rules AnalyzerId="xunit.analyzers" RuleNamespace="xunit.analyzers">
+    <Rule Id="xUnit1026" Action="None" /> <!-- Theory methods must use all parameters -->
+    <Rule Id="xUnit1004" Action="None" /> <!-- Test methods should not be skipped -->
+  </Rules>
+</RuleSet>

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -73,3 +73,50 @@ jobs:
         failTaskOnFailedTests: true
       continueOnError: true
       condition: always()
+
+- job: Spanish
+  pool:
+    name: NetCorePublic-Pool
+    queue: BuildPool.Windows.10.Amd64.ES.VS2017.Open
+  variables:
+    _configuration: Debug
+  timeoutInMinutes: 20
+  steps:
+    - script: $(Build.SourcesDirectory)\build\CIBuild.cmd -configuration $(_configuration) -prepareMachine
+    - task: PublishBuildArtifacts@1
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\$(_configuration)\log'
+        ArtifactName: '$(_configuration) unit test logs'
+        publishLocation: Container
+      continueOnError: true
+      condition: failed()
+    - task: PublishBuildArtifacts@1
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\$(_configuration)\bin'
+        ArtifactName: '$(_configuration) bin folder'
+        publishLocation: Container
+      continueOnError: true
+      condition: failed()
+    - task: PublishBuildArtifacts@1
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\$(_configuration)\VSSetup'
+        ArtifactName: '$(_configuration) VSSetup folder'
+        publishLocation: Container
+      continueOnError: true
+      condition: failed()
+    - task: PublishBuildArtifacts@1
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\$(_configuration)\TestResults'
+        ArtifactName: '$(_configuration) Test Result Logs'
+        publishLocation: Container
+      continueOnError: true
+      condition: failed()
+    - task: PublishTestResults@2
+      inputs:
+        testRunner: 'xUnit'
+        testResultsFiles: '**/*.xml' 
+        searchFolder: '$(Build.SourcesDirectory)\artifacts\$(_configuration)\TestResults'
+        configuration: '$(_configuration)'
+        publishRunAttachments: true
+      continueOnError: true
+      condition: always()

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -42,6 +42,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <CodeAnalysisRuleSet Condition="'$(IsTestProject)' == 'true'">$(RepoRoot)build\Test.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet Condition="'$(IsTestProject)' != 'true'">$(RepoRoot)build\Default.ruleset</CodeAnalysisRuleSet>
+
     <TestArchitectures>x86</TestArchitectures>
 
     <!-- Use IBC optimization data if available -->
@@ -53,8 +56,6 @@
     <CopyVsixManifestToOutput>false</CopyVsixManifestToOutput>
     
     <NoWarn>$(NoWarn);NU5125</NoWarn>
-
-    <DiscoverEditorConfigFiles>true</DiscoverEditorConfigFiles>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/HostAgnostic.props
+++ b/src/HostAgnostic.props
@@ -27,6 +27,8 @@
     <PackageReference Include="Microsoft.CodeQuality.Analyzers" />
     <PackageReference Include="Microsoft.NetFramework.Analyzers" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" />
+    <PackageReference Include="Text.Analyzers" />
+    
 
     <!-- MSBuild -->
     <PackageReference Include="Microsoft.Build" />


### PR DESCRIPTION
Reverts dotnet/project-system#4929

We need 2019 for this feature to work, and our signed build can't use 2019 for reasons I don't really understand. So the .editorconfig support broke the signed build. In order to unblock everyone else I'm backing out the change.