### PR TITLE
Simplify how we find media recorder

### DIFF
--- a/build/Scripts/IntegrationTests.targets
+++ b/build/Scripts/IntegrationTests.targets
@@ -18,17 +18,10 @@
   <PropertyGroup>
     <TestResultsDirectory>$(ArtifactsTestResultsDir)</TestResultsDirectory>
     <RunSettingsFilePath>$(IntermediateOutputPath)$(TargetName)$(TargetExt).runsettings</RunSettingsFilePath>
-    <MediaRecorderDirectory>$(PkgMicrosoft_DevDiv_Validation_MediaRecorder)\lib\net461</MediaRecorderDirectory>
   </PropertyGroup>
 
   <Target Name="GenerateRunSettings">
 
-    <Error
-      Text="The project must be restored before running tests"
-      File="$(MSBuildProjectFile)"
-      Condition="!Exists('$(MediaRecorderDirectory)')"
-      />
-    
     <PropertyGroup>
       <RunSettingsContents>
         <![CDATA[
@@ -38,7 +31,7 @@
   </TestRunParameters>
   <RunConfiguration>
     <MaxCpuCount>1</MaxCpuCount>
-    <TestAdaptersPaths>$(MediaRecorderDirectory)</TestAdaptersPaths>
+    
   </RunConfiguration>
   
   <DataCollectionRunSettings>

--- a/src/VisualStudioIntegration.props
+++ b/src/VisualStudioIntegration.props
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Test.Apex.VisualStudio" />
     <PackageReference Include="Microsoft.VisualStudio.Composition" />
-    <PackageReference Include="Microsoft.DevDiv.Validation.MediaRecorder" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.DevDiv.Validation.MediaRecorder" />
     <PackageReference Include="MSTest.TestFramework" />
     <PackageReference Include="MSTest.TestAdapter" />
   </ItemGroup>


### PR DESCRIPTION
It gets deployed to output and we just load it from there.