### PR TITLE
Remove unused PackageReference.Path XAML property

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/PackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/PackageReference.xaml
@@ -34,11 +34,6 @@
                   Description="Comma-delimited list of warnings that should be suppressed for this package."
                   DisplayName="Suppress warnings" />
 
-  <StringProperty Name="Path"
-                  Description="Location of the package being referenced."
-                  ReadOnly="True"
-                  DisplayName="Path" />
-
   <StringProperty Name="PrivateAssets"
                   Description="Assets that are private in this reference."
                   DisplayName="Private assets" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.cs.xlf
@@ -62,11 +62,6 @@
         <target state="needs-review-translation">Seznam upozornění oddělených čárkou, která by se měla u tohoto balíčku potlačit</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Path|Description">
-        <source>Location of the package being referenced.</source>
-        <target state="translated">Umístění odkazovaného balíčku</target>
-        <note />
-      </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
         <source>Generate path property</source>
         <target state="translated">Generovat vlastnost cesty</target>
@@ -75,11 +70,6 @@
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">
         <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
         <target state="translated">Určuje, jestli se má generovat vlastnost MSBuildu s umístěním kořenového adresáře balíčku. Název generované vlastnosti je ve formátu Pkg[ID_balíčku], kde [ID_balíčku] je ID balíčku, ve kterém jsou tečky nahrazené podtržítky.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Path|DisplayName">
-        <source>Path</source>
-        <target state="new">Path</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.de.xlf
@@ -62,11 +62,6 @@
         <target state="needs-review-translation">Durch Trennzeichen getrennte Liste von Warnungen, die für dieses Paket unterdrückt werden sollen</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Path|Description">
-        <source>Location of the package being referenced.</source>
-        <target state="translated">Speicherort des Pakets, auf das verwiesen wird.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
         <source>Generate path property</source>
         <target state="translated">Pfadeigenschaft generieren</target>
@@ -75,11 +70,6 @@
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">
         <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
         <target state="translated">Gibt an, ob eine MSBuild-Eigenschaft mit dem Speicherort des Stammverzeichnisses des Pakets generiert werden soll. Der Name der generierten Eigenschaft weist das Format "Pkg[Paket-ID]" auf, wobei "[Paket-ID]" der ID des Pakets entspricht. Hierbei müssen Punkte (.) jedoch durch Unterstriche (_) ersetzt werden.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Path|DisplayName">
-        <source>Path</source>
-        <target state="new">Path</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.es.xlf
@@ -62,11 +62,6 @@
         <target state="needs-review-translation">Lista de advertencias delimitada por comas que se deben suprimir en este paquete</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Path|Description">
-        <source>Location of the package being referenced.</source>
-        <target state="translated">Ubicación del paquete al que se hace referencia.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
         <source>Generate path property</source>
         <target state="translated">Generar la propiedad path</target>
@@ -75,11 +70,6 @@
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">
         <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
         <target state="translated">Indica si se va a generar una propiedad de MSBuild con la ubicación del directorio raíz del paquete. El nombre de la propiedad generada tiene el formato "pkg [PackageID]", donde "[PackageID]" es el ID del paquete con cualquier punto "." reemplazado por guiones bajos " _ ".</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Path|DisplayName">
-        <source>Path</source>
-        <target state="new">Path</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.fr.xlf
@@ -62,11 +62,6 @@
         <target state="needs-review-translation">Liste délimitée par des virgules, qui répertorie les avertissements à supprimer pour ce package</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Path|Description">
-        <source>Location of the package being referenced.</source>
-        <target state="translated">Emplacement du package actuellement référencé.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
         <source>Generate path property</source>
         <target state="translated">Générer la propriété path</target>
@@ -75,11 +70,6 @@
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">
         <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
         <target state="translated">Indique s'il faut générer une propriété MSBuild avec l'emplacement du répertoire racine du package. Le nom de la propriété générée est au format 'Pkg[PackageID]', où '[PackageID]' est l'ID du package avec tous les points '.' remplacés par des traits de soulignement '_'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Path|DisplayName">
