### PR TITLE
Reduce allocations in ImmutablePropertyCollection<T>

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/ImmutablePropertyCollection.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/ImmutablePropertyCollection.cs
@@ -63,9 +63,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
 
         private T? GetItemByName(string name)
         {
-            if (_itemsByName.TryGetValue(name, out T value))
+            if (_itemsByName.TryGetValue(name, out T? item))
             {
-                return value;
+                return item;
             }
 
             return null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/ImmutablePropertyCollection.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/ImmutablePropertyCollection.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
         private readonly IReadOnlyList<T> _items;
         private readonly IReadOnlyDictionary<string, T> _itemsByName;
 
-        protected ImmutablePropertyCollection(IEnumerable<T> items)
+        protected ImmutablePropertyCollection(IEnumerable<T> items, Func<T, string> keyAccessor)
         {
             // Build a list, to maintain order for index-based lookup.
             var itemList = new List<T>();
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
             {
                 itemList.Add(item);
 
-                string key = GetKeyForItem(item);
+                string key = keyAccessor(item);
 
                 // While the majority of elements (items, properties, metadata) are guaranteed to be unique,
                 // Target Frameworks are not, filter out duplicates - NuGet uses the int-based indexer anyway.
@@ -59,8 +59,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
         {
             return _items.GetEnumerator();
         }
-
-        protected abstract string GetKeyForItem(T item);
 
         public T? Item(object index)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/ImmutablePropertyCollection.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/ImmutablePropertyCollection.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
@@ -14,21 +13,36 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
     [DebuggerDisplay("Count = {Count}")]
     internal abstract class ImmutablePropertyCollection<T> : IEnumerable<T> where T : class
     {
-        private readonly IImmutableList<T> _items;
-        private readonly IImmutableDictionary<string, T> _itemsByName;
+        // Data here must be treated as immutable. We use readonly interfaces into mutable backing types
+        // for the reduction in memory and improvements in performance.
+
+        private readonly IReadOnlyList<T> _items;
+        private readonly IReadOnlyDictionary<string, T> _itemsByName;
 
         protected ImmutablePropertyCollection(IEnumerable<T> items)
         {
-            // While the majority of elements (items, properties, metadata) are guaranteed to be unique,
-            // Target Frameworks are not, filter out duplicates - NuGet uses the int-based indexer anyway.
+            // Build a list, to maintain order for index-based lookup.
+            var itemList = new List<T>();
 
-#pragma warning disable IDE0039 // We want to cache the delegate
-            Func<T, string> keySelector = i => GetKeyForItem(i);
-#pragma warning restore IDE0039
+            // Build a dictionary to support key-based lookup.
+            var itemByName = new Dictionary<string, T>();
 
-            _items = ImmutableList.CreateRange(items);
-            _itemsByName = items.Distinct(keySelector, StringComparers.ItemNames)
-                                .ToImmutableDictionary(keySelector, StringComparers.ItemNames);
+            foreach (T item in items)
+            {
+                itemList.Add(item);
+
+                string key = GetKeyForItem(item);
+
+                // While the majority of elements (items, properties, metadata) are guaranteed to be unique,
+                // Target Frameworks are not, filter out duplicates - NuGet uses the int-based indexer anyway.
+                if (!itemByName.ContainsKey(key))
+                {
+                    itemByName.Add(key, item);
+                }
+            }
+
+            _items = itemList;
+            _itemsByName = itemByName;
         }
 
         public int Count

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/ImmutablePropertyCollection.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/ImmutablePropertyCollection.cs
@@ -35,6 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
         {
             get { return _items.Count; }
         }
+
         public IEnumerator<T> GetEnumerator()
         {
             return _items.GetEnumerator();
@@ -49,16 +50,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
 
         public T? Item(object index)
         {
-            if (index is string name)
+            return index switch
             {
-                return GetItemByName(name);
-            }
-            else if (index is int intIndex)
-            {
-                return GetItemByIndex(intIndex);
-            }
-
-            throw new ArgumentException(null, nameof(index));
+                string name => GetItemByName(name),
+                int intIndex => GetItemByIndex(intIndex),
+                _ => throw new ArgumentException(null, nameof(index))
+            };
         }
 
         private T? GetItemByName(string name)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/ProjectProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/ProjectProperties.cs
@@ -12,10 +12,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
     internal class ProjectProperties : ImmutablePropertyCollection<IVsProjectProperty>, IVsProjectProperties
     {
         public ProjectProperties(IEnumerable<IVsProjectProperty> items)
-            : base(items)
+            : base(items, item => item.Name)
         {
         }
-
-        protected override string GetKeyForItem(IVsProjectProperty value) => value.Name;
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/ReferenceItems.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/ReferenceItems.cs
@@ -12,10 +12,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
     internal class ReferenceItems : ImmutablePropertyCollection<IVsReferenceItem>, IVsReferenceItems
     {
         public ReferenceItems(IEnumerable<IVsReferenceItem> items) 
-            : base(items)
+            : base(items, item => item.Name)
         {
         }
-
-        protected override string GetKeyForItem(IVsReferenceItem value) => value.Name;
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/ReferenceProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/ReferenceProperties.cs
@@ -12,10 +12,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
     internal class ReferenceProperties : ImmutablePropertyCollection<IVsReferenceProperty>, IVsReferenceProperties
     {
         public ReferenceProperties(IEnumerable<IVsReferenceProperty> items)
-            : base(items)
+            : base(items, item => item.Name)
         {
         }
-
-        protected override string GetKeyForItem(IVsReferenceProperty value) => value.Name;
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/TargetFrameworks.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/TargetFrameworks.cs
@@ -12,10 +12,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
     internal class TargetFrameworks : ImmutablePropertyCollection<IVsTargetFrameworkInfo2>, IVsTargetFrameworks2
     {
         public TargetFrameworks(IEnumerable<IVsTargetFrameworkInfo2> items)
-            : base(items)
+            : base(items, item => item.TargetFrameworkMoniker)
         {
         }
-
-        protected override string GetKeyForItem(IVsTargetFrameworkInfo2 value) => value.TargetFrameworkMoniker;
     }
 }


### PR DESCRIPTION
- Previous implementation would enumerate input items twice. Most callers of this constructor would lazily construct objects, meaning twice the allocation. This implementation enumerates once.

  ![image](https://user-images.githubusercontent.com/350947/62666151-8609dd00-b9c5-11e9-91f8-19eccdc4f5ef.png)

- Previous implementation would allocate a `HashSet<string>` to track unique keys, then produce an immutable dictionary as the backing store for this object. This implementation uses the backing store collection directly while it is being built, avoiding the need for the temporary set.

- Previous implementation would store data using immutable list and dictionary, both of which use many GC tracked node objects to store items. This implementation maintains immutability through the API, but uses mutable collections internally as they have lower memory consumption, and less fragmentation leading to better locality of reference.