### PR TITLE
Add telemetry to track compilation queue info

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/TempPECompilerManagerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/TempPECompilerManagerTests.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
+using Microsoft.VisualStudio.Telemetry;
 
 using Moq;
 
@@ -246,6 +247,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             watcherMock.SetupGet(s => s.SourceBlock)
                 .Returns(fileWatcherSource.SourceBlock);
 
+            var telemetryService = ITelemetryServiceFactory.Create();
             var threadingService = IProjectThreadingServiceFactory.Create();
             var projectSubscriptionService = IActiveConfiguredProjectSubscriptionServiceFactory.Create();
             var activeWorkspaceProjectContextHost = IActiveWorkspaceProjectContextHostFactory.ImplementProjectContextAccessor(IWorkspaceProjectContextAccessorFactory.Create());
@@ -265,7 +267,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                                       dataSourceMock.Object,
                                       watcherMock.Object,
                                       compilerMock.Object,
-                                      _fileSystem);
+                                      _fileSystem,
+                                      telemetryService);
         }
 
         private void CompilationCallBack(string output, ISet<string> files)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryEventName.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryEventName.cs
@@ -42,6 +42,16 @@ namespace Microsoft.VisualStudio.Telemetry
         /// </summary>
         public static readonly string SDKVersion = BuildEventName("SDKVersion");
 
+        /// <summary>
+        ///     Indicates that the TempPE compilation queue has been processed
+        /// </summary>
+        public static readonly string TempPEProcessQueue = BuildEventName("TempPE/ProcessCompileQueue");
+
+        /// <summary>
+        ///     Indicates that the TempPE compilation has occurred on demand from a designer
+        /// </summary>
+        public static readonly string TempPECompileOnDemand = BuildEventName("TempPE/CompileOnDemand");
+
         private static string BuildEventName(string eventName)
         {
             return Prefix + "/" + eventName.ToLowerInvariant();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryPropertyName.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryPropertyName.cs
@@ -57,6 +57,26 @@ namespace Microsoft.VisualStudio.Telemetry
         /// </summary>
         public static readonly string SDKVersionNETCoreSdkVersion = BuildPropertyName(TelemetryEventName.SDKVersion, "NETCoreSdkVersion");
 
+        /// <summary>
+        ///     Indicates the number of TempPE DLLs compiled
+        /// </summary>
+        public static readonly string TempPECompileCount = BuildPropertyName(TelemetryEventName.TempPEProcessQueue, "CompileCount");
+
+        /// <summary>
+        ///     Indicates the starting length of the TempPE compilation queue
+        /// </summary>
+        public static readonly string TempPEInitialQueueLength = BuildPropertyName(TelemetryEventName.TempPEProcessQueue, "QueueLength");
+
+        /// <summary>
+        ///     Indicates whether the TempPE compilation was cancelled
+        /// </summary>
+        public static readonly string TempPECompileWasCancelled = BuildPropertyName(TelemetryEventName.TempPEProcessQueue, "Cancelled");
+
+        /// <summary>
+        ///     Indicates the duration of the TempPE compilation
+        /// </summary>
+        public static readonly string TempPECompileDuration = BuildPropertyName(TelemetryEventName.TempPEProcessQueue, "Duration");
+
         private static string BuildPropertyName(string eventName, string propertyName)
         {
             // Property names use the event names, but with slashes replaced by periods.


### PR DESCRIPTION
Telemetry to track things like queue size, how often cancellations are, how often things are actually compiled, etc.

May be refined in future.