### PR TITLE
Framework reference browse object

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -390,23 +390,8 @@
 
   <Target
     Name="ResolveFrameworkReferencesDesignTime"
-    Returns="@(_ResolvedFrameworkReference)"
-    DependsOnTargets="ResolveFrameworkReferences">
-
-    <!--
-    This is temporary. It populates some metadata on _ResolvedFrameworkReference items.
-    Once we have a version of the SDK that produces ResolvedFrameworkReference items, this
-    can be removed and the item type above (and in the RFR.xaml rule data source) have the
-    underscore prefix removed.
-    -->
-    <ItemGroup>
-      <_ResolvedFrameworkReference Include="@(FrameworkReference)">
-        <OriginalItemSpec>%(FrameworkReference.ItemSpec)</OriginalItemSpec>
-        <TargetingPackPath>c:\some\path</TargetingPackPath>
-      </_ResolvedFrameworkReference>
-    </ItemGroup>
-
-  </Target>
+    Returns="@(ResolvedFrameworkReference)"
+    DependsOnTargets="ResolveFrameworkReferences" />
 
   <!-- This target is used to collect the PackageReferences in the project. This target can be overriden to add\remove packagereferences before they are
        sent to NuGet to be restored.-->

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedFrameworkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedFrameworkReference.xaml
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Rule Name="ResolvedFrameworkReference"
-      Description="Framework Reference Properties"
-      DisplayName="Framework Reference"
+      Description="Framework Properties"
+      DisplayName="Framework"
       PageTemplate="generic"
       xmlns="http://schemas.microsoft.com/build/2009/properties">
   

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedFrameworkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ResolvedFrameworkReference.xaml
@@ -23,6 +23,10 @@
                   DisplayName="Path"
                   ReadOnly="True" />
 
+  <StringProperty Name="TargetingPackVersion"
+                  DisplayName="Version"
+                  ReadOnly="True" />
+
   <StringProperty Name="Profile"
                   DisplayName="Profile"
                   ReadOnly="True" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.cs.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../ResolvedFrameworkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedFrameworkReference|Description">
-        <source>Framework Reference Properties</source>
-        <target state="new">Framework Reference Properties</target>
+        <source>Framework Properties</source>
+        <target state="new">Framework Properties</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedFrameworkReference|DisplayName">
-        <source>Framework Reference</source>
-        <target state="new">Framework Reference</target>
+        <source>Framework</source>
+        <target state="new">Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.cs.xlf
@@ -27,6 +27,11 @@
         <target state="new">Private Assets</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.de.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="de" original="../ResolvedFrameworkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedFrameworkReference|Description">
-        <source>Framework Reference Properties</source>
-        <target state="new">Framework Reference Properties</target>
+        <source>Framework Properties</source>
+        <target state="new">Framework Properties</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedFrameworkReference|DisplayName">
-        <source>Framework Reference</source>
-        <target state="new">Framework Reference</target>
+        <source>Framework</source>
+        <target state="new">Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.de.xlf
@@ -27,6 +27,11 @@
         <target state="new">Private Assets</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.es.xlf
@@ -27,6 +27,11 @@
         <target state="new">Private Assets</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.es.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="es" original="../ResolvedFrameworkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedFrameworkReference|Description">
-        <source>Framework Reference Properties</source>
-        <target state="new">Framework Reference Properties</target>
+        <source>Framework Properties</source>
+        <target state="new">Framework Properties</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedFrameworkReference|DisplayName">
-        <source>Framework Reference</source>
-        <target state="new">Framework Reference</target>
+        <source>Framework</source>
+        <target state="new">Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.fr.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../ResolvedFrameworkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedFrameworkReference|Description">
-        <source>Framework Reference Properties</source>
-        <target state="new">Framework Reference Properties</target>
+        <source>Framework Properties</source>
+        <target state="new">Framework Properties</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedFrameworkReference|DisplayName">
-        <source>Framework Reference</source>
-        <target state="new">Framework Reference</target>
+        <source>Framework</source>
+        <target state="new">Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.fr.xlf
@@ -27,6 +27,11 @@
         <target state="new">Private Assets</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.it.xlf
@@ -27,6 +27,11 @@
         <target state="new">Private Assets</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.it.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="it" original="../ResolvedFrameworkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedFrameworkReference|Description">
-        <source>Framework Reference Properties</source>
-        <target state="new">Framework Reference Properties</target>
+        <source>Framework Properties</source>
+        <target state="new">Framework Properties</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedFrameworkReference|DisplayName">
-        <source>Framework Reference</source>
-        <target state="new">Framework Reference</target>
+        <source>Framework</source>
+        <target state="new">Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.ja.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../ResolvedFrameworkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedFrameworkReference|Description">
-        <source>Framework Reference Properties</source>
-        <target state="new">Framework Reference Properties</target>
+        <source>Framework Properties</source>
+        <target state="new">Framework Properties</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedFrameworkReference|DisplayName">
-        <source>Framework Reference</source>
-        <target state="new">Framework Reference</target>
+        <source>Framework</source>
+        <target state="new">Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.ja.xlf
@@ -27,6 +27,11 @@
         <target state="new">Private Assets</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.ko.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../ResolvedFrameworkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedFrameworkReference|Description">
