### PR TITLE
Use shared project for build files

### DIFF
--- a/ProjectSystem.sln
+++ b/ProjectSystem.sln
@@ -33,42 +33,16 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DeployTestDependencies", "s
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DeployIntegrationDependencies", "src\deploy\DeployIntegrationDependencies\DeployIntegrationDependencies.csproj", "{C16993CC-6063-4447-AE16-BE671AFDE08A}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{DD7EF107-AAD4-4C43-8A58-0DC1BC614ADE}"
-	ProjectSection(SolutionItems) = preProject
-		.editorconfig = .editorconfig
-		.vsts-ci.yml = .vsts-ci.yml
-		build\azure-pipelines-integration.yml = build\azure-pipelines-integration.yml
-		build\azure-pipelines.yml = build\azure-pipelines.yml
-		build\SignToolData.json = build\SignToolData.json
-	EndProjectSection
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ruleset", "ruleset", "{E09AD054-22FC-4E70-8889-0F3DCF1267C7}"
-	ProjectSection(SolutionItems) = preProject
-		build\ruleset\Default.ruleset = build\ruleset\Default.ruleset
-		build\ruleset\Test.ruleset = build\ruleset\Test.ruleset
-	EndProjectSection
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Documentation", "docs\Documentation.csproj", "{C51202A5-0C1F-4146-8059-5F7B8A048232}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "import", "import", "{52A4E4D7-5658-4BD7-A8FC-2D7ABB5A8AFF}"
-	ProjectSection(SolutionItems) = preProject
-		build\import\HostAgnostic.props = build\import\HostAgnostic.props
-		build\import\IntegrationTests.targets = build\import\IntegrationTests.targets
-		build\import\Packages.targets = build\import\Packages.targets
-		build\import\Stubs.targets = build\import\Stubs.targets
-		build\import\UnitTests.targets = build\import\UnitTests.targets
-		build\import\Versions.props = build\import\Versions.props
-		build\import\VisualStudio.props = build\import\VisualStudio.props
-		build\import\VisualStudio.XamlRules.props = build\import\VisualStudio.XamlRules.props
-		build\import\VisualStudio.XamlRules.targets = build\import\VisualStudio.XamlRules.targets
-		build\import\VisualStudioDesigner.props = build\import\VisualStudioDesigner.props
-		build\import\VisualStudioIntegration.props = build\import\VisualStudioIntegration.props
-		build\import\Workarounds.targets = build\import\Workarounds.targets
-	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Deploy", "Deploy", "{FD8EF6D9-B9AD-40AA-8015-D74AB6E82A5A}"
 EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "build", "build\build.shproj", "{41D1FA55-B719-4E8D-9D79-F7610004D496}"
+EndProject
 Global
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		build\build.projitems*{41d1fa55-b719-4e8d-9d79-f7610004d496}*SharedItemsImports = 13
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
@@ -143,8 +117,6 @@ Global
 		{46C756B9-2D8E-4453-8F06-42BBE25D1805} = {AC8DB8AE-AC9F-4503-83C6-255B66C318C6}
 		{892500A5-BF6B-4FD5-A7B9-5EEA20EB775F} = {FD8EF6D9-B9AD-40AA-8015-D74AB6E82A5A}
 		{C16993CC-6063-4447-AE16-BE671AFDE08A} = {FD8EF6D9-B9AD-40AA-8015-D74AB6E82A5A}
-		{E09AD054-22FC-4E70-8889-0F3DCF1267C7} = {DD7EF107-AAD4-4C43-8A58-0DC1BC614ADE}
-		{52A4E4D7-5658-4BD7-A8FC-2D7ABB5A8AFF} = {DD7EF107-AAD4-4C43-8A58-0DC1BC614ADE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6B652C28-D1FD-4885-A0CA-4704C54E78E7}

--- a/build/build.projitems
+++ b/build/build.projitems
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>41d1fa55-b719-4e8d-9d79-f7610004d496</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>build</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="**/*.*" />
+    <None Remove="build.shproj" />
+    <None Remove="build.shproj.user" />
+    <None Remove="build.projitems" />
+  </ItemGroup>
+</Project>

--- a/build/build.shproj
+++ b/build/build.shproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>41d1fa55-b719-4e8d-9d79-f7610004d496</ProjectGuid>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <PropertyGroup />
+  <Import Project="build.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>


### PR DESCRIPTION
This avoids having to keep the list of solution items up to date.

Having these items in the solution means their contents will be searched by find-in-files.

![image](https://user-images.githubusercontent.com/350947/62996833-8f091b80-bea9-11e9-80fe-b31b3998c769.png)
