### PR TITLE
Add IPhysicalProjectTreeStorage.AddFileAsync

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IPhysicalProjectTreeStorage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IPhysicalProjectTreeStorage.cs
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// <exception cref="NotSupportedException">
         ///     <paramref name="path"/> contains a colon character (:) that is not part of a drive label ("C:\").
         /// </exception>
-        Task<IProjectItem?> CreateEmpyFileAsync(string path);
+        Task<IProjectItem?> CreateEmptyFileAsync(string path);
 
         /// <summary>
         ///     Creates a folder on disk, adding it add to the physical project tree.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IPhysicalProjectTreeStorage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IPhysicalProjectTreeStorage.cs
@@ -25,9 +25,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// <param name="path">
         ///     The path of the folder to create, can be relative to the project directory.
         /// </param>
-        /// <returns>
-        ///     The created <see cref="IProjectItem"/>.
-        /// </returns>
         /// <remarks>
         ///     This method will automatically publish the resulting tree to <see cref="IProjectTreeService.CurrentTree"/>.
         /// </remarks>
@@ -60,7 +57,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// <exception cref="NotSupportedException">
         ///     <paramref name="path"/> contains a colon character (:) that is not part of a drive label ("C:\").
         /// </exception>
-        Task<IProjectItem?> CreateEmptyFileAsync(string path);
+        Task CreateEmptyFileAsync(string path);
 
         /// <summary>
         ///     Creates a folder on disk, adding it add to the physical project tree.
@@ -68,9 +65,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// <param name="path">
         ///     The path of the folder to create, can be relative to the project directory.
         /// </param>
-        /// <returns>
-        ///     The created <see cref="IProjectTree"/>.
-        /// </returns>
         /// <remarks>
         ///     This method will automatically publish the resulting tree to <see cref="IProjectTreeService.CurrentTree"/>.
         /// </remarks>
@@ -103,6 +97,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// <exception cref="NotSupportedException">
         ///     <paramref name="path"/> contains a colon character (:) that is not part of a drive label ("C:\").
         /// </exception>
-        Task<IProjectTree?> CreateFolderAsync(string path);
+        Task CreateFolderAsync(string path);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IPhysicalProjectTreeStorage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IPhysicalProjectTreeStorage.cs
@@ -14,11 +14,54 @@ namespace Microsoft.VisualStudio.ProjectSystem
     /// </summary>
     /// <remarks>
     ///     This interface provides a simple facade over the <see cref="IFileSystem"/>, <see cref="IFolderManager"/>, 
