### PR TITLE
Shutdown VS only after last test has finished

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Environment/AssemblyLifetime.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Environment/AssemblyLifetime.cs
@@ -1,16 +1,23 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Microsoft.VisualStudio.LifetimeActions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.VisualStudio
 {
-    [TestClass] // Just to make sure AssemblyInitialize get called
+    [TestClass] // Just to make sure AssemblyInitialize/Cleanup get called
     public static class AssemblyLifetime
     {
         [AssemblyInitialize]
         public static void OnAssemblyInitialize(TestContext context)
         {
             TestEnvironment.OnAssemblyInitialize(context);
+        }
+
+        [AssemblyCleanup]
+        public static void OnAssemblyCleanup()
+        {
+            ShutdownVisualStudioAfterLastTestLifetimeAction.OnAssemblyCleanup();
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Environment/AssemblyLifetime.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Environment/AssemblyLifetime.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.VisualStudio
+{
+    [TestClass] // Just to make sure AssemblyInitialize get called
+    public static class AssemblyLifetime
+    {
+        [AssemblyInitialize]
+        public static void OnAssemblyInitialize(TestContext context)
+        {
+            TestEnvironment.OnAssemblyInitialize(context);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Environment/TestEnvironment.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Environment/TestEnvironment.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.VisualStudio
+{
+    internal static class TestEnvironment
+    {
+        /// <summary>
+        ///     Gets the Visual Studio hive to run tests under.
+        /// </summary>
+        public static string VisualStudioHive
+        {
+            get;
+            private set;
+        }
+
+        public static void OnAssemblyInitialize(TestContext context)
+        {
+            SetTestInstallationDirectoryIfUnset();
+
+            // Get hive from .runsettings if present (command-line)
+            string rootSuffix = (string)context.Properties["VsRootSuffix"];
+            if (string.IsNullOrEmpty(rootSuffix))
+            {
+                // Otherwise, respect the environment, failing that use the default
+                rootSuffix = Environment.GetEnvironmentVariable("RootSuffix") ?? "Exp";
+            }
+
+            VisualStudioHive = rootSuffix;
+        }
+
+        private static void SetTestInstallationDirectoryIfUnset()
+        {
+            string installationUnderTest = "VisualStudio.InstallationUnderTest.Path";
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(installationUnderTest)))
+            {
+                string vsDirectory = Environment.GetEnvironmentVariable("VSAPPIDDIR");
+                string devenv = Environment.GetEnvironmentVariable("VSAPPIDNAME");
+                if (!string.IsNullOrEmpty(vsDirectory) && !string.IsNullOrEmpty(devenv))
+                {   // Use the same version we're running inside (Test Explorer)
+
+                    Environment.SetEnvironmentVariable(installationUnderTest, Path.Combine(vsDirectory, devenv));
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/LifetimeActions/ShutdownVisualStudioAfterLastTestLifetimeAction.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/LifetimeActions/ShutdownVisualStudioAfterLastTestLifetimeAction.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+
+using Microsoft.Test.Apex;
+using Microsoft.Test.Apex.Services;
+using Microsoft.VisualStudio.ProjectSystem.VS;
+
+namespace Microsoft.VisualStudio.LifetimeActions
+{
+    /// <summary>
+    ///     Responsible for shutting down Visual Studio after last test is done with it.
+    /// </summary>
+    [ProvidesOperationsExtension]
+    [Export(typeof(ITestLifetimeAction))]
+    internal class ShutdownVisualStudioAfterLastTestLifetimeAction : ITestLifetimeAction
+    {
+        private static TestBase? _lastTest;
+
+        public void OnTestLifeTimeAction(ApexTest testClass, Type classType, TestLifeTimeAction action)
+        {
+            if (action == TestLifeTimeAction.PostTestCleanup)
+            {
+                _lastTest = testClass as TestBase;
+            }
+        }
+
+        public static void OnAssemblyCleanup()
+        {
+            // To reduce integration test time, we want to reuse Visual Studio instances where possible.
+            // Apex will automatically close VS only if the previous test failed, this shuts down Visual Studio
+            // after all the tests have finished.            
+            _lastTest?.TryShutdownVisualStudioInstance();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/ProjectSystemHostConfiguration.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/ProjectSystemHostConfiguration.cs
@@ -19,11 +19,9 @@ namespace Microsoft.VisualStudio
                     typeof(OmniLogSink).Assembly.Location,                          // Omni
                     };
 
-        public ProjectSystemHostConfiguration(string rootSuffix)
+        public ProjectSystemHostConfiguration()
         {
-            Assumes.NotNullOrEmpty(rootSuffix);
-
-            CommandLineArguments = $"/rootSuffix {rootSuffix}";
+            CommandLineArguments = $"/rootSuffix {TestEnvironment.VisualStudioHive}";
             RestoreUserSettings = false;
             InheritProcessEnvironment = true;
             AutomaticallyDismissMessageBoxes = true;

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
@@ -1,8 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.IO;
-
 using Microsoft.Test.Apex;
 using Microsoft.Test.Apex.VisualStudio;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -14,8 +11,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     [TestClass] // AssemblyInitialize won't be found without it
     public abstract class TestBase : VisualStudioHostTest
     {
-        private static string _hiveName;
-
         protected TestBase()
         {
             // TestCleanup will fire up another instance of Visual Studio to reset 
@@ -28,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         protected override VisualStudioHostConfiguration GetHostConfiguration()
         {
-            return new ProjectSystemHostConfiguration(_hiveName);
+            return new ProjectSystemHostConfiguration();
         }
 
         protected override OperationsConfiguration GetOperationsConfiguration()
@@ -41,40 +36,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             base.DoHostTestCleanup();
 
             TryShutdownVisualStudioInstance();
-        }
-
-        [AssemblyInitialize]
-        public static void Initialize(TestContext context)
-        {
-            _hiveName = GetVsHiveName(context);
-
-            SetTestInstallationDirectoryIfUnset();
-        }
-
-        private static string GetVsHiveName(TestContext context)
-        {
-            // Get hive from .runsettings if present (command-line)
-            string rootSuffix = (string)context.Properties["VsRootSuffix"];
-            if (!string.IsNullOrEmpty(rootSuffix))
-                return rootSuffix;
-
-            // Otherwise, respect the environment, failing that use the default
-            return Environment.GetEnvironmentVariable("RootSuffix") ?? "Exp";
-        }
-
-        private static void SetTestInstallationDirectoryIfUnset()
-        {
-            string installationUnderTest = "VisualStudio.InstallationUnderTest.Path";
-            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(installationUnderTest)))
-            {
-                string vsDirectory = Environment.GetEnvironmentVariable("VSAPPIDDIR");
-                string devenv = Environment.GetEnvironmentVariable("VSAPPIDNAME");
-                if (!string.IsNullOrEmpty(vsDirectory) && !string.IsNullOrEmpty(devenv))
-                {   // Use the same version we're running inside (Test Explorer)
-
-                    Environment.SetEnvironmentVariable(installationUnderTest, Path.Combine(vsDirectory, devenv));
-                }
-            }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/TestBase.cs
@@ -31,11 +31,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             return new ProjectSystemOperationsConfiguration(TestContext);
         }
 
-        protected override void DoHostTestCleanup()
+        public new void TryShutdownVisualStudioInstance()
         {
-            base.DoHostTestCleanup();
-
-            TryShutdownVisualStudioInstance();
+            base.TryShutdownVisualStudioInstance();
         }
     }
 }


### PR DESCRIPTION
This includes https://github.com/dotnet/project-system/pull/5169, so just review https://github.com/dotnet/project-system/commit/c162c209f351e1a7602c4cb505aeb4d427ccf168.

Previously we were shutting down VS after each test - this increases test time significantly. Apex already shuts down VS if a test fails (to avoid dirtying future tests), but it does not shutdown VS after the last test. Introduce a lifetime action that does this.