-        <source>Path</source>
-        <target state="new">Path</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.it.xlf
@@ -62,11 +62,6 @@
         <target state="needs-review-translation">Elenco di avvisi delimitati da virgole che non devono essere visualizzati per questo pacchetto</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Path|Description">
-        <source>Location of the package being referenced.</source>
-        <target state="translated">Percorso del pacchetto a cui viene fatto riferimento.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
         <source>Generate path property</source>
         <target state="translated">Genera la proprietà Path</target>
@@ -75,11 +70,6 @@
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">
         <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
         <target state="translated">Indica se generare una proprietà MSBuild con il percorso della directory radice del pacchetto. Il nome di proprietà generato è in formato 'Pkg[IDpacchetto]', dove '[IDpacchetto]' è l'ID del pacchetto in cui gli eventuali punti ('.') sono stati sostituiti da caratteri di sottolineatura ('_').</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Path|DisplayName">
-        <source>Path</source>
-        <target state="new">Path</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ja.xlf
@@ -62,11 +62,6 @@
         <target state="needs-review-translation">このパッケージで非表示にする必要がある警告のコンマ区切りリスト</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Path|Description">
-        <source>Location of the package being referenced.</source>
-        <target state="translated">参照されているパッケージの場所。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
         <source>Generate path property</source>
         <target state="translated">パス プロパティを生成します</target>
@@ -75,11 +70,6 @@
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">
         <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
         <target state="translated">MSBuild プロパティをパッケージのルート ディレクトリーの場所に生成するかどうかを示します。生成されるプロパティ名は 'Pkg[PackageID]' という形式になります。'[PackageID]' はパッケージの ID で、ピリオド (.) はアンダースコア (_) に置き換えられます。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Path|DisplayName">
-        <source>Path</source>
-        <target state="new">Path</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ko.xlf
@@ -62,11 +62,6 @@
         <target state="needs-review-translation">이 패키지에 대해 표시하지 않는, 쉼표로 구분된 경고 목록</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Path|Description">
-        <source>Location of the package being referenced.</source>
-        <target state="translated">참조되는 패키지의 위치입니다.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
         <source>Generate path property</source>
         <target state="translated">경로 속성 생성</target>
@@ -75,11 +70,6 @@
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">
         <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
         <target state="translated">패키지의 루트 디렉터리 위치를 사용하여 MSBuild 속성을 생성할지 여부를 제어합니다. 생성된 속성 이름은 'Pkg[PackageID]' 형식입니다. 여기서 '[PackageID]'는 패키지의 ID이고 마침표 '.'는 밑줄 '_'로 바뀝니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Path|DisplayName">
-        <source>Path</source>
-        <target state="new">Path</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.pl.xlf
@@ -62,11 +62,6 @@
         <target state="needs-review-translation">Rozdzielona przecinkami lista ostrzeżeń, które mają zostać pominięte dla tego pakietu</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Path|Description">
-        <source>Location of the package being referenced.</source>
-        <target state="translated">Lokalizacja pakietu, którego dotyczy odwołanie.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
         <source>Generate path property</source>
         <target state="translated">Generuj właściwość ścieżki</target>
@@ -75,11 +70,6 @@
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">
         <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
         <target state="translated">Wskazuje, czy należy generowania właściwość MSBuild z lokalizacją katalogu głównego pakietu. Nazwa właściwości generowane jest w formie 'Pkg [PackageID]', gdzie '[PackageID] 'jest identyfikator pakietu z okresów'.' zastąpione znakami podkreślenia '_'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Path|DisplayName">
-        <source>Path</source>
-        <target state="new">Path</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.pt-BR.xlf
@@ -62,11 +62,6 @@
         <target state="needs-review-translation">Lista de avisos delimitada por vírgulas que deve ser suprimida para este pacote</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Path|Description">
-        <source>Location of the package being referenced.</source>
-        <target state="translated">Localização do pacote que está sendo referenciado.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
         <source>Generate path property</source>
         <target state="translated">Gerar propriedade do caminho</target>
