### PR TITLE
Azure pipelines calls build.cmd directly

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -25,8 +25,8 @@ if /I "%1" == "/test"                 set OptTest=$true                         
 if /I "%1" == "/no-test"              set OptTest=$false                           && shift && goto :ParseArguments
 if /I "%1" == "/integration"          set OptIntegrationTest=$true                 && shift && goto :ParseArguments
 if /I "%1" == "/no-integration"       set OptIntegrationTest=$false                && shift && goto :ParseArguments
-if /I "%1" == "/deploy-extension"     set OptDeploy=$true                          && shift && goto :ParseArguments
-if /I "%1" == "/no-deploy-extension"  set OptDeploy=$false                         && shift && goto :ParseArguments
+if /I "%1" == "/deploy"               set OptDeploy=$true                          && shift && goto :ParseArguments
+if /I "%1" == "/no-deploy"            set OptDeploy=$false                         && shift && goto :ParseArguments
 if /I "%1" == "/diagnostic"           set OptLog=$true                             && shift && goto :ParseArguments
 if /I "%1" == "/sign"                 set OptSign=$true                            && shift && goto :ParseArguments
 if /I "%1" == "/ci"                   set OptCI=$true && set PrepareMachine=$true  && shift && goto :ParseArguments
@@ -55,7 +55,7 @@ echo.
 echo   Build options:
 echo     /diagnostic               Turns on logging to a binlog
 echo     /rootsuffix ^<hive^>        Hive to use when deploying Visual Studio extensions (default is 'Exp')
-echo     /[no-]deploy-extension    Deploy (default) or skip deploying Visual Studio extensions
+echo     /[no-]deploy              Deploy (default) or skip deploying Visual Studio extensions
 echo     /configuration ^<config^>   Use Debug (default) or Release build configuration
 echo     /sign                     Sign build outputs
 echo     /ci                       Configures a continuous integration build

--- a/build/CIBuild.cmd
+++ b/build/CIBuild.cmd
@@ -1,3 +1,0 @@
-@echo off
-powershell -ExecutionPolicy ByPass %~dp0Build.ps1 -restore -build -test -pack -ci %*
-exit /b %ErrorLevel%

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -34,7 +34,7 @@ jobs:
         _configuration: Release
   timeoutInMinutes: 20
   steps:
-    - script: $(Build.SourcesDirectory)\build\CIBuild.cmd -configuration $(_configuration) -prepareMachine -sign
+    - script: $(Build.SourcesDirectory)\build.cmd /build /test /ci /no-deploy /configuration $(_configuration) /sign
     - task: PublishBuildArtifacts@1
       inputs:
         PathtoPublish: '$(Build.SourcesDirectory)\artifacts\$(_configuration)\log'
@@ -82,7 +82,7 @@ jobs:
     _configuration: Debug
   timeoutInMinutes: 20
   steps:
-    - script: $(Build.SourcesDirectory)\build\CIBuild.cmd -configuration $(_configuration) -prepareMachine
+    - script: $(Build.SourcesDirectory)\build.cmd /build /test /ci /no-deploy /configuration $(_configuration)
     - task: PublishBuildArtifacts@1
       inputs:
         PathtoPublish: '$(Build.SourcesDirectory)\artifacts\$(_configuration)\log'


### PR DESCRIPTION
This removes the `CIBuild.cmd` script. This may not be safe to do if other branches use `master`'s version of these build scripts. If that turns out to be the case, we'll revert this commit.

The easiest way for us to test this is to get this change into `master` then submit a PR to a branch such as `dev16.0.x` and see if that PR builds.