### PR TITLE
Handle when TRX is missing

### DIFF
--- a/build/Scripts/IntegrationTests.targets
+++ b/build/Scripts/IntegrationTests.targets
@@ -12,7 +12,7 @@
   
   <Target 
     Name="IntegrationTest" 
-    DependsOnTargets="GenerateRunSettings;ExecuteTests" 
+    DependsOnTargets="GenerateRunSettings;ExecuteTests;ReportTestResults" 
     />
 
   <PropertyGroup>
@@ -88,13 +88,13 @@
 
     <MakeDir Directories="$(TestResultsDirectory)" />
 
-    <Error 
+    <Error
       Text="The project must built before running tests"
       File="$(MSBuildProjectFile)"
       Condition="!Exists('$(TargetPath)')"
       />
 
-    <Message 
+    <Message
       Text="$(MSBuildProjectName) -> Running tests (this might take a while)..."
       Importance="High"
       />
@@ -102,32 +102,36 @@
     <!-- Delete the TRX to avoid warning about overwriting it -->
     <Delete Files="$(TestAssemblyLogFullPath)" />
 
-    <Exec 
+    <Exec
       Command='"$(VSTestExe)" /Blame /ResultsDirectory:"$(TestResultsDirectory)\" /Settings:"$(RunSettingsFilePath)" /Logger:trx;LogFileName=$(TestAssemblyLogFileName) "$(TargetPath)"'
       EnvironmentVariables="$(VSTestExeEnvironment)"
       LogStandardErrorAsError="true"
       StandardOutputImportance="Low"
       IgnoreExitCode="true"
       >
-      
-      <Output 
-        TaskParameter="ExitCode" 
-        PropertyName="ExitCode"
+
+      <Output
+        TaskParameter="ExitCode"
+        PropertyName="VSTestExeExitCode"
         />
-      
+
     </Exec>
+  </Target>
+
+  <Target Name="ReportTestResults">
+    
     <Message
       Text="$(MSBuildProjectName) -> Tests succeeded"
-      Condition="$(ExitCode) == 0"
+      Condition="$(VSTestExeExitCode) == 0"
       Importance="High"
       />
 
     <Error
       Text="Tests failed, see $(TestAssemblyLogFullPath) for full results."
-      Condition="$(ExitCode) != 0"
+      Condition="$(VSTestExeExitCode) != 0"
       File="Apex"
       />
-    
+
   </Target>
 
 </Project>

--- a/build/Scripts/IntegrationTests.targets
+++ b/build/Scripts/IntegrationTests.targets
@@ -77,8 +77,8 @@
 
     <PropertyGroup>
       <VSTestExe>$(PkgMicrosoft_TestPlatform)\tools\net451\Common7\IDE\Extensions\TestPlatform\vstest.console.exe</VSTestExe>
-      <TestAssemblyLogFileName>$(TargetName)$(TargetExt).trx</TestAssemblyLogFileName>
-      <TestAssemblyLogFullPath>$(TestResultsDirectory)$(TestAssemblyLogFileName)</TestAssemblyLogFullPath>
+      <TrxLogFileName>$(TargetName)$(TargetExt).trx</TrxLogFileName>
+      <TrxLogFilePath>$(TestResultsDirectory)$(TrxLogFileName)</TrxLogFilePath>
       <VSTestExeEnvironment>
         VisualBasicDesignTimeTargetsPath=$(VisualStudioXamlRulesDir)Microsoft.VisualBasic.DesignTime.targets;
         FSharpDesignTimeTargetsPath=$(VisualStudioXamlRulesDir)Microsoft.FSharp.DesignTime.targets;
@@ -100,10 +100,10 @@
       />
 
     <!-- Delete the TRX to avoid warning about overwriting it -->
-    <Delete Files="$(TestAssemblyLogFullPath)" />
+    <Delete Files="$(TrxLogFilePath)" />
 
     <Exec
-      Command='"$(VSTestExe)" /Blame /ResultsDirectory:"$(TestResultsDirectory)\" /Settings:"$(RunSettingsFilePath)" /Logger:trx;LogFileName=$(TestAssemblyLogFileName) "$(TargetPath)"'
+      Command='"$(VSTestExe)" /Blame /ResultsDirectory:"$(TestResultsDirectory)\" /Settings:"$(RunSettingsFilePath)" /Logger:trx;LogFileName=$(TrxLogFileName) "$(TargetPath)"'
       EnvironmentVariables="$(VSTestExeEnvironment)"
       LogStandardErrorAsError="true"
       StandardOutputImportance="Low"
