### PR TITLE
Prevent NRE in WpfBasedPropertyPage.Dispose

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WpfBasedPropertyPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WpfBasedPropertyPage.cs
@@ -1,18 +1,17 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 using System;
 using System.Threading.Tasks;
 using System.Windows.Controls;
 using System.Windows.Forms;
 
-#nullable disable
-
 namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 {
     internal abstract partial class WpfBasedPropertyPage : PropertyPage
     {
-        private PropertyPageElementHost _host;
-        private PropertyPageControl _control;
-        private PropertyPageViewModel _viewModel;
+        private PropertyPageElementHost? _host;
+        private PropertyPageControl? _control;
+        private PropertyPageViewModel? _viewModel;
 
         protected WpfBasedPropertyPage()
         {
@@ -27,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         {
             if (isClosing)
             {
-                _control.DetachViewModel();
+                _control?.DetachViewModel();
                 return;
             }
             else
@@ -47,7 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 
         protected override Task<int> OnApply()
         {
-            return _control.Apply();
+            return _control?.Apply() ?? Task.FromResult((int)HResult.Fail);
         }
 
         protected override Task OnDeactivate()
@@ -94,6 +93,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 
         private void OnControlStatusChanged(object sender, EventArgs e)
         {
+            if (_control == null)
+            {
+                return;
+            }
+
             if (IsDirty != _control.IsDirty)
             {
                 IsDirty = _control.IsDirty;
@@ -106,7 +110,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             {
                 if (disposing)
                 {
-                    _host.Dispose();
+                    _host?.Dispose();
                 }
             }
             finally


### PR DESCRIPTION
I observed this when closing the property page.

It may have followed a previous bug, as IIRC I double-clicked the project node in Solution Explorer, expecting an editor to appear, and the property page appeared instead.

The assertion failure dialog read:

```text
---------------------------
Assertion Failed: Abort=Quit, Retry=Debug, Ignore=Continue
---------------------------
Dispose

Exception: System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages.WpfBasedPropertyPage.Dispose(Boolean disposing)
   at Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages.PropertyPage.Deactivate()
   at Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageInfo.Dispose(Boolean disposing)
--- End of stack trace from previous location where exception was thrown ---
   at Microsoft.VisualStudio.Telemetry.WindowsErrorReporting.WatsonReport.GetClrWatsonExceptionInfo(Exception exceptionObject)

   at Microsoft.VisualStudio.Editors.AppDesCommon.Utils.ReportWithoutCrash(Exception ex, String exceptionEventDescription, String throwingComponentName)
   at Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageInfo.Dispose(Boolean disposing)
   at Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages.WpfBasedPropertyPage.Dispose(Boolean disposing)
   at Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages.PropertyPage.Deactivate()
   at Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageInfo.Dispose(Boolean disposing)
   at Microsoft.VisualStudio.Editors.ApplicationDesigner.PropertyPageInfo.Dispose()
   at Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerPanel.Dispose(Boolean disposing)
   at System.ComponentModel.Component.Dispose()
   at Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerView.Dispose(Boolean disposing)
   at System.ComponentModel.Component.Dispose()
   at Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerRootDesigner.Dispose(Boolean Disposing)
   at System.ComponentModel.Design.ComponentDesigner.Dispose()
   at System.ComponentModel.Design.DesignerHost.Unload()
   at System.ComponentModel.Design.DesignerHost.DisposeHost()
   at System.ComponentModel.Design.DesignSurface.Dispose(Boolean disposing)
   at Microsoft.VisualStudio.Shell.Design.DesignerWindowPane.Dispose(Boolean disposing)
   at Microsoft.VisualStudio.Shell.Design.DesignerWindowPane.OnClose()
   at Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerWindowPane.OnClose()
   at Microsoft.VisualStudio.Shell.WindowPane.Microsoft.VisualStudio.Shell.Interop.IVsUIElementPane.CloseUIElementPane()
   at Microsoft.VisualStudio.Platform.WindowManagement.UIElementDocumentObject.<DisposeManagedResources>b__22_0()
   at Microsoft.VisualStudio.ErrorHandler.CallWithCOMConvention(Action method, Boolean reportError)
   at Microsoft.VisualStudio.Platform.WindowManagement.UIElementDocumentObject.DisposeManagedResources()
   at Microsoft.VisualStudio.PlatformUI.DisposableObject.Dispose(Boolean disposing)
   at Microsoft.VisualStudio.PlatformUI.DisposableObject.Dispose()
   at Microsoft.VisualStudio.Platform.WindowManagement.WindowFrame.DisposeManagedResources()
   at Microsoft.VisualStudio.PlatformUI.DisposableObject.Dispose(Boolean disposing)
   at Microsoft.VisualStudio.Platform.WindowManagement.WindowFrame.<>c__DisplayClass460_0.<CloseFrame>b__0()
   at Microsoft.VisualStudio.ErrorHandler.CallWithCOMConvention(Func`1 method, Boolean reportError, Boolean setShellErrorInfo)
   at Microsoft.VisualStudio.Platform.WindowManagement.WindowFrame.CloseFrame(__FRAMECLOSE frameClose)
   at Microsoft.VisualStudio.Platform.WindowManagement.WindowFrame.frameView_Hiding(Object sender, CancelEventArgs e)
   at Microsoft.VisualStudio.PlatformUI.ExtensionMethods.RaiseEvent(CancelEventHandler eventHandler, Object source, CancelEventArgs args)
   at Microsoft.VisualStudio.PlatformUI.Shell.View.RaiseHiding()
   at Microsoft.VisualStudio.PlatformUI.Shell.View.Hide()
   at Microsoft.VisualStudio.PlatformUI.Shell.ViewManager.OnHideViewCore(ViewElement closingViewElement, Boolean hideOnlyActiveView)
   at Microsoft.VisualStudio.PlatformUI.Shell.ViewManager.OnHideView(Object sender, ExecutedRoutedEventArgs args)
   at Microsoft.VisualStudio.PlatformUI.Shell.ViewManager.<>c.<.cctor>b__24_9(Object sender, ExecutedRoutedEventArgs args)
   at System.Windows.Input.CommandBinding.OnExecuted(Object sender, ExecutedRoutedEventArgs e)
   at System.Windows.Input.CommandManager.ExecuteCommandBinding(Object sender, ExecutedRoutedEventArgs e, CommandBinding commandBinding)
   at System.Windows.Input.CommandManager.FindCommandBinding(Object sender, RoutedEventArgs e, ICommand command, Boolean execute)
   at System.Windows.Input.CommandManager.OnExecuted(Object sender, ExecutedRoutedEventArgs e)
   at System.Windows.UIElement.OnExecutedThunk(Object sender, ExecutedRoutedEventArgs e)
   at System.Windows.Input.ExecutedRoutedEventArgs.InvokeEventHandler(Delegate genericHandler, Object target)
   at System.Windows.RoutedEventArgs.InvokeHandler(Delegate handler, Object target)
   at System.Windows.RoutedEventHandlerInfo.InvokeHandler(Object target, RoutedEventArgs routedEventArgs)
   at System.Windows.EventRoute.InvokeHandlersImpl(Object source, RoutedEventArgs args, Boolean reRaised)
   at System.Windows.UIElement.RaiseEventImpl(DependencyObject sender, RoutedEventArgs args)
   at System.Windows.UIElement.RaiseEvent(RoutedEventArgs args, Boolean trusted)
   at System.Windows.Input.RoutedCommand.ExecuteImpl(Object parameter, IInputElement target, Boolean userInitiated)
   at System.Windows.Input.RoutedCommand.Execute(Object parameter, IInputElement target)
   at Microsoft.VisualStudio.Platform.WindowManagement.DocumentTabItemStyle.OnMouseDown(Object sender, MouseButtonEventArgs e)
   at System.Windows.Input.MouseButtonEventArgs.InvokeEventHandler(Delegate genericHandler, Object genericTarget)
   at System.Windows.RoutedEventArgs.InvokeHandler(Delegate handler, Object target)
   at System.Windows.RoutedEventHandlerInfo.InvokeHandler(Object target, RoutedEventArgs routedEventArgs)
   at System.Windows.EventRoute.InvokeHandlersImpl(Object source, RoutedEventArgs args, Boolean reRaised)
   at System.Windows.UIElement.RaiseEventImpl(DependencyObject sender, RoutedEventArgs args)
   at System.Windows.UIElement.RaiseTrustedEvent(RoutedEventArgs args)
   at System.Windows.UIElement.RaiseEvent(RoutedEventArgs args, Boolean trusted)
   at System.Windows.Input.InputManager.ProcessStagingArea()
   at System.Windows.Input.InputManager.ProcessInput(InputEventArgs input)
   at System.Windows.Input.InputProviderSite.ReportInput(InputReport inputReport)
   at System.Windows.Interop.HwndMouseInputProvider.ReportInput(IntPtr hwnd, InputMode mode, Int32 timestamp, RawMouseActions actions, Int32 x, Int32 y, Int32 wheel)
   at System.Windows.Interop.HwndMouseInputProvider.FilterMessage(IntPtr hwnd, WindowMessage msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at System.Windows.Interop.HwndSource.InputFilterMessage(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at MS.Win32.HwndWrapper.WndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at MS.Win32.HwndSubclass.DispatcherCallbackOperation(Object o)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
   at System.Windows.Threading.Dispatcher.LegacyInvokeImpl(DispatcherPriority priority, TimeSpan timeout, Delegate method, Object args, Int32 numArgs)
   at MS.Win32.HwndSubclass.SubclassWndProc(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam)

---------------------------
Abort   Retry   Ignore   
---------------------------
```