### PR TITLE
Add 'minimal' log level for up-to-date check

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageControl.xaml.vb
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageControl.xaml.vb
@@ -11,6 +11,7 @@ Namespace Microsoft.VisualStudio.Editors.OptionPages
 
         Public Shared ReadOnly FastUpToDateLogLevelItemSource As String() = {
             My.Resources.GeneralOptionPageResources.General_FastUpToDateCheck_LogLevel_None,
+            My.Resources.GeneralOptionPageResources.General_FastUpToDateCheck_LogLevel_Minimal,
             My.Resources.GeneralOptionPageResources.General_FastUpToDateCheck_LogLevel_Info,
             My.Resources.GeneralOptionPageResources.General_FastUpToDateCheck_LogLevel_Verbose
         }

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.Designer.vb
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.Designer.vb
@@ -92,6 +92,15 @@ Namespace My.Resources
         End Property
 
         '''<summary>
+        '''  Looks up a localized string similar to Minimal.
+        '''</summary>
+        Friend Shared ReadOnly Property General_FastUpToDateCheck_LogLevel_Minimal() As String
+            Get
+                Return ResourceManager.GetString("General_FastUpToDateCheck_LogLevel_Minimal", resourceCulture)
+            End Get
+        End Property
+
+        '''<summary>
         '''  Looks up a localized string similar to None.
         '''</summary>
         Friend Shared ReadOnly Property General_FastUpToDateCheck_LogLevel_None() As String

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.resx
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageResources.resx
@@ -126,6 +126,9 @@
   <data name="General_FastUpToDateCheck_LogLevel_Info" xml:space="preserve">
     <value>Info</value>
   </data>
+  <data name="General_FastUpToDateCheck_LogLevel_Minimal" xml:space="preserve">
+    <value>Minimal</value>
+  </data>
   <data name="General_FastUpToDateCheck_LogLevel_None" xml:space="preserve">
     <value>None</value>
   </data>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptions.vb
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptions.vb
@@ -5,7 +5,7 @@ Imports System.Runtime.InteropServices
 Imports Microsoft.VisualStudio.Settings
 
 Namespace Microsoft.VisualStudio.Editors.OptionPages
-    Public NotInheritable Class GeneralOptions
+    Friend NotInheritable Class GeneralOptions
         <Guid("9B164E40-C3A2-4363-9BC5-EB4039DEF653")>
         Private Class SVsSettingsPersistenceManager
         End Class

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/LogLevel.vb
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/LogLevel.vb
@@ -2,6 +2,7 @@
 
 Public Enum LogLevel
     None
+    Minimal
     Info
     Verbose
 End Enum

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/LogLevel.vb
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/LogLevel.vb
@@ -1,8 +1,12 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Public Enum LogLevel
-    None
-    Minimal
-    Info
-    Verbose
-End Enum
+Namespace Microsoft.VisualStudio.Editors.OptionPages
+
+    Friend Enum LogLevel
+        None
+        Minimal
+        Info
+        Verbose
+    End Enum
+
+End Namespace

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.cs.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Informace</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_FastUpToDateCheck_LogLevel_Minimal">
+        <source>Minimal</source>
+        <target state="new">Minimal</target>
+        <note />
+      </trans-unit>
       <trans-unit id="General_FastUpToDateCheck_LogLevel_None">
         <source>None</source>
         <target state="translated">Žádné</target>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.de.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Info</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_FastUpToDateCheck_LogLevel_Minimal">
+        <source>Minimal</source>
+        <target state="new">Minimal</target>
+        <note />
+      </trans-unit>
       <trans-unit id="General_FastUpToDateCheck_LogLevel_None">
         <source>None</source>
         <target state="translated">Keine</target>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.es.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Información</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_FastUpToDateCheck_LogLevel_Minimal">
+        <source>Minimal</source>
+        <target state="new">Minimal</target>
+        <note />
+      </trans-unit>
       <trans-unit id="General_FastUpToDateCheck_LogLevel_None">
         <source>None</source>
         <target state="translated">Ninguno</target>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.fr.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Informations</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_FastUpToDateCheck_LogLevel_Minimal">
+        <source>Minimal</source>
+        <target state="new">Minimal</target>
+        <note />
+      </trans-unit>
       <trans-unit id="General_FastUpToDateCheck_LogLevel_None">
         <source>None</source>
         <target state="translated">Aucun</target>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.it.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Informazioni</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_FastUpToDateCheck_LogLevel_Minimal">
+        <source>Minimal</source>
+        <target state="new">Minimal</target>
+        <note />
+      </trans-unit>
       <trans-unit id="General_FastUpToDateCheck_LogLevel_None">
         <source>None</source>
         <target state="translated">Nessuno</target>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.ja.xlf
@@ -17,6 +17,11 @@
         <target state="translated">情報</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_FastUpToDateCheck_LogLevel_Minimal">
+        <source>Minimal</source>
+        <target state="new">Minimal</target>
+        <note />
+      </trans-unit>
       <trans-unit id="General_FastUpToDateCheck_LogLevel_None">
         <source>None</source>
         <target state="translated">なし</target>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.ko.xlf
