### PR TITLE
Fix optimization for signed builds

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -32,7 +32,7 @@ steps:
   displayName: Run script build.cmd
   inputs:
     filename: '$(Build.SourcesDirectory)\build.cmd '
-    arguments: '/build /test /ci /sign /diagnostic /no-deploy /no-integration /configuration $(BuildConfiguration) '
+    arguments: '/build /test /ci /sign /diagnostic /no-deploy /no-integration /ibc /configuration $(BuildConfiguration) '
     modifyEnvironment: false
     
 - task: PublishTestResults@1

--- a/build.cmd
+++ b/build.cmd
@@ -57,9 +57,9 @@ echo     /[no-]integration         Run or skip (default) integration tests
 echo.
 echo   Build options:
 echo     /[no-]diagnostic          Turns on or turns off (default) logging to a binlog
-echo     /rootsuffix ^<hive^>        Hive to use when deploying Visual Studio extensions (default is 'Exp')
 echo     /[no-]deploy              Deploy (default) or skip deploying Visual Studio extensions
-echo     /configuration ^<config^>   Use Debug (default) or Release build configuration
 echo     /[no-]sign                Sign (default) or skip signing build outputs
 echo     /[no-]ci                  Turns on (default) or turns off a continuous integration build
+echo     /rootsuffix ^<hive^>        Hive to use when deploying Visual Studio extensions (default is 'Exp')
+echo     /configuration ^<config^>   Use Debug (default) or Release build configuration
 goto :eof

--- a/build.cmd
+++ b/build.cmd
@@ -15,6 +15,7 @@ set OptLog=$false
 set OptCI=$false
 set OptPrepareMachine=$false
 set OptSign=$false
+set OptIbc=$false
 
 :ParseArguments
 if    "%1" == "" goto :DoneParsing
@@ -33,6 +34,8 @@ if /I "%1" == "/sign"                 set OptSign=$true                         
 if /I "%1" == "/no-sign"              set OptSign=$false                            && shift && goto :ParseArguments
 if /I "%1" == "/ci"                   set OptCI=$true && set PrepareMachine=$true   && shift && goto :ParseArguments
 if /I "%1" == "/no-ci"                set OptCI=$false && set PrepareMachine=$false && shift && goto :ParseArguments
+if /I "%1" == "/ibc"                  set OptIbc=$true                              && shift && goto :ParseArguments
+if /I "%1" == "/no-ibc"               set OptIbc=$false                             && shift && goto :ParseArguments
 if /I "%1" == "/rootsuffix"           set PropRootSuffix=/p:RootSuffix=%2           && shift && shift && goto :ParseArguments
 if /I "%1" == "/configuration"        set BuildConfiguration=%2                     && shift && shift && goto :ParseArguments
 
@@ -40,7 +43,7 @@ call :Usage && exit /b 1
 
 :DoneParsing
 
