### PR TITLE
Avoid assuming target framework is unique across configurations

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/ImmutablePropertyCollection.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/ImmutablePropertyCollection.cs
@@ -19,8 +19,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
 
         protected ImmutablePropertyCollection(IEnumerable<T> items)
         {
+            // While the majority of elements (items, properties, metadata) are guaranteed to be unique,
+            // Target Frameworks are not, filter out duplicates - NuGet uses the int-based indexer anyway.
+
+#pragma warning disable IDE0039 // We want to cache the delegate
+            Func<T, string> keySelector = i => GetKeyForItem(i);
+#pragma warning restore IDE0039
+
             _items = ImmutableList.CreateRange(items);
-            _itemsByName = _items.ToImmutableDictionary(i => GetKeyForItem(i), StringComparers.ItemNames);
+            _itemsByName = items.Distinct(keySelector, StringComparers.ItemNames)
+                                .ToImmutableDictionary(keySelector, StringComparers.ItemNames);
         }
 
         public int Count

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/LinqExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/LinqExtensions.cs
@@ -50,5 +50,30 @@ namespace Microsoft.VisualStudio
 
             return default!;
         }
+
+        /// <summary>
+        ///     Returns distinct elements from a sequence by using a specified key selector and <see cref="IEqualityComparer{T}"/> to compare values.
+        /// </summary>
+        public static IEnumerable<TSource> Distinct<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            return DistinctIterator(source, keySelector, comparer);
+        }
+
+        private static IEnumerable<TSource> DistinctIterator<TSource, TKey>(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            HashSet<TKey>? set = null;
+            foreach (TSource element in source)
+            {
+                // Avoid allocating unless needed
+                set ??= new HashSet<TKey>(comparer);
+
+                TKey key = keySelector(element);
+
+                if (set.Add(key))
+                {
+                    yield return element;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
It's perfectly valid to have a multi-TFM project where two of the <TargetFrameworks> values map to the same underlying TFM. An example of this is the Microsoft.Toolkit.Uwp.Notifications project in the https://github.com/windows-toolkit/WindowsCommunityToolkit.

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/957711/