### PR TITLE
Fix Starting Tab Selection on Debug Property Page

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml
@@ -73,7 +73,7 @@
                 AutomationProperties.Name="{x:Static Member=local:PropertyPageResources.Profile}">
                 <ComboBox.IsEnabled>
                     <MultiBinding Converter="{StaticResource MultiValueBoolToBoolAnd}">
-                        <Binding Path="HasProfiles" Mode="OneWay"/>
+                        <Binding Path="HasProfilesOrNotInitialized" Mode="OneWay"/>
                         <Binding Path="EnvironmentVariablesValid" Mode="OneWay"/>
                         <Binding Path="DoesNotHaveErrors" Mode="OneWay"/>
                     </MultiBinding>
@@ -143,6 +143,13 @@
                         <Setter Property="AutomationProperties.Name" Value="{Binding Path=Name}"/>
                     </Style>
                 </ComboBox.ItemContainerStyle>
+                <ComboBox.IsEnabled>
+                    <MultiBinding Converter="{StaticResource MultiValueBoolToBoolAnd}">
+                        <Binding Path="HasProfilesOrNotInitialized" Mode="OneWay"/>
+                        <Binding Path="EnvironmentVariablesValid" Mode="OneWay"/>
+                        <Binding Path="DoesNotHaveErrors" Mode="OneWay"/>
+                    </MultiBinding>
+                </ComboBox.IsEnabled>
             </ComboBox>
             <Label 
                 Grid.Row="2"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
@@ -414,11 +414,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             OnPropertyChanged(nameof(NewProfileEnabled));
         }
 
+        private bool _debugTargetsCoreInitialized = false;
         public bool HasProfiles
         {
             get
             {
-                return CurrentLaunchSettings != null && CurrentLaunchSettings.Profiles.Count > 0;
+                return !_debugTargetsCoreInitialized || (CurrentLaunchSettings != null && CurrentLaunchSettings.Profiles.Count > 0);
             }
         }
 
@@ -712,6 +713,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 {
                     _firstSnapshotCompleteSource.TrySetResult(true);
                 }
+
+                _debugTargetsCoreInitialized = true;
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
@@ -411,15 +411,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         private void NotifyProfileCollectionChanged()
         {
             OnPropertyChanged(nameof(HasProfiles));
+            OnPropertyChanged(nameof(HasProfilesOrNotInitialized));
             OnPropertyChanged(nameof(NewProfileEnabled));
         }
 
         private bool _debugTargetsCoreInitialized = false;
+        public bool HasProfilesOrNotInitialized 
+        { 
+            get 
+            {
+                return !_debugTargetsCoreInitialized || HasProfiles;
+            }
+        }
+
+        
         public bool HasProfiles
         {
             get
             {
-                return !_debugTargetsCoreInitialized || (CurrentLaunchSettings != null && CurrentLaunchSettings.Profiles.Count > 0);
+                return CurrentLaunchSettings != null && CurrentLaunchSettings.Profiles.Count > 0;
             }
         }
 


### PR DESCRIPTION
Fix for: https://github.com/dotnet/project-system/issues/5180

This ensures that when tabbing onto the WPF Debug property page, the first item is consistently selected. The issue was that not all of the properties had been initialized - HasProfiles was returning false and the Profile ComboBox was disabled when the page placed the tab selection on the first enabled control. This fix just assumes that if the property has not been initialized, enable the ComboBox. If, after initialization, the property is still false, the tab selection will go to the correct control and the ComboBox will be disabled. 

Note: I am not sure why the page is not showing the selection around the ComboBox until you tab off and back onto it, but I confirmed via the Narrator that it is selected and will respond to key commands.  