### PR TITLE
/ci no longer implies /diagnostic

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -32,7 +32,7 @@ steps:
   displayName: Run script build.cmd
   inputs:
     filename: '$(Build.SourcesDirectory)\build.cmd '
-    arguments: '/build /test /ci /sign /no-deploy /no-diagnostic /no-integration /configuration $(BuildConfiguration) '
+    arguments: '/build /test /ci /sign /diagnostic /no-deploy /no-integration /configuration $(BuildConfiguration) '
     modifyEnvironment: false
     
 - task: PublishTestResults@1

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -36,7 +36,7 @@ jobs:
         _configuration: Release
   timeoutInMinutes: 20
   steps:
-    - script: $(Build.SourcesDirectory)\build.cmd /build /test /ci /sign /no-deploy /no-diagnostic /no-integration /configuration $(_configuration)
+    - script: $(Build.SourcesDirectory)\build.cmd /build /test /ci /sign /diagnostic /no-deploy /no-integration /configuration $(_configuration)
     - task: PublishBuildArtifacts@1
       inputs:
         PathtoPublish: '$(Build.SourcesDirectory)\artifacts\$(_configuration)\log'
@@ -84,7 +84,7 @@ jobs:
     _configuration: Debug
   timeoutInMinutes: 20
   steps:
-    - script: $(Build.SourcesDirectory)\build.cmd /build /test /ci /no-sign /no-deploy /no-diagnostic /no-integration /configuration $(_configuration)
+    - script: $(Build.SourcesDirectory)\build.cmd /build /test /ci /diagnostic /no-sign /no-deploy /no-integration /configuration $(_configuration)
     - task: PublishBuildArtifacts@1
       inputs:
         PathtoPublish: '$(Build.SourcesDirectory)\artifacts\$(_configuration)\log'

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -121,7 +121,7 @@ function LocateMSBuild {
 }
 
 function InstallToolset {
-  if ($ci -or $log) {
+  if ($log) {
     $logCmd = "/bl:" + (Join-Path $LogDir "RestoreToolset.binlog")
   } else {
     $logCmd = ""
@@ -133,7 +133,7 @@ function InstallToolset {
 }
 
 function Build {
-  if ($ci -or $log) {
+  if ($log) {
     $logCmd = "/bl:" + (Join-Path $LogDir "Build.binlog")
   } else {
     $logCmd = ""
@@ -225,7 +225,7 @@ try {
     Write-Host "Using $MsbuildExe"
   }
 
-  if ($ci -or $log) {
+  if ($log) {
     # Always create these directories so publish 
     # and writes to these folders succeed
     Create-Directory $LogDir


### PR DESCRIPTION
It was confusing that ci implies other switches, explicitly set /diagnostic on unit tests & signed builds.