### PR TITLE
Remove Text.Analyzers

### DIFF
--- a/build/Packages.targets
+++ b/build/Packages.targets
@@ -109,7 +109,6 @@
     <PackageReference Update="Microsoft.NetFramework.Analyzers" Version="2.9.3" />
     <PackageReference Update="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="2.9.3" />
     <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="2.9.3" />
-    <PackageReference Update="Text.Analyzers" Version="2.6.4" />
     <PackageReference Update="Roslyn.Diagnostics.Analyzers" Version="2.9.4-beta1.final" />
 
     <!-- NuGet -->

--- a/src/HostAgnostic.props
+++ b/src/HostAgnostic.props
@@ -27,7 +27,6 @@
     <PackageReference Include="Microsoft.CodeQuality.Analyzers" />
     <PackageReference Include="Microsoft.NetFramework.Analyzers" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" />
-    <PackageReference Include="Text.Analyzers" />
     
 
     <!-- MSBuild -->


### PR DESCRIPTION
Fixes: https://github.com/dotnet/project-system/issues/4933

These are deprecated.

Microsoft.CodeQuality.Analyzers.Exp were already removed.