### PR TITLE
Options layout

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageControl.xaml
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageControl.xaml
@@ -7,7 +7,7 @@
         <GroupBox x:Uid="FastUpToDateGroupBox" Header="{x:Static r:GeneralOptionPageResources.General_FastUpToDateCheck_Title}" VerticalAlignment="Top">
             <StackPanel Orientation="Vertical">
                 <CheckBox x:Name="FastUpToDateCheck" x:Uid="General_FastUpToDateCheck" Content="{x:Static r:GeneralOptionPageResources.General_FastUpToDateCheck}" Margin="0" />
-                <StackPanel Orientation="Horizontal">
+                <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
                     <TextBlock Text="{x:Static r:GeneralOptionPageResources.General_FastUpToDateCheck_LogLevel}" Margin="0" VerticalAlignment="Center" MinWidth="128" />
                     <ComboBox x:Name="FastUpToDateLogLevel" ItemsSource="{x:Static local:GeneralOptionPageControl.FastUpToDateLogLevelItemSource}" x:Uid="General_LogLevel" VerticalContentAlignment="Center" Margin="0"/>
                 </StackPanel>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageControl.xaml
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageControl.xaml
@@ -4,7 +4,7 @@
                          xmlns:r="clr-namespace:My.Resources"
                          xmlns:local="clr-namespace:Microsoft.VisualStudio.Editors.OptionPages">
     <ScrollViewer VerticalScrollBarVisibility="Auto" Focusable="false">
-        <GroupBox x:Uid="FastUpToDateGroupBox" Header="{x:Static r:GeneralOptionPageResources.General_FastUpToDateCheck_Title}">
+        <GroupBox x:Uid="FastUpToDateGroupBox" Header="{x:Static r:GeneralOptionPageResources.General_FastUpToDateCheck_Title}" VerticalAlignment="Top">
             <StackPanel Orientation="Vertical">
                 <CheckBox x:Name="FastUpToDateCheck" x:Uid="General_FastUpToDateCheck" Content="{x:Static r:GeneralOptionPageResources.General_FastUpToDateCheck}" Margin="0" />
                 <StackPanel Orientation="Horizontal">

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageControl.xaml
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageControl.xaml
@@ -8,7 +8,7 @@
             <StackPanel Orientation="Vertical">
                 <CheckBox x:Name="FastUpToDateCheck" x:Uid="General_FastUpToDateCheck" Content="{x:Static r:GeneralOptionPageResources.General_FastUpToDateCheck}" Margin="0" />
                 <StackPanel Orientation="Horizontal">
-                    <Label Content="{x:Static r:GeneralOptionPageResources.General_FastUpToDateCheck_LogLevel}" Margin="0" />
+                    <TextBlock Text="{x:Static r:GeneralOptionPageResources.General_FastUpToDateCheck_LogLevel}" Margin="0" VerticalAlignment="Center" MinWidth="128" />
                     <ComboBox x:Name="FastUpToDateLogLevel" ItemsSource="{x:Static local:GeneralOptionPageControl.FastUpToDateLogLevelItemSource}" x:Uid="General_LogLevel" VerticalContentAlignment="Center" Margin="0"/>
                 </StackPanel>
             </StackPanel>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageControl.xaml
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageControl.xaml
@@ -4,16 +4,14 @@
                          xmlns:r="clr-namespace:My.Resources"
                          xmlns:local="clr-namespace:Microsoft.VisualStudio.Editors.OptionPages">
     <ScrollViewer VerticalScrollBarVisibility="Auto" Focusable="false">
