### PR TITLE
Simplify CodeCov usage

### DIFF
--- a/build/Codecov.proj
+++ b/build/Codecov.proj
@@ -1,6 +1,7 @@
 <Project DefaultTargets="CodeCov">
-  
+
   <Import Project="Versions.props" />
+  <Import Project="NuGet.props" />
   <Import Project="RepoToolset\RepoLayout.props" />
 
   <Target Name="Codecov">

--- a/build/Codecov.proj
+++ b/build/Codecov.proj
@@ -1,11 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <PropertyGroup>
-    <RepoRoot>$(MSBuildThisFileDirectory)..\</RepoRoot>
-  </PropertyGroup>
-
   <Import Project="Versions.props" />
-  <Import Project="RepoToolset\ProjectLayout.props" />
+  <Import Project="RepoToolset\RepoLayout.props" />
 
   <Target Name="Codecov">
     <PropertyGroup>

--- a/build/Codecov.proj
+++ b/build/Codecov.proj
@@ -8,14 +8,14 @@
   <Import Project="RepoToolset\ProjectLayout.props" />
 
   <Target Name="Codecov">
-    <PropertyGroup Condition="'$(UseCodecov)' == 'true'">
+    <PropertyGroup>
       <_CodecovPath>$(NuGetPackageRoot)codecov\$(CodecovVersion)\tools\Codecov.exe</_CodecovPath>
 
       <_BranchName Condition="'$(_BranchName)' == ''">$(ghprbTargetBranch)</_BranchName>
       <_BranchName Condition="'$(_BranchName)' == ''">$(BranchName)</_BranchName>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(UseCodecov)' == 'true'">
+    <ItemGroup>
       <_CoverageReports Include="$(ArtifactsTestResultsDir)*.coverage" />
 
       <_CodecovArgs Include="-f;@(_CoverageReports)" />
@@ -28,8 +28,7 @@
       <_CodecovArgs Include="--flag;$(Configuration)" Condition="'$(Configuration)' != ''" />
     </ItemGroup>
 
-    <Exec Condition="'$(UseCodecov)' == 'true'"
-          Command="&quot;$(_CodecovPath)&quot; @(_CodecovArgs, ' ')" />
+    <Exec Command="&quot;$(_CodecovPath)&quot; @(_CodecovArgs, ' ')" />
   </Target>
 
   <Import Project="..\Packages.targets" />

--- a/build/Codecov.proj
+++ b/build/Codecov.proj
@@ -28,5 +28,5 @@
     <Exec Command="&quot;$(_CodecovPath)&quot; @(_CodecovArgs, ' ')" />
   </Target>
 
-  <Import Project="..\Packages.targets" />
+  <Import Project="Packages.targets" />
 </Project>

--- a/build/Codecov.proj
+++ b/build/Codecov.proj
@@ -1,4 +1,5 @@
-<Project>
+<Project DefaultTargets="CodeCov">
+  
   <Import Project="Versions.props" />
   <Import Project="RepoToolset\RepoLayout.props" />
 

--- a/build/Scripts/GenerateDependentAssemblyVersionFile.targets
+++ b/build/Scripts/GenerateDependentAssemblyVersionFile.targets
@@ -12,7 +12,7 @@
   -->
   
   <Import Project="..\Versions.props"/>
-  <Import Project="..\RepoToolset\ProjectLayout.props" />
+  <Import Project="..\RepoToolset\RepoLayout.props" />
 
   <Target Name="GenerateDependentAssemblyVersionsFile">
 

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -104,7 +104,7 @@ function Build {
 
   if ($useCodecov) {
     $CodecovProj = Join-Path $PSScriptRoot 'Codecov.proj'
-    & $MsbuildExe $CodecovProj /m /nologo /clp:Summary /nodeReuse:$nodeReuse /warnaserror /v:diag /t:Codecov /p:Configuration=$configuration /p:NuGetPackageRoot=$NuGetPackageRoot $properties
+    & $MsbuildExe $CodecovProj /m /nologo /clp:Summary /nodeReuse:$nodeReuse /warnaserror /v:diag /p:Configuration=$configuration /p:NuGetPackageRoot=$NuGetPackageRoot $properties
   }
 
   $GenerateDependentAssemblyVersionsProj = Join-Path $PSScriptRoot 'Scripts\GenerateDependentAssemblyVersionFile.targets'

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -104,7 +104,7 @@ function Build {
 
   if ($useCodecov) {
     $CodecovProj = Join-Path $PSScriptRoot 'Codecov.proj'
-    & $MsbuildExe $CodecovProj /m /nologo /clp:Summary /nodeReuse:$nodeReuse /warnaserror /v:diag /p:Configuration=$configuration /p:NuGetPackageRoot=$NuGetPackageRoot $properties
+    & $MsbuildExe $CodecovProj /m /nologo /clp:Summary /nodeReuse:$nodeReuse /warnaserror /v:diag /p:Configuration=$configuration $properties
   }
 
   $GenerateDependentAssemblyVersionsProj = Join-Path $PSScriptRoot 'Scripts\GenerateDependentAssemblyVersionFile.targets'

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -104,7 +104,7 @@ function Build {
 
   if ($useCodecov) {
     $CodecovProj = Join-Path $PSScriptRoot 'Codecov.proj'
-    & $MsbuildExe $CodecovProj /m /nologo /clp:Summary /nodeReuse:$nodeReuse /warnaserror /v:diag /t:Codecov /p:Configuration=$configuration /p:UseCodecov=$useCodecov /p:NuGetPackageRoot=$NuGetPackageRoot $properties
+    & $MsbuildExe $CodecovProj /m /nologo /clp:Summary /nodeReuse:$nodeReuse /warnaserror /v:diag /t:Codecov /p:Configuration=$configuration /p:NuGetPackageRoot=$NuGetPackageRoot $properties
   }
 
   $GenerateDependentAssemblyVersionsProj = Join-Path $PSScriptRoot 'Scripts\GenerateDependentAssemblyVersionFile.targets'


### PR DESCRIPTION
Preparing to replace build.ps1 with msbuild file, and CodeCov is harder than it needs to be, simplify it.

Note: This still doesn't get it to run - the GitHub properties are all wrong.