### PR TITLE
Add MyType property

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -174,6 +174,9 @@
     </StringProperty.DataSource>
   </StringProperty>
 
+  <StringProperty Name="MyType"
+                  Visible="False" />
+
   <StringProperty Name="Name"
                   Visible="False" />
 


### PR DESCRIPTION
For the VB MyApplication model we need to support the `MyType` property from our browse object. This is currently retrieved by the property pages via the `VBProjectProperties3` interface, which CPS doesn't implement, so this PR adds a fallback to use `ICustomTypeDescriptor`.

Legacy only uses `VBProjectProperties3` for the `MyType` and `MyApplication` properties, and I couldn't find any other consumers, so actually doing the work to allow CPS to implement various project properties interfaces is overkill at the moment (The `MyApplication` property support was already added for #4708 and just needs to be turned on for CPS projects when ready).

Fixes #5046