@@ -17,6 +17,11 @@
         <target state="translated">정보</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_FastUpToDateCheck_LogLevel_Minimal">
+        <source>Minimal</source>
+        <target state="new">Minimal</target>
+        <note />
+      </trans-unit>
       <trans-unit id="General_FastUpToDateCheck_LogLevel_None">
         <source>None</source>
         <target state="translated">없음</target>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.pl.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Informacje</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_FastUpToDateCheck_LogLevel_Minimal">
+        <source>Minimal</source>
+        <target state="new">Minimal</target>
+        <note />
+      </trans-unit>
       <trans-unit id="General_FastUpToDateCheck_LogLevel_None">
         <source>None</source>
         <target state="translated">Brak</target>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.pt-BR.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Informações</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_FastUpToDateCheck_LogLevel_Minimal">
+        <source>Minimal</source>
+        <target state="new">Minimal</target>
+        <note />
+      </trans-unit>
       <trans-unit id="General_FastUpToDateCheck_LogLevel_None">
         <source>None</source>
         <target state="translated">Nenhum</target>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.ru.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Информация</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_FastUpToDateCheck_LogLevel_Minimal">
+        <source>Minimal</source>
+        <target state="new">Minimal</target>
+        <note />
+      </trans-unit>
       <trans-unit id="General_FastUpToDateCheck_LogLevel_None">
         <source>None</source>
         <target state="translated">Нет</target>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.tr.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Bilgi</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_FastUpToDateCheck_LogLevel_Minimal">
+        <source>Minimal</source>
+        <target state="new">Minimal</target>
+        <note />
+      </trans-unit>
       <trans-unit id="General_FastUpToDateCheck_LogLevel_None">
         <source>None</source>
         <target state="translated">Hiçbiri</target>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.zh-Hans.xlf
@@ -17,6 +17,11 @@
         <target state="translated">信息</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_FastUpToDateCheck_LogLevel_Minimal">
+        <source>Minimal</source>
+        <target state="new">Minimal</target>
+        <note />
+      </trans-unit>
       <trans-unit id="General_FastUpToDateCheck_LogLevel_None">
         <source>None</source>
         <target state="translated">无</target>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/xlf/GeneralOptionPageResources.zh-Hant.xlf
@@ -17,6 +17,11 @@
         <target state="translated">資訊</target>
         <note />
       </trans-unit>
+      <trans-unit id="General_FastUpToDateCheck_LogLevel_Minimal">
+        <source>Minimal</source>
+        <target state="new">Minimal</target>
+        <note />
+      </trans-unit>
       <trans-unit id="General_FastUpToDateCheck_LogLevel_None">
         <source>None</source>
         <target state="translated">無</target>

