### PR TITLE
Move omni reset into a lifetime action

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/LifetimeActions/MakeOmniLogTestSpecificLifetimeAction.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/LifetimeActions/MakeOmniLogTestSpecificLifetimeAction.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+
+using Microsoft.Test.Apex;
+using Microsoft.Test.Apex.Services;
+
+using Omni.Logging;
+
+namespace Microsoft.VisualStudio.LifetimeActions
+{
+    /// <summary>
+    ///     Responsible for making the OmniLog test-specific and prevent incremental logging.
+    /// </summary>
+    [ProvidesOperationsExtension]
+    [Export(typeof(ITestLifetimeAction))]
+    public class MakeOmniLogTestSpecificLifetimeAction : ITestLifetimeAction
+    {
+        public void OnTestLifeTimeAction(ApexTest testClass, Type classType, TestLifeTimeAction action)
+        {
+            if (action == TestLifeTimeAction.PreTestInitialize)
+            {
+                Log.ResetLog($"{testClass.GetType().Name}.{testClass.TestContext.TestName}");
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
@@ -6,7 +6,6 @@ using System.IO;
 using Microsoft.Test.Apex;
 using Microsoft.Test.Apex.VisualStudio;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Omni.Logging;
 
 #nullable disable
 
@@ -35,15 +34,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         protected override OperationsConfiguration GetOperationsConfiguration()
         {
             return new ProjectSystemOperationsConfiguration(TestContext);
-        }
-
-        [TestInitialize]
-        public override void TestInitialize()
-        {
-            // Make the omni log test specific and prevent incremental logging
-            Log.ResetLog($"{GetType().Name}.{TestContext.TestName}");
-
-            base.TestInitialize();
         }
 
         protected override void DoHostTestCleanup()


### PR DESCRIPTION
Actually start using the features that Apex provides rather than using inheritance/overrides.