-    ///     <see cref="IProjectTreeService"/> and <see cref="IProjectItemProvider"/> interfaces.
+    ///     <see cref="IProjectTreeService"/>, <see cref="IProjectItemProvider"/> and <see cref="IProjectItemProvider"/> interfaces.
     /// </remarks>
     [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
     internal interface IPhysicalProjectTreeStorage
     {
+        /// <summary>
+        ///     Creates a zeroed file on disk, adding it add to the physical project tree.
+        /// </summary>
+        /// <param name="path">
+        ///     The path of the folder to create, can be relative to the project directory.
+        /// </param>
+        /// <returns>
+        ///     The created <see cref="IProjectItem"/>.
+        /// </returns>
+        /// <remarks>
+        ///     This method will automatically publish the resulting tree to <see cref="IProjectTreeService.CurrentTree"/>.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="path"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="path"/> is an empty string (""), contains only white space, or contains one or more invalid characters.
+        ///     <para>
+        ///         -or-
+        ///     </para>
+        ///     <paramref name="path"/> is prefixed with, or contains, only a colon character (:).
+        /// </exception>
+        /// <exception cref="IOException">
+        ///     The file specified by <paramref name="path"/> is a directory.
+        ///     <para>
+        ///         -or-
+        ///     </para>
+        ///     The network name is not known.
+        /// </exception>
+        /// <exception cref="UnauthorizedAccessException">
+        ///     The caller does not have the required permission.
+        /// </exception>
+        /// <exception cref="PathTooLongException"> 
+        ///     The specified path, file name, or both exceed the system-defined maximum length.
+        /// </exception>
+        /// <exception cref="DirectoryNotFoundException">
+        ///     The specified path is invalid (for example, it is on an unmapped drive).
+        /// </exception>
+        /// <exception cref="NotSupportedException">
+        ///     <paramref name="path"/> contains a colon character (:) that is not part of a drive label ("C:\").
+        /// </exception>
+        Task<IProjectItem?> CreateFileAsync(string path);
+
         /// <summary>
         ///     Creates a folder on disk, adding it add to the physical project tree.
         /// </summary>
@@ -36,7 +79,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// </exception>
         /// <exception cref="ArgumentException">
         ///     <paramref name="path"/> is an empty string (""), contains only white space, or contains one or more invalid characters.
-        ///     
+        ///     <para>
+        ///         -or-
+        ///     </para>
         ///     <paramref name="path"/> is prefixed with, or contains, only a colon character (:).
         /// </exception>
         /// <exception cref="IOException">
@@ -58,6 +103,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// <exception cref="NotSupportedException">
         ///     <paramref name="path"/> contains a colon character (:) that is not part of a drive label ("C:\").
         /// </exception>
-        Task<IProjectTree> CreateFolderAsync(string path);
+        Task<IProjectTree?> CreateFolderAsync(string path);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IPhysicalProjectTreeStorage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IPhysicalProjectTreeStorage.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
     internal interface IPhysicalProjectTreeStorage
     {
         /// <summary>
-        ///     Creates a zeroed file on disk, adding it add to the physical project tree.
+        ///     Creates a zero-byte file on disk, adding it add to the physical project tree.
         /// </summary>
         /// <param name="path">
         ///     The path of the folder to create, can be relative to the project directory.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IPhysicalProjectTreeStorage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IPhysicalProjectTreeStorage.cs
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// <exception cref="NotSupportedException">
         ///     <paramref name="path"/> contains a colon character (:) that is not part of a drive label ("C:\").
         /// </exception>
-        Task<IProjectItem?> CreateFileAsync(string path);
+        Task<IProjectItem?> CreateEmpyFileAsync(string path);
 
         /// <summary>
         ///     Creates a folder on disk, adding it add to the physical project tree.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PhysicalProjectTreeStorage.ConfiguredImports.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PhysicalProjectTreeStorage.ConfiguredImports.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    internal partial class PhysicalProjectTreeStorage
+    {
+        [Export]
+        internal class ConfiguredImports
+        {
+            public readonly IFolderManager FolderManager;
+            public readonly IProjectItemProvider SourceItemsProvider;
+
+            [ImportingConstructor]
+            public ConfiguredImports(IFolderManager folderManager, [Import(ExportContractNames.ProjectItemProviders.SourceFiles)]IProjectItemProvider sourceItemsProvider)
+            {
+                FolderManager = folderManager;
+                SourceItemsProvider = sourceItemsProvider;
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PhysicalProjectTreeStorage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PhysicalProjectTreeStorage.cs
@@ -14,11 +14,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
         private readonly Lazy<IFileSystem> _fileSystem;
         private readonly ActiveConfiguredProject<IFolderManager> _folderManager;
         private readonly ActiveConfiguredProject<IProjectItemProvider> _sourceItemProvider;
-        private readonly Lazy<IProjectTreeService> _treeService;
+        private readonly IProjectTreeService _treeService;
         private readonly UnconfiguredProject _unconfiguredProject;
 
         [ImportingConstructor]
-        public PhysicalProjectTreeStorage([Import(ExportContractNames.ProjectTreeProviders.PhysicalProjectTreeService)]Lazy<IProjectTreeService> treeService,
+        public PhysicalProjectTreeStorage([Import(ExportContractNames.ProjectTreeProviders.PhysicalProjectTreeService)]IProjectTreeService treeService,
                                           Lazy<IFileSystem> fileSystem,
                                           ActiveConfiguredProject<IFolderManager> folderManager,
                                           [Import(ExportContractNames.ProjectItemProviders.SourceFiles)]ActiveConfiguredProject<IProjectItemProvider> sourceItemProvider,
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             await addToProject(fullPath);
 
-            IProjectTreeServiceState state = await _treeService.Value.PublishLatestTreeAsync(waitForFileSystemUpdates);
+            IProjectTreeServiceState state = await _treeService.PublishLatestTreeAsync(waitForFileSystemUpdates);
 
             return state.TreeProvider.FindByPath(state.Tree, fullPath);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PhysicalProjectTreeStorage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PhysicalProjectTreeStorage.cs
@@ -61,9 +61,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         private async Task<IProjectTree?> AddToProjectAsync(string path, bool waitForFileSystemUpdates, Func<string, Task> addToProject)
         {
-            if (_treeService.Value.CurrentTree == null)
-                throw new InvalidOperationException("Physical project tree has not yet been published.");
-
             string fullPath = _unconfiguredProject.MakeRooted(path);
 
             await addToProject(fullPath);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PhysicalProjectTreeStorage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PhysicalProjectTreeStorage.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             _unconfiguredProject = project;
         }
 
-        public async Task<IProjectItem?> CreateFileAsync(string path)
+        public async Task<IProjectItem?> CreateEmpyFileAsync(string path)
         {
             Requires.NotNullOrEmpty(path, nameof(path));
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PhysicalProjectTreeStorage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PhysicalProjectTreeStorage.cs
@@ -35,11 +35,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             Requires.NotNullOrEmpty(path, nameof(path));
 
-            return await AddToProjectAsync(path, waitForFileSystemUpdates: true, async fullPath =>
+            return await AddToProjectAsync(path, waitForFileSystemUpdates: true, fullPath =>
             {
                 using (_fileSystem.Value.Create(fullPath)) { }
 
-                await _sourceItemProvider.Value.AddAsync(fullPath);
+                return _sourceItemProvider.Value.AddAsync(fullPath);
 
             }) as IProjectItem;
         }
@@ -48,11 +48,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             Requires.NotNullOrEmpty(path, nameof(path));
 
-            return AddToProjectAsync(path, waitForFileSystemUpdates: false, async fullPath =>
+            return AddToProjectAsync(path, waitForFileSystemUpdates: false, fullPath =>
             {
                 _fileSystem.Value.CreateDirectory(fullPath);
 
-                await _folderManager.Value.IncludeFolderInProjectAsync(fullPath, recursive: false);
+                return _folderManager.Value.IncludeFolderInProjectAsync(fullPath, recursive: false);
             });
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PhysicalProjectTreeStorage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PhysicalProjectTreeStorage.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             _unconfiguredProject = project;
         }
 
-        public async Task<IProjectItem?> CreateEmpyFileAsync(string path)
+        public async Task<IProjectItem?> CreateEmptyFileAsync(string path)
         {
             Requires.NotNullOrEmpty(path, nameof(path));
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PhysicalProjectTreeStorage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PhysicalProjectTreeStorage.cs
@@ -15,19 +15,16 @@ namespace Microsoft.VisualStudio.ProjectSystem
         private readonly ActiveConfiguredProject<IFolderManager> _folderManager;
         private readonly ActiveConfiguredProject<IProjectItemProvider> _sourceItemProvider;
         private readonly Lazy<IProjectTreeService> _treeService;
-        private readonly Lazy<IProjectTreeProvider> _treeProvider;
         private readonly UnconfiguredProject _unconfiguredProject;
 
         [ImportingConstructor]
         public PhysicalProjectTreeStorage([Import(ExportContractNames.ProjectTreeProviders.PhysicalProjectTreeService)]Lazy<IProjectTreeService> treeService,
-                                          [Import(ExportContractNames.ProjectTreeProviders.PhysicalViewTree)]Lazy<IProjectTreeProvider> treeProvider,
                                           Lazy<IFileSystem> fileSystem,
                                           ActiveConfiguredProject<IFolderManager> folderManager,
                                           [Import(ExportContractNames.ProjectItemProviders.SourceFiles)]ActiveConfiguredProject<IProjectItemProvider> sourceItemProvider,
                                           UnconfiguredProject project)
         {
             _treeService = treeService;
-            _treeProvider = treeProvider;
             _sourceItemProvider = sourceItemProvider;
             _fileSystem = fileSystem;
             _folderManager = folderManager;
@@ -65,9 +62,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             await addToProject(fullPath);
 
-            await _treeService.Value.PublishLatestTreeAsync(waitForFileSystemUpdates);
+            IProjectTreeServiceState state = await _treeService.Value.PublishLatestTreeAsync(waitForFileSystemUpdates);
 
-            return _treeProvider.Value.FindByPath(_treeService.Value.CurrentTree.Tree, fullPath);
+            return state.TreeProvider.FindByPath(state.Tree, fullPath);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractFindByNameSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractFindByNameSpecialFileProvider.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Immutable;
-using System.ComponentModel.Composition;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -29,8 +28,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
 
         protected AbstractFindByNameSpecialFileProvider(
             IPhysicalProjectTree projectTree,
-            [Import(ExportContractNames.ProjectItemProviders.SourceFiles)] IProjectItemProvider sourceItemsProvider,
-            [Import(AllowDefault = true)] Lazy<ICreateFileFromTemplateService>? templateFileCreationService,
+            IProjectItemProvider sourceItemsProvider,
+            Lazy<ICreateFileFromTemplateService>? templateFileCreationService,
             IFileSystem fileSystem,
             ISpecialFilesManager specialFileManager)
         {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemFactory.cs
@@ -14,6 +14,15 @@ namespace Microsoft.VisualStudio.IO
             return Mock.Of<IFileSystem>();
         }
 
+        public static IFileSystem ImplementCreate(Func<string, Stream> action)
+        {
+            var mock = new Mock<IFileSystem>();
+            mock.Setup(f => f.Create(It.IsAny<string>()))
+                .Returns(action);
+
+            return mock.Object;
+        }
+
         public static IFileSystem ImplementCreateDirectory(Action<string> action)
         {
             var mock = new Mock<IFileSystem>();

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectItemProviderFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectItemProviderFactory.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -12,6 +13,15 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public static IProjectItemProvider Create()
         {
             return Mock.Of<IProjectItemProvider>();
+        }
+
+        public static IProjectItemProvider AddItemAsync(Func<string, IProjectItem> action)
+        {
+            var mock = new Mock<IProjectItemProvider>();
+            mock.Setup(p => p.AddAsync(It.IsAny<string>()))
+                .ReturnsAsync(action);
+
+            return mock.Object;
         }
 
         public static IProjectItemProvider CreateWithAdd(IProjectTree inputTree)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectTreeServiceFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectTreeServiceFactory.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal static class IProjectTreeServiceFactory
     {
-        public static IProjectTreeService Create(IProjectTree tree, IProjectTreeProvider? treeProvider = null)
+        public static IProjectTreeService Create(IProjectTree? tree = null, IProjectTreeProvider? treeProvider = null)
         {
             var mock = new Mock<IProjectTreeService>();
 
@@ -19,6 +19,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 .ReturnsAsync(treeState);
 
             mock.Setup(s => s.PublishAnyNonNullTreeAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(treeState);
+
+            mock.Setup(s => s.PublishLatestTreeAsync(It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(treeState);
 
             mock.SetupGet(s => s.CurrentTree)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectTreeServiceStateFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectTreeServiceStateFactory.cs
@@ -13,12 +13,20 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return Mock.Of<IProjectTreeServiceState>();
         }
 
-        public static IProjectTreeServiceState ImplementTree(Func<IProjectTree?> treeAction, Func<IProjectTreeProvider>? treeProviderAction = null)
+        public static IProjectTreeServiceState ImplementTreeProvider(Func<IProjectTreeProvider>? action)
+        {
+            return ImplementTree(null, action);
+        }
+
+        public static IProjectTreeServiceState ImplementTree(Func<IProjectTree?>? treeAction = null, Func<IProjectTreeProvider>? treeProviderAction = null)
         {
             var mock = new Mock<IProjectTreeServiceState>();
 
-            mock.SetupGet<IProjectTree?>(s => s.Tree)
-                .Returns(treeAction);
+            if (treeAction != null)
+            {
+                mock.SetupGet<IProjectTree?>(s => s.Tree)
+                    .Returns(treeAction);
+            }
 
             if (treeProviderAction != null)
             {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeStorageTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeStorageTests.cs
@@ -57,18 +57,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         [Fact]
-        public void CreateFolderAsync_WhenTreeNotPublished_ThrowsInvalidOperation()
-        {
-            var treeService = IProjectTreeServiceFactory.ImplementCurrentTree(() => null);
-            var storage = CreateInstance(treeService: treeService);
-
-            Assert.Throws<InvalidOperationException>(() =>
-            {
-                storage.CreateFolderAsync("path");
-            });
-        }
-
-        [Fact]
         public async Task CreateFileAsync_CreatesFileOnDisk()
         {
             string? result = null;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeStorageTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeStorageTests.cs
@@ -13,24 +13,24 @@ namespace Microsoft.VisualStudio.ProjectSystem
     public class PhysicalProjectTreeStorageTests
     {
         [Fact]
-        public async Task CreateFileAsync_NullAsPath_ThrowsArgumentNull()
+        public async Task CreateEmptyFileAsync_NullAsPath_ThrowsArgumentNull()
         {
             var storage = CreateInstance();
 
             await Assert.ThrowsAsync<ArgumentNullException>("path", () =>
             {
-                return storage.CreateFileAsync((string?)null!);
+                return storage.CreateEmpyFileAsync((string?)null!);
             });
         }
 
         [Fact]
-        public async Task CreateFileAsync_EmptyAsPath_ThrowsArgument()
+        public async Task CreateEmptyFileAsync_EmptyAsPath_ThrowsArgument()
         {
             var storage = CreateInstance();
 
             await Assert.ThrowsAsync<ArgumentException>("path", () =>
             {
-                return storage.CreateFileAsync(string.Empty);
+                return storage.CreateEmpyFileAsync(string.Empty);
             });
         }
 
@@ -57,7 +57,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         [Fact]
-        public async Task CreateFileAsync_CreatesFileOnDisk()
+        public async Task CreateEmptyFileAsync_CreatesFileOnDisk()
         {
             string? result = null;
             var project = UnconfiguredProjectFactory.Create(filePath: @"C:\Project\Project.csproj");
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             var storage = CreateInstance(fileSystem: fileSystem, project: project);
 
-            await storage.CreateFileAsync(@"Properties\File.cs");
+            await storage.CreateEmpyFileAsync(@"Properties\File.cs");
 
             Assert.Equal(@"C:\Project\Properties\File.cs", result);
         }
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         [Fact]
-        public async Task CreateFileAsync_AddsFileToProject()
+        public async Task CreateEmptyFileAsync_AddsFileToProject()
         {
             string? result = null;
             var project = UnconfiguredProjectFactory.Create(filePath: @"C:\Project.csproj");
@@ -93,7 +93,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var sourceItemsProvider = IProjectItemProviderFactory.AddItemAsync(path => { result = path; return null!; });
             var storage = CreateInstance(sourceItemsProvider: sourceItemsProvider, project: project);
 
-            await storage.CreateFileAsync("File.cs");
+            await storage.CreateEmpyFileAsync("File.cs");
 
             Assert.Equal(@"C:\File.cs", result);
         }
@@ -142,7 +142,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         [InlineData(@"C:\Projects\Project.csproj",  @"..\Folder With Spaces\Folder\File.cs", @"C:\Folder With Spaces\Folder\File.cs")]
         [InlineData(@"C:\Projects\Project.csproj",  @"C:\Folder With Spaces\Folder\File.cs", @"C:\Folder With Spaces\Folder\File.cs")]
         [InlineData(@"C:\Projects\Project.csproj",  @"D:\Folder With Spaces\Folder\File.cs", @"D:\Folder With Spaces\Folder\File.cs")]
-        public async Task CreateFileAsync_ValueAsPath_IsCalculatedRelativeToProjectDirectory(string projectPath, string input, string expected)
+        public async Task CreateEmptyFileAsync_ValueAsPath_IsCalculatedRelativeToProjectDirectory(string projectPath, string input, string expected)
         {
             var project = UnconfiguredProjectFactory.Create(filePath: projectPath);
             string? result = null;
@@ -151,7 +151,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             var storage = CreateInstance(projectTreeService: projectTreeService, project: project);
 
-            await storage.CreateFileAsync(input);
+            await storage.CreateEmpyFileAsync(input);
 
             Assert.Equal(expected, result);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeStorageTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeStorageTests.cs
@@ -35,24 +35,24 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         [Fact]
-        public void CreateFolderAsync_NullAsPath_ThrowsArgumentNull()
+        public async Task CreateFolderAsync_NullAsPath_ThrowsArgumentNull()
         {
             var storage = CreateInstance();
 
-            Assert.Throws<ArgumentNullException>("path", () =>
+            await Assert.ThrowsAsync<ArgumentNullException>("path", async () =>
             {
-                storage.CreateFolderAsync((string?)null!);
+                await storage.CreateFolderAsync((string?)null!);
             });
         }
 
         [Fact]
-        public void CreateFolderAsync_EmptyAsPath_ThrowsArgument()
+        public async Task CreateFolderAsync_EmptyAsPath_ThrowsArgument()
         {
             var storage = CreateInstance();
 
-            Assert.Throws<ArgumentException>("path", () =>
+            await Assert.ThrowsAsync<ArgumentException>("path", async () =>
             {
-                storage.CreateFolderAsync(string.Empty);
+                await storage.CreateFolderAsync(string.Empty);
             });
         }
 
@@ -146,10 +146,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             var project = UnconfiguredProjectFactory.Create(filePath: projectPath);
             string? result = null;
-            var treeProvider = IProjectTreeProviderFactory.ImplementFindByPath((root, path) => { result = path; return null; });
-            var projectTreeService = IProjectTreeServiceFactory.Create(treeProvider: treeProvider);
+            var fileSystem = IFileSystemFactory.ImplementCreate(path => { result = path; return new MemoryStream(); });
 
-            var storage = CreateInstance(projectTreeService: projectTreeService, project: project);
+            var storage = CreateInstance(fileSystem: fileSystem, project: project);
 
             await storage.CreateEmptyFileAsync(input);
 
@@ -176,10 +175,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             var project = UnconfiguredProjectFactory.Create(filePath: projectPath);
             string? result = null;
-            var treeProvider = IProjectTreeProviderFactory.ImplementFindByPath((root, path) => { result = path; return null; });
-            var projectTreeService = IProjectTreeServiceFactory.Create(treeProvider: treeProvider);
+            var fileSystem = IFileSystemFactory.ImplementCreateDirectory(path => { result = path; });
 
-            var storage = CreateInstance(projectTreeService: projectTreeService, project: project);
+            var storage = CreateInstance(fileSystem: fileSystem, project: project);
 
             await storage.CreateFolderAsync(input);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeStorageTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeStorageTests.cs
@@ -147,9 +147,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var project = UnconfiguredProjectFactory.Create(filePath: projectPath);
             string? result = null;
             var treeProvider = IProjectTreeProviderFactory.ImplementFindByPath((root, path) => { result = path; return null; });
-            var currentTree = ProjectTreeParser.Parse(projectPath);
+            var projectTreeService = IProjectTreeServiceFactory.Create(treeProvider: treeProvider);
 
-            var storage = CreateInstance(treeProvider: treeProvider, project: project);
+            var storage = CreateInstance(projectTreeService: projectTreeService, project: project);
 
             await storage.CreateFileAsync(input);
 
@@ -177,26 +177,24 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var project = UnconfiguredProjectFactory.Create(filePath: projectPath);
             string? result = null;
             var treeProvider = IProjectTreeProviderFactory.ImplementFindByPath((root, path) => { result = path; return null; });
-            var currentTree = ProjectTreeParser.Parse(projectPath);
+            var projectTreeService = IProjectTreeServiceFactory.Create(treeProvider: treeProvider);
 
-            var storage = CreateInstance(treeProvider: treeProvider, project: project);
+            var storage = CreateInstance(projectTreeService: projectTreeService, project: project);
 
             await storage.CreateFolderAsync(input);
 
             Assert.Equal(expected, result);
         }
 
-        private static PhysicalProjectTreeStorage CreateInstance(IProjectTreeService? treeService = null, IProjectTreeProvider? treeProvider = null, IProjectItemProvider? sourceItemsProvider = null, IFileSystem? fileSystem = null, IFolderManager? folderManager = null, UnconfiguredProject? project = null)
+        private static PhysicalProjectTreeStorage CreateInstance(IProjectTreeService? projectTreeService = null, IProjectItemProvider? sourceItemsProvider = null, IFileSystem? fileSystem = null, IFolderManager? folderManager = null, UnconfiguredProject? project = null)
         {
-            treeService ??= IProjectTreeServiceFactory.Create(ProjectTreeParser.Parse("Root"));
-            treeProvider ??= IProjectTreeProviderFactory.Create();
+            projectTreeService ??= IProjectTreeServiceFactory.Create(ProjectTreeParser.Parse("Root"));
             fileSystem ??= IFileSystemFactory.Create();
             folderManager ??= IFolderManagerFactory.Create();
             sourceItemsProvider ??= IProjectItemProviderFactory.Create();
             project ??= UnconfiguredProjectFactory.Create();
 
-            return new PhysicalProjectTreeStorage(new Lazy<IProjectTreeService>(() => treeService),
-                                                  new Lazy<IProjectTreeProvider>(() => treeProvider),
+            return new PhysicalProjectTreeStorage(new Lazy<IProjectTreeService>(() => projectTreeService),
                                                   new Lazy<IFileSystem>(() => fileSystem),
                                                   ActiveConfiguredProjectFactory.ImplementValue(() => folderManager),
                                                   ActiveConfiguredProjectFactory.ImplementValue(() => sourceItemsProvider),

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeStorageTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeStorageTests.cs
@@ -192,11 +192,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
             sourceItemsProvider ??= IProjectItemProviderFactory.Create();
             project ??= UnconfiguredProjectFactory.Create();
 
-            return new PhysicalProjectTreeStorage(projectTreeService,
-                                                  new Lazy<IFileSystem>(() => fileSystem),
-                                                  ActiveConfiguredProjectFactory.ImplementValue(() => folderManager),
-                                                  ActiveConfiguredProjectFactory.ImplementValue(() => sourceItemsProvider),
-                                                  project);
+            return new PhysicalProjectTreeStorage(
+                project,
+                projectTreeService,
+                new Lazy<IFileSystem>(() => fileSystem),
+                ActiveConfiguredProjectFactory.ImplementValue(() => new PhysicalProjectTreeStorage.ConfiguredImports(folderManager, sourceItemsProvider)));
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeStorageTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeStorageTests.cs
@@ -194,7 +194,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             sourceItemsProvider ??= IProjectItemProviderFactory.Create();
             project ??= UnconfiguredProjectFactory.Create();
 
-            return new PhysicalProjectTreeStorage(new Lazy<IProjectTreeService>(() => projectTreeService),
+            return new PhysicalProjectTreeStorage(projectTreeService,
                                                   new Lazy<IFileSystem>(() => fileSystem),
                                                   ActiveConfiguredProjectFactory.ImplementValue(() => folderManager),
                                                   ActiveConfiguredProjectFactory.ImplementValue(() => sourceItemsProvider),

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeStorageTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeStorageTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             await Assert.ThrowsAsync<ArgumentNullException>("path", () =>
             {
-                return storage.CreateEmpyFileAsync((string?)null!);
+                return storage.CreateEmptyFileAsync((string?)null!);
             });
         }
 
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             await Assert.ThrowsAsync<ArgumentException>("path", () =>
             {
-                return storage.CreateEmpyFileAsync(string.Empty);
+                return storage.CreateEmptyFileAsync(string.Empty);
             });
         }
 
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             var storage = CreateInstance(fileSystem: fileSystem, project: project);
 
-            await storage.CreateEmpyFileAsync(@"Properties\File.cs");
+            await storage.CreateEmptyFileAsync(@"Properties\File.cs");
 
             Assert.Equal(@"C:\Project\Properties\File.cs", result);
         }
@@ -93,7 +93,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var sourceItemsProvider = IProjectItemProviderFactory.AddItemAsync(path => { result = path; return null!; });
             var storage = CreateInstance(sourceItemsProvider: sourceItemsProvider, project: project);
 
-            await storage.CreateEmpyFileAsync("File.cs");
+            await storage.CreateEmptyFileAsync("File.cs");
 
             Assert.Equal(@"C:\File.cs", result);
         }
@@ -151,7 +151,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             var storage = CreateInstance(projectTreeService: projectTreeService, project: project);
 
-            await storage.CreateEmpyFileAsync(input);
+            await storage.CreateEmptyFileAsync(input);
 
             Assert.Equal(expected, result);
         }


### PR DESCRIPTION
This is breakout from a larger PR where I'm adding licenses special file provider support, this adds a new method called `IPhysicalProjectTreeStorage.AddFileAsync` which creates a zero'd file on disk and publishes it to Solution Explorer before it has returned.