### PR TITLE
Remove FrameworkReference PrivateAssets properties

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CollectedFrameworkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CollectedFrameworkReference.xaml
@@ -17,6 +17,6 @@
 
   <!-- NuGet uses PrivateAssets to prevent framework references from being manifested in nuspec. -->
   <StringProperty Name="PrivateAssets"
-                  DisplayName="Private Assets" />
+                  Visible="False" />
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CollectedFrameworkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CollectedFrameworkReference.xaml
@@ -15,6 +15,7 @@
                 SourceType="TargetResults" />
   </Rule.DataSource>
 
+  <!-- NuGet uses PrivateAssets to prevent framework references from being manifested in nuspec. -->
   <StringProperty Name="PrivateAssets"
                   DisplayName="Private Assets" />
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/FrameworkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/FrameworkReference.xaml
@@ -17,8 +17,4 @@
                   ReadOnly="True"
                   Visible="False" />
 
-  <StringProperty Name="PrivateAssets"
-                  Description="Assets that are private in this reference."
-                  DisplayName="Private Assets" />
-
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedFrameworkReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedFrameworkReference.xaml
@@ -35,15 +35,4 @@
                   ReadOnly="True"
                   Visible="False" />
 
-  <StringProperty Name="PrivateAssets"
-                  Description="Assets that are private in this reference."
-                  DisplayName="Private Assets">
-    <StringProperty.DataSource>
-      <DataSource HasConfigurationCondition="False"
-                  ItemType="FrameworkReference"
-                  Persistence="ProjectFile"
-                  SourceOfDefaultValue="AfterContext" />
-    </StringProperty.DataSource>
-  </StringProperty>
-
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.cs.xlf
@@ -12,16 +12,6 @@
         <target state="new">Framework Reference</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference.</source>
-        <target state="new">Assets that are private in this reference.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private Assets</source>
-        <target state="new">Private Assets</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.de.xlf
@@ -12,16 +12,6 @@
         <target state="new">Framework Reference</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference.</source>
-        <target state="new">Assets that are private in this reference.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private Assets</source>
-        <target state="new">Private Assets</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.es.xlf
@@ -12,16 +12,6 @@
         <target state="new">Framework Reference</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference.</source>
-        <target state="new">Assets that are private in this reference.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private Assets</source>
-        <target state="new">Private Assets</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.fr.xlf
@@ -12,16 +12,6 @@
         <target state="new">Framework Reference</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference.</source>
-        <target state="new">Assets that are private in this reference.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private Assets</source>
-        <target state="new">Private Assets</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.it.xlf
@@ -12,16 +12,6 @@
         <target state="new">Framework Reference</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference.</source>
-        <target state="new">Assets that are private in this reference.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private Assets</source>
-        <target state="new">Private Assets</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.ja.xlf
@@ -12,16 +12,6 @@
         <target state="new">Framework Reference</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference.</source>
-        <target state="new">Assets that are private in this reference.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private Assets</source>
-        <target state="new">Private Assets</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.ko.xlf
@@ -12,16 +12,6 @@
         <target state="new">Framework Reference</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference.</source>
-        <target state="new">Assets that are private in this reference.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private Assets</source>
-        <target state="new">Private Assets</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.pl.xlf
@@ -12,16 +12,6 @@
         <target state="new">Framework Reference</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference.</source>
-        <target state="new">Assets that are private in this reference.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private Assets</source>
-        <target state="new">Private Assets</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.pt-BR.xlf
@@ -12,16 +12,6 @@
         <target state="new">Framework Reference</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference.</source>
-        <target state="new">Assets that are private in this reference.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private Assets</source>
-        <target state="new">Private Assets</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.ru.xlf
@@ -12,16 +12,6 @@
         <target state="new">Framework Reference</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference.</source>
-        <target state="new">Assets that are private in this reference.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private Assets</source>
-        <target state="new">Private Assets</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.tr.xlf
@@ -12,16 +12,6 @@
         <target state="new">Framework Reference</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference.</source>
-        <target state="new">Assets that are private in this reference.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private Assets</source>
-        <target state="new">Private Assets</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.zh-Hans.xlf
@@ -12,16 +12,6 @@
         <target state="new">Framework Reference</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference.</source>
-        <target state="new">Assets that are private in this reference.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private Assets</source>
-        <target state="new">Private Assets</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/FrameworkReference.xaml.zh-Hant.xlf
@@ -12,16 +12,6 @@
         <target state="new">Framework Reference</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference.</source>
-        <target state="new">Assets that are private in this reference.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private Assets</source>
-        <target state="new">Private Assets</target>
-        <note />
-      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.cs.xlf
@@ -12,11 +12,6 @@
         <target state="new">Framework</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference.</source>
-        <target state="new">Assets that are private in this reference.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">
         <source>Path</source>
         <target state="new">Path</target>
@@ -25,11 +20,6 @@
       <trans-unit id="StringProperty|Profile|DisplayName">
         <source>Profile</source>
         <target state="new">Profile</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private Assets</source>
-        <target state="new">Private Assets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.de.xlf
@@ -12,11 +12,6 @@
         <target state="new">Framework</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference.</source>
-        <target state="new">Assets that are private in this reference.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">
         <source>Path</source>
         <target state="new">Path</target>
