### PR TITLE
Fix restore failure

### DIFF
--- a/build/Packages.targets
+++ b/build/Packages.targets
@@ -20,7 +20,6 @@
 
     <!-- Toolset -->
     <PackageReference Update="RoslynTools.RepoToolset"                                                Version="$(RoslynToolsRepoToolsetVersion)" />
-    <PackageReference Update="RoslynTools.VsixExpInstaller"                                           Version="$(RoslynToolsVsixExpInstallerVersion)" />
     <PackageReference Update="RoslynDependencies.ProjectSystem.OptimizationData"                      Version="$(RoslynDependenciesProjectSystemOptimizationDataVersion)" />
     <PackageReference Update="Microsoft.DotNet.IBCMerge"                                              Version="[$(MicrosoftDotNetIBCMergeVersion)]" />
     <PackageReference Update="Microsoft.DiaSymReader.Pdb2Pdb"                                         Version="$(MicrosoftDiaSymReaderPdb2PdbVersion)" />

--- a/build/Toolset.proj
+++ b/build/Toolset.proj
@@ -10,12 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="RoslynTools.RepoToolset" />
-    <PackageReference Include="RoslynTools.VsixExpInstaller" />
     <PackageReference Include="Codecov" />
     <PackageReference Include="OpenCover" />
     <PackageReference Include="Microsoft.DiaSymReader.Pdb2Pdb" />
-    <PackageReference Include="Microsoft.DevDiv.Validation.MediaRecorder" />
-    <PackageReference Include="Microsoft.DevDiv.Validation.Logging.ScreenshotCollector" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
These package references are never used, and/or given a version which breaks restore.

This caused one of the failures in https://github.com/dotnet/project-system/pull/5111.