### PR TITLE
Remove double-writes in the build

### DIFF
--- a/build/Packages.targets
+++ b/build/Packages.targets
@@ -83,6 +83,10 @@
     <PackageReference Update="EnvDTE80" Version="8.0.1" />
     <PackageReference Update="EnvDTE90" Version="9.0.1" />
     <PackageReference Update="StreamJsonRpc" Version="2.0.167" />
+    
+    <!-- Avoid double-writes, can remove when https://github.com/NuGet/Home/issues/8343 is fixed -->
+    <PackageReference Include="VSSDK.DTE" Version="7.0.4" ExcludeAssets="All" />
+    <PackageReference Include="VSSDK.TemplateWizardInterface" Version="12.0.4" ExcludeAssets="All" />
 
     <!-- VS Editor APIs -->
     <PackageReference Update="Microsoft.VisualStudio.CoreUtility" Version="16.0.177-g0ae5fa46a1" />


### PR DESCRIPTION
VSSDK.DTE/VSSDK.TemplateWizardInterface are non-official Microsoft packages that NuGet.VisualStudio has taken a dependency on. These packages contain the same dlls as other packages. I've asked them to remove the dependency but in the meantime avoid using assets from those packages.

Fixes: https://github.com/dotnet/project-system/issues/4802.