-        <source>Framework Reference Properties</source>
-        <target state="new">Framework Reference Properties</target>
+        <source>Framework Properties</source>
+        <target state="new">Framework Properties</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedFrameworkReference|DisplayName">
-        <source>Framework Reference</source>
-        <target state="new">Framework Reference</target>
+        <source>Framework</source>
+        <target state="new">Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.ko.xlf
@@ -27,6 +27,11 @@
         <target state="new">Private Assets</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.pl.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../ResolvedFrameworkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedFrameworkReference|Description">
-        <source>Framework Reference Properties</source>
-        <target state="new">Framework Reference Properties</target>
+        <source>Framework Properties</source>
+        <target state="new">Framework Properties</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedFrameworkReference|DisplayName">
-        <source>Framework Reference</source>
-        <target state="new">Framework Reference</target>
+        <source>Framework</source>
+        <target state="new">Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.pl.xlf
@@ -27,6 +27,11 @@
         <target state="new">Private Assets</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.pt-BR.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../ResolvedFrameworkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedFrameworkReference|Description">
-        <source>Framework Reference Properties</source>
-        <target state="new">Framework Reference Properties</target>
+        <source>Framework Properties</source>
+        <target state="new">Framework Properties</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedFrameworkReference|DisplayName">
-        <source>Framework Reference</source>
-        <target state="new">Framework Reference</target>
+        <source>Framework</source>
+        <target state="new">Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.pt-BR.xlf
@@ -27,6 +27,11 @@
         <target state="new">Private Assets</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.ru.xlf
@@ -27,6 +27,11 @@
         <target state="new">Private Assets</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.ru.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../ResolvedFrameworkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedFrameworkReference|Description">
-        <source>Framework Reference Properties</source>
-        <target state="new">Framework Reference Properties</target>
+        <source>Framework Properties</source>
+        <target state="new">Framework Properties</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedFrameworkReference|DisplayName">
-        <source>Framework Reference</source>
-        <target state="new">Framework Reference</target>
+        <source>Framework</source>
+        <target state="new">Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.tr.xlf
@@ -27,6 +27,11 @@
         <target state="new">Private Assets</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.tr.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../ResolvedFrameworkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedFrameworkReference|Description">
-        <source>Framework Reference Properties</source>
-        <target state="new">Framework Reference Properties</target>
+        <source>Framework Properties</source>
+        <target state="new">Framework Properties</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedFrameworkReference|DisplayName">
-        <source>Framework Reference</source>
-        <target state="new">Framework Reference</target>
+        <source>Framework</source>
+        <target state="new">Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.zh-Hans.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../ResolvedFrameworkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedFrameworkReference|Description">
-        <source>Framework Reference Properties</source>
-        <target state="new">Framework Reference Properties</target>
+        <source>Framework Properties</source>
+        <target state="new">Framework Properties</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedFrameworkReference|DisplayName">
-        <source>Framework Reference</source>
-        <target state="new">Framework Reference</target>
+        <source>Framework</source>
+        <target state="new">Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.zh-Hans.xlf
@@ -27,6 +27,11 @@
         <target state="new">Private Assets</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.zh-Hant.xlf
@@ -27,6 +27,11 @@
         <target state="new">Private Assets</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">
+        <source>Version</source>
+        <target state="new">Version</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/xlf/ResolvedFrameworkReference.xaml.zh-Hant.xlf
@@ -3,13 +3,13 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../ResolvedFrameworkReference.xaml">
     <body>
       <trans-unit id="Rule|ResolvedFrameworkReference|Description">
-        <source>Framework Reference Properties</source>
-        <target state="new">Framework Reference Properties</target>
+        <source>Framework Properties</source>
+        <target state="new">Framework Properties</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|ResolvedFrameworkReference|DisplayName">
-        <source>Framework Reference</source>
-        <target state="new">Framework Reference</target>
+        <source>Framework</source>
+        <target state="new">Framework</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">


### PR DESCRIPTION
Relates to #5070 and #4762.

With SDK 3.0.100-preview8, we now receive `ResolvedFrameworkReference` items with the required properties. This PR removes the workaround that was required until now to framework references correctly.

- The `Path` property is populated.
- The item's description is now "Framework Properties" rather than "Framework Reference Properties". This matches "Package Properties" for `<PackageReference />`.
- The version has been added. Although the version is available in the path itself, it's usually off screen.

### Before

![image](https://user-images.githubusercontent.com/350947/62105212-0dc85b00-b2e5-11e9-8dbf-e8dadd478e03.png)

### After

![image](https://user-images.githubusercontent.com/350947/62105109-cfcb3700-b2e4-11e9-8b22-fafc791d8f3a.png)