### PR TITLE
Remove some PackageReference XAML properties

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/DependencyRuleTests.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/DependencyRuleTests.cs
@@ -109,6 +109,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
             Assert.Equal("True", property.Attribute("ReadOnly")?.Value, StringComparer.OrdinalIgnoreCase);
         }
 
+        [Theory]
+        [MemberData(nameof(GetUnresolvedDependenciesRules))]
+        public void UnresolvedDependenciesRulesMustNotHaveOriginalItemSpec(string ruleName, string fullPath)
+        {
+            XElement rule = LoadXamlRule(fullPath, out var namespaceManager);
+
+            var property = rule.XPathSelectElement(@"/msb:Rule/msb:StringProperty[@Name=""OriginalItemSpec""]", namespaceManager);
+
+            Assert.Null(property);
+        }
+
         public static IEnumerable<object[]> GetUnresolvedDependenciesRules()
         {
             return Project(GetRules("Dependencies")

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/PackageReference.xaml
@@ -14,22 +14,9 @@
                 SourceType="TargetResults" />
   </Rule.DataSource>
 
-  <StringProperty Name="Description"
-                  Description="Dependency description."
-                  DisplayName="Description"
-                  ReadOnly="True" />
-
   <StringProperty Name="ExcludeAssets"
                   Description="Assets to exclude from this reference."
                   DisplayName="Excluded assets" />
-
-  <StringProperty Name="FrameworkName"
-                  ReadOnly="True"
-                  Visible="False" />
-
-  <StringProperty Name="FrameworkVersion"
-                  ReadOnly="True"
-                  Visible="False" />
 
   <BoolProperty Name="GeneratePathProperty"
                 Description="Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'."
@@ -43,10 +30,6 @@
                   ReadOnly="True"
                   Visible="False" />
 
-  <StringProperty Name="Name"
-                  ReadOnly="True"
-                  DisplayName="Name" />
-
   <StringProperty Name="NoWarn"
                   Description="Comma-delimited list of warnings that should be suppressed for this package."
                   DisplayName="Suppress warnings" />
@@ -59,18 +42,6 @@
   <StringProperty Name="PrivateAssets"
                   Description="Assets that are private in this reference."
                   DisplayName="Private assets" />
-
-  <StringProperty Name="RuntimeIdentifier"
-                  ReadOnly="True"
-                  Visible="False" />
-
-  <StringProperty Name="TargetFramework"
-                  ReadOnly="True"
-                  Visible="False" />
-
-  <StringProperty Name="Type"
-                  ReadOnly="True"
-                  Visible="False" />
 
   <StringProperty Name="Version"
                   Description="Version of dependency."

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/PackageReference.xaml
@@ -51,10 +51,6 @@
                   Description="Comma-delimited list of warnings that should be suppressed for this package."
                   DisplayName="Suppress warnings" />
 
-  <StringProperty Name="OriginalItemSpec"
-                  ReadOnly="True"
-                  Visible="False" />
-
   <StringProperty Name="Path"
                   Description="Location of the package being referenced."
                   ReadOnly="True"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.cs.xlf
@@ -12,16 +12,6 @@
         <target state="translated">Vlastnosti balíčku</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Description|DisplayName">
-        <source>Description</source>
-        <target state="translated">Popis</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Description|Description">
-        <source>Dependency description.</source>
-        <target state="translated">Popis závislosti</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Verze</target>
@@ -85,11 +75,6 @@
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">
         <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
         <target state="translated">Určuje, jestli se má generovat vlastnost MSBuildu s umístěním kořenového adresáře balíčku. Název generované vlastnosti je ve formátu Pkg[ID_balíčku], kde [ID_balíčku] je ID balíčku, ve kterém jsou tečky nahrazené podtržítky.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Name|DisplayName">
-        <source>Name</source>
-        <target state="new">Name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.de.xlf
@@ -12,16 +12,6 @@
         <target state="translated">Paketeigenschaften</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Description|DisplayName">
-        <source>Description</source>
-        <target state="translated">Beschreibung</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Description|Description">
-        <source>Dependency description.</source>
-        <target state="translated">Beschreibung der Abhängigkeit.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Version</target>
@@ -85,11 +75,6 @@
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">
         <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
         <target state="translated">Gibt an, ob eine MSBuild-Eigenschaft mit dem Speicherort des Stammverzeichnisses des Pakets generiert werden soll. Der Name der generierten Eigenschaft weist das Format "Pkg[Paket-ID]" auf, wobei "[Paket-ID]" der ID des Pakets entspricht. Hierbei müssen Punkte (.) jedoch durch Unterstriche (_) ersetzt werden.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Name|DisplayName">
-        <source>Name</source>
-        <target state="new">Name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.es.xlf
@@ -12,16 +12,6 @@
         <target state="translated">Propiedades de paquete</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Description|DisplayName">
-        <source>Description</source>
-        <target state="translated">Descripción</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Description|Description">
-        <source>Dependency description.</source>
-        <target state="translated">Descripción de la dependencia.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Versión</target>
@@ -85,11 +75,6 @@
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">
         <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
         <target state="translated">Indica si se va a generar una propiedad de MSBuild con la ubicación del directorio raíz del paquete. El nombre de la propiedad generada tiene el formato "pkg [PackageID]", donde "[PackageID]" es el ID del paquete con cualquier punto "." reemplazado por guiones bajos " _ ".</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Name|DisplayName">
-        <source>Name</source>
-        <target state="new">Name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.fr.xlf
@@ -12,16 +12,6 @@
         <target state="translated">Propriétés du package</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Description|DisplayName">
-        <source>Description</source>
-        <target state="translated">Description</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Description|Description">
-        <source>Dependency description.</source>
-        <target state="translated">Description de la dépendance.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Version</target>
@@ -85,11 +75,6 @@
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">
         <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
         <target state="translated">Indique s'il faut générer une propriété MSBuild avec l'emplacement du répertoire racine du package. Le nom de la propriété générée est au format 'Pkg[PackageID]', où '[PackageID]' est l'ID du package avec tous les points '.' remplacés par des traits de soulignement '_'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Name|DisplayName">
-        <source>Name</source>
-        <target state="new">Name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.it.xlf
@@ -12,16 +12,6 @@
         <target state="translated">Proprietà del pacchetto</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Description|DisplayName">
-        <source>Description</source>
-        <target state="translated">Descrizione</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Description|Description">
-        <source>Dependency description.</source>
-        <target state="translated">Descrizione della dipendenza.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Versione</target>
@@ -85,11 +75,6 @@
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">
         <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
         <target state="translated">Indica se generare una proprietà MSBuild con il percorso della directory radice del pacchetto. Il nome di proprietà generato è in formato 'Pkg[IDpacchetto]', dove '[IDpacchetto]' è l'ID del pacchetto in cui gli eventuali punti ('.') sono stati sostituiti da caratteri di sottolineatura ('_').</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Name|DisplayName">
-        <source>Name</source>
-        <target state="new">Name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ja.xlf
@@ -12,16 +12,6 @@
         <target state="translated">パッケージのプロパティ</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Description|DisplayName">
-        <source>Description</source>
-        <target state="translated">説明</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Description|Description">
-        <source>Dependency description.</source>
-        <target state="translated">依存関係の説明。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">バージョン</target>
@@ -85,11 +75,6 @@
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">
         <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
         <target state="translated">MSBuild プロパティをパッケージのルート ディレクトリーの場所に生成するかどうかを示します。生成されるプロパティ名は 'Pkg[PackageID]' という形式になります。'[PackageID]' はパッケージの ID で、ピリオド (.) はアンダースコア (_) に置き換えられます。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Name|DisplayName">
-        <source>Name</source>
-        <target state="new">Name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ko.xlf
@@ -12,16 +12,6 @@
         <target state="translated">패키지 속성</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Description|DisplayName">
-        <source>Description</source>
-        <target state="translated">설명</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Description|Description">
-        <source>Dependency description.</source>
-        <target state="translated">종속성 설명입니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">버전</target>
@@ -85,11 +75,6 @@
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">
         <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
         <target state="translated">패키지의 루트 디렉터리 위치를 사용하여 MSBuild 속성을 생성할지 여부를 제어합니다. 생성된 속성 이름은 'Pkg[PackageID]' 형식입니다. 여기서 '[PackageID]'는 패키지의 ID이고 마침표 '.'는 밑줄 '_'로 바뀝니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Name|DisplayName">
-        <source>Name</source>
-        <target state="new">Name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.pl.xlf
@@ -12,16 +12,6 @@
         <target state="translated">Właściwości pakietu</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Description|DisplayName">
-        <source>Description</source>
-        <target state="translated">Opis</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Description|Description">
-        <source>Dependency description.</source>
-        <target state="translated">Opis zależności.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Wersja</target>
@@ -85,11 +75,6 @@
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">
         <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
         <target state="translated">Wskazuje, czy należy generowania właściwość MSBuild z lokalizacją katalogu głównego pakietu. Nazwa właściwości generowane jest w formie 'Pkg [PackageID]', gdzie '[PackageID] 'jest identyfikator pakietu z okresów'.' zastąpione znakami podkreślenia '_'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Name|DisplayName">
-        <source>Name</source>
-        <target state="new">Name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.pt-BR.xlf
@@ -12,16 +12,6 @@
         <target state="translated">Propriedades do Pacote</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Description|DisplayName">
-        <source>Description</source>
-        <target state="translated">Descrição</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Description|Description">
-        <source>Dependency description.</source>
-        <target state="translated">Descrição da dependência.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Versão</target>
@@ -85,11 +75,6 @@
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">
         <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
         <target state="translated">Indica se é necessário gerar uma propriedade do MSBuild com a localização do diretório de raiz do pacote. O nome da propriedade gerado é em forma de 'Pkg [PackageID]', onde '[PackageID] 'é o ID do pacote com quaisquer períodos'.' substituído com caracteres de sublinhado '_'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Name|DisplayName">
-        <source>Name</source>
-        <target state="new">Name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ru.xlf
@@ -12,16 +12,6 @@
         <target state="translated">Свойства пакета</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Description|DisplayName">
-        <source>Description</source>
-        <target state="translated">Описание</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Description|Description">
-        <source>Dependency description.</source>
-        <target state="translated">Описание зависимости.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Версия</target>
@@ -85,11 +75,6 @@
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">
         <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
         <target state="translated">Указывает, необходимо ли создать свойство MSBuild, содержащее расположение корневого каталог пакета. Имя созданного свойства имеет вид 'Pkg[PackageID]', где '[PackageID]' — идентификатор пакета, в котором точки ('.') заменены на нижние подчеркивания ('_').</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Name|DisplayName">
-        <source>Name</source>
-        <target state="new">Name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.tr.xlf
@@ -12,16 +12,6 @@
         <target state="translated">Paket Özellikleri</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Description|DisplayName">
-        <source>Description</source>
-        <target state="translated">Açıklama</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Description|Description">
-        <source>Dependency description.</source>
-        <target state="translated">Bağımlılık açıklaması</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">Sürüm</target>
@@ -85,11 +75,6 @@
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">
         <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
         <target state="translated">Paket kök dizini konumuyla bir MSBuild özelliği oluşturulup oluşturulmayacağını belirtir. Oluşturulan özellik adı 'Pkg[PackageID]' biçimindedir. Burada '[PackageID]', noktalar '.' alt çizgi '_' ile değiştirilmiş olarak paketin adıdır.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Name|DisplayName">
-        <source>Name</source>
-        <target state="new">Name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.zh-Hans.xlf
@@ -12,16 +12,6 @@
         <target state="translated">包属性</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Description|DisplayName">
-        <source>Description</source>
-        <target state="translated">说明</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Description|Description">
-        <source>Dependency description.</source>
-        <target state="translated">依赖项说明。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">版本</target>
@@ -85,11 +75,6 @@
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">
         <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
         <target state="translated">指示是否要使用包的根目录的位置生成 MSBuild 属性。所生成的属性名称采用 "Pkg[PackageID]" 的形式，其中 "[PackageID]" 是包的 ID，且所有句点 "." 均替换为下划线 "_"。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Name|DisplayName">
-        <source>Name</source>
-        <target state="new">Name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.zh-Hant.xlf
@@ -12,16 +12,6 @@
         <target state="translated">套件屬性</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Description|DisplayName">
-        <source>Description</source>
-        <target state="translated">說明</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Description|Description">
-        <source>Dependency description.</source>
-        <target state="translated">相依性描述。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="StringProperty|Version|DisplayName">
         <source>Version</source>
         <target state="translated">版本</target>
@@ -85,11 +75,6 @@
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">
         <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
         <target state="translated">表示是否要以套件根目錄的位置產生 MSBuild 屬性。產生屬性的名稱格式為 'Pkg[PackageID]'，其中 '[PackageID]' 是套件的識別碼，所有句點 '.' 均會替換為底線 '_'。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Name|DisplayName">
-        <source>Name</source>
-        <target state="new">Name</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|Path|DisplayName">


### PR DESCRIPTION
- 0b0a0bfbbc9828c808d5eacccd123dc3431ac9b5 Unresolved dependency rules should not have `OriginalItemSpec` properties. Added unit test to this effect and removed from `PackageReference.xaml`.
- a73dacdd8ddace4ec59c4d05d260c3ad670165e4 Removed additional `PackageReference` properties. To the best of my knowledge, and according to my testing, these properties will not be present on evaluated `PackageReference` items.

Relates to #4105 and #5078. 