### PR TITLE
 Allow signing on VS 2019

### DIFF
--- a/build/proj/CoreBuild.proj
+++ b/build/proj/CoreBuild.proj
@@ -98,9 +98,8 @@
     </PropertyGroup>
 
     <MSBuild 
-      Projects="$(ToolsetPath)Sign.proj"
+      Projects="Sign.proj"
       Properties="@(CommonBuildProperty);RealSign=$(RealSign);ConfigFile=$(RepoRoot)build\ci\SignToolData.json"
-      Targets="Sign"
       />
     
   </Target>

--- a/build/proj/Sign.proj
+++ b/build/proj/Sign.proj
@@ -17,9 +17,7 @@
   <Target Name="Sign">
 
     <PropertyGroup>
-      <!-- VS2019 and later place msbuild.exe under "MSBuild\Current", while VS2017 places it under "MSBuild\15.0". -->
-      <_MSBuildExePath Condition="Exists('$(VSINSTALLDIR)\MSBuild\Current\Bin\msbuild.exe')">$(VSINSTALLDIR)\MSBuild\Current\Bin\msbuild.exe</_MSBuildExePath>
-      <_MSBuildExePath Condition="'$(_MSBuildExePath)' == ''">$(VSINSTALLDIR)\MSBuild\15.0\Bin\msbuild.exe</_MSBuildExePath>
+      <_MSBuildExePath>$(VSINSTALLDIR)\MSBuild\$(MSBuildToolsVersion)\Bin\msbuild.exe</_MSBuildExePath>
     </PropertyGroup>
 
     <ItemGroup>

--- a/build/proj/Sign.proj
+++ b/build/proj/Sign.proj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Sign">
   <!--
     Required parameters:
-      ConfigFile                    SigntToolData.json path.
+      ConfigFile                    SignToolData.json path.
       RealSign                      "true" to send binaries to the signing service, "false" to only validate signing configuration.
     Optional parameters:
       OutputConfigFile              If specified, output a manifest similar to SignToolData.json but with checksums of all relevant files included 

--- a/build/proj/Sign.proj
+++ b/build/proj/Sign.proj
@@ -2,8 +2,6 @@
 <Project DefaultTargets="Sign">
   <!--
     Required parameters:
-      VersionsPropsPath             Versions.props path. 
-      FixedVersionsPropsPath        FixedVersions.props path.
       ConfigFile                    SigntToolData.json path.
       RealSign                      "true" to send binaries to the signing service, "false" to only validate signing configuration.
     Optional parameters:
@@ -12,20 +10,16 @@
                                     SignTool will attempt to unpack all zips provided and match on checksums for any missing files.
   -->
 
-  <Import Project="BuildStep.props" />
+  <Import Project="..\import\Versions.props" />
+  <Import Project="..\import\NuGet.props" />
+  <Import Project="..\import\RepoLayout.props" />
 
   <Target Name="Sign">
-    <Exec Command='"$(MSBuildProjectDirectory)\vswhere.exe" -latest -prerelease -property installationPath -requires Microsoft.Component.MSBuild'
-          Condition="'$(RealSign)' == 'true'"
-          ConsoleToMsBuild="true"
-          StandardErrorImportance="high">
-      <Output TaskParameter="ConsoleOutput" PropertyName="_VsInstallDir" />
-    </Exec>
 
     <PropertyGroup>
       <!-- VS2019 and later place msbuild.exe under "MSBuild\Current", while VS2017 places it under "MSBuild\15.0". -->
