### PR TITLE
Compute alias when needed

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Dependency.cs
@@ -214,18 +214,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
         public ITargetFramework TargetFramework { get; }
 
-        public string Alias
-        {
-            get
-            {
-                string path = OriginalItemSpec ?? Path;
-
-                return string.IsNullOrEmpty(path) || path.Equals(Caption, StringComparison.OrdinalIgnoreCase)
-                    ? Caption
-                    : string.Concat(Caption, " (", path, ")");
-            }
-        }
-
         public IDependency SetProperties(
             string? caption = null,
             bool? resolved = null,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/DuplicatedDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/DuplicatedDependenciesSnapshotFilter.cs
@@ -68,16 +68,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
                 if (matchingDependency != null)
                 {
                     // Change the matching dependency's alias too
-                    context.AddOrUpdate(matchingDependency.SetProperties(caption: matchingDependency.Alias));
+                    context.AddOrUpdate(matchingDependency.SetProperties(caption: GetAlias(matchingDependency)));
                 }
 
                 // Use the alias for the caption
-                context.Accept(dependency.SetProperties(caption: dependency.Alias));
+                context.Accept(dependency.SetProperties(caption: GetAlias(dependency)));
             }
             else
             {
                 // Accept without changes
                 context.Accept(dependency);
+            }
+
+            return;
+
+            static string GetAlias(IDependency dependency)
+            {
+                string path = dependency.OriginalItemSpec ?? dependency.Path;
+
+                return string.IsNullOrEmpty(path) || path.Equals(dependency.Caption, StringComparison.OrdinalIgnoreCase)
+                    ? dependency.Caption
+                    : string.Concat(dependency.Caption, " (", path, ")");
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/IDependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/IDependency.cs
@@ -22,12 +22,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         string FullPath { get; }
 
         /// <summary>
-        /// Alias is used to de-dupe tree nodes in the CPS tree. If there are several nodes in the same
-        /// folder with the same name, we replace them all with: <c>Alias = "Caption (OriginalItemSpec)"</c>.
-        /// </summary>
-        string Alias { get; }
-
-        /// <summary>
         /// Gets the set of icons to use for this dependency based on its state (e.g. resolved, expanded).
         /// </summary>
         DependencyIconSet IconSet { get; }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DependencyTests.cs
@@ -153,29 +153,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             Assert.Equal(expectedId, dependency.Id);
         }
 
-        [Theory]
-        [InlineData(@"SomeDependency", @"", @"SomeDependency", @"SomeDependency")]
-        [InlineData(null, @"SomeDependency", @"SomeDependency", @"SomeDependency")]
-        [InlineData(null, null, @"SomeDependency", @"SomeDependency")]
-        [InlineData(@"SomeOriginalItemSpec", @"", @"SomeDependency", @"SomeDependency (SomeOriginalItemSpec)")]
-        public void Dependency_Alias(string originalItemSpec, string path, string caption, string expectedAlias)
-        {
-            var dependencyModel = new TestDependencyModel
-            {
-                ProviderType = "providerType",
-                Id = "someId",
-                OriginalItemSpec = originalItemSpec,
-                Path = path,
-                Caption = caption
-            };
-
-            var targetFramework = new TargetFramework("tfm");
-
-            var dependency = new Dependency(dependencyModel, targetFramework, @"C:\Foo\Project.csproj");
-
-            Assert.Equal(expectedAlias, dependency.Alias);
-        }
-
         [Fact]
         public void Dependency_EqualsAndGetHashCode()
         {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DuplicatedDependenciesSnapshotFilterTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DuplicatedDependenciesSnapshotFilterTests.cs
@@ -65,12 +65,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             //   -> Changes caption for both to match alias
 
             const string providerType = "provider";
-            const string caption = "caption1";
+            const string caption = "caption";
 
             var dependency = new TestDependency
             {
-                Id = "dependency1",
-                Alias = "dependency1 (dependency1ItemSpec)",
+                Id = "id1",
+                OriginalItemSpec = "originalItemSpec1",
                 ProviderType = providerType,
                 Caption = caption,
                 TopLevel = true
@@ -80,8 +80,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             {
                 ClonePropertiesFrom = dependency, // clone, with changes
 
-                Id = "dependency2",
-                Alias = "dependency2 (dependency2ItemSpec)"
+                Id = "id2",
+                OriginalItemSpec = "originalItemSpec2"
             };
 
             var worldBuilder = new IDependency[] { dependency, otherDependency }.ToImmutableDictionary(d => d.Id).ToBuilder();
@@ -103,12 +103,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             // The filtered dependency had its caption changed to its alias
             var dependencyAfter = context.GetResult(filter);
             dependencyAfter!.AssertEqualTo(
-                new TestDependency { ClonePropertiesFrom = dependency, Caption = dependency.Alias });
+                new TestDependency { ClonePropertiesFrom = dependency, Caption = "caption (originalItemSpec1)" });
 
             // The other dependency had its caption changed to its alias
             Assert.True(context.TryGetDependency(otherDependency.Id, out IDependency otherDependencyAfter));
             otherDependencyAfter.AssertEqualTo(
-                new TestDependency { ClonePropertiesFrom = otherDependency, Caption = otherDependency.Alias });
+                new TestDependency { ClonePropertiesFrom = otherDependency, Caption = "caption (originalItemSpec2)" });
         }
 
         [Fact]
