### PR TITLE
Take ownership of http://index indexing

### DIFF
--- a/build/ci/official.yml
+++ b/build/ci/official.yml
@@ -37,6 +37,18 @@ steps:
 - script: $(Build.SourcesDirectory)\build.cmd /build /test /ci /sign /diagnostic /no-deploy /no-integration /ibc /no-clearnugetcache /configuration $(BuildConfiguration)
   displayName: Build ProjectSystem.sln
 
+- task: Ref12.ref12-analyze-task.ref12-analyze-task.Ref12Analyze@0
+  displayName: Produce Codex index for http://index
+  inputs:
+    workflowArguments: |
+     /sourcesDirectory:$(Build.SourcesDirectory) 
+     /codexRepoUrl:$(Build.Repository.Uri) 
+     /repoName:$(Build.Repository.Name)
+     /additionalCodexArguments:-bld  
+     /additionalCodexArguments:$(Build.SourcesDirectory)\artifacts\Release\log
+  condition: succeeded()
+  continueOnError: true
+
 - task: PublishTestResults@1
   displayName: Publish Test Results
   inputs:


### PR DESCRIPTION
Previously this was located in another repository and kept being out of sync with our build, moving it to the official build.