-      <_MSBuildExePath Condition="Exists('$(_VsInstallDir)\MSBuild\Current\Bin\msbuild.exe')">$(_VsInstallDir)\MSBuild\Current\Bin\msbuild.exe</_MSBuildExePath>
-      <_MSBuildExePath Condition="'$(_MSBuildExePath)' == ''">$(_VsInstallDir)\MSBuild\15.0\Bin\msbuild.exe</_MSBuildExePath>
+      <_MSBuildExePath Condition="Exists('$(VSINSTALLDIR)\MSBuild\Current\Bin\msbuild.exe')">$(VSINSTALLDIR)\MSBuild\Current\Bin\msbuild.exe</_MSBuildExePath>
+      <_MSBuildExePath Condition="'$(_MSBuildExePath)' == ''">$(VSINSTALLDIR)\MSBuild\15.0\Bin\msbuild.exe</_MSBuildExePath>
     </PropertyGroup>
 
     <ItemGroup>

--- a/build/proj/Sign.proj
+++ b/build/proj/Sign.proj
@@ -1,0 +1,45 @@
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project DefaultTargets="Sign">
+  <!--
+    Required parameters:
+      VersionsPropsPath             Versions.props path. 
+      FixedVersionsPropsPath        FixedVersions.props path.
+      ConfigFile                    SigntToolData.json path.
+      RealSign                      "true" to send binaries to the signing service, "false" to only validate signing configuration.
+    Optional parameters:
+      OutputConfigFile              If specified, output a manifest similar to SignToolData.json but with checksums of all relevant files included 
+                                    for reassembly later when only zip archives are available.  If this file is later used as the '-config' file, 
+                                    SignTool will attempt to unpack all zips provided and match on checksums for any missing files.
+  -->
+
+  <Import Project="BuildStep.props" />
+
+  <Target Name="Sign">
+    <Exec Command='"$(MSBuildProjectDirectory)\vswhere.exe" -latest -prerelease -property installationPath -requires Microsoft.Component.MSBuild'
+          Condition="'$(RealSign)' == 'true'"
+          ConsoleToMsBuild="true"
+          StandardErrorImportance="high">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_VsInstallDir" />
+    </Exec>
+
+    <PropertyGroup>
+      <!-- VS2019 and later place msbuild.exe under "MSBuild\Current", while VS2017 places it under "MSBuild\15.0". -->
+      <_MSBuildExePath Condition="Exists('$(_VsInstallDir)\MSBuild\Current\Bin\msbuild.exe')">$(_VsInstallDir)\MSBuild\Current\Bin\msbuild.exe</_MSBuildExePath>
+      <_MSBuildExePath Condition="'$(_MSBuildExePath)' == ''">$(_VsInstallDir)\MSBuild\15.0\Bin\msbuild.exe</_MSBuildExePath>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <SignToolArgs Include='-outputconfig "$(OutputConfigFile)"' Condition="'$(OutputConfigFile)' != ''" />      
+      <SignToolArgs Include='-nugetPackagesPath "$(NuGetPackageRoot)\"' />
+      <SignToolArgs Include='-intermediateOutputPath "$(ArtifactsObjDir)\"' />
+      <SignToolArgs Include='-config "$(ConfigFile)"' />
+      <SignToolArgs Include='-test' Condition="'$(RealSign)' != 'true'" />
+      <SignToolArgs Include='-msbuildpath "$(_MSBuildExePath)"' Condition="'$(RealSign)' == 'true'"/>
+      <SignToolArgs Include='"$(ArtifactsConfigurationDir)\"' />
+    </ItemGroup>
+    
+    <Exec Command="$(NuGetPackageRoot)roslyntools.signtool\$(RoslynToolsSignToolVersion)\tools\SignTool.exe @(SignToolArgs, ' ')"
+          LogStandardErrorAsError="true" />
+  </Target>
+
+</Project>


### PR DESCRIPTION
This allows signing on VS 2019, instead of limiting to VS 2017.

Originally we were going to consume this by upgrading to the latest version of RoslynTools.RepoToolset. I spent 2 days on that port and gave up; it's a significant work item due to a large number of breaking changes. I timeboxed and ran out of time.

Instead, I've gone down the approach of copying the Sign.proj from the toolset, and slightly changing it. Both are in two separate commits.