### PR TITLE
Move official build to VS 2019

### DIFF
--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -10,7 +10,7 @@ resources:
 - repo: self
   clean: true
 queue:
-  name: VSEng-MicroBuildVS2017
+  name: VSEng-MicroBuildVS2019
   demands: Cmd
 variables:
   BuildConfiguration: Release


### PR DESCRIPTION
This will enable us to use some of the new VS 2019 features, such as .editorconfig support.