### PR TITLE
Enable inline test failures during build

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,4 +1,5 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project>
   <Import Project="build\Packages.targets"/>
+  <Import Project="build\Scripts\UnitTests.targets" />
 </Project>

--- a/build/Scripts/UnitTests.targets
+++ b/build/Scripts/UnitTests.targets
@@ -7,8 +7,10 @@
     <UsingToolXUnit>false</UsingToolXUnit>
   </PropertyGroup>
 
-  <Target Name="Test" 
-          Condition="'$(IsUnitTestProject)' == 'true'">
+  <Target 
+    Name="Test" 
+    Condition="'$(IsUnitTestProject)' == 'true'"
+    >
 
     <PropertyGroup>
       <TestResultsDirectory>$(ArtifactsTestResultsDir)</TestResultsDirectory>
@@ -18,39 +20,45 @@
       <HtmlTestResultsFile>$(TestResultsDirectory)$(TargetName)$(TargetExt).html</HtmlTestResultsFile>  <!-- For Humans to read -->
     </PropertyGroup>
 
-    <Error Text="The project must be restored and built before running tests"
-           File="$(MSBuildProjectFile)"
-           Condition="!Exists('$(XUnitExe)') Or !Exists('$(TargetPath)')"
-           />
+    <Error 
+      Text="The project must be restored and built before running tests"
+      File="$(MSBuildProjectFile)"
+      Condition="!Exists('$(XUnitExe)') Or !Exists('$(TargetPath)')"
+      />
 
-    <Message Text="Running tests for $(MSBuildProjectFile) [$(Configuration)]..."
-             Importance="high"
-             />
+    <Message 
+      Text="Running tests for $(MSBuildProjectFile) [$(Configuration)]..."
+      Importance="high"
+      />
 
     <MakeDir Directories="$(TestResultsDirectory)" />
 
     <!-- xUnit writes to STDERR (test name) and STDOUT (error message, stack). STDERR gets logged as an error.  -->
-    <Exec Command='"$(XUnitExe)" "$(TargetPath)" -quiet -nologo -noshadow -parallel all -xml "$(XmlTestResultsFile)" -html "$(HtmlTestResultsFile)"'
-          LogStandardErrorAsError="true"
-          IgnoreExitCode="true"
-          >
+    <Exec 
+      Command='"$(XUnitExe)" "$(TargetPath)" -quiet -nologo -noshadow -parallel all -xml "$(XmlTestResultsFile)" -html "$(HtmlTestResultsFile)"'
+      LogStandardErrorAsError="true"
+      IgnoreExitCode="true"
+      >
 
-      <Output TaskParameter="ExitCode"
-              PropertyName="ExitCode"
-              />
+      <Output 
+        TaskParameter="ExitCode"
+        PropertyName="ExitCode"
+        />
 
     </Exec>
 
-    <Message Text="Succeeded running tests for $(MSBuildProjectFile) [$(Configuration)]."
-             Condition="$(ExitCode) == 0"
-             Importance="High"
-             />
+    <Message 
+      Text="Succeeded running tests for $(MSBuildProjectFile) [$(Configuration)]."
+      Condition="$(ExitCode) == 0"
+      Importance="High"
+      />
 
     <!-- Exec.LogStandardErrorAsError does not fail the build, we need to output explicit error to do that. -->
-    <Error Text="There were test failures, see $(HtmlTestResultsFile) for full results."
-           Condition="$(ExitCode) != 0"
-           File="xUnit"
-           />
+    <Error 
+      Text="There were test failures, see $(HtmlTestResultsFile) for full results."
+      Condition="$(ExitCode) != 0"
+      File="xUnit"
+      />
 
   </Target>
 

