### PR TITLE
Ban StandardRuleDataflowLinkOptions/DataflowLinkOptions

### DIFF
--- a/src/BannedSymbols.txt
+++ b/src/BannedSymbols.txt
@@ -68,3 +68,6 @@ M:Microsoft.VisualStudio.OLE.Interop.Constants.OLECMDERR_E_NOTSUPPORTED;Use HRes
 M:Microsoft.VisualStudio.OLE.Interop.Constants.OLECMDERR_E_UNKNOWNGROUP;Use HResult.Ole.Cmd.UnknownGroup
 
 T:Microsoft.VisualStudio.Shell.ThreadHelper;Import JoinableTaskContext if inside a MEF component for unit testing purposes
+
+T:Microsoft.VisualStudio.ProjectSystem.Properties.StandardRuleDataflowLinkOptions;Use DataflowOption.WithRuleNames to avoid boilerplate initialization
+T:System.Threading.Tasks.Dataflow.DataflowLinkOptions;Use DataflowOption.PropagateCompletion to avoid boilerplate initialization

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/TempPEBuildManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/TempPEBuildManager.cs
@@ -13,7 +13,6 @@ using System.Threading.Tasks.Dataflow;
 using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
-using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.VS.Automation;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Threading;
@@ -402,19 +401,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 
             return ProjectDataSources.SyncLinkTo(
                 _projectSubscriptionService.SourceItemsRuleSource.SourceBlock.SyncLinkOptions(
-                    linkOptions: new StandardRuleDataflowLinkOptions
-                    {
-                        RuleNames = Empty.OrdinalIgnoreCaseStringSet.Add(Compile.SchemaName),
-                        PropagateCompletion = true,
-                    }),
+                    linkOptions: DataflowOption.WithRuleNames(Compile.SchemaName)),
                 _projectSubscriptionService.ProjectRuleSource.SourceBlock.SyncLinkOptions(
-                   linkOptions: new StandardRuleDataflowLinkOptions
-                   {
-                       RuleNames = Empty.OrdinalIgnoreCaseStringSet.Add(ConfigurationGeneral.SchemaName),
-                       PropagateCompletion = true,
-                   }),
+                    linkOptions: DataflowOption.WithRuleNames(ConfigurationGeneral.SchemaName)),
+
                 targetBlock,
-                new DataflowLinkOptions { PropagateCompletion = true },
+                DataflowOption.PropagateCompletion,
                 cancellationToken: ProjectAsynchronousTasksService.UnloadCancellationToken);
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DataflowOption.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DataflowOption.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#pragma warning disable RS0030 // Do not used banned APIs (we are wrapping them)
+
 using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks.Dataflow;


### PR DESCRIPTION
We have wrappers that simplify the boilerplate and make dataflow links easier to read.