### PR TITLE
Binding redirection

### DIFF
--- a/build/Scripts/GenerateDependentAssemblyVersionFile.targets
+++ b/build/Scripts/GenerateDependentAssemblyVersionFile.targets
@@ -2,7 +2,7 @@
   <!-- 
    
    Generates DependentAssemblyVersions.csv that enables the Roslyn insertion tool to update various 
-   assembly verisons in the VS repository under src\ProductData.
+   assembly versions in the VS repository under src\ProductData.
    See: https://github.com/dotnet/roslyn-tools/tree/master/src/RoslynInsertionTool).
    
     $(VisualStudioVersion):         The version number of Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.AppDesigner
@@ -19,8 +19,14 @@
     <PropertyGroup>
       <DependentAssemblyVersionsOutputDirectory>$(ArtifactsConfigurationDir)DevDivInsertionFiles\</DependentAssemblyVersionsOutputDirectory>
       <DependentAssemblyVersionsFilePath>$(DependentAssemblyVersionsOutputDirectory)DependentAssemblyVersions.csv</DependentAssemblyVersionsFilePath>
+      
+    <!-- 
+     We use individual version for AppDesigner/Editors, however Managed and Managed.VS share
+     the same variable in VS repository under src\ProductData\AssemblyVersions.tt 
+     -->
       <DependentAssemblyVersionsContents>
  <![CDATA[
+Microsoft.VisualStudio.AppDesigner,$(VisualStudioVersion).0
 Microsoft.VisualStudio.Editors,$(VisualStudioVersion).0
 Microsoft.VisualStudio.ProjectSystem.Managed,$(ProjectSystemVersion).0
  ]]>

--- a/src/Common/ProvideCodeBaseBindingRedirection.cs
+++ b/src/Common/ProvideCodeBaseBindingRedirection.cs
@@ -9,14 +9,14 @@ using Microsoft.VisualStudio.Shell;
 namespace Microsoft.VisualStudio
 {
     /// <summary>
-    ///     A <see cref="RegistrationAttribute"/> that provides binding redirects for the project system.
+    ///     A <see cref="RegistrationAttribute"/> that provides code-base binding redirects.
     /// </summary>
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
-    internal sealed class ProvideProjectSystemBindingRedirectionAttribute : RegistrationAttribute
+    internal sealed class ProvideCodeBaseBindingRedirectionAttribute : RegistrationAttribute
     {
         private readonly ProvideBindingRedirectionAttribute _redirectionAttribute;
 
-        public ProvideProjectSystemBindingRedirectionAttribute(string assemblyName)
+        public ProvideCodeBaseBindingRedirectionAttribute(string assemblyName)
         {
             // ProvideBindingRedirectionAttribute is sealed, so we can't inherit from it to provide defaults.
             // Instead, we'll do more of an aggregation pattern here.

--- a/src/setup/ProjectSystemSetup/AssemblyRedirects.cs
+++ b/src/setup/ProjectSystemSetup/AssemblyRedirects.cs
@@ -2,5 +2,8 @@
 
 using Microsoft.VisualStudio;
 
-[assembly: ProvideProjectSystemBindingRedirection("Microsoft.VisualStudio.ProjectSystem.Managed")]
-[assembly: ProvideProjectSystemBindingRedirection("Microsoft.VisualStudio.ProjectSystem.Managed.VS")]
+// These provide code-base binding redirects for the assemblies we provide in this VSIX. For NGEN purposes,
+// we also need to update src/appid/devenv/stub/devenv.urt.config.tt inside VS repo, which is done automatically 
+// via the Roslyn Insertion tool when it consumes artifacts\Debug\DevDivInsertionFiles\DependentAssemblyVersions.csv.
+[assembly: ProvideCodeBaseBindingRedirection("Microsoft.VisualStudio.ProjectSystem.Managed")]
+[assembly: ProvideCodeBaseBindingRedirection("Microsoft.VisualStudio.ProjectSystem.Managed.VS")]

--- a/src/setup/ProjectSystemSetup/ProjectSystemSetup.csproj
+++ b/src/setup/ProjectSystemSetup/ProjectSystemSetup.csproj
@@ -38,8 +38,8 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
-    <Compile Include="..\..\Common\ProvideBindingRedirectionAttribute.cs">
-      <Link>ProvideBindingRedirectionAttribute.cs</Link>
+    <Compile Include="..\..\Common\ProvideCodeBaseBindingRedirection.cs">
+      <Link>ProvideCodeBaseBindingRedirection.cs</Link>
     </Compile>
   </ItemGroup>
 </Project>

--- a/src/setup/VisualStudioEditorsSetup/AssemblyRedirects.cs
+++ b/src/setup/VisualStudioEditorsSetup/AssemblyRedirects.cs
@@ -2,5 +2,8 @@
 
 using Microsoft.VisualStudio;
 
-[assembly: ProvideProjectSystemBindingRedirection("Microsoft.VisualStudio.Editors")]
-[assembly: ProvideProjectSystemBindingRedirection("Microsoft.VisualStudio.AppDesigner")]
+// These provide code-base binding redirects for the assemblies we provide in this VSIX. For NGEN purposes,
+// we also need to update src/appid/devenv/stub/devenv.urt.config.tt inside VS repo, which is done automatically 
+// via the Roslyn Insertion tool when it consumes artifacts\Debug\DevDivInsertionFiles\DependentAssemblyVersions.csv.
+[assembly: ProvideCodeBaseBindingRedirection("Microsoft.VisualStudio.Editors")]
+[assembly: ProvideCodeBaseBindingRedirection("Microsoft.VisualStudio.AppDesigner")]

--- a/src/setup/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
+++ b/src/setup/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
@@ -32,8 +32,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\Common\ProvideBindingRedirectionAttribute.cs">
-      <Link>ProvideBindingRedirectionAttribute.cs</Link>
+    <Compile Include="..\..\Common\ProvideCodeBaseBindingRedirection.cs">
+      <Link>ProvideCodeBaseBindingRedirection.cs</Link>
     </Compile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Rename binding redirect attribute and add some comments
- Add AppDesigner to the list of assembly versions that get updated on insertion, it was missing, see: https://devdiv.visualstudio.com/DevDiv/_git/VS?path=%2Fsrc%2FProductData%2FAssemblyVersions.tt&version=GBmaster&line=50&lineStyle=plain&lineEnd=51&lineStartColumn=1&lineEndColumn=1.