### PR TITLE
Create a TempPE Compiler Manager

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ConfiguredProjectServicesFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ConfiguredProjectServicesFactory.cs
@@ -15,7 +15,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
                                                        IProjectSubscriptionService projectSubscriptionService = null,
                                                        IProjectPropertiesProvider projectPropertiesProvider = null,
                                                        IProjectService projectService = null,
-                                                       IProjectThreadingService threadingService = null)
+                                                       IProjectThreadingService threadingService = null,
+                                                       IProjectAsynchronousTasksService projectAsynchronousTasksService = null)
         {
             var mock = new Mock<ConfiguredProjectServices>();
             mock.Setup(c => c.PropertyPagesCatalog).Returns(propertyPagesCatalogProvider);
@@ -23,6 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             mock.Setup(c => c.ProjectSubscription).Returns(projectSubscriptionService);
             mock.Setup(c => c.ProjectPropertiesProvider).Returns(projectPropertiesProvider);
             mock.Setup(c => c.ThreadingPolicy).Returns(threadingService);
+            mock.Setup(c => c.ProjectAsynchronousTasks).Returns(projectAsynchronousTasksService);
             mock.SetupGet(s => s.ProjectService).Returns(projectService);
             return mock.Object;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/GlobalSuppressions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/GlobalSuppressions.cs
@@ -1,2 +1,5 @@
 ﻿[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1063:Implement IDisposable Correctly", Justification = "<Pending>", Scope = "member", Target = "~M:Microsoft.VisualStudio.Telemetry.TelemetryTestContext.Dispose")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1063:Implement IDisposable Correctly", Justification = "<Pending>", Scope = "type", Target = "~T:Microsoft.VisualStudio.Telemetry.TelemetryTestContext")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1063:Implement IDisposable Correctly", Justification = "<Pending>", Scope = "member", Target = "~M:Microsoft.VisualStudio.ProjectSystem.VS.TempPE.TempPECompilerManagerTests.Dispose")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1063:Implement IDisposable Correctly", Justification = "<Pending>", Scope = "type", Target = "~T:Microsoft.VisualStudio.ProjectSystem.VS.TempPE.TempPECompilerManagerTests")]
+

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IActiveWorkspaceProjectContextHostFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IActiveWorkspaceProjectContextHostFactory.cs
@@ -6,8 +6,6 @@ using System.Threading.Tasks;
 
 using Moq;
 
-#nullable disable
-
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
     internal static class IActiveWorkspaceProjectContextHostFactory
@@ -28,6 +26,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         {
             var accessor = IWorkspaceProjectContextAccessorFactory.ImplementHostSpecificErrorReporter(action);
 
+            return new ActiveWorkspaceProjectContextHost(accessor);
+        }
+
+        public static IActiveWorkspaceProjectContextHost ImplementProjectContextAccessor(IWorkspaceProjectContextAccessor accessor)
+        {
             return new ActiveWorkspaceProjectContextHost(accessor);
         }
 
@@ -54,8 +57,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             {
                 return action(_accessor);
             }
