### PR TITLE
Move GenerateDependentAssemblyVersionFile to msbuild

### DIFF
--- a/build/RepoToolset/RepoLayout.props
+++ b/build/RepoToolset/RepoLayout.props
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <RepoRoot>$(MSBuildThisFileDirectory)..\..\</RepoRoot>
     <!-- Respect environment variable for the .NET install directory if set; otherwise, use the current default location -->
     <DotNetRoot Condition="'$(DotNetRoot)' == ''">$(DOTNET_INSTALL_DIR)</DotNetRoot>
     <DotNetRoot Condition="'$(DotNetRoot)' == ''">$(RepoRoot).dotnet\</DotNetRoot>

--- a/build/Scripts/GenerateDependentAssemblyVersionFile.targets
+++ b/build/Scripts/GenerateDependentAssemblyVersionFile.targets
@@ -1,0 +1,40 @@
+<Project DefaultTargets="GenerateDependentAssemblyVersionsFile">
+  <!-- 
+   
+   Generates DependentAssemblyVersions.csv that enables the Roslyn insertion tool to update various 
+   assembly verisons in the VS repository under src\ProductData.
+   See: https://github.com/dotnet/roslyn-tools/tree/master/src/RoslynInsertionTool).
+   
+    $(VisualStudioVersion):         The version number of Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.AppDesigner
+    $(ProjectSystemVersion):        The version number of Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.VS
+    $(ArtifactsConfigurationDir):   The configured-based build output location.
+    
+  -->
+  
+  <Import Project="..\Versions.props"/>
+  <Import Project="..\RepoToolset\ProjectLayout.props" />
+
+  <Target Name="GenerateDependentAssemblyVersionsFile">
+
+    <PropertyGroup>
+      <DependentAssemblyVersionsOutputDirectory>$(ArtifactsConfigurationDir)DevDivInsertionFiles\</DependentAssemblyVersionsOutputDirectory>
+      <DependentAssemblyVersionsFilePath>$(DependentAssemblyVersionsOutputDirectory)DependentAssemblyVersions.csv</DependentAssemblyVersionsFilePath>
+      <DependentAssemblyVersionsContents>
+ <![CDATA[
+Microsoft.VisualStudio.Editors,$(VisualStudioVersion).0
+Microsoft.VisualStudio.ProjectSystem.Managed,$(ProjectSystemVersion).0
+ ]]>
+      </DependentAssemblyVersionsContents>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(DependentAssemblyVersionsOutputDirectory)" />
+    
+    <WriteLinesToFile
+      File="$(DependentAssemblyVersionsFilePath)"
+      Lines="$(DependentAssemblyVersionsContents)"
+      Overwrite="true"
+      />
+    
+  </Target>
+  
+</Project>

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -106,6 +106,9 @@ function Build {
     $CodecovProj = Join-Path $PSScriptRoot 'Codecov.proj'
     & $MsbuildExe $CodecovProj /m /nologo /clp:Summary /nodeReuse:$nodeReuse /warnaserror /v:diag /t:Codecov /p:Configuration=$configuration /p:UseCodecov=$useCodecov /p:NuGetPackageRoot=$NuGetPackageRoot $properties
   }
+
+  $GenerateDependentAssemblyVersionsProj = Join-Path $PSScriptRoot 'Scripts\GenerateDependentAssemblyVersionFile.targets'
+  & $MsbuildExe $GenerateDependentAssemblyVersionsProj /m /nologo /clp:Summary /nodeReuse:$nodeReuse /warnaserror /p:Configuration=$configuration
 }
 
 function Stop-Processes() {
@@ -124,21 +127,6 @@ function Clear-NuGetCache() {
   if (Test-Path $nugetRoot) {
     Remove-Item $nugetRoot -Recurse -Force
   }
-}
-
-function GenerateDependentAssemblyVersionFile() {
-  $vsAssemblyName = "Microsoft.VisualStudio.Editors"
-  $visualStudioVersion = GetVersion("VisualStudioVersion")
-  $projectSystemAssemblyName = "Microsoft.VisualStudio.ProjectSystem.Managed"
-  $projectSystemVersion = GetVersion("ProjectSystemVersion")
-  $devDivInsertionFiles = Join-Path (Join-Path $ArtifactsDir $configuration) "DevDivInsertionFiles"
-  $dependentAssemblyVersionsCsv = Join-Path $devDivInsertionFiles "DependentAssemblyVersions.csv"
-  $csv =@"
-$vsAssemblyName,$visualStudioVersion.0
-$projectSystemAssemblyName,$projectSystemVersion.0
-"@
-  & mkdir -force $devDivInsertionFiles > $null
-  $csv > $dependentAssemblyVersionsCsv
 }
 
 try {
@@ -200,8 +188,6 @@ try {
 
   Build
 
-  GenerateDependentAssemblyVersionFile
-  
   exit $lastExitCode
 }
 catch {


### PR DESCRIPTION
This moves GenerateDependentAssemblyVersionFile to msbuild.

While this is significantly more code than what we had before, the benefits will be clear when build.ps1 is replaced with an msbuild proj and you can use MSBuild Structured Build Logger to investigate the build.