### PR TITLE
Intern dependencyid string

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -12,6 +12,7 @@
     <Summary>Microsoft VisualStudio Managed Project System</Summary>
     <PackageTags>Roslyn Managed Project System VisualStudio</PackageTags>
     <NoWarn>$(NoWarn);NU5125</NoWarn>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledStringBuilder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledStringBuilder.cs
@@ -52,6 +52,15 @@ namespace Microsoft.VisualStudio.Buffers.PooledObjects
             return result;
         }
 
+        public string InternStringAndFree()
+        {
+            var st = StringTable.GetInstance();
+            string result = st.Add(_builder);
+            Free();
+
+            return result;
+        }
+
         // global pool
         private static readonly ObjectPool<PooledStringBuilder> s_poolInstance = CreatePool();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/StringTable.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/StringTable.cs
@@ -85,8 +85,6 @@ namespace Microsoft.VisualStudio.Buffers.PooledObjects
         public void Free()
         {
             // leave cache content in the cache, just return it to the pool
-            // Array.Clear(this.localTable, 0, this.localTable.Length);
-            // Array.Clear(sharedTable, 0, sharedTable.Length);
 
             _pool?.Free(this);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/StringTable.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/StringTable.cs
@@ -1,0 +1,880 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+using System.Threading;
+
+namespace Microsoft.VisualStudio.Buffers.PooledObjects
+{
+    internal class StringTable
+    {
+        // entry in the caches
+        private struct Entry
+        {
+            // hash code of the entry
+            public int HashCode;
+
+            // full text of the item
+            public string Text;
+        }
+
+        // Size of local cache.
+        private const int LocalSizeBits = 11;
+        private const int LocalSize = (1 << LocalSizeBits);
+        private const int LocalSizeMask = LocalSize - 1;
+
+        // max size of shared cache.
+        private const int SharedSizeBits = 16;
+        private const int SharedSize = (1 << SharedSizeBits);
+        private const int SharedSizeMask = SharedSize - 1;
+
+        // size of bucket in shared cache. (local cache has bucket size 1).
+        private const int SharedBucketBits = 4;
+        private const int SharedBucketSize = (1 << SharedBucketBits);
+        private const int SharedBucketSizeMask = SharedBucketSize - 1;
+
+        // local (L1) cache
+        // simple fast and not threadsafe cache 
+        // with limited size and "last add wins" expiration policy
+        //
+        // The main purpose of the local cache is to use in long lived
+        // single threaded operations with lots of locality (like parsing).
+        // Local cache is smaller (and thus faster) and is not affected
+        // by cache misses on other threads.
+        private readonly Entry[] _localTable = new Entry[LocalSize];
+
+        // shared (L2) threadsafe cache
+        // slightly slower than local cache
+        // we read this cache when having a miss in local cache
+        // writes to local cache will update shared cache as well.
+        private static readonly Entry[] s_sharedTable = new Entry[SharedSize];
+
+        // essentially a random number 
+        // the usage pattern will randomly use and increment this
+        // the counter is not static to avoid interlocked operations and cross-thread traffic
+        private int _localRandom = Environment.TickCount;
+
+        // same as above but for users that go directly with unbuffered shared cache.
+        private static int s_sharedRandom = Environment.TickCount;
+
+        internal StringTable() :
+            this(null)
+        {
+        }
+
+        private StringTable(ObjectPool<StringTable>? pool)
+        {
+            _pool = pool;
+        }
+
+        private readonly ObjectPool<StringTable>? _pool;
+        private static readonly ObjectPool<StringTable> s_staticPool = CreatePool();
+
+        private static ObjectPool<StringTable> CreatePool()
+        {
+            ObjectPool<StringTable>? pool = null;
+            pool = new ObjectPool<StringTable>(() => new StringTable(pool), Environment.ProcessorCount * 2);
+            return pool;
+        }
+
+        public static StringTable GetInstance()
+        {
+            return s_staticPool.Allocate();
+        }
+
+        public void Free()
+        {
+            // leave cache content in the cache, just return it to the pool
+            // Array.Clear(this.localTable, 0, this.localTable.Length);
+            // Array.Clear(sharedTable, 0, sharedTable.Length);
+
+            _pool?.Free(this);
+        }
+
+        internal string Add(char[] chars, int start, int len)
+        {
+            Span<char> span = chars.AsSpan(start, len);
+            int hashCode = GetFNVHashCode(chars, start, len);
+
+            // capture array to avoid extra range checks
+            Entry[] arr = _localTable;
+            int idx = LocalIdxFromHash(hashCode);
+
+            string text = arr[idx].Text;
+
+            if (text != null && arr[idx].HashCode == hashCode)
+            {
+                string result = arr[idx].Text;
+                if (TextEquals(result, span))
+                {
+                    return result;
+                }
+            }
+
+            string? shared = FindSharedEntry(chars, start, len, hashCode);
+            if (shared != null)
+            {
+                // PERF: the following code does element-wise assignment of a struct
+                //       because current JIT produces better code compared to
+                //       arr[idx] = new Entry(...)
+                arr[idx].HashCode = hashCode;
+                arr[idx].Text = shared;
+
+                return shared;
+            }
+
+            return AddItem(chars, start, len, hashCode);
+        }
+
+        internal string Add(string chars, int start, int len)
+        {
+            int hashCode = GetFNVHashCode(chars, start, len);
+
+            // capture array to avoid extra range checks
+            Entry[] arr = _localTable;
+            int idx = LocalIdxFromHash(hashCode);
+
+            string text = arr[idx].Text;
+
+            if (text != null && arr[idx].HashCode == hashCode)
+            {
+                string result = arr[idx].Text;
+                if (TextEquals(result, chars, start, len))
+                {
+                    return result;
+                }
+            }
+
+            string? shared = FindSharedEntry(chars, start, len, hashCode);
+            if (shared != null)
+            {
+                // PERF: the following code does element-wise assignment of a struct
+                //       because current JIT produces better code compared to
+                //       arr[idx] = new Entry(...)
+                arr[idx].HashCode = hashCode;
+                arr[idx].Text = shared;
+
+                return shared;
+            }
+
+            return AddItem(chars, start, len, hashCode);
+        }
+
+        internal string Add(char chars)
+        {
+            int hashCode = GetFNVHashCode(chars);
+
+            // capture array to avoid extra range checks
+            Entry[] arr = _localTable;
+            int idx = LocalIdxFromHash(hashCode);
+
+            string text = arr[idx].Text;
+
+            if (text != null)
+            {
+                string result = arr[idx].Text;
+                if (text.Length == 1 && text[0] == chars)
+                {
+                    return result;
+                }
+            }
+
+            string? shared = FindSharedEntry(chars, hashCode);
+            if (shared != null)
+            {
+                // PERF: the following code does element-wise assignment of a struct
+                //       because current JIT produces better code compared to
+                //       arr[idx] = new Entry(...)
+                arr[idx].HashCode = hashCode;
+                arr[idx].Text = shared;
+
+                return shared;
+            }
+
+            return AddItem(chars, hashCode);
+        }
+
+        internal string Add(StringBuilder chars)
+        {
+            int hashCode = GetFNVHashCode(chars);
+
+            // capture array to avoid extra range checks
+            Entry[] arr = _localTable;
+            int idx = LocalIdxFromHash(hashCode);
+
+            string text = arr[idx].Text;
+
+            if (text != null && arr[idx].HashCode == hashCode)
+            {
+                string result = arr[idx].Text;
+                if (TextEquals(result, chars))
+                {
+                    return result;
+                }
+            }
+
+            string? shared = FindSharedEntry(chars, hashCode);
+            if (shared != null)
+            {
+                // PERF: the following code does element-wise assignment of a struct
+                //       because current JIT produces better code compared to
+                //       arr[idx] = new Entry(...)
+                arr[idx].HashCode = hashCode;
+                arr[idx].Text = shared;
+
+                return shared;
+            }
+
+            return AddItem(chars, hashCode);
+        }
+
+        internal string Add(string chars)
+        {
+            int hashCode = GetFNVHashCode(chars);
+
+            // capture array to avoid extra range checks
+            Entry[] arr = _localTable;
+            int idx = LocalIdxFromHash(hashCode);
+
+            string text = arr[idx].Text;
+
+            if (text != null && arr[idx].HashCode == hashCode)
+            {
+                string result = arr[idx].Text;
+                if (result == chars)
+                {
+                    return result;
+                }
+            }
+
+            string? shared = FindSharedEntry(chars, hashCode);
+            if (shared != null)
+            {
+                // PERF: the following code does element-wise assignment of a struct
+                //       because current JIT produces better code compared to
+                //       arr[idx] = new Entry(...)
+                arr[idx].HashCode = hashCode;
+                arr[idx].Text = shared;
+
+                return shared;
+            }
+
+            AddCore(chars, hashCode);
+            return chars;
+        }
+
+
+        private static string? FindSharedEntry(char[] chars, int start, int len, int hashCode)
+        {
+            Entry[] arr = s_sharedTable;
+            int idx = SharedIdxFromHash(hashCode);
+
+            string? e = null;
+            // we use quadratic probing here
+            // bucket positions are (n^2 + n)/2 relative to the masked hashcode
+            for (int i = 1; i < SharedBucketSize + 1; i++)
+            {
+                e = arr[idx].Text;
+                int hash = arr[idx].HashCode;
+
+                if (e != null)
+                {
+                    if (hash == hashCode && TextEquals(e, chars.AsSpan(start, len)))
+                    {
+                        break;
+                    }
+
+                    // this is not e we are looking for
+                    e = null;
+                }
+                else
+                {
+                    // once we see unfilled entry, the rest of the bucket will be empty
+                    break;
+                }
+
+                idx = (idx + i) & SharedSizeMask;
+            }
+
+            return e;
+        }
+
+        private static string? FindSharedEntry(string chars, int start, int len, int hashCode)
+        {
+            Entry[] arr = s_sharedTable;
+            int idx = SharedIdxFromHash(hashCode);
+
+            string? e = null;
+            // we use quadratic probing here
+            // bucket positions are (n^2 + n)/2 relative to the masked hashcode
+            for (int i = 1; i < SharedBucketSize + 1; i++)
+            {
+                e = arr[idx].Text;
+                int hash = arr[idx].HashCode;
+
+                if (e != null)
+                {
+                    if (hash == hashCode && TextEquals(e, chars, start, len))
+                    {
+                        break;
+                    }
+
+                    // this is not e we are looking for
+                    e = null;
+                }
+                else
+                {
+                    // once we see unfilled entry, the rest of the bucket will be empty
+                    break;
+                }
+
+                idx = (idx + i) & SharedSizeMask;
+            }
+
+            return e;
+        }
+
+        private static string? FindSharedEntryASCII(int hashCode, ReadOnlySpan<byte> asciiChars)
+        {
+            Entry[] arr = s_sharedTable;
+            int idx = SharedIdxFromHash(hashCode);
+
+            string? e = null;
+            // we use quadratic probing here
+            // bucket positions are (n^2 + n)/2 relative to the masked hashcode
+            for (int i = 1; i < SharedBucketSize + 1; i++)
+            {
+                e = arr[idx].Text;
+                int hash = arr[idx].HashCode;
+
+                if (e != null)
+                {
+                    if (hash == hashCode && TextEqualsASCII(e, asciiChars))
+                    {
+                        break;
+                    }
+
+                    // this is not e we are looking for
+                    e = null;
+                }
+                else
+                {
+                    // once we see unfilled entry, the rest of the bucket will be empty
+                    break;
+                }
+
+                idx = (idx + i) & SharedSizeMask;
+            }
+
+            return e;
+        }
+
+        private static string? FindSharedEntry(char chars, int hashCode)
+        {
+            Entry[] arr = s_sharedTable;
+            int idx = SharedIdxFromHash(hashCode);
+
+            string? e = null;
+            // we use quadratic probing here
+            // bucket positions are (n^2 + n)/2 relative to the masked hashcode
+            for (int i = 1; i < SharedBucketSize + 1; i++)
+            {
+                e = arr[idx].Text;
+
+                if (e != null)
+                {
+                    if (e.Length == 1 && e[0] == chars)
+                    {
+                        break;
+                    }
+
+                    // this is not e we are looking for
+                    e = null;
+                }
+                else
+                {
+                    // once we see unfilled entry, the rest of the bucket will be empty
+                    break;
+                }
+
+                idx = (idx + i) & SharedSizeMask;
+            }
+
+            return e;
+        }
+
+        private static string? FindSharedEntry(StringBuilder chars, int hashCode)
+        {
+            Entry[] arr = s_sharedTable;
+            int idx = SharedIdxFromHash(hashCode);
+
+            string? e = null;
+            // we use quadratic probing here
+            // bucket positions are (n^2 + n)/2 relative to the masked hashcode
+            for (int i = 1; i < SharedBucketSize + 1; i++)
+            {
+                e = arr[idx].Text;
+                int hash = arr[idx].HashCode;
+
+                if (e != null)
+                {
+                    if (hash == hashCode && TextEquals(e, chars))
+                    {
+                        break;
+                    }
+
+                    // this is not e we are looking for
+                    e = null;
+                }
+                else
+                {
+                    // once we see unfilled entry, the rest of the bucket will be empty
+                    break;
+                }
+
+                idx = (idx + i) & SharedSizeMask;
+            }
+
+            return e;
+        }
+
+        private static string? FindSharedEntry(string chars, int hashCode)
+        {
+            Entry[] arr = s_sharedTable;
+            int idx = SharedIdxFromHash(hashCode);
+
+            string? e = null;
+            // we use quadratic probing here
+            // bucket positions are (n^2 + n)/2 relative to the masked hashcode
+            for (int i = 1; i < SharedBucketSize + 1; i++)
+            {
+                e = arr[idx].Text;
+                int hash = arr[idx].HashCode;
+
+                if (e != null)
+                {
+                    if (hash == hashCode && e == chars)
+                    {
+                        break;
+                    }
+
+                    // this is not e we are looking for
+                    e = null;
+                }
+                else
+                {
+                    // once we see unfilled entry, the rest of the bucket will be empty
+                    break;
+                }
+
+                idx = (idx + i) & SharedSizeMask;
+            }
+
+            return e;
+        }
+
+
+        private string AddItem(char[] chars, int start, int len, int hashCode)
+        {
+            string text = new string(chars, start, len);
+            AddCore(text, hashCode);
+            return text;
+        }
+
+        private string AddItem(string chars, int start, int len, int hashCode)
+        {
+            string text = chars.Substring(start, len);
+            AddCore(text, hashCode);
+            return text;
+        }
+
+        private string AddItem(char chars, int hashCode)
+        {
+            string text = new string(chars, 1);
+            AddCore(text, hashCode);
+            return text;
+        }
+
+        private string AddItem(StringBuilder chars, int hashCode)
+        {
+            string text = chars.ToString();
+            AddCore(text, hashCode);
+            return text;
+        }
+
+
+        private void AddCore(string chars, int hashCode)
+        {
+            // add to the shared table first (in case someone looks for same item)
+            AddSharedEntry(hashCode, chars);
+
+            // add to the local table too
+            Entry[] arr = _localTable;
+            int idx = LocalIdxFromHash(hashCode);
+            arr[idx].HashCode = hashCode;
+            arr[idx].Text = chars;
+        }
+
+        private void AddSharedEntry(int hashCode, string text)
+        {
+            Entry[] arr = s_sharedTable;
+            int idx = SharedIdxFromHash(hashCode);
+
+            // try finding an empty spot in the bucket
+            // we use quadratic probing here
+            // bucket positions are (n^2 + n)/2 relative to the masked hashcode
+            int curIdx = idx;
+            for (int i = 1; i < SharedBucketSize + 1; i++)
+            {
+                if (arr[curIdx].Text is null)
+                {
+                    idx = curIdx;
+                    goto foundIdx;
+                }
+
+                curIdx = (curIdx + i) & SharedSizeMask;
+            }
+
+            // or pick a random victim within the bucket range
+            // and replace with new entry
+            int i1 = LocalNextRandom() & SharedBucketSizeMask;
+            idx = (idx + ((i1 * i1 + i1) / 2)) & SharedSizeMask;
+
+            foundIdx:
+            arr[idx].HashCode = hashCode;
+            Volatile.Write(ref arr[idx].Text, text);
+        }
+
+        internal static string AddShared(StringBuilder chars)
+        {
+            int hashCode = GetFNVHashCode(chars);
+
+            string? shared = FindSharedEntry(chars, hashCode);
+            if (shared != null)
+            {
+                return shared;
+            }
+
+            return AddSharedSlow(hashCode, chars);
+        }
+
+        private static string AddSharedSlow(int hashCode, StringBuilder builder)
+        {
+            string text = builder.ToString();
+            AddSharedSlow(hashCode, text);
+            return text;
+        }
+
+        internal static string AddSharedUTF8(ReadOnlySpan<byte> bytes)
+        {
+            int hashCode = GetFNVHashCode(bytes, out bool isAscii);
+
+            if (isAscii)
+            {
+                string? shared = FindSharedEntryASCII(hashCode, bytes);
+                if (shared != null)
+                {
+                    return shared;
+                }
+            }
+
+            return AddSharedSlow(hashCode, bytes, isAscii);
+        }
+
+        private static string AddSharedSlow(int hashCode, ReadOnlySpan<byte> utf8Bytes, bool isAscii)
+        {
+            string text;
+
+            unsafe
+            {
+                fixed (byte* bytes = &utf8Bytes.GetPinnableReference())
+                {
+                    text = Encoding.UTF8.GetString(bytes, utf8Bytes.Length);
+                }
+            }
+
+            // Don't add non-ascii strings to table. The hashCode we have here is not correct and we won't find them again.
+            // Non-ascii in UTF8-encoded parts of metadata (the only use of this at the moment) is assumed to be rare in 
+            // practice. If that turns out to be wrong, we could decode to pooled memory and rehash here.
+            if (isAscii)
+            {
+                AddSharedSlow(hashCode, text);
+            }
+
+            return text;
+        }
+
+        private static void AddSharedSlow(int hashCode, string text)
+        {
+            Entry[] arr = s_sharedTable;
+            int idx = SharedIdxFromHash(hashCode);
+
+            // try finding an empty spot in the bucket
+            // we use quadratic probing here
+            // bucket positions are (n^2 + n)/2 relative to the masked hashcode
+            int curIdx = idx;
+            for (int i = 1; i < SharedBucketSize + 1; i++)
+            {
+                if (arr[curIdx].Text is null)
+                {
+                    idx = curIdx;
+                    goto foundIdx;
+                }
+
+                curIdx = (curIdx + i) & SharedSizeMask;
+            }
+
+            // or pick a random victim within the bucket range
+            // and replace with new entry
+            int i1 = SharedNextRandom() & SharedBucketSizeMask;
+            idx = (idx + ((i1 * i1 + i1) / 2)) & SharedSizeMask;
+
+            foundIdx:
+            arr[idx].HashCode = hashCode;
+            Volatile.Write(ref arr[idx].Text, text);
+        }
+
+        private static int LocalIdxFromHash(int hash)
+        {
+            return hash & LocalSizeMask;
+        }
+
+        private static int SharedIdxFromHash(int hash)
+        {
+            // we can afford to mix some more hash bits here
+            return (hash ^ (hash >> LocalSizeBits)) & SharedSizeMask;
+        }
+
+        private int LocalNextRandom()
+        {
+            return _localRandom++;
+        }
+
+        private static int SharedNextRandom()
+        {
+            return Interlocked.Increment(ref s_sharedRandom);
+        }
+
+        internal static bool TextEquals(string array, string text, int start, int length)
+        {
+            if (array.Length != length)
+            {
+                return false;
+            }
+
+            // use array.Length to eliminate the range check
+            for (int i = 0; i < array.Length; i++)
+            {
+                if (array[i] != text[start + i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        internal static bool TextEquals(string array, StringBuilder text)
+        {
+            if (array.Length != text.Length)
+            {
+                return false;
+            }
+
+            // interestingly, stringbuilder holds the list of chunks by the tail
+            // so accessing positions at the beginning may cost more than those at the end.
+            for (int i = array.Length - 1; i >= 0; i--)
+            {
+                if (array[i] != text[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        internal static bool TextEqualsASCII(string text, ReadOnlySpan<byte> ascii)
+        {
+            if (ascii.Length != text.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < ascii.Length; i++)
+            {
+                if (ascii[i] != text[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        internal static bool TextEquals(string array, ReadOnlySpan<char> text)
+            => text.Equals(array.AsSpan(), StringComparison.Ordinal);
+
+
+        /// <summary>
+        /// The offset bias value used in the FNV-1a algorithm
+        /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+        /// </summary>
+        private const int FnvOffsetBias = unchecked((int)2166136261);
+
+        /// <summary>
+        /// The generative factor used in the FNV-1a algorithm
+        /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+        /// </summary>
+        private const int FnvPrime = 16777619;
+
+        /// <summary>
+        /// Compute the hashcode of a sub-string using FNV-1a
+        /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+        /// Note: FNV-1a was developed and tuned for 8-bit sequences. We're using it here
+        /// for 16-bit Unicode chars on the understanding that the majority of chars will
+        /// fit into 8-bits and, therefore, the algorithm will retain its desirable traits
+        /// for generating hash codes.
+        /// </summary>
+        /// <param name="text">The input string</param>
+        /// <param name="start">The start index of the first character to hash</param>
+        /// <param name="length">The number of characters, beginning with <paramref name="start"/> to hash</param>
+        /// <returns>The FNV-1a hash code of the substring beginning at <paramref name="start"/> and ending after <paramref name="length"/> characters.</returns>
+        private static int GetFNVHashCode(string text, int start, int length)
+        {
+            int hashCode = FnvOffsetBias;
+            int end = start + length;
+
+            for (int i = start; i < end; i++)
+            {
+                hashCode = unchecked((hashCode ^ text[i]) * FnvPrime);
+            }
+
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Compute the hashcode of a sub-string using FNV-1a
+        /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+        /// Note: FNV-1a was developed and tuned for 8-bit sequences. We're using it here
+        /// for 16-bit Unicode chars on the understanding that the majority of chars will
+        /// fit into 8-bits and, therefore, the algorithm will retain its desirable traits
+        /// for generating hash codes.
+        /// </summary>
+        /// <param name="text">The input string</param>
+        /// <param name="start">The start index of the first character to hash</param>
+        /// <param name="length">The number of characters, beginning with <paramref name="start"/> to hash</param>
+        /// <returns>The FNV-1a hash code of the substring beginning at <paramref name="start"/> and ending after <paramref name="length"/> characters.</returns>
+        private static int GetFNVHashCode(char[] text, int start, int length)
+        {
+            int hashCode = FnvOffsetBias;
+            int end = start + length;
+
+            for (int i = start; i < end; i++)
+            {
+                hashCode = unchecked((hashCode ^ text[i]) * FnvPrime);
+            }
+
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Compute the hashcode of a string using FNV-1a
+        /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+        /// </summary>
+        /// <param name="text">The input string</param>
+        /// <returns>The FNV-1a hash code of <paramref name="text"/></returns>
+        private static int GetFNVHashCode(string text)
+        {
+            return CombineFNVHash(FnvOffsetBias, text);
+        }
+
+        /// <summary>
+        /// Compute the FNV-1a hash of a sequence of bytes and determines if the byte
+        /// sequence is valid ASCII and hence the hash code matches a char sequence
+        /// encoding the same text.
+        /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+        /// </summary>
+        /// <param name="data">The sequence of bytes that are likely to be ASCII text.</param>
+        /// <param name="isAscii">True if the sequence contains only characters in the ASCII range.</param>
+        /// <returns>The FNV-1a hash of <paramref name="data"/></returns>
+        private static int GetFNVHashCode(ReadOnlySpan<byte> data, out bool isAscii)
+        {
+            int hashCode = FnvOffsetBias;
+
+            byte asciiMask = 0;
+
+            for (int i = 0; i < data.Length; i++)
+            {
+                byte b = data[i];
+                asciiMask |= b;
+                hashCode = unchecked((hashCode ^ b) * FnvPrime);
+            }
+
+            isAscii = (asciiMask & 0x80) == 0;
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Compute the hashcode of a string using FNV-1a
+        /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+        /// </summary>
+        /// <param name="text">The input string</param>
+        /// <returns>The FNV-1a hash code of <paramref name="text"/></returns>
+        private static int GetFNVHashCode(StringBuilder text)
+        {
+            int hashCode = FnvOffsetBias;
+            int end = text.Length;
+
+            for (int i = 0; i < end; i++)
+            {
+                hashCode = unchecked((hashCode ^ text[i]) * FnvPrime);
+            }
+
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Compute the hashcode of a single character using the FNV-1a algorithm
+        /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+        /// Note: In general, this isn't any more useful than "char.GetHashCode". However,
+        /// it may be needed if you need to generate the same hash code as a string or
+        /// substring with just a single character.
+        /// </summary>
+        /// <param name="ch">The character to hash</param>
+        /// <returns>The FNV-1a hash code of the character.</returns>
+        private static int GetFNVHashCode(char ch)
+        {
+            return CombineFNVHash(FnvOffsetBias, ch);
+        }
+
+        /// <summary>
+        /// Combine a string with an existing FNV-1a hash code
+        /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+        /// </summary>
+        /// <param name="hashCode">The accumulated hash code</param>
+        /// <param name="text">The string to combine</param>
+        /// <returns>The result of combining <paramref name="hashCode"/> with <paramref name="text"/> using the FNV-1a algorithm</returns>
+        private static int CombineFNVHash(int hashCode, string text)
+        {
+            foreach (char ch in text)
+            {
+                hashCode = unchecked((hashCode ^ ch) * FnvPrime);
+            }
+
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Combine a char with an existing FNV-1a hash code
+        /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+        /// </summary>
+        /// <param name="hashCode">The accumulated hash code</param>
+        /// <param name="ch">The new character to combine</param>
+        /// <returns>The result of combining <paramref name="hashCode"/> with <paramref name="ch"/> using the FNV-1a algorithm</returns>
+        private static int CombineFNVHash(int hashCode, char ch)
+        {
+            return unchecked((hashCode ^ ch) * FnvPrime);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/StringTable.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/StringTable.cs
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio.Buffers.PooledObjects
         }
 
         private readonly ObjectPool<StringTable>? _pool;
-        private static readonly ObjectPool<StringTable> s_staticPool = CreatePool();
+        private static ObjectPool<StringTable> s_staticPool = CreatePool();
 
         private static ObjectPool<StringTable> CreatePool()
         {
@@ -84,8 +84,12 @@ namespace Microsoft.VisualStudio.Buffers.PooledObjects
 
         public void Free()
         {
-            // leave cache content in the cache, just return it to the pool
+            _pool?.Free(this);
+        }
 
+        public void ClearAll()
+        {
+            s_staticPool = CreatePool();
             _pool?.Free(this);
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/StringTableLifetimeService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/StringTableLifetimeService.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.ProjectSystem;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.Buffers.PooledObjects
+{
+    /// <summary>
+    /// Ensures that the string table will release all its strings when the solution is unloads all .NET projects
+    /// </summary>
+    [Export(typeof(IImplicitlyActiveService))]
+    [AppliesTo(ProjectCapability.DotNet)]
+    internal class StringTableLifetimeService : AbstractMultiLifetimeComponent<StringTableLifetimeService.Instance>, IImplicitlyActiveService
+    {
+        private Instance? _instance;
+
+        public StringTableLifetimeService(JoinableTaskContextNode joinableTaskContextNode)
+            : base(joinableTaskContextNode)
+        {
+        }
+
+        public Task ActivateAsync()
+        {
+            if (_instance is null)
+            {
+                CreateInstance();
+            }
+         
+            return _instance!.InitializeAsync();
+        }
+
+        public Task DeactivateAsync()
+        {
+            if (_instance != null)
+            {
+                return _instance.DisposeAsync();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        protected override Instance CreateInstance()
+        {
+            _instance = new Instance();
+            return _instance;
+        }
+
+        internal class Instance : IMultiLifetimeInstance
+        {
+            public StringTable? StringTable { get; private set; }
+
+            public Task InitializeAsync()
+            {
+                StringTable = StringTable.GetInstance();
+                return Task.CompletedTask;
+            }
+
+            public Task DisposeAsync()
+            {
+                StringTable?.ClearAll();
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Dependency.cs
@@ -357,7 +357,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             sb.Replace('/', '\\', offset, modelId.Length);
             sb.Replace("..", "__", offset, modelId.Length);
             sb.TrimEnd(Delimiter.BackSlash);
-            return sb.ToStringAndFree();
+            return string.Intern(sb.ToStringAndFree());
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Dependency.cs
@@ -357,13 +357,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             sb.Replace('/', '\\', offset, modelId.Length);
             sb.Replace("..", "__", offset, modelId.Length);
             sb.TrimEnd(Delimiter.BackSlash);
-            return Intern(sb.ToStringAndFree());
-        }
-
-        private static string Intern(string s)
-        {
-            var st = StringTable.GetInstance();
-            return st.Add(s);
+            return sb.InternStringAndFree();
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Dependency.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.Collections.Immutable;
-
+using System.Runtime.CompilerServices;
 using Microsoft.VisualStudio.Buffers.PooledObjects;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models;
 using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
@@ -357,7 +357,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             sb.Replace('/', '\\', offset, modelId.Length);
             sb.Replace("..", "__", offset, modelId.Length);
             sb.TrimEnd(Delimiter.BackSlash);
-            return string.Intern(sb.ToStringAndFree());
+            return Intern(sb.ToStringAndFree());
+        }
+
+        private static string Intern(string s)
+        {
+            var st = StringTable.GetInstance();
+            return st.Add(s);
         }
     }
 }


### PR DESCRIPTION
potential fix for https://github.com/dotnet/project-system/issues/5051

This uses the same strategy for string interning that roslyn does in the parser.

A few notes:

1. checks if the `char` array present in the `PooledStringBuilder` has already been interned, this should be the main source of improvements ([here](https://github.com/jmarolf/project-system/blob/d8432c42b42f3a9cc34baffe31dc2a343dce0b1c/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/StringTable.cs#L195))
2. Uses our pooled objects class so if every thread needs to intern a string we will have enough objects without needing to lock.  Using this approach, under heavy contention some strings will be interned multiple times. May re-write this to just use a single global `StringTable` that is held under lock.  Will need to investigate perf via ETL trace.
3. ~~The set of interned strings is never cleared.  I should probably add an implicitly active component that releases all strings once no .NET projects are loaded in VS.~~ fixed this in https://github.com/dotnet/project-system/pull/5052/commits/4805b75161df4c1067850e07bd01adf0d91ebd15