### PR TITLE
Dependency node integration tests

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Construction/GlobalJson.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Construction/GlobalJson.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.IO;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    /// <summary>
+    /// Defines a <c>global.json</c> file to be created when using <see cref="ProjectLayoutTestBase"/>.
+    /// </summary>
+    public sealed class GlobalJson
+    {
+        public string SdkVersion { get; }
+
+        public GlobalJson(string sdkVersion) => SdkVersion = sdkVersion;
+
+        public void Save(string rootPath)
+        {
+            File.WriteAllText(
+                Path.Combine(rootPath, "global.json"),
+                $"{{ \"sdk\": {{ \"version\": \"{SdkVersion}\" }} }}");
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Construction/Project.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Construction/Project.cs
@@ -20,6 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         private List<Project>? _referencedProjects;
         private List<PackageReference>? _packageReferences;
+        private List<IFile>? _files;
 
         public XElement XElement { get; } = new XElement("Project");
 
@@ -41,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             Sdk = sdk;
         }
 
-        public void Save(string rootPath)
+        public void Save(string solutionRoot)
         {
             XElement.Add(new XAttribute("Sdk", Sdk));
 
@@ -68,9 +69,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                         new XAttribute("Version", p.Version)))));
             }
 
-            Directory.CreateDirectory(Path.Combine(rootPath, ProjectName));
+            var projectRoot = Path.Combine(solutionRoot, ProjectName);
 
-            XElement.Save(Path.Combine(rootPath, RelativeProjectFilePath));
+            Directory.CreateDirectory(projectRoot);
+
+            XElement.Save(Path.Combine(solutionRoot, RelativeProjectFilePath));
+
+            if (_files != null)
+            {
+                foreach (var file in _files)
+                {
+                    file.Save(projectRoot);
+                }
+            }
         }
 
         /// <summary>
@@ -89,6 +100,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             _packageReferences.Add(packageReference);
         }
 
+        public void Add(IFile file)
+        {
+            _files ??= new List<IFile>();
+            _files.Add(file);
+        }
+
         /// <summary>
         /// We only implement <see cref="IEnumerable"/> to support collection initialiser syntax.
         /// </summary>
@@ -104,6 +121,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             PackageId = packageId;
             Version = version;
+        }
+    }
+
+    public interface IFile
+    {
+        void Save(string projectRoot);
+    }
+
+    public sealed class CSharpClass : IFile
+    {
+        public string Name { get; }
+
+        public CSharpClass(string name)
+        {
+            Name = name;
+        }
+
+        public void Save(string projectRoot)
+        {
+            var content = $@"class {Name} {{ }}";
+
+            File.WriteAllText(Path.Combine(projectRoot, $"{Name}.cs"), content);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Construction/Project.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Construction/Project.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -13,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     /// <summary>
     /// Defines a <c>.csproj</c> file to be created when using <see cref="ProjectLayoutTestBase"/>.
     /// </summary>
-    public sealed class Project
+    public sealed class Project : IEnumerable   
     {
         private static readonly Guid _sdkProjectTypeGuid = Guid.Parse("9A19103F-16F7-4668-BE54-9A1E7A4F7556");
 
@@ -65,10 +66,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         /// Adds a P2P (project-to-project) reference from this project to <paramref name="referree"/>.
         /// </summary>
         /// <param name="referree">The project to reference.</param>
-        public void AddProjectReference(Project referree)
+        public void Add(Project referree)
         {
             _referencedProjects ??= new List<Project>();
             _referencedProjects.Add(referree);
         }
+
+        /// <summary>
+        /// We only implement <see cref="IEnumerable"/> to support collection initialiser syntax.
+        /// </summary>
+        IEnumerator IEnumerable.GetEnumerator() => throw new NotSupportedException();
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Construction/Project.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Construction/Project.cs
@@ -20,6 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         private List<Project>? _referencedProjects;
         private List<PackageReference>? _packageReferences;
+        private List<AssemblyReference>? _assemblyReferences;
         private List<IFile>? _files;
 
         public XElement XElement { get; } = new XElement("Project");
@@ -57,6 +58,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                     _referencedProjects.Select(p => new XElement(
                         "ProjectReference",
                         new XAttribute("Include", $"..\\{p.RelativeProjectFilePath}")))));
+            }
+
+            if (_assemblyReferences != null)
+            {
+                XElement.Add(new XElement(
+                    "ItemGroup",
+                    _assemblyReferences.Select(p => new XElement(
+                        "Reference",
+                        new XAttribute("Include", p.Name)))));
             }
 
             if (_packageReferences != null)
