### PR TITLE
Use dedicated comparer for IDependencyModel

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DependencyModelTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/DependencyModelTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 {
-    public class DependencyModelTests
+    public sealed class DependencyModelTests
     {
         private class TestableDependencyModel : DependencyModel
         {
@@ -116,40 +116,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.True(model.Resolved);
             Assert.True(model.Implicit);
             Assert.Single(model.Properties);
-        }
-
-        [Fact]
-        public void EqualsAndGetHashCode()
-        {
-            var model1 = new TestableDependencyModel(
-                path: "somePath",
-                originalItemSpec: "SomeItemSpec1",
-                flags: ProjectTreeFlags.HiddenProjectItem,
-                resolved: true,
-                isImplicit: true,
-                properties: ImmutableStringDictionary<string>.EmptyOrdinal.Add("someProp1", "someVal1"));
-
-            var model2 = new TestableDependencyModel(
-                path: "somePath",
-                originalItemSpec: "SomeItemSpec1",
-                flags: ProjectTreeFlags.HiddenProjectItem,
-                resolved: true,
-                isImplicit: true,
-                properties: ImmutableStringDictionary<string>.EmptyOrdinal.Add("someProp1", "someVal1"));
-
-            var model3 = new TestableDependencyModel(
-                path: "somePath",
-                originalItemSpec: "SomeItemSpec2",
-                flags: ProjectTreeFlags.HiddenProjectItem,
-                resolved: true,
-                isImplicit: true,
-                properties: ImmutableStringDictionary<string>.EmptyOrdinal.Add("someProp1", "someVal1"));
-
-            Assert.Equal(model1, model2);
-            Assert.NotEqual(model1, model3);
-
-            Assert.Equal(model1.GetHashCode(), model2.GetHashCode());
-            Assert.NotEqual(model1.GetHashCode(), model3.GetHashCode());
         }
 
         [Fact]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/IDependencyModelEqualityComparerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/IDependencyModelEqualityComparerTests.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
+{
+    public sealed class IDependencyModelEqualityComparerTests
+    {
+        [Fact]
+        public void EqualsAndGetHashCode()
+        {
+            var model1 = new TestDependencyModel
+            {
+                Id = "id1",
+                ProviderType = "provider1"
+            };
+
+            var model2 = new TestDependencyModel
+            {
+                Id = "id1",
+                ProviderType = "provider1"
+            };
+
+            var model3 = new TestDependencyModel
+            {
+                Id = "DIFFERENT",
+                ProviderType = "provider1"
+            };
+
+            var model4 = new TestDependencyModel
+            {
+                Id = "id1",
+                ProviderType = "DIFFERENT"
+            };
+
+            Assert.True(IDependencyModelEqualityComparer.Instance.Equals(model1, model2));
+            Assert.True(IDependencyModelEqualityComparer.Instance.Equals(model2, model1));
+
+            Assert.False(IDependencyModelEqualityComparer.Instance.Equals(model1, model3));
+            Assert.False(IDependencyModelEqualityComparer.Instance.Equals(model3, model1));
+
+            Assert.False(IDependencyModelEqualityComparer.Instance.Equals(model1, model4));
+            Assert.False(IDependencyModelEqualityComparer.Instance.Equals(model4, model1));
+
+            Assert.False(IDependencyModelEqualityComparer.Instance.Equals(model3, model4));
+            Assert.False(IDependencyModelEqualityComparer.Instance.Equals(model4, model3));
+
+            Assert.Equal(
+                IDependencyModelEqualityComparer.Instance.GetHashCode(model1),
+                IDependencyModelEqualityComparer.Instance.GetHashCode(model2));
+
+            Assert.NotEqual(
+                IDependencyModelEqualityComparer.Instance.GetHashCode(model1),
+                IDependencyModelEqualityComparer.Instance.GetHashCode(model3));
+
+            Assert.NotEqual(
+                IDependencyModelEqualityComparer.Instance.GetHashCode(model1),
+                IDependencyModelEqualityComparer.Instance.GetHashCode(model4));
+
+            Assert.NotEqual(
+                IDependencyModelEqualityComparer.Instance.GetHashCode(model3),
+                IDependencyModelEqualityComparer.Instance.GetHashCode(model4));
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/IDependencyModelEqualityComparerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Models/IDependencyModelEqualityComparerTests.cs
@@ -45,16 +45,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             Assert.False(IDependencyModelEqualityComparer.Instance.Equals(model3, model4));
             Assert.False(IDependencyModelEqualityComparer.Instance.Equals(model4, model3));
 
+            Assert.False(IDependencyModelEqualityComparer.Instance.Equals(model1, null));
+            Assert.False(IDependencyModelEqualityComparer.Instance.Equals(null, model1));
+
+            Assert.True(IDependencyModelEqualityComparer.Instance.Equals(null, null));
+
             Assert.Equal(
-                IDependencyModelEqualityComparer.Instance.GetHashCode(model1),
+                IDependencyModelEqualityComparer.Instance.GetHashCode(model1!),
                 IDependencyModelEqualityComparer.Instance.GetHashCode(model2));
 
             Assert.NotEqual(
-                IDependencyModelEqualityComparer.Instance.GetHashCode(model1),
+                IDependencyModelEqualityComparer.Instance.GetHashCode(model1!),
                 IDependencyModelEqualityComparer.Instance.GetHashCode(model3));
 
             Assert.NotEqual(
-                IDependencyModelEqualityComparer.Instance.GetHashCode(model1),
+                IDependencyModelEqualityComparer.Instance.GetHashCode(model1!),
                 IDependencyModelEqualityComparer.Instance.GetHashCode(model4));
 
             Assert.NotEqual(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/IDependencyModelEqualityComparer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/IDependencyModelEqualityComparer.cs
@@ -9,10 +9,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     {
         public static IDependencyModelEqualityComparer Instance { get; } = new IDependencyModelEqualityComparer();
 
-        public bool Equals(IDependencyModel x, IDependencyModel y)
+        public bool Equals(IDependencyModel? x, IDependencyModel? y)
         {
-            Requires.NotNull(x, nameof(x));
-            Requires.NotNull(y, nameof(y));
+            if (x is null && y is null)
+                return true;
+
+            if (x is null || y is null)
+                return false;
 
             return string.Equals(x.Id, y.Id, StringComparison.OrdinalIgnoreCase) &&
                    string.Equals(x.ProviderType, y.ProviderType, StringComparisons.DependencyProviderTypes);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/IDependencyModelEqualityComparer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/IDependencyModelEqualityComparer.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
+{
+    internal sealed class IDependencyModelEqualityComparer : IEqualityComparer<IDependencyModel>
+    {
+        public static IDependencyModelEqualityComparer Instance { get; } = new IDependencyModelEqualityComparer();
+
+        public bool Equals(IDependencyModel x, IDependencyModel y)
+        {
+            Requires.NotNull(x, nameof(x));
+            Requires.NotNull(y, nameof(y));
+
+            return string.Equals(x.Id, y.Id, StringComparison.OrdinalIgnoreCase) &&
+                   string.Equals(x.ProviderType, y.ProviderType, StringComparisons.DependencyProviderTypes);
+        }
+
+        public int GetHashCode(IDependencyModel obj)
+        {
+            Requires.NotNull(obj, nameof(obj));
+
+            return unchecked(StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Id) * 397 ^
+                             StringComparer.OrdinalIgnoreCase.GetHashCode(obj.ProviderType));
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/DependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Models/DependencyModel.cs
@@ -82,20 +82,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models
 
         public string Id => OriginalItemSpec;
 
-        public override int GetHashCode()
-        {
-            return unchecked(
-                StringComparer.OrdinalIgnoreCase.GetHashCode(Id) +
-                StringComparers.DependencyProviderTypes.GetHashCode(ProviderType));
-        }
-
-        public override bool Equals(object obj)
-        {
-            return obj is IDependencyModel other &&
-                   other.Id.Equals(Id, StringComparison.OrdinalIgnoreCase) &&
-                   StringComparers.DependencyProviderTypes.Equals(other.ProviderType, ProviderType);
-        }
-
         public override string ToString() => $"{ProviderType}-{Id}";
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependenciesChangesBuilder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependenciesChangesBuilder.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
         {
             if (_added == null)
             {
-                _added = new HashSet<IDependencyModel>();
+                _added = new HashSet<IDependencyModel>(IDependencyModelEqualityComparer.Instance);
             }
 
             _added.Remove(model);
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
         {
             if (_removed == null)
             {
-                _removed = new HashSet<IDependencyModel>();
+                _removed = new HashSet<IDependencyModel>(IDependencyModelEqualityComparer.Instance);
             }
 
             var identity = new RemovedDependencyModel(providerType, dependencyId);
@@ -112,15 +112,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             public ProjectTreeFlags Flags => throw NotImplemented();
             public IImmutableDictionary<string, string> Properties => throw NotImplemented();
             public IImmutableList<string> DependencyIDs => throw NotImplemented();
-
-            public override bool Equals(object obj)
-                => obj is RemovedDependencyModel other &&
-                   string.Equals(Id, other.Id, StringComparison.OrdinalIgnoreCase) &&
-                   string.Equals(ProviderType, other.ProviderType, StringComparisons.DependencyProviderTypes);
-
-            public override int GetHashCode()
-                => unchecked(StringComparer.OrdinalIgnoreCase.GetHashCode(Id) * 397 ^
-                             StringComparer.OrdinalIgnoreCase.GetHashCode(ProviderType));
 
             public override string ToString() => $"{ProviderType}-{Id}";
         }


### PR DESCRIPTION
`IDependencyModel` is an extensibility point and we should not be requiring implementors to add correct `Equals`/`GetHashCode` methods. There's no good way to express this on the interface, but we don't want the implementation to vary based on provider anyway.