### PR TITLE
Reduce allocation in DisposableBag and remove locking

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreUnconfiguredInputDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreUnconfiguredInputDataSource.cs
@@ -50,15 +50,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
                                     .Select(DropConfiguredProjectVersions),
                 includeSourceVersions: true);
 
-            disposables.AddDisposable(restoreConfiguredInputSource);
+            disposables.Add(restoreConfiguredInputSource);
 
             IProjectValueDataSource<IConfigurationGroup<ConfiguredProject>> activeConfiguredProjectsSource = _activeConfigurationGroupService.ActiveConfiguredProjectGroupSource;
-            disposables.AddDisposable(activeConfiguredProjectsSource.SourceBlock.LinkTo(restoreConfiguredInputSource, DataflowOption.PropagateCompletion));
+            disposables.Add(activeConfiguredProjectsSource.SourceBlock.LinkTo(restoreConfiguredInputSource, DataflowOption.PropagateCompletion));
 
             // Transform all restore data -> combined restore data
             DisposableValue<ISourceBlock<RestoreInfo>> mergeBlock = restoreConfiguredInputSource.SourceBlock
                                                                                                 .TransformWithNoDelta(update => update.Derive(MergeRestoreInputs));
-            disposables.AddDisposable(mergeBlock);
+            disposables.Add(mergeBlock);
 
             // Set the link up so that we publish changes to target block
             mergeBlock.Value.LinkTo(targetBlock, DataflowOption.PropagateCompletion);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
@@ -67,7 +67,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
                 _activeWorkspaceProjectContextTracker.RegisterContext(_contextAccessor.ContextId);
 
-                _disposables = new DisposableBag(CancellationToken.None);
+                _disposables = new DisposableBag();
 
                 _applyChangesToWorkspaceContext = _applyChangesToWorkspaceContextFactory.CreateExport();
                 _applyChangesToWorkspaceContext.Value.Initialize(_contextAccessor.Context);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceProjectContextHost.WorkspaceProjectContextHostInstance.cs
@@ -71,22 +71,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
                 _applyChangesToWorkspaceContext = _applyChangesToWorkspaceContextFactory.CreateExport();
                 _applyChangesToWorkspaceContext.Value.Initialize(_contextAccessor.Context);
-                _disposables.AddDisposable(_applyChangesToWorkspaceContext);
+                _disposables.Add(_applyChangesToWorkspaceContext);
 
                 _evaluationProgressRegistration = _dataProgressTrackerService.RegisterForIntelliSense(_project, nameof(WorkspaceProjectContextHostInstance) + ".Evaluation");
-                _disposables.AddDisposable(_evaluationProgressRegistration);
+                _disposables.Add(_evaluationProgressRegistration);
 
                 _projectBuildProgressRegistration = _dataProgressTrackerService.RegisterForIntelliSense(_project, nameof(WorkspaceProjectContextHostInstance) + ".ProjectBuild");
-                _disposables.AddDisposable(_projectBuildProgressRegistration);
+                _disposables.Add(_projectBuildProgressRegistration);
 
                 // We avoid suppressing version updates, so that progress tracker doesn't
                 // think we're still "in progress" in the case of an empty change