@@ -100,6 +110,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             _packageReferences.Add(packageReference);
         }
 
+        public void Add(AssemblyReference assemblyReference)
+        {
+            _assemblyReferences ??= new List<AssemblyReference>();
+            _assemblyReferences.Add(assemblyReference);
+        }
+
         public void Add(IFile file)
         {
             _files ??= new List<IFile>();
@@ -121,6 +137,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             PackageId = packageId;
             Version = version;
+        }
+    }
+
+    public readonly struct AssemblyReference
+    {
+        public string Name { get; }
+
+        public AssemblyReference(string name)
+        {
+            Name = name;
         }
     }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Construction/Project.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Construction/Project.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+using Microsoft.Test.Apex.VisualStudio.Solution;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    /// <summary>
+    /// Defines a <c>.csproj</c> file to be created when using <see cref="ProjectLayoutTestBase"/>.
+    /// </summary>
+    public sealed class Project
+    {
+        private static readonly Guid _sdkProjectTypeGuid = Guid.Parse("9A19103F-16F7-4668-BE54-9A1E7A4F7556");
+
+        private List<Project>? _referencedProjects;
+
+        public XElement XElement { get; } = new XElement("Project");
+
+        public string Sdk { get; }
+        public string TargetFrameworks { get; }
+
+        public string ProjectName { get; } = "Project_" + Guid.NewGuid().ToString("N").Substring(0, 12);
+        public string ProjectFileName => $"{ProjectName}.csproj";
+        public string RelativeProjectFilePath => $"{ProjectName}\\{ProjectName}.csproj";
+
+        public Guid ProjectGuid { get; } = Guid.NewGuid();
+        public object ProjectTypeGuid => _sdkProjectTypeGuid;
+
+        public ProjectTestExtension? Extension { get; set; }
+
+        public Project(string targetFrameworks, string sdk = "Microsoft.NET.Sdk")
+        {
+            TargetFrameworks = targetFrameworks;
+            Sdk = sdk;
+        }
+
+        public void Save(string rootPath)
+        {
+            XElement.Add(new XAttribute("Sdk", Sdk));
+
+            XElement.Add(new XElement(
+                "PropertyGroup",
+                new XElement("TargetFrameworks", TargetFrameworks)));
+
+            if (_referencedProjects != null)
+            {
+                XElement.Add(new XElement(
+                    "ItemGroup",
+                    _referencedProjects.Select(p => new XElement(
+                        "ProjectReference",
+                        new XAttribute("Include", $"..\\{p.RelativeProjectFilePath}")))));
+            }
+
+            Directory.CreateDirectory(Path.Combine(rootPath, ProjectName));
+
+            XElement.Save(Path.Combine(rootPath, RelativeProjectFilePath));
+        }
+
+        /// <summary>
+        /// Adds a P2P (project-to-project) reference from this project to <paramref name="referree"/>.
+        /// </summary>
+        /// <param name="referree">The project to reference.</param>
+        public void AddProjectReference(Project referree)
+        {
+            _referencedProjects ??= new List<Project>();
+            _referencedProjects.Add(referree);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Construction/Project.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Construction/Project.cs
@@ -19,6 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         private static readonly Guid _sdkProjectTypeGuid = Guid.Parse("9A19103F-16F7-4668-BE54-9A1E7A4F7556");
 
         private List<Project>? _referencedProjects;
+        private List<PackageReference>? _packageReferences;
 
         public XElement XElement { get; } = new XElement("Project");
 
@@ -57,6 +58,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                         new XAttribute("Include", $"..\\{p.RelativeProjectFilePath}")))));
             }
 
