### PR TITLE
Reduce locking and allocation in dependency node telemetry

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -440,7 +440,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                         {
                             dependenciesNode = await viewProvider.BuildTreeAsync(dependenciesNode, snapshot, cancellationToken);
 
-                            await _treeTelemetryService.ObserveTreeUpdateCompletedAsync(snapshot.HasVisibleUnresolvedDependency);
+                            if (_treeTelemetryService.IsActive)
+                            {
+                                await _treeTelemetryService.ObserveTreeUpdateCompletedAsync(snapshot.HasVisibleUnresolvedDependency);
+                            }
                         }
 
                         // TODO We still are getting mismatched data sources and need to figure out better 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     /// </remarks>
     [Export(typeof(IDependencyTreeTelemetryService))]
     [AppliesTo(ProjectCapability.DependenciesTree)]
-    internal class DependencyTreeTelemetryService : IDependencyTreeTelemetryService
+    internal sealed class DependencyTreeTelemetryService : IDependencyTreeTelemetryService
     {
         private const int MaxEventCount = 10;
 
@@ -166,7 +166,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// <summary>
         /// Maintain state for a single target framework.
         /// </summary>
-        private class TelemetryState
+        private sealed class TelemetryState
         {
             private readonly Dictionary<string, bool> _observedRules = new Dictionary<string, bool>(StringComparers.RuleNames);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -107,7 +107,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 if (_stopTelemetry)
                     return;
                 _stopTelemetry = !hasUnresolvedDependency || (++_eventCount >= MaxEventCount);
-                observedAllRules = ObservedAllRules();
+                observedAllRules = _telemetryStates.All(state => state.Value.ObservedAllRules());
             }
 
             if (_projectId == null)
@@ -133,8 +133,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             }
 
             return;
-
-            bool ObservedAllRules() => _telemetryStates.All(state => state.Value.ObservedAllRules());
 
             async Task<string> GetProjectIdAsync()
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Linq;
 using System.Threading.Tasks;
@@ -53,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// <summary>
         /// Initialize telemetry state with the set of rules we expect to observe for target framework
         /// </summary>
-        public void InitializeTargetFrameworkRules(ITargetFramework targetFramework, IEnumerable<string> rules)
+        public void InitializeTargetFrameworkRules(ImmutableArray<ITargetFramework> targetFrameworks, IReadOnlyCollection<string> rules)
         {
             if (_stopTelemetry)
                 return;
@@ -63,11 +64,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 if (_stopTelemetry)
                     return;
 
-                TelemetryState telemetryState = _telemetryStates.GetOrAdd(targetFramework, (key) => new TelemetryState());
-
-                foreach (string rule in rules)
+                foreach (ITargetFramework targetFramework in targetFrameworks)
                 {
-                    telemetryState.InitializeRule(rule);
+                    TelemetryState telemetryState = _telemetryStates.GetOrAdd(targetFramework, _ => new TelemetryState());
+
+                    foreach (string rule in rules)
+                    {
+                        telemetryState.InitializeRule(rule);
+                    }
                 }
             }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -110,10 +110,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
                 observedAllRules = _telemetryStates.All(state => state.Value.ObservedAllRules());
             }
 
-            if (_projectId == null)
-            {
-                _projectId = await GetProjectIdAsync();
-            }
+            _projectId ??= await GetProjectIdAsync();
 
             if (hasUnresolvedDependency)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -51,9 +51,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             }
         }
 
-        /// <summary>
-        /// Initialize telemetry state with the set of rules we expect to observe for target framework
-        /// </summary>
+        /// <inheritdoc />
         public void InitializeTargetFrameworkRules(ImmutableArray<ITargetFramework> targetFrameworks, IReadOnlyCollection<string> rules)
         {
             if (_stopTelemetry)
@@ -76,11 +74,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             }
         }
 
-        /// <summary>
-        /// Indicate that a set of rules has been observed in either an Evaluation or Design Time pass.
-        /// This information is used when firing tree update telemetry events to indicate whether all rules
-        /// have been observed.
-        /// </summary>
+        /// <inheritdoc />
         public void ObserveTargetFrameworkRules(ITargetFramework targetFramework, IEnumerable<string> rules)
         {
             if (_stopTelemetry)
@@ -101,10 +95,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
             }
         }
 
