### PR TITLE
Force generate package on build to false when packing

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommand.cs
@@ -112,13 +112,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 
         public int UpdateSolution_Done(int fSucceeded, int fModified, int fCancelCommand)
         {
-            _generatePackageOnBuildPropertyProvider.OverrideGeneratePackageOnBuild(false);
+            _generatePackageOnBuildPropertyProvider.OverrideGeneratePackageOnBuild(null);
             return HResult.OK;
         }
 
         public int UpdateSolution_Cancel()
         {
-            _generatePackageOnBuildPropertyProvider.OverrideGeneratePackageOnBuild(false);
+            _generatePackageOnBuildPropertyProvider.OverrideGeneratePackageOnBuild(null);
             return HResult.OK;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommand.cs
@@ -100,7 +100,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 
                 // We tell the Solution Build Manager to Package, which will call the Pack target, which will build if necessary.
                 uint[] buildFlags = new[] { VSConstants.VS_BUILDABLEPROJECTCFGOPTS_PACKAGE };
-                ErrorHandler.ThrowOnFailure(_buildManager.StartUpdateSpecificProjectConfigurations(1, new[] { projectVsHierarchy }, null, null, buildFlags, null, dwFlags, 0));
+                ErrorHandler.ThrowOnFailure(_buildManager.StartUpdateSpecificProjectConfigurations(cProjs: 1,
+                                                                                                   rgpHier: new[] { projectVsHierarchy },
+                                                                                                   rgpcfg: null,
+                                                                                                   rgdwCleanFlags: null,
+                                                                                                   rgdwBuildFlags: buildFlags,
+                                                                                                   rgdwDeployFlags: null,
+                                                                                                   dwFlags: dwFlags,
+                                                                                                   fSuppressUI: 0));
             }
 
             return true;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/GeneratePackageOnBuildPropertyProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/GeneratePackageOnBuildPropertyProvider.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Build
     [AppliesTo(ProjectCapability.Pack)]
     internal class GeneratePackageOnBuildPropertyProvider : StaticGlobalPropertiesProviderBase
     {
-        private bool _overrideGeneratePackageOnBuild;
+        private bool? _overrideGeneratePackageOnBuild;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TargetFrameworkGlobalBuildPropertyProvider"/> class.
@@ -24,10 +24,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Build
         internal GeneratePackageOnBuildPropertyProvider(IProjectService projectService)
             : base(projectService.Services)
         {
-            _overrideGeneratePackageOnBuild = false;
         }
 
-        public void OverrideGeneratePackageOnBuild(bool value)
+        /// <summary>
+        /// Overrides the value of GeneratePackageOnBuild to the value specified, or resets to the project property value if <c>null</c> is passed in.
+        /// </summary>
+        public void OverrideGeneratePackageOnBuild(bool? value)
         {
             _overrideGeneratePackageOnBuild = value;
         }
@@ -40,9 +42,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Build
         {
             IImmutableDictionary<string, string> properties = Empty.PropertiesMap;
 
-            if (_overrideGeneratePackageOnBuild)
+            if (_overrideGeneratePackageOnBuild.HasValue)
             {
-                properties = properties.Add(ConfigurationGeneralBrowseObject.GeneratePackageOnBuildProperty, "true");
+                properties = properties.Add(ConfigurationGeneralBrowseObject.GeneratePackageOnBuildProperty, _overrideGeneratePackageOnBuild.Value ? "true" : "false");
             }
 
             return Task.FromResult(properties);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -21,6 +21,9 @@
     <SupportedOutputTypes Condition="'$(SupportedOutputTypes)' == ''">Exe;WinExe;Library</SupportedOutputTypes>
 
     <SuppressOutOfDateMessageOnBuild Condition="'$(SuppressOutOfDateMessageOnBuild)' == ''">true</SuppressOutOfDateMessageOnBuild>
+
+    <!-- Tells CPS which target to run for the Package solution build type -->
+    <PackageAction Condition="'$(PackageAction)' == ''">Pack</PackageAction>
   </PropertyGroup>
 
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsSolutionBuildManager2Factory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsSolutionBuildManager2Factory.cs
@@ -39,8 +39,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
                     return VSConstants.S_OK;
                 }
 
-                uint dwFlags = (uint)(VSSOLNBUILDUPDATEFLAGS.SBF_SUPPRESS_SAVEBEFOREBUILD_QUERY | VSSOLNBUILDUPDATEFLAGS.SBF_OPERATION_BUILD);
-                buildManager.Setup(b => b.StartSimpleUpdateProjectConfiguration(hierarchyToBuild, It.IsAny<IVsHierarchy>(), It.IsAny<string>(), dwFlags, It.IsAny<uint>(), It.IsAny<int>()))
+                buildManager.Setup(b => b.StartUpdateSpecificProjectConfigurations(It.IsAny<uint>(), It.IsAny<IVsHierarchy[]>(), It.IsAny<IVsCfg[]>(), It.IsAny<uint[]>(), It.IsAny<uint[]>(), It.IsAny<uint[]>(), It.IsAny<uint>(), It.IsAny<int>()))
                     .Returns(onBuildStartedWithReturn);
             }
 


### PR DESCRIPTION
Previously for the Pack command we would set GeneratePackageOnBuild to true, and then do a build. This causes a problem as we would see the project as up to date even if the package output didn't exist.

This fixes the problem by setting GeneratePackageOnBuild to false, and then calling the Pack target, which will create build outputs and/or package outputs as necessary. Just calling Pack isn't enough, as it has a condition that it doesn't do a build if GeneratePackageOnBuild is true, which according to the Nuget team is by design.

Fixes #1339
Fixes [AB#935258](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/935258)