### PR TITLE
Add user-facing up-to-date check documentation

### DIFF
--- a/docs/repo/up-to-date-check-implementation.md
+++ b/docs/repo/up-to-date-check-implementation.md
@@ -1,8 +1,6 @@
-# Up-to-date Check
+# Up-to-date Check Implementation
 
-If a project's outputs are up-to-date with its inputs, there's no need to run a build.
-
-The _Fast Up To Date Check_ attempts to perform a fast validation of whether a build is required.
+See [this documenent](../up-to-date-check.md) for more general information about the up-to-date check.
 
 The `IBuildUpToDateCheckProvider` interface (from CPS) has two members:
 
@@ -75,17 +73,3 @@ For each `_copiedOutputFiles` source/destination
 
 - [`BuildUpToDateCheck.cs`](https://github.com/dotnet/project-system/blob/master/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs)
 - [`BuildUpToDateCheckTests.cs`](https://github.com/dotnet/project-system/blob/master/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs)
-
-## Debugging
-
-The `BuildUpToDateCheck` class uses a `BuildUpToDateCheckLogger` to log verbose and info level information that is very useful during debugging.
-
-The log level is obtained via `IProjectSystemOptions.GetFastUpToDateLoggingLevelAsync` which is user-controlled in Visual Studio via:
-
-> Tools | Options | Projects and Solutions | .NET Core
-
-![Projects and Solutions, .NET Core options](images/options.png)
-
-With a log level of info or verbose, you'll see messages prefixed with "FastUpToDate:" in the "Build" section of the "Output" pane in Visual Studio. These messages will explain why the project is considered up to date or not.
-
-Uncheck the check box to disable the fast up to date check and always call MSBuild.

--- a/docs/up-to-date-check.md
+++ b/docs/up-to-date-check.md
@@ -1,0 +1,72 @@
+# Up-to-date Check
+
+The Project System's _Fast Up-to-date Check_ save developers time by quickly assessing whether a project needs to be
+built or not. If not, Visual Studio can avoid a comparatively expensive call to MSBuild.
+
+At a superficial level, the check compares timestamps between the project's inputs and its outputs. For more
+information on how it works in detail, see [this document](repo/up-to-date-check-implementation.md).
+
+## Customization
+
+For most projects the up-to-date check works automatically and you won't need to know or think about this feature.
+However if your build is highly customized then you may need to provide some extra information to help the up-to-date
+check work correctly.
+
+For customized builds, you may add to the following item types:
+
+- `UpToDateCheckInput` &mdash; Describes an input file that MSBuild would not otherwise know about
+- `UpToDateCheckOutput` &mdash; Describes an output file that MSBuild would not otherwise know about
+- `UpToDateCheckBuilt` &mdash; Similar to `UpToDateCheckOutput` but with optional `Original` property that denotes
+  that the output was copied, not built.
+
+You may add to these item types declaratively. For example:
+
+```xml
+<ItemGroup>
+  <UpToDateCheckInput Include="MyCustomBuildInput.abc" />
+</ItemGroup>
+```
+
+Alternatively, you may override the MSBuild targets that Visual Studio calls to collect these items. Overriding targets
+allows custom logic to be executed when determining the set of items. The relevant targets are defined in
+`Microsoft.Managed.DesignTime.targets` with names:
+
+- `CollectUpToDateCheckInputDesignTime`
+- `CollectUpToDateCheckOutputDesignTime`
+- `CollectUpToDateCheckBuiltDesignTime`
+
+Note that changes to inputs **must** result in changes to outputs. If this rule is not observed, then an input may
+have a timestamp after all outputs, which leads the up-to-date check to consider the project out-of-date after building.
+
+## Debugging
+
+By default the up-to-date check does not log anything, though you can infer its decision from your build output summary:
+
+```text
+========== Build: 0 succeeded, 0 failed, 1 up-to-date, 0 skipped ==========
+```
+
+In this example the up-to-date check determined the project was up-to-date. If `succeeded` or `failed` was instead
+non-zero, then the check would have determined the project was not up-to-date, resulting in a call to MSBuild.
+
+To debug issues with the up-to-date check, enable its logging.
+
+> Tools | Options | Projects and Solutions | .NET Core
+
+![Projects and Solutions, .NET Core options](repo/images/options.png)
+
+With a log level of info or verbose, you'll see messages prefixed with `FastUpToDate:` in Visual Studio's build output.
+These messages will explain why the project is considered up-to-date or not.
+
+## Disabling the Up-to-date Check
+
+If you do not wish to use the fast up-to-date check, preferring to always call MSBuild, you can disable it by either:
+
+- Unchecking "Don't call MSBuild if a project appears to be up to date" (shown above), or
+- Adding property `<DisableFastUpToDateCheck>True</DisableFastUpToDateCheck>` to your project
+
+Note that in both cases this only disables Visual Studio's up-to-date check. MSBuild will still perform its own
+determination as to whether the project should be rebuilt.
+
+If you are disabling the check because you feel it is not behaving correctly, please file an issue in this repo and
+include details from the verbose log so that we can improve the feature.

--- a/docs/up-to-date-check.md
+++ b/docs/up-to-date-check.md
@@ -1,6 +1,6 @@
 # Up-to-date Check
 
-The Project System's _Fast Up-to-date Check_ save developers time by quickly assessing whether a project needs to be
+The Project System's _Fast Up-to-date Check_ saves developers time by quickly assessing whether a project needs to be
 built or not. If not, Visual Studio can avoid a comparatively expensive call to MSBuild.
 
 At a superficial level, the check compares timestamps between the project's inputs and its outputs. For more

--- a/docs/up-to-date-check.md
+++ b/docs/up-to-date-check.md
@@ -6,6 +6,10 @@ built or not. If not, Visual Studio can avoid a comparatively expensive call to 
 At a superficial level, the check compares timestamps between the project's inputs and its outputs. For more
 information on how it works in detail, see [this document](repo/up-to-date-check-implementation.md).
 
+Note that the _fast_ up-to-date check is intended to speed up the majority of cases where a build is not required,
+yet it cannot reliably cover all cases correctly. Where necessary, it errs on the side of caution as triggering a
+redundant build is better than not triggering a required build.
+
 ## Customization
 
 For most projects the up-to-date check works automatically and you won't need to know or think about this feature.


### PR DESCRIPTION
Previous documentation on the up-to-date check was technical and focused on project contributors (hence being in the `docs/repo` folder).

This PR adds a more general document explaining what the up-to-date check is, how to configure it and how to debug it.