### PR TITLE
Simplify toolset restore

### DIFF
--- a/build/Packages.targets
+++ b/build/Packages.targets
@@ -14,6 +14,7 @@
       https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json;
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
       https://api.nuget.org/v3/index.json;
+      https://dotnet.myget.org/F/symreader-converter/api/v3/index.json;
     </RestoreSources>
   </PropertyGroup>
 

--- a/build/Toolset.proj
+++ b/build/Toolset.proj
@@ -1,18 +1,13 @@
 ﻿<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project Sdk="Microsoft.NET.Sdk">
-  <!--
-    Parameters:
-      DeployDeps   Restore and deploy assets (e.g. VSIXes) this repo depends on.
-  -->
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
-    <RestoreSources>https://api.nuget.org/v3/index.json;https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json;https://dotnet.myget.org/F/symreader-converter/api/v3/index.json</RestoreSources>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="RoslynTools.RepoToolset" />
-    <PackageReference Include="Codecov" />
-    <PackageReference Include="OpenCover" />
-    <PackageReference Include="Microsoft.DiaSymReader.Pdb2Pdb" />
+    <PackageReference Include="RoslynTools.RepoToolset" ExcludeAssets="all" />
+    <PackageReference Include="Codecov" ExcludeAssets="all" />
+    <PackageReference Include="OpenCover" ExcludeAssets="all" />
+    <PackageReference Include="Microsoft.DiaSymReader.Pdb2Pdb" ExcludeAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -82,7 +82,7 @@ function InstallToolset {
   }
 
   if (!(Test-Path $ToolsetBuildProj)) {
-    & $MsbuildExe $ToolsetRestoreProj /t:restore /m /nologo /clp:None /warnaserror /v:quiet /p:NuGetPackageRoot=$NuGetPackageRoot /p:BaseIntermediateOutputPath=$ToolsetDir /p:ExcludeRestorePackageImports=true $logCmd
+    & $MsbuildExe $ToolsetRestoreProj /t:restore /m /nologo /clp:None /warnaserror /v:quiet $logCmd
   }
 }
 
@@ -134,7 +134,6 @@ try {
   $ToolsRoot = Join-Path $RepoRoot ".tools"
   $ToolsetRestoreProj = Join-Path $PSScriptRoot "Toolset.proj"
   $ArtifactsDir = Join-Path $RepoRoot "artifacts"
-  $ToolsetDir = Join-Path $ArtifactsDir "toolset"
   $LogDir = Join-Path (Join-Path $ArtifactsDir $configuration) "log"
   $BinDir = Join-Path (Join-Path $ArtifactsDir $configuration) "bin"
   $VSSetupDir = Join-Path (Join-Path $ArtifactsDir $configuration) "VSSetup"

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -131,7 +131,6 @@ function Clear-NuGetCache() {
 
 try {
   $RepoRoot = Join-Path $PSScriptRoot "..\"
-  $ToolsRoot = Join-Path $RepoRoot ".tools"
   $ToolsetRestoreProj = Join-Path $PSScriptRoot "Toolset.proj"
   $ArtifactsDir = Join-Path $RepoRoot "artifacts"
   $LogDir = Join-Path (Join-Path $ArtifactsDir $configuration) "log"


### PR DESCRIPTION
The toolset already has access to the required properties it needs (from Directory.Build.props/targets), and does not need the properties passed to it.

Also skipped passing ExcludeRestorePackageImports, we can avoid picking up imports for PackageReferences by excluding them.
b95ec25