@@ -124,8 +124,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
             var dependency = new TestDependency
             {
-                Id = "dependency1",
-                Alias = "dependency1 (dependency1ItemSpec)",
+                Id = "id1",
+                OriginalItemSpec = "originalItemSpec1",
                 ProviderType = providerType,
                 Caption = caption,
                 TopLevel = true
@@ -135,9 +135,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             {
                 ClonePropertiesFrom = dependency,
 
-                Id = "dependency2",
-                OriginalItemSpec = "dependency2ItemSpec",
-                Caption = $"{caption} (dependency2ItemSpec)" // caption already includes alias
+                Id = "id2",
+                OriginalItemSpec = "originalItemSpec2",
+                Caption = $"{caption} (originalItemSpec2)" // caption already includes alias
             };
 
             var worldBuilder = new IDependency[] { dependency, otherDependency }.ToImmutableDictionary(d => d.Id).ToBuilder();
@@ -159,7 +159,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             // The filtered dependency had its caption changed to its alias
             var dependencyAfter = context.GetResult(filter);
             dependencyAfter!.AssertEqualTo(
-                new TestDependency { ClonePropertiesFrom = dependency, Caption = dependency.Alias });
+                new TestDependency { ClonePropertiesFrom = dependency, Caption = "caption (originalItemSpec1)" });
+
+            // The other dependency had its caption changed to its alias
+            Assert.True(context.TryGetDependency(otherDependency.Id, out IDependency otherDependencyAfter));
+            otherDependencyAfter.AssertEqualTo(
+                new TestDependency { ClonePropertiesFrom = otherDependency, Caption = "caption (originalItemSpec2)" });
         }
 
         [Fact]

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependency.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependency.cs
@@ -39,7 +39,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
                 DependencyIDs = value.DependencyIDs;
                 Flags = value.Flags;
                 Id = value.Id;
-                Alias = value.Alias;
                 TargetFramework = value.TargetFramework;
             }
         }
@@ -62,7 +61,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
         public ImmutableArray<string> DependencyIDs { get; set; } = ImmutableArray<string>.Empty;
         public ProjectTreeFlags Flags { get; set; } = ProjectTreeFlags.Empty;
         public string Id { get; set; }
-        public string Alias { get; set; }
         public ITargetFramework TargetFramework { get; set; }
         public DependencyIconSet IconSet { get; set; } = s_defaultIconSet;
 #pragma warning restore CS8618 // Non-nullable property is uninitialized

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependencyExtensions.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependencyExtensions.cs
@@ -9,25 +9,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             Xunit.Assert.NotNull(actual);
             Xunit.Assert.NotNull(expected);
 
