### PR TITLE
Add Code Analysis property page with Roslyn Analyzers section

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.pkgdef
+++ b/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.pkgdef
@@ -122,6 +122,12 @@
 "InprocServer32"="$System$\mscoree.dll"
 "ThreadingModel"="Both"
 
+[$RootKey$\CLSID\{c02f393c-8a1e-480d-aa82-6a75d693559d}]
+"Assembly"="Microsoft.VisualStudio.Editors,version=15.0.0.0,publicKeyToken=b03f5f7f11d50a3a,culture=neutral"
+"Class"="Microsoft.VisualStudio.Editors.PropertyPages.CodeAnalysisPropPageComClass"
+"InprocServer32"="$System$\mscoree.dll"
+"ThreadingModel"="Both"
+
 [$RootKey$\Editors]
 
 [$RootKey$\Editors\{04b8ab82-a572-4fef-95ce-5222444b6b64}]

--- a/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
+++ b/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
@@ -111,6 +111,11 @@
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.BuildPropPage.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Update="PropPages\CodeAnalysisPropPage.resx">
+      <DependentUpon>CodeAnalysisPropPage.vb</DependentUpon>
+      <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.CodeAnalysisPropPage.resources</LogicalName>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Update="PropPages\CompilePropPage2.resx">
       <DependentUpon>CompilePropPage2.vb</DependentUpon>
       <LogicalName>Microsoft.VisualStudio.Editors.PropertyPages.CompilePropPage2.resources</LogicalName>
@@ -291,6 +296,10 @@
       <DependentUpon>BuildPropPage.vb</DependentUpon>
       <SubType>UserControl</SubType>
     </Compile>
+    <Compile Update="PropPages\CodeAnalysisPropPage.Designer.vb">
+      <DependentUpon>CodeAnalysisPropPage.vb</DependentUpon>
+      <SubType>UserControl</SubType>
+    </Compile>
     <Compile Update="PropPages\CompilePropPage2.Designer.vb">
       <DependentUpon>CompilePropPage2.vb</DependentUpon>
       <SubType>UserControl</SubType>
@@ -437,6 +446,9 @@
       <SubType>UserControl</SubType>
     </Compile>
     <Compile Update="proppages\BuildPropPageBase.vb">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Update="proppages\CodeAnalysisPropPage.vb">
       <SubType>UserControl</SubType>
     </Compile>
     <Compile Update="proppages\CompilePropPage2.vb">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.Designer.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.Designer.vb
@@ -14,8 +14,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Friend WithEvents RoslynAnalyzersLabel As System.Windows.Forms.Label
         Friend WithEvents RoslynAnalyzersLineLabel As System.Windows.Forms.Label
         Friend WithEvents RoslynAnalyzersHelpLinkLabel As System.Windows.Forms.LinkLabel
-        Friend WithEvents RunRoslynAnalyzersDuringLiveAnalysis As System.Windows.Forms.CheckBox
-        Friend WithEvents RunRoslynAnalyzersDuringBuild As System.Windows.Forms.CheckBox
+        Friend WithEvents RunAnalyzersDuringLiveAnalysis As System.Windows.Forms.CheckBox
+        Friend WithEvents RunAnalyzersDuringBuild As System.Windows.Forms.CheckBox
         Private _components As System.ComponentModel.IContainer
 
         Protected Overloads Overrides Sub Dispose(disposing As Boolean)
@@ -30,8 +30,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         <System.Diagnostics.DebuggerStepThrough()> Private Sub InitializeComponent()
             Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(CodeAnalysisPropPage))
             Me.FxCopAnalyzersPanel = New System.Windows.Forms.Panel()
-            Me.RunRoslynAnalyzersDuringLiveAnalysis = New System.Windows.Forms.CheckBox()
-            Me.RunRoslynAnalyzersDuringBuild = New System.Windows.Forms.CheckBox()
+            Me.RunAnalyzersDuringLiveAnalysis = New System.Windows.Forms.CheckBox()
+            Me.RunAnalyzersDuringBuild = New System.Windows.Forms.CheckBox()
             Me.RoslynAnalyzersLabel = New System.Windows.Forms.Label()
             Me.RoslynAnalyzersLineLabel = New System.Windows.Forms.Label()
             Me.RoslynAnalyzersHelpLinkLabel = New System.Windows.Forms.LinkLabel()
@@ -47,8 +47,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             '
             'FxCopAnalyzersPanel
             '
-            Me.FxCopAnalyzersPanel.Controls.Add(Me.RunRoslynAnalyzersDuringLiveAnalysis)
-            Me.FxCopAnalyzersPanel.Controls.Add(Me.RunRoslynAnalyzersDuringBuild)
+            Me.FxCopAnalyzersPanel.Controls.Add(Me.RunAnalyzersDuringLiveAnalysis)
+            Me.FxCopAnalyzersPanel.Controls.Add(Me.RunAnalyzersDuringBuild)
             Me.FxCopAnalyzersPanel.Controls.Add(Me.RoslynAnalyzersLabel)
             Me.FxCopAnalyzersPanel.Controls.Add(Me.RoslynAnalyzersLineLabel)
             Me.FxCopAnalyzersPanel.Controls.Add(Me.RoslynAnalyzersHelpLinkLabel)
@@ -62,21 +62,21 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             resources.ApplyResources(Me.FxCopAnalyzersPanel, "FxCopAnalyzersPanel")
             Me.FxCopAnalyzersPanel.Name = "FxCopAnalyzersPanel"
             '
-            'RunRoslynAnalyzersDuringLiveAnalysis
+            'RunAnalyzersDuringLiveAnalysis
             '
-            resources.ApplyResources(Me.RunRoslynAnalyzersDuringLiveAnalysis, "RunRoslynAnalyzersDuringLiveAnalysis")
-            Me.RunRoslynAnalyzersDuringLiveAnalysis.Checked = True
-            Me.RunRoslynAnalyzersDuringLiveAnalysis.CheckState = System.Windows.Forms.CheckState.Checked
-            Me.RunRoslynAnalyzersDuringLiveAnalysis.Name = "RunRoslynAnalyzersDuringLiveAnalysis"
-            Me.RunRoslynAnalyzersDuringLiveAnalysis.UseVisualStyleBackColor = True
+            resources.ApplyResources(Me.RunAnalyzersDuringLiveAnalysis, "RunAnalyzersDuringLiveAnalysis")
+            Me.RunAnalyzersDuringLiveAnalysis.Checked = True
+            Me.RunAnalyzersDuringLiveAnalysis.CheckState = System.Windows.Forms.CheckState.Checked
+            Me.RunAnalyzersDuringLiveAnalysis.Name = "RunAnalyzersDuringLiveAnalysis"
+            Me.RunAnalyzersDuringLiveAnalysis.UseVisualStyleBackColor = True
             '
-            'RunRoslynAnalyzersDuringBuild
+            'RunAnalyzersDuringBuild
             '
-            resources.ApplyResources(Me.RunRoslynAnalyzersDuringBuild, "RunRoslynAnalyzersDuringBuild")
-            Me.RunRoslynAnalyzersDuringBuild.Checked = True
-            Me.RunRoslynAnalyzersDuringBuild.CheckState = System.Windows.Forms.CheckState.Checked
-            Me.RunRoslynAnalyzersDuringBuild.Name = "RunRoslynAnalyzersDuringBuild"
-            Me.RunRoslynAnalyzersDuringBuild.UseVisualStyleBackColor = True
+            resources.ApplyResources(Me.RunAnalyzersDuringBuild, "RunAnalyzersDuringBuild")
+            Me.RunAnalyzersDuringBuild.Checked = True
+            Me.RunAnalyzersDuringBuild.CheckState = System.Windows.Forms.CheckState.Checked
+            Me.RunAnalyzersDuringBuild.Name = "RunAnalyzersDuringBuild"
+            Me.RunAnalyzersDuringBuild.UseVisualStyleBackColor = True
             '
             'RoslynAnalyzersLabel
             '

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.Designer.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.Designer.vb
@@ -9,7 +9,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Friend WithEvents InstallCustomVersionButton As System.Windows.Forms.Button
         Friend WithEvents InstallLatestVersionButton As System.Windows.Forms.Button
         Friend WithEvents UninstallAnalyzersButton As System.Windows.Forms.Button
-        Friend WithEvents RefreshButton As System.Windows.Forms.Button
         Friend WithEvents FxCopAnalyzersPackageNameTextBox As System.Windows.Forms.TextBox
         Friend WithEvents FxCopAnalyzersPackageNameLabel As System.Windows.Forms.Label
         Friend WithEvents RoslynAnalyzersLabel As System.Windows.Forms.Label
@@ -38,7 +37,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Me.RoslynAnalyzersHelpLinkLabel = New System.Windows.Forms.LinkLabel()
             Me.FxCopAnalyzersPackageNameTextBox = New System.Windows.Forms.TextBox()
             Me.FxCopAnalyzersPackageNameLabel = New System.Windows.Forms.Label()
-            Me.RefreshButton = New System.Windows.Forms.Button()
             Me.InstalledVersionTextBox = New System.Windows.Forms.TextBox()
             Me.InstalledVersionLabel = New System.Windows.Forms.Label()
             Me.InstallLatestVersionButton = New System.Windows.Forms.Button()
@@ -56,7 +54,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Me.FxCopAnalyzersPanel.Controls.Add(Me.RoslynAnalyzersHelpLinkLabel)
             Me.FxCopAnalyzersPanel.Controls.Add(Me.FxCopAnalyzersPackageNameTextBox)
             Me.FxCopAnalyzersPanel.Controls.Add(Me.FxCopAnalyzersPackageNameLabel)
-            Me.FxCopAnalyzersPanel.Controls.Add(Me.RefreshButton)
             Me.FxCopAnalyzersPanel.Controls.Add(Me.InstalledVersionTextBox)
             Me.FxCopAnalyzersPanel.Controls.Add(Me.InstalledVersionLabel)
             Me.FxCopAnalyzersPanel.Controls.Add(Me.InstallLatestVersionButton)
@@ -109,12 +106,6 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             '
             resources.ApplyResources(Me.FxCopAnalyzersPackageNameLabel, "FxCopAnalyzersPackageNameLabel")
             Me.FxCopAnalyzersPackageNameLabel.Name = "FxCopAnalyzersPackageNameLabel"
