### PR TITLE
Increate test timeouts to try to out-flake the flakyness

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
@@ -21,6 +21,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 {
     public class DesignTimeInputsFileWatcherTests
     {
+        private const int TestTimeoutMillisecondsDelay = 1000;
+
         public static IEnumerable<object[]> GetTestCases()
         {
             return new[]
@@ -112,7 +114,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             watcher.FilesChanged((uint)fileChangeNotificationsToSend.Length, fileChangeNotificationsToSend, null);
 
             // The timeout here is annoying, but even though our test is "smart" and waits for data, unfortunately if the code breaks the test is more likely to hang than fail
-            if (await Task.WhenAny(finished.Task, Task.Delay(500)) != finished.Task)
+            if (await Task.WhenAny(finished.Task, Task.Delay(TestTimeoutMillisecondsDelay)) != finished.Task)
             {
                 throw new AssertActualExpectedException(fileChangeNotificationsExpected.Length, notificationCount, "Timed out after 500ms");
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/TempPECompilerManagerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/TempPECompilerManagerTests.cs
@@ -22,6 +22,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 {
     public class TempPECompilerManagerTests : IDisposable
     {
+        private const int TestTimeoutMillisecondsDelay = 2000;
+
         private string? _lastIntermediateOutputPath;
         private readonly string _projectFolder = @"C:\MyProject";
         private string _intermediateOutputPath = "MyOutput";
@@ -385,7 +387,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             await actionThatCausesCompilation();
 
             // Sadly, we need a timeout
-            var delay = Task.Delay(TimeSpan.FromSeconds(1));
+            var delay = Task.Delay(TestTimeoutMillisecondsDelay);
 
             if (await Task.WhenAny(_compilationOccurredCompletionSource.Task, delay) == delay)
             {


### PR DESCRIPTION
I know timeouts are terrible, and I'm loathed to just try this, but I _love_ how un-compromised the implementation classes are by the tests because they actually exercise dataflow etc.

This might not work anyway ¯\\\_(ツ)_/¯