--- a/src/Microsoft.VisualStudio.Editors/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.Editors/PublicAPI.Shipped.txt
@@ -7,11 +7,6 @@ Const Microsoft.VisualStudio.Editors.PropPageDesigner.PropPageDesignerView.SW_SH
 Const Microsoft.VisualStudio.Editors.PropertyPages.ChildPageSite.NestingCharacter = ":" -> String (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Const Microsoft.VisualStudio.Editors.SettingsDesigner.PublicSettingsSingleFileGenerator.SingleFileGeneratorName = "PublicSettingsSingleFileGenerator" -> String
 Const Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator.SingleFileGeneratorName = "SettingsSingleFileGenerator" -> String
-LogLevel
-LogLevel.Info = 2 -> LogLevel
-LogLevel.Minimal = 1 -> LogLevel
-LogLevel.None = 0 -> LogLevel
-LogLevel.Verbose = 3 -> LogLevel
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerEditorFactory (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerEditorFactory.Close() -> Integer (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerEditorFactory.MapLogicalView(ByRef rguidLogicalView As System.Guid, ByRef pbstrPhysicalView As String) -> Integer (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
@@ -277,12 +272,6 @@ Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties.SingleInsta
 Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties.SingleInstance(value As Boolean) -> Void
 Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties.SplashScreen() -> String
 Microsoft.VisualStudio.Editors.MyApplication.MyApplicationProperties.SplashScreen(value As String) -> Void
-Microsoft.VisualStudio.Editors.OptionPages.GeneralOptions
-Microsoft.VisualStudio.Editors.OptionPages.GeneralOptions.FastUpToDateCheckEnabled() -> Boolean
-Microsoft.VisualStudio.Editors.OptionPages.GeneralOptions.FastUpToDateCheckEnabled(Value As Boolean) -> Void
-Microsoft.VisualStudio.Editors.OptionPages.GeneralOptions.FastUpToDateLogLevel() -> LogLevel
-Microsoft.VisualStudio.Editors.OptionPages.GeneralOptions.FastUpToDateLogLevel(Value As LogLevel) -> Void
-Microsoft.VisualStudio.Editors.OptionPages.GeneralOptions.New(serviceProvider As System.IServiceProvider) -> Void
 Microsoft.VisualStudio.Editors.PropPageDesigner.ConfigurationState (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.PropPageDesigner.ConfigurationState.ChangeSelection(ConfigIndex As Integer, PlatformIndex As Integer, FireNotifications As Boolean) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.PropPageDesigner.ConfigurationState.ChangeSelection(ConfigName As String, ConfigSelectionType As Microsoft.VisualStudio.Editors.PropPageDesigner.ConfigurationState.SelectionTypes, PlatformName As String, PlatformSelectionType As Microsoft.VisualStudio.Editors.PropPageDesigner.ConfigurationState.SelectionTypes, PreferExactMatch As Boolean, FireNotifications As Boolean) -> Void (forwarded, contained in Microsoft.VisualStudio.AppDesigner)

--- a/src/Microsoft.VisualStudio.Editors/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.Editors/PublicAPI.Shipped.txt
@@ -8,9 +8,10 @@ Const Microsoft.VisualStudio.Editors.PropertyPages.ChildPageSite.NestingCharacte
 Const Microsoft.VisualStudio.Editors.SettingsDesigner.PublicSettingsSingleFileGenerator.SingleFileGeneratorName = "PublicSettingsSingleFileGenerator" -> String
 Const Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator.SingleFileGeneratorName = "SettingsSingleFileGenerator" -> String
 LogLevel
-LogLevel.Info = 1 -> LogLevel
+LogLevel.Info = 2 -> LogLevel
+LogLevel.Minimal = 1 -> LogLevel
 LogLevel.None = 0 -> LogLevel
-LogLevel.Verbose = 2 -> LogLevel
+LogLevel.Verbose = 3 -> LogLevel
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerEditorFactory (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerEditorFactory.Close() -> Integer (forwarded, contained in Microsoft.VisualStudio.AppDesigner)
 Microsoft.VisualStudio.Editors.ApplicationDesigner.ApplicationDesignerEditorFactory.MapLogicalView(ByRef rguidLogicalView As System.Guid, ByRef pbstrPhysicalView As String) -> Integer (forwarded, contained in Microsoft.VisualStudio.AppDesigner)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Menus.vsct
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Menus.vsct
@@ -24,7 +24,7 @@
   <!--<Extern href="msobtnid.h" xmlns="http://schemas.microsoft.com/VisualStudio/2005-10-18/CommandTable" />-->
 
   <!-- This command is associated with the DebugTargetHandlerPackage as we want this package to handle our commands placed on the
-       debug (play button) menu contoller. It will redirect through code to our implementation of IVsProjectCfgDebugTargetSelection
+       debug (play button) menu controller. It will redirect through code to our implementation of IVsProjectCfgDebugTargetSelection
   -->
   <Commands package="guidDebugTargetHandlerPackage">
     <Buttons>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LogLevel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LogLevel.cs
@@ -5,6 +5,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
     internal enum LogLevel
     {
         None,
+        Minimal,
         Info,
         Verbose
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -154,7 +154,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
         private bool Fail(BuildUpToDateCheckLogger logger, string reason, string message, params object[] values)
         {
-            logger.Info(message, values);
+            logger.Minimal(message, values);
             _telemetryService.PostProperty(TelemetryEventName.UpToDateCheckFail, TelemetryPropertyName.UpToDateCheckFailReason, reason);
             return false;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheckLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheckLogger.cs
@@ -41,6 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             }
         }
 
+        public void Minimal(string message, params object[] values) => Log(LogLevel.Minimal, message, values);
         public void Info(string message, params object[] values) => Log(LogLevel.Info, message, values);
         public void Verbose(string message, params object[] values) => Log(LogLevel.Verbose, message, values);
     }


### PR DESCRIPTION
Fixes #5353.

This PR adds an additional log level option for the up-to-date check:

![image](https://user-images.githubusercontent.com/350947/64001226-b834d780-cb4a-11e9-8255-3b7e50048138.png)

The _Minimal_ level will cause the up to date check to log a single line for any project not considered up to date.

For example:

```
1>FastUpToDate: Input 'C:\Repo\Library\Class1.cs' is newer (30/08/2019 5:18:37 PM) than earliest output 'C:\Repo\Library\bin\Debug\netstandard2.0\Library.dll' (30/08/2019 4:54:01 PM), not up to date. (Library)
1>------ Build started: Project: Library, Configuration: Debug Any CPU ------
1>Library -> C:\Repo\Library\bin\Debug\netstandard2.0\Library.dll
2>FastUpToDate: Input 'C:\Repo\Library\bin\Debug\netstandard2.0\Library.dll' is newer (30/08/2019 5:18:43 PM) than earliest output 'C:\Repo\ConsoleApp\bin\Debug\netcoreapp2.2\ConsoleApp.dll' (30/08/2019 4:54:02 PM), not up to date. (ConsoleApp)
2>------ Build started: Project: ConsoleApp, Configuration: Debug Any CPU ------
2>ConsoleApp -> C:\Repo\ConsoleApp\bin\Debug\netcoreapp2.2\ConsoleApp.dll
========== Build: 2 succeeded, 0 failed, 0 up-to-date, 0 skipped ==========
```