-            '
-            'RefreshButton
-            '
-            resources.ApplyResources(Me.RefreshButton, "RefreshButton")
-            Me.RefreshButton.Name = "RefreshButton"
-            Me.RefreshButton.UseVisualStyleBackColor = True
             '
             'InstalledVersionTextBox
             '

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.Designer.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.Designer.vb
@@ -1,0 +1,161 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Namespace Microsoft.VisualStudio.Editors.PropertyPages
+
+    Partial Class CodeAnalysisPropPage
+        Friend WithEvents FxCopAnalyzersPanel As System.Windows.Forms.Panel
+        Friend WithEvents InstalledVersionLabel As System.Windows.Forms.Label
+        Friend WithEvents InstalledVersionTextBox As System.Windows.Forms.TextBox
+        Friend WithEvents InstallCustomVersionButton As System.Windows.Forms.Button
+        Friend WithEvents InstallLatestVersionButton As System.Windows.Forms.Button
+        Friend WithEvents UninstallAnalyzersButton As System.Windows.Forms.Button
+        Friend WithEvents RefreshButton As System.Windows.Forms.Button
+        Friend WithEvents FxCopAnalyzersPackageNameTextBox As System.Windows.Forms.TextBox
+        Friend WithEvents FxCopAnalyzersPackageNameLabel As System.Windows.Forms.Label
+        Friend WithEvents RoslynAnalyzersLabel As System.Windows.Forms.Label
+        Friend WithEvents RoslynAnalyzersLineLabel As System.Windows.Forms.Label
+        Friend WithEvents RoslynAnalyzersHelpLinkLabel As System.Windows.Forms.LinkLabel
+        Friend WithEvents RunRoslynAnalyzersDuringLiveAnalysis As System.Windows.Forms.CheckBox
+        Friend WithEvents RunRoslynAnalyzersDuringBuild As System.Windows.Forms.CheckBox
+        Private _components As System.ComponentModel.IContainer
+
+        Protected Overloads Overrides Sub Dispose(disposing As Boolean)
+            If disposing Then
+                If Not (_components Is Nothing) Then
+                    _components.Dispose()
+                End If
+            End If
+            MyBase.Dispose(disposing)
+        End Sub
+
+        <System.Diagnostics.DebuggerStepThrough()> Private Sub InitializeComponent()
+            Dim resources As System.ComponentModel.ComponentResourceManager = New System.ComponentModel.ComponentResourceManager(GetType(CodeAnalysisPropPage))
+            Me.FxCopAnalyzersPanel = New System.Windows.Forms.Panel()
+            Me.RunRoslynAnalyzersDuringLiveAnalysis = New System.Windows.Forms.CheckBox()
+            Me.RunRoslynAnalyzersDuringBuild = New System.Windows.Forms.CheckBox()
+            Me.RoslynAnalyzersLabel = New System.Windows.Forms.Label()
+            Me.RoslynAnalyzersLineLabel = New System.Windows.Forms.Label()
+            Me.RoslynAnalyzersHelpLinkLabel = New System.Windows.Forms.LinkLabel()
+            Me.FxCopAnalyzersPackageNameTextBox = New System.Windows.Forms.TextBox()
+            Me.FxCopAnalyzersPackageNameLabel = New System.Windows.Forms.Label()
+            Me.RefreshButton = New System.Windows.Forms.Button()
+            Me.InstalledVersionTextBox = New System.Windows.Forms.TextBox()
+            Me.InstalledVersionLabel = New System.Windows.Forms.Label()
+            Me.InstallLatestVersionButton = New System.Windows.Forms.Button()
+            Me.InstallCustomVersionButton = New System.Windows.Forms.Button()
+            Me.UninstallAnalyzersButton = New System.Windows.Forms.Button()
+            Me.FxCopAnalyzersPanel.SuspendLayout()
+            Me.SuspendLayout()
+            '
+            'FxCopAnalyzersPanel
+            '
+            Me.FxCopAnalyzersPanel.Controls.Add(Me.RunRoslynAnalyzersDuringLiveAnalysis)
+            Me.FxCopAnalyzersPanel.Controls.Add(Me.RunRoslynAnalyzersDuringBuild)
+            Me.FxCopAnalyzersPanel.Controls.Add(Me.RoslynAnalyzersLabel)
+            Me.FxCopAnalyzersPanel.Controls.Add(Me.RoslynAnalyzersLineLabel)
+            Me.FxCopAnalyzersPanel.Controls.Add(Me.RoslynAnalyzersHelpLinkLabel)
+            Me.FxCopAnalyzersPanel.Controls.Add(Me.FxCopAnalyzersPackageNameTextBox)
+            Me.FxCopAnalyzersPanel.Controls.Add(Me.FxCopAnalyzersPackageNameLabel)
+            Me.FxCopAnalyzersPanel.Controls.Add(Me.RefreshButton)
+            Me.FxCopAnalyzersPanel.Controls.Add(Me.InstalledVersionTextBox)
+            Me.FxCopAnalyzersPanel.Controls.Add(Me.InstalledVersionLabel)
+            Me.FxCopAnalyzersPanel.Controls.Add(Me.InstallLatestVersionButton)
+            Me.FxCopAnalyzersPanel.Controls.Add(Me.InstallCustomVersionButton)
+            Me.FxCopAnalyzersPanel.Controls.Add(Me.UninstallAnalyzersButton)
+            resources.ApplyResources(Me.FxCopAnalyzersPanel, "FxCopAnalyzersPanel")
+            Me.FxCopAnalyzersPanel.Name = "FxCopAnalyzersPanel"
+            '
+            'RunRoslynAnalyzersDuringLiveAnalysis
+            '
+            resources.ApplyResources(Me.RunRoslynAnalyzersDuringLiveAnalysis, "RunRoslynAnalyzersDuringLiveAnalysis")
+            Me.RunRoslynAnalyzersDuringLiveAnalysis.Checked = True
+            Me.RunRoslynAnalyzersDuringLiveAnalysis.CheckState = System.Windows.Forms.CheckState.Checked
+            Me.RunRoslynAnalyzersDuringLiveAnalysis.Name = "RunRoslynAnalyzersDuringLiveAnalysis"
+            Me.RunRoslynAnalyzersDuringLiveAnalysis.UseVisualStyleBackColor = True
+            '
+            'RunRoslynAnalyzersDuringBuild
+            '
+            resources.ApplyResources(Me.RunRoslynAnalyzersDuringBuild, "RunRoslynAnalyzersDuringBuild")
+            Me.RunRoslynAnalyzersDuringBuild.Checked = True
+            Me.RunRoslynAnalyzersDuringBuild.CheckState = System.Windows.Forms.CheckState.Checked
+            Me.RunRoslynAnalyzersDuringBuild.Name = "RunRoslynAnalyzersDuringBuild"
+            Me.RunRoslynAnalyzersDuringBuild.UseVisualStyleBackColor = True
+            '
+            'RoslynAnalyzersLabel
+            '
+            resources.ApplyResources(Me.RoslynAnalyzersLabel, "RoslynAnalyzersLabel")
+            Me.RoslynAnalyzersLabel.Name = "RoslynAnalyzersLabel"
+            '
+            'RoslynAnalyzersLineLabel
+            '
+            Me.RoslynAnalyzersLineLabel.AccessibleRole = System.Windows.Forms.AccessibleRole.Separator
+            Me.RoslynAnalyzersLineLabel.BackColor = System.Drawing.SystemColors.ControlDark
+            resources.ApplyResources(Me.RoslynAnalyzersLineLabel, "RoslynAnalyzersLineLabel")
+            Me.RoslynAnalyzersLineLabel.Name = "RoslynAnalyzersLineLabel"
+            '
+            'RoslynAnalyzersHelpLinkLabel
+            '
+            resources.ApplyResources(Me.RoslynAnalyzersHelpLinkLabel, "RoslynAnalyzersHelpLinkLabel")
+            Me.RoslynAnalyzersHelpLinkLabel.Name = "RoslynAnalyzersHelpLinkLabel"
+            Me.RoslynAnalyzersHelpLinkLabel.TabStop = True
+            '
+            'FxCopAnalyzersPackageNameTextBox
+            '
+            resources.ApplyResources(Me.FxCopAnalyzersPackageNameTextBox, "FxCopAnalyzersPackageNameTextBox")
+            Me.FxCopAnalyzersPackageNameTextBox.Name = "FxCopAnalyzersPackageNameTextBox"
+            Me.FxCopAnalyzersPackageNameTextBox.ReadOnly = True
+            '
+            'FxCopAnalyzersPackageNameLabel
+            '
+            resources.ApplyResources(Me.FxCopAnalyzersPackageNameLabel, "FxCopAnalyzersPackageNameLabel")
+            Me.FxCopAnalyzersPackageNameLabel.Name = "FxCopAnalyzersPackageNameLabel"
+            '
+            'RefreshButton
+            '
+            resources.ApplyResources(Me.RefreshButton, "RefreshButton")
+            Me.RefreshButton.Name = "RefreshButton"
+            Me.RefreshButton.UseVisualStyleBackColor = True
+            '
+            'InstalledVersionTextBox
+            '
+            resources.ApplyResources(Me.InstalledVersionTextBox, "InstalledVersionTextBox")
+            Me.InstalledVersionTextBox.Name = "InstalledVersionTextBox"
+            Me.InstalledVersionTextBox.ReadOnly = True
+            '
+            'InstalledVersionLabel
+            '
+            resources.ApplyResources(Me.InstalledVersionLabel, "InstalledVersionLabel")
+            Me.InstalledVersionLabel.Name = "InstalledVersionLabel"
+            '
+            'InstallLatestVersionButton
+            '
+            resources.ApplyResources(Me.InstallLatestVersionButton, "InstallLatestVersionButton")
+            Me.InstallLatestVersionButton.Name = "InstallLatestVersionButton"
+            Me.InstallLatestVersionButton.UseVisualStyleBackColor = True
+            '
+            'InstallCustomVersionButton
+            '
+            resources.ApplyResources(Me.InstallCustomVersionButton, "InstallCustomVersionButton")
+            Me.InstallCustomVersionButton.Name = "InstallCustomVersionButton"
+            Me.InstallCustomVersionButton.UseVisualStyleBackColor = True
+            '
+            'UninstallAnalyzersButton
+            '
+            resources.ApplyResources(Me.UninstallAnalyzersButton, "UninstallAnalyzersButton")
+            Me.UninstallAnalyzersButton.Name = "UninstallAnalyzersButton"
+            Me.UninstallAnalyzersButton.UseVisualStyleBackColor = True
+            '
+            'CodeAnalysisPropPage
+            '
+            resources.ApplyResources(Me, "$this")
+            Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+            Me.Controls.Add(Me.FxCopAnalyzersPanel)
+            Me.Name = "CodeAnalysisPropPage"
+            Me.FxCopAnalyzersPanel.ResumeLayout(False)
+            Me.FxCopAnalyzersPanel.PerformLayout()
+            Me.ResumeLayout(False)
+
+        End Sub
+    End Class
+
+End Namespace

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.resx
@@ -1,0 +1,531 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="RunRoslynAnalyzersDuringLiveAnalysis.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="RunRoslynAnalyzersDuringLiveAnalysis.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="RunRoslynAnalyzersDuringLiveAnalysis.Location" type="System.Drawing.Point, System.Drawing">
+    <value>41, 85</value>
+  </data>
+  <data name="RunRoslynAnalyzersDuringLiveAnalysis.Size" type="System.Drawing.Size, System.Drawing">
+    <value>120, 17</value>
+  </data>
+  <data name="RunRoslynAnalyzersDuringLiveAnalysis.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="RunRoslynAnalyzersDuringLiveAnalysis.Text" xml:space="preserve">
+    <value>Run on &amp;live analysis</value>
+  </data>
+  <data name="&gt;&gt;RunRoslynAnalyzersDuringLiveAnalysis.Name" xml:space="preserve">
+    <value>RunRoslynAnalyzersDuringLiveAnalysis</value>
+  </data>
+  <data name="&gt;&gt;RunRoslynAnalyzersDuringLiveAnalysis.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;RunRoslynAnalyzersDuringLiveAnalysis.Parent" xml:space="preserve">
+    <value>FxCopAnalyzersPanel</value>
+  </data>
+  <data name="&gt;&gt;RunRoslynAnalyzersDuringLiveAnalysis.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="RunRoslynAnalyzersDuringBuild.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="RunRoslynAnalyzersDuringBuild.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="RunRoslynAnalyzersDuringBuild.Location" type="System.Drawing.Point, System.Drawing">
+    <value>41, 62</value>
+  </data>
+  <data name="RunRoslynAnalyzersDuringBuild.Size" type="System.Drawing.Size, System.Drawing">
+    <value>86, 17</value>
+  </data>
+  <data name="RunRoslynAnalyzersDuringBuild.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="RunRoslynAnalyzersDuringBuild.Text" xml:space="preserve">
+    <value>Run on &amp;build</value>
+  </data>
+  <data name="&gt;&gt;RunRoslynAnalyzersDuringBuild.Name" xml:space="preserve">
+    <value>RunRoslynAnalyzersDuringBuild</value>
+  </data>
+  <data name="&gt;&gt;RunRoslynAnalyzersDuringBuild.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;RunRoslynAnalyzersDuringBuild.Parent" xml:space="preserve">
+    <value>FxCopAnalyzersPanel</value>
+  </data>
+  <data name="&gt;&gt;RunRoslynAnalyzersDuringBuild.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="RoslynAnalyzersLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>31, 9</value>
+  </data>
+  <data name="RoslynAnalyzersLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>121, 13</value>
+  </data>
+  <data name="RoslynAnalyzersLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="RoslynAnalyzersLabel.Text" xml:space="preserve">
+    <value>Roslyn source analyzers</value>
+  </data>
+  <data name="&gt;&gt;RoslynAnalyzersLabel.Name" xml:space="preserve">
+    <value>RoslynAnalyzersLabel</value>
+  </data>
+  <data name="&gt;&gt;RoslynAnalyzersLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;RoslynAnalyzersLabel.Parent" xml:space="preserve">
+    <value>FxCopAnalyzersPanel</value>
+  </data>
+  <data name="&gt;&gt;RoslynAnalyzersLabel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="RoslynAnalyzersLineLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>157, 16</value>
+  </data>
+  <data name="RoslynAnalyzersLineLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>280, 1</value>
+  </data>
+  <data name="RoslynAnalyzersLineLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="RoslynAnalyzersLineLabel.Text" xml:space="preserve">
+    <value>Label1</value>
+  </data>
+  <data name="&gt;&gt;RoslynAnalyzersLineLabel.Name" xml:space="preserve">
+    <value>RoslynAnalyzersLineLabel</value>
+  </data>
+  <data name="&gt;&gt;RoslynAnalyzersLineLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;RoslynAnalyzersLineLabel.Parent" xml:space="preserve">
+    <value>FxCopAnalyzersPanel</value>
+  </data>
+  <data name="&gt;&gt;RoslynAnalyzersLineLabel.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="RoslynAnalyzersHelpLinkLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>39, 36</value>
+  </data>
+  <data name="RoslynAnalyzersHelpLinkLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>244, 13</value>
+  </data>
+  <data name="RoslynAnalyzersHelpLinkLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="RoslynAnalyzersHelpLinkLabel.Text" xml:space="preserve">
+    <value>What are the benefits of Roslyn source analyzers?</value>
+  </data>
+  <data name="&gt;&gt;RoslynAnalyzersHelpLinkLabel.Name" xml:space="preserve">
+    <value>RoslynAnalyzersHelpLinkLabel</value>
+  </data>
+  <data name="&gt;&gt;RoslynAnalyzersHelpLinkLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;RoslynAnalyzersHelpLinkLabel.Parent" xml:space="preserve">
+    <value>FxCopAnalyzersPanel</value>
+  </data>
+  <data name="&gt;&gt;RoslynAnalyzersHelpLinkLabel.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="FxCopAnalyzersPackageNameTextBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>41, 135</value>
+  </data>
+  <data name="FxCopAnalyzersPackageNameTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
+  </data>
+  <data name="FxCopAnalyzersPackageNameTextBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>220, 20</value>
+  </data>
+  <data name="FxCopAnalyzersPackageNameTextBox.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="FxCopAnalyzersPackageNameTextBox.Text" xml:space="preserve">
+    <value>Microsoft.CodeAnalysis.FxCopAnalyzers</value>
+  </data>
+  <data name="&gt;&gt;FxCopAnalyzersPackageNameTextBox.Name" xml:space="preserve">
+    <value>FxCopAnalyzersPackageNameTextBox</value>
+  </data>
+  <data name="&gt;&gt;FxCopAnalyzersPackageNameTextBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;FxCopAnalyzersPackageNameTextBox.Parent" xml:space="preserve">
+    <value>FxCopAnalyzersPanel</value>
+  </data>
+  <data name="&gt;&gt;FxCopAnalyzersPackageNameTextBox.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="FxCopAnalyzersPackageNameLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="FxCopAnalyzersPackageNameLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>39, 115</value>
+  </data>
+  <data name="FxCopAnalyzersPackageNameLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 0, 2, 0</value>
+  </data>
+  <data name="FxCopAnalyzersPackageNameLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>175, 13</value>
+  </data>
+  <data name="FxCopAnalyzersPackageNameLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="FxCopAnalyzersPackageNameLabel.Text" xml:space="preserve">
+    <value>Recommended analyzer package:</value>
+  </data>
+  <data name="&gt;&gt;FxCopAnalyzersPackageNameLabel.Name" xml:space="preserve">
+    <value>FxCopAnalyzersPackageNameLabel</value>
+  </data>
+  <data name="&gt;&gt;FxCopAnalyzersPackageNameLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;FxCopAnalyzersPackageNameLabel.Parent" xml:space="preserve">
+    <value>FxCopAnalyzersPanel</value>
+  </data>
+  <data name="&gt;&gt;FxCopAnalyzersPackageNameLabel.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="RefreshButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="RefreshButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>40, 217</value>
+  </data>
+  <data name="RefreshButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>87, 22</value>
+  </data>
+  <data name="RefreshButton.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="RefreshButton.Text" xml:space="preserve">
+    <value>&amp;Refresh</value>
+  </data>
+  <data name="&gt;&gt;RefreshButton.Name" xml:space="preserve">
+    <value>RefreshButton</value>
+  </data>
+  <data name="&gt;&gt;RefreshButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;RefreshButton.Parent" xml:space="preserve">
+    <value>FxCopAnalyzersPanel</value>
+  </data>
+  <data name="&gt;&gt;RefreshButton.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="InstalledVersionTextBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>41, 185</value>
+  </data>
+  <data name="InstalledVersionTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
+  </data>
+  <data name="InstalledVersionTextBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>87, 20</value>
+  </data>
+  <data name="InstalledVersionTextBox.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;InstalledVersionTextBox.Name" xml:space="preserve">
+    <value>InstalledVersionTextBox</value>
+  </data>
+  <data name="&gt;&gt;InstalledVersionTextBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;InstalledVersionTextBox.Parent" xml:space="preserve">
+    <value>FxCopAnalyzersPanel</value>
+  </data>
+  <data name="&gt;&gt;InstalledVersionTextBox.ZOrder" xml:space="preserve">
+    <value>8</value>
+  </data>
+  <data name="InstalledVersionLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="InstalledVersionLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>39, 164</value>
+  </data>
+  <data name="InstalledVersionLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 0, 2, 0</value>
+  </data>
+  <data name="InstalledVersionLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>90, 15</value>
+  </data>
+  <data name="InstalledVersionLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="InstalledVersionLabel.Text" xml:space="preserve">
+    <value>Installed Version:</value>
+  </data>
+  <data name="&gt;&gt;InstalledVersionLabel.Name" xml:space="preserve">
+    <value>InstalledVersionLabel</value>
+  </data>
+  <data name="&gt;&gt;InstalledVersionLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;InstalledVersionLabel.Parent" xml:space="preserve">
+    <value>FxCopAnalyzersPanel</value>
+  </data>
+  <data name="&gt;&gt;InstalledVersionLabel.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="InstallLatestVersionButton.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="InstallLatestVersionButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="InstallLatestVersionButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>140, 184</value>
+  </data>
+  <data name="InstallLatestVersionButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
+  </data>
+  <data name="InstallLatestVersionButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>80, 22</value>
+  </data>
+  <data name="InstallLatestVersionButton.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="InstallLatestVersionButton.Text" xml:space="preserve">
+    <value>&amp;Install</value>
+  </data>
+  <data name="&gt;&gt;InstallLatestVersionButton.Name" xml:space="preserve">
+    <value>InstallLatestVersionButton</value>
+  </data>
+  <data name="&gt;&gt;InstallLatestVersionButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;InstallLatestVersionButton.Parent" xml:space="preserve">
+    <value>FxCopAnalyzersPanel</value>
+  </data>
+  <data name="&gt;&gt;InstallLatestVersionButton.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="InstallCustomVersionButton.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="InstallCustomVersionButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="InstallCustomVersionButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>233, 185</value>
+  </data>
+  <data name="InstallCustomVersionButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
+  </data>
+  <data name="InstallCustomVersionButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>28, 22</value>
+  </data>
+  <data name="InstallCustomVersionButton.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="InstallCustomVersionButton.Text" xml:space="preserve">
+    <value>&amp;...</value>
+  </data>
+  <data name="&gt;&gt;InstallCustomVersionButton.Name" xml:space="preserve">
+    <value>InstallCustomVersionButton</value>
+  </data>
+  <data name="&gt;&gt;InstallCustomVersionButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;InstallCustomVersionButton.Parent" xml:space="preserve">
+    <value>FxCopAnalyzersPanel</value>
+  </data>
+  <data name="&gt;&gt;InstallCustomVersionButton.ZOrder" xml:space="preserve">
+    <value>11</value>
+  </data>
+  <data name="UninstallAnalyzersButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="UninstallAnalyzersButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>140, 184</value>
+  </data>
+  <data name="UninstallAnalyzersButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>80, 22</value>
+  </data>
+  <data name="UninstallAnalyzersButton.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="UninstallAnalyzersButton.Text" xml:space="preserve">
+    <value>&amp;Uninstall</value>
+  </data>
+  <data name="&gt;&gt;UninstallAnalyzersButton.Name" xml:space="preserve">
+    <value>UninstallAnalyzersButton</value>
+  </data>
+  <data name="&gt;&gt;UninstallAnalyzersButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;UninstallAnalyzersButton.Parent" xml:space="preserve">
+    <value>FxCopAnalyzersPanel</value>
+  </data>
+  <data name="&gt;&gt;UninstallAnalyzersButton.ZOrder" xml:space="preserve">
+    <value>12</value>
+  </data>
+  <data name="FxCopAnalyzersPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>-30, 6</value>
+  </data>
+  <data name="FxCopAnalyzersPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
+  </data>
+  <data name="FxCopAnalyzersPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>448, 253</value>
+  </data>
+  <data name="FxCopAnalyzersPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;FxCopAnalyzersPanel.Name" xml:space="preserve">
+    <value>FxCopAnalyzersPanel</value>
+  </data>
+  <data name="&gt;&gt;FxCopAnalyzersPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;FxCopAnalyzersPanel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;FxCopAnalyzersPanel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>359, 259</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>418, 259</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>CodeAnalysisPropPage</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>Microsoft.VisualStudio.Editors.PropertyPages.PropPageUserControlBase, Microsoft.VisualStudio.AppDesigner, Version=42.42.42.42, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+</root>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.resx
@@ -118,66 +118,66 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="RunRoslynAnalyzersDuringLiveAnalysis.AutoSize" type="System.Boolean, mscorlib">
+  <data name="RunAnalyzersDuringLiveAnalysis.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="RunRoslynAnalyzersDuringLiveAnalysis.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="RunAnalyzersDuringLiveAnalysis.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="RunRoslynAnalyzersDuringLiveAnalysis.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="RunAnalyzersDuringLiveAnalysis.Location" type="System.Drawing.Point, System.Drawing">
     <value>41, 85</value>
   </data>
