### PR TITLE
Avoid logging errors we can do nothing about

### DIFF
--- a/build/Scripts/IntegrationTests.targets
+++ b/build/Scripts/IntegrationTests.targets
@@ -101,8 +101,7 @@
     <Exec 
       Command='vstest.console.exe /Blame /ResultsDirectory:"$(TestResultsDirectory)\" /Settings:"$(RunSettingsFilePath)" /Logger:trx;LogFileName=$(TestAssemblyLogFileName) "$(TargetPath)"'
       EnvironmentVariables="$(VSTestExeEnvironment)"
-      LogStandardErrorAsError="false"
-      StandardErrorImportance="Low"
+      LogStandardErrorAsError="true"
       StandardOutputImportance="Low"
       IgnoreExitCode="true"
       >

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/ProjectSystemOperationsConfiguration.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/ProjectSystemOperationsConfiguration.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 
 using Microsoft.Test.Apex;
 using Microsoft.Test.Apex.Providers;
@@ -26,7 +25,7 @@ namespace Microsoft.VisualStudio
 
         protected override Type Verifier => typeof(IAssertionVerifier);
 
-        protected override Type Logger => typeof(TestContextLogger);
+        protected override Type Logger => typeof(WarningIgnorerLogger);
 
         protected override void OnOperationsCreated(Operations operations)
         {
@@ -36,13 +35,8 @@ namespace Microsoft.VisualStudio
             verifier.AssertionDelegate = Assert.Fail;
             verifier.FinalFailure += WriteVerificationFailureTree;
 
-            var logger = operations.Get<TestContextLogger>();
-
-            var property = typeof(TestContextLogger).GetProperty("TestContext", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-            if (property == null)
-                throw new InvalidOperationException("Unable to find TestContextLogger.TestContext. Has it been renamed?");
-
-            property.SetValue(logger, TestContext);
+            var logger = operations.Get<WarningIgnorerLogger>();
+            logger.SetTestContext(TestContext);
         }
 
         protected override void OnProbingDirectoriesProviderCreated(IProbingDirectoriesProvider provider)

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/WarningIgnorerLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/WarningIgnorerLogger.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Reflection;
+
+using Microsoft.Test.Apex;
+using Microsoft.Test.Apex.Services;
+using Microsoft.Test.Apex.Services.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.VisualStudio
+{
+    /// <summary>
+    ///     Avoids logging "known" warnings that only make investigating real errors harder.
+    /// </summary>
+    [Export(typeof(ITestLoggerSink))]
+    [Export(typeof(WarningIgnorerLogger))]
+    [Export(typeof(TestContextLogger))]
+    [Export(typeof(IExecutionScopeSink))]
+    public class WarningIgnorerLogger : TestContextLogger, ITestLoggerSink
+    {
+        // Other than WriteEntry(SinkEntryType, String), everything else is delegated to the base
+        public WarningIgnorerLogger()
+        {
+        }
+
+        public new void WriteEntry(SinkEntryType entryType, string message)
+        {
+            if (IsKnownLifeTimeActionWarning(entryType, message))
+                return;
+
+            WriteEntry(entryType, LogMessageHelpers.EscapeCurlyBraces(message), string.Empty);
+        }
+
+        internal void SetTestContext(TestContext context)
+        {
+            // Set the base TestContext
+            var property = typeof(TestContextLogger).GetProperty("TestContext", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            if (property == null)
+                throw new InvalidOperationException("Unable to find TestContextLogger.TestContext. Has it been renamed?");
+
+            property.SetValue(this, context);
+        }
+
+        private bool IsKnownLifeTimeActionWarning(SinkEntryType entryType, string message)
+        {
+            // We have lifetime actions that we have no control over that fail to run due to the lack of
+            // elevated process, we don't output these warnings to the log as it only confuses investigations.
+
+            if (entryType == SinkEntryType.Warning)
+            {
+                if (message.Contains("Could not find path to the Apex dependency libraries to install 'Microsoft.Test.Apex.ElevateClient'"))
+                    return true;
+
+                if (message.Contains("CodeMarker Libraries Installation Failure"))
+                    return true;
+
+                if (message.Contains("to 'Microsoft.Internal.Performance.CodeMarkers.dll' to enable CodeMarkers"))
+                    return true;
+
+                if (message.Contains("Unable to locate a file named 'Microsoft.Test.Apex.ElevateClient.exe' within the avaliable probing directories"))
+                    return true;
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Certain errors occur because the process is not elevated, we cannot turn off these lifetime actions, so to avoid logging out errors that just confuse investigations - ignore them.

This also lets us start to pick up standard error as only "real" errors are now logged through it.