-        <StackPanel>
-            <GroupBox x:Uid="FastUpToDateGroupBox" Header="{x:Static r:GeneralOptionPageResources.General_FastUpToDateCheck_Title}">
-                <StackPanel Orientation="Vertical">
-                    <CheckBox x:Name="FastUpToDateCheck" x:Uid="General_FastUpToDateCheck" Content="{x:Static r:GeneralOptionPageResources.General_FastUpToDateCheck}" Margin="0" />
-                    <StackPanel Orientation="Horizontal">
-                        <Label Content="{x:Static r:GeneralOptionPageResources.General_FastUpToDateCheck_LogLevel}" Margin="0" />
-                        <ComboBox x:Name="FastUpToDateLogLevel" SelectedIndex="2" ItemsSource="{x:Static local:GeneralOptionPageControl.FastUpToDateLogLevelItemSource}" x:Uid="General_LogLevel" VerticalContentAlignment="Center" Margin="0"/>
-                    </StackPanel>
+        <GroupBox x:Uid="FastUpToDateGroupBox" Header="{x:Static r:GeneralOptionPageResources.General_FastUpToDateCheck_Title}">
+            <StackPanel Orientation="Vertical">
+                <CheckBox x:Name="FastUpToDateCheck" x:Uid="General_FastUpToDateCheck" Content="{x:Static r:GeneralOptionPageResources.General_FastUpToDateCheck}" Margin="0" />
+                <StackPanel Orientation="Horizontal">
+                    <Label Content="{x:Static r:GeneralOptionPageResources.General_FastUpToDateCheck_LogLevel}" Margin="0" />
+                    <ComboBox x:Name="FastUpToDateLogLevel" SelectedIndex="2" ItemsSource="{x:Static local:GeneralOptionPageControl.FastUpToDateLogLevelItemSource}" x:Uid="General_LogLevel" VerticalContentAlignment="Center" Margin="0"/>
                 </StackPanel>
-            </GroupBox>
-        </StackPanel>
+            </StackPanel>
+        </GroupBox>
     </ScrollViewer>
 </local:OptionPageControl>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageControl.xaml
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/GeneralOptionPageControl.xaml
@@ -9,7 +9,7 @@
                 <CheckBox x:Name="FastUpToDateCheck" x:Uid="General_FastUpToDateCheck" Content="{x:Static r:GeneralOptionPageResources.General_FastUpToDateCheck}" Margin="0" />
                 <StackPanel Orientation="Horizontal">
                     <Label Content="{x:Static r:GeneralOptionPageResources.General_FastUpToDateCheck_LogLevel}" Margin="0" />
-                    <ComboBox x:Name="FastUpToDateLogLevel" SelectedIndex="2" ItemsSource="{x:Static local:GeneralOptionPageControl.FastUpToDateLogLevelItemSource}" x:Uid="General_LogLevel" VerticalContentAlignment="Center" Margin="0"/>
+                    <ComboBox x:Name="FastUpToDateLogLevel" ItemsSource="{x:Static local:GeneralOptionPageControl.FastUpToDateLogLevelItemSource}" x:Uid="General_LogLevel" VerticalContentAlignment="Center" Margin="0"/>
                 </StackPanel>
             </StackPanel>
         </GroupBox>

--- a/src/Microsoft.VisualStudio.Editors/OptionPages/LoggingLevelToInt32Converter.vb
+++ b/src/Microsoft.VisualStudio.Editors/OptionPages/LoggingLevelToInt32Converter.vb
@@ -7,13 +7,7 @@ Namespace Microsoft.VisualStudio.Editors.OptionPages
     Friend NotInheritable Class LoggingLevelToInt32Converter
         Implements IValueConverter
 
-        Private Shared ReadOnly s_instance As New LoggingLevelToInt32Converter()
-
-        Public Shared ReadOnly Property Instance As LoggingLevelToInt32Converter
-            Get
-                Return s_instance
-            End Get
-        End Property
+        Public Shared ReadOnly Property Instance As LoggingLevelToInt32Converter = New LoggingLevelToInt32Converter()
 
         Public Function Convert(value As Object, targetType As Type, parameter As Object, culture As CultureInfo) As Object Implements IValueConverter.Convert
             Debug.Assert(value IsNot Nothing)


### PR DESCRIPTION
- Adds some vertical space between options
- Removes left margin from the "Logging Level" text so the left column is flush aligned
- Moves the combo box to the same horizontal offset as is used in other property pages (e.g. _VB Defaults_)
- Makes the group box align to top, as in other property pages (e.g. _Performance_)
- Reduces the height of the combo box to match other property pages

Before:

![image](https://user-images.githubusercontent.com/350947/64143104-fd5e4f80-ce51-11e9-9620-7366ffdcc885.png)

After:

![image](https://user-images.githubusercontent.com/350947/64143111-04855d80-ce52-11e9-959e-2c56b699f197.png)