-                _disposables.AddDisposable(_projectSubscriptionService.ProjectRuleSource.SourceBlock.LinkToAsyncAction(
+                _disposables.Add(_projectSubscriptionService.ProjectRuleSource.SourceBlock.LinkToAsyncAction(
                         target: e => OnProjectChangedAsync(e, evaluation: true),
                         suppressVersionOnlyUpdates: false,
                         ruleNames: _applyChangesToWorkspaceContext.Value.GetProjectEvaluationRules()));
 
-                _disposables.AddDisposable(_projectSubscriptionService.ProjectBuildRuleSource.SourceBlock.LinkToAsyncAction(
+                _disposables.Add(_projectSubscriptionService.ProjectBuildRuleSource.SourceBlock.LinkToAsyncAction(
                         target: e => OnProjectChangedAsync(e, evaluation: false),
                         suppressVersionOnlyUpdates: false,
                         ruleNames: _applyChangesToWorkspaceContext.Value.GetProjectBuildRules()));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/DisposableBag.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/DisposableBag.cs
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
         /// Adds a value to be disposed of when this collection is disposed of.
         /// </summary>
         /// <param name="disposable">The value to be disposed of later. May be <c>null</c>.</param>
-        internal void AddDisposable(IDisposable? disposable)
+        public void AddDisposable(IDisposable? disposable)
         {
             if (disposable == null)
             {
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
         /// <summary>
         /// Adds values to be disposed of when this collection is disposed of.
         /// </summary>
-        internal void AddDisposables(IEnumerable<IDisposable?> disposables)
+        public void AddDisposables(IEnumerable<IDisposable?> disposables)
         {
             Requires.NotNull(disposables, nameof(disposables));
 
@@ -96,7 +96,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
         /// Removes a disposable value from the collection.
         /// </summary>
         /// <param name="disposable">The value to remove. May be <c>null</c>.</param>
-        internal void RemoveDisposable(IDisposable? disposable)
+        public void RemoveDisposable(IDisposable? disposable)
         {
             if (disposable == null)
             {
@@ -113,7 +113,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
         /// Calls <see cref="IDisposable.Dispose"/> on all elements in a sequence,
         /// allowing the sequence itself or elements inside it to be null.
         /// </summary>
-        internal static void DisposeAllIfNotNull(IEnumerable<IDisposable?>? sequence, bool cacheSequence = false)
+        private static void DisposeAllIfNotNull(IEnumerable<IDisposable?>? sequence, bool cacheSequence = false)
         {
             if (sequence != null)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/DisposableBag.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/DisposableBag.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. 
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
@@ -10,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
     /// <summary>
     /// Tracks a bag of distinct disposable objects which will be disposed when the bag itself is disposed.
     /// </summary>
-    internal sealed class DisposableBag : IDisposable
+    internal sealed class DisposableBag : IDisposable, IEnumerable
     {
         /// <summary>
         /// The set of disposable blocks. If <see langword="null" />, then this disposable bag has been disposed.
@@ -99,5 +100,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
                 (set, item) => set?.Remove(item)!,
                 disposable);
         }
+
+        /// <summary>
+        /// Implemented only to allow collection initialization of this type.
+        /// </summary>
+        IEnumerator IEnumerable.GetEnumerator() => throw new NotSupportedException();
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/DisposableBag.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/DisposableBag.cs
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
         /// If this disposable bag has already been disposed, <paramref name="disposable" /> will be disposed immediately.
         /// </remarks>
         /// <param name="disposable">The value to be included in this disposable bag.</param>
-        public void AddDisposable(IDisposable? disposable)
+        public void Add(IDisposable? disposable)
         {
             if (disposable == null)
             {
@@ -72,13 +72,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
         /// <summary>
         /// Adds objects to this bag, to each be disposed when the bag itself is disposed.
         /// </summary>
-        public void AddDisposables(IEnumerable<IDisposable?> disposables)
+        public void Add(IEnumerable<IDisposable?> disposables)
         {
             Requires.NotNull(disposables, nameof(disposables));
 
             foreach (IDisposable? disposable in disposables)
             {
-                AddDisposable(disposable);
+                Add(disposable);
             }
         }
 
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
         /// <paramref name="disposable"/> from being disposed along with the bag itself.
         /// </summary>
         /// <param name="disposable">The object to remove.</param>
-        public void RemoveDisposable(IDisposable? disposable)
+        public void Remove(IDisposable? disposable)
         {
             if (disposable == null)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/DisposableBag.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/DisposableBag.cs
@@ -63,7 +63,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
         public void Dispose()
         {
             bool disposedThisTime = false;
-            var disposables = ImmutableHashSet.Create<IDisposable?>();
+            ImmutableHashSet<IDisposable?>? disposables = null;
             lock (this)
             {
                 if (!IsDisposed)
@@ -180,7 +180,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
         /// Calls <see cref="IDisposable.Dispose"/> on all elements in a sequence,
         /// allowing the sequence itself or elements inside it to be null.
         /// </summary>
-        internal static void DisposeAllIfNotNull(IEnumerable<IDisposable?> sequence, bool cacheSequence = false)
+        internal static void DisposeAllIfNotNull(IEnumerable<IDisposable?>? sequence, bool cacheSequence = false)
         {
             if (sequence != null)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
@@ -126,14 +126,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
                 _subscriptions ??= new DisposableBag();
 
-                _subscriptions.AddDisposable(
+                _subscriptions.Add(
                     dataSource.SourceBlock.LinkTo(
                         intermediateBlock,
                         ruleNames: ruleNames,
                         suppressVersionOnlyUpdates: true,
                         linkOptions: DataflowOption.PropagateCompletion));
 
-                _subscriptions.AddDisposable(ProjectDataSources.SyncLinkTo(
+                _subscriptions.Add(ProjectDataSources.SyncLinkTo(
                     intermediateBlock.SyncLinkOptions(),
                     subscriptionService.ProjectCatalogSource.SourceBlock.SyncLinkOptions(),
                     configuredProject.Capabilities.SourceBlock.SyncLinkOptions(),


### PR DESCRIPTION
- The cancellation support was unused so I removed it. It makes the type much smaller and simpler.
- The 'observable disposable' concept was unused, so has been removed.
- `AddDisposable` was renamed to `Add`, and object initializer support enabled. `RemoveDisposable` was also shortened. This looks better to me in usages.
- Removed `lock (this)` (which is a bad idea anyway as `this` is public which allows deadlocks if others locked on the instance too) from the implementation. Replaced with lock-free operations to guarantee safety and correctness.

Further questions:

- Should this be a stack, rather than a set, so that disposal is LIFO? I'm not sure it matters with our current usages, but in general it might be more correct. The current implementation gives no guarantee about disposal order, and it will in fact differ between executions. This could make certain classes of bug hard to find.
- Currently the implementation allows calling `Add`/`Remove` after the bag is disposed. `Add` will just dispose the argument immediately. I feel like throwing `ObjectDisposedException` in such cases would be better, as in general we shouldn't be using objects after disposing them.