### PR TITLE
Don't fire a change when a new file is being watched.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsAsyncFileChangeExMock.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsAsyncFileChangeExMock.cs
@@ -13,11 +13,16 @@ namespace Microsoft.VisualStudio.Shell
     {
         private uint _lastCookie;
         private readonly Dictionary<uint, string> _watchedFiles = new Dictionary<uint, string>();
+        private readonly HashSet<string> _uniqueFilesWatched = new HashSet<string>();
+
+        public IEnumerable<string> UniqueFilesWatched => _uniqueFilesWatched;
 
         public IEnumerable<string> WatchedFiles => _watchedFiles.Values;
 
         public Task<uint> AdviseFileChangeAsync(string filename, _VSFILECHANGEFLAGS filter, IVsFreeThreadedFileChangeEvents2 sink, CancellationToken cancellationToken = default)
         {
+            _uniqueFilesWatched.Add(filename);
+
             uint cookie = _lastCookie++;
             _watchedFiles.Add(cookie, filename);
             return System.Threading.Tasks.Task.FromResult(cookie);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
@@ -104,7 +104,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                 }
             }
 
-            var newFiles = new List<string>();
             // Now watch and output files that are new
             foreach (string file in allFiles)
             {
@@ -114,15 +113,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                     uint cookie = await vsAsyncFileChangeEx.AdviseFileChangeAsync(file, _VSFILECHANGEFLAGS.VSFILECHG_Time | _VSFILECHANGEFLAGS.VSFILECHG_Size, sink: this);
 
                     _fileWatcherCookies.Add(file, cookie);
-
-                    // Advise of an addition now
-                    newFiles.Add(file);
                 }
-            }
-
-            if (newFiles.Count > 0)
-            {
-                PostToOutput(newFiles.ToArray());
             }
         }
 


### PR DESCRIPTION
The compiler (which you haven't seen yet) makes a lot more sense when the file watcher just watches.