### PR TITLE
Add /no-build option

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -54,9 +54,8 @@ exit /b %ERRORLEVEL%
 echo Usage: %BatchFile% [options]
 echo.
 echo   Build targets:
-echo     /build                    Perform a build (default)
 echo     /rebuild                  Perform a clean, then build
-echo     /no-build                 Don't build at all (useful if running tests)
+echo     /[no]-build               Perform a build (default) or not
 echo.
 echo   Test targets:
 echo     /[no-]test                Run (default) or skip unit tests

--- a/build.cmd
+++ b/build.cmd
@@ -22,6 +22,7 @@ set OptIbc=$false
 if    "%1" == "" goto :DoneParsing
 if /I "%1" == "/?" call :Usage && exit /b 1
 if /I "%1" == "/build"                set OptBuild=$true  && set OptRebuild=$false  && shift && goto :ParseArguments
+if /I "%1" == "/no-build"             set OptBuild=$false && set OptRebuild=$false  && shift && goto :ParseArguments
 if /I "%1" == "/rebuild"              set OptBuild=$false && set OptRebuild=$true   && shift && goto :ParseArguments
 if /I "%1" == "/test"                 set OptTest=$true                             && shift && goto :ParseArguments
 if /I "%1" == "/no-test"              set OptTest=$false                            && shift && goto :ParseArguments
@@ -55,6 +56,7 @@ echo.
 echo   Build targets:
 echo     /build                    Perform a build (default)
 echo     /rebuild                  Perform a clean, then build
+echo     /no-build                 Don't build at all (useful if running tests)
 echo.
 echo   Test targets:
 echo     /[no-]test                Run (default) or skip unit tests


### PR DESCRIPTION
This will be useful now while investigating test failures where we don't want anything to build. It might be removed later, but is pretty harmless to leave in.