-        /// <summary>
-        /// Fire telemetry when dependency tree completes an update
-        /// </summary>
-        /// <param name="hasUnresolvedDependency">indicates if the snapshot used for the update had any unresolved dependencies</param>
+        /// <inheritdoc />
         public async Task ObserveTreeUpdateCompletedAsync(bool hasUnresolvedDependency)
         {
             if (_stopTelemetry)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -154,18 +154,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// <summary>
         /// Maintain state for a single target framework.
         /// </summary>
-        internal class TelemetryState
+        private class TelemetryState
         {
             private readonly ConcurrentDictionary<string, bool> _observedRules = new ConcurrentDictionary<string, bool>(StringComparers.RuleNames);
 
-            internal void InitializeRule(string rule) =>
-                _observedRules.TryAdd(rule, false);
+            public void InitializeRule(string rule) => _observedRules.TryAdd(rule, false);
 
-            internal void ObserveRule(string rule) =>
-                _observedRules.TryUpdate(rule, true, false);
+            public void ObserveRule(string rule) => _observedRules.TryUpdate(rule, true, false);
 
-            internal bool ObservedAllRules() =>
-                !_observedRules.IsEmpty && _observedRules.All(entry => entry.Value);
+            public bool ObservedAllRules() => !_observedRules.IsEmpty && _observedRules.All(entry => entry.Value);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -58,6 +58,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         }
 
         /// <inheritdoc />
+        public bool IsActive => _stateByFramework != null;
+
+        /// <inheritdoc />
         public void InitializeTargetFrameworkRules(ImmutableArray<ITargetFramework> targetFrameworks, IReadOnlyCollection<string> rules)
         {
             if (_stateByFramework == null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/IDependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/IDependencyTreeTelemetryService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 
 using Microsoft.VisualStudio.Composition;
@@ -14,9 +15,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     internal interface IDependencyTreeTelemetryService
     {
         /// <summary>
-        /// Initialize telemetry state with the set of rules we expect to observe for target framework
+        /// Initialize telemetry state with the set of target frameworks and rules we expect to observe.
         /// </summary>
-        void InitializeTargetFrameworkRules(ITargetFramework targetFramework, IEnumerable<string> rules);
+        void InitializeTargetFrameworkRules(ImmutableArray<ITargetFramework> targetFrameworks, IReadOnlyCollection<string> rules);
 
         /// <summary>
         /// Indicate that a set of rules has been observed in either an Evaluation or Design Time pass.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/IDependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/IDependencyTreeTelemetryService.cs
@@ -15,6 +15,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
     internal interface IDependencyTreeTelemetryService
     {
         /// <summary>
+        /// Gets a value indicating whether this telemetry service is active.
+        /// If not, then it will remain inactive and no methods need be called on it.
+        /// Note that an instance may become inactive during its lifetime.
+        /// </summary>
+        bool IsActive { get; }
+
+        /// <summary>
         /// Initialize telemetry state with the set of target frameworks and rules we expect to observe.
         /// </summary>
         void InitializeTargetFrameworkRules(ImmutableArray<ITargetFramework> targetFrameworks, IReadOnlyCollection<string> rules);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
@@ -72,11 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             IReadOnlyCollection<string> watchedEvaluationRules = GetRuleNames(RuleSource.Evaluation);
             IReadOnlyCollection<string> watchedJointRules = GetRuleNames(RuleSource.Joint);
 
-            // initialize telemetry with all rules for each target framework
-            foreach (ITargetFramework targetFramework in projectContext.TargetFrameworks)
-            {
-                _treeTelemetryService.InitializeTargetFrameworkRules(targetFramework, watchedJointRules);
-            }
+            _treeTelemetryService.InitializeTargetFrameworkRules(projectContext.TargetFrameworks, watchedJointRules);
 
             foreach (ConfiguredProject configuredProject in projectContext.InnerConfiguredProjects)
             {


### PR DESCRIPTION
A series of small tidy ups in the dependency node telemetry code.

