### PR TITLE
Remove redundant #pragma warning disables

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -265,10 +265,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             if (state.CustomInputs.Count != 0)
             {
                 logger.Verbose("Adding " + UpToDateCheckInput.SchemaName + " inputs:");
-                // TODO remove pragmas when https://github.com/dotnet/roslyn/issues/37040 is fixed
-#pragma warning disable CS8622
                 foreach (string input in state.CustomInputs.Select(_configuredProject.UnconfiguredProject.MakeRooted))
-#pragma warning restore CS8622
                 {
                     logger.Verbose("    '{0}'", input);
                     yield return input;
@@ -282,10 +279,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 logger.Verbose("Adding " + UpToDateCheckOutput.SchemaName + " outputs:");
 
-                // TODO remove pragmas when https://github.com/dotnet/roslyn/issues/37040 is fixed
-#pragma warning disable CS8622
                 foreach (string output in state.CustomOutputs.Select(_configuredProject.UnconfiguredProject.MakeRooted))
-#pragma warning restore CS8622
                 {
                     logger.Verbose("    '{0}'", output);
                     yield return output;
@@ -296,10 +290,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 logger.Verbose("Adding " + UpToDateCheckBuilt.SchemaName + " outputs:");
 
-                // TODO remove pragmas when https://github.com/dotnet/roslyn/issues/37040 is fixed
-#pragma warning disable CS8622
                 foreach (string output in state.BuiltOutputs.Select(_configuredProject.UnconfiguredProject.MakeRooted))
-#pragma warning restore CS8622
                 {
                     logger.Verbose("    '{0}'", output);
                     yield return output;
@@ -318,10 +309,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                 if (time > latest)
                 {
-                    // TODO remove pragmas when https://github.com/dotnet/roslyn/issues/37039 is fixed
-#pragma warning disable CS8629 // Nullable value type may be null
                     latest = time.Value;
-#pragma warning restore CS8629
                     latestPath = input;
                 }
             }


### PR DESCRIPTION
The underlying Roslyn bug has been fixed.