### PR TITLE
Move to UnconfiguredProject scope and directly declare more dependencies

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectCommonServicesFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectCommonServicesFactory.cs
@@ -10,14 +10,14 @@ namespace Microsoft.VisualStudio.ProjectSystem
     {
         public static IProjectCommonServices CreateWithDefaultThreadingPolicy()
         {
-            return ImplementThreadingPolicy(null);
+            return Create(null);
         }
 
-        public static IProjectCommonServices ImplementThreadingPolicy(IProjectThreadingService threadingService)
+        public static IProjectCommonServices Create(IProjectThreadingService threadingService = null, IProjectLockService projectLockService = null)
         {
             threadingService ??= IProjectThreadingServiceFactory.Create();
 
-            var services = ProjectServicesFactory.Create(threadingService);
+            var services = ProjectServicesFactory.Create(threadingService: threadingService, projectLockService: projectLockService);
             var projectService = IProjectServiceFactory.Create(services);
 
             var mock = new Mock<IProjectCommonServices>();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsDataSourceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsDataSourceTests.cs
@@ -141,15 +141,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 
         private static DesignTimeInputsDataSource CreateDesignTimeInputsDataSource(out ProjectValueDataSource<IProjectSubscriptionUpdate> sourceItemsRuleSource)
         {
-            var projectServices = ProjectServicesFactory.Create(threadingService: IProjectThreadingServiceFactory.Create(), projectLockService: IProjectLockServiceFactory.Create());
-            var projectService = IProjectServiceFactory.Create(projectServices);
             var projectSubscriptionService = IProjectSubscriptionServiceFactory.Create();
+            var unconfiguredProject = UnconfiguredProjectFactory.Create();
+            var projectCommonServices = IProjectCommonServicesFactory.Create(IProjectThreadingServiceFactory.Create(), IProjectLockServiceFactory.Create());
 
-            var configuredProject = ConfiguredProjectFactory.Create(
-                services: ConfiguredProjectServicesFactory.Create(projectService: projectService),
-                unconfiguredProject: UnconfiguredProjectFactory.Create());
-
-            var dataSource = new DesignTimeInputsDataSource(configuredProject, projectSubscriptionService);
+            var dataSource = new DesignTimeInputsDataSource(unconfiguredProject, projectCommonServices, projectSubscriptionService);
 
             sourceItemsRuleSource = (ProjectValueDataSource<IProjectSubscriptionUpdate>)projectSubscriptionService.SourceItemsRuleSource;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
@@ -141,17 +141,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 
             var dataSource = mock.Object;
 
-            // Set up all of the mocks in the world
             var threadingService = IProjectThreadingServiceFactory.Create();
-            var projectServices = ProjectServicesFactory.Create(threadingService: threadingService, projectLockService: IProjectLockServiceFactory.Create());
-            var projectService = IProjectServiceFactory.Create(projectServices);
-
-            var configuredProject = ConfiguredProjectFactory.Create(
-                services: ConfiguredProjectServicesFactory.Create(projectService: projectService, threadingService: threadingService),
-                unconfiguredProject: UnconfiguredProjectFactory.Create());
+            var unconfiguredProject = UnconfiguredProjectFactory.Create();
+            var projectCommonServicesFactory = IProjectCommonServicesFactory.Create(threadingService);
 
             // Create our class under test
-            return new DesignTimeInputsFileWatcher(configuredProject, dataSource, IVsServiceFactory.Create<SVsFileChangeEx, Shell.IVsAsyncFileChangeEx>(fileChangeService));
+            return new DesignTimeInputsFileWatcher(unconfiguredProject, projectCommonServicesFactory, threadingService, dataSource, IVsServiceFactory.Create<SVsFileChangeEx, Shell.IVsAsyncFileChangeEx>(fileChangeService));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsDataSource.cs
@@ -23,10 +23,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         private readonly IProjectSubscriptionService _projectSubscriptionService;
 
         [ImportingConstructor]
-        public DesignTimeInputsDataSource(ConfiguredProject project, IProjectSubscriptionService projectSubscriptionService)
-            : base(project.Services, synchronousDisposal: true, registerDataSource: false)
+        public DesignTimeInputsDataSource(UnconfiguredProject project,
+                                          IProjectCommonServices projectCommonServices,
+                                          IProjectSubscriptionService projectSubscriptionService)
+            : base(projectCommonServices, synchronousDisposal: true, registerDataSource: false)
         {
-            _project = project.UnconfiguredProject;
+            _project = project;
             _projectSubscriptionService = projectSubscriptionService;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
@@ -45,12 +45,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         private ITargetBlock<IProjectVersionedValue<DesignTimeInputs>>? _actionBlock;
 
         [ImportingConstructor]
-        public DesignTimeInputsFileWatcher(ConfiguredProject project,
+        public DesignTimeInputsFileWatcher(UnconfiguredProject project,
+                                           IProjectCommonServices projectCommonServices,
+                                           IProjectThreadingService threadingService,
                                            IDesignTimeInputsDataSource designTimeInputsDataSource,
                                            IVsService<SVsFileChangeEx, IVsAsyncFileChangeEx> fileChangeService)
-             : base(project.Services, synchronousDisposal: true, registerDataSource: false)
+             : base(projectCommonServices, synchronousDisposal: true, registerDataSource: false)
         {
-            _threadingService = project.Services.ThreadingPolicy;
+            _threadingService = threadingService;
             _designTimeInputsDataSource = designTimeInputsDataSource;
             _fileChangeService = fileChangeService;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/IDesignTimeInputsDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/IDesignTimeInputsDataSource.cs
@@ -7,7 +7,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
     /// <summary>
     /// Represents the data source of source items that are design time inputs or shared design time inputs
     /// </summary>
-    [ProjectSystemContract(ProjectSystemContractScope.ConfiguredProject, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
+    [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
     internal interface IDesignTimeInputsDataSource : IProjectValueDataSource<DesignTimeInputs>
     {
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/IDesignTimeInputsFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/IDesignTimeInputsFileWatcher.cs
@@ -7,7 +7,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
     /// <summary>
     /// Represents a data source that produces output whenever a design time input changes
     /// </summary>
-    [ProjectSystemContract(ProjectSystemContractScope.ConfiguredProject, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
+    [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
     internal interface IDesignTimeInputsFileWatcher : IProjectValueDataSource<string[]>
     {
     }


### PR DESCRIPTION
Move these two to UnconfiguredProject scope as we don't need to worry about TempPE for anything but the active configuration, so we only need one instance per project.