### PR TITLE
Consistently call build.cmd 

### DIFF
--- a/build/ci/integration-tests.yml
+++ b/build/ci/integration-tests.yml
@@ -20,6 +20,8 @@ jobs:
   timeoutInMinutes: 60
   steps:
     - script: $(Build.SourcesDirectory)\build.cmd /build /no-test /integration /diagnostic /ci /no-sign /deploy /no-clearnugetcache /configuration $(_configuration)
+      displayName: Build ProjectSystem.sln
+
     - task: PublishBuildArtifacts@1
       inputs:
         PathtoPublish: '$(Build.SourcesDirectory)\artifacts\$(_configuration)\log'
@@ -27,6 +29,7 @@ jobs:
         publishLocation: Container
       continueOnError: true
       condition: failed()
+
     - task: PublishBuildArtifacts@1
       inputs:
         PathtoPublish: '$(Build.SourcesDirectory)\artifacts\$(_configuration)\tmp'
@@ -34,6 +37,7 @@ jobs:
         publishLocation: Container
       continueOnError: true
       condition: failed()
+
     - task: PublishBuildArtifacts@1
       inputs:
         PathtoPublish: '$(Build.SourcesDirectory)\artifacts\$(_configuration)\bin'
@@ -41,6 +45,7 @@ jobs:
         publishLocation: Container
       continueOnError: true
       condition: failed()
+
     - task: PublishBuildArtifacts@1
       inputs:
         PathtoPublish: '$(Build.SourcesDirectory)\artifacts\$(_configuration)\VSSetup'
@@ -48,6 +53,7 @@ jobs:
         publishLocation: Container
       continueOnError: true
       condition: failed()
+
     - task: PublishBuildArtifacts@1
       inputs:
         PathtoPublish: '$(Build.SourcesDirectory)\artifacts\$(_configuration)\TestResults'
@@ -55,6 +61,7 @@ jobs:
         publishLocation: Container
       continueOnError: true
       condition: failed()
+
     - task: PublishTestResults@2
       inputs:
         testRunner: 'VSTest'

--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -34,13 +34,9 @@ steps:
     solution: 'build\proj\internal\RestoreIBCMerge.csproj'
     feed: '8f470c7e-ac49-4afe-a6ee-cf784e438b93'
 
-- task: BatchScript@1
-  displayName: Run script build.cmd
-  inputs:
-    filename: '$(Build.SourcesDirectory)\build.cmd '
-    arguments: '/build /test /ci /sign /diagnostic /no-deploy /no-integration /ibc /no-clearnugetcache /configuration $(BuildConfiguration) '
-    modifyEnvironment: false
-    
+- script: $(Build.SourcesDirectory)\build.cmd /build /test /ci /sign /diagnostic /no-deploy /no-integration /ibc /no-clearnugetcache /configuration $(BuildConfiguration)
+  displayName: Build ProjectSystem.sln
+
 - task: PublishTestResults@1
   displayName: Publish Test Results
   inputs:

--- a/build/ci/unit-tests-template.yml
+++ b/build/ci/unit-tests-template.yml
@@ -5,6 +5,8 @@ jobs:
   timeoutInMinutes: 20
   steps:
     - script: $(Build.SourcesDirectory)\build.cmd /build /test /ci /sign /diagnostic /clearnugetcache /no-deploy /no-integration /no-ibc /configuration ${{ parameters.configuration }}
+      displayName: Build ProjectSystem.sln
+
     - task: PublishBuildArtifacts@1
       inputs:
         PathtoPublish: '$(Build.SourcesDirectory)\artifacts\${{ parameters.configuration }}\log'


### PR DESCRIPTION
This includes https://github.com/dotnet/project-system/pull/5312 so just review https://github.com/dotnet/project-system/commit/25dac9a10c473f35767a16c1ae11c6781bc07c6e.

his moves official build from BatchScript -> CmdLine ("script"). The docs are not clear on the differences and cannot find the source code for BatchScript, but this consistently brings it inline with unit-tests and integration-tests.