-
-
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsAsyncFileChangeExMock.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsAsyncFileChangeExMock.cs
@@ -13,11 +13,16 @@ namespace Microsoft.VisualStudio.Shell
     {
         private uint _lastCookie;
         private readonly Dictionary<uint, string> _watchedFiles = new Dictionary<uint, string>();
+        private readonly HashSet<string> _uniqueFilesWatched = new HashSet<string>();
+
+        public IEnumerable<string> UniqueFilesWatched => _uniqueFilesWatched;
 
         public IEnumerable<string> WatchedFiles => _watchedFiles.Values;
 
         public Task<uint> AdviseFileChangeAsync(string filename, _VSFILECHANGEFLAGS filter, IVsFreeThreadedFileChangeEvents2 sink, CancellationToken cancellationToken = default)
         {
+            _uniqueFilesWatched.Add(filename);
+
             uint cookie = _lastCookie++;
             _watchedFiles.Add(cookie, filename);
             return System.Threading.Tasks.Task.FromResult(cookie);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/TempPECompilerManagerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/TempPECompilerManagerTests.cs
@@ -1,0 +1,398 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.IO;
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
+
+using Moq;
+
+using Xunit;
+using Xunit.Sdk;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
+{
+    public class TempPECompilerManagerTests
+    {
+        private string? _lastProjectFolder;
+        private string? _lastIntermediateOutputPath;
+        private readonly string _projectFolder = @"C:\MyProject";
+        private string _intermediateOutputPath = "MyOutput";
+        private readonly IFileSystemMock _fileSystem;
+        private readonly TempPECompilerManager _manager;
+        private readonly List<(string OutputFileName, string[] SourceFiles)> _compilationResults = new List<(string, string[])>();
+        private TaskCompletionSource<bool>? _compilationOccurredCompletionSource;
+        private int _expectedCompilations;
+
+        [Fact]
+        public async Task SingleDesignTimeInput_ShouldCompile()
+        {
+            var inputs = new DesignTimeInputs(new string[] { "File1.cs" }, new string[] { });
+
+            await VerifyProjectChangeCausesCompilation(1, inputs);
+
+            Assert.Single(_compilationResults);
+            Assert.Single(_compilationResults[0].SourceFiles);
+            Assert.Contains("File1.cs", _compilationResults[0].SourceFiles);
+            Assert.Equal(Path.Combine(TempPECompilerManager.GetOutputPath(_projectFolder, _intermediateOutputPath), "File1.cs.dll"), _compilationResults[0].OutputFileName);
+        }
+
+        [Fact]
+        public async Task SingleDesignTimeInput_OutputDoesntExist_ShouldCompile()
+        {
+            var inputs = new DesignTimeInputs(new string[] { "File1.cs" }, new string[] { });
+
+            await VerifyProjectChangeCausesCompilation(1, inputs);
+
+            string tempPEDescriptionXml = await _manager.GetDesignTimeInputXML("File1.cs");
+
+            // This also validates that getting the description didn't force a compile, because the output is up to date
+            Assert.Single(_compilationResults);
+            Assert.Single(_compilationResults[0].SourceFiles);
+            Assert.Contains("File1.cs", _compilationResults[0].SourceFiles);
+            Assert.Equal(Path.Combine(TempPECompilerManager.GetOutputPath(_projectFolder, _intermediateOutputPath), "File1.cs.dll"), _compilationResults[0].OutputFileName);
+
+            Assert.Equal(@"<root>
+  <Application private_binpath = ""C:\MyProject\MyOutput\TempPE""/>
+  <Assembly
+    codebase = ""File1.cs.dll""
+    name = ""File1.cs""
+    version = ""0.0.0.0""
+    snapshot_id = ""1""
+    replaceable = ""True""
+  />
+</root>", tempPEDescriptionXml);
+        }
+
+        [Fact]
+        public async Task SingleDesignTimeInput_OutputDoesntExist_ShouldCompileWhenGettingXML()
+        {
+            var inputs = new DesignTimeInputs(new string[] { "File1.cs" }, new string[] { });
+
+            await VerifyProjectChangeCausesCompilation(1, inputs);
+
+            // If the first compile didn't happen, our test results won't be valid
+            Assert.Single(_compilationResults);
+            Assert.Single(_compilationResults[0].SourceFiles);
+            Assert.Contains("File1.cs", _compilationResults[0].SourceFiles);
+            Assert.Equal(Path.Combine(TempPECompilerManager.GetOutputPath(_projectFolder, _intermediateOutputPath), "File1.cs.dll"), _compilationResults[0].OutputFileName);
+
+            // Remove the output file, should mean that getting the XML forces a compile
+            _fileSystem.RemoveFile(Path.Combine(TempPECompilerManager.GetOutputPath(_projectFolder, _intermediateOutputPath), "File1.cs.dll"));
+
+            string tempPEDescriptionXml = await _manager.GetDesignTimeInputXML("File1.cs");
+
+            // Verify a second compile happened
+            Assert.Equal(2, _compilationResults.Count);
+            Assert.Single(_compilationResults[1].SourceFiles);
+            Assert.Contains("File1.cs", _compilationResults[1].SourceFiles);
+            Assert.Equal(Path.Combine(TempPECompilerManager.GetOutputPath(_projectFolder, _intermediateOutputPath), "File1.cs.dll"), _compilationResults[1].OutputFileName);
+
+            Assert.Equal(@"<root>
+  <Application private_binpath = ""C:\MyProject\MyOutput\TempPE""/>
+  <Assembly
+    codebase = ""File1.cs.dll""
+    name = ""File1.cs""
+    version = ""0.0.0.0""
+    snapshot_id = ""1""
+    replaceable = ""True""
+  />
+</root>", tempPEDescriptionXml);
+        }
+
+        [Fact]
+        public async Task SingleDesignTimeInput_Changes_ShouldCompileTwice()
+        {
+            var inputs = new DesignTimeInputs(new string[] { "File1.cs" }, new string[] { });
+
+            await VerifyProjectChangeCausesCompilation(1, inputs);
+
+            await VerifyFileChangeCausesCompilation(1, "File1.cs");
+
+            Assert.Equal(2, _compilationResults.Count);
+            Assert.Single(_compilationResults[0].SourceFiles);
+            Assert.Contains("File1.cs", _compilationResults[0].SourceFiles);
+            Assert.Equal(Path.Combine(TempPECompilerManager.GetOutputPath(_projectFolder, _intermediateOutputPath), "File1.cs.dll"), _compilationResults[0].OutputFileName);
+
+            Assert.Single(_compilationResults[1].SourceFiles);
+            Assert.Contains("File1.cs", _compilationResults[1].SourceFiles);
+            Assert.Equal(Path.Combine(TempPECompilerManager.GetOutputPath(_projectFolder, _intermediateOutputPath), "File1.cs.dll"), _compilationResults[1].OutputFileName);
+        }
+
+        [Fact]
+        public async Task NoDesignTimeInputs_NeverCompiles()
+        {
+            var inputs = new DesignTimeInputs(new string[] { }, new string[] { });
+
+            await VerifyProjectChangeCausesCompilation(0, inputs);
+
+            Assert.Empty(_compilationResults);
+        }
+
+        [Fact]
+        public async Task SingleDesignTimeInput_OutputUpToDate_ShouldntCompile()
+        {
+            _fileSystem.AddFile(Path.Combine(TempPECompilerManager.GetOutputPath(_projectFolder, _intermediateOutputPath), "File1.cs.dll"), DateTime.UtcNow.AddMinutes(10));
+
+            var inputs = new DesignTimeInputs(new string[] { "File1.cs" }, new string[] { });
+
+            await VerifyProjectChangeCausesCompilation(0, inputs);
+
+            Assert.Empty(_compilationResults);
+        }
+
+        [Fact]
+        public async Task SingleDesignTimeInput_OutputOutOfDate_ShouldCompile()
+        {
+            var inputs = new DesignTimeInputs(new string[] { "File1.cs" }, new string[] { });
+
+            _fileSystem.AddFile(Path.Combine(TempPECompilerManager.GetOutputPath(_projectFolder, _intermediateOutputPath), "File1.cs.dll"), DateTime.UtcNow.AddMinutes(-10));
+
+            await VerifyProjectChangeCausesCompilation(1, inputs);
+
+            Assert.Single(_compilationResults);
+            Assert.Single(_compilationResults[0].SourceFiles);
+        }
+
+        [Fact]
+        public async Task TwoDesignTimeInputs_SharedInputChanges_BothCompiled()
+        {
+            var inputs = new DesignTimeInputs(new string[] { "File1.cs", "File2.cs" }, new string[] { "SharedFile.cs" });
+
+            await VerifyProjectChangeCausesCompilation(2, inputs);
+
+            await VerifyFileChangeCausesCompilation(2, "SharedFile.cs");
+
+            Assert.Equal(4, _compilationResults.Count);
+            Assert.Contains("File2.cs", _compilationResults[0].SourceFiles);
+            Assert.DoesNotContain("File1.cs", _compilationResults[0].SourceFiles);
+            Assert.Contains("SharedFile.cs", _compilationResults[0].SourceFiles);
+            Assert.Equal(Path.Combine(TempPECompilerManager.GetOutputPath(_projectFolder, _intermediateOutputPath), "File2.cs.dll"), _compilationResults[0].OutputFileName);
+        }
+
+        [Fact]
+        public async Task SingleDesignTimeInput_Removed_ShouldntCompile()
+        {
+            var inputs = new DesignTimeInputs(new string[] { "File1.cs" }, new string[] { });
+
+            await VerifyDLLsCompiled(0, () =>
+            {
+                SendDesignTimeInputs(inputs);
+
+                SendDesignTimeInputs(new DesignTimeInputs(new string[] { }, new string[] { }));
+            });
+
+            Assert.Empty(_compilationResults);
+        }
+
+        [Fact]
+        public async Task TwoDesignTimeInputs_OutputPathChanged_BothCompiled()
+        {
+            var inputs = new DesignTimeInputs(new string[] { "File1.cs", "File2.cs" }, new string[] { });
+
+            await VerifyProjectChangeCausesCompilation(2, inputs);
+
+            await VerifyProjectChangeCausesCompilation(2, inputs, "NewOutputPath");
+
+            Assert.Equal(4, _compilationResults.Count);
+            Assert.Contains("File2.cs", _compilationResults[0].SourceFiles);
+            Assert.DoesNotContain("File1.cs", _compilationResults[0].SourceFiles);
+        }
+
+
+        [Fact]
+        public async Task NewSharedDesignTimeInput_ModifiedInThePast_ShouldCompileAll()
+        {
+            var inputs = new DesignTimeInputs(new string[] { "File1.cs" }, new string[] { });
+
+            await VerifyProjectChangeCausesCompilation(1, inputs);
+
+            // Add an existing, old, file as a shared input which should cause a compilation even though the DLL is newer than its inputs
+            _fileSystem.AddFile(Path.Combine(_projectFolder, "OldFile.cs"), DateTime.UtcNow.AddMinutes(-10));
+
+            inputs = new DesignTimeInputs(new string[] { "File1.cs" }, new string[] { "OldFile.cs" });
+
+            await VerifyProjectChangeCausesCompilation(1, inputs);
+
+
+            Assert.Equal(2, _compilationResults.Count);
+            Assert.Contains("File1.cs", _compilationResults[0].SourceFiles);
+            Assert.DoesNotContain("OldFile.cs", _compilationResults[0].SourceFiles);
+
+            Assert.Contains("File1.cs", _compilationResults[1].SourceFiles);
+            Assert.Contains("OldFile.cs", _compilationResults[1].SourceFiles);
+        }
+
+        public TempPECompilerManagerTests()
+        {
+            _fileSystem = new IFileSystemMock();
+
+            var services = IProjectCommonServicesFactory.CreateWithDefaultThreadingPolicy();
+            using var designTimeInputsSource = ProjectValueDataSourceFactory.Create<DesignTimeInputs>(services);
+
+            var dataSourceMock = new Mock<IDesignTimeInputsDataSource>();
+            dataSourceMock.SetupGet(s => s.SourceBlock)
+                .Returns(designTimeInputsSource.SourceBlock);
+
+            using var fileWatcherSource = ProjectValueDataSourceFactory.Create<string[]>(services);
+
+            var watcherMock = new Mock<IDesignTimeInputsFileWatcher>();
+            watcherMock.SetupGet(s => s.SourceBlock)
+                .Returns(fileWatcherSource.SourceBlock);
+
+            var threadingService = IProjectThreadingServiceFactory.Create();
+
+            var projectServices = ProjectServicesFactory.Create(threadingService: threadingService, projectLockService: IProjectLockServiceFactory.Create());
+            var projectService = IProjectServiceFactory.Create(projectServices);
+
+            var projectSubscriptionService = IProjectSubscriptionServiceFactory.Create();
+
+            var configuredProjectServices = ConfiguredProjectServicesFactory.Create(projectService: projectService, projectAsynchronousTasksService: IProjectAsynchronousTasksServiceFactory.Create());
+            var configuredProject = ConfiguredProjectFactory.Create(
+                services: configuredProjectServices,
+                unconfiguredProject: UnconfiguredProjectFactory.Create(filePath: Path.Combine(_projectFolder, "Project.csproj")));
+
+            var compilerMock = new Mock<ITempPECompiler>();
+            compilerMock.Setup(c => c.CompileAsync(It.IsAny<IWorkspaceProjectContext>(), It.IsAny<string>(), It.IsAny<ISet<string>>(), It.IsAny<CancellationToken>()))
+                        .Callback((IWorkspaceProjectContext context, string outputFile, ISet<string> filesToCompile, CancellationToken token) => CompilationCallBack(outputFile, filesToCompile))
+                        .ReturnsAsync(true);
+
+            _manager = new TempPECompilerManager(configuredProject,
+                                      projectSubscriptionService,
+                                      IActiveWorkspaceProjectContextHostFactory.ImplementProjectContextAccessor(IWorkspaceProjectContextAccessorFactory.Create()),
+                                      threadingService,
+                                      dataSourceMock.Object,
+                                      watcherMock.Object,
+                                      compilerMock.Object,
+                                      _fileSystem);
+        }
+
+        private void CompilationCallBack(string output, ISet<string> files)
+        {
+            // "Create" our output file
+            _fileSystem.AddFile(output);
+
+            _compilationResults.Add((output, files.Select(f => Path.GetFileName(f)).ToArray()));
+            if (_compilationResults.Count == _expectedCompilations)
+            {
+                _compilationOccurredCompletionSource?.SetResult(true);
+            }
+        }
+
+        private async Task VerifyProjectChangeCausesCompilation(int numberOfDLLsExpected, DesignTimeInputs designTimeInputs, string? intermediateOutputPath = null)
+        {
+            await VerifyDLLsCompiled(numberOfDLLsExpected, () => SendDesignTimeInputs(designTimeInputs, intermediateOutputPath));
+        }
+
+        private async Task VerifyFileChangeCausesCompilation(int numberOfDLLsExpected, params string[] filesToChange)
+        {
+            await VerifyDLLsCompiled(numberOfDLLsExpected, async () => await SendFileChange(filesToChange));
+        }
+
+        private Task VerifyDLLsCompiled(int numberOfDLLs, Action actionThatCausesCompilation)
+        {
+            return VerifyDLLsCompiled(numberOfDLLs, () =>
+            {
+                actionThatCausesCompilation();
+                return Task.CompletedTask;
+            });
+        }
+
+        private async Task VerifyDLLsCompiled(int expectedDLLs, Func<Task> actionThatCausesCompilation)
+        {
+            int initialComplations = _compilationResults.Count;
+            _expectedCompilations = initialComplations + expectedDLLs;
+            _compilationOccurredCompletionSource = new TaskCompletionSource<bool>();
+
+            await actionThatCausesCompilation();
+
+            // Sadly, we need a timeout
+            var delay = Task.Delay(TimeSpan.FromSeconds(1));
+
+            if (await Task.WhenAny(_compilationOccurredCompletionSource.Task, delay) == delay)
+            {
+                var actualDLLs = _compilationResults.Count - initialComplations;
+                if (expectedDLLs != actualDLLs)
+                {
+                    throw new AssertActualExpectedException(expectedDLLs, actualDLLs, "Timed out after 1s");
+                }
+            }
+        }
+
+        private void SendDesignTimeInputs(DesignTimeInputs inputs, string? intermediateOutputPath = null)
+        {
+            _intermediateOutputPath = intermediateOutputPath ?? _intermediateOutputPath;
+
+            var ruleUpdate = @"{
+                                      ""ProjectChanges"": {
+                                          ""ConfigurationGeneral"": {
+                                              ""Difference"": {
+                                                  ""ChangedProperties"": [ ";
+
+            if (_lastProjectFolder != _projectFolder)
+            {
+                ruleUpdate += @"                        ""ProjectDir"",";
+            }
+            if (_lastIntermediateOutputPath != _intermediateOutputPath)
+            {
+                ruleUpdate += @"                        ""IntermediateOutputPath"",";
+            }
+            // root namespace has changed if its the first time we've sent inputs
+            if (_lastProjectFolder == null)
+            {
+                ruleUpdate += @"                        ""RootNamespace""";
+            }
+            ruleUpdate = ruleUpdate.TrimEnd(',');
+            ruleUpdate += @"                      ]
+                                              },
+                                              ""After"": {
+                                                  ""Properties"": {
+                                                      ""ProjectDir"": """ + _projectFolder.Replace("\\", "\\\\") + @""",
+                                                      ""IntermediateOutputPath"": """ + _intermediateOutputPath.Replace("\\", "\\\\") + @""",
+                                                      ""RootNamespace"": ""MyNamespace""
+                                                  }
+                                              }
+                                          }
+                                      }
+                                  }";
+            IProjectSubscriptionUpdate subscriptionUpdate = IProjectSubscriptionUpdateFactory.FromJson(ruleUpdate);
+
+            _lastProjectFolder = _projectFolder;
+            _lastIntermediateOutputPath = _intermediateOutputPath;
+
+            // Ensure our input files are in the mock file system
+            foreach (string file in inputs.Inputs.Concat(inputs.SharedInputs))
+            {
+                var fullFilePath = Path.Combine(_projectFolder, file);
+                if (!_fileSystem.FileExists(fullFilePath))
+                {
+                    _fileSystem.AddFile(fullFilePath);
+                }
+            }
+
+            _manager.ProcessDataflowChanges(new ProjectVersionedValue<Tuple<DesignTimeInputs, IProjectSubscriptionUpdate>>(new Tuple<DesignTimeInputs, IProjectSubscriptionUpdate>(inputs, subscriptionUpdate), ImmutableDictionary<NamedIdentity, IComparable>.Empty));
+        }
+
+        private async Task SendFileChange(params string[] files)
+        {
+            // Short delay so that files are actually newer than any previous output, since tests run fast
+            await Task.Delay(1);
+
+            // Ensure our input files are in, and up to date, in the mock file system
+            foreach (string file in files)
+            {
+                var fullFilePath = Path.Combine(_projectFolder, file);
+                _fileSystem.AddFile(fullFilePath);
+            }
+
+            _manager.ProcessFileChangeNotification(new ProjectVersionedValue<string[]>(files, ImmutableDictionary<NamedIdentity, IComparable>.Empty));
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/TempPECompilerManagerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/TempPECompilerManagerTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 
             await VerifyProjectChangeCausesCompilation(1, inputs);
 
-            string tempPEDescriptionXml = await _manager.GetDesignTimeInputXML("File1.cs");
+            string tempPEDescriptionXml = await _manager.GetDesignTimeInputXmlAsync("File1.cs");
 
             // This also validates that getting the description didn't force a compile, because the output is up to date
             Assert.Single(_compilationResults);
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             // Remove the output file, should mean that getting the XML forces a compile
             _fileSystem.RemoveFile(Path.Combine(TempPECompilerManager.GetOutputPath(_projectFolder, _intermediateOutputPath), "File1.cs.dll"));
 
-            string tempPEDescriptionXml = await _manager.GetDesignTimeInputXML("File1.cs");
+            string tempPEDescriptionXml = await _manager.GetDesignTimeInputXmlAsync("File1.cs");
 
             // Verify a second compile happened
             Assert.Equal(2, _compilationResults.Count);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/TempPECompilerManagerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/TempPECompilerManagerTests.cs
@@ -19,7 +19,7 @@ using Xunit.Sdk;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 {
-    public class TempPECompilerManagerTests
+    public class TempPECompilerManagerTests : IDisposable
     {
         private string? _lastProjectFolder;
         private string? _lastIntermediateOutputPath;
@@ -393,6 +393,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             }
 
             _manager.ProcessFileChangeNotification(new ProjectVersionedValue<string[]>(files, ImmutableDictionary<NamedIdentity, IComparable>.Empty));
+        }
+
+        public void Dispose()
+        {
+            _manager.Dispose();
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
@@ -104,7 +104,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                 }
             }
 
-            var newFiles = new List<string>();
             // Now watch and output files that are new
             foreach (string file in allFiles)
             {
@@ -114,15 +113,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                     uint cookie = await vsAsyncFileChangeEx.AdviseFileChangeAsync(file, _VSFILECHANGEFLAGS.VSFILECHG_Time | _VSFILECHANGEFLAGS.VSFILECHG_Size, sink: this);
 
                     _fileWatcherCookies.Add(file, cookie);
-
-                    // Advise of an addition now
-                    newFiles.Add(file);
                 }
-            }
-
-            if (newFiles.Count > 0)
-            {
-                PostToOutput(newFiles.ToArray());
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/TempPECompilerManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/TempPECompilerManager.cs
@@ -212,21 +212,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 
         protected override async Task DisposeCoreAsync(bool initialized)
         {
-            if (initialized)
+            // This will stop our blocks taking any more input
+            _inputsActionBlock?.Complete();
+            _fileWatcherActionBlock?.Complete();
+
+            if (_inputsActionBlock != null)
             {
-                // This will stop our blocks taking any more input
-                _inputsActionBlock?.Complete();
-                _fileWatcherActionBlock?.Complete();
-
-                if (_inputsActionBlock != null)
-                {
-                    await Task.WhenAll(_inputsActionBlock.Completion, _fileWatcherActionBlock!.Completion);
-                }
-
-                // By waiting for completion we know that the following dispose will cancel any pending compilations, and there won't be any more
-                _scheduler.Dispose();
-                _disposables.Dispose();
+                await Task.WhenAll(_inputsActionBlock.Completion, _fileWatcherActionBlock!.Completion);
             }
+
+            // By waiting for completion we know that the following dispose will cancel any pending compilations, and there won't be any more
+            _scheduler.Dispose();
+            _disposables.Dispose();
         }
 
         private async Task ProcessCompileQueue(CancellationToken token)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/TempPECompilerManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/TempPECompilerManager.cs
@@ -13,7 +13,6 @@ using System.Threading.Tasks.Dataflow;
 using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
-using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using Microsoft.VisualStudio.Threading;
 using Microsoft.VisualStudio.Threading.Tasks;
@@ -205,13 +204,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 
         protected override async Task DisposeCoreAsync(bool initialized)
         {
-            // This will stop our blocks taking any more input
-            _inputsActionBlock?.Complete();
-            _fileWatcherActionBlock?.Complete();
-
             if (_inputsActionBlock != null)
             {
-                await Task.WhenAll(_inputsActionBlock.Completion, _fileWatcherActionBlock!.Completion);
+                // This will stop our blocks taking any more input
+                _inputsActionBlock.Complete();
+                _fileWatcherActionBlock!.Complete();
+
+                await Task.WhenAll(_inputsActionBlock.Completion, _fileWatcherActionBlock.Completion);
             }
 
             // By waiting for completion we know that the following dispose will cancel any pending compilations, and there won't be any more
@@ -252,8 +251,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         /// <summary>
         /// Gets the XML that describes a TempPE DLL, including building it if necessary
         /// </summary>
-        /// <param name="fileName"></param>
-        /// <returns></returns>
+        /// <param name="fileName">A project relative path to a source file that is a design time input</param>
+        /// <returns>An XML description of the TempPE DLL for the specified file</returns>
         public async Task<string> GetDesignTimeInputXmlAsync(string fileName)
         {
             // Make sure we're not being asked to compile a random file

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/TempPECompilerManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/TempPECompilerManager.cs
@@ -1,0 +1,372 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+
+using Microsoft.VisualStudio.IO;
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.Utilities;
+using Microsoft.VisualStudio.Threading;
+using Microsoft.VisualStudio.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
+{
+    internal class TempPECompilerManager : OnceInitializedOnceDisposedAsync
+    {
+        private static readonly TimeSpan s_compilationDelayTime = TimeSpan.FromMilliseconds(500);
+
+        private readonly ConfiguredProject _project;
+        private readonly IProjectSubscriptionService _projectSubscriptionService;
+        private readonly IActiveWorkspaceProjectContextHost _activeWorkspaceProjectContextHost;
+        private readonly IDesignTimeInputsDataSource _inputsDataSource;
+        private readonly IDesignTimeInputsFileWatcher _fileWatcher;
+        private readonly ITempPECompiler _compiler;
+        private readonly IFileSystem _fileSystem;
+        private readonly TaskDelayScheduler _scheduler;
+
+        private readonly DisposableBag _disposables = new DisposableBag();
+
+        private ImmutableArray<string> _designTimeInputs;
+        private ImmutableArray<string> _sharedDesignTimeInputs;
+        private ImmutableDictionary<string, bool> _filesToCompile = ImmutableDictionary<string, bool>.Empty.WithComparers(StringComparers.Paths); // Key is filename, value is whether to ignore the last write time check
+        private string? _outputPath;
+        private readonly TaskCompletionSource<bool> _receivedProjectRuleSource = new TaskCompletionSource<bool>();
+
+        private ITargetBlock<IProjectVersionedValue<Tuple<DesignTimeInputs, IProjectSubscriptionUpdate>>>? _inputsActionBlock;
+        private ITargetBlock<IProjectVersionedValue<string[]>>? _fileWatcherActionBlock;
+
+        [ImportingConstructor]
+        public TempPECompilerManager(ConfiguredProject project,
+                                     IProjectSubscriptionService projectSubscriptionService,
+                                     IActiveWorkspaceProjectContextHost activeWorkspaceProjectContextHost,
+                                     IProjectThreadingService threadingService,
+                                     IDesignTimeInputsDataSource inputsDataSource,
+                                     IDesignTimeInputsFileWatcher fileWatcher,
+                                     ITempPECompiler compiler,
+                                     IFileSystem fileSystem)
+            : base(threadingService.JoinableTaskContext)
+        {
+            _project = project;
+            _projectSubscriptionService = projectSubscriptionService;
+            _activeWorkspaceProjectContextHost = activeWorkspaceProjectContextHost;
+            _inputsDataSource = inputsDataSource;
+            _fileWatcher = fileWatcher;
+            _compiler = compiler;
+            _fileSystem = fileSystem;
+
+            _scheduler = new TaskDelayScheduler(s_compilationDelayTime, threadingService, CancellationToken.None);
+        }
+
+        protected override Task InitializeCoreAsync(CancellationToken cancellationToken)
+        {
+            // Create an action block process the design time inputs and configuration general changes
+            _inputsActionBlock = DataflowBlockSlim.CreateActionBlock<IProjectVersionedValue<Tuple<DesignTimeInputs, IProjectSubscriptionUpdate>>>(ProcessDataflowChanges);
+
+            IDisposable projectLink = ProjectDataSources.SyncLinkTo(
+                   _inputsDataSource.SourceBlock.SyncLinkOptions(
+                       linkOptions: new StandardRuleDataflowLinkOptions
+                       {
+                           PropagateCompletion = true,
+                       }),
+                   _projectSubscriptionService.ProjectRuleSource.SourceBlock.SyncLinkOptions(
+                      linkOptions: new StandardRuleDataflowLinkOptions
+                      {
+                          RuleNames = Empty.OrdinalIgnoreCaseStringSet.Add(ConfigurationGeneral.SchemaName),
+                          PropagateCompletion = true,
+                      }),
+                   _inputsActionBlock,
+                   DataflowOption.PropagateCompletion,
+                   cancellationToken: _project.Services.ProjectAsynchronousTasks.UnloadCancellationToken);
+
+            // Create an action block to process file change notifications
+            _fileWatcherActionBlock = DataflowBlockSlim.CreateActionBlock<IProjectVersionedValue<string[]>>(ProcessFileChangeNotification);
+            IDisposable watcherLink = _fileWatcher.SourceBlock.LinkTo(_fileWatcherActionBlock, DataflowOption.PropagateCompletion);
+
+            _disposables.AddDisposable(projectLink);
+            _disposables.AddDisposable(watcherLink);
+
+            return Task.CompletedTask;
+        }
+
+        internal void ProcessFileChangeNotification(IProjectVersionedValue<string[]> arg)
+        {
+            // Ignore any updates until we've received the first set of design time inputs (which shouldn't happen anyway)
+            // That first update will queue all of the files so we're not losing anything
+            if (_designTimeInputs == null)
+            {
+                return;
+            }
+
+            foreach (string changedFile in arg.Value)
+            {
+                // if a shared input changes, we recompile everything
+                if (_sharedDesignTimeInputs.Contains(changedFile))
+                {
+                    foreach (string file in _designTimeInputs)
+                    {
+                        ImmutableInterlocked.TryAdd(ref _filesToCompile, file, /* ignoreWriteTime */ false);
+                    }
+                    // Since we've just queued every file, we don't care about any other changes
+                    break;
+                }
+                else
+                {
+                    // A normal design time input, so just add it to the queue
+                    ImmutableInterlocked.TryAdd(ref _filesToCompile, changedFile, /* ignoreWriteTime */ false);
+                }
+            }
+
+            QueueCompilation();
+        }
+
+        internal void ProcessDataflowChanges(IProjectVersionedValue<Tuple<DesignTimeInputs, IProjectSubscriptionUpdate>> input)
+        {
+            DesignTimeInputs inputs = input.Value.Item1;
+
+            IProjectChangeDescription configChanges = input.Value.Item2.ProjectChanges[ConfigurationGeneral.SchemaName];
+
+            // On the first call where we receive design time inputs we queue compilation of all of them, knowing that we'll only compile if the file write date requires it
+            if (_designTimeInputs == null)
+            {
+                AddAllInputsToQueue(false);
+            }
+            else
+            {
+                // If its not the first call...
+
+                // If a new shared design time input is added, we need to recompile everything regardless of source file modified date
+                // because it could be an old file that is being promoted to a shared input
+                if (inputs.SharedInputs.Except(_sharedDesignTimeInputs, StringComparers.Paths).Any())
+                {
+                    AddAllInputsToQueue(true);
+                }
+                // If the namespace or output path inputs have changed, then we recompile every file regardless of date
+                else if (configChanges.Difference.ChangedProperties.Contains(ConfigurationGeneral.RootNamespaceProperty) ||
+                         configChanges.Difference.ChangedProperties.Contains(ConfigurationGeneral.ProjectDirProperty) ||
+                         configChanges.Difference.ChangedProperties.Contains(ConfigurationGeneral.IntermediateOutputPathProperty))
+                {
+                    AddAllInputsToQueue(true);
+                }
+                else
+                {
+                    // Otherwise we just queue any new design time inputs, and still do date checks
+                    foreach (string file in inputs.Inputs.Except(_designTimeInputs, StringComparers.Paths))
+                    {
+                        ImmutableInterlocked.TryAdd(ref _filesToCompile, file, /* ignoreWriteTime */ false);
+                    }
+                }
+            }
+
+            // Make sure we have the up to date list of inputs
+            _designTimeInputs = inputs.Inputs;
+            _sharedDesignTimeInputs = inputs.SharedInputs;
+
+            // Make sure we have the up to date output path
+            string basePath = configChanges.After.Properties[ConfigurationGeneral.ProjectDirProperty];
+            string objPath = configChanges.After.Properties[ConfigurationGeneral.IntermediateOutputPathProperty];
+            _outputPath = GetOutputPath(basePath, objPath);
+
+            // Remove any files in the queue that we don't care about any more
+            foreach (string file in _filesToCompile.Keys)
+            {
+                if (!inputs.Inputs.Contains(file))
+                {
+                    ImmutableInterlocked.TryRemove(ref _filesToCompile, file, out _);
+                }
+            }
+
+            _receivedProjectRuleSource.TrySetResult(true);
+
+            QueueCompilation();
+
+            void AddAllInputsToQueue(bool skipFileWriteChecks)
+            {
+                foreach (string file in inputs.Inputs)
+                {
+                    ImmutableInterlocked.TryAdd(ref _filesToCompile, file, skipFileWriteChecks);
+                }
+            }
+        }
+
+        internal static string GetOutputPath(string projectPath, string intermediateOutputPath)
+        {
+            return Path.Combine(projectPath, intermediateOutputPath, "TempPE");
+        }
+
+        private void QueueCompilation()
+        {
+            if (_filesToCompile.Count > 0)
+            {
+                _scheduler.ScheduleAsyncTask(ProcessCompileQueue, _project.Services.ProjectAsynchronousTasks.UnloadCancellationToken);
+            }
+        }
+
+        protected override async Task DisposeCoreAsync(bool initialized)
+        {
+            if (initialized)
+            {
+                // This will stop our blocks taking any more input
+                _inputsActionBlock?.Complete();
+                _fileWatcherActionBlock?.Complete();
+
+                if (_inputsActionBlock != null)
+                {
+                    await Task.WhenAll(_inputsActionBlock.Completion, _fileWatcherActionBlock!.Completion);
+                }
+
+                // By waiting for completion we know that the following dispose will cancel any pending compilations, and there won't be any more
+                _scheduler.Dispose();
+                _disposables.Dispose();
+            }
+        }
+
+        private async Task ProcessCompileQueue(CancellationToken token)
+        {
+            await _activeWorkspaceProjectContextHost.OpenContextForWriteAsync(async accessor =>
+            {
+                // Grab the next file to compile off the queue
+                (string fileName, bool ignoreFileWriteTime) = _filesToCompile.FirstOrDefault();
+                while (fileName != null)
+                {
+                    if (IsDisposing || IsDisposed)
+                    {
+                        return;
+                    }
+
+                    token.ThrowIfCancellationRequested();
+
+                    // Remove the file from our todo list. If it wasn't there (because it was removed as a design time input while we were busy) we don't need to compile it
+                    bool wasInQueue = ThreadingTools.ApplyChangeOptimistically(ref _filesToCompile, fileName, (s, f) => s.Remove(f));
+
+                    string outputFileName = await GetOutputFileName(fileName);
+                    if (wasInQueue)
+                    {
+                        await CompileDesignTimeInput(accessor.Context, fileName, outputFileName, ignoreFileWriteTime, token);
+                    }
+
+                    // Grab another file off the queue
+                    (fileName, ignoreFileWriteTime) = _filesToCompile.FirstOrDefault();
+                }
+            });
+        }
+
+        /// <summary>
+        /// Gets the XML that describes a TempPE DLL, including building it if necessary
+        /// </summary>
+        /// <param name="fileName"></param>
+        /// <returns></returns>
+        public async Task<string> GetDesignTimeInputXML(string fileName)
+        {
+            // Make sure we're not being asked to compile a random file
+            if (!_designTimeInputs.Contains(fileName, StringComparers.Paths))
+            {
+                throw new ArgumentException("Can only get XML snippets for design time inputs", nameof(fileName));
+            }
+
+            // Remove the file from our todo list, in case it was in there.
+            ThreadingTools.ApplyChangeOptimistically(ref _filesToCompile, fileName, (s, f) => s.Remove(f));
+
+            string outputFileName = await GetOutputFileName(fileName);
+            // make sure the file is up to date
+            await _activeWorkspaceProjectContextHost.OpenContextForWriteAsync(async accessor =>
+            {
+                await CompileDesignTimeInput(accessor.Context, fileName, outputFileName, ignoreFileWriteTime: false);
+            });
+
+            return $@"<root>
+  <Application private_binpath = ""{Path.GetDirectoryName(outputFileName)}""/>
+  <Assembly
+    codebase = ""{Path.GetFileName(outputFileName)}""
+    name = ""{fileName}""
+    version = ""0.0.0.0""
+    snapshot_id = ""1""
+    replaceable = ""True""
+  />
+</root>";
+        }
+
+        private async Task CompileDesignTimeInput(IWorkspaceProjectContext context, string designTimeInput, string outputFileName, bool ignoreFileWriteTime, CancellationToken token = default)
+        {
+            HashSet<string> filesToCompile = GetFilesToCompile(designTimeInput);
+
+            if (ignoreFileWriteTime || CompilationNeeded(filesToCompile, outputFileName))
+            {
+                bool result = await _compiler.CompileAsync(context, outputFileName, filesToCompile, token);
+
+                // if the compilation failed or was cancelled we should clean up any old TempPE outputs lest a designer gets the wrong types, plus its what legacy did
+                if (!result)
+                {
+                    try
+                    {
+                        _fileSystem.RemoveFile(outputFileName);
+                    }
+                    catch (IOException)
+                    { }
+                    catch (UnauthorizedAccessException)
+                    { }
+                }
+            }
+        }
+
+        private async Task<string> GetOutputFileName(string designTimeInput)
+        {
+            // Wait until we've received at least one project rule update, or we won't know where to put the file
+            await _receivedProjectRuleSource.Task;
+
+            // All monikers are project relative paths by defintion (anything else is a link, and linked files can't be TempPE inputs), meaning 
+            // the only invalid filename characters possible are path separators so we just replace them
+            return Path.Combine(_outputPath, designTimeInput.Replace('\\', '.') + ".dll");
+        }
+
+        private bool CompilationNeeded(HashSet<string> files, string outputFileName)
+        {
+            if (!_fileSystem.FileExists(outputFileName))
+            {
+                return true;
+            }
+
+            try
+            {
+                DateTime outputDateTime = _fileSystem.LastFileWriteTimeUtc(outputFileName);
+
+                foreach (string file in files)
+                {
+                    DateTime fileDateTime = _fileSystem.LastFileWriteTimeUtc(file);
+                    if (fileDateTime > outputDateTime)
+                        return true;
+                }
+            }
+            // if we can't read the file time of the output file, then we presumably can't compile to it either, so returning false is appropriate.
+            // if we can't read the file time of an input file, then we presumably can't read from it to compile either, so returning false is appropriate
+            catch (IOException)
+            { }
+            catch (UnauthorizedAccessException)
+            { }
+
+            return false;
+        }
+
+        private HashSet<string> GetFilesToCompile(string moniker)
+        {
+            // This is a HashSet because we allow files to be both inputs and shared inputs, and we don't want to compile the same file twice,
+            // plus Roslyn needs to call Contains on this quite a lot in order to ensure its only compiling the right files so we want that to be fast.
+            // When it comes to compiling the files there is no difference between shared and normal design time inputs, we just track differently because
+            // shared are included in every DLL.
+            var files = new HashSet<string>(_sharedDesignTimeInputs.Length + 1, StringComparers.Paths);
+            // All monikers are project relative paths by defintion (anything else is a link, and linked files can't be TempPE inputs) so we can convert
+            // them to full paths using MakeRooted.
+            files.AddRange(_sharedDesignTimeInputs.Select(_project.UnconfiguredProject.MakeRooted));
+            files.Add(_project.UnconfiguredProject.MakeRooted(moniker));
+            return files;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/TempPECompilerManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/TempPECompilerManager.cs
@@ -73,16 +73,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 
             IDisposable projectLink = ProjectDataSources.SyncLinkTo(
                    _inputsDataSource.SourceBlock.SyncLinkOptions(
-                       linkOptions: new StandardRuleDataflowLinkOptions
-                       {
-                           PropagateCompletion = true,
-                       }),
+                       linkOptions: DataflowOption.PropagateCompletion),
                    _projectSubscriptionService.ProjectRuleSource.SourceBlock.SyncLinkOptions(
-                      linkOptions: new StandardRuleDataflowLinkOptions
-                      {
-                          RuleNames = Empty.OrdinalIgnoreCaseStringSet.Add(ConfigurationGeneral.SchemaName),
-                          PropagateCompletion = true,
-                      }),
+                      linkOptions: DataflowOption.WithRuleNames(ConfigurationGeneral.SchemaName)),
                    _inputsActionBlock,
                    DataflowOption.PropagateCompletion,
                    cancellationToken: _project.Services.ProjectAsynchronousTasks.UnloadCancellationToken);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/TempPECompilerManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/TempPECompilerManager.cs
@@ -226,9 +226,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             _disposables.Dispose();
         }
 
-        private async Task ProcessCompileQueue(CancellationToken token)
+        private Task ProcessCompileQueue(CancellationToken token)
         {
-            await _activeWorkspaceProjectContextHost.OpenContextForWriteAsync(async accessor =>
+            return _activeWorkspaceProjectContextHost.OpenContextForWriteAsync(async accessor =>
             {
                 // Grab the next file to compile off the queue
                 (string fileName, bool ignoreFileWriteTime) = _filesToCompile.FirstOrDefault();
@@ -274,9 +274,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 
             string outputFileName = await GetOutputFileName(fileName);
             // make sure the file is up to date
-            await _activeWorkspaceProjectContextHost.OpenContextForWriteAsync(async accessor =>
+            await _activeWorkspaceProjectContextHost.OpenContextForWriteAsync(accessor =>
             {
-                await CompileDesignTimeInput(accessor.Context, fileName, outputFileName, ignoreFileWriteTime: false);
+                return CompileDesignTimeInput(accessor.Context, fileName, outputFileName, ignoreFileWriteTime: false);
             });
 
             return $@"<root>


### PR DESCRIPTION
Contains #5081 so skip the first two commits (or don't they're really small).

This PR contains a class that manages the compilation of TempPE DLLs. It has two dataflow subscriptions:

* One for the design time inputs, and project information, which give it the state that it will be working with
* One for file changes, so it knows when to recompile

The basic idea is that as a design time input is changed or added, the manager collects them in a queue, and then after a short delay it starts running through the whole queue on a background thread. As needed, when more files change, that work is stopped and a new processing task is scheduled. Additionally there is a facility for "I need this now!" which will cause a compile (presumably on the UI thread) if required, without interrupting the queue.