### PR TITLE
Disable integration tests build triggers

### DIFF
--- a/build/azure-pipelines-integration.yml
+++ b/build/azure-pipelines-integration.yml
@@ -1,9 +1,6 @@
-# NOTE we do not currently trigger PR status. Once we stablise the integration tests we will enable PR triggers too.
+# NOTE we do not currently trigger builds. Once we stablise the integration tests we will enable this.
 pr: none
-
-# Branches that trigger a build on commit
-trigger:
-- master
+trigger: none
 
 jobs:
 - job: Visual_Studio


### PR DESCRIPTION
Once we stabilise the tests, we'll turn them back on.