+            if (_packageReferences != null)
+            {
+                XElement.Add(new XElement(
+                    "ItemGroup",
+                    _packageReferences.Select(p => new XElement(
+                        "PackageReference",
+                        new XAttribute("Include", p.PackageId),
+                        new XAttribute("Version", p.Version)))));
+            }
+
             Directory.CreateDirectory(Path.Combine(rootPath, ProjectName));
 
             XElement.Save(Path.Combine(rootPath, RelativeProjectFilePath));
@@ -72,9 +83,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             _referencedProjects.Add(referree);
         }
 
+        public void Add(PackageReference packageReference)
+        {
+            _packageReferences ??= new List<PackageReference>();
+            _packageReferences.Add(packageReference);
+        }
+
         /// <summary>
         /// We only implement <see cref="IEnumerable"/> to support collection initialiser syntax.
         /// </summary>
         IEnumerator IEnumerable.GetEnumerator() => throw new NotSupportedException();
+    }
+
+    public readonly struct PackageReference
+    {
+        public string PackageId { get; }
+        public string Version { get; }
+
+        public PackageReference(string packageId, string version)
+        {
+            PackageId = packageId;
+            Version = version;
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Construction/Solution.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Construction/Solution.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    /// <summary>
+    /// Defines a <c>.sln</c> file to be created when using <see cref="ProjectLayoutTestBase"/>.
+    /// </summary>
+    public sealed class Solution : IEnumerable
+    {
+        private readonly List<Project> _projects = new List<Project>();
+
+        public IEnumerable<Project> Projects => _projects;
+
+        public GlobalJson? GlobalJson { get; private set; }
+
+        public void Save(string path)
+        {
+            using (var stream = File.OpenWrite(path))
+            using (var writer = new StreamWriter(stream, Encoding.ASCII))
+            {
+                writer.WriteLine();
+                writer.WriteLine(
+@"Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2019
+MinimumVisualStudioVersion = 10.0.40219.1");
+
+                foreach (var project in _projects)
+                {
+                    writer.WriteLine(
+$@"Project(""{project.ProjectTypeGuid:B}"") = ""{project.ProjectName}"", ""{project.RelativeProjectFilePath}"", ""{project.ProjectGuid:B}""
+EndProject");
+                }
+
+                writer.WriteLine(
+@"Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution");
+                foreach (var project in _projects)
+                {
+                    writer.WriteLine(
+$@"        {project.ProjectGuid:B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {project.ProjectGuid:B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {project.ProjectGuid:B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {project.ProjectGuid:B}.Release|Any CPU.Build.0 = Release|Any CPU");
+                }
+                writer.WriteLine(
+$@"    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
+    GlobalSection(ExtensibilityGlobals) = postSolution
+        SolutionGuid = {Guid.NewGuid():B}
+    EndGlobalSection
+EndGlobal");
+            }
+        }
+
+        public void Add(Project project) => _projects.Add(project);
+
+        public void Add(GlobalJson globalJson) => GlobalJson = globalJson;
+
+        IEnumerator IEnumerable.GetEnumerator() => throw new NotImplementedException();
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/DependencyNodeIntegrationTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/DependencyNodeIntegrationTests.cs
@@ -55,10 +55,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         [TestMethod]
         public void ProjectToProjectReferences()
         {
-            var project1 = new Project("netcoreapp2.1");
             var project2 = new Project("netstandard1.6");
 
-            project1.AddProjectReference(project2);
+            var project1 = new Project("netcoreapp2.1")
+            {
+                project2
+            };
 
             var solution = new Solution
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/DependencyNodeIntegrationTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/DependencyNodeIntegrationTests.cs
@@ -53,6 +53,35 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         }
 
         [TestMethod]
+        public void MultiTarget_WithPackageRef()
+        {
+            var project = new Project("netstandard2.0;net461")
+            {
+                new PackageReference("MetadataExtractor", "2.1.0")
+            };
+
+            CreateProject(project);
+
+            VerifyDependenciesNode(
+                new Node(".NETFramework 4.6.1", ManagedImageMonikers.Library)
+                {
+                    new Node("Assemblies", ManagedImageMonikers.Reference),
+                    new Node("Packages", ManagedImageMonikers.NuGetGrey)
+                    {
+                        new Node("MetadataExtractor (2.1.0)", ManagedImageMonikers.NuGetGrey)
+                    }
+                },
+                new Node(".NETStandard 2.0", ManagedImageMonikers.Library)
+                {
+                    new Node("Packages", ManagedImageMonikers.NuGetGrey)
+                    {
+                        new Node("MetadataExtractor (2.1.0)", ManagedImageMonikers.NuGetGrey)
+                    },
+                    new Node("SDK", ManagedImageMonikers.Sdk)
+                });
+        }
+
+        [TestMethod]
         public void ProjectToProjectReferences()
         {
             var project2 = new Project("netstandard1.6");

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/DependencyNodeIntegrationTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/DependencyNodeIntegrationTests.cs
@@ -1,5 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+using System.Linq;
+
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
@@ -138,6 +141,49 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                     new Node("System.Xml", ManagedImageMonikers.ReferencePrivate),
                     new Node("System.Xml.Linq", ManagedImageMonikers.ReferencePrivate)
                 });
+        }
+
+        [TestMethod]
+        [DataRow("net461;netstandard1.3")]
+        [DataRow("net461")]
+        public void DteFindsReferences(string targetFrameworks)
+        {
+            // NOTE the dependencies node makes only the first TFM visible via DTE.
+            // For example, netstandard1.3 has 49 references while net461 has the 14 shown here.
+
+            CreateProject(new Project(targetFrameworks)
+            {
+                new PackageReference("MetadataExtractor", "2.1.0"),
+                new AssemblyReference("System.Windows.Forms"),
+                new CSharpClass("Class1")
+            });
+
+            var expected = new[]
+            {
+                "System.IO.Compression.FileSystem",
+                "System.Numerics",
+                "System.Xml.Linq",
+                "System.Data",
+                "System.Core",
+                "System",
+                "System.Runtime.Serialization",
+                "System.Drawing",
+                "System.Xml",
+                "System.Windows.Forms",
+                "mscorlib",
+                "MetadataExtractor",
+                "Microsoft.CSharp",
+                "XmpCore"
+            };
+
+            var projects = (Array)VisualStudio.Dte.ActiveSolutionProjects;
+            var vsproject = (VSLangProj.VSProject)projects.Cast<EnvDTE.Project>().First().Object;
+            var actual = vsproject.References
+                .Cast<VSLangProj.Reference>()
+                .Select(r => r.Name)
+                .ToList();
+
+            CollectionAssert.AreEquivalent(expected, actual);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/DependencyNodeIntegrationTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/DependencyNodeIntegrationTests.cs
@@ -112,5 +112,32 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 project2,
                 new Node("SDK", ManagedImageMonikers.Sdk));
         }
+
+        [TestMethod]
+        public void AssemblyReferences()
+        {
+            var project = new Project("net461")
+            {
+                new AssemblyReference("System.Windows.Forms")
+            };
+
+            CreateProject(project);
+
+            VerifyDependenciesNode(
+                project,
+                new Node("Assemblies", ManagedImageMonikers.Reference)
+                {
+                    new Node("System", ManagedImageMonikers.ReferencePrivate),
+                    new Node("System.Core", ManagedImageMonikers.ReferencePrivate),
+                    new Node("System.Data", ManagedImageMonikers.ReferencePrivate),
+                    new Node("System.Drawing", ManagedImageMonikers.ReferencePrivate),
+                    new Node("System.IO.Compression.FileSystem", ManagedImageMonikers.ReferencePrivate),
+                    new Node("System.Numerics", ManagedImageMonikers.ReferencePrivate),
+                    new Node("System.Runtime.Serialization", ManagedImageMonikers.ReferencePrivate),
+                    new Node("System.Windows.Forms", ManagedImageMonikers.Reference), // non private as explicitly added
+                    new Node("System.Xml", ManagedImageMonikers.ReferencePrivate),
+                    new Node("System.Xml.Linq", ManagedImageMonikers.ReferencePrivate)
+                });
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/DependencyNodeIntegrationTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/DependencyNodeIntegrationTests.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    // TODO test different SDK version
+    // TODO review GitHub issues and produce tests for known bugs
+    // TODO ensure VS shut down after test fixture completes
+
+    [TestClass]
+    public sealed class DependencyNodeIntegrationTests : ProjectLayoutTestBase
+    {
+        [TestMethod]
+        public void SingleTarget_NetCoreApp21()
+        {
+            CreateProject(new Project("netcoreapp2.1"));
+
+            VerifyDependenciesNode(
+                new Node("SDK", ManagedImageMonikers.Sdk));
+        }
+
+        [TestMethod]
+        public void MultiTarget_NetCoreApp21_Net45()
+        {
+            CreateProject(new Project("netcoreapp2.1;net45"));
+
+            VerifyDependenciesNode(
+                new Node(".NETCoreApp 2.1", ManagedImageMonikers.Library)
+                {
+                    new Node("SDK", ManagedImageMonikers.Sdk)
+                },
+                new Node(".NETFramework 4.5", ManagedImageMonikers.Library)
+                {
+                    new Node("Assemblies", ManagedImageMonikers.Reference)
+                });
+        }
+
+        [TestMethod]
+        public void MultiTarget_NetStandard20_Net461()
+        {
+            CreateProject(new Project("netstandard2.0;net461"));
+
+            VerifyDependenciesNode(
+                new Node(".NETFramework 4.6.1", ManagedImageMonikers.Library)
+                {
+                    new Node("Assemblies", ManagedImageMonikers.Reference)
+                },
+                new Node(".NETStandard 2.0", ManagedImageMonikers.Library)
+                {
+                    new Node("SDK", ManagedImageMonikers.Sdk)
+                });
+        }
+
+        [TestMethod]
+        public void ProjectToProjectReferences()
+        {
+            var project1 = new Project("netcoreapp2.1");
+            var project2 = new Project("netstandard1.6");
+
+            project1.AddProjectReference(project2);
+
+            var solution = new Solution
+            {
+                new GlobalJson(sdkVersion: "2.1.600"),
+                project1,
+                project2
+            };
+
+            CreateSolution(solution);
+
+            VerifyDependenciesNode(
+                project1,
+                new Node("Projects", ManagedImageMonikers.Application)
+                {
+                    new Node(project2.ProjectName, ManagedImageMonikers.Application)
+                },
+                new Node("SDK", ManagedImageMonikers.Sdk));
+
+            VerifyDependenciesNode(
+                project2,
+                new Node("SDK", ManagedImageMonikers.Sdk));
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/IntegrationTestBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/IntegrationTestBase.cs
@@ -7,9 +7,9 @@ using Microsoft.Test.Apex.VisualStudio;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
-    public abstract class TestBase : VisualStudioHostTest
+    public abstract class IntegrationTestBase : VisualStudioHostTest
     {
-        protected TestBase()
+        protected IntegrationTestBase()
         {
             // TestCleanup will fire up another instance of Visual Studio to reset 
             // the AutoloadExternalChanges if it thinks the default changed even if

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/IntegrationTestBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/IntegrationTestBase.cs
@@ -3,8 +3,6 @@
 using Microsoft.Test.Apex;
 using Microsoft.Test.Apex.VisualStudio;
 
-#nullable disable
-
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
     public abstract class IntegrationTestBase : VisualStudioHostTest

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/LifetimeActions/ShutdownVisualStudioAfterLastTestLifetimeAction.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/LifetimeActions/ShutdownVisualStudioAfterLastTestLifetimeAction.cs
@@ -16,13 +16,13 @@ namespace Microsoft.VisualStudio.LifetimeActions
     [Export(typeof(ITestLifetimeAction))]
     internal class ShutdownVisualStudioAfterLastTestLifetimeAction : ITestLifetimeAction
     {
-        private static TestBase? _lastTest;
+        private static IntegrationTestBase? _lastTest;
 
         public void OnTestLifeTimeAction(ApexTest testClass, Type classType, TestLifeTimeAction action)
         {
             if (action == TestLifeTimeAction.PostTestCleanup)
             {
-                _lastTest = testClass as TestBase;
+                _lastTest = testClass as IntegrationTestBase;
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests.csproj
@@ -10,5 +10,9 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\deploy\DeployIntegrationDependencies\DeployIntegrationDependencies.csproj" ReferenceOutputAssembly="false" />
+    <Compile Include="..\Microsoft.VisualStudio.ProjectSystem.Managed\Resources\ManagedImageMonikers.cs" Link="ManagedImageMonikers.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Configuration" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/ProjectLayoutTestBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/ProjectLayoutTestBase.cs
@@ -1,0 +1,322 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+
+using Microsoft.Test.Apex.VisualStudio.Solution;
+using Microsoft.Test.Apex.VisualStudio.Shell.ToolWindows;
+using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    /// <summary>
+    /// Base class for integration tests that start with a specific solution/project layout on disk.
+    /// </summary>
+    public abstract class ProjectLayoutTestBase : IntegrationTestBase
+    {
+        /// <summary>
+        /// Paths of temporary workspaces to delete when the test fixture completes.
+        /// Each path is a root, so should be deleted recursively.
+        /// </summary>
+        private ImmutableList<string> _rootPaths = ImmutableList<string>.Empty;
+
+        /// <summary>
+        /// Verifies that the "Dependencies" node of <paramref name="project"/> has a structure that
+        /// matches <paramref name="nodes"/>.
+        /// </summary>
+        /// <param name="project">The project whose Dependencies node should be inspected.</param>
+        /// <param name="nodes">The expected structure for the Dependencies node.</param>
+        protected void VerifyDependenciesNode(Project project, params Node[] nodes)
+        {
+            using (Scope.Enter("Verify dependency nodes"))
+            {
+                var item = VisualStudio.ObjectModel.Solution.SolutionExplorer.FindItemRecursive(project.ProjectName, expandToFind: true);
+
+                item.Expand();
+
+                var actualDependencies = item.Items.FirstOrDefault(i => i.Name == "Dependencies");
+
+                VerifyDependenciesNode(actualDependencies, nodes);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the solution's first "Dependencies" node has a structure that
+        /// matches <paramref name="nodes"/>.
+        /// </summary>
+        /// <param name="nodes">The expected structure for the Dependencies node.</param>
+        protected void VerifyDependenciesNode(params Node[] nodes)
+        {
+            using (Scope.Enter("Verify dependency nodes"))
+            {
+                SolutionExplorerItemTestExtension actualDependencies = VisualStudio.ObjectModel.Solution.SolutionExplorer.FindItemRecursive("Dependencies", expandToFind: true);
+
+                VerifyDependenciesNode(actualDependencies, nodes);
+            }
+        }
+
+        private void VerifyDependenciesNode(SolutionExplorerItemTestExtension actualDependencies, Node[] nodes)
+        {
+            var expectDependencies = new Node("Dependencies", ManagedImageMonikers.ReferenceGroup)
+            {
+                Children = new List<Node>(nodes)
+            };
+
+            var expectOutput = new StringBuilder();
+            var actualOutput = new StringBuilder();
+
+            var same = true;
+
+            VerifyNode(expectDependencies, actualDependencies);
+
+            if (!same)
+            {
+                Assert.Fail($"Incorrect Dependencies tree.\n\nExpected:\n\n{expectOutput}\nActual:\n\n{actualOutput}");
+            }
+
+            return;
+
+            void VerifyNode(Node? expect, SolutionExplorerItemTestExtension? actual, int depth = 0)
+            {
+                Assert.IsTrue(expect != null || actual != null);
+
+                var thisSame = true;
+
+                if (actual != null && expect?.Text != null && expect.Text != actual.Name)
+                {
+                    same = false;
+                    thisSame = false;
+                }
+
+                if (actual != null && expect?.Icon != null && !AssertExtensions.AreEqual(expect.Icon.Value, actual.ExpandedIconMoniker))
+                {
+                    same = false;
+                    thisSame = false;
+                }
+
+                var actualIcon = actual?.ExpandedIconMoniker == null
+                    ? "null"
+                    : ManagedImageMonikers.ImageMonikerDebugDisplay(actual.ExpandedIconMoniker.Value.ToImageMoniker());
+
+                if (expect != null)
+                {
+                    expectOutput
+                        .Append(' ', depth * 4)
+                        .Append(expect.Text ?? actual!.Name)
+                        .Append(' ')
+                        .Append(expect.Icon != null
+                            ? ManagedImageMonikers.ImageMonikerDebugDisplay(expect.Icon.Value)
+                            : actualIcon)
+                        .AppendLine();
+                }
+
+                if (actual != null)
+                {
+                    actualOutput
+                        .Append(' ', depth * 4)
+                        .Append(actual.Name)
+                        .Append(' ')
+                        .Append(actualIcon)
+                        .Append(thisSame ? "" : " 🐛")
+                        .AppendLine();
+                }
+
+                if (expect?.Children != null)
+                {
+                    if (actual != null && !actual.IsExpanded && expect.Children != null && expect.Children.Count != 0)
+                    {
+                        actual.Expand();
+                    }
+
+                    var actualChildren = actual?.Items.ToList() ?? new List<SolutionExplorerItemTestExtension>();
+
+                    if (actualChildren.Count != expect.Children!.Count)
+                        same = false;
+
+                    var max = Math.Max(actualChildren.Count, expect.Children.Count);
+
+                    for (int i = 0; i < max; i++)
+                    {
+                        var expectChild = expect.Children.Count > i ? expect.Children[i] : null;
+                        var actualChild = actualChildren.Count > i ? actualChildren[i] : null;
+
+                        VerifyNode(
+                            expectChild,
+                            actualChild,
+                            depth + 1);
+                    }
+                }
+            }
+        }
+
+        protected override bool TryShutdownHostInstance()
+        {
+            bool result = base.TryShutdownHostInstance();
+
+            foreach (var projectPath in _rootPaths)
+            {
+                try
+                {
+                    Directory.Delete(projectPath, recursive: true);
+                }
+                catch
+                {
+                    continue;
+                }
+
+                ImmutableInterlocked.Update(ref _rootPaths, (list, item) => list.Remove(item), projectPath);
+            }
+
+            return result;
+        }
+
+        private string CreateRootPath()
+        {
+            string name;
+            string rootPath;
+
+            do
+            {
+                name = "IntegrationTest_" + Guid.NewGuid().ToString("N").Substring(0, 12);
+                rootPath = Path.Combine(Path.GetTempPath(), name);
+            }
+            while (Directory.Exists(rootPath));
+
+            Directory.CreateDirectory(rootPath);
+
+            ImmutableInterlocked.Update(ref _rootPaths, (list, path) => list.Add(path), rootPath);
+
+            return rootPath;
+        }
+
+        /// <summary>
+        /// Creates <paramref name="project"/> on disk and opens it, returning its test extension object.
+        /// </summary>
+        /// <param name="project"></param>
+        /// <returns></returns>
+        protected ProjectTestExtension CreateProject(Project project)
+        {
+            var rootPath = CreateRootPath();
+
+            project.Save(rootPath);
+
+            ProjectTestExtension projectExtension;
+
+            using (Scope.Enter("Open Project"))
+            {
+                projectExtension = VisualStudio.ObjectModel.Solution.OpenProject(Path.Combine(rootPath, project.RelativeProjectFilePath));
+            }
+
+            using (Scope.Enter("Verify Create Project"))
+            {
+                VisualStudio.ObjectModel.Solution.Verify.HasProject(projectExtension);
+            }
+
+            WaitForIntellisense();
+            WaitForDependenciesNodeSync();
+
+            return projectExtension;
+        }
+
+        protected void CreateSolution(Solution solution)
+        {
+            var rootPath = CreateRootPath();
+            var solutionFilePath = Path.Combine(rootPath, "Solution.sln");
+
+            solution.Save(solutionFilePath);
+
+            solution.GlobalJson?.Save(rootPath);
+
+            foreach (var project in solution.Projects)
+            {
+                project.Save(rootPath);
+            }
+
+            using (Scope.Enter("Open Solution"))
+            {
+                VisualStudio.ObjectModel.Solution.Open(solutionFilePath);
+            }
+
+            using (Scope.Enter("Verify Create Project"))
+            {
+                foreach (var project in solution.Projects)
+                {
+                    project.Extension = VisualStudio.ObjectModel.Solution.GetProjectExtension<ProjectTestExtension>(project.ProjectName);
+                }
+            }
+
+            WaitForIntellisense();
+            WaitForDependenciesNodeSync();
+        }
+
+        protected void WaitForIntellisense()
+        {
+            using (Scope.Enter("Wait for Intellisense"))
+            {
+                VisualStudio.ObjectModel.Solution.WaitForIntellisenseStage();
+            }
+        }
+
+        protected void WaitForDependenciesNodeSync()
+        {
+            using (Scope.Enter("Wait for dependencies node to sync"))
+            {
+                // Wait for dataflow to update the nodes
+                // TODO create a more reliable (and usually faster) way of doing this
+                // https://github.com/dotnet/project-system/issues/3426
+                Thread.Sleep(5 * 1000);
+            }
+        }
+
+        /// <summary>
+        /// Models the expected state of a node in the "Dependencies" node tree.
+        /// </summary>
+        /// <remarks>
+        /// This type is designed to work with object and collection initializers.
+        /// For example:
+        /// <example>
+        /// <code>new Node(".NETCoreApp 2.1", ManagedImageMonikers.Library)
+        /// {
+        ///     new Node("SDK", ManagedImageMonikers.Sdk)
+        /// }</code>
+        /// </example>
+        /// </remarks>
+        protected sealed class Node : IEnumerable
+        {
+            public List<Node>? Children { get; set; }
+
+            /// <summary>
+            /// Gets and sets the expected icon for this node.
+            /// A <see langword="null"/> value will disable validation.
+            /// </summary>
+            public string? Text { get; set; }
+
+            /// <summary>
+            /// Gets and sets the expected icon for this node.
+            /// A <see langword="null"/> value will disable validation.
+            /// </summary>
+            public ImageMoniker? Icon { get; set; }
+
+            public Node(string? text = null, ImageMoniker? icon = null)
+            {
+                Text = text;
+                Icon = icon;
+            }
+
+            public void Add(Node child)
+            {
+                Children ??= new List<Node>();
+                Children.Add(child);
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Utilities/AssertExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Utilities/AssertExtensions.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+using Microsoft.Test.Apex.VisualStudio.Shell.ToolWindows;
+using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    internal static class AssertExtensions
+    {
+        public static void AreEqual(this Assert assert, ImageMoniker expected, ExportableImageMoniker? actual)
+        {
+            if (actual == null)
+            {
+                throw new AssertFailedException($"ImageMoniker did not match.{Environment.NewLine}Expected: {S(expected)}{Environment.NewLine}Actual: null");
+            }
+
+            var actualMoniker = ToImageMoniker(actual.Value);
+
+            if (expected.Id != actualMoniker.Id || expected.Guid != actualMoniker.Guid)
+            {
+                throw new AssertFailedException($"ImageMoniker did not match.{Environment.NewLine}Expected: {S(expected)}{Environment.NewLine}Actual: {S(actualMoniker)}");
+            }
+
+            string S(ImageMoniker a) => ManagedImageMonikers.ImageMonikerDebugDisplay(a);
+        }
+
+        public static ImageMoniker ToImageMoniker(this ExportableImageMoniker actual)
+        {
+            return new ImageMoniker { Id = actual.Id, Guid = actual.Guid };
+        }
+
+        public static bool AreEqual(ImageMoniker expected, ExportableImageMoniker? actual)
+        {
+            if (actual == null)
+            {
+                return false;
+            }
+
+            if (expected.Id != actual.Value.Id || expected.Guid != actual.Value.Guid)
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
First cut of integration tests for the dependencies node. Relates to #1607.

This revitalises PR #4658 which was automatically closed when we deleted the `feature/integration-tests` branch.

These tests build up a solution/project(s)/global.json on disk, load the solution, then inspect the dependencies nodes.

See `DependencyNodeIntegrationTests` for how such tests are authored.