### PR TITLE
Fix up-to-date false negative on project load

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.State.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.State.cs
@@ -294,6 +294,29 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     copyReferenceInputs,
                     lastItemsChangedAtUtc,
                     LastCheckedAtUtc);
+
+                static CopyToOutputDirectoryType GetCopyType(IImmutableDictionary<string, string> itemMetadata)
+                {
+                    if (itemMetadata.TryGetValue(CopyToOutputDirectory, out string value))
+                    {
+                        if (string.Equals(value, Always, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return CopyToOutputDirectoryType.CopyAlways;
+                        }
+
+                        if (string.Equals(value, PreserveNewest, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return CopyToOutputDirectoryType.CopyIfNewer;
+                        }
+                    }
+
+                    return CopyToOutputDirectoryType.CopyNever;
+                }
+
+                static string? GetLink(IImmutableDictionary<string, string> itemMetadata)
+                {
+                    return itemMetadata.TryGetValue(Link, out string link) ? link : null;
+                }
             }
 
             public State WithLastCheckedAtUtc(DateTime lastCheckedAtUtc)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.State.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.State.cs
@@ -28,8 +28,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             /// Gets the time at which the set of items changed.
             /// </summary>
             /// <remarks>
+            /// <para>
             /// This is not the last timestamp of the items themselves. It is time at which items were
             /// last added or removed from the project.
+            /// </para>
+            /// <para>
+            /// This property is not updated until after the first query occurs. Until that time it will
+            /// equal <see cref="DateTime.MinValue"/> which represents the fact that we do not know when
+            /// the set of items was last changed, so we cannot base any decisions on this data property.
+            /// </para>
             /// </remarks>
             public DateTime LastItemsChangedAtUtc { get; }
 
@@ -273,7 +280,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     itemsChanged = true;
                 }
 
-                DateTime lastItemsChangedAtUtc = itemsChanged ? DateTime.UtcNow : LastItemsChangedAtUtc;
+                // NOTE when we previously had zero item types, we can surmise that the project has just been loaded. In such
+                // a case it is not correct to assume that the items changed, and so we do not update the timestamp.
+                // See https://github.com/dotnet/project-system/issues/5386
+                DateTime lastItemsChangedAtUtc = itemsChanged && ItemTypes.Count != 0 ? DateTime.UtcNow : LastItemsChangedAtUtc;
 
                 return new State(
                     msBuildProjectFullPath,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -119,27 +119,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             return Task.CompletedTask;
         }
 
-        private static string? GetLink(IImmutableDictionary<string, string> itemMetadata) =>
-            itemMetadata.TryGetValue(Link, out string link) ? link : null;
-
-        private static CopyToOutputDirectoryType GetCopyType(IImmutableDictionary<string, string> itemMetadata)
-        {
-            if (itemMetadata.TryGetValue(CopyToOutputDirectory, out string value))
-            {
-                if (string.Equals(value, Always, StringComparison.OrdinalIgnoreCase))
-                {
-                    return CopyToOutputDirectoryType.CopyAlways;
-                }
-
-                if (string.Equals(value, PreserveNewest, StringComparison.OrdinalIgnoreCase))
-                {
-                    return CopyToOutputDirectoryType.CopyIfNewer;
-                }
-            }
-
-            return CopyToOutputDirectoryType.CopyNever;
-        }
-
         internal void OnChanged(IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectSubscriptionUpdate, IProjectItemSchema>> e)
         {
             lock (_stateLock)


### PR DESCRIPTION
Fixes #5386.

A data point used by the fast up-to-date check in VS is the last time the set of inputs changed. This is used to address issues described in #4736 and #3245.

After #5089 that time stamp was updated when the project loaded. This meant that loading a project which is up-to-date (from MSBuild's perspective) would always have `LastItemsChangedAtUtc` after the last output time, but building would not update the outputs and the project would be considered out of date until it was actually rebuilt (either due to clean/rebuild/input change).

This change only updates `LastItemsChangedAtUtc` when we already have a set of items. This means the property maintains its default value (`DateTime.MinValue`) after project load and is only updated when the set of items actually changes.

(This PR targets `dev16.3.x` and once merged I'll cherry-pick it to `master` as well.)