@@ -75,11 +70,6 @@
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">
         <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
         <target state="translated">Indica se é necessário gerar uma propriedade do MSBuild com a localização do diretório de raiz do pacote. O nome da propriedade gerado é em forma de 'Pkg [PackageID]', onde '[PackageID] 'é o ID do pacote com quaisquer períodos'.' substituído com caracteres de sublinhado '_'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Path|DisplayName">
-        <source>Path</source>
-        <target state="new">Path</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.ru.xlf
@@ -62,11 +62,6 @@
         <target state="needs-review-translation">Разделенный запятыми список предупреждений, которые должны быть подавлены для этого пакета.</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Path|Description">
-        <source>Location of the package being referenced.</source>
-        <target state="translated">Расположение пакета, на который указывает ссылка.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
         <source>Generate path property</source>
         <target state="translated">Создать свойство пути</target>
@@ -75,11 +70,6 @@
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">
         <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
         <target state="translated">Указывает, необходимо ли создать свойство MSBuild, содержащее расположение корневого каталог пакета. Имя созданного свойства имеет вид 'Pkg[PackageID]', где '[PackageID]' — идентификатор пакета, в котором точки ('.') заменены на нижние подчеркивания ('_').</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Path|DisplayName">
-        <source>Path</source>
-        <target state="new">Path</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.tr.xlf
@@ -62,11 +62,6 @@
         <target state="needs-review-translation">Bu paket için gizlenmesi gereken virgülle ayrılmış uyarı listesi</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Path|Description">
-        <source>Location of the package being referenced.</source>
-        <target state="translated">Başvurulan paketin konumu.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
         <source>Generate path property</source>
         <target state="translated">Yol özelliği oluştur</target>
@@ -75,11 +70,6 @@
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">
         <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
         <target state="translated">Paket kök dizini konumuyla bir MSBuild özelliği oluşturulup oluşturulmayacağını belirtir. Oluşturulan özellik adı 'Pkg[PackageID]' biçimindedir. Burada '[PackageID]', noktalar '.' alt çizgi '_' ile değiştirilmiş olarak paketin adıdır.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Path|DisplayName">
-        <source>Path</source>
-        <target state="new">Path</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.zh-Hans.xlf
@@ -62,11 +62,6 @@
         <target state="needs-review-translation">应为此包取消的警告逗号分隔列表</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Path|Description">
-        <source>Location of the package being referenced.</source>
-        <target state="translated">所引用的包的位置。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
         <source>Generate path property</source>
         <target state="translated">生成路径属性</target>
@@ -75,11 +70,6 @@
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">
         <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
         <target state="translated">指示是否要使用包的根目录的位置生成 MSBuild 属性。所生成的属性名称采用 "Pkg[PackageID]" 的形式，其中 "[PackageID]" 是包的 ID，且所有句点 "." 均替换为下划线 "_"。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Path|DisplayName">
-        <source>Path</source>
-        <target state="new">Path</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/xlf/PackageReference.xaml.zh-Hant.xlf
@@ -62,11 +62,6 @@
         <target state="needs-review-translation">不應對此套件顯示的警告清單 (以逗點分隔)</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Path|Description">
-        <source>Location of the package being referenced.</source>
-        <target state="translated">目前參考的套件位置。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="BoolProperty|GeneratePathProperty|DisplayName">
         <source>Generate path property</source>
         <target state="translated">產生路徑屬性</target>
@@ -75,11 +70,6 @@
       <trans-unit id="BoolProperty|GeneratePathProperty|Description">
         <source>Indicates whether to generate an MSBuild property with the location of the package's root directory. The generated property name is in the form of 'Pkg[PackageID]', where '[PackageID]' is the ID of the package with any periods '.' replaced with underscores '_'.</source>
         <target state="translated">表示是否要以套件根目錄的位置產生 MSBuild 屬性。產生屬性的名稱格式為 'Pkg[PackageID]'，其中 '[PackageID]' 是套件的識別碼，所有句點 '.' 均會替換為底線 '_'。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|Path|DisplayName">
-        <source>Path</source>
-        <target state="new">Path</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
Unresolved `PackageReference` items will not have a path property. This exists on `ResolvedPackageReference`.