### PR TITLE
Rename the "NuGet" dependencies node to "Packages"

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.Designer.cs
@@ -151,11 +151,11 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to NuGet.
+        ///   Looks up a localized string similar to Packages.
         /// </summary>
-        internal static string NuGetPackagesNodeName {
+        internal static string PackagesNodeName {
             get {
-                return ResourceManager.GetString("NuGetPackagesNodeName", resourceCulture);
+                return ResourceManager.GetString("PackagesNodeName", resourceCulture);
             }
         }
         

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.resx
@@ -146,8 +146,8 @@
   <data name="FrameworkAssembliesNodeName" xml:space="preserve">
     <value>Framework Assemblies</value>
   </data>
-  <data name="NuGetPackagesNodeName" xml:space="preserve">
-    <value>NuGet</value>
+  <data name="PackagesNodeName" xml:space="preserve">
+    <value>Packages</value>
   </data>
   <data name="ProjectsNodeName" xml:space="preserve">
     <value>Projects</value>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
         private static readonly SubTreeRootDependencyModel s_rootModel = new SubTreeRootDependencyModel(
             ProviderTypeString,
-            Resources.NuGetPackagesNodeName,
+            Resources.PackagesNodeName,
             s_iconSet,
             DependencyTreeFlags.NuGetSubTreeRootNode);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
@@ -47,11 +47,6 @@
         <target state="translated">Sestavení rozhraní</target>
         <note />
       </trans-unit>
-      <trans-unit id="NuGetPackagesNodeName">
-        <source>NuGet</source>
-        <target state="translated">NuGet</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ProjectsNodeName">
         <source>Projects</source>
         <target state="translated">Projekty</target>
@@ -65,6 +60,11 @@
       <trans-unit id="FrameworkNodeName">
         <source>Frameworks</source>
         <target state="new">Frameworks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagesNodeName">
+        <source>Packages</source>
+        <target state="new">Packages</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
@@ -47,11 +47,6 @@
         <target state="translated">Frameworkassemblys</target>
         <note />
       </trans-unit>
-      <trans-unit id="NuGetPackagesNodeName">
-        <source>NuGet</source>
-        <target state="translated">NuGet</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ProjectsNodeName">
         <source>Projects</source>
         <target state="translated">Projekte</target>
@@ -65,6 +60,11 @@
       <trans-unit id="FrameworkNodeName">
         <source>Frameworks</source>
         <target state="new">Frameworks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagesNodeName">
+        <source>Packages</source>
+        <target state="new">Packages</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
@@ -47,11 +47,6 @@
         <target state="translated">Ensamblados de plataforma</target>
         <note />
       </trans-unit>
-      <trans-unit id="NuGetPackagesNodeName">
-        <source>NuGet</source>
-        <target state="translated">NuGet</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ProjectsNodeName">
         <source>Projects</source>
         <target state="translated">Proyectos</target>
@@ -65,6 +60,11 @@
       <trans-unit id="FrameworkNodeName">
         <source>Frameworks</source>
         <target state="new">Frameworks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagesNodeName">
+        <source>Packages</source>
+        <target state="new">Packages</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
@@ -47,11 +47,6 @@
         <target state="translated">Assemblys de framework</target>
         <note />
       </trans-unit>
-      <trans-unit id="NuGetPackagesNodeName">
-        <source>NuGet</source>
-        <target state="translated">NuGet</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ProjectsNodeName">
         <source>Projects</source>
         <target state="translated">Projets</target>
@@ -65,6 +60,11 @@
       <trans-unit id="FrameworkNodeName">
         <source>Frameworks</source>
         <target state="new">Frameworks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagesNodeName">
+        <source>Packages</source>
+        <target state="new">Packages</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
@@ -47,11 +47,6 @@
         <target state="translated">Assembly del framework</target>
         <note />
       </trans-unit>
-      <trans-unit id="NuGetPackagesNodeName">
-        <source>NuGet</source>
-        <target state="translated">NuGet</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ProjectsNodeName">
         <source>Projects</source>
         <target state="translated">Progetti</target>
@@ -65,6 +60,11 @@
       <trans-unit id="FrameworkNodeName">
         <source>Frameworks</source>
         <target state="new">Frameworks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagesNodeName">
+        <source>Packages</source>
+        <target state="new">Packages</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
@@ -47,11 +47,6 @@
         <target state="translated">フレームワーク アセンブリ</target>
         <note />
       </trans-unit>
-      <trans-unit id="NuGetPackagesNodeName">
-        <source>NuGet</source>
-        <target state="translated">NuGet</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ProjectsNodeName">
         <source>Projects</source>
         <target state="translated">プロジェクト</target>
@@ -65,6 +60,11 @@
       <trans-unit id="FrameworkNodeName">
         <source>Frameworks</source>
         <target state="new">Frameworks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagesNodeName">
+        <source>Packages</source>
+        <target state="new">Packages</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
@@ -47,11 +47,6 @@
         <target state="translated">프레임워크 어셈블리</target>
         <note />
       </trans-unit>
-      <trans-unit id="NuGetPackagesNodeName">
-        <source>NuGet</source>
-        <target state="translated">NuGet</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ProjectsNodeName">
         <source>Projects</source>
         <target state="translated">프로젝트</target>
@@ -65,6 +60,11 @@
       <trans-unit id="FrameworkNodeName">
         <source>Frameworks</source>
         <target state="new">Frameworks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagesNodeName">
+        <source>Packages</source>
+        <target state="new">Packages</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
@@ -47,11 +47,6 @@
         <target state="translated">Zestawy platformy</target>
         <note />
       </trans-unit>
-      <trans-unit id="NuGetPackagesNodeName">
-        <source>NuGet</source>
-        <target state="translated">NuGet</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ProjectsNodeName">
         <source>Projects</source>
         <target state="translated">Projekty</target>
@@ -65,6 +60,11 @@
       <trans-unit id="FrameworkNodeName">
         <source>Frameworks</source>
         <target state="new">Frameworks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagesNodeName">
+        <source>Packages</source>
+        <target state="new">Packages</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
@@ -47,11 +47,6 @@
         <target state="translated">Assemblies do Framework</target>
         <note />
       </trans-unit>
-      <trans-unit id="NuGetPackagesNodeName">
-        <source>NuGet</source>
-        <target state="translated">NuGet</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ProjectsNodeName">
         <source>Projects</source>
         <target state="translated">Projetos</target>
@@ -65,6 +60,11 @@
       <trans-unit id="FrameworkNodeName">
         <source>Frameworks</source>
         <target state="new">Frameworks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagesNodeName">
+        <source>Packages</source>
+        <target state="new">Packages</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
@@ -47,11 +47,6 @@
         <target state="translated">Сборки платформы</target>
         <note />
       </trans-unit>
-      <trans-unit id="NuGetPackagesNodeName">
-        <source>NuGet</source>
-        <target state="translated">NuGet</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ProjectsNodeName">
         <source>Projects</source>
         <target state="translated">Проекты</target>
@@ -65,6 +60,11 @@
       <trans-unit id="FrameworkNodeName">
         <source>Frameworks</source>
         <target state="new">Frameworks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagesNodeName">
+        <source>Packages</source>
+        <target state="new">Packages</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
@@ -47,11 +47,6 @@
         <target state="translated">Çerçeve Bütünleştirilmiş Kodları</target>
         <note />
       </trans-unit>
-      <trans-unit id="NuGetPackagesNodeName">
-        <source>NuGet</source>
-        <target state="translated">NuGet</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ProjectsNodeName">
         <source>Projects</source>
         <target state="translated">Projeler</target>
@@ -65,6 +60,11 @@
       <trans-unit id="FrameworkNodeName">
         <source>Frameworks</source>
         <target state="new">Frameworks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagesNodeName">
+        <source>Packages</source>
+        <target state="new">Packages</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
@@ -47,11 +47,6 @@
         <target state="translated">框架程序集</target>
         <note />
       </trans-unit>
-      <trans-unit id="NuGetPackagesNodeName">
-        <source>NuGet</source>
-        <target state="translated">NuGet</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ProjectsNodeName">
         <source>Projects</source>
         <target state="translated">项目</target>
@@ -65,6 +60,11 @@
       <trans-unit id="FrameworkNodeName">
         <source>Frameworks</source>
         <target state="new">Frameworks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagesNodeName">
+        <source>Packages</source>
+        <target state="new">Packages</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
@@ -47,11 +47,6 @@
         <target state="translated">架構組件</target>
         <note />
       </trans-unit>
-      <trans-unit id="NuGetPackagesNodeName">
-        <source>NuGet</source>
-        <target state="translated">NuGet</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ProjectsNodeName">
         <source>Projects</source>
         <target state="translated">專案</target>
@@ -65,6 +60,11 @@
       <trans-unit id="FrameworkNodeName">
         <source>Frameworks</source>
         <target state="new">Frameworks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="PackagesNodeName">
+        <source>Packages</source>
+        <target state="new">Packages</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
This is more in keeping with its siblings, such as "Assemblies", "Projects", "Frameworks" and so on.

This change will likely effect localisation, as previously "NuGet" was unmodified in translation files.

![image](https://user-images.githubusercontent.com/350947/61296574-ba9ed480-a81d-11e9-959b-066036d74880.png)

(It's possible "SDK" should become "SDKs" as well.)

Relates to #4362.