### PR TITLE
Update Microsoft.Net.Compilers to one that enables .editorconfig discovery

### DIFF
--- a/build/Packages.targets
+++ b/build/Packages.targets
@@ -28,7 +28,7 @@
     <PackageReference Update="RoslynDependencies.ProjectSystem.OptimizationData"                      Version="$(RoslynDependenciesProjectSystemOptimizationDataVersion)" />
     <PackageReference Update="Microsoft.DotNet.IBCMerge"                                              Version="[$(MicrosoftDotNetIBCMergeVersion)]" />
     <PackageReference Update="Microsoft.DiaSymReader.Pdb2Pdb"                                         Version="$(MicrosoftDiaSymReaderPdb2PdbVersion)" />
-    <PackageReference Update="Microsoft.Net.Compilers"                                                Version="3.3.0-beta2-19357-02" />
+    <PackageReference Update="Microsoft.Net.Compilers"                                                Version="3.3.0-beta2-19375-02" />
     <PackageReference Update="OpenCover"                                                              Version="$(OpenCoverVersion)" />
     <PackageReference Update="Codecov"                                                                Version="$(CodecovVersion)" />
     <PackageReference Update="MicroBuild.Core"                                                        Version="0.2.0" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsBuildManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsBuildManager.cs
@@ -40,12 +40,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
         /// <summary>
         /// Occurs when a design time output moniker is deleted.
         /// </summary>
-        public event _dispBuildManagerEvents_DesignTimeOutputDeletedEventHandler DesignTimeOutputDeleted;
+        public event _dispBuildManagerEvents_DesignTimeOutputDeletedEventHandler? DesignTimeOutputDeleted;
 
         /// <summary>
         /// Occurs when a design time output moniker is dirty
         /// </summary>
-        public event _dispBuildManagerEvents_DesignTimeOutputDirtyEventHandler DesignTimeOutputDirty;
+        public event _dispBuildManagerEvents_DesignTimeOutputDirtyEventHandler? DesignTimeOutputDirty;
 
         /// <summary>
         /// Gets the project of which the selected item is a part.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/NameValuePair.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/NameValuePair.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
             set { NotifyPropertyChanged(ref _value, value); }
         }
 
-        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler? PropertyChanged;
 
         private void NotifyPropertyChanged<T>(ref T refProperty, T value, [CallerMemberName] string? propertyName = null)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/ObservableList.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/ObservableList.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
 {
     internal class ObservableList<T> : ObservableCollection<T>
     {
-        public event EventHandler ValidationStatusChanged;
+        public event EventHandler? ValidationStatusChanged;
 
         private void OnItemPropertyChanged(object sender, PropertyChangedEventArgs e)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/AggregateDependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/AggregateDependenciesSnapshotProvider.cs
@@ -28,10 +28,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         }
 
         /// <inheritdoc />
-        public event EventHandler<SnapshotChangedEventArgs> SnapshotChanged;
+        public event EventHandler<SnapshotChangedEventArgs>? SnapshotChanged;
 
         /// <inheritdoc />
-        public event EventHandler<SnapshotProviderUnloadingEventArgs> SnapshotProviderUnloading;
+        public event EventHandler<SnapshotProviderUnloadingEventArgs>? SnapshotProviderUnloading;
 
         /// <inheritdoc />
         public void RegisterSnapshotProvider(IDependenciesSnapshotProvider snapshotProvider)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
@@ -28,9 +28,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
     {
         public const string DependencySubscriptionsHostContract = "DependencySubscriptionsHostContract";
 
-        public event EventHandler<ProjectRenamedEventArgs> SnapshotRenamed;
-        public event EventHandler<SnapshotChangedEventArgs> SnapshotChanged;
-        public event EventHandler<SnapshotProviderUnloadingEventArgs> SnapshotProviderUnloading;
+        public event EventHandler<ProjectRenamedEventArgs>? SnapshotRenamed;
+        public event EventHandler<SnapshotChangedEventArgs>? SnapshotChanged;
+        public event EventHandler<SnapshotProviderUnloadingEventArgs>? SnapshotProviderUnloading;
 
         private readonly TimeSpan _dependenciesUpdateThrottleInterval = TimeSpan.FromMilliseconds(250);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             _treeTelemetryService = treeTelemetryService;
         }
 
-        public event EventHandler<DependencySubscriptionChangedEventArgs> DependenciesChanged;
+        public event EventHandler<DependencySubscriptionChangedEventArgs>? DependenciesChanged;
 
         public async Task InitializeSubscriberAsync(ICrossTargetSubscriptionsHost host, IProjectSubscriptionService subscriptionService)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
@@ -202,7 +202,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             }
         }
 
-        public event EventHandler<DependencySubscriptionChangedEventArgs> DependenciesChanged;
+        public event EventHandler<DependencySubscriptionChangedEventArgs>? DependenciesChanged;
 
         protected override void Initialize()
         {


### PR DESCRIPTION
The older package was explicitly turning it off. Since that was a pre-release package that doesn't represent what we are shipping, just upgrade. The version chosen here matches the current internal dogfood build.