### PR TITLE
Exclude MSBuild items cache file from up to date check inputs

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -413,12 +413,7 @@
   <Target Name="CollectResolvedCompilationReferencesDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(ReferencePathWithRefAssemblies)" />
 
   <!-- This target collects all the extra inputs for the up to date check. -->
-  <Target Name="CollectUpToDateCheckInputDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(UpToDateCheckInput)">
-    <ItemGroup>
-      <!-- MSBuild additional compile file, such as the file input cache file -->
-      <UpToDateCheckInput Include="@(CustomAdditionalCompileInputs)"/>
-    </ItemGroup>
-  </Target>
+  <Target Name="CollectUpToDateCheckInputDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(UpToDateCheckInput)" />
 
   <!-- This target collects all the extra outputs for the up to date check. -->
   <Target Name="CollectUpToDateCheckOutputDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(UpToDateCheckOutput)" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -356,7 +356,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 : (null, null);
         }
 
-        private bool CheckOutputs(BuildUpToDateCheckLogger logger, IDictionary<string, DateTime> timestampCache, State state)
+        private bool CheckInputsAndOutputs(BuildUpToDateCheckLogger logger, IDictionary<string, DateTime> timestampCache, State state)
         {
             // We assume there are fewer outputs than inputs, so perform a full scan of outputs to find the earliest
             (DateTime? outputTime, string? outputPath) = GetEarliestOutput(CollectOutputs(logger, state), timestampCache);
@@ -584,7 +584,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     // Short-lived cache of timestamp by path
                     var timestampCache = new Dictionary<string, DateTime>(StringComparers.Paths);
 
-                    if (!CheckOutputs(logger, timestampCache, state) ||
+                    if (!CheckInputsAndOutputs(logger, timestampCache, state) ||
                         !CheckMarkers(logger, timestampCache, state) ||
                         !CheckCopyToOutputDirectoryFiles(logger, timestampCache, state) ||
                         !CheckCopiedOutputFiles(logger, timestampCache, state))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -604,8 +604,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             }
         }
 
-        public Task<bool> IsUpToDateCheckEnabledAsync(CancellationToken cancellationToken = default) =>
-            _projectSystemOptions.GetIsFastUpToDateCheckEnabledAsync(cancellationToken);
+        public Task<bool> IsUpToDateCheckEnabledAsync(CancellationToken cancellationToken = default)
+        {
+            return _projectSystemOptions.GetIsFastUpToDateCheckEnabledAsync(cancellationToken);
+        }
 
         internal readonly struct TestAccessor
         {


### PR DESCRIPTION
This partially reverts a change made in 97b3d5755562dedd304404d9946990077fd227c9 that resolved #3245. More recently PR #5089 was merged that addresses the same issue and others, making this addition to the inputs obsolete (and potentially harmful by triggering unnecessary builds). As @rainersigwald explained, the cache file is an implementation detail of MSBuild that we should not depend upon.

I've tested this in various scenarios, including those in #3245 and #4736.
