### PR TITLE
Force a build when packing

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsSolutionBuildManager2Factory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsSolutionBuildManager2Factory.cs
@@ -39,8 +39,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
                     return VSConstants.S_OK;
                 }
 
-                uint dwFlags = (uint)(VSSOLNBUILDUPDATEFLAGS.SBF_SUPPRESS_SAVEBEFOREBUILD_QUERY | VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD);
-                buildManager.Setup(b => b.StartSimpleUpdateProjectConfiguration(hierarchyToBuild, It.IsAny<IVsHierarchy>(), It.IsAny<string>(), dwFlags, It.IsAny<uint>(), It.IsAny<int>()))
+                buildManager.Setup(b => b.StartSimpleUpdateProjectConfiguration(hierarchyToBuild, It.IsAny<IVsHierarchy>(), It.IsAny<string>(), It.IsAny<uint>(), It.IsAny<uint>(), It.IsAny<int>()))
                     .Returns(onBuildStartedWithReturn);
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommand.cs
@@ -96,8 +96,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
                 // Enable generating package on build ("GeneratePackageOnBuild") for all projects being built.
                 _generatePackageOnBuildPropertyProvider.OverrideGeneratePackageOnBuild(true);
 
-                // Kick off the build.
-                uint dwFlags = (uint)(VSSOLNBUILDUPDATEFLAGS.SBF_SUPPRESS_SAVEBEFOREBUILD_QUERY | VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD);
+                // Because packaging is part of a build we need to force a build even if the project is up to date so we ensure a package is always created
+                uint dwFlags = (uint)(VSSOLNBUILDUPDATEFLAGS.SBF_SUPPRESS_SAVEBEFOREBUILD_QUERY | VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD | VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_FORCE_UPDATE);
                 ErrorHandler.ThrowOnFailure(_buildManager.StartSimpleUpdateProjectConfiguration(projectVsHierarchy, null, null, dwFlags, 0, 0));
             }
 


### PR DESCRIPTION
When the build output is up to date, the Pack command currently does nothing. This ensures it always does a build, and therefore a pack.

Fixes [AB#935258](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/935258)