-            Xunit.Assert.Equal(actual.ProviderType, expected.ProviderType);
-            Xunit.Assert.Equal(actual.Name, expected.Name);
-            Xunit.Assert.Equal(actual.Caption, expected.Caption);
-            Xunit.Assert.Equal(actual.OriginalItemSpec, expected.OriginalItemSpec);
-            Xunit.Assert.Equal(actual.Path, expected.Path);
-            Xunit.Assert.Equal(actual.FullPath, expected.FullPath);
-            Xunit.Assert.Equal(actual.SchemaName, expected.SchemaName);
-            Xunit.Assert.Equal(actual.SchemaItemType, expected.SchemaItemType);
-            Xunit.Assert.Equal(actual.Resolved, expected.Resolved);
-            Xunit.Assert.Equal(actual.TopLevel, expected.TopLevel);
-            Xunit.Assert.Equal(actual.Implicit, expected.Implicit);
-            Xunit.Assert.Equal(actual.Visible, expected.Visible);
-            Xunit.Assert.Equal(actual.Priority, expected.Priority);
-            Xunit.Assert.Equal(actual.IconSet, expected.IconSet);
-            Xunit.Assert.Equal(actual.Properties, expected.Properties);
-            Xunit.Assert.Equal(actual.DependencyIDs, expected.DependencyIDs);
-            Xunit.Assert.Equal(actual.Flags, expected.Flags);
-            Xunit.Assert.Equal(actual.Id, expected.Id);
-            Xunit.Assert.Equal(actual.TargetFramework, expected.TargetFramework);
+            Xunit.Assert.Equal(expected.ProviderType, actual.ProviderType);
+            Xunit.Assert.Equal(expected.Name, actual.Name);
+            Xunit.Assert.Equal(expected.Caption, actual.Caption);
+            Xunit.Assert.Equal(expected.OriginalItemSpec, actual.OriginalItemSpec);
+            Xunit.Assert.Equal(expected.Path, actual.Path);
+            Xunit.Assert.Equal(expected.FullPath, actual.FullPath);
+            Xunit.Assert.Equal(expected.SchemaName, actual.SchemaName);
+            Xunit.Assert.Equal(expected.SchemaItemType, actual.SchemaItemType);
+            Xunit.Assert.Equal(expected.Resolved, actual.Resolved);
+            Xunit.Assert.Equal(expected.TopLevel, actual.TopLevel);
+            Xunit.Assert.Equal(expected.Implicit, actual.Implicit);
+            Xunit.Assert.Equal(expected.Visible, actual.Visible);
+            Xunit.Assert.Equal(expected.Priority, actual.Priority);
+            Xunit.Assert.Equal(expected.IconSet, actual.IconSet);
+            Xunit.Assert.Equal(expected.Properties, actual.Properties);
+            Xunit.Assert.Equal(expected.DependencyIDs, actual.DependencyIDs);
+            Xunit.Assert.Equal(expected.Flags, actual.Flags);
+            Xunit.Assert.Equal(expected.Id, actual.Id);
+            Xunit.Assert.Equal(expected.TargetFramework, actual.TargetFramework);
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependencyExtensions.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/TestDependencyExtensions.cs
@@ -27,7 +27,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
             Xunit.Assert.Equal(actual.DependencyIDs, expected.DependencyIDs);
             Xunit.Assert.Equal(actual.Flags, expected.Flags);
             Xunit.Assert.Equal(actual.Id, expected.Id);
-            Xunit.Assert.Equal(actual.Alias, expected.Alias);
             Xunit.Assert.Equal(actual.TargetFramework, expected.TargetFramework);
         }
     }


### PR DESCRIPTION
This computed property does not need to be on `IDependency`.

Part of work to consolidate code across the dependency node (in this case `IDependencyModel` and `IDependency`).