-  <data name="RunRoslynAnalyzersDuringLiveAnalysis.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="RunAnalyzersDuringLiveAnalysis.Size" type="System.Drawing.Size, System.Drawing">
     <value>120, 17</value>
   </data>
-  <data name="RunRoslynAnalyzersDuringLiveAnalysis.TabIndex" type="System.Int32, mscorlib">
+  <data name="RunAnalyzersDuringLiveAnalysis.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
-  <data name="RunRoslynAnalyzersDuringLiveAnalysis.Text" xml:space="preserve">
+  <data name="RunAnalyzersDuringLiveAnalysis.Text" xml:space="preserve">
     <value>Run on &amp;live analysis</value>
   </data>
-  <data name="&gt;&gt;RunRoslynAnalyzersDuringLiveAnalysis.Name" xml:space="preserve">
-    <value>RunRoslynAnalyzersDuringLiveAnalysis</value>
+  <data name="&gt;&gt;RunAnalyzersDuringLiveAnalysis.Name" xml:space="preserve">
+    <value>RunAnalyzersDuringLiveAnalysis</value>
   </data>
-  <data name="&gt;&gt;RunRoslynAnalyzersDuringLiveAnalysis.Type" xml:space="preserve">
+  <data name="&gt;&gt;RunAnalyzersDuringLiveAnalysis.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;RunRoslynAnalyzersDuringLiveAnalysis.Parent" xml:space="preserve">
+  <data name="&gt;&gt;RunAnalyzersDuringLiveAnalysis.Parent" xml:space="preserve">
     <value>FxCopAnalyzersPanel</value>
   </data>
-  <data name="&gt;&gt;RunRoslynAnalyzersDuringLiveAnalysis.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;RunAnalyzersDuringLiveAnalysis.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="RunRoslynAnalyzersDuringBuild.AutoSize" type="System.Boolean, mscorlib">
+  <data name="RunAnalyzersDuringBuild.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="RunRoslynAnalyzersDuringBuild.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="RunAnalyzersDuringBuild.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="RunRoslynAnalyzersDuringBuild.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="RunAnalyzersDuringBuild.Location" type="System.Drawing.Point, System.Drawing">
     <value>41, 62</value>
   </data>
-  <data name="RunRoslynAnalyzersDuringBuild.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="RunAnalyzersDuringBuild.Size" type="System.Drawing.Size, System.Drawing">
     <value>86, 17</value>
   </data>
-  <data name="RunRoslynAnalyzersDuringBuild.TabIndex" type="System.Int32, mscorlib">
+  <data name="RunAnalyzersDuringBuild.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
-  <data name="RunRoslynAnalyzersDuringBuild.Text" xml:space="preserve">
+  <data name="RunAnalyzersDuringBuild.Text" xml:space="preserve">
     <value>Run on &amp;build</value>
   </data>
-  <data name="&gt;&gt;RunRoslynAnalyzersDuringBuild.Name" xml:space="preserve">
-    <value>RunRoslynAnalyzersDuringBuild</value>
+  <data name="&gt;&gt;RunAnalyzersDuringBuild.Name" xml:space="preserve">
+    <value>RunAnalyzersDuringBuild</value>
   </data>
-  <data name="&gt;&gt;RunRoslynAnalyzersDuringBuild.Type" xml:space="preserve">
+  <data name="&gt;&gt;RunAnalyzersDuringBuild.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;RunRoslynAnalyzersDuringBuild.Parent" xml:space="preserve">
+  <data name="&gt;&gt;RunAnalyzersDuringBuild.Parent" xml:space="preserve">
     <value>FxCopAnalyzersPanel</value>
   </data>
-  <data name="&gt;&gt;RunRoslynAnalyzersDuringBuild.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;RunAnalyzersDuringBuild.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <data name="RoslynAnalyzersLabel.AutoSize" type="System.Boolean, mscorlib">
@@ -187,13 +187,13 @@
     <value>31, 9</value>
   </data>
   <data name="RoslynAnalyzersLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 13</value>
+    <value>52, 13</value>
   </data>
   <data name="RoslynAnalyzersLabel.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
   </data>
   <data name="RoslynAnalyzersLabel.Text" xml:space="preserve">
-    <value>Roslyn source analyzers</value>
+    <value>Analyzers</value>
   </data>
   <data name="&gt;&gt;RoslynAnalyzersLabel.Name" xml:space="preserve">
     <value>RoslynAnalyzersLabel</value>
@@ -208,10 +208,10 @@
     <value>2</value>
   </data>
   <data name="RoslynAnalyzersLineLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>157, 16</value>
+    <value>87, 16</value>
   </data>
   <data name="RoslynAnalyzersLineLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>280, 1</value>
+    <value>350, 1</value>
   </data>
   <data name="RoslynAnalyzersLineLabel.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -235,13 +235,13 @@
     <value>39, 36</value>
   </data>
   <data name="RoslynAnalyzersHelpLinkLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>244, 13</value>
+    <value>236, 13</value>
   </data>
   <data name="RoslynAnalyzersHelpLinkLabel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
   <data name="RoslynAnalyzersHelpLinkLabel.Text" xml:space="preserve">
-    <value>What are the benefits of Roslyn source analyzers?</value>
+    <value>What are the benefits of source code analyzers?</value>
   </data>
   <data name="&gt;&gt;RoslynAnalyzersHelpLinkLabel.Name" xml:space="preserve">
     <value>RoslynAnalyzersHelpLinkLabel</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.resx
@@ -180,6 +180,9 @@
   <data name="&gt;&gt;RunRoslynAnalyzersDuringBuild.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="RoslynAnalyzersLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
   <data name="RoslynAnalyzersLabel.Location" type="System.Drawing.Point, System.Drawing">
     <value>31, 9</value>
   </data>
@@ -213,9 +216,6 @@
   <data name="RoslynAnalyzersLineLabel.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
   </data>
-  <data name="RoslynAnalyzersLineLabel.Text" xml:space="preserve">
-    <value>Label1</value>
-  </data>
   <data name="&gt;&gt;RoslynAnalyzersLineLabel.Name" xml:space="preserve">
     <value>RoslynAnalyzersLineLabel</value>
   </data>
@@ -227,6 +227,9 @@
   </data>
   <data name="&gt;&gt;RoslynAnalyzersLineLabel.ZOrder" xml:space="preserve">
     <value>3</value>
+  </data>
+  <data name="RoslynAnalyzersHelpLinkLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="RoslynAnalyzersHelpLinkLabel.Location" type="System.Drawing.Point, System.Drawing">
     <value>39, 36</value>
@@ -430,7 +433,7 @@
     <value>NoControl</value>
   </data>
   <data name="InstallCustomVersionButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>233, 185</value>
+    <value>233, 184</value>
   </data>
   <data name="InstallCustomVersionButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>
@@ -484,7 +487,7 @@
     <value>12</value>
   </data>
   <data name="FxCopAnalyzersPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>-30, 6</value>
+    <value>-30, 0</value>
   </data>
   <data name="FxCopAnalyzersPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.resx
@@ -312,33 +312,6 @@
   <data name="&gt;&gt;FxCopAnalyzersPackageNameLabel.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="RefreshButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="RefreshButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>40, 217</value>
-  </data>
-  <data name="RefreshButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>87, 22</value>
-  </data>
-  <data name="RefreshButton.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="RefreshButton.Text" xml:space="preserve">
-    <value>&amp;Refresh</value>
-  </data>
-  <data name="&gt;&gt;RefreshButton.Name" xml:space="preserve">
-    <value>RefreshButton</value>
-  </data>
-  <data name="&gt;&gt;RefreshButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;RefreshButton.Parent" xml:space="preserve">
-    <value>FxCopAnalyzersPanel</value>
-  </data>
-  <data name="&gt;&gt;RefreshButton.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
   <data name="InstalledVersionTextBox.Location" type="System.Drawing.Point, System.Drawing">
     <value>41, 185</value>
   </data>
@@ -361,7 +334,7 @@
     <value>FxCopAnalyzersPanel</value>
   </data>
   <data name="&gt;&gt;InstalledVersionTextBox.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>7</value>
   </data>
   <data name="InstalledVersionLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -391,7 +364,7 @@
     <value>FxCopAnalyzersPanel</value>
   </data>
   <data name="&gt;&gt;InstalledVersionLabel.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>8</value>
   </data>
   <data name="InstallLatestVersionButton.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -424,7 +397,7 @@
     <value>FxCopAnalyzersPanel</value>
   </data>
   <data name="&gt;&gt;InstallLatestVersionButton.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>9</value>
   </data>
   <data name="InstallCustomVersionButton.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
@@ -457,7 +430,7 @@
     <value>FxCopAnalyzersPanel</value>
   </data>
   <data name="&gt;&gt;InstallCustomVersionButton.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>10</value>
   </data>
   <data name="UninstallAnalyzersButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -484,7 +457,7 @@
     <value>FxCopAnalyzersPanel</value>
   </data>
   <data name="&gt;&gt;UninstallAnalyzersButton.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>11</value>
   </data>
   <data name="FxCopAnalyzersPanel.Location" type="System.Drawing.Point, System.Drawing">
     <value>-30, 0</value>
@@ -493,7 +466,7 @@
     <value>2, 2, 2, 2</value>
   </data>
   <data name="FxCopAnalyzersPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>448, 253</value>
+    <value>448, 222</value>
   </data>
   <data name="FxCopAnalyzersPanel.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.vb
@@ -1,0 +1,246 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Diagnostics
+Imports System.Threading
+Imports System.Windows.Forms
+Imports Microsoft.VisualStudio.ComponentModelHost
+Imports Microsoft.VisualStudio.ProjectSystem
+Imports Microsoft.VisualStudio.Shell
+Imports Microsoft.VisualStudio.Shell.Interop
+Imports NuGet.VisualStudio
+
+Namespace Microsoft.VisualStudio.Editors.PropertyPages
+
+    Friend NotInheritable Class CodeAnalysisPropPage
+        Inherits PropPageUserControlBase
+
+        Private Const NugetFeed As String = "https://packages.nuget.org/api/v2"
+        Private Const FxCopAnalyzersPackageId As String = "Microsoft.CodeAnalysis.FxCopAnalyzers"
+
+        Private Shared ReadOnly s_latestStableVersion As Version = New Version(2, 9, 3)
+        Private Shared ReadOnly s_childPackageIds As HashSet(Of String) = New HashSet(Of String)(
+            {"Microsoft.CodeQuality.Analyzers", "Microsoft.NetCore.Analyzers", "Microsoft.NetFramework.Analyzers"},
+            StringComparer.OrdinalIgnoreCase)
+
+        Private _packageInstallerServices As IVsPackageInstallerServices
+        Private _packageInstaller As IVsPackageInstaller2
+        Private _packageUninstaller As IVsPackageUninstaller
+        Private _packageRestorer As IVsPackageRestorer
+        Private _threadedWaitDialogFactory As IVsThreadedWaitDialogFactory
+        Private _nugetPackage As IVsPackage
+        Private _installedFxCopAnalyzersVersionString As String
+
+        Public Sub New()
+            MyBase.New()
+
+            InitializeComponent()
+            RefreshInstallFxCopAnalyzersButtons(reset:=True)
+
+            'Opt out of page scaling since we're using AutoScaleMode
+            PageRequiresScaling = False
+
+            'Add any initialization after the InitializeComponent() call
+            AddChangeHandlers()
+        End Sub
+
+        Protected Overrides Sub PostInitPage()
+            MyBase.PostInitPage()
+
+            Dim componentModel = CType(ServiceProvider.GetService(GetType(SComponentModel)), IComponentModel)
+            _packageInstallerServices = componentModel.GetExtensions(Of IVsPackageInstallerServices)().SingleOrDefault()
+            _packageInstaller = componentModel.GetService(Of IVsPackageInstaller2)()
+            _packageUninstaller = componentModel.GetService(Of IVsPackageUninstaller)()
+            _packageRestorer = componentModel.GetService(Of IVsPackageRestorer)()
+            _threadedWaitDialogFactory = CType(ServiceProvider.GetService(GetType(SVsThreadedWaitDialogFactory)), IVsThreadedWaitDialogFactory)
+
+            Dim shell = CType(ServiceProvider.GetService(GetType(SVsShell)), IVsShell)
+            Dim nugetGuid = New Guid("5fcc8577-4feb-4d04-ad72-d6c629b083cc")
+            shell?.LoadPackage(nugetGuid, _nugetPackage)
+
+            RefreshInstalledFxCopAnalyzersVersionAndButtons()
+        End Sub
+
+        Protected Overrides ReadOnly Property ControlData() As PropertyControlData()
+            Get
+                If m_ControlData Is Nothing Then
+                    m_ControlData = New PropertyControlData() {
+                        New PropertyControlData(1, "RunRoslynAnalyzersDuringBuild", RunRoslynAnalyzersDuringBuild, ControlDataFlags.None),
+                        New PropertyControlData(2, "RunRoslynAnalyzersDuringLiveAnalysis", RunRoslynAnalyzersDuringLiveAnalysis, ControlDataFlags.None)
+                    }
+                End If
+                Return m_ControlData
+            End Get
+        End Property
+
+        Protected Overrides Function GetF1HelpKeyword() As String
+            ' TODO: New help keyword
+            Return HelpKeywords.VBProjPropAssemblyInfo
+        End Function
+
+        Private Sub RefreshInstalledFxCopAnalyzersVersionAndButtons()
+            If Not TryGetInstalledFxCopAnalyzersVersion(_installedFxCopAnalyzersVersionString) Then
+                RefreshInstallFxCopAnalyzersButtons(reset:=True)
+                Return
+            End If
+
+            InstalledVersionTextBox.Text = If(_installedFxCopAnalyzersVersionString, My.Resources.Strings.NotInstalledText)
+            RefreshInstallFxCopAnalyzersButtons(reset:=False)
+        End Sub
+
+        Private Sub RefreshInstallFxCopAnalyzersButtons(reset As Boolean)
+            If DTEProject Is Nothing Then
+                reset = True
+            End If
+
+            InstallLatestVersionButton.Enabled = Not reset AndAlso Not HasFxCopAnalyzersInstalled()
+            UninstallAnalyzersButton.Enabled = Not reset AndAlso HasFxCopAnalyzersInstalled()
+            InstallCustomVersionButton.Enabled = Not reset AndAlso _nugetPackage IsNot Nothing
+
+            InstallLatestVersionButton.Visible = Not HasFxCopAnalyzersInstalled()
+            UninstallAnalyzersButton.Visible = Not InstallLatestVersionButton.Visible
+        End Sub
+
+        Private Function HasFxCopAnalyzersInstalled() As Boolean
+            Return Not String.IsNullOrEmpty(_installedFxCopAnalyzersVersionString)
+        End Function
+
+        ' Returns False if attempt to GetInstalledPackages did not succeed
+        Private Function TryGetInstalledFxCopAnalyzersVersion(ByRef versionString As String) As Boolean
+            versionString = Nothing
+
+            If DTEProject Is Nothing Then
+                Return False
+            End If
+
+            Using session = _threadedWaitDialogFactory.StartWaitDialog(My.Resources.Strings.RestoringPackagesMessage)
+                _packageRestorer.RestorePackages(DTEProject)
+
+                session.UserCancellationToken.ThrowIfCancellationRequested()
+
+                ' Add a small delay to ensure GetInstalledPackages invocation below gets updated packages.
+                Thread.Sleep(2000)
+
+                Dim installedPackages As IEnumerable(Of IVsPackageMetadata)
+                Try
+                    installedPackages = _packageInstallerServices.GetInstalledPackages(DTEProject)
+                Catch
+                    Return False
+                End Try
+
+                For Each package As IVsPackageMetadata In installedPackages
+                    If String.Equals(package.Id, FxCopAnalyzersPackageId, StringComparison.OrdinalIgnoreCase) OrElse
+                       s_childPackageIds.Contains(package.Id, StringComparer.OrdinalIgnoreCase) Then
+                        versionString = package.VersionString
+                        Exit For
+                    End If
+                Next
+
+                Return True
+            End Using
+        End Function
+
+        Private Sub InstallLatestVersionButton_Click(sender As Object, e As EventArgs) Handles InstallLatestVersionButton.Click
+            Debug.Assert(DTEProject IsNot Nothing)
+
+            Try
+                _packageInstaller.InstallPackage(NugetFeed, DTEProject, FxCopAnalyzersPackageId, s_latestStableVersion, ignoreDependencies:=False)
+            Catch
+                _installedFxCopAnalyzersVersionString = Nothing
+            End Try
+
+            RefreshInstalledFxCopAnalyzersVersionAndButtons()
+
+            If _installedFxCopAnalyzersVersionString Is Nothing Then
+                DesignerFramework.DesignUtil.ShowMessage(ServiceProvider, My.Resources.Strings.FxCopAnalyzersInstallFailedMessage, DesignerFramework.DesignUtil.GetDefaultCaption(ServiceProvider), MessageBoxButtons.OK, MessageBoxIcon.Error)
+            End If
+        End Sub
+
+        Private Sub UninstallAnalyzersButton_Click(sender As Object, e As EventArgs) Handles UninstallAnalyzersButton.Click
+            Debug.Assert(DTEProject IsNot Nothing)
+            Debug.Assert(_installedFxCopAnalyzersVersionString IsNot Nothing)
+            Dim versionText = _installedFxCopAnalyzersVersionString
+
+            Try
+                _packageUninstaller.UninstallPackage(DTEProject, FxCopAnalyzersPackageId, removeDependencies:=True)
+            Catch
+            End Try
+
+            RefreshInstalledFxCopAnalyzersVersionAndButtons()
+
+            If _installedFxCopAnalyzersVersionString IsNot Nothing Then
+                DesignerFramework.DesignUtil.ShowMessage(ServiceProvider, String.Format(My.Resources.Strings.FxCopAnalyzersUninstallFailedMessage, versionText), DesignerFramework.DesignUtil.GetDefaultCaption(ServiceProvider), MessageBoxButtons.OK, MessageBoxIcon.Error)
+            End If
+        End Sub
+
+        Private Sub InstallCustomVersionButton_Click(sender As Object, e As EventArgs) Handles InstallCustomVersionButton.Click
+            Debug.Assert(_nugetPackage IsNot Nothing)
+
+            ' Reset and disable all the buttons (except Refresh) as we are about to navigate
+            ' away from this page to the NuGet Package manager.
+            RefreshInstallFxCopAnalyzersButtons(reset:=True)
+
+            ' We're able to launch the package manager (with an item in its search box) by
+            ' using the IVsSearchProvider API that the NuGet package exposes.
+            '
+            ' We get that interface for it and then pass it a SearchQuery that effectively
+            ' wraps the package name we're looking for. The NuGet package will then read
+            ' out that string and populate their search box with it.
+
+            Dim extensionProvider = CType(_nugetPackage, IVsPackageExtensionProvider)
+            Dim extensionGuid = New Guid("042C2B4B-C7F7-49DB-B7A2-402EB8DC7892")
+            Dim emptyGuid = Guid.Empty
+            Dim searchProvider = CType(extensionProvider.CreateExtensionInstance(emptyGuid, extensionGuid), IVsSearchProvider)
+            Dim task = searchProvider.CreateSearch(dwCookie:=1, pSearchQuery:=SearchQuery.FxCopAnalyzersQueryInstance, pSearchCallback:=SearchQuery.FxCopAnalyzersQueryInstance)
+            task.Start()
+        End Sub
+
+        Private Sub RefreshButton_Click(sender As Object, e As EventArgs) Handles RefreshButton.Click
+            RefreshInstalledFxCopAnalyzersVersionAndButtons()
+        End Sub
+
+        Private Sub RoslynAnalyzersLabel_LinkClicked(sender As Object, e As LinkLabelLinkClickedEventArgs) Handles RoslynAnalyzersHelpLinkLabel.LinkClicked
+            RoslynAnalyzersHelpLinkLabel.LinkVisited = True
+            Process.Start("https://docs.microsoft.com/visualstudio/code-quality/roslyn-analyzers-overview")
+        End Sub
+
+        Private NotInheritable Class SearchQuery
+            Implements IVsSearchQuery
+            Implements IVsSearchProviderCallback
+
+            Public Shared FxCopAnalyzersQueryInstance As SearchQuery = New SearchQuery()
+
+            Private Sub New()
+            End Sub
+
+            Public ReadOnly Property SearchString As String Implements IVsSearchQuery.SearchString
+                Get
+                    Return FxCopAnalyzersPackageId
+                End Get
+            End Property
+
+            Public ReadOnly Property ParseError As UInteger Implements IVsSearchQuery.ParseError
+                Get
+                    Return 0
+                End Get
+            End Property
+
+            Public Function GetTokens(dwMaxTokens As UInteger, rgpSearchTokens As IVsSearchToken()) As UInteger Implements IVsSearchQuery.GetTokens
+                Return 0
+            End Function
+
+            Public Sub ReportProgress(pTask As IVsSearchTask, dwProgress As UInteger, dwMaxProgress As UInteger) Implements IVsSearchCallback.ReportProgress, IVsSearchProviderCallback.ReportProgress
+            End Sub
+
+            Public Sub ReportComplete(pTask As IVsSearchTask, dwResultsFound As UInteger) Implements IVsSearchCallback.ReportComplete, IVsSearchProviderCallback.ReportComplete
+            End Sub
+
+            Public Sub ReportResult(pTask As IVsSearchTask, pSearchItemResult As IVsSearchItemResult) Implements IVsSearchProviderCallback.ReportResult
+                pSearchItemResult.InvokeAction()
+            End Sub
+
+            Public Sub ReportResults(pTask As IVsSearchTask, dwResults As UInteger, pSearchItemResults As IVsSearchItemResult()) Implements IVsSearchProviderCallback.ReportResults
+            End Sub
+        End Class
+    End Class
+
+End Namespace

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.vb
@@ -67,8 +67,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Get
                 If m_ControlData Is Nothing Then
                     m_ControlData = New PropertyControlData() {
-                        New PropertyControlData(1, "RunRoslynAnalyzersDuringBuild", RunRoslynAnalyzersDuringBuild, ControlDataFlags.None),
-                        New PropertyControlData(2, "RunRoslynAnalyzersDuringLiveAnalysis", RunRoslynAnalyzersDuringLiveAnalysis, ControlDataFlags.None)
+                        New PropertyControlData(1, "RunAnalyzersDuringBuild", RunAnalyzersDuringBuild, ControlDataFlags.None),
+                        New PropertyControlData(2, "RunAnalyzersDuringLiveAnalysis", RunAnalyzersDuringLiveAnalysis, ControlDataFlags.None)
                     }
                 End If
                 Return m_ControlData

