### PR TITLE
[WIP] New integration test infrastructure

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,4 +1,5 @@
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project>
   <Import Project="build\Packages.targets"/>
+  <Import Project="build\Scripts\IntegrationTests.targets"/>
 </Project>

--- a/build/Scripts/IntegrationTests.targets
+++ b/build/Scripts/IntegrationTests.targets
@@ -27,8 +27,6 @@
     <RunSettingsFilePath>$(IntermediateOutputPath)$(TargetName)$(TargetExt).runsettings</RunSettingsFilePath>
   </PropertyGroup>
 
-  <!-- 1. Initialize VS (reset settings, etc) -->
-
   <Target Name="GenerateRunSettings">
 
     <PropertyGroup>
@@ -57,8 +55,6 @@
       Overwrite="true" />
 
   </Target>
-
-  <!-- 4. Disable Windows Error Reporting -->
 
   <Target Name="ExecuteTests">
 
@@ -107,9 +103,5 @@
       />
 
   </Target>
-
-  <!-- 6. Kill VS (can we get PID's that we launched?) -->
-
-  <!-- 7. Reenable Windows Error Reporting -->
 
 </Project>

--- a/build/Scripts/IntegrationTests.targets
+++ b/build/Scripts/IntegrationTests.targets
@@ -79,7 +79,7 @@
            Condition="!Exists('$(TargetPath)')"
            />
 
-    <Message Text="Running integration tests for $(MSBuildProjectFile) [$(Configuration)]..."
+    <Message Text="Running integration tests for $(MSBuildProjectFile) [$(Configuration)] (this might take a while)..."
              Importance="High"
              />
 

--- a/build/Scripts/IntegrationTests.targets
+++ b/build/Scripts/IntegrationTests.targets
@@ -1,0 +1,105 @@
+<Project>
+
+  <!-- Assumptions: We've already built and the VSIX is deployed 
+       Inputs: $(VSSDKTargetPlatformRegRootSuffix) - I think we should consider a random RootSuffix (this might not be great on local machine)
+               $(RunningUnderCI)
+  	           $(VisualStudioXamlRulesDir)
+  -->
+  
+  <!-- Runs integration tests for a project via vstest.console.exe -->
+  
+  <PropertyGroup>
+    <!-- Opt out of RoslynTools.RepoToolset's xUnit integration -->
+    <UsingToolXUnit>false</UsingToolXUnit>
+  </PropertyGroup>
+  
+  <Target Name="Test" 
+          Condition="$(IsIntegrationTestProject) == 'true'"
+          DependsOnTargets="GenerateRunSettings;RunIntegrationTest" />
+
+  <PropertyGroup>
+    <TestResultsDirectory>$(ArtifactsTestResultsDir)</TestResultsDirectory>
+    <RunSettingsFilePath>$(IntermediateOutputPath)$(TargetName)$(TargetExt).runsettings</RunSettingsFilePath>
+  </PropertyGroup>
+
+  <!-- 1. Initialize VS (reset settings, etc) -->
+
+  <Target Name="GenerateRunSettings">
+
+    <PropertyGroup>
+      <RunSettingsContents>
+        <![CDATA[
+<RunSettings>
+  <TestRunParameters>
+    <Parameter name="VsRootSuffix" value="$(VSSDKTargetPlatformRegRootSuffix)" />
+  </TestRunParameters>
+  <RunConfiguration>
+    <MaxCpuCount>1</MaxCpuCount>
+  </RunConfiguration>
+  
+  <MSTest>
+     <DeploymentEnabled>false</DeploymentEnabled>
+     <DeleteDeploymentDirectoryAfterTestRunIsComplete>False</DeleteDeploymentDirectoryAfterTestRunIsComplete>
+  </MSTest>
+</RunSettings>
+]]>
+      </RunSettingsContents>
+    </PropertyGroup>
+
+    <WriteLinesToFile
+      File="$(RunSettingsFilePath)"
+      Lines="$(RunSettingsContents)"
+      Overwrite="true" />
+
+  </Target>
+
+  <!-- 4. Disable Windows Error Reporting -->
+
+  <Target Name="RunIntegrationTest">
+
+    <PropertyGroup>
+      <TestAssemblyLogFileName>$(TargetName)$(TargetExt).trx</TestAssemblyLogFileName>
+      <VSTestExeEnvironment>
+        VisualBasicDesignTimeTargetsPath=$(VisualStudioXamlRulesDir)Microsoft.VisualBasic.DesignTime.targets;
+        FSharpDesignTimeTargetsPath=$(VisualStudioXamlRulesDir)Microsoft.FSharp.DesignTime.targets;
+        CSharpDesignTimeTargetsPath=$(VisualStudioXamlRulesDir)Microsoft.CSharp.DesignTime.targets;
+      </VSTestExeEnvironment>
+    </PropertyGroup>
+
+    <MakeDir 
+      Directories="$(TestResultsDirectory)" />
+
+    <Error Text="The project must built before running tests"
+           File="$(MSBuildProjectFile)"
+           Condition="!Exists('$(TargetPath)')"
+           />
+
+    <Message Text="Running integration tests for $(MSBuildProjectFile) [$(Configuration)]"
+            Importance="high"
+             />
+
+    <Exec 
+      Command='vstest.console.exe /Blame /ResultsDirectory:"$(TestResultsDirectory)\" /Settings:"$(RunSettingsFilePath)" /Logger:trx;LogFileName=$(TestAssemblyLogFileName) "$(TargetPath)"'
+      EnvironmentVariables="$(VSTestExeEnvironment)"
+      LogStandardErrorAsError="false"
+      IgnoreStandardErrorWarningFormat="true"
+      StandardErrorImportance="Low"
+      StandardOutputImportance="Low"
+      IgnoreExitCode="true">
+      
+      <Output TaskParameter="ExitCode" PropertyName="ExitCode" />
+    </Exec>
+
+    <Error 
+      Text="There were integration test failures, see $(TestResultsDirectory)$(TestAssemblyLogFileName) for full results." 
+      Condition="$(ExitCode) != 0" 
+      File="Apex"
+      />
+
+  </Target>
+
+  <!-- 6. Kill VS (can we get PID's that we launched?) -->
+
+  <!-- 7. Reenable Windows Error Reporting -->
+
+</Project>

--- a/build/Scripts/IntegrationTests.targets
+++ b/build/Scripts/IntegrationTests.targets
@@ -8,14 +8,14 @@
   
   <!-- Runs integration tests for a project via vstest.console.exe -->
   
-  <PropertyGroup>
+  <PropertyGroup Condition="$(IsIntegrationTestProject) == 'true'">
     <!-- Opt out of RoslynTools.RepoToolset's xUnit integration -->
     <UsingToolXUnit>false</UsingToolXUnit>
   </PropertyGroup>
-  
+
   <Target Name="Test" 
-          Condition="$(IsIntegrationTestProject) == 'true'"
-          DependsOnTargets="GenerateRunSettings;RunIntegrationTest" />
+          Condition="$(IsIntegrationTestProject) == 'true' AND '$(IntegrationTest)' == 'true'"
+          DependsOnTargets="GenerateRunSettings;ExecuteTests" />
 
   <PropertyGroup>
     <TestResultsDirectory>$(ArtifactsTestResultsDir)</TestResultsDirectory>
@@ -55,7 +55,7 @@
 
   <!-- 4. Disable Windows Error Reporting -->
 
-  <Target Name="RunIntegrationTest">
+  <Target Name="ExecuteTests">
 
     <PropertyGroup>
       <TestAssemblyLogFileName>$(TargetName)$(TargetExt).trx</TestAssemblyLogFileName>

--- a/build/Scripts/IntegrationTests.targets
+++ b/build/Scripts/IntegrationTests.targets
@@ -9,10 +9,9 @@
     $(VisualStudioXamlRulesDir): The build output location containing the XAML rules.
   -->       
   
-  
-  <PropertyGroup Condition="$(IsIntegrationTestProject) == 'true'">
+  <PropertyGroup>
     <!-- Opt out of RoslynTools.RepoToolset's xUnit integration -->
-    <UsingToolXUnit>false</UsingToolXUnit>
+    <UsingToolXUnit Condition="$(IsIntegrationTestProject) == 'true'">false</UsingToolXUnit>
   </PropertyGroup>
 
   <Target Name="Test" 

--- a/build/Scripts/IntegrationTests.targets
+++ b/build/Scripts/IntegrationTests.targets
@@ -1,12 +1,14 @@
 <Project>
-
-  <!-- Assumptions: We've already built and the VSIX is deployed 
-       Inputs: $(VSSDKTargetPlatformRegRootSuffix) - I think we should consider a random RootSuffix (this might not be great on local machine)
-               $(RunningUnderCI)
-  	           $(VisualStudioXamlRulesDir)
-  -->
+  <!-- 
+   
+   Runs APEX integration tests for a project via vstest.console.exe
   
-  <!-- Runs integration tests for a project via vstest.console.exe -->
+   Inputs:
+  
+    $(VSSDKTargetPlatformRegRootSuffix): The root suffix of the hive to open.
+    $(VisualStudioXamlRulesDir): The build output location containing the XAML rules.
+  -->       
+  
   
   <PropertyGroup Condition="$(IsIntegrationTestProject) == 'true'">
     <!-- Opt out of RoslynTools.RepoToolset's xUnit integration -->
@@ -75,7 +77,7 @@
            />
 
     <Message Text="Running integration tests for $(MSBuildProjectFile) [$(Configuration)]"
-            Importance="high"
+             Importance="high"
              />
 
     <Exec 

--- a/build/Scripts/IntegrationTests.targets
+++ b/build/Scripts/IntegrationTests.targets
@@ -14,6 +14,10 @@
     <UsingToolXUnit Condition="$(IsIntegrationTestProject) == 'true'">false</UsingToolXUnit>
   </PropertyGroup>
 
+  <!-- To make RoslynTools.RepoToolset happy -->
+  <Target Name="IntegrationTest"
+          Condition="$(IsIntegrationTestProject) == 'true'" />
+  
   <Target Name="Test" 
           Condition="$(IsIntegrationTestProject) == 'true' AND '$(IntegrationTest)' == 'true'"
           DependsOnTargets="GenerateRunSettings;ExecuteTests" />
@@ -75,8 +79,8 @@
            Condition="!Exists('$(TargetPath)')"
            />
 
-    <Message Text="Running integration tests for $(MSBuildProjectFile) [$(Configuration)]"
-             Importance="high"
+    <Message Text="Running integration tests for $(MSBuildProjectFile) [$(Configuration)]..."
+             Importance="High"
              />
 
     <Exec 
@@ -91,6 +95,11 @@
       <Output TaskParameter="ExitCode" PropertyName="ExitCode" />
     </Exec>
 
+    <Message Text="Succeeded running integration tests for $(MSBuildProjectFile)."
+             Condition="$(ExitCode) == 0"
+             Importance="High"
+             />
+    
     <Error 
       Text="There were integration test failures, see $(TestResultsDirectory)$(TestAssemblyLogFileName) for full results." 
       Condition="$(ExitCode) != 0" 

--- a/build/Versions.props
+++ b/build/Versions.props
@@ -13,11 +13,9 @@
 
     <!-- Toolset -->
     <RoslynToolsRepoToolsetVersion>1.0.0-beta-62705-01</RoslynToolsRepoToolsetVersion>
-    <RoslynToolsVsixExpInstallerVersion>1.0.0-beta-62503-02</RoslynToolsVsixExpInstallerVersion>
     <RoslynIntegrationVsixVersion>2.6.0.6211302</RoslynIntegrationVsixVersion>
     <RoslynDependenciesProjectSystemOptimizationDataVersion>2.6.0-beta1-62205-02</RoslynDependenciesProjectSystemOptimizationDataVersion>
     <VSWhereVersion>2.3.2</VSWhereVersion>
-    <TRXUnitVersion>1.0.0-beta1</TRXUnitVersion>
     <MicrosoftDotNetIBCMergeVersion>4.7.1-alpha-00001</MicrosoftDotNetIBCMergeVersion>
     <MicrosoftNetCompilersVersion>3.3.0-beta2-19357-02</MicrosoftNetCompilersVersion>
     <MicrosoftDiaSymReaderPdb2PdbVersion>1.1.0-beta1-62624-01</MicrosoftDiaSymReaderPdb2PdbVersion>

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -180,7 +180,7 @@ function Build {
   $useCodecov = $ci -and $env:CODECOV_TOKEN -and ($configuration -eq 'Debug') -and ($env:ghprbPullAuthorLogin -ne 'dotnet-bot')
   $useOpenCover = $useCodecov
 
-  & $MsbuildExe $ToolsetBuildProj /m /nologo /clp:Summary /nodeReuse:$nodeReuse /warnaserror /v:$verbosity $logCmd /p:Configuration=$configuration /p:SolutionPath=$solution /p:Restore=$restore /p:QuietRestore=true /p:Build=$build /p:Rebuild=$rebuild /p:Deploy=$deploy /p:Test=$test /p:IntegrationTest="false" /p:Sign=$sign /p:Pack=$pack /p:UseCodecov=$useCodecov /p:UseOpenCover=$useOpenCover /p:CIBuild=$ci /p:Optimize=$optimize /p:NuGetPackageRoot=$NuGetPackageRoot $properties
+  & $MsbuildExe $ToolsetBuildProj /m /nologo /clp:Summary /nodeReuse:$nodeReuse /warnaserror /v:$verbosity $logCmd /p:Configuration=$configuration /p:SolutionPath=$solution /p:Restore=$restore /p:QuietRestore=true /p:Build=$build /p:Rebuild=$rebuild /p:Deploy=$deploy /p:Test=$test /p:IntegrationTest=$integrationTest /p:Sign=$sign /p:Pack=$pack /p:UseCodecov=$useCodecov /p:UseOpenCover=$useOpenCover /p:CIBuild=$ci /p:Optimize=$optimize /p:NuGetPackageRoot=$NuGetPackageRoot $properties
   if ((-not $?) -or ($lastExitCode -ne 0)) {
     throw "Aborting after build failure."
   }
@@ -188,23 +188,6 @@ function Build {
   if ($useCodecov) {
     $CodecovProj = Join-Path $PSScriptRoot 'Codecov.proj'
     & $MsbuildExe $CodecovProj /m /nologo /clp:Summary /nodeReuse:$nodeReuse /warnaserror /v:diag /t:Codecov /p:Configuration=$configuration /p:UseCodecov=$useCodecov /p:NuGetPackageRoot=$NuGetPackageRoot $properties
-  }
-
-  # create suite.json file
-  $IntegrationTestDir = Join-Path (Join-Path $ArtifactsDir $configuration) "bin\IntegrationTests"
-  $testSuite = Join-Path $IntegrationTestDir "suite.json"
-  if (!(Test-Path $testSuite)) {
-    $testSuiteContents = @'
-{
-    "_comment":  "dotnet project-system built tests",
-    "testcontainer":  [
-                          {
-                              "name":  "Microsoft.VisualStudio.ProjectSystem.IntegrationTests.dll"
-                          }
-                      ]
-}
-'@
-    $testSuiteContents >> $testSuite
   }
 }
 
@@ -239,136 +222,6 @@ $projectSystemAssemblyName,$projectSystemVersion.0
 "@
   & mkdir -force $devDivInsertionFiles > $null
   $csv > $dependentAssemblyVersionsCsv
-}
-
-# Ensure project system is installed to the correct hive
-function InstallProjectSystemVSIX ([string] $rootSuffix, [string] $vsInstallDir) {
-  UninstallVSIXes $rootSuffix
-  Write-Host "Installing project system into '$vsInstallDir'"
-  $vsixExpInstalleExe = GetVSIXExpInstallerExe
-  $ProjectSystemVsix = [System.IO.Path]::GetFullPath((Join-Path (Join-Path $ArtifactsDir $configuration) "VSSetup\ProjectSystem.vsix"))
-  InstallVSIX $vsixExpInstalleExe $rootsuffix $vsInstallDir $ProjectSystemVsix
-  $VisualStudioEditorsSetupVsix = [System.IO.Path]::GetFullPath((Join-Path (Join-Path $ArtifactsDir $configuration) "VSSetup\VisualStudioEditorsSetup.vsix"))
-  InstallVSIX $vsixExpInstalleExe $rootsuffix $vsInstallDir $VisualStudioEditorsSetupVsix
-  
-  $DevEnvExe = Join-Path $vsInstallDir "Common7\IDE\devenv.exe"
-  & $DevEnvExe /clearcache /rootsuffix $rootSuffix
-  & $DevEnvExe /updateconfiguration /rootsuffix $rootSuffix
-  & $DevEnvExe /resetsettings General.vssettings /command "File.Exit" /rootsuffix $rootSuffix
-  
-  Stop-Process-Name "DbgCLR"
-  Stop-Process-Name "VsJITDebugger"
-  Stop-Process-Name "dexplore"
-}
-
-# Ensure rules files can be found by msbuild
-function SetIntegrationEnvironmentVariables {
-  $VisualStudioXamlRulesDir = Join-Path (Join-Path $ArtifactsDir $configuration) "VSSetup\Rules"
-  $env:VisualBasicDesignTimeTargetsPath = Join-Path $VisualStudioXamlRulesDir "Microsoft.VisualBasic.DesignTime.targets"
-  $env:FSharpDesignTimeTargetsPath = Join-Path $VisualStudioXamlRulesDir "Microsoft.FSharp.DesignTime.targets"
-  $env:CSharpDesignTimeTargetsPath = Join-Path $VisualStudioXamlRulesDir "Microsoft.CSharp.DesignTime.targets"
-}
-
-function ConvertTRXFiles([string] $folderPath) {
-  $trxUnitExe = GetTRXUnitExe
-  $trxFiles = Get-ChildItem -Path $folderPath -Recurse -Include *.trx 
-  foreach ($trxFile in $trxFiles) {
-    & $trxUnitExe $trxFile
-  }
-}
-
-function UninstallVSIXes([string] $hive){
-  $vsid = Get-VisualStudioId
-  
-  $extDir = Join-Path ${env:USERPROFILE} "AppData\Local\Microsoft\VisualStudio\15.0_$($vsid)$($hive)\Extensions"
-    if (Test-Path $extDir) {
-        foreach ($dir in Get-ChildItem -Directory $extDir) {
-            $name = Split-Path -leaf $dir
-            Write-Host "`tUninstalling $name"
-        }
-        Remove-Item -re -fo $extDir
-    }
-    
-    $DevEnvExe = Join-Path $vsInstallDir "Common7\IDE\devenv.exe"
-    & $DevEnvExe /Updateconfiguration
-}
-
-function RunIntegrationTests {
-  InstallProjectSystemVSIX $rootsuffix $vsInstallDir
-  SetIntegrationEnvironmentVariables
-  
-  # Run integration tests
-  $VSTestExe = Join-Path $vsInstallDir "Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
-  $IntegrationTestTempDir = Join-Path (Join-Path $ArtifactsDir $configuration) "IntegrationTestTemp"
-  Create-Directory $IntegrationTestTempDir
-  $LogFileArgs = "trx;LogFileName=Microsoft.VisualStudio.ProjectSystem.IntegrationTests.trx"
-  $TestAssembly = Join-Path (Join-Path $ArtifactsDir $configuration) "bin\IntegrationTests\Microsoft.VisualStudio.ProjectSystem.IntegrationTests.dll"
-  # create runsettings file
-  $ScreenshotCollectorVersion = GetVersion("MicrosoftDevDivValidationLoggingScreenshotCollectorVersion")
-  $pathToScreenShotCollector = Join-Path $NuGetPackageRoot "Microsoft.DevDiv.Validation.Logging.ScreenshotCollector\$ScreenshotCollectorVersion\lib\net461"
-  
-  $MediaRecorderVersion = GetVersion("MicrosoftDevDivValidationMediaRecorderVersion")
-  $pathToMediaRecorder = Join-Path $NuGetPackageRoot "Microsoft.DevDiv.Validation.MediaRecorder\$MediaRecorderVersion\lib\net461"
-  
-  $runSettings = Join-Path $IntegrationTestTempDir "integration.runsettings"
-  if (!(Test-Path $runSettings)) {
-    $runSettingsContents = @"
-<?xml version="1.0" encoding="utf-8"?>  
-<RunSettings>  
-  <TestRunParameters>
-    <Parameter name="VsRootSuffix" value="$rootsuffix" />
-  </TestRunParameters>
-  <RunConfiguration>
-    <MaxCpuCount>1</MaxCpuCount>
-    <!-- Path to Test Adapters -->
-    <TestAdaptersPaths>$pathToScreenShotCollector;$pathToMediaRecorder</TestAdaptersPaths>
-  </RunConfiguration>
-  
-  <!-- Configurations for DataCollectors -->
-  <DataCollectionRunSettings>
-    <DataCollectors>
-      <DataCollector friendlyName="Screen and Voice Recorder" uri="datacollector://Microsoft/DevDiv/VideoRecorder/2.0" assemblyQualifiedName="Microsoft.DevDiv.Validation.MediaRecorder.Collector, Microsoft.DevDiv.Validation.MediaRecorder.Collector.VideoRecorderDataCollector, Version=15.0.0.0, Culture=neutral, PublicKeyToken=null" enabled="true"/>
-      <DataCollector friendlyName="Screenshot Collector" uri="datacollector://Microsoft/DevDiv/Validation/Logging/Screenshot/v1" assemblyQualifiedName="Microsoft.DevDiv.Validation.Logging.ScreenshotCollector, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-        <Configuration>
-          <Triggers>OnTestCaseFail</Triggers>
-        </Configuration>
-      </DataCollector>
-    </DataCollectors>
-  </DataCollectionRunSettings>
-</RunSettings>
-"@
-    $runSettingsContents >> $runSettings
-  }
-
-  Disable-WindowsErrorReporting
-  Write-Host "Using $VSTestExe"
-  & $VSTestExe /blame /logger:$LogFileArgs /ResultsDirectory:"$IntegrationTestTempDir" /Settings:$runSettings $TestAssembly
-  $integrationTestsFailed = $false
-  if ((-not $?) -or ($lastExitCode -ne 0)) {
-    $integrationTestsFailed = $true
-  }
-  Enable-WindowsErrorReporting
-  
-  # Kill any VS processes left over
-  Stop-Process-Name "devenv"
-  
-  # Convert trx to be an xUnit xml file
-  Write-Host "Converting MSTest results"
-  ConvertTRXFiles $IntegrationTestTempDir
-  
-  # Move test results to test results folder
-  $TestResultsDir = Join-Path (Join-Path $ArtifactsDir $configuration) "TestResults"
-  Copy-Item -Filter *.xml -Path $IntegrationTestTempDir -Recurse -Destination $TestResultsDir
-  
-  # Uninstall extensions as other test runs could happen on the VM
-  # NOTE: it sometimes takes 2 tries for it to succeed
-  UninstallVSIXes $rootSuffix
-  
-  if ($integrationTestsFailed) {
-    # Copy screenshots and video files on failure
-    Copy-Item -Path $IntegrationTestTempDir -Recurse -Destination $TestResultsDir -Container
-    throw "Aborting after integration test failure."
-  }
 }
 
 try {
@@ -434,10 +287,6 @@ try {
   Build
 
   GenerateDependentAssemblyVersionFile
- 
-  if($integrationTest){
-    RunIntegrationTests
-  }
   
   exit $lastExitCode
 }

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -87,37 +87,6 @@ function GetVsWhereExe{
   return $vsWhereExe
 }
 
-function GetVSIXExpInstallerExe{
-  $vsixExpInstallerVersion = GetVersion("RoslynToolsVsixExpInstallerVersion")
-  $vsixExpInstalleDir = Join-Path $ToolsRoot "VSIXExpInstaller\$vsixExpInstallerVersion"
-  $vsixExpInstalleExe = Join-Path $vsixExpInstalleDir "tools\VSIXExpInstaller.exe"
-  
-  if (!(Test-Path $vsixExpInstalleExe)) {
-    Create-Directory $vsixExpInstalleDir
-    Write-Host "Downloading VSIXExpInstaller"
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    Invoke-WebRequest "https://dotnet.myget.org/F/roslyn-tools/api/v2/package/RoslynTools.VSIXExpInstaller/$vsixExpInstallerVersion" -OutFile RoslynTools.VSIXExpInstaller.zip
-    Expand-Archive .\RoslynTools.VSIXExpInstaller.zip -DestinationPath $vsixExpInstalleDir
-  }
-  
-  return $vsixExpInstalleExe
-}
-
-function GetTRXUnitExe{
-  $trxUnitVersion = GetVersion("TRXUnitVersion")
-  $trxUnitDir = Join-Path $ToolsRoot "TRXUnit\$trxUnitVersion"
-  $trxUnitExe = Join-Path $trxUnitDir "tools\TRXunit.exe"
-  if (!(Test-Path $trxUnitExe)) {
-    Create-Directory $trxUnitDir
-    Write-Host "Downloading TRXUnit"
-    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    Invoke-WebRequest "https://dotnet.myget.org/F/roslyn-tools/api/v2/package/TRXunit/$trxUnitVersion" -OutFile TRXUnit.zip
-    Expand-Archive .\TRXUnit.zip -DestinationPath $trxUnitDir
-  }
-  
-  return $trxUnitExe
-}
-
 function InstallVSIX([string] $vsixExpInstalleExe, [string] $rootsuffix, [string] $vsInstallDir, [string] $pathToVSIX){
   $rootedPath = [System.IO.Path]::GetFullPath($vsInstallDir)
   & $vsixExpInstalleExe /rootSuffix:$rootsuffix /vsInstallDir:"$rootedPath" $pathToVSIX
@@ -149,12 +118,6 @@ function LocateMSBuild {
 
   # Dev16
   return Join-Path $vsInstallDir "MSBuild\Current\Bin\msbuild.exe"
-}
-
-function Get-VisualStudioId(){
-  $vsWhereExe = GetVsWhereExe
-  $vsinstanceId = & $vsWhereExe -all -latest -prerelease -property instanceId -requires Microsoft.Component.MSBuild -requires Microsoft.VisualStudio.Component.VSSDK -requires Microsoft.Net.Component.4.6.TargetingPack -requires Microsoft.VisualStudio.Component.Roslyn.Compiler
-  return $vsinstanceId
 }
 
 function InstallToolset {

--- a/src/Common/Integration/App.config
+++ b/src/Common/Integration/App.config
@@ -1,27 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
-  <configSections>
-    <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
-      <section name="Microsoft.VisualStudio.IntegrationTest.Utilities.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
-    </sectionGroup>
-  </configSections>
-  <appSettings>
-    <add key="xunit.appDomain" value="ifAvailable" />
-    <add key="xunit.methodDisplay" value="method" />
-    <add key="xunit.shadowCopy" value="false"/>
-    <!-- Path relative to the integration test output dir -->
-    <add key="ProjectSystem.XamlRulesDirRelativeToTestAssembly" value="..\..\VSSetup\Rules"/>
-  </appSettings>
-  <userSettings>
-    <Microsoft.VisualStudio.IntegrationTest.Utilities.Settings>
-      <setting name="VsProductVersion" serializeAs="String">
-        <value>15</value>
-      </setting>
-      <setting name="VsRootSuffix" serializeAs="String">
-        <value>ProjectSystem</value>
-      </setting>
-    </Microsoft.VisualStudio.IntegrationTest.Utilities.Settings>
-  </userSettings>
   <system.diagnostics>
     <trace>
       <listeners>


### PR DESCRIPTION
This is the initial start of the new integration test infrastructure from myself and @drewnoakes, biggest changes from previous:

- Logic has been moved from build.ps1 -> msbuild
- We reuse VSIX deployment that occurs during the build, where as previously we'd uninstall/reinstall the VSIXes
- The logic has been simplified, less copying files around, no more "mstest deployment" - everything just runs from output location and results are output directly to where we want them.
- The integration test logic is tied to a project, similar to how build/test already works. It makes the logic much simpilier as we can reuse all the evaluation state of the build.
- Integration tests can now be run multiple times in a row 
- A new VS instance no longer crashes if you run them while VS is open
- VS is no longer torn down while if you run them while it is open
- Settings are no longer thrown away after they are run:

The current state of these tests are ready for "personal run" but not CI runs. CI run logic is being tracked by : https://github.com/dotnet/project-system/issues/5092.