### PR TITLE
Dependency filter review

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/DeduplicateCaptionsSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/DeduplicateCaptionsSnapshotFilter.cs
@@ -8,14 +8,13 @@ using System.ComponentModel.Composition;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Filters
 {
     /// <summary>
-    /// If there are several top level dependencies with same captions and same provider type,
-    /// we need to change their captions, to avoid collision. To de-dupe captions we change captions 
-    /// for all such nodes to Alias which is "Caption (OriginalItemSpec)".
+    /// Deduplicates captions of top-level dependencies from the same provider. This is done by
+    /// appending the <see cref="IDependencyModel.OriginalItemSpec"/> to the caption in parentheses.
     /// </summary>
     [Export(typeof(IDependenciesSnapshotFilter))]
     [AppliesTo(ProjectCapability.DependenciesTree)]
     [Order(Order)]
-    internal sealed class DuplicatedDependenciesSnapshotFilter : DependenciesSnapshotFilterBase
+    internal sealed class DeduplicateCaptionsSnapshotFilter : DependenciesSnapshotFilterBase
     {
         public const int Order = 101;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/DuplicatedDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/DuplicatedDependenciesSnapshotFilter.cs
@@ -26,6 +26,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Fil
             IImmutableSet<string>? projectItemSpecs,
             IAddDependencyContext context)
         {
+            // Only apply to top-level dependencies
+            if (!dependency.TopLevel)
+            {
+                context.Accept(dependency);
+                return;
+            }
+
             IDependency? matchingDependency = null;
             bool shouldApplyAlias = false;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/UnresolvedDependenciesSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/UnresolvedDependenciesSnapshotFilter.cs
@@ -7,10 +7,13 @@ using System.ComponentModel.Composition;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Filters
 {
     /// <summary>
-    /// Filter does not allow unresolved dependency rule to override resolved one in the snapshot. 
-    /// When project changes and old resolved dependency cannot be resolved anymore, only removed
-    /// resolved dependency rule can delete old dependency (not unresolved rule).
+    /// Prohibits the unresolved dependency rule (evaluation) from overriding the corresponding 
+    /// resolved rule (design-time build) in the snapshot. 
     /// </summary>
+    /// <remarks>
+    /// Once resolved, a dependency cannot revert to unresolved state. It will only appear as
+    /// unresolved again if it is first removed.
+    /// </remarks>
     [Export(typeof(IDependenciesSnapshotFilter))]
     [AppliesTo(ProjectCapability.DependenciesTree)]
     [Order(Order)]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/UnresolvedProjectReferenceSnapshotFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Snapshot/Filters/UnresolvedProjectReferenceSnapshotFilter.cs
@@ -7,21 +7,19 @@ using System.ComponentModel.Composition;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot.Filters
 {
     /// <summary>
-    /// Changes resolved top level project dependencies to unresolved if:
-    ///     - dependent project has any unresolved dependencies in a snapshot for given target framework
-    /// This helps to bubble up error status (yellow icon) for project dependencies.
+    /// Marks project references as unresolved where the referenced project contains a visible unresolved dependency.
     /// </summary>
     [Export(typeof(IDependenciesSnapshotFilter))]
     [AppliesTo(ProjectCapability.DependenciesTree)]
     [Order(Order)]
-    internal sealed class UnsupportedProjectsSnapshotFilter : DependenciesSnapshotFilterBase
+    internal sealed class UnresolvedProjectReferenceSnapshotFilter : DependenciesSnapshotFilterBase
     {
         public const int Order = 120;
 
         private readonly IAggregateDependenciesSnapshotProvider _aggregateSnapshotProvider;
 
         [ImportingConstructor]
-        public UnsupportedProjectsSnapshotFilter(IAggregateDependenciesSnapshotProvider aggregateSnapshotProvider)
+        public UnresolvedProjectReferenceSnapshotFilter(IAggregateDependenciesSnapshotProvider aggregateSnapshotProvider)
         {
             _aggregateSnapshotProvider = aggregateSnapshotProvider;
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DeduplicateCaptionsSnapshotFilterTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/DeduplicateCaptionsSnapshotFilterTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 {
-    public sealed class DuplicatedDependenciesSnapshotFilterTests
+    public sealed class DeduplicateCaptionsSnapshotFilterTests
     {
         [Fact]
         public void BeforeAddOrUpdate_NoDuplicate_ShouldNotUpdateCaption()
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
             var context = new AddDependencyContext(worldBuilder);
 
-            var filter = new DuplicatedDependenciesSnapshotFilter();
+            var filter = new DeduplicateCaptionsSnapshotFilter();
 
             filter.BeforeAddOrUpdate(
                 null!,
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
             var context = new AddDependencyContext(worldBuilder);
 
-            var filter = new DuplicatedDependenciesSnapshotFilter();
+            var filter = new DeduplicateCaptionsSnapshotFilter();
 
             filter.BeforeAddOrUpdate(
                 null!,
@@ -144,7 +144,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
             var context = new AddDependencyContext(worldBuilder);
 
-            var filter = new DuplicatedDependenciesSnapshotFilter();
+            var filter = new DeduplicateCaptionsSnapshotFilter();
 
             filter.BeforeAddOrUpdate(
                 null!,
@@ -201,7 +201,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
             var context = new AddDependencyContext(worldBuilder);
 
-            var filter = new DuplicatedDependenciesSnapshotFilter();
+            var filter = new DeduplicateCaptionsSnapshotFilter();
 
             filter.BeforeAddOrUpdate(
                 null!,

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnresolvedProjectReferenceSnapshotFilterTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/Snapshot/UnresolvedProjectReferenceSnapshotFilterTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 {
-    public sealed class UnsupportedProjectsSnapshotFilterTests
+    public sealed class UnresolvedProjectReferenceSnapshotFilterTests
     {
         [Fact]
         public void BeforeAddOrUpdate_WhenDependencyNotRecognized_ShouldDoNothing()
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
                 var context = new AddDependencyContext(worldBuilder);
 
-                var filter = new UnsupportedProjectsSnapshotFilter(aggregateSnapshotProvider);
+                var filter = new UnresolvedProjectReferenceSnapshotFilter(aggregateSnapshotProvider);
 
                 filter.BeforeAddOrUpdate(
                     null!,
@@ -99,7 +99,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
             var context = new AddDependencyContext(worldBuilder);
 
-            var filter = new UnsupportedProjectsSnapshotFilter(aggregateSnapshotProvider.Object);
+            var filter = new UnresolvedProjectReferenceSnapshotFilter(aggregateSnapshotProvider.Object);
 
             filter.BeforeAddOrUpdate(
                 null!,
@@ -140,7 +140,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
             var context = new AddDependencyContext(worldBuilder);
 
-            var filter = new UnsupportedProjectsSnapshotFilter(aggregateSnapshotProvider.Object);
+            var filter = new UnresolvedProjectReferenceSnapshotFilter(aggregateSnapshotProvider.Object);
 
             filter.BeforeAddOrUpdate(
                 null!,
@@ -183,7 +183,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot
 
             var context = new AddDependencyContext(worldBuilder);
 
-            var filter = new UnsupportedProjectsSnapshotFilter(aggregateSnapshotProvider.Object);
+            var filter = new UnresolvedProjectReferenceSnapshotFilter(aggregateSnapshotProvider.Object);
 
             filter.BeforeAddOrUpdate(
                 null!,


### PR DESCRIPTION
Looking over the filters used in processing dependency updates, they had misleading names and documentation.

b8f2576c995b01d86bc14a921b61caca6eb31eb3 makes a perf improvement too.