--- a/build/Scripts/UnitTests.targets
+++ b/build/Scripts/UnitTests.targets
@@ -1,0 +1,64 @@
+<Project>
+
+  <!-- Runs unit tests for a project via xUnit -->
+
+  <PropertyGroup>
+    <!-- Opt out of RoslynTools.RepoToolset's xUnit integration -->
+    <UsingToolXUnit>false</UsingToolXUnit>
+  </PropertyGroup>
+
+  <Target Name="Test" 
+          Condition="'$(IsUnitTestProject)' == 'true'">
+
+    <PropertyGroup>
+      <TestResultsDirectory>$(ArtifactsTestResultsDir)</TestResultsDirectory>
+      <XUnitExe>$(Pkgxunit_runner_console)\tools\net472\xunit.console.x86.exe</XUnitExe>
+
+      <XmlTestResultsFile>$(TestResultsDirectory)$(TargetName)$(TargetExt).xml</XmlTestResultsFile>     <!-- For AzureDevOps to read -->
+      <HtmlTestResultsFile>$(TestResultsDirectory)$(TargetName)$(TargetExt).html</HtmlTestResultsFile>  <!-- For Humans to read -->
+    </PropertyGroup>
+
+    <Error Text="The project must be restored and built before running tests"
+           File="$(MSBuildProjectFile)"
+           Condition="!Exists('$(XUnitExe)') Or !Exists('$(TargetPath)')"
+           />
+
+    <Message Text="Running tests for $(MSBuildProjectFile) [$(Configuration)]"
+             Importance="high"
+             />
+
+    <!-- xUnit writes to STDERR (test name) and STDOUT (error message, stack). STDERR gets logged as an error.  -->
+    <Exec Command='"$(XUnitExe)" "$(TargetPath)" -quiet -nologo -noshadow -parallel all -xml "$(XmlTestResultsFile)" -html "$(HtmlTestResultsFile)"'
+          LogStandardErrorAsError="true"
+          IgnoreExitCode="true"
+          >
+
+      <Output TaskParameter="ExitCode"
+              PropertyName="ExitCode"
+              />
+
+    </Exec>
+
+    <!-- Exec.LogStandardErrorAsError does not fail the build, we need to output explicit error to do that. -->
+    <Error Text="There were test failures, see $(HtmlTestResultsFile) for full results."
+           Condition="$(ExitCode) != 0"
+           File="xUnit"
+           />
+
+  </Target>
+
+  <!-- Both xunit.runner.console and xunit.runner.visualstudio carry the same file, 
+       remove it to avoid double-write. 
+  -->
+  <PropertyGroup>
+    <PrepareForBuildDependsOn>RemoveDuplicateXUnitAbstractions;$(PrepareForBuildDependsOn)</PrepareForBuildDependsOn>
+  </PropertyGroup>
+  
+  <Target Name="RemoveDuplicateXUnitAbstractions">
+    
+    <ItemGroup>
+      <None Remove="@(None)" Condition="'%(Filename)%(Extension)' == 'xunit.abstractions.dll'" />
+    </ItemGroup>
+    
+  </Target>
+</Project>

--- a/build/Scripts/UnitTests.targets
+++ b/build/Scripts/UnitTests.targets
@@ -23,7 +23,7 @@
            Condition="!Exists('$(XUnitExe)') Or !Exists('$(TargetPath)')"
            />
 
-    <Message Text="Running tests for $(MSBuildProjectFile) [$(Configuration)]"
+    <Message Text="Running tests for $(MSBuildProjectFile) [$(Configuration)]..."
              Importance="high"
              />
 
@@ -38,6 +38,11 @@
               />
 
     </Exec>
+
+    <Message Text="Succeeded running tests for $(MSBuildProjectFile) [$(Configuration)]."
+             Condition="$(ExitCode) == 0"
+             Importance="High"
+             />
 
     <!-- Exec.LogStandardErrorAsError does not fail the build, we need to output explicit error to do that. -->
     <Error Text="There were test failures, see $(HtmlTestResultsFile) for full results."

--- a/build/Scripts/UnitTests.targets
+++ b/build/Scripts/UnitTests.targets
@@ -27,6 +27,8 @@
              Importance="high"
              />
 
+    <MakeDir Directories="$(TestResultsDirectory)" />
+
     <!-- xUnit writes to STDERR (test name) and STDOUT (error message, stack). STDERR gets logged as an error.  -->
     <Exec Command='"$(XUnitExe)" "$(TargetPath)" -quiet -nologo -noshadow -parallel all -xml "$(XmlTestResultsFile)" -html "$(HtmlTestResultsFile)"'
           LogStandardErrorAsError="true"


### PR DESCRIPTION
This brings back inline test failures that we used to have before we adopted RoslynTools.RepoToolset:

## Before
![image](https://user-images.githubusercontent.com/1103906/61573528-9b40c980-aaf3-11e9-9653-9ef3918fa7e4.png)

## After
![image](https://user-images.githubusercontent.com/1103906/61573517-63d21d00-aaf3-11e9-802a-ec8a6d71dd1e.png)