### PR TITLE
Split unit-tests.yml into template

### DIFF
--- a/build/ci/unit-tests-template.yml
+++ b/build/ci/unit-tests-template.yml
@@ -1,0 +1,49 @@
+# Template used by unit-tests.yml
+jobs:
+- job: ${{ parameters.name }}
+  pool: ${{ parameters.pool }}
+  timeoutInMinutes: 20
+  steps:
+    - script: $(Build.SourcesDirectory)\build.cmd /build /test /ci /sign /diagnostic /clearnugetcache /no-deploy /no-integration /no-ibc /configuration ${{ parameters.configuration }}
+    - task: PublishBuildArtifacts@1
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\${{ parameters.configuration }}\log'
+        ArtifactName: '${{ parameters.configuration }} unit test logs'
+        publishLocation: Container
+      continueOnError: true
+      condition: failed()
+
+    - task: PublishBuildArtifacts@1
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\${{ parameters.configuration }}\bin'
+        ArtifactName: '${{ parameters.configuration }} bin folder'
+        publishLocation: Container
+      continueOnError: true
+      condition: failed()
+
+    - task: PublishBuildArtifacts@1
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\${{ parameters.configuration }}\VSSetup'
+        ArtifactName: '${{ parameters.configuration }} VSSetup folder'
+        publishLocation: Container
+      continueOnError: true
+      condition: failed()
+
+    - task: PublishBuildArtifacts@1
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\${{ parameters.configuration }}\TestResults'
+        ArtifactName: '${{ parameters.configuration }} Test Result Logs'
+        publishLocation: Container
+      continueOnError: true
+      condition: failed()
+
+    - task: PublishTestResults@2
+      inputs:
+        testRunner: 'xUnit'	
+        testResultsFiles: '**/*.xml' 	
+        searchFolder: '$(Build.SourcesDirectory)\artifacts\${{ parameters.configuration }}\TestResults'	
+        configuration: '${{ parameters.configuration }}'	
+        publishRunAttachments: true	
+        failTaskOnFailedTests: true
+      continueOnError: true
+      condition: always()  

--- a/build/ci/unit-tests.yml
+++ b/build/ci/unit-tests.yml
@@ -38,102 +38,26 @@ pr:
     - README.md
 
 jobs:
-- job: Windows
-  pool:
-    name: NetCorePublic-Pool
-    queue: buildpool.windows.10.amd64.vs2019.pre.open
-  strategy:
-    maxParallel: 4
-    matrix:
-      Debug:
-        _configuration: Debug
-      Release:
-        _configuration: Release
-  timeoutInMinutes: 20
-  steps:
-    - script: $(Build.SourcesDirectory)\build.cmd /build /test /ci /sign /diagnostic /no-deploy /no-integration /no-ibc /configuration $(_configuration)
-    - task: PublishBuildArtifacts@1
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\$(_configuration)\log'
-        ArtifactName: '$(_configuration) unit test logs'
-        publishLocation: Container
-      continueOnError: true
-      condition: failed()
-    - task: PublishBuildArtifacts@1
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\$(_configuration)\bin'
-        ArtifactName: '$(_configuration) bin folder'
-        publishLocation: Container
-      continueOnError: true
-      condition: failed()
-    - task: PublishBuildArtifacts@1
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\$(_configuration)\VSSetup'
-        ArtifactName: '$(_configuration) VSSetup folder'
-        publishLocation: Container
-      continueOnError: true
-      condition: failed()
-    - task: PublishBuildArtifacts@1
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\$(_configuration)\TestResults'
-        ArtifactName: '$(_configuration) Test Result Logs'
-        publishLocation: Container
-      continueOnError: true
-      condition: failed()
-    - task: PublishTestResults@2
-      inputs:
-        testRunner: 'xUnit'
-        testResultsFiles: '**/*.xml' 
-        searchFolder: '$(Build.SourcesDirectory)\artifacts\$(_configuration)\TestResults'
-        configuration: '$(_configuration)'
-        publishRunAttachments: true
-        failTaskOnFailedTests: true
-      continueOnError: true
-      condition: always()
+- template: unit-tests-template.yml
+  parameters:
+    name: Windows_Debug
+    configuration: Debug
+    pool:
+      name: NetCorePublic-Pool
+      queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
 
-- job: Spanish
-  pool:
-    name: NetCorePublic-Pool
-    queue: BuildPool.Windows.Amd64.VS2019.Pre.ES.Open
-  variables:
-    _configuration: Debug
-  timeoutInMinutes: 20
-  steps:
-    - script: $(Build.SourcesDirectory)\build.cmd /build /test /ci /diagnostic /no-sign /no-deploy /no-integration /no-ibc /clearnugetcache /configuration $(_configuration)
-    - task: PublishBuildArtifacts@1
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\$(_configuration)\log'
-        ArtifactName: '$(_configuration) unit test logs'
-        publishLocation: Container
-      continueOnError: true
-      condition: failed()
-    - task: PublishBuildArtifacts@1
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\$(_configuration)\bin'
-        ArtifactName: '$(_configuration) bin folder'
-        publishLocation: Container
-      continueOnError: true
-      condition: failed()
-    - task: PublishBuildArtifacts@1
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\$(_configuration)\VSSetup'
-        ArtifactName: '$(_configuration) VSSetup folder'
-        publishLocation: Container
-      continueOnError: true
-      condition: failed()
-    - task: PublishBuildArtifacts@1
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\$(_configuration)\TestResults'
-        ArtifactName: '$(_configuration) Test Result Logs'
-        publishLocation: Container
-      continueOnError: true
-      condition: failed()
-    - task: PublishTestResults@2
-      inputs:
-        testRunner: 'xUnit'
-        testResultsFiles: '**/*.xml' 
-        searchFolder: '$(Build.SourcesDirectory)\artifacts\$(_configuration)\TestResults'
-        configuration: '$(_configuration)'
-        publishRunAttachments: true
-      continueOnError: true
-      condition: always()
+- template: unit-tests-template.yml
+  parameters:
+    name: Windows_Release
+    configuration: Release
+    pool:
+      name: NetCorePublic-Pool
+      queue: BuildPool.Windows.10.Amd64.VS2019.Pre.Open
+
+- template: unit-tests-template.yml
+  parameters:
+    name: Spanish
+    configuration: Debug
+    pool: 
+      name: NetCorePublic-Pool
+      queue: BuildPool.Windows.Amd64.VS2019.Pre.ES.Open


### PR DESCRIPTION
This splits common logic from unit-test into a parameter-driven template file.

This unifies the build logic between Spanish and Windows runs, by changing the following:

1) NuGet Cache is cleared in Windows runs, it was only running on Spanish previously which was an oversight. This caches when our sources don't contain a package that we've referred to.

2) Spanish runs also test sign, similar to Windows.