### PR TITLE
Make media recording actually work

### DIFF
--- a/src/VisualStudioIntegration.props
+++ b/src/VisualStudioIntegration.props
@@ -10,9 +10,15 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Test.Apex.VisualStudio" />
     <PackageReference Include="Microsoft.VisualStudio.Composition" />
-    <PackageReference Include="Microsoft.DevDiv.Validation.MediaRecorder" GeneratePathProperty="true" />
     <PackageReference Include="MSTest.TestFramework" />
     <PackageReference Include="MSTest.TestAdapter" />
+
+    <!-- 
+    The MediaRecorder package is not defined correctly and does not deploy the VSTestVideoRecorder.exe 
+    it requires. Instead, avoid deploying any of its binaries and just run it directly from package 
+    folder so that it can probe for its exe.
+    -->
+    <PackageReference Include="Microsoft.DevDiv.Validation.MediaRecorder" GeneratePathProperty="true" ExcludeAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
We already setup the correct paths in IntegrationTests.targets to load the adapter directly from the package.