### PR TITLE
Remove "pack" and "restore" concepts from CoreBuild.proj

### DIFF
--- a/build/proj/Build.proj
+++ b/build/proj/Build.proj
@@ -39,7 +39,6 @@
       <CoreBuildProperties>
         UseOpenCover=$(IsCodeCoverageBuild);
         Configuration=$(Configuration);
-        Restore=true;
         CIBuild=$(CIBuild);
         EnableIbc=$(EnableIbc);
         Build=$(Build);

--- a/build/proj/Build.proj
+++ b/build/proj/Build.proj
@@ -40,7 +40,6 @@
         UseOpenCover=$(IsCodeCoverageBuild);
         Configuration=$(Configuration);
         Restore=true;
-        Pack=true;
         CIBuild=$(CIBuild);
         EnableIbc=$(EnableIbc);
         Build=$(Build);

--- a/build/proj/CoreBuild.proj
+++ b/build/proj/CoreBuild.proj
@@ -13,7 +13,6 @@
     Deploy                          "true" to deploy assets (e.g. VSIXes)
     Test                            "true" to run tests
     IntegrationTest                 "true" to run integration tests
-    Pack                            "true" to build NuGet packages and VS insertion manifests
     Sign                            "true" to sign built binaries
     SignType                        "real" to send binaries to signing service, "test" to only validate signing configuration.
   -->
@@ -62,11 +61,10 @@
 
   <Target Name="Build">
     <ItemGroup>
-      <SolutionBuildTarget Include="Rebuild" Condition="'$(Rebuild)' == 'true'" />
-      <SolutionBuildTarget Include="Build" Condition="'$(Build)' == 'true' and '$(Rebuild)' != 'true'" />
+      <SolutionBuildTarget Include="Rebuild;Pack" Condition="'$(Rebuild)' == 'true'" />
+      <SolutionBuildTarget Include="Build;Pack" Condition="'$(Build)' == 'true' and '$(Rebuild)' != 'true'" />
       <SolutionBuildTarget Include="Test" Condition="'$(Test)' == 'true'" />
       <SolutionBuildTarget Include="IntegrationTest" Condition="'$(IntegrationTest)' == 'true'" />
-      <SolutionBuildTarget Include="Pack" Condition="'$(Pack)' == 'true'" />
     </ItemGroup>
 
     <MSBuild 
@@ -106,7 +104,7 @@
 
   <Target
     Name="GenerateVSManifest"
-    Condition="'$(Pack)' == 'true'">
+    Condition="'$(Build)' == 'true' or '$(Rebuild)' == 'true'">
 
     <!-- Because multiple projects can contribute to a single insertion component we package them in a separate phase.
          Also due to insertion manifests containing hashes of references VSIXes, so we need to run this after signing  -->

--- a/build/proj/CoreBuild.proj
+++ b/build/proj/CoreBuild.proj
@@ -59,10 +59,11 @@
 
   <Target Name="Build">
     <ItemGroup>
-      <SolutionBuildTarget Include="Rebuild;Pack" Condition="'$(Rebuild)' == 'true'" />
-      <SolutionBuildTarget Include="Build;Pack" Condition="'$(Build)' == 'true' and '$(Rebuild)' != 'true'" />
+      <SolutionBuildTarget Include="Rebuild" Condition="'$(Rebuild)' == 'true'" />
+      <SolutionBuildTarget Include="Build" Condition="'$(Build)' == 'true' and '$(Rebuild)' != 'true'" />
       <SolutionBuildTarget Include="Test" Condition="'$(Test)' == 'true'" />
       <SolutionBuildTarget Include="IntegrationTest" Condition="'$(IntegrationTest)' == 'true'" />
+      <SolutionBuildTarget Include="Pack" Condition="'$(BuildOrRebuild)' == 'true'" />
     </ItemGroup>
 
     <MSBuild 

--- a/build/proj/CoreBuild.proj
+++ b/build/proj/CoreBuild.proj
@@ -24,6 +24,7 @@
   <PropertyGroup>
     <SolutionPath>$(RepoRoot)ProjectSystem.sln</SolutionPath>
     <ToolsetPath>$(NuGetPackageRoot)RoslynTools.RepoToolset\$(RoslynToolsRepoToolsetVersion)\tools\</ToolsetPath>
+    <BuildOrRebuild Condition="'$(Build)' == 'true' or '$(Rebuild)' == 'true'">true</BuildOrRebuild>
   </PropertyGroup>
 
   <ItemGroup>
@@ -77,7 +78,9 @@
   </Target>
 
   <!-- Generate insertion assets -->
-  <Target Name="GenerateDependentAssemblyVersionsFile">
+  <Target 
+    Name="GenerateDependentAssemblyVersionsFile"
+    Condition="'$(BuildOrRebuild)' == 'true'">
 
     <MSBuild
       Projects="GenerateDependentAssemblyVersionFile.proj"
@@ -104,7 +107,7 @@
 
   <Target
     Name="GenerateVSManifest"
-    Condition="'$(Build)' == 'true' or '$(Rebuild)' == 'true'">
+    Condition="'$(BuildOrRebuild)' == 'true'">
 
     <!-- Because multiple projects can contribute to a single insertion component we package them in a separate phase.
          Also due to insertion manifests containing hashes of references VSIXes, so we need to run this after signing  -->

--- a/build/proj/CoreBuild.proj
+++ b/build/proj/CoreBuild.proj
@@ -7,7 +7,6 @@
                                     
   Optional parameters:              
     CIBuild                         "true" when building on CI server
-    Restore                         "true" to restore toolset and solution
     Build                           "true" to build solution
     Rebuild                         "true" to rebuild solution
     Deploy                          "true" to deploy assets (e.g. VSIXes)
@@ -39,9 +38,7 @@
     <SolutionRestoreAndBuildProperty Include="__DeployProjectOutput=$(Deploy)" Condition="'$(Deploy)' != ''"/>
   </ItemGroup>
 
-  <Target 
-    Name="Restore" 
-    Condition="'$(Restore)' == 'true'">
+  <Target Name="Restore">
 
     <!--
       Run solution restore separately from the other targets, in a different build phase.


### PR DESCRIPTION
This removes the ability inside CoreBuild.proj to turn off pack/restore. Build.proj (which calls CoreBuild) always passed true for these. 

- Restore always occurs, there's no way to turn it off. If folks decide they want this ability, we can always add it back.
- Pack always occurs when you `/build` or `/rebuild`.

This lets https://github.com/dotnet/project-system/pull/4768 do a restore only build via:

```
build /no-build /no-test /no-deploy
```

