### PR TITLE
Move to UnconfiguredProject scope

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectCommonServicesFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectCommonServicesFactory.cs
@@ -10,14 +10,14 @@ namespace Microsoft.VisualStudio.ProjectSystem
     {
         public static IProjectCommonServices CreateWithDefaultThreadingPolicy()
         {
-            return ImplementThreadingPolicy(null);
+            return Create(null);
         }
 
-        public static IProjectCommonServices ImplementThreadingPolicy(IProjectThreadingService threadingService)
+        public static IProjectCommonServices Create(IProjectThreadingService threadingService = null, IProjectLockService projectLockService = null)
         {
             threadingService ??= IProjectThreadingServiceFactory.Create();
 
-            var services = ProjectServicesFactory.Create(threadingService);
+            var services = ProjectServicesFactory.Create(threadingService: threadingService, projectLockService: projectLockService);
             var projectService = IProjectServiceFactory.Create(services);
 
             var mock = new Mock<IProjectCommonServices>();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IUnconfiguredProjectServicesFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IUnconfiguredProjectServicesFactory.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal static class IUnconfiguredProjectServicesFactory
     {
-        public static IUnconfiguredProjectServices Create(IProjectAsynchronousTasksService asyncTaskService = null, IActiveConfiguredProjectProvider activeConfiguredProjectProvider = null, IProjectConfigurationsService projectConfigurationsService = null)
+        public static IUnconfiguredProjectServices Create(IProjectAsynchronousTasksService asyncTaskService = null, IActiveConfiguredProjectProvider activeConfiguredProjectProvider = null, IProjectConfigurationsService projectConfigurationsService = null, IProjectService projectService = null)
         {
             var mock = new Mock<IUnconfiguredProjectServices>();
 
@@ -28,6 +28,12 @@ namespace Microsoft.VisualStudio.ProjectSystem
             {
                 mock.Setup(s => s.ProjectConfigurationsService)
                     .Returns(projectConfigurationsService);
+            }
+
+            if (projectService != null)
+            {
+                mock.Setup(s => s.ProjectService)
+                    .Returns(projectService);
             }
 
             return mock.Object;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IActiveConfiguredProjectSubscriptionServiceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IActiveConfiguredProjectSubscriptionServiceFactory.cs
@@ -8,12 +8,18 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     public static class IActiveConfiguredProjectSubscriptionServiceFactory
     {
-        public static IActiveConfiguredProjectSubscriptionService Create()
+        public static IActiveConfiguredProjectSubscriptionService Create(IProjectValueDataSource<IProjectSubscriptionUpdate> sourceItemsRuleSource = null)
         {
             var mock = new Mock<IActiveConfiguredProjectSubscriptionService>();
 
             mock.SetupGet(s => s.ProjectRuleSource)
                 .Returns(() => IProjectValueDataSourceFactory.CreateInstance<IProjectSubscriptionUpdate>());
+
+            if (sourceItemsRuleSource != null)
+            {
+                mock.SetupGet(s => s.SourceItemsRuleSource)
+                    .Returns(() => sourceItemsRuleSource);
+            }
 
             return mock.Object;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsDataSourceTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsDataSourceTests.cs
@@ -141,17 +141,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 
         private static DesignTimeInputsDataSource CreateDesignTimeInputsDataSource(out ProjectValueDataSource<IProjectSubscriptionUpdate> sourceItemsRuleSource)
         {
-            var projectServices = ProjectServicesFactory.Create(threadingService: IProjectThreadingServiceFactory.Create(), projectLockService: IProjectLockServiceFactory.Create());
-            var projectService = IProjectServiceFactory.Create(projectServices);
-            var projectSubscriptionService = IProjectSubscriptionServiceFactory.Create();
+            var unconfiguredProject = UnconfiguredProjectFactory.Create();
+            var unconfiguredProjectServices = IUnconfiguredProjectServicesFactory.Create(
+                    projectService: IProjectServiceFactory.Create(
+                        services: ProjectServicesFactory.Create(
+                            threadingService: IProjectThreadingServiceFactory.Create(),
+                            projectLockService: IProjectLockServiceFactory.Create())));
 
-            var configuredProject = ConfiguredProjectFactory.Create(
-                services: ConfiguredProjectServicesFactory.Create(projectService: projectService),
-                unconfiguredProject: UnconfiguredProjectFactory.Create());
+            sourceItemsRuleSource = new ProjectValueDataSource<IProjectSubscriptionUpdate>(unconfiguredProjectServices);
 
-            var dataSource = new DesignTimeInputsDataSource(configuredProject, projectSubscriptionService);
+            var projectSubscriptionService = IActiveConfiguredProjectSubscriptionServiceFactory.Create(sourceItemsRuleSource: sourceItemsRuleSource);
 
-            sourceItemsRuleSource = (ProjectValueDataSource<IProjectSubscriptionUpdate>)projectSubscriptionService.SourceItemsRuleSource;
+            var dataSource = new DesignTimeInputsDataSource(unconfiguredProject, unconfiguredProjectServices, projectSubscriptionService);
 
             return dataSource;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
@@ -141,17 +141,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 
             var dataSource = mock.Object;
 
-            // Set up all of the mocks in the world
             var threadingService = IProjectThreadingServiceFactory.Create();
-            var projectServices = ProjectServicesFactory.Create(threadingService: threadingService, projectLockService: IProjectLockServiceFactory.Create());
-            var projectService = IProjectServiceFactory.Create(projectServices);
-
-            var configuredProject = ConfiguredProjectFactory.Create(
-                services: ConfiguredProjectServicesFactory.Create(projectService: projectService, threadingService: threadingService),
-                unconfiguredProject: UnconfiguredProjectFactory.Create());
+            var unconfiguredProject = UnconfiguredProjectFactory.Create();
+            var unconfiguredProjectServices = IUnconfiguredProjectServicesFactory.Create(
+                    projectService: IProjectServiceFactory.Create(
+                        services: ProjectServicesFactory.Create(
+                            threadingService: threadingService)));
 
             // Create our class under test
-            return new DesignTimeInputsFileWatcher(configuredProject, dataSource, IVsServiceFactory.Create<SVsFileChangeEx, Shell.IVsAsyncFileChangeEx>(fileChangeService));
+            return new DesignTimeInputsFileWatcher(unconfiguredProject, unconfiguredProjectServices, threadingService, dataSource, IVsServiceFactory.Create<SVsFileChangeEx, Shell.IVsAsyncFileChangeEx>(fileChangeService));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsDataSource.cs
@@ -20,13 +20,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         private static readonly ImmutableHashSet<string> s_ruleNames = Empty.OrdinalIgnoreCaseStringSet.Add(Compile.SchemaName);
 
         private readonly UnconfiguredProject _project;
-        private readonly IProjectSubscriptionService _projectSubscriptionService;
+        private readonly IActiveConfiguredProjectSubscriptionService _projectSubscriptionService;
 
         [ImportingConstructor]
-        public DesignTimeInputsDataSource(ConfiguredProject project, IProjectSubscriptionService projectSubscriptionService)
-            : base(project.Services, synchronousDisposal: true, registerDataSource: false)
+        public DesignTimeInputsDataSource(UnconfiguredProject project,
+                                          IUnconfiguredProjectServices unconfiguredProjectServices,
+                                          IActiveConfiguredProjectSubscriptionService projectSubscriptionService)
+            : base(unconfiguredProjectServices, synchronousDisposal: true, registerDataSource: false)
         {
-            _project = project.UnconfiguredProject;
+            _project = project;
             _projectSubscriptionService = projectSubscriptionService;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
@@ -45,12 +45,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         private ITargetBlock<IProjectVersionedValue<DesignTimeInputs>>? _actionBlock;
 
         [ImportingConstructor]
-        public DesignTimeInputsFileWatcher(ConfiguredProject project,
+        public DesignTimeInputsFileWatcher(UnconfiguredProject project,
+                                           IUnconfiguredProjectServices unconfiguredProjectServices,
+                                           IProjectThreadingService threadingService,
                                            IDesignTimeInputsDataSource designTimeInputsDataSource,
                                            IVsService<SVsFileChangeEx, IVsAsyncFileChangeEx> fileChangeService)
-             : base(project.Services, synchronousDisposal: true, registerDataSource: false)
+             : base(unconfiguredProjectServices, synchronousDisposal: true, registerDataSource: false)
         {
-            _threadingService = project.Services.ThreadingPolicy;
+            _threadingService = threadingService;
             _designTimeInputsDataSource = designTimeInputsDataSource;
             _fileChangeService = fileChangeService;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/IDesignTimeInputsDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/IDesignTimeInputsDataSource.cs
@@ -7,7 +7,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
     /// <summary>
     /// Represents the data source of source items that are design time inputs or shared design time inputs
     /// </summary>
-    [ProjectSystemContract(ProjectSystemContractScope.ConfiguredProject, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
+    [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
     internal interface IDesignTimeInputsDataSource : IProjectValueDataSource<DesignTimeInputs>
     {
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/IDesignTimeInputsFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/IDesignTimeInputsFileWatcher.cs
@@ -7,7 +7,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
     /// <summary>
     /// Represents a data source that produces output whenever a design time input changes
     /// </summary>
-    [ProjectSystemContract(ProjectSystemContractScope.ConfiguredProject, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
+    [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
     internal interface IDesignTimeInputsFileWatcher : IProjectValueDataSource<string[]>
     {
     }


### PR DESCRIPTION
This moves the TempPE stuff to the unconfigured project scope so there is only one instance per project.

Note: This is untested, as that is blocked on getting the compiler manager merged and I don't want to cloud that PR, however this is to a feature branch so it doesn't matter :)