### PR TITLE
More TempPECompilerManager Tests

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -123,7 +124,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             watcher.Dispose();
 
             // Make sure we watched all of the files we should
-            Assert.Equal(watchedFiles, fileChangeService.UniqueFilesWatched.ToArray());
+            Assert.Equal(watchedFiles, fileChangeService.UniqueFilesWatched.Select(f => Path.GetFileName(f)).ToArray());
 
             // Should clean up and unwatch everything
             Assert.Empty(fileChangeService.WatchedFiles.ToArray());
@@ -142,7 +143,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             var dataSource = mock.Object;
 
             var threadingService = IProjectThreadingServiceFactory.Create();
-            var unconfiguredProject = UnconfiguredProjectFactory.Create();
+            var unconfiguredProject = UnconfiguredProjectFactory.Create(filePath: @"C:\MyProject\MyProject.csproj");
             var unconfiguredProjectServices = IUnconfiguredProjectServicesFactory.Create(
                     projectService: IProjectServiceFactory.Create(
                         services: ProjectServicesFactory.Create(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/TempPECompilerManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/TempPECompilerManager.cs
@@ -100,8 +100,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 
             foreach (string changedFile in arg.Value)
             {
+                string relativeFilePath = _project.MakeRelative(changedFile);
+
                 // if a shared input changes, we recompile everything
-                if (_sharedDesignTimeInputs.Contains(changedFile))
+                if (_sharedDesignTimeInputs.Contains(relativeFilePath))
                 {
                     foreach (string file in _designTimeInputs)
                     {
@@ -113,7 +115,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                 else
                 {
                     // A normal design time input, so just add it to the queue
-                    ImmutableInterlocked.TryAdd(ref _filesToCompile, changedFile, /* ignoreWriteTime */ false);
+                    ImmutableInterlocked.TryAdd(ref _filesToCompile, relativeFilePath, /* ignoreWriteTime */ false);
                 }
             }
 


### PR DESCRIPTION
Fixes an issue where a compilation being cancelled would leave a 0 byte file on disk, and adds a couple of other test cases that didn't have coverage.

Also include #5158 so only review https://github.com/dotnet/project-system/commit/4b4b9d7b4634f725c9d8a7ca2ad4487282ba581e