### PR TITLE
Remove test.cmd

### DIFF
--- a/Test.cmd
+++ b/Test.cmd
@@ -1,3 +1,0 @@
-@echo off
-powershell -ExecutionPolicy ByPass -Command "& """%~dp0build\Build.ps1""" -test %*"
-exit /b %ErrorLevel%


### PR DESCRIPTION
I'm removing this under the assumption no one is using it.

@dotnet/project-system Please tell me if you are using this script to run unit tests, and if so, I'll update it to call through the updated build.cmd.