### PR TITLE
Improve dependency node MSBuild rule data handling

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/CrossTarget/IDependenciesRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/CrossTarget/IDependenciesRuleHandler.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         /// <summary>
         /// Gets the set of rule names this handler handles.
         /// </summary>
-        ImmutableHashSet<string> GetRuleNames(RuleHandlerType handlerType);
+        ImmutableHashSet<string> GetRuleNames(RuleSource source);
 
         /// <summary>
         /// Handles the specified set of changes to a rule, and applies them

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/CrossTarget/IDependenciesRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/CrossTarget/IDependenciesRuleHandler.cs
@@ -22,9 +22,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
     internal interface IDependenciesRuleHandler
     {
         /// <summary>
-        /// Gets the set of rule names this handler handles.
+        /// Gets the rule name for dependency items returned via evaluation (eg: <c>PackageReference</c>).
         /// </summary>
-        ImmutableHashSet<string> GetRuleNames(RuleSource source);
+        string EvaluatedRuleName { get; }
+
+        /// <summary>
+        /// Gets the rule name for dependency items resolved by design-time builds (eg: <c>ResolvedPackageReference</c>).
+        /// </summary>
+        string ResolvedRuleName { get; }
 
         /// <summary>
         /// Handles the specified set of changes to a rule, and applies them

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/CrossTarget/IDependenciesRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/CrossTarget/IDependenciesRuleHandler.cs
@@ -7,7 +7,18 @@ using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 {
-    [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ZeroOrMore, ContractName = DependencyRulesSubscriber.DependencyRulesSubscriberContract)]
+    /// <summary>
+    /// Implementations of this interface add, update and remove <see cref="IDependencyModel"/> instances in response to
+    /// project rule changes. They use both evaluated items and items returned by targets called during design-time builds.
+    /// The latter are fully resolved with all item metadata, while the former contain just the information found in the
+    /// project file, which is enough to quickly populate the dependency tree while we wait for the slower design-time
+    /// build to complete and return richer item metadata.
+    /// </summary>
+    [ProjectSystemContract(
+        ProjectSystemContractScope.UnconfiguredProject,
+        ProjectSystemContractProvider.Private,
+        Cardinality = ImportCardinality.ZeroOrMore,
+        ContractName = DependencyRulesSubscriber.DependencyRulesSubscriberContract)]
     internal interface IDependenciesRuleHandler
     {
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/CrossTarget/RuleSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/CrossTarget/RuleSource.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 {
-    internal enum RuleHandlerType
+    internal enum RuleSource
     {
         /// <summary>
         ///     The <see cref="IDependenciesRuleHandler"/> handles changes 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/CrossTarget/RuleSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/CrossTarget/RuleSource.cs
@@ -5,15 +5,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
     internal enum RuleSource
     {
         /// <summary>
-        ///     The <see cref="IDependenciesRuleHandler"/> handles changes 
-        ///     to evaluation rules.
+        ///     Rule data sourced by evaluation.
         /// </summary>
         Evaluation,
 
         /// <summary>
-        ///     The <see cref="IDependenciesRuleHandler"/> handles changes 
-        ///     to design-time build rules.
+        ///     Rule data sourced by both evaluation and design-time build,
+        ///     joined by project version to ensure consistency.
         /// </summary>
-        DesignTimeBuild,
+        Joint
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/IDependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/IDependenciesSnapshotProvider.cs
@@ -32,11 +32,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         event EventHandler<ProjectRenamedEventArgs> SnapshotRenamed;
 
         /// <summary>
-        /// Raised when the project's dependencies snapshot changed.
-        /// </summary>
-        event EventHandler<SnapshotChangedEventArgs> SnapshotChanged;
-
-        /// <summary>
         /// Raised when the project and its snapshot provider are unloading.
         /// </summary>
         event EventHandler<SnapshotProviderUnloadingEventArgs> SnapshotProviderUnloading;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
@@ -190,7 +190,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 // Ensure the project doesn't unload during the update
                 await _tasksService.LoadedProjectAsync(async () =>
                 {
-                    // TODO pass _tasksService.UnloadCancellationToken into handler to reduce redundant work on unload
+                    // TODO pass _tasksService.UnloadCancellationToken into HandleAsync to reduce redundant work on unload
 
                     // Ensure the project's capabilities don't change during the update
                     using (ProjectCapabilitiesContext.CreateIsolatedContext(configuredProject, capabilities))
@@ -207,6 +207,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             RuleSource source)
         {
             AggregateCrossTargetProjectContext? currentAggregateContext = await _host!.GetCurrentAggregateProjectContextAsync();
+
             if (currentAggregateContext == null || _currentProjectContext != currentAggregateContext)
             {
                 return;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
@@ -144,9 +144,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
         private IReadOnlyCollection<string> GetRuleNames(RuleSource source)
         {
-            return new HashSet<string>(
-                _handlers.SelectMany(h => h.Value.GetRuleNames(source)),
-                StringComparers.RuleNames);
+            var rules = new HashSet<string>(StringComparers.RuleNames);
+            
+            foreach (Lazy<IDependenciesRuleHandler, IOrderPrecedenceMetadataView> item in _handlers)
+            {
+                rules.Add(item.Value.EvaluatedRuleName);
+
+                if (source == RuleSource.Joint)
+                {
+                    rules.Add(item.Value.ResolvedRuleName);
+                }
+            }
+
+            return rules;
         }
 
         private async Task OnProjectChangedAsync(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
@@ -212,17 +212,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             // Give each handler a chance to register dependency changes.
             foreach (Lazy<IDependenciesRuleHandler, IOrderPrecedenceMetadataView> handler in _handlers)
             {
-                ImmutableHashSet<string> handlerRules = handler.Value.GetRuleNames(source);
-
-                // Slice project changes to include only rules the handler claims an interest in.
-                var projectChanges = projectUpdate.ProjectChanges
-                    .Where(x => handlerRules.Contains(x.Key))
-                    .ToImmutableDictionary();
-
-                if (projectChanges.Any(x => x.Value.Difference.AnyChanges))
-                {
-                    handler.Value.Handle(projectChanges, targetFrameworkToUpdate, changesBuilder);
-                }
+                handler.Value.Handle(projectUpdate.ProjectChanges, targetFrameworkToUpdate, changesBuilder);
             }
 
             ImmutableDictionary<ITargetFramework, IDependenciesChanges>? changes = changesBuilder.TryBuildChanges();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
@@ -56,8 +56,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
             await InitializeAsync();
 
-            IReadOnlyCollection<string> watchedEvaluationRules = GetWatchedRules(RuleSource.Evaluation);
-            IReadOnlyCollection<string> watchedJointRules = GetWatchedRules(RuleSource.Joint);
+            IReadOnlyCollection<string> watchedEvaluationRules = GetRuleNames(RuleSource.Evaluation);
+            IReadOnlyCollection<string> watchedJointRules = GetRuleNames(RuleSource.Joint);
 
             SubscribeToConfiguredProject(
                 _commonServices.ActiveConfiguredProject, subscriptionService, watchedEvaluationRules, watchedJointRules);
@@ -69,8 +69,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
             _currentProjectContext = projectContext;
 
-            IReadOnlyCollection<string> watchedEvaluationRules = GetWatchedRules(RuleSource.Evaluation);
-            IReadOnlyCollection<string> watchedJointRules = GetWatchedRules(RuleSource.Joint);
+            IReadOnlyCollection<string> watchedEvaluationRules = GetRuleNames(RuleSource.Evaluation);
+            IReadOnlyCollection<string> watchedJointRules = GetRuleNames(RuleSource.Joint);
 
             // initialize telemetry with all rules for each target framework
             foreach (ITargetFramework targetFramework in projectContext.TargetFrameworks)
@@ -165,7 +165,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 linkOptions: DataflowOption.PropagateCompletion));
         }
 
-        private IReadOnlyCollection<string> GetWatchedRules(RuleSource source)
+        private IReadOnlyCollection<string> GetRuleNames(RuleSource source)
         {
             return new HashSet<string>(
                 _handlers.SelectMany(h => h.Value.GetRuleNames(source)),

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
@@ -75,7 +75,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             // initialize telemetry with all rules for each target framework
             foreach (ITargetFramework targetFramework in projectContext.TargetFrameworks)
             {
-                _treeTelemetryService.InitializeTargetFrameworkRules(targetFramework, watchedEvaluationRules);
                 _treeTelemetryService.InitializeTargetFrameworkRules(targetFramework, watchedJointRules);
             }
 
@@ -124,7 +123,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             _subscriptions.AddDisposable(
                 subscriptionService.JointRuleSource.SourceBlock.LinkTo(
                     intermediateBlockDesignTime,
-                    ruleNames: watchedJointRules.Union(watchedEvaluationRules),
+                    ruleNames: watchedJointRules,
                     suppressVersionOnlyUpdates: true,
                     linkOptions: DataflowOption.PropagateCompletion));
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
@@ -216,6 +216,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 return;
             }
 
+            if (!projectUpdate.ProjectChanges.Any(x => x.Value.Difference.AnyChanges))
+            {
+                return;
+            }
+
             // Create an object to track dependency changes.
             var changesBuilder = new CrossTargetDependenciesChangesBuilder();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
           IProjectDependenciesSubTreeProviderInternal
     {
         private readonly ImmutableHashSet<string> _evaluationRuleNames;
-        private readonly ImmutableHashSet<string> _designTimeBuildRuleNames;
+        private readonly ImmutableHashSet<string> _jointRuleNames;
 
         protected string UnresolvedRuleName { get; }
         protected string ResolvedRuleName { get; }
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             ResolvedRuleName = resolvedRuleName;
 
             _evaluationRuleNames = ImmutableStringHashSet.EmptyOrdinal.Add(unresolvedRuleName);
-            _designTimeBuildRuleNames = _evaluationRuleNames.Add(resolvedRuleName);
+            _jointRuleNames = _evaluationRuleNames.Add(resolvedRuleName);
         }
 
         #region IDependenciesRuleHandler
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
         {
             return source == RuleSource.Evaluation ?
                 _evaluationRuleNames :
-                _designTimeBuildRuleNames;
+                _jointRuleNames;
         }
 
         public abstract ImageMoniker ImplicitIcon { get; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
@@ -14,31 +14,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
         : IDependenciesRuleHandler,
           IProjectDependenciesSubTreeProviderInternal
     {
-        private readonly ImmutableHashSet<string> _evaluationRuleNames;
-        private readonly ImmutableHashSet<string> _jointRuleNames;
-
-        protected string EvaluatedRuleName { get; }
-        protected string ResolvedRuleName { get; }
+        public string EvaluatedRuleName { get; }
+        public string ResolvedRuleName { get; }
 
         protected DependenciesRuleHandlerBase(
             string evaluatedRuleName,
             string resolvedRuleName)
         {
+            Requires.NotNullOrWhiteSpace(evaluatedRuleName, nameof(evaluatedRuleName));
+            Requires.NotNullOrWhiteSpace(resolvedRuleName, nameof(resolvedRuleName));
+
             EvaluatedRuleName = evaluatedRuleName;
             ResolvedRuleName = resolvedRuleName;
-
-            _evaluationRuleNames = ImmutableStringHashSet.EmptyOrdinal.Add(evaluatedRuleName);
-            _jointRuleNames = _evaluationRuleNames.Add(resolvedRuleName);
         }
 
         #region IDependenciesRuleHandler
-
-        public ImmutableHashSet<string> GetRuleNames(RuleSource source)
-        {
-            return source == RuleSource.Evaluation ?
-                _evaluationRuleNames :
-                _jointRuleNames;
-        }
 
         public abstract ImageMoniker ImplicitIcon { get; }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
@@ -33,9 +33,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
         #region IDependenciesRuleHandler
 
-        public ImmutableHashSet<string> GetRuleNames(RuleHandlerType handlerType)
+        public ImmutableHashSet<string> GetRuleNames(RuleSource source)
         {
-            return handlerType == RuleHandlerType.Evaluation ?
+            return source == RuleSource.Evaluation ?
                 _evaluationRuleNames :
                 _designTimeBuildRuleNames;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
@@ -17,17 +17,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
         private readonly ImmutableHashSet<string> _evaluationRuleNames;
         private readonly ImmutableHashSet<string> _jointRuleNames;
 
-        protected string UnresolvedRuleName { get; }
+        protected string EvaluatedRuleName { get; }
         protected string ResolvedRuleName { get; }
 
         protected DependenciesRuleHandlerBase(
-            string unresolvedRuleName,
+            string evaluatedRuleName,
             string resolvedRuleName)
         {
-            UnresolvedRuleName = unresolvedRuleName;
+            EvaluatedRuleName = evaluatedRuleName;
             ResolvedRuleName = resolvedRuleName;
 
-            _evaluationRuleNames = ImmutableStringHashSet.EmptyOrdinal.Add(unresolvedRuleName);
+            _evaluationRuleNames = ImmutableStringHashSet.EmptyOrdinal.Add(evaluatedRuleName);
             _jointRuleNames = _evaluationRuleNames.Add(resolvedRuleName);
         }
 
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             // We receive unresolved and resolved changes separately.
 
             // Process all unresolved changes.
-            if (changesByRuleName.TryGetValue(UnresolvedRuleName, out IProjectChangeDescription unresolvedChanges))
+            if (changesByRuleName.TryGetValue(EvaluatedRuleName, out IProjectChangeDescription unresolvedChanges))
             {
                 HandleChangesForRule(
                     resolved: false,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
         {
             var caseInsensitiveUnresolvedChanges = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            if (changesByRuleName.TryGetValue(UnresolvedRuleName, out IProjectChangeDescription unresolvedChanges))
+            if (changesByRuleName.TryGetValue(EvaluatedRuleName, out IProjectChangeDescription unresolvedChanges))
             {
                 caseInsensitiveUnresolvedChanges.AddRange(unresolvedChanges.After.Items.Keys);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
@@ -12,8 +12,7 @@ using Microsoft.VisualStudio.ProjectSystem.VS.Utilities;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions.RuleHandlers
 {
-    [Export(DependencyRulesSubscriber.DependencyRulesSubscriberContract,
-            typeof(IDependenciesRuleHandler))]
+    [Export(DependencyRulesSubscriber.DependencyRulesSubscriberContract, typeof(IDependenciesRuleHandler))]
     [Export(typeof(IProjectDependenciesSubTreeProvider))]
     [AppliesTo(ProjectCapability.DependenciesTree)]
     internal sealed partial class PackageRuleHandler : DependenciesRuleHandlerBase


### PR DESCRIPTION
Steps towards larger refactoring of how the dependency node gets data from MSBuild.

Easiest to review commit by commit. Of note are:

- 7a04e2d5cf7175477fc3b8e32dca731bdf9d73dd which replaces the last usages of a .NET event with the Dataflow block @lifengl added a while back.
- 5394ef890ee6d172c71722bab874d03e41fda792 which removes redundant operations as joint rule name sets contain evaluated rule names
- 5b325d2c0d98a69550d2cb2cf6b6ec2a95534d46 which pulls duplicated code into a method and calls it twice
- 48b0d370e9ba314fb97f78650146f75e3ccd904c which avoids slicing the set of rules before calling handlers, as handlers only query items they're interested in anyway, which saves some allocation