@@ -127,7 +127,7 @@
       />
 
     <Error
-      Text="Tests failed, see $(TestAssemblyLogFullPath) for full results."
+      Text="Tests failed, see $(TrxLogFilePath) for full results."
       Condition="$(VSTestExeExitCode) != 0"
       File="Apex"
       />

--- a/build/Scripts/IntegrationTests.targets
+++ b/build/Scripts/IntegrationTests.targets
@@ -76,6 +76,7 @@
   <Target Name="ExecuteTests">
 
     <PropertyGroup>
+      <VSTestExe>$(PkgMicrosoft_TestPlatform)\tools\net451\Common7\IDE\Extensions\TestPlatform\vstest.console.exe</VSTestExe>
       <TestAssemblyLogFileName>$(TargetName)$(TargetExt).trx</TestAssemblyLogFileName>
       <TestAssemblyLogFullPath>$(TestResultsDirectory)$(TestAssemblyLogFileName)</TestAssemblyLogFullPath>
       <VSTestExeEnvironment>
@@ -102,7 +103,7 @@
     <Delete Files="$(TestAssemblyLogFullPath)" />
 
     <Exec 
-      Command='$(PkgMicrosoft_TestPlatform)\tools\net451\Common7\IDE\Extensions\TestPlatform\vstest.console.exe /Blame /ResultsDirectory:"$(TestResultsDirectory)\" /Settings:"$(RunSettingsFilePath)" /Logger:trx;LogFileName=$(TestAssemblyLogFileName) "$(TargetPath)"'
+      Command='"$(VSTestExe)" /Blame /ResultsDirectory:"$(TestResultsDirectory)\" /Settings:"$(RunSettingsFilePath)" /Logger:trx;LogFileName=$(TestAssemblyLogFileName) "$(TargetPath)"'
       EnvironmentVariables="$(VSTestExeEnvironment)"
       LogStandardErrorAsError="true"
       StandardOutputImportance="Low"
@@ -115,19 +116,18 @@
         />
       
     </Exec>
-
-    <Message 
+    <Message
       Text="$(MSBuildProjectName) -> Tests succeeded"
       Condition="$(ExitCode) == 0"
       Importance="High"
       />
-    
+
     <Error
       Text="Tests failed, see $(TestAssemblyLogFullPath) for full results."
-      Condition="$(ExitCode) != 0" 
+      Condition="$(ExitCode) != 0"
       File="Apex"
       />
-
+    
   </Target>
 
 </Project>

--- a/build/Scripts/IntegrationTests.targets
+++ b/build/Scripts/IntegrationTests.targets
@@ -128,7 +128,13 @@
 
     <Error
       Text="Tests failed, see $(TrxLogFilePath) for full results."
-      Condition="$(VSTestExeExitCode) != 0"
+      Condition="$(VSTestExeExitCode) != 0 AND Exists('$(TrxLogFilePath)')"
+      File="Apex"
+      />
+
+    <Error
+      Text="The test runner $(VSTestExe) failed with error level $(VSTestExeExitCode) and failed to produce any results. See Build.binlog for more information."
+      Condition="$(VSTestExeExitCode) != 0 AND !Exists('$(TrxLogFilePath)')"
       File="Apex"
       />
 

--- a/build/Scripts/IntegrationTests.targets
+++ b/build/Scripts/IntegrationTests.targets
@@ -17,12 +17,15 @@
 
   <PropertyGroup>
     <TestResultsDirectory>$(ArtifactsTestResultsDir)</TestResultsDirectory>
-    <RunSettingsFilePath>$(IntermediateOutputPath)$(TargetName)$(TargetExt).runsettings</RunSettingsFilePath>
-    <MediaRecorderDirectory>$(PkgMicrosoft_DevDiv_Validation_MediaRecorder)\lib\net461</MediaRecorderDirectory>
+    <RunSettingsFilePath>$(IntermediateOutputPath)$(TargetName)$(TargetExt).runsettings</RunSettingsFilePath>    
   </PropertyGroup>
 
   <Target Name="GenerateRunSettings">
 
+    <PropertyGroup>
+      <MediaRecorderDirectory>$(PkgMicrosoft_DevDiv_Validation_MediaRecorder)\lib\net461</MediaRecorderDirectory>
+    </PropertyGroup>
+    
     <Error
       Text="The project must be restored before running tests"
       File="$(MSBuildProjectFile)"


### PR DESCRIPTION
Handle when TRX is missing because vstest.console.exe failed to produce one, due to it missing on disk - or for other reasons.