--- a/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/CodeAnalysisPropPage.vb
@@ -16,6 +16,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
         Private Const NugetFeed As String = "https://packages.nuget.org/api/v2"
         Private Const FxCopAnalyzersPackageId As String = "Microsoft.CodeAnalysis.FxCopAnalyzers"
+        Private Const NuGetPackageManagerPackageGuid As String = "5fcc8577-4feb-4d04-ad72-d6c629b083cc"
+        Private Const NuGetPackageManagerSearchProviderGuid As String = "042C2B4B-C7F7-49DB-B7A2-402EB8DC7892"
+        Private Const RoslynAnalyzersDocumentationLink As String = "https://docs.microsoft.com/visualstudio/code-quality/roslyn-analyzers-overview"
 
         Private Shared ReadOnly s_latestStableVersion As Version = New Version(2, 9, 3)
         Private Shared ReadOnly s_childPackageIds As HashSet(Of String) = New HashSet(Of String)(
@@ -54,7 +57,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             _threadedWaitDialogFactory = CType(ServiceProvider.GetService(GetType(SVsThreadedWaitDialogFactory)), IVsThreadedWaitDialogFactory)
 
             Dim shell = CType(ServiceProvider.GetService(GetType(SVsShell)), IVsShell)
-            Dim nugetGuid = New Guid("5fcc8577-4feb-4d04-ad72-d6c629b083cc")
+            Dim nugetGuid = New Guid(NuGetPackageManagerPackageGuid)
             shell?.LoadPackage(nugetGuid, _nugetPackage)
 
             RefreshInstalledFxCopAnalyzersVersionAndButtons()
@@ -129,7 +132,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
                 For Each package As IVsPackageMetadata In installedPackages
                     If String.Equals(package.Id, FxCopAnalyzersPackageId, StringComparison.OrdinalIgnoreCase) OrElse
-                       s_childPackageIds.Contains(package.Id, StringComparer.OrdinalIgnoreCase) Then
+                       s_childPackageIds.Contains(package.Id) Then
                         versionString = package.VersionString
                         Exit For
                     End If
@@ -187,7 +190,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             ' out that string and populate their search box with it.
 
             Dim extensionProvider = CType(_nugetPackage, IVsPackageExtensionProvider)
-            Dim extensionGuid = New Guid("042C2B4B-C7F7-49DB-B7A2-402EB8DC7892")
+            Dim extensionGuid = New Guid(NuGetPackageManagerSearchProviderGuid)
             Dim emptyGuid = Guid.Empty
             Dim searchProvider = CType(extensionProvider.CreateExtensionInstance(emptyGuid, extensionGuid), IVsSearchProvider)
             Dim task = searchProvider.CreateSearch(dwCookie:=1, pSearchQuery:=SearchQuery.FxCopAnalyzersQueryInstance, pSearchCallback:=SearchQuery.FxCopAnalyzersQueryInstance)
@@ -200,7 +203,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
         Private Sub RoslynAnalyzersLabel_LinkClicked(sender As Object, e As LinkLabelLinkClickedEventArgs) Handles RoslynAnalyzersHelpLinkLabel.LinkClicked
             RoslynAnalyzersHelpLinkLabel.LinkVisited = True
-            Process.Start("https://docs.microsoft.com/visualstudio/code-quality/roslyn-analyzers-overview")
+            Process.Start(RoslynAnalyzersDocumentationLink)
         End Sub
 
         Private NotInheritable Class SearchQuery

--- a/src/Microsoft.VisualStudio.Editors/PropPages/PropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/PropPage.vb
@@ -352,6 +352,31 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
 #End Region
 
+#Region "CodeAnalysisPropPageComClass (Code Analysis property page)"
+
+    <Guid("c02f393c-8a1e-480d-aa82-6a75d693559d"), ComVisible(True), CLSCompliant(False)>
+    Public NotInheritable Class CodeAnalysisPropPageComClass 'See class hierarchy comments above
+        Inherits VBPropPageBase
+
+        Protected Overrides ReadOnly Property Title() As String
+            Get
+                Return My.Resources.Microsoft_VisualStudio_Editors_Designer.PPG_CodeAnalysisTitle
+            End Get
+        End Property
+
+        Protected Overrides ReadOnly Property ControlType() As Type
+            Get
+                Return GetType(CodeAnalysisPropPage)
+            End Get
+        End Property
+
+        Protected Overrides Function CreateControl() As Control
+            Return New CodeAnalysisPropPage
+        End Function
+
+    End Class
+#End Region
+
 #End Region
 
 End Namespace

--- a/src/Microsoft.VisualStudio.Editors/PropPages/Strings.Designer.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/Strings.Designer.vb
@@ -85,6 +85,24 @@ Namespace My.Resources
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to Failed to install the latest Microsoft.CodeAnalysis.FxCopAnalyzers package.
+        '''</summary>
+        Friend Shared ReadOnly Property FxCopAnalyzersInstallFailedMessage() As String
+            Get
+                Return ResourceManager.GetString("FxCopAnalyzersInstallFailedMessage", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Failed to uninstall Microsoft.CodeAnalysis.FxCopAnalyzers version &apos;{0}&apos;.
+        '''</summary>
+        Friend Shared ReadOnly Property FxCopAnalyzersUninstallFailedMessage() As String
+            Get
+                Return ResourceManager.GetString("FxCopAnalyzersUninstallFailedMessage", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to Install other frameworks....
         '''</summary>
         Friend Shared ReadOnly Property InstallOtherFrameworks() As String
@@ -108,6 +126,24 @@ Namespace My.Resources
         Friend Shared ReadOnly Property LanguageVersionAutomaticallySelected() As String
             Get
                 Return ResourceManager.GetString("LanguageVersionAutomaticallySelected", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to (not installed).
+        '''</summary>
+        Friend Shared ReadOnly Property NotInstalledText() As String
+            Get
+                Return ResourceManager.GetString("NotInstalledText", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Restoring Packages....
+        '''</summary>
+        Friend Shared ReadOnly Property RestoringPackagesMessage() As String
+            Get
+                Return ResourceManager.GetString("RestoringPackagesMessage", resourceCulture)
             End Get
         End Property
     End Class

--- a/src/Microsoft.VisualStudio.Editors/PropPages/Strings.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/Strings.resx
@@ -139,4 +139,16 @@
     <value>https://aka.ms/csharp-versions</value>
     <comment>{Locked}</comment>
   </data>
+  <data name="FxCopAnalyzersInstallFailedMessage" xml:space="preserve">
+    <value>Failed to install the latest Microsoft.CodeAnalysis.FxCopAnalyzers package</value>
+  </data>
+  <data name="FxCopAnalyzersUninstallFailedMessage" xml:space="preserve">
+    <value>Failed to uninstall Microsoft.CodeAnalysis.FxCopAnalyzers version '{0}'</value>
+  </data>
+  <data name="NotInstalledText" xml:space="preserve">
+    <value>(not installed)</value>
+  </data>
+  <data name="RestoringPackagesMessage" xml:space="preserve">
+    <value>Restoring Packages...</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.cs.xlf
@@ -52,11 +52,6 @@
         <target state="new">&amp;Refresh</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoslynAnalyzersLineLabel.Text">
-        <source>Label1</source>
-        <target state="new">Label1</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
         <source>What are the benefits of Roslyn source analyzers?</source>
         <target state="new">What are the benefits of Roslyn source analyzers?</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.cs.xlf
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="cs" original="../CodeAnalysisPropPage.resx">
+    <body>
+      <trans-unit id="InstallCustomVersionButton.Text">
+        <source>&amp;...</source>
+        <target state="new">&amp;...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallLatestVersionButton.Text">
+        <source>&amp;Install</source>
+        <target state="new">&amp;Install</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstalledVersionLabel.Text">
+        <source>Installed Version:</source>
+        <target state="new">Installed Version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallAnalyzersButton.Text">
+        <source>&amp;Uninstall</source>
+        <target state="new">&amp;Uninstall</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersPackageNameLabel.Text">
+        <source>Recommended analyzer package:</source>
+        <target state="new">Recommended analyzer package:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersPackageNameTextBox.Text">
+        <source>Microsoft.CodeAnalysis.FxCopAnalyzers</source>
+        <target state="new">Microsoft.CodeAnalysis.FxCopAnalyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersLabel.Text">
+        <source>Roslyn source analyzers</source>
+        <target state="new">Roslyn source analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunRoslynAnalyzersDuringBuild.Text">
+        <source>Run on &amp;build</source>
+        <target state="new">Run on &amp;build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunRoslynAnalyzersDuringLiveAnalysis.Text">
+        <source>Run on &amp;live analysis</source>
+        <target state="new">Run on &amp;live analysis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RefreshButton.Text">
+        <source>&amp;Refresh</source>
+        <target state="new">&amp;Refresh</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersLineLabel.Text">
+        <source>Label1</source>
+        <target state="new">Label1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
+        <source>What are the benefits of Roslyn source analyzers?</source>
+        <target state="new">What are the benefits of Roslyn source analyzers?</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.cs.xlf
@@ -33,23 +33,23 @@
         <note />
       </trans-unit>
       <trans-unit id="RoslynAnalyzersLabel.Text">
-        <source>Roslyn source analyzers</source>
-        <target state="new">Roslyn source analyzers</target>
+        <source>Analyzers</source>
+        <target state="new">Analyzers</target>
         <note />
       </trans-unit>
-      <trans-unit id="RunRoslynAnalyzersDuringBuild.Text">
-        <source>Run on &amp;build</source>
-        <target state="new">Run on &amp;build</target>
+      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
+        <source>What are the benefits of source code analyzers?</source>
+        <target state="new">What are the benefits of source code analyzers?</target>
         <note />
       </trans-unit>
-      <trans-unit id="RunRoslynAnalyzersDuringLiveAnalysis.Text">
+      <trans-unit id="RunAnalyzersDuringLiveAnalysis.Text">
         <source>Run on &amp;live analysis</source>
         <target state="new">Run on &amp;live analysis</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
-        <source>What are the benefits of Roslyn source analyzers?</source>
-        <target state="new">What are the benefits of Roslyn source analyzers?</target>
+      <trans-unit id="RunAnalyzersDuringBuild.Text">
+        <source>Run on &amp;build</source>
+        <target state="new">Run on &amp;build</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.cs.xlf
@@ -47,11 +47,6 @@
         <target state="new">Run on &amp;live analysis</target>
         <note />
       </trans-unit>
-      <trans-unit id="RefreshButton.Text">
-        <source>&amp;Refresh</source>
-        <target state="new">&amp;Refresh</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
         <source>What are the benefits of Roslyn source analyzers?</source>
         <target state="new">What are the benefits of Roslyn source analyzers?</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.de.xlf
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="de" original="../CodeAnalysisPropPage.resx">
+    <body>
+      <trans-unit id="InstallCustomVersionButton.Text">
+        <source>&amp;...</source>
+        <target state="new">&amp;...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallLatestVersionButton.Text">
+        <source>&amp;Install</source>
+        <target state="new">&amp;Install</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstalledVersionLabel.Text">
+        <source>Installed Version:</source>
+        <target state="new">Installed Version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallAnalyzersButton.Text">
+        <source>&amp;Uninstall</source>
+        <target state="new">&amp;Uninstall</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersPackageNameLabel.Text">
+        <source>Recommended analyzer package:</source>
+        <target state="new">Recommended analyzer package:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersPackageNameTextBox.Text">
+        <source>Microsoft.CodeAnalysis.FxCopAnalyzers</source>
+        <target state="new">Microsoft.CodeAnalysis.FxCopAnalyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersLabel.Text">
+        <source>Roslyn source analyzers</source>
+        <target state="new">Roslyn source analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunRoslynAnalyzersDuringBuild.Text">
+        <source>Run on &amp;build</source>
+        <target state="new">Run on &amp;build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunRoslynAnalyzersDuringLiveAnalysis.Text">
+        <source>Run on &amp;live analysis</source>
+        <target state="new">Run on &amp;live analysis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RefreshButton.Text">
+        <source>&amp;Refresh</source>
+        <target state="new">&amp;Refresh</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersLineLabel.Text">
+        <source>Label1</source>
+        <target state="new">Label1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
+        <source>What are the benefits of Roslyn source analyzers?</source>
+        <target state="new">What are the benefits of Roslyn source analyzers?</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.de.xlf
@@ -52,11 +52,6 @@
         <target state="new">&amp;Refresh</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoslynAnalyzersLineLabel.Text">
-        <source>Label1</source>
-        <target state="new">Label1</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
         <source>What are the benefits of Roslyn source analyzers?</source>
         <target state="new">What are the benefits of Roslyn source analyzers?</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.de.xlf
@@ -33,23 +33,23 @@
         <note />
       </trans-unit>
       <trans-unit id="RoslynAnalyzersLabel.Text">
-        <source>Roslyn source analyzers</source>
-        <target state="new">Roslyn source analyzers</target>
+        <source>Analyzers</source>
+        <target state="new">Analyzers</target>
         <note />
       </trans-unit>
-      <trans-unit id="RunRoslynAnalyzersDuringBuild.Text">
-        <source>Run on &amp;build</source>
-        <target state="new">Run on &amp;build</target>
+      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
+        <source>What are the benefits of source code analyzers?</source>
+        <target state="new">What are the benefits of source code analyzers?</target>
         <note />
       </trans-unit>
-      <trans-unit id="RunRoslynAnalyzersDuringLiveAnalysis.Text">
+      <trans-unit id="RunAnalyzersDuringLiveAnalysis.Text">
         <source>Run on &amp;live analysis</source>
         <target state="new">Run on &amp;live analysis</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
-        <source>What are the benefits of Roslyn source analyzers?</source>
-        <target state="new">What are the benefits of Roslyn source analyzers?</target>
+      <trans-unit id="RunAnalyzersDuringBuild.Text">
+        <source>Run on &amp;build</source>
+        <target state="new">Run on &amp;build</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.de.xlf
@@ -47,11 +47,6 @@
         <target state="new">Run on &amp;live analysis</target>
         <note />
       </trans-unit>
-      <trans-unit id="RefreshButton.Text">
-        <source>&amp;Refresh</source>
-        <target state="new">&amp;Refresh</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
         <source>What are the benefits of Roslyn source analyzers?</source>
         <target state="new">What are the benefits of Roslyn source analyzers?</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.es.xlf
@@ -52,11 +52,6 @@
         <target state="new">&amp;Refresh</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoslynAnalyzersLineLabel.Text">
-        <source>Label1</source>
-        <target state="new">Label1</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
         <source>What are the benefits of Roslyn source analyzers?</source>
         <target state="new">What are the benefits of Roslyn source analyzers?</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.es.xlf
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="es" original="../CodeAnalysisPropPage.resx">
+    <body>
+      <trans-unit id="InstallCustomVersionButton.Text">
+        <source>&amp;...</source>
+        <target state="new">&amp;...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallLatestVersionButton.Text">
+        <source>&amp;Install</source>
+        <target state="new">&amp;Install</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstalledVersionLabel.Text">
+        <source>Installed Version:</source>
+        <target state="new">Installed Version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallAnalyzersButton.Text">
+        <source>&amp;Uninstall</source>
+        <target state="new">&amp;Uninstall</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersPackageNameLabel.Text">
+        <source>Recommended analyzer package:</source>
+        <target state="new">Recommended analyzer package:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersPackageNameTextBox.Text">
+        <source>Microsoft.CodeAnalysis.FxCopAnalyzers</source>
+        <target state="new">Microsoft.CodeAnalysis.FxCopAnalyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersLabel.Text">
+        <source>Roslyn source analyzers</source>
+        <target state="new">Roslyn source analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunRoslynAnalyzersDuringBuild.Text">
+        <source>Run on &amp;build</source>
+        <target state="new">Run on &amp;build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunRoslynAnalyzersDuringLiveAnalysis.Text">
+        <source>Run on &amp;live analysis</source>
+        <target state="new">Run on &amp;live analysis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RefreshButton.Text">
+        <source>&amp;Refresh</source>
+        <target state="new">&amp;Refresh</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersLineLabel.Text">
+        <source>Label1</source>
+        <target state="new">Label1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
+        <source>What are the benefits of Roslyn source analyzers?</source>
+        <target state="new">What are the benefits of Roslyn source analyzers?</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.es.xlf
@@ -33,23 +33,23 @@
         <note />
       </trans-unit>
       <trans-unit id="RoslynAnalyzersLabel.Text">
-        <source>Roslyn source analyzers</source>
-        <target state="new">Roslyn source analyzers</target>
+        <source>Analyzers</source>
+        <target state="new">Analyzers</target>
         <note />
       </trans-unit>
-      <trans-unit id="RunRoslynAnalyzersDuringBuild.Text">
-        <source>Run on &amp;build</source>
-        <target state="new">Run on &amp;build</target>
+      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
+        <source>What are the benefits of source code analyzers?</source>
+        <target state="new">What are the benefits of source code analyzers?</target>
         <note />
       </trans-unit>
-      <trans-unit id="RunRoslynAnalyzersDuringLiveAnalysis.Text">
+      <trans-unit id="RunAnalyzersDuringLiveAnalysis.Text">
         <source>Run on &amp;live analysis</source>
         <target state="new">Run on &amp;live analysis</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
-        <source>What are the benefits of Roslyn source analyzers?</source>
-        <target state="new">What are the benefits of Roslyn source analyzers?</target>
+      <trans-unit id="RunAnalyzersDuringBuild.Text">
+        <source>Run on &amp;build</source>
+        <target state="new">Run on &amp;build</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.es.xlf
@@ -47,11 +47,6 @@
         <target state="new">Run on &amp;live analysis</target>
         <note />
       </trans-unit>
-      <trans-unit id="RefreshButton.Text">
-        <source>&amp;Refresh</source>
-        <target state="new">&amp;Refresh</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
         <source>What are the benefits of Roslyn source analyzers?</source>
         <target state="new">What are the benefits of Roslyn source analyzers?</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.fr.xlf
@@ -52,11 +52,6 @@
         <target state="new">&amp;Refresh</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoslynAnalyzersLineLabel.Text">
-        <source>Label1</source>
-        <target state="new">Label1</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
         <source>What are the benefits of Roslyn source analyzers?</source>
         <target state="new">What are the benefits of Roslyn source analyzers?</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.fr.xlf
@@ -33,23 +33,23 @@
         <note />
       </trans-unit>
       <trans-unit id="RoslynAnalyzersLabel.Text">
-        <source>Roslyn source analyzers</source>
-        <target state="new">Roslyn source analyzers</target>
+        <source>Analyzers</source>
+        <target state="new">Analyzers</target>
         <note />
       </trans-unit>
-      <trans-unit id="RunRoslynAnalyzersDuringBuild.Text">
-        <source>Run on &amp;build</source>
-        <target state="new">Run on &amp;build</target>
+      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
+        <source>What are the benefits of source code analyzers?</source>
+        <target state="new">What are the benefits of source code analyzers?</target>
         <note />
       </trans-unit>
-      <trans-unit id="RunRoslynAnalyzersDuringLiveAnalysis.Text">
+      <trans-unit id="RunAnalyzersDuringLiveAnalysis.Text">
         <source>Run on &amp;live analysis</source>
         <target state="new">Run on &amp;live analysis</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
-        <source>What are the benefits of Roslyn source analyzers?</source>
-        <target state="new">What are the benefits of Roslyn source analyzers?</target>
+      <trans-unit id="RunAnalyzersDuringBuild.Text">
+        <source>Run on &amp;build</source>
+        <target state="new">Run on &amp;build</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.fr.xlf
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="fr" original="../CodeAnalysisPropPage.resx">
+    <body>
+      <trans-unit id="InstallCustomVersionButton.Text">
+        <source>&amp;...</source>
+        <target state="new">&amp;...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallLatestVersionButton.Text">
+        <source>&amp;Install</source>
+        <target state="new">&amp;Install</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstalledVersionLabel.Text">
+        <source>Installed Version:</source>
+        <target state="new">Installed Version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallAnalyzersButton.Text">
+        <source>&amp;Uninstall</source>
+        <target state="new">&amp;Uninstall</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersPackageNameLabel.Text">
+        <source>Recommended analyzer package:</source>
+        <target state="new">Recommended analyzer package:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersPackageNameTextBox.Text">
+        <source>Microsoft.CodeAnalysis.FxCopAnalyzers</source>
+        <target state="new">Microsoft.CodeAnalysis.FxCopAnalyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersLabel.Text">
+        <source>Roslyn source analyzers</source>
+        <target state="new">Roslyn source analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunRoslynAnalyzersDuringBuild.Text">
+        <source>Run on &amp;build</source>
+        <target state="new">Run on &amp;build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunRoslynAnalyzersDuringLiveAnalysis.Text">
+        <source>Run on &amp;live analysis</source>
+        <target state="new">Run on &amp;live analysis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RefreshButton.Text">
+        <source>&amp;Refresh</source>
+        <target state="new">&amp;Refresh</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersLineLabel.Text">
+        <source>Label1</source>
+        <target state="new">Label1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
+        <source>What are the benefits of Roslyn source analyzers?</source>
+        <target state="new">What are the benefits of Roslyn source analyzers?</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.fr.xlf
@@ -47,11 +47,6 @@
         <target state="new">Run on &amp;live analysis</target>
         <note />
       </trans-unit>
-      <trans-unit id="RefreshButton.Text">
-        <source>&amp;Refresh</source>
-        <target state="new">&amp;Refresh</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
         <source>What are the benefits of Roslyn source analyzers?</source>
         <target state="new">What are the benefits of Roslyn source analyzers?</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.it.xlf
@@ -52,11 +52,6 @@
         <target state="new">&amp;Refresh</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoslynAnalyzersLineLabel.Text">
-        <source>Label1</source>
-        <target state="new">Label1</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
         <source>What are the benefits of Roslyn source analyzers?</source>
         <target state="new">What are the benefits of Roslyn source analyzers?</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.it.xlf
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="it" original="../CodeAnalysisPropPage.resx">
+    <body>
+      <trans-unit id="InstallCustomVersionButton.Text">
+        <source>&amp;...</source>
+        <target state="new">&amp;...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallLatestVersionButton.Text">
+        <source>&amp;Install</source>
+        <target state="new">&amp;Install</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstalledVersionLabel.Text">
+        <source>Installed Version:</source>
+        <target state="new">Installed Version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallAnalyzersButton.Text">
+        <source>&amp;Uninstall</source>
+        <target state="new">&amp;Uninstall</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersPackageNameLabel.Text">
+        <source>Recommended analyzer package:</source>
+        <target state="new">Recommended analyzer package:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersPackageNameTextBox.Text">
+        <source>Microsoft.CodeAnalysis.FxCopAnalyzers</source>
+        <target state="new">Microsoft.CodeAnalysis.FxCopAnalyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersLabel.Text">
+        <source>Roslyn source analyzers</source>
+        <target state="new">Roslyn source analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunRoslynAnalyzersDuringBuild.Text">
+        <source>Run on &amp;build</source>
+        <target state="new">Run on &amp;build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunRoslynAnalyzersDuringLiveAnalysis.Text">
+        <source>Run on &amp;live analysis</source>
+        <target state="new">Run on &amp;live analysis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RefreshButton.Text">
+        <source>&amp;Refresh</source>
+        <target state="new">&amp;Refresh</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersLineLabel.Text">
+        <source>Label1</source>
+        <target state="new">Label1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
+        <source>What are the benefits of Roslyn source analyzers?</source>
+        <target state="new">What are the benefits of Roslyn source analyzers?</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.it.xlf
@@ -33,23 +33,23 @@
         <note />
       </trans-unit>
       <trans-unit id="RoslynAnalyzersLabel.Text">
-        <source>Roslyn source analyzers</source>
-        <target state="new">Roslyn source analyzers</target>
+        <source>Analyzers</source>
+        <target state="new">Analyzers</target>
         <note />
       </trans-unit>
-      <trans-unit id="RunRoslynAnalyzersDuringBuild.Text">
-        <source>Run on &amp;build</source>
-        <target state="new">Run on &amp;build</target>
+      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
+        <source>What are the benefits of source code analyzers?</source>
+        <target state="new">What are the benefits of source code analyzers?</target>
         <note />
       </trans-unit>
-      <trans-unit id="RunRoslynAnalyzersDuringLiveAnalysis.Text">
+      <trans-unit id="RunAnalyzersDuringLiveAnalysis.Text">
         <source>Run on &amp;live analysis</source>
         <target state="new">Run on &amp;live analysis</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
-        <source>What are the benefits of Roslyn source analyzers?</source>
-        <target state="new">What are the benefits of Roslyn source analyzers?</target>
+      <trans-unit id="RunAnalyzersDuringBuild.Text">
+        <source>Run on &amp;build</source>
+        <target state="new">Run on &amp;build</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.it.xlf
@@ -47,11 +47,6 @@
         <target state="new">Run on &amp;live analysis</target>
         <note />
       </trans-unit>
-      <trans-unit id="RefreshButton.Text">
-        <source>&amp;Refresh</source>
-        <target state="new">&amp;Refresh</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
         <source>What are the benefits of Roslyn source analyzers?</source>
         <target state="new">What are the benefits of Roslyn source analyzers?</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ja.xlf
@@ -52,11 +52,6 @@
         <target state="new">&amp;Refresh</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoslynAnalyzersLineLabel.Text">
-        <source>Label1</source>
-        <target state="new">Label1</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
         <source>What are the benefits of Roslyn source analyzers?</source>
         <target state="new">What are the benefits of Roslyn source analyzers?</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ja.xlf
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ja" original="../CodeAnalysisPropPage.resx">
+    <body>
+      <trans-unit id="InstallCustomVersionButton.Text">
+        <source>&amp;...</source>
+        <target state="new">&amp;...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallLatestVersionButton.Text">
+        <source>&amp;Install</source>
+        <target state="new">&amp;Install</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstalledVersionLabel.Text">
+        <source>Installed Version:</source>
+        <target state="new">Installed Version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallAnalyzersButton.Text">
+        <source>&amp;Uninstall</source>
+        <target state="new">&amp;Uninstall</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersPackageNameLabel.Text">
+        <source>Recommended analyzer package:</source>
+        <target state="new">Recommended analyzer package:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersPackageNameTextBox.Text">
+        <source>Microsoft.CodeAnalysis.FxCopAnalyzers</source>
+        <target state="new">Microsoft.CodeAnalysis.FxCopAnalyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersLabel.Text">
+        <source>Roslyn source analyzers</source>
+        <target state="new">Roslyn source analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunRoslynAnalyzersDuringBuild.Text">
+        <source>Run on &amp;build</source>
+        <target state="new">Run on &amp;build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunRoslynAnalyzersDuringLiveAnalysis.Text">
+        <source>Run on &amp;live analysis</source>
+        <target state="new">Run on &amp;live analysis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RefreshButton.Text">
+        <source>&amp;Refresh</source>
+        <target state="new">&amp;Refresh</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersLineLabel.Text">
+        <source>Label1</source>
+        <target state="new">Label1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
+        <source>What are the benefits of Roslyn source analyzers?</source>
+        <target state="new">What are the benefits of Roslyn source analyzers?</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ja.xlf
@@ -33,23 +33,23 @@
         <note />
       </trans-unit>
       <trans-unit id="RoslynAnalyzersLabel.Text">
-        <source>Roslyn source analyzers</source>
-        <target state="new">Roslyn source analyzers</target>
+        <source>Analyzers</source>
+        <target state="new">Analyzers</target>
         <note />
       </trans-unit>
-      <trans-unit id="RunRoslynAnalyzersDuringBuild.Text">
-        <source>Run on &amp;build</source>
-        <target state="new">Run on &amp;build</target>
+      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
+        <source>What are the benefits of source code analyzers?</source>
+        <target state="new">What are the benefits of source code analyzers?</target>
         <note />
       </trans-unit>
-      <trans-unit id="RunRoslynAnalyzersDuringLiveAnalysis.Text">
+      <trans-unit id="RunAnalyzersDuringLiveAnalysis.Text">
         <source>Run on &amp;live analysis</source>
         <target state="new">Run on &amp;live analysis</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
-        <source>What are the benefits of Roslyn source analyzers?</source>
-        <target state="new">What are the benefits of Roslyn source analyzers?</target>
+      <trans-unit id="RunAnalyzersDuringBuild.Text">
+        <source>Run on &amp;build</source>
+        <target state="new">Run on &amp;build</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ja.xlf
@@ -47,11 +47,6 @@
         <target state="new">Run on &amp;live analysis</target>
         <note />
       </trans-unit>
-      <trans-unit id="RefreshButton.Text">
-        <source>&amp;Refresh</source>
-        <target state="new">&amp;Refresh</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
         <source>What are the benefits of Roslyn source analyzers?</source>
         <target state="new">What are the benefits of Roslyn source analyzers?</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ko.xlf
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ko" original="../CodeAnalysisPropPage.resx">
+    <body>
+      <trans-unit id="InstallCustomVersionButton.Text">
+        <source>&amp;...</source>
+        <target state="new">&amp;...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallLatestVersionButton.Text">
+        <source>&amp;Install</source>
+        <target state="new">&amp;Install</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstalledVersionLabel.Text">
+        <source>Installed Version:</source>
+        <target state="new">Installed Version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallAnalyzersButton.Text">
+        <source>&amp;Uninstall</source>
+        <target state="new">&amp;Uninstall</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersPackageNameLabel.Text">
+        <source>Recommended analyzer package:</source>
+        <target state="new">Recommended analyzer package:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersPackageNameTextBox.Text">
+        <source>Microsoft.CodeAnalysis.FxCopAnalyzers</source>
+        <target state="new">Microsoft.CodeAnalysis.FxCopAnalyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersLabel.Text">
+        <source>Roslyn source analyzers</source>
+        <target state="new">Roslyn source analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunRoslynAnalyzersDuringBuild.Text">
+        <source>Run on &amp;build</source>
+        <target state="new">Run on &amp;build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunRoslynAnalyzersDuringLiveAnalysis.Text">
+        <source>Run on &amp;live analysis</source>
+        <target state="new">Run on &amp;live analysis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RefreshButton.Text">
+        <source>&amp;Refresh</source>
+        <target state="new">&amp;Refresh</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersLineLabel.Text">
+        <source>Label1</source>
+        <target state="new">Label1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
+        <source>What are the benefits of Roslyn source analyzers?</source>
+        <target state="new">What are the benefits of Roslyn source analyzers?</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ko.xlf
@@ -52,11 +52,6 @@
         <target state="new">&amp;Refresh</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoslynAnalyzersLineLabel.Text">
-        <source>Label1</source>
-        <target state="new">Label1</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
         <source>What are the benefits of Roslyn source analyzers?</source>
         <target state="new">What are the benefits of Roslyn source analyzers?</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ko.xlf
@@ -33,23 +33,23 @@
         <note />
       </trans-unit>
       <trans-unit id="RoslynAnalyzersLabel.Text">
-        <source>Roslyn source analyzers</source>
-        <target state="new">Roslyn source analyzers</target>
+        <source>Analyzers</source>
+        <target state="new">Analyzers</target>
         <note />
       </trans-unit>
-      <trans-unit id="RunRoslynAnalyzersDuringBuild.Text">
-        <source>Run on &amp;build</source>
-        <target state="new">Run on &amp;build</target>
+      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
+        <source>What are the benefits of source code analyzers?</source>
+        <target state="new">What are the benefits of source code analyzers?</target>
         <note />
       </trans-unit>
-      <trans-unit id="RunRoslynAnalyzersDuringLiveAnalysis.Text">
+      <trans-unit id="RunAnalyzersDuringLiveAnalysis.Text">
         <source>Run on &amp;live analysis</source>
         <target state="new">Run on &amp;live analysis</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
-        <source>What are the benefits of Roslyn source analyzers?</source>
-        <target state="new">What are the benefits of Roslyn source analyzers?</target>
+      <trans-unit id="RunAnalyzersDuringBuild.Text">
+        <source>Run on &amp;build</source>
+        <target state="new">Run on &amp;build</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ko.xlf
@@ -47,11 +47,6 @@
         <target state="new">Run on &amp;live analysis</target>
         <note />
       </trans-unit>
-      <trans-unit id="RefreshButton.Text">
-        <source>&amp;Refresh</source>
-        <target state="new">&amp;Refresh</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
         <source>What are the benefits of Roslyn source analyzers?</source>
         <target state="new">What are the benefits of Roslyn source analyzers?</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.pl.xlf
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pl" original="../CodeAnalysisPropPage.resx">
+    <body>
+      <trans-unit id="InstallCustomVersionButton.Text">
+        <source>&amp;...</source>
+        <target state="new">&amp;...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallLatestVersionButton.Text">
+        <source>&amp;Install</source>
+        <target state="new">&amp;Install</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstalledVersionLabel.Text">
+        <source>Installed Version:</source>
+        <target state="new">Installed Version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallAnalyzersButton.Text">
+        <source>&amp;Uninstall</source>
+        <target state="new">&amp;Uninstall</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersPackageNameLabel.Text">
+        <source>Recommended analyzer package:</source>
+        <target state="new">Recommended analyzer package:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersPackageNameTextBox.Text">
+        <source>Microsoft.CodeAnalysis.FxCopAnalyzers</source>
+        <target state="new">Microsoft.CodeAnalysis.FxCopAnalyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersLabel.Text">
+        <source>Roslyn source analyzers</source>
+        <target state="new">Roslyn source analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunRoslynAnalyzersDuringBuild.Text">
+        <source>Run on &amp;build</source>
+        <target state="new">Run on &amp;build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunRoslynAnalyzersDuringLiveAnalysis.Text">
+        <source>Run on &amp;live analysis</source>
+        <target state="new">Run on &amp;live analysis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RefreshButton.Text">
+        <source>&amp;Refresh</source>
+        <target state="new">&amp;Refresh</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersLineLabel.Text">
+        <source>Label1</source>
+        <target state="new">Label1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
+        <source>What are the benefits of Roslyn source analyzers?</source>
+        <target state="new">What are the benefits of Roslyn source analyzers?</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.pl.xlf
@@ -52,11 +52,6 @@
         <target state="new">&amp;Refresh</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoslynAnalyzersLineLabel.Text">
-        <source>Label1</source>
-        <target state="new">Label1</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
         <source>What are the benefits of Roslyn source analyzers?</source>
         <target state="new">What are the benefits of Roslyn source analyzers?</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.pl.xlf
@@ -33,23 +33,23 @@
         <note />
       </trans-unit>
       <trans-unit id="RoslynAnalyzersLabel.Text">
-        <source>Roslyn source analyzers</source>
-        <target state="new">Roslyn source analyzers</target>
+        <source>Analyzers</source>
+        <target state="new">Analyzers</target>
         <note />
       </trans-unit>
-      <trans-unit id="RunRoslynAnalyzersDuringBuild.Text">
-        <source>Run on &amp;build</source>
-        <target state="new">Run on &amp;build</target>
+      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
+        <source>What are the benefits of source code analyzers?</source>
+        <target state="new">What are the benefits of source code analyzers?</target>
         <note />
       </trans-unit>
-      <trans-unit id="RunRoslynAnalyzersDuringLiveAnalysis.Text">
+      <trans-unit id="RunAnalyzersDuringLiveAnalysis.Text">
         <source>Run on &amp;live analysis</source>
         <target state="new">Run on &amp;live analysis</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
-        <source>What are the benefits of Roslyn source analyzers?</source>
-        <target state="new">What are the benefits of Roslyn source analyzers?</target>
+      <trans-unit id="RunAnalyzersDuringBuild.Text">
+        <source>Run on &amp;build</source>
+        <target state="new">Run on &amp;build</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.pl.xlf
@@ -47,11 +47,6 @@
         <target state="new">Run on &amp;live analysis</target>
         <note />
       </trans-unit>
-      <trans-unit id="RefreshButton.Text">
-        <source>&amp;Refresh</source>
-        <target state="new">&amp;Refresh</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
         <source>What are the benefits of Roslyn source analyzers?</source>
         <target state="new">What are the benefits of Roslyn source analyzers?</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.pt-BR.xlf
@@ -52,11 +52,6 @@
         <target state="new">&amp;Refresh</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoslynAnalyzersLineLabel.Text">
-        <source>Label1</source>
-        <target state="new">Label1</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
         <source>What are the benefits of Roslyn source analyzers?</source>
         <target state="new">What are the benefits of Roslyn source analyzers?</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.pt-BR.xlf
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="pt-BR" original="../CodeAnalysisPropPage.resx">
+    <body>
+      <trans-unit id="InstallCustomVersionButton.Text">
+        <source>&amp;...</source>
+        <target state="new">&amp;...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallLatestVersionButton.Text">
+        <source>&amp;Install</source>
+        <target state="new">&amp;Install</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstalledVersionLabel.Text">
+        <source>Installed Version:</source>
+        <target state="new">Installed Version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallAnalyzersButton.Text">
+        <source>&amp;Uninstall</source>
+        <target state="new">&amp;Uninstall</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersPackageNameLabel.Text">
+        <source>Recommended analyzer package:</source>
+        <target state="new">Recommended analyzer package:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersPackageNameTextBox.Text">
+        <source>Microsoft.CodeAnalysis.FxCopAnalyzers</source>
+        <target state="new">Microsoft.CodeAnalysis.FxCopAnalyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersLabel.Text">
+        <source>Roslyn source analyzers</source>
+        <target state="new">Roslyn source analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunRoslynAnalyzersDuringBuild.Text">
+        <source>Run on &amp;build</source>
+        <target state="new">Run on &amp;build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunRoslynAnalyzersDuringLiveAnalysis.Text">
+        <source>Run on &amp;live analysis</source>
+        <target state="new">Run on &amp;live analysis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RefreshButton.Text">
+        <source>&amp;Refresh</source>
+        <target state="new">&amp;Refresh</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersLineLabel.Text">
+        <source>Label1</source>
+        <target state="new">Label1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
+        <source>What are the benefits of Roslyn source analyzers?</source>
+        <target state="new">What are the benefits of Roslyn source analyzers?</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.pt-BR.xlf
@@ -33,23 +33,23 @@
         <note />
       </trans-unit>
       <trans-unit id="RoslynAnalyzersLabel.Text">
-        <source>Roslyn source analyzers</source>
-        <target state="new">Roslyn source analyzers</target>
+        <source>Analyzers</source>
+        <target state="new">Analyzers</target>
         <note />
       </trans-unit>
-      <trans-unit id="RunRoslynAnalyzersDuringBuild.Text">
-        <source>Run on &amp;build</source>
-        <target state="new">Run on &amp;build</target>
+      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
+        <source>What are the benefits of source code analyzers?</source>
+        <target state="new">What are the benefits of source code analyzers?</target>
         <note />
       </trans-unit>
-      <trans-unit id="RunRoslynAnalyzersDuringLiveAnalysis.Text">
+      <trans-unit id="RunAnalyzersDuringLiveAnalysis.Text">
         <source>Run on &amp;live analysis</source>
         <target state="new">Run on &amp;live analysis</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
-        <source>What are the benefits of Roslyn source analyzers?</source>
-        <target state="new">What are the benefits of Roslyn source analyzers?</target>
+      <trans-unit id="RunAnalyzersDuringBuild.Text">
+        <source>Run on &amp;build</source>
+        <target state="new">Run on &amp;build</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.pt-BR.xlf
@@ -47,11 +47,6 @@
         <target state="new">Run on &amp;live analysis</target>
         <note />
       </trans-unit>
-      <trans-unit id="RefreshButton.Text">
-        <source>&amp;Refresh</source>
-        <target state="new">&amp;Refresh</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
         <source>What are the benefits of Roslyn source analyzers?</source>
         <target state="new">What are the benefits of Roslyn source analyzers?</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ru.xlf
@@ -52,11 +52,6 @@
         <target state="new">&amp;Refresh</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoslynAnalyzersLineLabel.Text">
-        <source>Label1</source>
-        <target state="new">Label1</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
         <source>What are the benefits of Roslyn source analyzers?</source>
         <target state="new">What are the benefits of Roslyn source analyzers?</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ru.xlf
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="ru" original="../CodeAnalysisPropPage.resx">
+    <body>
+      <trans-unit id="InstallCustomVersionButton.Text">
+        <source>&amp;...</source>
+        <target state="new">&amp;...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallLatestVersionButton.Text">
+        <source>&amp;Install</source>
+        <target state="new">&amp;Install</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstalledVersionLabel.Text">
+        <source>Installed Version:</source>
+        <target state="new">Installed Version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallAnalyzersButton.Text">
+        <source>&amp;Uninstall</source>
+        <target state="new">&amp;Uninstall</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersPackageNameLabel.Text">
+        <source>Recommended analyzer package:</source>
+        <target state="new">Recommended analyzer package:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersPackageNameTextBox.Text">
+        <source>Microsoft.CodeAnalysis.FxCopAnalyzers</source>
+        <target state="new">Microsoft.CodeAnalysis.FxCopAnalyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersLabel.Text">
+        <source>Roslyn source analyzers</source>
+        <target state="new">Roslyn source analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunRoslynAnalyzersDuringBuild.Text">
+        <source>Run on &amp;build</source>
+        <target state="new">Run on &amp;build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunRoslynAnalyzersDuringLiveAnalysis.Text">
+        <source>Run on &amp;live analysis</source>
+        <target state="new">Run on &amp;live analysis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RefreshButton.Text">
+        <source>&amp;Refresh</source>
+        <target state="new">&amp;Refresh</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersLineLabel.Text">
+        <source>Label1</source>
+        <target state="new">Label1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
+        <source>What are the benefits of Roslyn source analyzers?</source>
+        <target state="new">What are the benefits of Roslyn source analyzers?</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ru.xlf
@@ -33,23 +33,23 @@
         <note />
       </trans-unit>
       <trans-unit id="RoslynAnalyzersLabel.Text">
-        <source>Roslyn source analyzers</source>
-        <target state="new">Roslyn source analyzers</target>
+        <source>Analyzers</source>
+        <target state="new">Analyzers</target>
         <note />
       </trans-unit>
-      <trans-unit id="RunRoslynAnalyzersDuringBuild.Text">
-        <source>Run on &amp;build</source>
-        <target state="new">Run on &amp;build</target>
+      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
+        <source>What are the benefits of source code analyzers?</source>
+        <target state="new">What are the benefits of source code analyzers?</target>
         <note />
       </trans-unit>
-      <trans-unit id="RunRoslynAnalyzersDuringLiveAnalysis.Text">
+      <trans-unit id="RunAnalyzersDuringLiveAnalysis.Text">
         <source>Run on &amp;live analysis</source>
         <target state="new">Run on &amp;live analysis</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
-        <source>What are the benefits of Roslyn source analyzers?</source>
-        <target state="new">What are the benefits of Roslyn source analyzers?</target>
+      <trans-unit id="RunAnalyzersDuringBuild.Text">
+        <source>Run on &amp;build</source>
+        <target state="new">Run on &amp;build</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.ru.xlf
@@ -47,11 +47,6 @@
         <target state="new">Run on &amp;live analysis</target>
         <note />
       </trans-unit>
-      <trans-unit id="RefreshButton.Text">
-        <source>&amp;Refresh</source>
-        <target state="new">&amp;Refresh</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
         <source>What are the benefits of Roslyn source analyzers?</source>
         <target state="new">What are the benefits of Roslyn source analyzers?</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.tr.xlf
@@ -52,11 +52,6 @@
         <target state="new">&amp;Refresh</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoslynAnalyzersLineLabel.Text">
-        <source>Label1</source>
-        <target state="new">Label1</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
         <source>What are the benefits of Roslyn source analyzers?</source>
         <target state="new">What are the benefits of Roslyn source analyzers?</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.tr.xlf
@@ -33,23 +33,23 @@
         <note />
       </trans-unit>
       <trans-unit id="RoslynAnalyzersLabel.Text">
-        <source>Roslyn source analyzers</source>
-        <target state="new">Roslyn source analyzers</target>
+        <source>Analyzers</source>
+        <target state="new">Analyzers</target>
         <note />
       </trans-unit>
-      <trans-unit id="RunRoslynAnalyzersDuringBuild.Text">
-        <source>Run on &amp;build</source>
-        <target state="new">Run on &amp;build</target>
+      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
+        <source>What are the benefits of source code analyzers?</source>
+        <target state="new">What are the benefits of source code analyzers?</target>
         <note />
       </trans-unit>
-      <trans-unit id="RunRoslynAnalyzersDuringLiveAnalysis.Text">
+      <trans-unit id="RunAnalyzersDuringLiveAnalysis.Text">
         <source>Run on &amp;live analysis</source>
         <target state="new">Run on &amp;live analysis</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
-        <source>What are the benefits of Roslyn source analyzers?</source>
-        <target state="new">What are the benefits of Roslyn source analyzers?</target>
+      <trans-unit id="RunAnalyzersDuringBuild.Text">
+        <source>Run on &amp;build</source>
+        <target state="new">Run on &amp;build</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.tr.xlf
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="tr" original="../CodeAnalysisPropPage.resx">
+    <body>
+      <trans-unit id="InstallCustomVersionButton.Text">
+        <source>&amp;...</source>
+        <target state="new">&amp;...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallLatestVersionButton.Text">
+        <source>&amp;Install</source>
+        <target state="new">&amp;Install</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstalledVersionLabel.Text">
+        <source>Installed Version:</source>
+        <target state="new">Installed Version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallAnalyzersButton.Text">
+        <source>&amp;Uninstall</source>
+        <target state="new">&amp;Uninstall</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersPackageNameLabel.Text">
+        <source>Recommended analyzer package:</source>
+        <target state="new">Recommended analyzer package:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersPackageNameTextBox.Text">
+        <source>Microsoft.CodeAnalysis.FxCopAnalyzers</source>
+        <target state="new">Microsoft.CodeAnalysis.FxCopAnalyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersLabel.Text">
+        <source>Roslyn source analyzers</source>
+        <target state="new">Roslyn source analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunRoslynAnalyzersDuringBuild.Text">
+        <source>Run on &amp;build</source>
+        <target state="new">Run on &amp;build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunRoslynAnalyzersDuringLiveAnalysis.Text">
+        <source>Run on &amp;live analysis</source>
+        <target state="new">Run on &amp;live analysis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RefreshButton.Text">
+        <source>&amp;Refresh</source>
+        <target state="new">&amp;Refresh</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersLineLabel.Text">
+        <source>Label1</source>
+        <target state="new">Label1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
+        <source>What are the benefits of Roslyn source analyzers?</source>
+        <target state="new">What are the benefits of Roslyn source analyzers?</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.tr.xlf
@@ -47,11 +47,6 @@
         <target state="new">Run on &amp;live analysis</target>
         <note />
       </trans-unit>
-      <trans-unit id="RefreshButton.Text">
-        <source>&amp;Refresh</source>
-        <target state="new">&amp;Refresh</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
         <source>What are the benefits of Roslyn source analyzers?</source>
         <target state="new">What are the benefits of Roslyn source analyzers?</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.zh-Hans.xlf
@@ -52,11 +52,6 @@
         <target state="new">&amp;Refresh</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoslynAnalyzersLineLabel.Text">
-        <source>Label1</source>
-        <target state="new">Label1</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
         <source>What are the benefits of Roslyn source analyzers?</source>
         <target state="new">What are the benefits of Roslyn source analyzers?</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.zh-Hans.xlf
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hans" original="../CodeAnalysisPropPage.resx">
+    <body>
+      <trans-unit id="InstallCustomVersionButton.Text">
+        <source>&amp;...</source>
+        <target state="new">&amp;...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallLatestVersionButton.Text">
+        <source>&amp;Install</source>
+        <target state="new">&amp;Install</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstalledVersionLabel.Text">
+        <source>Installed Version:</source>
+        <target state="new">Installed Version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallAnalyzersButton.Text">
+        <source>&amp;Uninstall</source>
+        <target state="new">&amp;Uninstall</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersPackageNameLabel.Text">
+        <source>Recommended analyzer package:</source>
+        <target state="new">Recommended analyzer package:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersPackageNameTextBox.Text">
+        <source>Microsoft.CodeAnalysis.FxCopAnalyzers</source>
+        <target state="new">Microsoft.CodeAnalysis.FxCopAnalyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersLabel.Text">
+        <source>Roslyn source analyzers</source>
+        <target state="new">Roslyn source analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunRoslynAnalyzersDuringBuild.Text">
+        <source>Run on &amp;build</source>
+        <target state="new">Run on &amp;build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunRoslynAnalyzersDuringLiveAnalysis.Text">
+        <source>Run on &amp;live analysis</source>
+        <target state="new">Run on &amp;live analysis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RefreshButton.Text">
+        <source>&amp;Refresh</source>
+        <target state="new">&amp;Refresh</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersLineLabel.Text">
+        <source>Label1</source>
+        <target state="new">Label1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
+        <source>What are the benefits of Roslyn source analyzers?</source>
+        <target state="new">What are the benefits of Roslyn source analyzers?</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.zh-Hans.xlf
@@ -33,23 +33,23 @@
         <note />
       </trans-unit>
       <trans-unit id="RoslynAnalyzersLabel.Text">
-        <source>Roslyn source analyzers</source>
-        <target state="new">Roslyn source analyzers</target>
+        <source>Analyzers</source>
+        <target state="new">Analyzers</target>
         <note />
       </trans-unit>
-      <trans-unit id="RunRoslynAnalyzersDuringBuild.Text">
-        <source>Run on &amp;build</source>
-        <target state="new">Run on &amp;build</target>
+      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
+        <source>What are the benefits of source code analyzers?</source>
+        <target state="new">What are the benefits of source code analyzers?</target>
         <note />
       </trans-unit>
-      <trans-unit id="RunRoslynAnalyzersDuringLiveAnalysis.Text">
+      <trans-unit id="RunAnalyzersDuringLiveAnalysis.Text">
         <source>Run on &amp;live analysis</source>
         <target state="new">Run on &amp;live analysis</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
-        <source>What are the benefits of Roslyn source analyzers?</source>
-        <target state="new">What are the benefits of Roslyn source analyzers?</target>
+      <trans-unit id="RunAnalyzersDuringBuild.Text">
+        <source>Run on &amp;build</source>
+        <target state="new">Run on &amp;build</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.zh-Hans.xlf
@@ -47,11 +47,6 @@
         <target state="new">Run on &amp;live analysis</target>
         <note />
       </trans-unit>
-      <trans-unit id="RefreshButton.Text">
-        <source>&amp;Refresh</source>
-        <target state="new">&amp;Refresh</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
         <source>What are the benefits of Roslyn source analyzers?</source>
         <target state="new">What are the benefits of Roslyn source analyzers?</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.zh-Hant.xlf
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
+  <file datatype="xml" source-language="en" target-language="zh-Hant" original="../CodeAnalysisPropPage.resx">
+    <body>
+      <trans-unit id="InstallCustomVersionButton.Text">
+        <source>&amp;...</source>
+        <target state="new">&amp;...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstallLatestVersionButton.Text">
+        <source>&amp;Install</source>
+        <target state="new">&amp;Install</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="InstalledVersionLabel.Text">
+        <source>Installed Version:</source>
+        <target state="new">Installed Version:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallAnalyzersButton.Text">
+        <source>&amp;Uninstall</source>
+        <target state="new">&amp;Uninstall</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersPackageNameLabel.Text">
+        <source>Recommended analyzer package:</source>
+        <target state="new">Recommended analyzer package:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersPackageNameTextBox.Text">
+        <source>Microsoft.CodeAnalysis.FxCopAnalyzers</source>
+        <target state="new">Microsoft.CodeAnalysis.FxCopAnalyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersLabel.Text">
+        <source>Roslyn source analyzers</source>
+        <target state="new">Roslyn source analyzers</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunRoslynAnalyzersDuringBuild.Text">
+        <source>Run on &amp;build</source>
+        <target state="new">Run on &amp;build</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RunRoslynAnalyzersDuringLiveAnalysis.Text">
+        <source>Run on &amp;live analysis</source>
+        <target state="new">Run on &amp;live analysis</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RefreshButton.Text">
+        <source>&amp;Refresh</source>
+        <target state="new">&amp;Refresh</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersLineLabel.Text">
+        <source>Label1</source>
+        <target state="new">Label1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
+        <source>What are the benefits of Roslyn source analyzers?</source>
+        <target state="new">What are the benefits of Roslyn source analyzers?</target>
+        <note />
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.zh-Hant.xlf
@@ -52,11 +52,6 @@
         <target state="new">&amp;Refresh</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoslynAnalyzersLineLabel.Text">
-        <source>Label1</source>
-        <target state="new">Label1</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
         <source>What are the benefits of Roslyn source analyzers?</source>
         <target state="new">What are the benefits of Roslyn source analyzers?</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.zh-Hant.xlf
@@ -33,23 +33,23 @@
         <note />
       </trans-unit>
       <trans-unit id="RoslynAnalyzersLabel.Text">
-        <source>Roslyn source analyzers</source>
-        <target state="new">Roslyn source analyzers</target>
+        <source>Analyzers</source>
+        <target state="new">Analyzers</target>
         <note />
       </trans-unit>
-      <trans-unit id="RunRoslynAnalyzersDuringBuild.Text">
-        <source>Run on &amp;build</source>
-        <target state="new">Run on &amp;build</target>
+      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
+        <source>What are the benefits of source code analyzers?</source>
+        <target state="new">What are the benefits of source code analyzers?</target>
         <note />
       </trans-unit>
-      <trans-unit id="RunRoslynAnalyzersDuringLiveAnalysis.Text">
+      <trans-unit id="RunAnalyzersDuringLiveAnalysis.Text">
         <source>Run on &amp;live analysis</source>
         <target state="new">Run on &amp;live analysis</target>
         <note />
       </trans-unit>
-      <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
-        <source>What are the benefits of Roslyn source analyzers?</source>
-        <target state="new">What are the benefits of Roslyn source analyzers?</target>
+      <trans-unit id="RunAnalyzersDuringBuild.Text">
+        <source>Run on &amp;build</source>
+        <target state="new">Run on &amp;build</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/CodeAnalysisPropPage.zh-Hant.xlf
@@ -47,11 +47,6 @@
         <target state="new">Run on &amp;live analysis</target>
         <note />
       </trans-unit>
-      <trans-unit id="RefreshButton.Text">
-        <source>&amp;Refresh</source>
-        <target state="new">&amp;Refresh</target>
-        <note />
-      </trans-unit>
       <trans-unit id="RoslynAnalyzersHelpLinkLabel.Text">
         <source>What are the benefits of Roslyn source analyzers?</source>
         <target state="new">What are the benefits of Roslyn source analyzers?</target>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.cs.xlf
@@ -25,6 +25,26 @@
         <target state="new">Automatically selected based on framework version</target>
         <note>Refers to the C# language version being automatically selected based on the target framework</note>
       </trans-unit>
+      <trans-unit id="FxCopAnalyzersInstallFailedMessage">
+        <source>Failed to install the latest Microsoft.CodeAnalysis.FxCopAnalyzers package</source>
+        <target state="new">Failed to install the latest Microsoft.CodeAnalysis.FxCopAnalyzers package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersUninstallFailedMessage">
+        <source>Failed to uninstall Microsoft.CodeAnalysis.FxCopAnalyzers version '{0}'</source>
+        <target state="new">Failed to uninstall Microsoft.CodeAnalysis.FxCopAnalyzers version '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoringPackagesMessage">
+        <source>Restoring Packages...</source>
+        <target state="new">Restoring Packages...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NotInstalledText">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.de.xlf
@@ -25,6 +25,26 @@
         <target state="new">Automatically selected based on framework version</target>
         <note>Refers to the C# language version being automatically selected based on the target framework</note>
       </trans-unit>
+      <trans-unit id="FxCopAnalyzersInstallFailedMessage">
+        <source>Failed to install the latest Microsoft.CodeAnalysis.FxCopAnalyzers package</source>
+        <target state="new">Failed to install the latest Microsoft.CodeAnalysis.FxCopAnalyzers package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersUninstallFailedMessage">
+        <source>Failed to uninstall Microsoft.CodeAnalysis.FxCopAnalyzers version '{0}'</source>
+        <target state="new">Failed to uninstall Microsoft.CodeAnalysis.FxCopAnalyzers version '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoringPackagesMessage">
+        <source>Restoring Packages...</source>
+        <target state="new">Restoring Packages...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NotInstalledText">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.es.xlf
@@ -25,6 +25,26 @@
         <target state="new">Automatically selected based on framework version</target>
         <note>Refers to the C# language version being automatically selected based on the target framework</note>
       </trans-unit>
+      <trans-unit id="FxCopAnalyzersInstallFailedMessage">
+        <source>Failed to install the latest Microsoft.CodeAnalysis.FxCopAnalyzers package</source>
+        <target state="new">Failed to install the latest Microsoft.CodeAnalysis.FxCopAnalyzers package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersUninstallFailedMessage">
+        <source>Failed to uninstall Microsoft.CodeAnalysis.FxCopAnalyzers version '{0}'</source>
+        <target state="new">Failed to uninstall Microsoft.CodeAnalysis.FxCopAnalyzers version '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoringPackagesMessage">
+        <source>Restoring Packages...</source>
+        <target state="new">Restoring Packages...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NotInstalledText">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.fr.xlf
@@ -25,6 +25,26 @@
         <target state="new">Automatically selected based on framework version</target>
         <note>Refers to the C# language version being automatically selected based on the target framework</note>
       </trans-unit>
+      <trans-unit id="FxCopAnalyzersInstallFailedMessage">
+        <source>Failed to install the latest Microsoft.CodeAnalysis.FxCopAnalyzers package</source>
+        <target state="new">Failed to install the latest Microsoft.CodeAnalysis.FxCopAnalyzers package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersUninstallFailedMessage">
+        <source>Failed to uninstall Microsoft.CodeAnalysis.FxCopAnalyzers version '{0}'</source>
+        <target state="new">Failed to uninstall Microsoft.CodeAnalysis.FxCopAnalyzers version '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoringPackagesMessage">
+        <source>Restoring Packages...</source>
+        <target state="new">Restoring Packages...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NotInstalledText">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.it.xlf
@@ -25,6 +25,26 @@
         <target state="new">Automatically selected based on framework version</target>
         <note>Refers to the C# language version being automatically selected based on the target framework</note>
       </trans-unit>
+      <trans-unit id="FxCopAnalyzersInstallFailedMessage">
+        <source>Failed to install the latest Microsoft.CodeAnalysis.FxCopAnalyzers package</source>
+        <target state="new">Failed to install the latest Microsoft.CodeAnalysis.FxCopAnalyzers package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersUninstallFailedMessage">
+        <source>Failed to uninstall Microsoft.CodeAnalysis.FxCopAnalyzers version '{0}'</source>
+        <target state="new">Failed to uninstall Microsoft.CodeAnalysis.FxCopAnalyzers version '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoringPackagesMessage">
+        <source>Restoring Packages...</source>
+        <target state="new">Restoring Packages...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NotInstalledText">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.ja.xlf
@@ -25,6 +25,26 @@
         <target state="new">Automatically selected based on framework version</target>
         <note>Refers to the C# language version being automatically selected based on the target framework</note>
       </trans-unit>
+      <trans-unit id="FxCopAnalyzersInstallFailedMessage">
+        <source>Failed to install the latest Microsoft.CodeAnalysis.FxCopAnalyzers package</source>
+        <target state="new">Failed to install the latest Microsoft.CodeAnalysis.FxCopAnalyzers package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersUninstallFailedMessage">
+        <source>Failed to uninstall Microsoft.CodeAnalysis.FxCopAnalyzers version '{0}'</source>
+        <target state="new">Failed to uninstall Microsoft.CodeAnalysis.FxCopAnalyzers version '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoringPackagesMessage">
+        <source>Restoring Packages...</source>
+        <target state="new">Restoring Packages...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NotInstalledText">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.ko.xlf
@@ -25,6 +25,26 @@
         <target state="new">Automatically selected based on framework version</target>
         <note>Refers to the C# language version being automatically selected based on the target framework</note>
       </trans-unit>
+      <trans-unit id="FxCopAnalyzersInstallFailedMessage">
+        <source>Failed to install the latest Microsoft.CodeAnalysis.FxCopAnalyzers package</source>
+        <target state="new">Failed to install the latest Microsoft.CodeAnalysis.FxCopAnalyzers package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersUninstallFailedMessage">
+        <source>Failed to uninstall Microsoft.CodeAnalysis.FxCopAnalyzers version '{0}'</source>
+        <target state="new">Failed to uninstall Microsoft.CodeAnalysis.FxCopAnalyzers version '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoringPackagesMessage">
+        <source>Restoring Packages...</source>
+        <target state="new">Restoring Packages...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NotInstalledText">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.pl.xlf
@@ -25,6 +25,26 @@
         <target state="new">Automatically selected based on framework version</target>
         <note>Refers to the C# language version being automatically selected based on the target framework</note>
       </trans-unit>
+      <trans-unit id="FxCopAnalyzersInstallFailedMessage">
+        <source>Failed to install the latest Microsoft.CodeAnalysis.FxCopAnalyzers package</source>
+        <target state="new">Failed to install the latest Microsoft.CodeAnalysis.FxCopAnalyzers package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersUninstallFailedMessage">
+        <source>Failed to uninstall Microsoft.CodeAnalysis.FxCopAnalyzers version '{0}'</source>
+        <target state="new">Failed to uninstall Microsoft.CodeAnalysis.FxCopAnalyzers version '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoringPackagesMessage">
+        <source>Restoring Packages...</source>
+        <target state="new">Restoring Packages...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NotInstalledText">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.pt-BR.xlf
@@ -25,6 +25,26 @@
         <target state="new">Automatically selected based on framework version</target>
         <note>Refers to the C# language version being automatically selected based on the target framework</note>
       </trans-unit>
+      <trans-unit id="FxCopAnalyzersInstallFailedMessage">
+        <source>Failed to install the latest Microsoft.CodeAnalysis.FxCopAnalyzers package</source>
+        <target state="new">Failed to install the latest Microsoft.CodeAnalysis.FxCopAnalyzers package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersUninstallFailedMessage">
+        <source>Failed to uninstall Microsoft.CodeAnalysis.FxCopAnalyzers version '{0}'</source>
+        <target state="new">Failed to uninstall Microsoft.CodeAnalysis.FxCopAnalyzers version '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoringPackagesMessage">
+        <source>Restoring Packages...</source>
+        <target state="new">Restoring Packages...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NotInstalledText">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.ru.xlf
@@ -25,6 +25,26 @@
         <target state="new">Automatically selected based on framework version</target>
         <note>Refers to the C# language version being automatically selected based on the target framework</note>
       </trans-unit>
+      <trans-unit id="FxCopAnalyzersInstallFailedMessage">
+        <source>Failed to install the latest Microsoft.CodeAnalysis.FxCopAnalyzers package</source>
+        <target state="new">Failed to install the latest Microsoft.CodeAnalysis.FxCopAnalyzers package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersUninstallFailedMessage">
+        <source>Failed to uninstall Microsoft.CodeAnalysis.FxCopAnalyzers version '{0}'</source>
+        <target state="new">Failed to uninstall Microsoft.CodeAnalysis.FxCopAnalyzers version '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoringPackagesMessage">
+        <source>Restoring Packages...</source>
+        <target state="new">Restoring Packages...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NotInstalledText">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.tr.xlf
@@ -25,6 +25,26 @@
         <target state="new">Automatically selected based on framework version</target>
         <note>Refers to the C# language version being automatically selected based on the target framework</note>
       </trans-unit>
+      <trans-unit id="FxCopAnalyzersInstallFailedMessage">
+        <source>Failed to install the latest Microsoft.CodeAnalysis.FxCopAnalyzers package</source>
+        <target state="new">Failed to install the latest Microsoft.CodeAnalysis.FxCopAnalyzers package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersUninstallFailedMessage">
+        <source>Failed to uninstall Microsoft.CodeAnalysis.FxCopAnalyzers version '{0}'</source>
+        <target state="new">Failed to uninstall Microsoft.CodeAnalysis.FxCopAnalyzers version '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoringPackagesMessage">
+        <source>Restoring Packages...</source>
+        <target state="new">Restoring Packages...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NotInstalledText">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.zh-Hans.xlf
@@ -25,6 +25,26 @@
         <target state="new">Automatically selected based on framework version</target>
         <note>Refers to the C# language version being automatically selected based on the target framework</note>
       </trans-unit>
+      <trans-unit id="FxCopAnalyzersInstallFailedMessage">
+        <source>Failed to install the latest Microsoft.CodeAnalysis.FxCopAnalyzers package</source>
+        <target state="new">Failed to install the latest Microsoft.CodeAnalysis.FxCopAnalyzers package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersUninstallFailedMessage">
+        <source>Failed to uninstall Microsoft.CodeAnalysis.FxCopAnalyzers version '{0}'</source>
+        <target state="new">Failed to uninstall Microsoft.CodeAnalysis.FxCopAnalyzers version '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoringPackagesMessage">
+        <source>Restoring Packages...</source>
+        <target state="new">Restoring Packages...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NotInstalledText">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/Strings.zh-Hant.xlf
@@ -25,6 +25,26 @@
         <target state="new">Automatically selected based on framework version</target>
         <note>Refers to the C# language version being automatically selected based on the target framework</note>
       </trans-unit>
+      <trans-unit id="FxCopAnalyzersInstallFailedMessage">
+        <source>Failed to install the latest Microsoft.CodeAnalysis.FxCopAnalyzers package</source>
+        <target state="new">Failed to install the latest Microsoft.CodeAnalysis.FxCopAnalyzers package</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FxCopAnalyzersUninstallFailedMessage">
+        <source>Failed to uninstall Microsoft.CodeAnalysis.FxCopAnalyzers version '{0}'</source>
+        <target state="new">Failed to uninstall Microsoft.CodeAnalysis.FxCopAnalyzers version '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RestoringPackagesMessage">
+        <source>Restoring Packages...</source>
+        <target state="new">Restoring Packages...</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NotInstalledText">
+        <source>(not installed)</source>
+        <target state="new">(not installed)</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Editors/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.VisualStudio.Editors.PropertyPages.CodeAnalysisPropPageComClass
+Microsoft.VisualStudio.Editors.PropertyPages.CodeAnalysisPropPageComClass.New() -> Void

--- a/src/Microsoft.VisualStudio.Editors/Resources/Microsoft.VisualStudio.Editors.Designer.Designer.vb
+++ b/src/Microsoft.VisualStudio.Editors/Resources/Microsoft.VisualStudio.Editors.Designer.Designer.vb
@@ -1002,6 +1002,15 @@ Namespace My.Resources
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to Code Analysis.
+        '''</summary>
+        Friend Shared ReadOnly Property PPG_CodeAnalysisTitle() As String
+            Get
+                Return ResourceManager.GetString("PPG_CodeAnalysisTitle", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to (None).
         '''</summary>
         Friend Shared ReadOnly Property PPG_ComboBoxSelect_None() As String

--- a/src/Microsoft.VisualStudio.Editors/Resources/Microsoft.VisualStudio.Editors.Designer.resx
+++ b/src/Microsoft.VisualStudio.Editors/Resources/Microsoft.VisualStudio.Editors.Designer.resx
@@ -141,6 +141,9 @@
   <data name="PPG_CompileTitle" xml:space="preserve">
     <value>Compile</value>
   </data>
+  <data name="PPG_CodeAnalysisTitle" xml:space="preserve">
+    <value>Code Analysis</value>
+  </data>
   <data name="PPG_DebugTitle" xml:space="preserve">
     <value>Debug</value>
   </data>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.cs.xlf
@@ -2782,6 +2782,11 @@ Chcete aktualizovat hodnotu v souboru .settings?</target>
 #  represent the first part of that filter
 #</note>
       </trans-unit>
+      <trans-unit id="PPG_CodeAnalysisTitle">
+        <source>Code Analysis</source>
+        <target state="new">Code Analysis</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.de.xlf
@@ -2782,6 +2782,11 @@ Möchten Sie den Wert in der SETTINGS-Datei aktualisieren?</target>
 #  represent the first part of that filter
 #</note>
       </trans-unit>
+      <trans-unit id="PPG_CodeAnalysisTitle">
+        <source>Code Analysis</source>
+        <target state="new">Code Analysis</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.es.xlf
@@ -2782,6 +2782,11 @@ El nuevo valor del archivo app.config es '{1}'
 #  represent the first part of that filter
 #</note>
       </trans-unit>
+      <trans-unit id="PPG_CodeAnalysisTitle">
+        <source>Code Analysis</source>
+        <target state="new">Code Analysis</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.fr.xlf
@@ -2782,6 +2782,11 @@ Voulez-vous mettre à jour la valeur dans le fichier .settings ?</target>
 #  represent the first part of that filter
 #</note>
       </trans-unit>
+      <trans-unit id="PPG_CodeAnalysisTitle">
+        <source>Code Analysis</source>
+        <target state="new">Code Analysis</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.it.xlf
@@ -2782,6 +2782,11 @@ Aggiornare il valore nel file .settings?</target>
 #  represent the first part of that filter
 #</note>
       </trans-unit>
+      <trans-unit id="PPG_CodeAnalysisTitle">
+        <source>Code Analysis</source>
+        <target state="new">Code Analysis</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ja.xlf
@@ -2782,6 +2782,11 @@ app.config ファイルでの新しい値は '{1}' です
 #  represent the first part of that filter
 #</note>
       </trans-unit>
+      <trans-unit id="PPG_CodeAnalysisTitle">
+        <source>Code Analysis</source>
+        <target state="new">Code Analysis</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ko.xlf
@@ -2782,6 +2782,11 @@ app.config 파일의 새 값은 '{1}'입니다.
 #  represent the first part of that filter
 #</note>
       </trans-unit>
+      <trans-unit id="PPG_CodeAnalysisTitle">
+        <source>Code Analysis</source>
+        <target state="new">Code Analysis</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.pl.xlf
@@ -2782,6 +2782,11 @@ Czy chcesz zaktualizować wartość w pliku settings?</target>
 #  represent the first part of that filter
 #</note>
       </trans-unit>
+      <trans-unit id="PPG_CodeAnalysisTitle">
+        <source>Code Analysis</source>
+        <target state="new">Code Analysis</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.pt-BR.xlf
@@ -2782,6 +2782,11 @@ Deseja atualizar o valor no arquivo .settings?</target>
 #  represent the first part of that filter
 #</note>
       </trans-unit>
+      <trans-unit id="PPG_CodeAnalysisTitle">
+        <source>Code Analysis</source>
+        <target state="new">Code Analysis</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ru.xlf
@@ -2782,6 +2782,11 @@ Do you want to update the value in the .settings file?</source>
 #  represent the first part of that filter
 #</note>
       </trans-unit>
+      <trans-unit id="PPG_CodeAnalysisTitle">
+        <source>Code Analysis</source>
+        <target state="new">Code Analysis</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.tr.xlf
@@ -2782,6 +2782,11 @@ app.config dosyasındaki yeni değer: '{1}'
 #  represent the first part of that filter
 #</note>
       </trans-unit>
+      <trans-unit id="PPG_CodeAnalysisTitle">
+        <source>Code Analysis</source>
+        <target state="new">Code Analysis</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.zh-Hans.xlf
@@ -2782,6 +2782,11 @@ app.config 文件中的新值为“{1}”
 #  represent the first part of that filter
 #</note>
       </trans-unit>
+      <trans-unit id="PPG_CodeAnalysisTitle">
+        <source>Code Analysis</source>
+        <target state="new">Code Analysis</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.zh-Hant.xlf
@@ -2782,6 +2782,11 @@ app.config 檔的新值是 '{1}'
 #  represent the first part of that filter
 #</note>
       </trans-unit>
+      <trans-unit id="PPG_CodeAnalysisTitle">
+        <source>Code Analysis</source>
+        <target state="new">Code Analysis</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/CSharp/CSharpProjectDesignerPageProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/CSharp/CSharpProjectDesignerPageProviderTests.cs
@@ -30,7 +30,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.CSharp
                 CSharpProjectDesignerPage.BuildEvents,
                 CSharpProjectDesignerPage.Package,
                 CSharpProjectDesignerPage.Debug,
-                CSharpProjectDesignerPage.Signing
+                CSharpProjectDesignerPage.Signing,
+                CSharpProjectDesignerPage.CodeAnalysis
             );
 
             Assert.Equal(expected, result);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/VisualBasic/VisualBasicProjectDesignerPageProviderTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/VisualBasic/VisualBasicProjectDesignerPageProviderTests.cs
@@ -30,7 +30,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.VisualBasic
                VisualBasicProjectDesignerPage.Package,
                VisualBasicProjectDesignerPage.References,
                VisualBasicProjectDesignerPage.Debug,
-               VisualBasicProjectDesignerPage.Signing
+               VisualBasicProjectDesignerPage.Signing,
+               VisualBasicProjectDesignerPage.CodeAnalysis
             );
 
             Assert.Equal(expected, result);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/CSharp/CSharpProjectDesignerPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/CSharp/CSharpProjectDesignerPage.cs
@@ -18,5 +18,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.CSharp
         public static readonly ProjectDesignerPageMetadata Debug = new ProjectDesignerPageMetadata(new Guid("{0273C280-1882-4ED0-9308-52914672E3AA}"), pageOrder: 4, hasConfigurationCondition: false);
         public static readonly ProjectDesignerPageMetadata ReferencePaths = new ProjectDesignerPageMetadata(new Guid("{031911C8-6148-4e25-B1B1-44BCA9A0C45C}"), pageOrder: 5, hasConfigurationCondition: false);
         public static readonly ProjectDesignerPageMetadata Signing = new ProjectDesignerPageMetadata(new Guid("{F8D6553F-F752-4DBF-ACB6-F291B744A792}"), pageOrder: 6, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata CodeAnalysis = new ProjectDesignerPageMetadata(new Guid("{c02f393c-8a1e-480d-aa82-6a75d693559d}"), pageOrder: 7, hasConfigurationCondition: false);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/CSharp/CSharpProjectDesignerPageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/CSharp/CSharpProjectDesignerPageProvider.cs
@@ -44,6 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.CSharp
             }
 
             builder.Add(CSharpProjectDesignerPage.Signing);
+            builder.Add(CSharpProjectDesignerPage.CodeAnalysis);
 
             return Task.FromResult<IReadOnlyCollection<IPageMetadata>>(builder.ToImmutableAndFree());
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/VisualBasicProjectDesignerPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/VisualBasicProjectDesignerPage.cs
@@ -17,5 +17,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.VisualBasic
         public static readonly ProjectDesignerPageMetadata References = new ProjectDesignerPageMetadata(new Guid("{4E43F4AB-9F03-4129-95BF-B8FF870AF6AB}"), pageOrder: 1, hasConfigurationCondition: false);
         public static readonly ProjectDesignerPageMetadata Debug = new ProjectDesignerPageMetadata(new Guid("{0273C280-1882-4ED0-9308-52914672E3AA}"), pageOrder: 2, hasConfigurationCondition: false);
         public static readonly ProjectDesignerPageMetadata Signing = new ProjectDesignerPageMetadata(new Guid("{F8D6553F-F752-4DBF-ACB6-F291B744A792}"), pageOrder: 6, hasConfigurationCondition: false);
+        public static readonly ProjectDesignerPageMetadata CodeAnalysis = new ProjectDesignerPageMetadata(new Guid("{c02f393c-8a1e-480d-aa82-6a75d693559d}"), pageOrder: 7, hasConfigurationCondition: false);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/VisualBasicProjectDesignerPageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/VisualBasicProjectDesignerPageProvider.cs
@@ -44,6 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.VisualBasic
             }
 
             builder.Add(VisualBasicProjectDesignerPage.Signing);
+            builder.Add(VisualBasicProjectDesignerPage.CodeAnalysis);
 
             return Task.FromResult<IReadOnlyCollection<IPageMetadata>>(builder.ToImmutableAndFree());
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -389,21 +389,21 @@
     </StringProperty.DataSource>
   </StringProperty>
 
-  <BoolProperty Name="RunRoslynAnalyzersDuringBuild"
+  <BoolProperty Name="RunAnalyzersDuringBuild"
                 Visible="False">
     <BoolProperty.DataSource>
       <DataSource HasConfigurationCondition="False"
-                  PersistedName="RunRoslynAnalyzersDuringBuild"
+                  PersistedName="RunAnalyzersDuringBuild"
                   Persistence="ProjectFile"
                   SourceOfDefaultValue="AfterContext" />
     </BoolProperty.DataSource>
   </BoolProperty>
 
-  <BoolProperty Name="RunRoslynAnalyzersDuringLiveAnalysis"
+  <BoolProperty Name="RunAnalyzersDuringLiveAnalysis"
                 Visible="False">
     <BoolProperty.DataSource>
       <DataSource HasConfigurationCondition="False"
-                  PersistedName="RunRoslynAnalyzersDuringLiveAnalysis"
+                  PersistedName="RunAnalyzersDuringLiveAnalysis"
                   Persistence="ProjectFile"
                   SourceOfDefaultValue="AfterContext" />
     </BoolProperty.DataSource>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -389,4 +389,23 @@
     </StringProperty.DataSource>
   </StringProperty>
 
+  <BoolProperty Name="RunRoslynAnalyzersDuringBuild"
+                Visible="False">
+    <BoolProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="RunRoslynAnalyzersDuringBuild"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </BoolProperty.DataSource>
+  </BoolProperty>
+
+  <BoolProperty Name="RunRoslynAnalyzersDuringLiveAnalysis"
+                Visible="False">
+    <BoolProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="RunRoslynAnalyzersDuringLiveAnalysis"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </BoolProperty.DataSource>
+  </BoolProperty>
 </Rule>


### PR DESCRIPTION
The UI implemented in this PR has been iterated over and approved by the UX team, see [this work item](https://devdiv-design.visualstudio.com/D3%20Studio/_workitems/edit/7294) for details.

![image](https://user-images.githubusercontent.com/10605811/61562356-01f7b180-aa26-11e9-8e3c-32ea08f08a62.png)

![image](https://user-images.githubusercontent.com/10605811/61562365-0623cf00-aa26-11e9-831f-338155f8c562.png)

This page includes a new Roslyn Analyzers section with the following controls:
1. Hyperlink for overview documentation on Roslyn analyzers
2. Check boxes to selectively disable analyzer execution during build and/or live analysis via project properties `RunRoslynAnalyzersDuringBuild` and `RunRoslynAnalyzersDuringLiveAnalysis`. Default values are 'true' for both of these. Addresses https://github.com/dotnet/roslyn/issues/23591. These properties will be respected once the targets change in https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/190487?path=%2Fsrc%2Fedev%2FStaticAnalysis%2Ffxcoptask%2FMicrosoft.CodeAnalysis.targets&_a=files makes it in.
3. Text box showing the installed FxCopAnalyzers NuGet package version, if any.
4. Following buttons:
   1. `Install`: Installs the latest stable FxCopAnalyzers NuGet package (currently 2.9.3).
   2. `...`: Opens NuGet package manager with "Microsoft.CodeAnalysis.FxCopAnalyzers" as the search string for custom installation.
   3. `Uninstall`: Uninstalls the currently installed FxCopAnalyzers NuGet package.
   4. `Refresh`: Refreshes the UI, in case user has done offline install/uninstall/upgrade of NuGet packages.

Addresses part of #266. Note that in very near future we plan to enhance this page with information about any project level editorconfig file and ability to create or view editorconfig file from this property page (similar to the ruleset selection and opening from Code Analysis page in legacy project system).

https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/190487 adds the corresponding section to the existing Code Analysis property page in the legacy project system.

Tagging @mikadumont who helped drive the UX review. Also tagging other folks involved in the design thread @jinujoseph @vatsalyaagrawal @jjmew @cartermp