@@ -25,11 +20,6 @@
       <trans-unit id="StringProperty|Profile|DisplayName">
         <source>Profile</source>
         <target state="new">Profile</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private Assets</source>
-        <target state="new">Private Assets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.es.xlf
@@ -12,11 +12,6 @@
         <target state="new">Framework</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference.</source>
-        <target state="new">Assets that are private in this reference.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">
         <source>Path</source>
         <target state="new">Path</target>
@@ -25,11 +20,6 @@
       <trans-unit id="StringProperty|Profile|DisplayName">
         <source>Profile</source>
         <target state="new">Profile</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private Assets</source>
-        <target state="new">Private Assets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.fr.xlf
@@ -12,11 +12,6 @@
         <target state="new">Framework</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference.</source>
-        <target state="new">Assets that are private in this reference.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">
         <source>Path</source>
         <target state="new">Path</target>
@@ -25,11 +20,6 @@
       <trans-unit id="StringProperty|Profile|DisplayName">
         <source>Profile</source>
         <target state="new">Profile</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private Assets</source>
-        <target state="new">Private Assets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.it.xlf
@@ -12,11 +12,6 @@
         <target state="new">Framework</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference.</source>
-        <target state="new">Assets that are private in this reference.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">
         <source>Path</source>
         <target state="new">Path</target>
@@ -25,11 +20,6 @@
       <trans-unit id="StringProperty|Profile|DisplayName">
         <source>Profile</source>
         <target state="new">Profile</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private Assets</source>
-        <target state="new">Private Assets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.ja.xlf
@@ -12,11 +12,6 @@
         <target state="new">Framework</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference.</source>
-        <target state="new">Assets that are private in this reference.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">
         <source>Path</source>
         <target state="new">Path</target>
@@ -25,11 +20,6 @@
       <trans-unit id="StringProperty|Profile|DisplayName">
         <source>Profile</source>
         <target state="new">Profile</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private Assets</source>
-        <target state="new">Private Assets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.ko.xlf
@@ -12,11 +12,6 @@
         <target state="new">Framework</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference.</source>
-        <target state="new">Assets that are private in this reference.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">
         <source>Path</source>
         <target state="new">Path</target>
@@ -25,11 +20,6 @@
       <trans-unit id="StringProperty|Profile|DisplayName">
         <source>Profile</source>
         <target state="new">Profile</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private Assets</source>
-        <target state="new">Private Assets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.pl.xlf
@@ -12,11 +12,6 @@
         <target state="new">Framework</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference.</source>
-        <target state="new">Assets that are private in this reference.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">
         <source>Path</source>
         <target state="new">Path</target>
@@ -25,11 +20,6 @@
       <trans-unit id="StringProperty|Profile|DisplayName">
         <source>Profile</source>
         <target state="new">Profile</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private Assets</source>
-        <target state="new">Private Assets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.pt-BR.xlf
@@ -12,11 +12,6 @@
         <target state="new">Framework</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference.</source>
-        <target state="new">Assets that are private in this reference.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">
         <source>Path</source>
         <target state="new">Path</target>
@@ -25,11 +20,6 @@
       <trans-unit id="StringProperty|Profile|DisplayName">
         <source>Profile</source>
         <target state="new">Profile</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private Assets</source>
-        <target state="new">Private Assets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.ru.xlf
@@ -12,11 +12,6 @@
         <target state="new">Framework</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference.</source>
-        <target state="new">Assets that are private in this reference.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">
         <source>Path</source>
         <target state="new">Path</target>
@@ -25,11 +20,6 @@
       <trans-unit id="StringProperty|Profile|DisplayName">
         <source>Profile</source>
         <target state="new">Profile</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private Assets</source>
-        <target state="new">Private Assets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.tr.xlf
@@ -12,11 +12,6 @@
         <target state="new">Framework</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference.</source>
-        <target state="new">Assets that are private in this reference.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">
         <source>Path</source>
         <target state="new">Path</target>
@@ -25,11 +20,6 @@
       <trans-unit id="StringProperty|Profile|DisplayName">
         <source>Profile</source>
         <target state="new">Profile</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private Assets</source>
-        <target state="new">Private Assets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.zh-Hans.xlf
@@ -12,11 +12,6 @@
         <target state="new">Framework</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference.</source>
-        <target state="new">Assets that are private in this reference.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">
         <source>Path</source>
         <target state="new">Path</target>
@@ -25,11 +20,6 @@
       <trans-unit id="StringProperty|Profile|DisplayName">
         <source>Profile</source>
         <target state="new">Profile</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private Assets</source>
-        <target state="new">Private Assets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/ResolvedFrameworkReference.xaml.zh-Hant.xlf
@@ -12,11 +12,6 @@
         <target state="new">Framework</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|Description">
-        <source>Assets that are private in this reference.</source>
-        <target state="new">Assets that are private in this reference.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|TargetingPackPath|DisplayName">
         <source>Path</source>
         <target state="new">Path</target>
@@ -25,11 +20,6 @@
       <trans-unit id="StringProperty|Profile|DisplayName">
         <source>Profile</source>
         <target state="new">Profile</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|PrivateAssets|DisplayName">
-        <source>Private Assets</source>
-        <target state="new">Private Assets</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|TargetingPackVersion|DisplayName">


### PR DESCRIPTION
Following discussion in #5070, removes the `PrivateAssets` property for framework references.

Fixes #4762.
Fixes #5070.