-powershell -ExecutionPolicy ByPass -Command "& """%Root%build\Build.ps1""" -configuration %BuildConfiguration% -restore -pack:$true -build:%OptBuild% -rebuild:%OptRebuild% -deploy:%OptDeploy% -test:%OptTest% -integrationTest:%OptIntegrationTest% -log:%OptLog% %PropRootSuffix% -ci:%OptCI% -prepareMachine:%OptPrepareMachine% -sign:%OptSign%"
+powershell -ExecutionPolicy ByPass -Command "& """%Root%build\Build.ps1""" -configuration %BuildConfiguration% -restore -pack:$true -build:%OptBuild% -rebuild:%OptRebuild% -deploy:%OptDeploy% -test:%OptTest% -integrationTest:%OptIntegrationTest% -log:%OptLog% %PropRootSuffix% -ci:%OptCI% -ibc:$OptIbc -prepareMachine:%OptPrepareMachine% -sign:%OptSign%"
 
 exit /b %ERRORLEVEL%
 
@@ -60,6 +63,7 @@ echo     /[no-]diagnostic          Turns on or turns off (default) logging to a 
 echo     /[no-]deploy              Deploy (default) or skip deploying Visual Studio extensions
 echo     /[no-]sign                Sign (default) or skip signing build outputs
 echo     /[no-]ci                  Turns on (default) or turns off a continuous integration build
+echo     /[no-]ibc                 Turns on or turns off (default) IBC (OptProf) optimization data usage
 echo     /rootsuffix ^<hive^>        Hive to use when deploying Visual Studio extensions (default is 'Exp')
 echo     /configuration ^<config^>   Use Debug (default) or Release build configuration
 goto :eof

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -36,7 +36,7 @@ jobs:
         _configuration: Release
   timeoutInMinutes: 20
   steps:
-    - script: $(Build.SourcesDirectory)\build.cmd /build /test /ci /sign /diagnostic /no-deploy /no-integration /configuration $(_configuration)
+    - script: $(Build.SourcesDirectory)\build.cmd /build /test /ci /sign /diagnostic /no-deploy /no-integration /no-ibc /configuration $(_configuration)
     - task: PublishBuildArtifacts@1
       inputs:
         PathtoPublish: '$(Build.SourcesDirectory)\artifacts\$(_configuration)\log'
@@ -84,7 +84,7 @@ jobs:
     _configuration: Debug
   timeoutInMinutes: 20
   steps:
-    - script: $(Build.SourcesDirectory)\build.cmd /build /test /ci /diagnostic /no-sign /no-deploy /no-integration /configuration $(_configuration)
+    - script: $(Build.SourcesDirectory)\build.cmd /build /test /ci /diagnostic /no-sign /no-deploy /no-integration /no-ibc /configuration $(_configuration)
     - task: PublishBuildArtifacts@1
       inputs:
         PathtoPublish: '$(Build.SourcesDirectory)\artifacts\$(_configuration)\log'

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -14,7 +14,7 @@ Param(
   [switch] $pack,
   [switch] $ci,
   [switch] $prepareMachine,
-  [switch] $optimize,
+  [switch] $ibc,
   [switch] $log,
   [switch] $help,
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
@@ -46,6 +46,7 @@ function Print-Usage() {
     Write-Host "  -ci                     Set when running on CI server"
     Write-Host "  -log                    Enable logging (by default on CI)"
     Write-Host "  -prepareMachine         Prepare machine for CI run"
+    Write-Host "  -ibc                    Enable IBC (OptProf) optimization data usage"
     Write-Host ""
     Write-Host "Command line arguments not listed above are passed thru to msbuild."
     Write-Host "The above arguments can be shortened as much as to be unambiguous (e.g. -co for configuration, -t for test, etc.)."
@@ -143,7 +144,7 @@ function Build {
   $useCodecov = $ci -and $env:CODECOV_TOKEN -and ($configuration -eq 'Debug') -and ($env:ghprbPullAuthorLogin -ne 'dotnet-bot')
   $useOpenCover = $useCodecov
 
-  & $MsbuildExe $ToolsetBuildProj /m /nologo /clp:Summary /nodeReuse:$nodeReuse /warnaserror /v:$verbosity $logCmd /p:Configuration=$configuration /p:SolutionPath=$solution /p:Restore=$restore /p:QuietRestore=true /p:Build=$build /p:Rebuild=$rebuild /p:Deploy=$deploy /p:Test=$test /p:IntegrationTest=$integrationTest /p:Sign=$sign /p:Pack=$pack /p:UseCodecov=$useCodecov /p:UseOpenCover=$useOpenCover /p:CIBuild=$ci /p:Optimize=$optimize /p:NuGetPackageRoot=$NuGetPackageRoot $properties
+  & $MsbuildExe $ToolsetBuildProj /m /nologo /clp:Summary /nodeReuse:$nodeReuse /warnaserror /v:$verbosity $logCmd /p:Configuration=$configuration /p:SolutionPath=$solution /p:Restore=$restore /p:QuietRestore=true /p:Build=$build /p:Rebuild=$rebuild /p:Deploy=$deploy /p:Test=$test /p:IntegrationTest=$integrationTest /p:Sign=$sign /p:Pack=$pack /p:UseCodecov=$useCodecov /p:UseOpenCover=$useOpenCover /p:CIBuild=$ci /p:EnableIbc=$ibc /p:NuGetPackageRoot=$NuGetPackageRoot $properties
   if ((-not $?) -or ($lastExitCode -ne 0)) {
     throw "Aborting after build failure."
   }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -48,7 +48,7 @@
     <TestArchitectures>x86</TestArchitectures>
 
     <!-- Use IBC optimization data if available -->
-    <IbcOptimizationDataDir Condition="$(Optimize) == 'true'">$(NuGetPackageRoot)\RoslynDependencies.ProjectSystem.OptimizationData\$(RoslynDependenciesProjectSystemOptimizationDataVersion)\content\OptimizationData\</IbcOptimizationDataDir>
+    <IbcOptimizationDataDir Condition="$(EnableIbc) == 'true'">$(NuGetPackageRoot)\RoslynDependencies.ProjectSystem.OptimizationData\$(RoslynDependenciesProjectSystemOptimizationDataVersion)\content\OptimizationData\</IbcOptimizationDataDir>
 
     <UseCommonOutputDirectory Condition="'$(UseCommonOutputDirectory)' == ''">true</UseCommonOutputDirectory>
 


### PR DESCRIPTION
f341eab removed the `-optimize` argument for signed builds, resulting in two changes:

1. Output binaries were not being optimised
2. IBC data was not being applied (when available)

The "optimize" parameter of `Build.ps1` was serving double duty.

This PR:

- adds a new `ibc` parameter
- sets `ibc` on signed builds only
- removes overriding the MSBuild `Optimize` property so that optimisation occurs for Release builds even if we don't want IBC