### PR TITLE
Reduce MEF composition errors in build log

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/ProjectSystemHostConfiguration.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/ProjectSystemHostConfiguration.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+using Microsoft.Test.Apex.Hosts;
+using Microsoft.Test.Apex.VisualStudio;
+
+namespace Microsoft.VisualStudio
+{
+    internal class ProjectSystemHostConfiguration : VisualStudioHostConfiguration
+    {
+        public ProjectSystemHostConfiguration(string rootSuffix)
+        {
+            Assumes.NotNullOrEmpty(rootSuffix);
+
+            CommandLineArguments = $"/rootSuffix {rootSuffix}";
+            RestoreUserSettings = false;
+            InheritProcessEnvironment = true;
+            AutomaticallyDismissMessageBoxes = true;
+            DelayInitialVsLicenseValidation = true;
+            ForceFirstLaunch = false;
+            BootstrapInjection = BootstrapInjectionMethod.DteFromROT;
+        }
+
+        public override IEnumerable<string> CompositionAssemblies
+        {
+            get
+            {
+                // This combined with TestBase.IncludeReferencedAssembliesInHostComposition set to false, deliberately limit
+                // the number of assemblies added to the composition to reduce MEF composition errors in the build log.
+                return new[] {
+                    typeof(VisualStudioHostConfiguration).Assembly.Location,        // Microsoft.Test.Apex.VisualStudio
+                    typeof(HostConfiguration).Assembly.Location                     // Microsoft.Test.Apex.Framework
+                };
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             SuppressReloadPrompt = false;
         }
 
-        protected override bool IncludeReferencedAssembliesInHostComposition => false; // Do not things we reference to the MEF Container
+        protected override bool IncludeReferencedAssembliesInHostComposition => false; // Do not add things we reference to the MEF Container
 
         protected override VisualStudioHostConfiguration GetHostConfiguration()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
@@ -23,20 +23,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             SuppressReloadPrompt = false;
         }
 
+        protected override bool IncludeReferencedAssembliesInHostComposition => false; // Do not things we reference to the MEF Container
+
         protected override VisualStudioHostConfiguration GetHostConfiguration()
         {
-            var visualStudioHostConfiguration = new VisualStudioHostConfiguration()
-            {
-                CommandLineArguments = $"/rootSuffix {_hiveName}",
-                RestoreUserSettings = false,
-                InheritProcessEnvironment = true,
-                AutomaticallyDismissMessageBoxes = true,
-                DelayInitialVsLicenseValidation = true,
-                ForceFirstLaunch = false,
-                BootstrapInjection = BootstrapInjectionMethod.DteFromROT,
-            };
-
-            return visualStudioHostConfiguration;
+            return new ProjectSystemHostConfiguration(_hiveName);
         }
 
         protected override void DoHostTestCleanup()


### PR DESCRIPTION
This reduces the MEF composition errors in the build log, there's a few remaining that require changes to Apex itself.