### PR TITLE
Fix flaky tests

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
@@ -21,6 +21,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 {
     public class DesignTimeInputsFileWatcherTests
     {
+        private const int TestTimeoutMillisecondsDelay = 1000;
+
         public static IEnumerable<object[]> GetTestCases()
         {
             return new[]
@@ -85,6 +87,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 
             using DesignTimeInputsFileWatcher watcher = CreateDesignTimeInputsFileWatcher(fileChangeService, out ProjectValueDataSource<DesignTimeInputs> source);
 
+            watcher.AllowSourceBlockCompletion = true;
+
             // Send our input
             await source.SendAsync(new DesignTimeInputs(designTimeInputs, sharedDesignTimeInputs));
 
@@ -111,8 +115,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             // Send down our fake file changes
             watcher.FilesChanged((uint)fileChangeNotificationsToSend.Length, fileChangeNotificationsToSend, null);
 
+            watcher.SourceBlock.Complete();
+
+            await watcher.SourceBlock.Completion;
+
             // The timeout here is annoying, but even though our test is "smart" and waits for data, unfortunately if the code breaks the test is more likely to hang than fail
-            if (await Task.WhenAny(finished.Task, Task.Delay(500)) != finished.Task)
+            if (await Task.WhenAny(finished.Task, Task.Delay(TestTimeoutMillisecondsDelay)) != finished.Task)
             {
                 throw new AssertActualExpectedException(fileChangeNotificationsExpected.Length, notificationCount, "Timed out after 500ms");
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/TempPECompilerManagerTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/TempPECompilerManagerTests.cs
@@ -22,6 +22,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 {
     public class TempPECompilerManagerTests : IDisposable
     {
+        private const int TestTimeoutMillisecondsDelay = 1000;
+
         private string? _lastIntermediateOutputPath;
         private readonly string _projectFolder = @"C:\MyProject";
         private string _intermediateOutputPath = "MyOutput";
@@ -183,6 +185,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         [Fact]
         public async Task SingleDesignTimeInput_Removed_ShouldntCompile()
         {
+            _manager.CompileSynchronously = false;
+
             var inputs = new DesignTimeInputs(new string[] { "File1.cs" }, new string[] { });
 
             await VerifyDLLsCompiled(0, () =>
@@ -208,9 +212,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             });
 
             Assert.Equal(2, _compilationResults.Count);
-            Assert.Contains("File2.cs", _compilationResults[0].SourceFiles);
-            Assert.DoesNotContain("File1.cs", _compilationResults[0].SourceFiles);
-            Assert.Equal(Path.Combine(TempPECompilerManager.GetOutputPath(_projectFolder, _intermediateOutputPath), "File2.cs.dll"), _compilationResults[0].OutputFileName);
+            Assert.Contains("File1.cs", _compilationResults[0].SourceFiles);
+            Assert.DoesNotContain("File2.cs", _compilationResults[0].SourceFiles);
+            Assert.Contains("File2.cs", _compilationResults[1].SourceFiles);
+            Assert.DoesNotContain("File1.cs", _compilationResults[1].SourceFiles);
+            Assert.Equal(Path.Combine(TempPECompilerManager.GetOutputPath(_projectFolder, _intermediateOutputPath), "File1.cs.dll"), _compilationResults[0].OutputFileName);
+            Assert.Equal(Path.Combine(TempPECompilerManager.GetOutputPath(_projectFolder, _intermediateOutputPath), "File2.cs.dll"), _compilationResults[1].OutputFileName);
         }
 
         [Fact]
@@ -340,7 +347,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                                       watcherMock.Object,
                                       compilerMock.Object,
                                       _fileSystem,
-                                      telemetryService);
+                                      telemetryService)
+            {
+                CompileSynchronously = true
+            };
         }
 
         private bool CompilationCallBack(string output, ISet<string> files)
@@ -385,7 +395,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             await actionThatCausesCompilation();
 
             // Sadly, we need a timeout
-            var delay = Task.Delay(TimeSpan.FromSeconds(1));
+            var delay = Task.Delay(TestTimeoutMillisecondsDelay);
 
             if (await Task.WhenAny(_compilationOccurredCompletionSource.Task, delay) == delay)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
@@ -60,6 +60,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             _fileChangeService = fileChangeService;
         }
 
+        /// <summary>
+        /// This is to allow unit tests to force completion of our source block rather than waiting for async work to complete
+        /// </summary>
+        internal bool AllowSourceBlockCompletion { get; set; }
+
         public override NamedIdentity DataSourceKey { get; } = new NamedIdentity(nameof(DesignTimeInputsFileWatcher));
 
         public override IComparable DataSourceVersion => _version;
@@ -79,7 +84,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             base.Initialize();
 
             _broadcastBlock = DataflowBlockSlim.CreateBroadcastBlock<IProjectVersionedValue<string[]>>(nameFormat: nameof(DesignTimeInputsFileWatcher) + "Broadcast {1}");
-            _publicBlock = _broadcastBlock.SafePublicize();
+            _publicBlock = AllowSourceBlockCompletion ? _broadcastBlock : _broadcastBlock.SafePublicize();
 
             _actionBlock = DataflowBlockSlim.CreateActionBlock<IProjectVersionedValue<DesignTimeInputs>>(ProcessDesignTimeInputs);
 


### PR DESCRIPTION
This seems to fix the flakyness of the tests by allowing the tests to complete the data flow block for the file watcher, and to wait for the task scheduler to do its work for the compiler.