### PR TITLE
Force VS 2019 for solution

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -82,6 +82,7 @@
   
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Language)' == 'C#'">


### PR DESCRIPTION
The build already forces VS 2019, make sure the same applies if you open the solution in VS 2017 or below. This causes projects to be not be loaded and results in:

![image](https://user-images.githubusercontent.com/1103906/63503988-ec3d4680-c513-11e9-91ec-838d3a0a4a1f.png)
