### PR TITLE
Update VSSDK Build Tools version

### DIFF
--- a/build/Packages.targets
+++ b/build/Packages.targets
@@ -35,7 +35,7 @@
     <PackageReference Update="Microsoft.DevDiv.Validation.MediaRecorder"                              Version="15.0.199" />
 
     <!-- VS SDK -->
-    <PackageReference Update="Microsoft.VSSDK.BuildTools"                                             Version="15.8.3252" />
+    <PackageReference Update="Microsoft.VSSDK.BuildTools"                                             Version="16.2.3073" />
     <PackageReference Update="Microsoft.VisualStudio.ComponentModelHost"                              Version="16.0.198-g52de9c2988"/>
     <PackageReference Update="Microsoft.VisualStudio.Composition"                                     Version="16.1.8"/>
     <PackageReference Update="Microsoft.VisualStudio.Data.Core"                                       Version="9.0.21022" />


### PR DESCRIPTION
This should fix a hang we're seeing on the CI box.