### PR TITLE
Remove all MEF discovery errors

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/ProjectSystemHostConfiguration.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/ProjectSystemHostConfiguration.cs
@@ -9,6 +9,14 @@ namespace Microsoft.VisualStudio
 {
     internal class ProjectSystemHostConfiguration : VisualStudioHostConfiguration
     {
+        // This combined with TestBase.IncludeReferencedAssembliesInHostComposition set to false, deliberately limit
+        // the number of assemblies added to the composition to reduce MEF composition errors in the build log.
+        internal static readonly string[] CompositionAssemblyPaths = new[] {
+                    typeof(VisualStudioHostConfiguration).Assembly.Location,        // Microsoft.Test.Apex.VisualStudio
+                    typeof(HostConfiguration).Assembly.Location,                    // Microsoft.Test.Apex.Framework
+                    typeof(ProjectSystemHostConfiguration).Assembly.Location        // This assembly
+                    };
+
         public ProjectSystemHostConfiguration(string rootSuffix)
         {
             Assumes.NotNullOrEmpty(rootSuffix);
@@ -22,17 +30,6 @@ namespace Microsoft.VisualStudio
             BootstrapInjection = BootstrapInjectionMethod.DteFromROT;
         }
 
-        public override IEnumerable<string> CompositionAssemblies
-        {
-            get
-            {
-                // This combined with TestBase.IncludeReferencedAssembliesInHostComposition set to false, deliberately limit
-                // the number of assemblies added to the composition to reduce MEF composition errors in the build log.
-                return new[] {
-                    typeof(VisualStudioHostConfiguration).Assembly.Location,        // Microsoft.Test.Apex.VisualStudio
-                    typeof(HostConfiguration).Assembly.Location                     // Microsoft.Test.Apex.Framework
-                };
-            }
-        }
+        public override IEnumerable<string> CompositionAssemblies => CompositionAssemblyPaths;
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/ProjectSystemOperationsConfiguration.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/ProjectSystemOperationsConfiguration.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using Microsoft.Test.Apex;
+using Microsoft.Test.Apex.Providers;
+using Microsoft.Test.Apex.Services.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.VisualStudio
+{
+    // Heavily based on MsTestOperationsConfiguration, which is only needed so that we can control the CompositionAssemblies
+    // to avoid MEF composition errors being output into the test output and making it harder to understand the build log.
+    internal class ProjectSystemOperationsConfiguration : OperationsConfiguration
+    {
+        internal ProjectSystemOperationsConfiguration(TestContext testContext)
+        {
+            TestContext = testContext;
+        }
+
+        public override IEnumerable<string> CompositionAssemblies => ProjectSystemHostConfiguration.CompositionAssemblyPaths;
+
+        public TestContext TestContext { get; }
+
+        protected override Type Verifier => typeof(IAssertionVerifier);
+
+        protected override Type Logger => typeof(TestContextLogger);
+
+        protected override void OnOperationsCreated(Operations operations)
+        {
+            base.OnOperationsCreated(operations);
+
+            IAssertionVerifier verifier = operations.Get<IAssertionVerifier>();
+            verifier.AssertionDelegate = Assert.Fail;
+            verifier.FinalFailure += WriteVerificationFailureTree;
+
+            var logger = operations.Get<TestContextLogger>();
+
+            var property = typeof(TestContextLogger).GetProperty("TestContext", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            if (property == null)
+                throw new InvalidOperationException("Unable to find TestContextLogger.TestContext. Has it been renamed?");
+
+            property.SetValue(logger, TestContext);
+        }
+
+        protected override void OnProbingDirectoriesProviderCreated(IProbingDirectoriesProvider provider)
+        {
+        }
+
+        private static void WriteVerificationFailureTree(object sender, FailureEventArgs e)
+        {
+            e.Logger.WriteEntry(SinkEntryType.Message, "Full verification failure tree:" + Environment.NewLine + Environment.NewLine + ResultMessageTreeController.Instance.FormatTreeAsText());
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
@@ -3,6 +3,7 @@
 using System;
 using System.IO;
 
+using Microsoft.Test.Apex;
 using Microsoft.Test.Apex.VisualStudio;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -28,6 +29,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         protected override VisualStudioHostConfiguration GetHostConfiguration()
         {
             return new ProjectSystemHostConfiguration(_hiveName);
+        }
+
+        protected override OperationsConfiguration GetOperationsConfiguration()
+        {
+            return new ProjectSystemOperationsConfiguration(TestContext);
         }
 
         protected override void DoHostTestCleanup()


### PR DESCRIPTION
Control the assemblies that end up in the MEF composition to remove all MEF discovery errors in test logs.

This required a single call to a non-public API on TestContextLogger - attempting to replace is impossible without reimplementing the entire MSTest infrastructure.

This replaced:

```
Populating Assembly Catalog: ApexAssemblyCatalog (attributed with [ProvidesOperationsExtensionAttribute])
    Failed to load assembly Microsoft.VisualStudio.TestTools.UnitTesting.AssertInconclusiveException while looking for exports. Exception: System.TypeLoadException: Cannot find type System.Exception in module System.Runtime.dll.
   at Microsoft.MetadataReader.MetadataOnlyAssembly.GetType(String name, Boolean throwOnError, Boolean ignoreCase)
   at Microsoft.MetadataReader.MetadataOnlyAssembly.GetType(String name, Boolean throwOnError)
   at Microsoft.MetadataReader.MetadataOnlyModule.ResolveTypeRef(ITypeReference typeReference)
   at Microsoft.MetadataReader.MetadataOnlyTypeReference.GetResolvedTypeWorker()
   at Microsoft.MetadataReader.TypeProxy.GetResolvedType()
   at Microsoft.MetadataReader.TypeProxy.GetCustomAttributesData()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate)
   at Microsoft.Test.Apex.ReflectionHelpers.HasAttributes(Type targetType, Boolean validateInheritedAttributes, Type[] attributeTypes)
   at Microsoft.Test.Apex.ApexTypeUniverse.<GetExportedTypes>d__11.MoveNext()
    Failed to load assembly Microsoft.VisualStudio.TestTools.UnitTesting.InternalTestFailureException while looking for exports. Exception: System.TypeLoadException: Cannot find type System.Exception in module System.Runtime.dll.
   at Microsoft.MetadataReader.MetadataOnlyAssembly.GetType(String name, Boolean throwOnError, Boolean ignoreCase)
   at Microsoft.MetadataReader.MetadataOnlyAssembly.GetType(String name, Boolean throwOnError)
   at Microsoft.MetadataReader.MetadataOnlyModule.ResolveTypeRef(ITypeReference typeReference)
   at Microsoft.MetadataReader.MetadataOnlyTypeReference.GetResolvedTypeWorker()
   at Microsoft.MetadataReader.TypeProxy.GetResolvedType()
   at Microsoft.MetadataReader.TypeProxy.GetCustomAttributesData()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate)
   at Microsoft.Test.Apex.ReflectionHelpers.HasAttributes(Type targetType, Boolean validateInheritedAttributes, Type[] attributeTypes)
   at Microsoft.Test.Apex.ApexTypeUniverse.<GetExportedTypes>d__11.MoveNext()
    Failed to load assembly Microsoft.VisualStudio.TestTools.UnitTesting.ExpectedExceptionAttribute while looking for exports. Exception: System.TypeLoadException: Cannot find type System.Attribute in module System.Runtime.dll.
   at Microsoft.MetadataReader.MetadataOnlyAssembly.GetType(String name, Boolean throwOnError, Boolean ignoreCase)
   at Microsoft.MetadataReader.MetadataOnlyAssembly.GetType(String name, Boolean throwOnError)
   at Microsoft.MetadataReader.MetadataOnlyModule.ResolveTypeRef(ITypeReference typeReference)
   at Microsoft.MetadataReader.MetadataOnlyTypeReference.GetResolvedTypeWorker()
   at Microsoft.MetadataReader.TypeProxy.GetResolvedType()
   at Microsoft.MetadataReader.TypeProxy.GetCustomAttributesData()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate)
   at Microsoft.Test.Apex.ReflectionHelpers.HasAttributes(Type targetType, Boolean validateInheritedAttributes, Type[] attributeTypes)
   at Microsoft.Test.Apex.ApexTypeUniverse.<GetExportedTypes>d__11.MoveNext()
    Failed to load assembly Microsoft.VisualStudio.TestTools.UnitTesting.TestCategoryAttribute while looking for exports. Exception: System.TypeLoadException: Cannot find type System.Attribute in module System.Runtime.dll.
   at Microsoft.MetadataReader.MetadataOnlyAssembly.GetType(String name, Boolean throwOnError, Boolean ignoreCase)
   at Microsoft.MetadataReader.MetadataOnlyAssembly.GetType(String name, Boolean throwOnError)
   at Microsoft.MetadataReader.MetadataOnlyModule.ResolveTypeRef(ITypeReference typeReference)
   at Microsoft.MetadataReader.MetadataOnlyTypeReference.GetResolvedTypeWorker()
   at Microsoft.MetadataReader.TypeProxy.GetResolvedType()
   at Microsoft.MetadataReader.TypeProxy.GetCustomAttributesData()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate)
   at Microsoft.Test.Apex.ReflectionHelpers.HasAttributes(Type targetType, Boolean validateInheritedAttributes, Type[] attributeTypes)
   at Microsoft.Test.Apex.ApexTypeUniverse.<GetExportedTypes>d__11.MoveNext()
    Failed to load assembly Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException while looking for exports. Exception: System.TypeLoadException: Cannot find type System.Exception in module System.Runtime.dll.
   at Microsoft.MetadataReader.MetadataOnlyAssembly.GetType(String name, Boolean throwOnError, Boolean ignoreCase)
   at Microsoft.MetadataReader.MetadataOnlyAssembly.GetType(String name, Boolean throwOnError)
   at Microsoft.MetadataReader.MetadataOnlyModule.ResolveTypeRef(ITypeReference typeReference)
   at Microsoft.MetadataReader.MetadataOnlyTypeReference.GetResolvedTypeWorker()
   at Microsoft.MetadataReader.TypeProxy.GetResolvedType()
   at Microsoft.MetadataReader.TypeProxy.GetCustomAttributesData()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate)
   at Microsoft.Test.Apex.ReflectionHelpers.HasAttributes(Type targetType, Boolean validateInheritedAttributes, Type[] attributeTypes)
   at Microsoft.Test.Apex.ApexTypeUniverse.<GetExportedTypes>d__11.MoveNext()
    Failed to load assembly Microsoft.VisualStudio.TestTools.UnitTesting.DataTestMethodAttribute while looking for exports. Exception: System.TypeLoadException: Cannot find type System.Attribute in module System.Runtime.dll.
   at Microsoft.MetadataReader.MetadataOnlyAssembly.GetType(String name, Boolean throwOnError, Boolean ignoreCase)
   at Microsoft.MetadataReader.MetadataOnlyAssembly.GetType(String name, Boolean throwOnError)
   at Microsoft.MetadataReader.MetadataOnlyModule.ResolveTypeRef(ITypeReference typeReference)
   at Microsoft.MetadataReader.MetadataOnlyTypeReference.GetResolvedTypeWorker()
   at Microsoft.MetadataReader.TypeProxy.GetResolvedType()
   at Microsoft.MetadataReader.TypeProxy.GetCustomAttributesData()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate)
   at Microsoft.Test.Apex.ReflectionHelpers.HasAttributes(Type targetType, Boolean validateInheritedAttributes, Type[] attributeTypes)
   at Microsoft.Test.Apex.ApexTypeUniverse.<GetExportedTypes>d__11.MoveNext()
    Failed to load assembly Microsoft.VisualStudio.TestTools.UnitTesting.DescriptionAttribute while looking for exports. Exception: System.TypeLoadException: Cannot find type System.Attribute in module System.Runtime.dll.
   at Microsoft.MetadataReader.MetadataOnlyAssembly.GetType(String name, Boolean throwOnError, Boolean ignoreCase)
   at Microsoft.MetadataReader.MetadataOnlyAssembly.GetType(String name, Boolean throwOnError)
   at Microsoft.MetadataReader.MetadataOnlyModule.ResolveTypeRef(ITypeReference typeReference)
   at Microsoft.MetadataReader.MetadataOnlyTypeReference.GetResolvedTypeWorker()
   at Microsoft.MetadataReader.TypeProxy.GetResolvedType()
   at Microsoft.MetadataReader.TypeProxy.GetCustomAttributesData()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate)
   at Microsoft.Test.Apex.ReflectionHelpers.HasAttributes(Type targetType, Boolean validateInheritedAttributes, Type[] attributeTypes)
   at Microsoft.Test.Apex.ApexTypeUniverse.<GetExportedTypes>d__11.MoveNext()
    Failed to load assembly Microsoft.VisualStudio.TestTools.UnitTesting.CssProjectStructureAttribute while looking for exports. Exception: System.TypeLoadException: Cannot find type System.Attribute in module System.Runtime.dll.
   at Microsoft.MetadataReader.MetadataOnlyAssembly.GetType(String name, Boolean throwOnError, Boolean ignoreCase)
   at Microsoft.MetadataReader.MetadataOnlyAssembly.GetType(String name, Boolean throwOnError)
   at Microsoft.MetadataReader.MetadataOnlyModule.ResolveTypeRef(ITypeReference typeReference)
   at Microsoft.MetadataReader.MetadataOnlyTypeReference.GetResolvedTypeWorker()
   at Microsoft.MetadataReader.TypeProxy.GetResolvedType()
   at Microsoft.MetadataReader.TypeProxy.GetCustomAttributesData()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate)
   at Microsoft.Test.Apex.ReflectionHelpers.HasAttributes(Type targetType, Boolean validateInheritedAttributes, Type[] attributeTypes)
   at Microsoft.Test.Apex.ApexTypeUniverse.<GetExportedTypes>d__11.MoveNext()
    Failed to load assembly Microsoft.VisualStudio.TestTools.UnitTesting.CssIterationAttribute while looking for exports. Exception: System.TypeLoadException: Cannot find type System.Attribute in module System.Runtime.dll.
   at Microsoft.MetadataReader.MetadataOnlyAssembly.GetType(String name, Boolean throwOnError, Boolean ignoreCase)
   at Microsoft.MetadataReader.MetadataOnlyAssembly.GetType(String name, Boolean throwOnError)
   at Microsoft.MetadataReader.MetadataOnlyModule.ResolveTypeRef(ITypeReference typeReference)
   at Microsoft.MetadataReader.MetadataOnlyTypeReference.GetResolvedTypeWorker()
   at Microsoft.MetadataReader.TypeProxy.GetResolvedType()
   at Microsoft.MetadataReader.TypeProxy.GetCustomAttributesData()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate)
   at Microsoft.Test.Apex.ReflectionHelpers.HasAttributes(Type targetType, Boolean validateInheritedAttributes, Type[] attributeTypes)
   at Microsoft.Test.Apex.ApexTypeUniverse.<GetExportedTypes>d__11.MoveNext()
    Failed to load assembly Microsoft.VisualStudio.TestTools.UnitTesting.WorkItemAttribute while looking for exports. Exception: System.TypeLoadException: Cannot find type System.Attribute in module System.Runtime.dll.
   at Microsoft.MetadataReader.MetadataOnlyAssembly.GetType(String name, Boolean throwOnError, Boolean ignoreCase)
   at Microsoft.MetadataReader.MetadataOnlyAssembly.GetType(String name, Boolean throwOnError)
   at Microsoft.MetadataReader.MetadataOnlyModule.ResolveTypeRef(ITypeReference typeReference)
   at Microsoft.MetadataReader.MetadataOnlyTypeReference.GetResolvedTypeWorker()
   at Microsoft.MetadataReader.TypeProxy.GetResolvedType()
   at Microsoft.MetadataReader.TypeProxy.GetCustomAttributesData()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at Microsoft.Test.Apex.ReflectionHelpers.<GetAllAttributes>d__3.MoveNext()
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate)
   at Microsoft.Test.Apex.ReflectionHelpers.HasAttributes(Type targetType, Boolean validateInheritedAttributes, Type[] attributeTypes)
   at Microsoft.Test.Apex.ApexTypeUniverse.<GetExportedTypes>d__11.MoveNext()
    Found 80 exported, and 0 unexportable types from assemblies 'Microsoft.Test.Apex.Framework.dll, Microsoft.Test.Apex.VSTestIntegration.dll, Microsoft.VisualStudio.ProjectSystem.IntegrationTests.dll, Microsoft.VisualStudio.TestPlatform.TestFramework.dll, Microsoft.Test.Apex.VisualStudio.dll, Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll, Microsoft.Test.Apex.VisualStudio.Hosting.dll, Microsoft.Test.Apex.OsIntegration.dll, Microsoft.Test.Apex.SourceControlIntegration.dll, Microsoft.Test.Apex.TeamFoundation.dll'

Assembly 'C:\project-system\artifacts\Debug\bin\IntegrationTests\Microsoft.Test.Apex.VisualStudio.dll' added to 'VisualStudioHostConfiguration' as 'Single'
Assembly 'C:\project-system\artifacts\Debug\bin\IntegrationTests\Microsoft.Test.Apex.Framework.dll' added to 'VisualStudioHostConfiguration' as 'Single'
Assembly 'C:\project-system\artifacts\Debug\bin\IntegrationTests\Microsoft.Test.Apex.VisualStudio.dll' added to 'VisualStudioHostConfiguration' as 'Single'
Assembly 'C:\project-system\artifacts\Debug\bin\IntegrationTests\Microsoft.Test.Apex.VisualStudio.dll' added to 'VisualStudioHostConfiguration' as 'Single'
Assembly 'C:\project-system\artifacts\Debug\bin\IntegrationTests\Microsoft.Test.Apex.Framework.dll' added to 'VisualStudioHostConfiguration' as 'Single'
Assembly 'C:\project-system\artifacts\Debug\bin\IntegrationTests\Microsoft.Test.Apex.VisualStudio.dll' added to 'VisualStudioHostConfiguration' as 'Single'
Populating Assembly Catalog: ApexAssemblyCatalog (attributed with [ProvidesHostExtensionAttribute(VisualStudioHost)])
    Found 54 exported, and 0 unexportable types from assemblies 'Microsoft.Test.Apex.VisualStudio.dll, Microsoft.Test.Apex.VisualStudio.Hosting.dll, Microsoft.Test.Apex.Framework.dll'

Assembly 'C:\project-system\artifacts\Debug\bin\IntegrationTests\Microsoft.Test.Apex.VisualStudio.dll' added to 'VisualStudioHostConfiguration' as 'Single'
Assembly 'C:\project-system\artifacts\Debug\bin\IntegrationTests\Microsoft.Test.Apex.Framework.dll' added to 'VisualStudioHostConfiguration' as 'Single'
Assembly 'C:\project-system\artifacts\Debug\bin\IntegrationTests\Microsoft.Test.Apex.VisualStudio.dll' added to 'VisualStudioHostConfiguration' as 'Single'

```

With:

```
Populating Assembly Catalog: ApexAssemblyCatalog (attributed with [ProvidesOperationsExtensionAttribute])
    Found 63 exported, and 0 unexportable types from assemblies 'Microsoft.Test.Apex.Framework.dll, Microsoft.VisualStudio.ProjectSystem.IntegrationTests.dll'

Assembly 'C:\project-system\artifacts\Debug\bin\IntegrationTests\Microsoft.VisualStudio.ProjectSystem.IntegrationTests.dll' added to 'ProjectSystemHostConfiguration' as 'Single'
Assembly 'C:\project-system\artifacts\Debug\bin\IntegrationTests\Microsoft.Test.Apex.Framework.dll' added to 'ProjectSystemHostConfiguration' as 'Single'
Assembly 'C:\project-system\artifacts\Debug\bin\IntegrationTests\Microsoft.Test.Apex.VisualStudio.dll' added to 'ProjectSystemHostConfiguration' as 'Single'
Assembly 'C:\project-system\artifacts\Debug\bin\IntegrationTests\Microsoft.VisualStudio.ProjectSystem.IntegrationTests.dll' added to 'ProjectSystemHostConfiguration' as 'Single'
Assembly 'C:\project-system\artifacts\Debug\bin\IntegrationTests\Microsoft.Test.Apex.Framework.dll' added to 'ProjectSystemHostConfiguration' as 'Single'
Assembly 'C:\project-system\artifacts\Debug\bin\IntegrationTests\Microsoft.Test.Apex.VisualStudio.dll' added to 'ProjectSystemHostConfiguration' as 'Single'
Populating Assembly Catalog: ApexAssemblyCatalog (attributed with [ProvidesHostExtensionAttribute(VisualStudioHost)])
    Found 54 exported, and 0 unexportable types from assemblies 'Microsoft.Test.Apex.VisualStudio.dll, Microsoft.Test.Apex.VisualStudio.Hosting.dll, Microsoft.Test.Apex.Framework.dll, Microsoft.VisualStudio.ProjectSystem.IntegrationTests.dll'

Assembly 'C:\project-system\artifacts\Debug\bin\IntegrationTests\Microsoft.VisualStudio.ProjectSystem.IntegrationTests.dll' added to 'ProjectSystemHostConfiguration' as 'Single'
Assembly 'C:\project-system\artifacts\Debug\bin\IntegrationTests\Microsoft.Test.Apex.Framework.dll' added to 'ProjectSystemHostConfiguration' as 'Single'
Assembly 'C:\project-system\artifacts\Debug\bin\IntegrationTests\Microsoft.Test.Apex.VisualStudio.dll' added to 'ProjectSystemHostConfiguration' as 'Single'
```