### PR TITLE
Turn off first launch

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 InheritProcessEnvironment = true,
                 AutomaticallyDismissMessageBoxes = true,
                 DelayInitialVsLicenseValidation = true,
-                ForceFirstLaunch = true,
+                ForceFirstLaunch = false,
                 BootstrapInjection = BootstrapInjectionMethod.DteFromROT,
             };
 


### PR DESCRIPTION
We don't want to force first launch and this was causing Apex to attempt to copy over a bunch of dlls into the VS directory failing the test run.