### PR TITLE
Fix up-to-date check false negatives

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.State.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.State.cs
@@ -237,6 +237,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                         continue;
                     if (!itemTypesChanged && !projectChange.Difference.AnyChanges)
                         continue;
+                    if (projectChange.After.Items.Count == 0)
+                        continue;
 
                     itemsBuilder[itemType] = projectChange.After.Items.Select(item => (item.Key, GetLink(item.Value), GetCopyType(item.Value))).ToImmutableHashSet(UpToDateCheckItemComparer.Instance);
                     itemsChanged = true;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -209,7 +209,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 return Fail(logger, "Disabled", "The 'DisableFastUpToDateCheck' property is true, not up to date.");
             }
 
-            string copyAlwaysItemPath = state.Items.SelectMany(kvp => kvp.Value).FirstOrDefault(item => item.copyType == CopyToOutputDirectoryType.CopyAlways).path;
+            string copyAlwaysItemPath = state.ItemsByItemType.SelectMany(kvp => kvp.Value).FirstOrDefault(item => item.copyType == CopyToOutputDirectoryType.CopyAlways).path;
 
             if (copyAlwaysItemPath != null)
             {
@@ -235,7 +235,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 yield return state.NewestImportInput;
             }
 
-            foreach ((string itemType, ImmutableHashSet<(string path, string? link, CopyToOutputDirectoryType copyType)> changes) in state.Items)
+            foreach ((string itemType, ImmutableHashSet<(string path, string? link, CopyToOutputDirectoryType copyType)> changes) in state.ItemsByItemType)
             {
                 if (!NonCompilationItemTypes.Contains(itemType))
                 {
@@ -517,7 +517,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
         private bool CheckCopyToOutputDirectoryFiles(BuildUpToDateCheckLogger logger, IDictionary<string, DateTime> timestampCache, State state)
         {
-            IEnumerable<(string path, string? link, CopyToOutputDirectoryType copyType)> items = state.Items.SelectMany(kvp => kvp.Value).Where(item => item.copyType == CopyToOutputDirectoryType.CopyIfNewer);
+            IEnumerable<(string path, string? link, CopyToOutputDirectoryType copyType)> items = state.ItemsByItemType.SelectMany(kvp => kvp.Value).Where(item => item.copyType == CopyToOutputDirectoryType.CopyIfNewer);
 
             string outputFullPath = Path.Combine(state.MSBuildProjectDirectory, state.OutputRelativeOrFullPath);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -58,8 +58,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
         private IDisposable? _link;
 
-        private bool _itemsChangedSinceLastCheck = true;
-
         internal DateTime LastCheckTimeUtc { get; private set; } = DateTime.MinValue;
 
         [ImportingConstructor]
@@ -96,7 +94,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 _state = State.Empty;
 
                 LastCheckTimeUtc = DateTime.MinValue;
-                _itemsChangedSinceLastCheck = true;
 
                 return Task.CompletedTask;
             });
@@ -148,13 +145,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 jointRuleUpdate: e.Value.Item1,
                 sourceItemsUpdate: e.Value.Item2,
                 projectItemSchema: e.Value.Item3,
-                configuredProjectVersion: e.DataSourceVersions[ProjectDataSources.ConfiguredProjectVersion],
-                out bool itemsChanged);
-
-            if (itemsChanged)
-            {
-                _itemsChangedSinceLastCheck = true;
-            }
+                configuredProjectVersion: e.DataSourceVersions[ProjectDataSources.ConfiguredProjectVersion]);
         }
 
         private DateTime? GetTimestampUtc(string path, IDictionary<string, DateTime> timestampCache)
@@ -186,9 +177,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 return false;
             }
 
-            bool itemsChangedSinceLastCheck = _itemsChangedSinceLastCheck;
-            _itemsChangedSinceLastCheck = false;
-
             if (!_tasksService.IsTaskQueueEmpty(ProjectCriticalOperation.Build))
             {
                 return Fail(logger, "CriticalTasks", "Critical build tasks are running, not up to date.");
@@ -197,11 +185,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             if (state.LastVersionSeen == null || _configuredProject.ProjectVersion.CompareTo(state.LastVersionSeen) > 0)
             {
                 return Fail(logger, "ProjectInfoOutOfDate", "Project information is older than current project version, not up to date.");
-            }
-
-            if (itemsChangedSinceLastCheck)
-            {
-                return Fail(logger, "ItemInfoOutOfDate", "The list of source items has changed since the last build, not up to date.");
             }
 
             if (state.IsDisabled)
@@ -381,6 +364,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             if (outputTime != null)
             {
                 Assumes.NotNull(outputPath);
+
+                if (outputTime < state.LastItemChangedAtUtc)
+                {
+                    return Fail(logger, "Outputs", "The inputs were changed more recently ({0}) than the earliest output '{1}' ({2}), not up to date.", state.LastItemChangedAtUtc, outputPath!, outputTime.Value);
+                }
 
                 // Search for an input that's either missing or newer than the earliest output.
                 // As soon as we find one, we can stop the scan.
@@ -618,5 +606,30 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
         public Task<bool> IsUpToDateCheckEnabledAsync(CancellationToken cancellationToken = default) =>
             _projectSystemOptions.GetIsFastUpToDateCheckEnabledAsync(cancellationToken);
+
+        internal readonly struct TestAccessor
+        {
+            private readonly BuildUpToDateCheck _check;
+
+            public TestAccessor(BuildUpToDateCheck check)
+            {
+                _check = check;
+            }
+
+            public State State => _check._state;
+
+            public void SetLastCheckTimeUtc(DateTime lastCheckTimeUtc)
+            {
+                _check.LastCheckTimeUtc = lastCheckTimeUtc;
+            }
+
+            public void SetLastItemChangedAtUtc(DateTime lastItemChangedAtUtc)
+            {
+                _check._state = _check._state.WithLastItemChangedAtUtc(lastItemChangedAtUtc);
+            }
+        }
+
+        /// <summary>For unit testing only.</summary>
+        internal TestAccessor TestAccess => new TestAccessor(this);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -237,7 +237,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             foreach ((string itemType, ImmutableHashSet<(string path, string? link, CopyToOutputDirectoryType copyType)> changes) in state.Items)
             {
-                if (changes.Count != 0 && !NonCompilationItemTypes.Contains(itemType))
+                if (!NonCompilationItemTypes.Contains(itemType))
                 {
                     logger.Verbose("Adding {0} inputs:", itemType);
 


### PR DESCRIPTION
Fixes #4736 without breaking #3245.

Rather than setting a flag `itemsChangedSinceLastCheck` dirty when items change and clearing it in `IsUpToDateAsync`, we now keep track of the last time an input item changed and compare that with output timestamps to determine if we need to rebuild.

Most of the work here went into updating the tests.