### PR TITLE
Turn on warnings

### DIFF
--- a/build/Packages.targets
+++ b/build/Packages.targets
@@ -33,6 +33,7 @@
     <PackageReference Update="MicroBuild.Core"                                                        Version="0.2.0" />
     <PackageReference Update="MicroBuild.Core.Sentinel"                                               Version="1.0.0" />
     <PackageReference Update="MicroBuild.Plugins.SwixBuild"                                           Version="1.0.422" />
+    <PackageReference Update="Microsoft.DevDiv.Validation.MediaRecorder"                              Version="15.0.199" />
 
     <!-- VS SDK -->
     <PackageReference Update="Microsoft.VSSDK.BuildTools"                                             Version="15.8.3252" />

--- a/build/Scripts/IntegrationTests.targets
+++ b/build/Scripts/IntegrationTests.targets
@@ -43,7 +43,13 @@
   
   <DataCollectionRunSettings>
     <DataCollectors>
-      <DataCollector friendlyName="Screen and Voice Recorder" uri="datacollector://Microsoft/DevDiv/VideoRecorder/2.0" assemblyQualifiedName="Microsoft.DevDiv.Validation.MediaRecorder.Collector, Microsoft.DevDiv.Validation.MediaRecorder.Collector.VideoRecorderDataCollector, Version=15.0.0.0, Culture=neutral, PublicKeyToken=null" enabled="true"/>
+      <DataCollector friendlyName="Screen and Voice Recorder" uri="datacollector://Microsoft/DevDiv/VideoRecorder/2.0" assemblyQualifiedName="Microsoft.DevDiv.Validation.MediaRecorder.Collector, Microsoft.DevDiv.Validation.MediaRecorder.Collector.VideoRecorderDataCollector, Version=15.0.0.0, Culture=neutral, PublicKeyToken=null" enabled="true">
+        <Configuration>
+          <MediaRecorder>
+            <AudioRecorder enabled="false" />
+          </MediaRecorder>
+        </Configuration>
+      </DataCollector>
     </DataCollectors>
   </DataCollectionRunSettings>
   

--- a/build/Scripts/IntegrationTests.targets
+++ b/build/Scripts/IntegrationTests.targets
@@ -18,10 +18,17 @@
   <PropertyGroup>
     <TestResultsDirectory>$(ArtifactsTestResultsDir)</TestResultsDirectory>
     <RunSettingsFilePath>$(IntermediateOutputPath)$(TargetName)$(TargetExt).runsettings</RunSettingsFilePath>
+    <MediaRecorderDirectory>$(PkgMicrosoft_DevDiv_Validation_MediaRecorder)\lib\net461</MediaRecorderDirectory>
   </PropertyGroup>
 
   <Target Name="GenerateRunSettings">
 
+    <Error
+      Text="The project must be restored before running tests"
+      File="$(MSBuildProjectFile)"
+      Condition="!Exists('$(MediaRecorderDirectory)')"
+      />
+    
     <PropertyGroup>
       <RunSettingsContents>
         <![CDATA[
@@ -31,7 +38,14 @@
   </TestRunParameters>
   <RunConfiguration>
     <MaxCpuCount>1</MaxCpuCount>
+    <TestAdaptersPaths>$(MediaRecorderDirectory)</TestAdaptersPaths>
   </RunConfiguration>
+  
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="Screen and Voice Recorder" uri="datacollector://Microsoft/DevDiv/VideoRecorder/2.0" assemblyQualifiedName="Microsoft.DevDiv.Validation.MediaRecorder.Collector, Microsoft.DevDiv.Validation.MediaRecorder.Collector.VideoRecorderDataCollector, Version=15.0.0.0, Culture=neutral, PublicKeyToken=null" enabled="true"/>
+    </DataCollectors>
+  </DataCollectionRunSettings>
   
   <MSTest>
      <DeploymentEnabled>false</DeploymentEnabled>

--- a/build/Scripts/IntegrationTests.targets
+++ b/build/Scripts/IntegrationTests.targets
@@ -74,6 +74,7 @@
 
     <PropertyGroup>
       <TestAssemblyLogFileName>$(TargetName)$(TargetExt).trx</TestAssemblyLogFileName>
+      <TestAssemblyLogFullPath>$(TestResultsDirectory)$(TestAssemblyLogFileName)</TestAssemblyLogFullPath>
       <VSTestExeEnvironment>
         VisualBasicDesignTimeTargetsPath=$(VisualStudioXamlRulesDir)Microsoft.VisualBasic.DesignTime.targets;
         FSharpDesignTimeTargetsPath=$(VisualStudioXamlRulesDir)Microsoft.FSharp.DesignTime.targets;
@@ -94,11 +95,13 @@
       Importance="High"
       />
 
+    <!-- Delete the TRX to avoid warning about overwriting it -->
+    <Delete Files="$(TestAssemblyLogFullPath)" />
+
     <Exec 
       Command='vstest.console.exe /Blame /ResultsDirectory:"$(TestResultsDirectory)\" /Settings:"$(RunSettingsFilePath)" /Logger:trx;LogFileName=$(TestAssemblyLogFileName) "$(TargetPath)"'
       EnvironmentVariables="$(VSTestExeEnvironment)"
       LogStandardErrorAsError="false"
-      IgnoreStandardErrorWarningFormat="true"
       StandardErrorImportance="Low"
       StandardOutputImportance="Low"
       IgnoreExitCode="true"
@@ -118,7 +121,7 @@
       />
     
     <Error
-      Text="Tests failed, see $(TestResultsDirectory)$(TestAssemblyLogFileName) for full results."
+      Text="Tests failed, see $(TestAssemblyLogFullPath) for full results."
       Condition="$(ExitCode) != 0" 
       File="Apex"
       />

--- a/src/VisualStudioIntegration.props
+++ b/src/VisualStudioIntegration.props
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Test.Apex.VisualStudio" />
     <PackageReference Include="Microsoft.VisualStudio.Composition" />
+    <PackageReference Include="Microsoft.DevDiv.Validation.MediaRecorder" GeneratePathProperty="true" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This includes https://github.com/dotnet/project-system/pull/5127, so just review https://github.com/dotnet/project-system/commit/9bf9c5d250049df68679db47505f97ce098a897b.

Turn on vstest.console.exe warnings so that they appear in the build. We were ignoring these warnings, turn them back on but avoid the original reason they were turned off.