### PR TITLE
Flatten package rule handler logic

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/CrossTarget/IDependenciesRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/CrossTarget/IDependenciesRuleHandler.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 
 using Microsoft.VisualStudio.Composition;
@@ -36,7 +37,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         /// to the given <see cref="CrossTargetDependenciesChangesBuilder"/>.
         /// </summary>
         void Handle(
+            IImmutableDictionary<NamedIdentity, IComparable> versions,
             IImmutableDictionary<string, IProjectChangeDescription> changesByRuleName,
+            RuleSource source,
             ITargetFramework targetFramework,
             CrossTargetDependenciesChangesBuilder changesBuilder);
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/ProjectItemMetadata.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/ProjectItemMetadata.cs
@@ -15,6 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
         public const string IsImplicitlyDefined = "IsImplicitlyDefined";
         public const string Severity = "Severity";
         public const string DiagnosticCode = "DiagnosticCode";
+        public const string OriginalItemSpec = "OriginalItemSpec";
 
         // Target Metadata
         public const string RuntimeIdentifier = "RuntimeIdentifier";

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
@@ -39,11 +39,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             // We receive evaluated and resolved project data separately, each as its own rule.
 
             // We always have evaluated data.
-            IProjectChangeDescription unresolvedChanges = changesByRuleName[EvaluatedRuleName];
+            IProjectChangeDescription evaluatedChanges = changesByRuleName[EvaluatedRuleName];
 
             HandleChangesForRule(
                 resolved: false,
-                projectChange: unresolvedChanges,
+                projectChange: evaluatedChanges,
                 shouldProcess: dependencyId => true);
 
             // We only have resolved data if the update came via the JointRule data source.
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 HandleChangesForRule(
                     resolved: true,
                     projectChange: resolvedChanges,
-                    shouldProcess: unresolvedChanges.After.Items.ContainsKey);
+                    shouldProcess: evaluatedChanges.After.Items.ContainsKey);
             }
 
             return;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                     foreach (string removedItem in projectChange.Difference.RemovedItems)
                     {
                         string dependencyId = resolved
-                            ? projectChange.Before.GetProjectItemProperties(removedItem)!.GetStringProperty(ResolvedAssemblyReference.OriginalItemSpecProperty) ?? removedItem
+                            ? projectChange.Before.GetProjectItemProperties(removedItem)!.GetStringProperty(ProjectItemMetadata.OriginalItemSpec) ?? removedItem
                             : removedItem;
 
                         if (shouldProcess(dependencyId))
@@ -110,7 +110,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             IImmutableDictionary<string, string> properties = projectRuleSnapshot.GetProjectItemProperties(itemSpec)!;
 
             string originalItemSpec = isResolved
-                ? properties.GetStringProperty(ResolvedAssemblyReference.OriginalItemSpecProperty) ?? itemSpec
+                ? properties.GetStringProperty(ProjectItemMetadata.OriginalItemSpec) ?? itemSpec
                 : itemSpec;
 
             bool isImplicit = properties.GetBoolProperty(ProjectItemMetadata.IsImplicitlyDefined) ?? false;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
@@ -61,36 +61,45 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
             void HandleChangesForRule(bool resolved, IProjectChangeDescription projectChange, Func<string, bool> shouldProcess)
             {
-                foreach (string removedItem in projectChange.Difference.RemovedItems)
+                if (projectChange.Difference.RemovedItems.Count != 0)
                 {
-                    string dependencyId = resolved
-                        ? projectChange.Before.GetProjectItemProperties(removedItem)!.GetStringProperty(ResolvedAssemblyReference.OriginalItemSpecProperty) ?? removedItem
-                        : removedItem;
-
-                    if (shouldProcess(dependencyId))
+                    foreach (string removedItem in projectChange.Difference.RemovedItems)
                     {
-                        changesBuilder.Removed(targetFramework, ProviderType, removedItem);
+                        string dependencyId = resolved
+                            ? projectChange.Before.GetProjectItemProperties(removedItem)!.GetStringProperty(ResolvedAssemblyReference.OriginalItemSpecProperty) ?? removedItem
+                            : removedItem;
+
+                        if (shouldProcess(dependencyId))
+                        {
+                            changesBuilder.Removed(targetFramework, ProviderType, removedItem);
+                        }
                     }
                 }
 
-                foreach (string changedItem in projectChange.Difference.ChangedItems)
+                if (projectChange.Difference.ChangedItems.Count != 0)
                 {
-                    IDependencyModel model = CreateDependencyModelForRule(changedItem, projectChange.After);
-                    if (shouldProcess(model.Id))
+                    foreach (string changedItem in projectChange.Difference.ChangedItems)
                     {
-                        // For changes we try to add new dependency. If it is a resolved dependency, it would just override
-                        // old one with new properties. If it is unresolved dependency, it would be added only when there no
-                        // resolved version in the snapshot.
-                        changesBuilder.Added(targetFramework, model);
+                        IDependencyModel model = CreateDependencyModelForRule(changedItem, projectChange.After);
+                        if (shouldProcess(model.Id))
+                        {
+                            // For changes we try to add new dependency. If it is a resolved dependency, it would just override
+                            // old one with new properties. If it is unresolved dependency, it would be added only when there no
+                            // resolved version in the snapshot.
+                            changesBuilder.Added(targetFramework, model);
+                        }
                     }
                 }
 
-                foreach (string addedItem in projectChange.Difference.AddedItems)
+                if (projectChange.Difference.AddedItems.Count != 0)
                 {
-                    IDependencyModel model = CreateDependencyModelForRule(addedItem, projectChange.After);
-                    if (shouldProcess(model.Id))
+                    foreach (string addedItem in projectChange.Difference.AddedItems)
                     {
-                        changesBuilder.Added(targetFramework, model);
+                        IDependencyModel model = CreateDependencyModelForRule(addedItem, projectChange.After);
+                        if (shouldProcess(model.Id))
+                        {
+                            changesBuilder.Added(targetFramework, model);
+                        }
                     }
                 }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
@@ -32,7 +32,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
         public abstract ImageMoniker ImplicitIcon { get; }
 
         public virtual void Handle(
+            IImmutableDictionary<NamedIdentity, IComparable> versions,
             IImmutableDictionary<string, IProjectChangeDescription> changesByRuleName,
+            RuleSource source,
             ITargetFramework targetFramework,
             CrossTargetDependenciesChangesBuilder changesBuilder)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
@@ -100,6 +100,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                         }
                     }
                 }
+
+                System.Diagnostics.Debug.Assert(evaluatedChanges.Difference.RenamedItems.Count == 0, "Project rule diff should not contain renamed items");
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 {
                     foreach (string changedItem in projectChange.Difference.ChangedItems)
                     {
-                        IDependencyModel model = CreateDependencyModelForRule(changedItem, projectChange.After);
+                        IDependencyModel model = CreateDependencyModelForRule(changedItem, projectChange.After, resolved);
                         if (shouldProcess(model.Id))
                         {
                             // For changes we try to add new dependency. If it is a resolved dependency, it would just override
@@ -93,34 +93,32 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 {
                     foreach (string addedItem in projectChange.Difference.AddedItems)
                     {
-                        IDependencyModel model = CreateDependencyModelForRule(addedItem, projectChange.After);
+                        IDependencyModel model = CreateDependencyModelForRule(addedItem, projectChange.After, resolved);
                         if (shouldProcess(model.Id))
                         {
                             changesBuilder.Added(targetFramework, model);
                         }
                     }
                 }
-
-                return;
-
-                IDependencyModel CreateDependencyModelForRule(string itemSpec, IProjectRuleSnapshot projectRuleSnapshot)
-                {
-                    IImmutableDictionary<string, string> properties = projectRuleSnapshot.GetProjectItemProperties(itemSpec)!;
-
-                    string originalItemSpec = resolved
-                        ? properties.GetStringProperty(ResolvedAssemblyReference.OriginalItemSpecProperty) ?? itemSpec
-                        : itemSpec;
-
-                    bool isImplicit = properties.GetBoolProperty(ProjectItemMetadata.IsImplicitlyDefined) ?? false;
-
-                    return CreateDependencyModel(
-                        itemSpec,
-                        originalItemSpec,
-                        resolved,
-                        isImplicit,
-                        properties);
-                }
             }
+        }
+
+        private IDependencyModel CreateDependencyModelForRule(string itemSpec, IProjectRuleSnapshot projectRuleSnapshot, bool isResolved)
+        {
+            IImmutableDictionary<string, string> properties = projectRuleSnapshot.GetProjectItemProperties(itemSpec)!;
+
+            string originalItemSpec = isResolved
+                ? properties.GetStringProperty(ResolvedAssemblyReference.OriginalItemSpecProperty) ?? itemSpec
+                : itemSpec;
+
+            bool isImplicit = properties.GetBoolProperty(ProjectItemMetadata.IsImplicitlyDefined) ?? false;
+
+            return CreateDependencyModel(
+                itemSpec,
+                originalItemSpec,
+                isResolved,
+                isImplicit,
+                properties);
         }
 
         protected virtual IDependencyModel CreateDependencyModel(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
@@ -36,20 +36,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             ITargetFramework targetFramework,
             CrossTargetDependenciesChangesBuilder changesBuilder)
         {
-            // We receive unresolved and resolved changes separately.
+            // We receive evaluated and resolved project data separately, each as its own rule.
 
-            // Process all unresolved changes.
-            if (changesByRuleName.TryGetValue(EvaluatedRuleName, out IProjectChangeDescription unresolvedChanges))
-            {
-                HandleChangesForRule(
-                    resolved: false,
-                    projectChange: unresolvedChanges,
-                    shouldProcess: dependencyId => true);
-            }
+            // We always have evaluated data.
+            IProjectChangeDescription unresolvedChanges = changesByRuleName[EvaluatedRuleName];
 
-            // Process only resolved changes that have a corresponding unresolved item.
-            if (unresolvedChanges != null &&
-                changesByRuleName.TryGetValue(ResolvedRuleName, out IProjectChangeDescription resolvedChanges))
+            HandleChangesForRule(
+                resolved: false,
+                projectChange: unresolvedChanges,
+                shouldProcess: dependencyId => true);
+
+            // We only have resolved data if the update came via the JointRule data source.
+            if (changesByRuleName.TryGetValue(ResolvedRuleName, out IProjectChangeDescription resolvedChanges))
             {
                 HandleChangesForRule(
                     resolved: true,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.PackageDependencyMetadata.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.PackageDependencyMetadata.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
             private readonly DependencyType _dependencyType;
 
-            public string? Target { get; }
+            public string? TargetFrameworkName { get; }
             public string ItemSpec { get; }
             public string OriginalItemSpec { get; }
             public string Name { get; }
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
             private PackageDependencyMetadata(
                 DependencyType dependencyType,
-                string? target,
+                string? targetFrameworkName,
                 string itemSpec,
                 string originalItemSpec,
                 string name,
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 IImmutableDictionary<string, string> properties)
             {
                 _dependencyType = dependencyType;
-                Target = target;
+                TargetFrameworkName = targetFrameworkName;
                 ItemSpec = itemSpec;
                 OriginalItemSpec = originalItemSpec;
                 Name = name;
@@ -81,10 +81,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                     }
 
                     int slashIndex = itemSpec.IndexOf('/');
-                    string? target = slashIndex == -1 ? null : s_targetFrameworkInternPool.Intern(itemSpec.Substring(0, slashIndex));
+                    string? targetFrameworkName = slashIndex == -1 ? null : s_targetFrameworkInternPool.Intern(itemSpec.Substring(0, slashIndex));
 
-                    if (target == null ||
-                        targetFrameworkProvider.GetTargetFramework(target)?.Equals(targetFramework) != true)
+                    if (targetFrameworkName == null ||
+                        targetFrameworkProvider.GetTargetFramework(targetFrameworkName)?.Equals(targetFramework) != true)
                     {
                         metadata = default;
                         return false;
@@ -99,7 +99,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
                     metadata = new PackageDependencyMetadata(
                         dependencyType,
-                        target,
+                        targetFrameworkName,
                         itemSpec,
                         originalItemSpec,
                         name,
@@ -116,7 +116,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
                     metadata = new PackageDependencyMetadata(
                         dependencyType: DependencyType.Package,
-                        target: null,
+                        targetFrameworkName: null,
                         itemSpec,
                         originalItemSpec: itemSpec,
                         name: itemSpec,
@@ -185,7 +185,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             {
                 if (Properties.TryGetValue(ProjectItemMetadata.Dependencies, out string dependencies) && !string.IsNullOrWhiteSpace(dependencies))
                 {
-                    Assumes.NotNull(Target);
+                    Assumes.NotNull(TargetFrameworkName);
 
                     var dependenciesItemSpecs = new HashSet<string>(StringComparers.ItemNames);
                     var dependencyIds = new LazyStringSplit(dependencies, ';');
@@ -193,7 +193,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                     // store only unique dependency IDs
                     foreach (string dependencyId in dependencyIds)
                     {
-                        dependenciesItemSpecs.Add($"{Target}/{dependencyId}");
+                        dependenciesItemSpecs.Add($"{TargetFrameworkName}/{dependencyId}");
                     }
 
                     return dependenciesItemSpecs;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.PackageDependencyMetadata.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.PackageDependencyMetadata.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions.RuleHandlers
 {
@@ -13,6 +14,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
     {
         private readonly struct PackageDependencyMetadata
         {
+            private static readonly InternPool<string> s_targetFrameworkInternPool = new InternPool<string>(StringComparer.Ordinal);
+
             private readonly DependencyType _dependencyType;
 
             public string Target { get; }
@@ -113,7 +116,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                     properties);
                 return true;
 
-                static string GetTargetFromDependencyId(string dependencyId) => new LazyStringSplit(dependencyId, '/').First();
+                static string GetTargetFromDependencyId(string dependencyId) => s_targetFrameworkInternPool.Intern(new LazyStringSplit(dependencyId, '/').First());
             }
 
             public IDependencyModel CreateDependencyModel()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.PackageDependencyMetadata.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.PackageDependencyMetadata.cs
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 ITargetFrameworkProvider targetFrameworkProvider,
                 out PackageDependencyMetadata metadata)
             {
-                Requires.NotNull(itemSpec, nameof(itemSpec));
+                Requires.NotNullOrEmpty(itemSpec, nameof(itemSpec));
                 Requires.NotNull(properties, nameof(properties));
                 Requires.NotNull(targetFramework, nameof(targetFramework));
                 Requires.NotNull(targetFrameworkProvider, nameof(targetFrameworkProvider));
@@ -113,18 +113,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                     properties);
                 return true;
 
-                static string GetTargetFromDependencyId(string dependencyId)
-                {
-                    string? firstPart = new LazyStringSplit(dependencyId, '/').FirstOrDefault();
-
-                    if (firstPart == null)
-                    {
-                        // should never happen
-                        throw new ArgumentException(nameof(dependencyId));
-                    }
-
-                    return firstPart;
-                }
+                static string GetTargetFromDependencyId(string dependencyId) => new LazyStringSplit(dependencyId, '/').First();
             }
 
             public IDependencyModel CreateDependencyModel()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.PackageDependencyMetadata.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.PackageDependencyMetadata.cs
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 string itemSpec,
                 bool isResolved,
                 IImmutableDictionary<string, string> properties,
-                HashSet<string>? evaluatedItemSpecs,
+                Func<string, bool>? isEvaluatedItemSpec,
                 ITargetFramework targetFramework,
                 ITargetFrameworkProvider targetFrameworkProvider,
                 out PackageDependencyMetadata metadata)
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
                     Requires.NotNull(targetFramework, nameof(targetFramework));
                     Requires.NotNull(targetFrameworkProvider, nameof(targetFrameworkProvider));
-                    Requires.NotNull(evaluatedItemSpecs, nameof(evaluatedItemSpecs));
+                    Requires.NotNull(isEvaluatedItemSpec, nameof(isEvaluatedItemSpec));
 
                     DependencyType dependencyType = properties.GetEnumProperty<DependencyType>(ProjectItemMetadata.Type) ?? DependencyType.Unknown;
 
@@ -93,7 +93,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                     string name = properties.GetStringProperty(ProjectItemMetadata.Name) ?? itemSpec;
 
                     bool isTopLevel = isImplicitlyDefined ||
-                        (dependencyType == DependencyType.Package && evaluatedItemSpecs!.Contains(name));
+                        (dependencyType == DependencyType.Package && isEvaluatedItemSpec!(name));
 
                     string originalItemSpec = isTopLevel ? name : itemSpec;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.PackageDependencyMetadata.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.PackageDependencyMetadata.cs
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 string itemSpec,
                 bool isResolved,
                 IImmutableDictionary<string, string> properties,
-                HashSet<string>? unresolvedChanges,
+                HashSet<string>? evaluatedItemSpecs,
                 ITargetFramework targetFramework,
                 ITargetFrameworkProvider targetFrameworkProvider,
                 out PackageDependencyMetadata metadata)
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                     }
 
                     isTopLevel = isImplicitlyDefined ||
-                        (dependencyType == DependencyType.Package && unresolvedChanges?.Contains(name) == true);
+                        (dependencyType == DependencyType.Package && evaluatedItemSpecs?.Contains(name) == true);
 
                     originalItemSpec = isTopLevel ? name : itemSpec;
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.PackageDependencyMetadata.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.PackageDependencyMetadata.cs
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
                     Requires.NotNull(targetFramework, nameof(targetFramework));
                     Requires.NotNull(targetFrameworkProvider, nameof(targetFrameworkProvider));
-                    Requires.NotNull(isEvaluatedItemSpec, nameof(isEvaluatedItemSpec));
+                    Requires.NotNull(isEvaluatedItemSpec!, nameof(isEvaluatedItemSpec));
 
                     DependencyType dependencyType = properties.GetEnumProperty<DependencyType>(ProjectItemMetadata.Type) ?? DependencyType.Unknown;
 
@@ -93,7 +93,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                     string name = properties.GetStringProperty(ProjectItemMetadata.Name) ?? itemSpec;
 
                     bool isTopLevel = isImplicitlyDefined ||
-                        (dependencyType == DependencyType.Package && isEvaluatedItemSpec!(name));
+                        (dependencyType == DependencyType.Package && isEvaluatedItemSpec(name));
 
                     string originalItemSpec = isTopLevel ? name : itemSpec;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.PackageDependencyMetadata.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.PackageDependencyMetadata.cs
@@ -77,15 +77,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
                 if (isResolved)
                 {
-                    isTopLevel = isImplicitlyDefined ||
-                        (dependencyType == DependencyType.Package && unresolvedChanges?.Contains(name) == true);
-
                     if (target == null ||
                         targetFrameworkProvider.GetTargetFramework(target)?.Equals(targetFramework) != true)
                     {
                         metadata = default;
                         return false;
                     }
+
+                    isTopLevel = isImplicitlyDefined ||
+                        (dependencyType == DependencyType.Package && unresolvedChanges?.Contains(name) == true);
 
                 }
                 else

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.PackageDependencyMetadata.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.PackageDependencyMetadata.cs
@@ -64,6 +64,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 Requires.NotNull(targetFrameworkProvider, nameof(targetFrameworkProvider));
 
                 bool isTopLevel;
+                string originalItemSpec;
 
                 int slashIndex = itemSpec.IndexOf('/');
                 string? target = slashIndex == -1 ? null : s_targetFrameworkInternPool.Intern(itemSpec.Substring(0, slashIndex));
@@ -77,6 +78,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
                 if (isResolved)
                 {
+                    // We have design-time build data
                     if (target == null ||
                         targetFrameworkProvider.GetTargetFramework(target)?.Equals(targetFramework) != true)
                     {
@@ -87,15 +89,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                     isTopLevel = isImplicitlyDefined ||
                         (dependencyType == DependencyType.Package && unresolvedChanges?.Contains(name) == true);
 
+                    originalItemSpec = isTopLevel ? name : itemSpec;
                 }
                 else
                 {
+                    // We only have evaluation data
                     isTopLevel = true;
+                    originalItemSpec = itemSpec;
                 }
-
-                string originalItemSpec = isResolved && isTopLevel
-                    ? name
-                    : itemSpec;
 
                 metadata = new PackageDependencyMetadata(
                     dependencyType,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
@@ -63,13 +63,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
 
             return;
 
-            void HandleChangesForRule(
-                bool resolved,
-                IProjectChangeDescription projectChange,
-                Func<string, bool>? isEvaluatedItemSpec)
+            void HandleChangesForRule(bool resolved, IProjectChangeDescription projectChange, Func<string, bool>? isEvaluatedItemSpec)
             {
-                Requires.NotNull(targetFramework, nameof(targetFramework));
-
                 if (projectChange.Difference.RemovedItems.Count != 0)
                 {
                     foreach (string removedItem in projectChange.Difference.RemovedItems)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
@@ -47,16 +47,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             ITargetFramework targetFramework,
             CrossTargetDependenciesChangesBuilder changesBuilder)
         {
-            var caseInsensitiveUnresolvedChanges = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var evaluatedItemSpecs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
             if (changesByRuleName.TryGetValue(EvaluatedRuleName, out IProjectChangeDescription unresolvedChanges))
             {
-                caseInsensitiveUnresolvedChanges.AddRange(unresolvedChanges.After.Items.Keys);
+                evaluatedItemSpecs.AddRange(unresolvedChanges.After.Items.Keys);
 
                 HandleChangesForRule(
                     resolved: false,
                     projectChange: unresolvedChanges,
-                    unresolvedChanges: null);
+                    evaluatedItemSpecs: null);
             }
 
             if (changesByRuleName.TryGetValue(ResolvedRuleName, out IProjectChangeDescription resolvedChanges))
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 HandleChangesForRule(
                     resolved: true,
                     projectChange: resolvedChanges,
-                    unresolvedChanges: caseInsensitiveUnresolvedChanges);
+                    evaluatedItemSpecs: evaluatedItemSpecs);
             }
 
             return;
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             void HandleChangesForRule(
                 bool resolved,
                 IProjectChangeDescription projectChange,
-                HashSet<string>? unresolvedChanges)
+                HashSet<string>? evaluatedItemSpecs)
             {
                 Requires.NotNull(targetFramework, nameof(targetFramework));
 
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                             removedItem,
                             resolved,
                             properties: projectChange.Before.GetProjectItemProperties(removedItem) ?? ImmutableDictionary<string, string>.Empty,
-                            unresolvedChanges,
+                            evaluatedItemSpecs,
                             targetFramework,
                             _targetFrameworkProvider,
                             out PackageDependencyMetadata metadata))
@@ -102,7 +102,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                             changedItem,
                             resolved,
                             properties: projectChange.After.GetProjectItemProperties(changedItem) ?? ImmutableDictionary<string, string>.Empty,
-                            unresolvedChanges,
+                            evaluatedItemSpecs,
                             targetFramework,
                             _targetFrameworkProvider,
                             out PackageDependencyMetadata metadata))
@@ -121,7 +121,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                             addedItem,
                             resolved,
                             properties: projectChange.After.GetProjectItemProperties(addedItem) ?? ImmutableDictionary<string, string>.Empty,
-                            unresolvedChanges,
+                            evaluatedItemSpecs,
                             targetFramework,
                             _targetFrameworkProvider,
                             out PackageDependencyMetadata metadata))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
@@ -80,49 +80,58 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             {
                 Requires.NotNull(targetFramework, nameof(targetFramework));
 
-                foreach (string removedItem in projectChange.Difference.RemovedItems)
+                if (projectChange.Difference.RemovedItems.Count != 0)
                 {
-                    if (PackageDependencyMetadata.TryGetMetadata(
-                        removedItem,
-                        resolved,
-                        properties: projectChange.Before.GetProjectItemProperties(removedItem) ?? ImmutableDictionary<string, string>.Empty,
-                        unresolvedChanges,
-                        targetFramework,
-                        _targetFrameworkProvider,
-                        out PackageDependencyMetadata metadata))
+                    foreach (string removedItem in projectChange.Difference.RemovedItems)
                     {
-                        changesBuilder.Removed(targetFramework, ProviderTypeString, metadata.OriginalItemSpec);
+                        if (PackageDependencyMetadata.TryGetMetadata(
+                            removedItem,
+                            resolved,
+                            properties: projectChange.Before.GetProjectItemProperties(removedItem) ?? ImmutableDictionary<string, string>.Empty,
+                            unresolvedChanges,
+                            targetFramework,
+                            _targetFrameworkProvider,
+                            out PackageDependencyMetadata metadata))
+                        {
+                            changesBuilder.Removed(targetFramework, ProviderTypeString, metadata.OriginalItemSpec);
+                        }
                     }
                 }
 
-                foreach (string changedItem in projectChange.Difference.ChangedItems)
+                if (projectChange.Difference.ChangedItems.Count != 0)
                 {
-                    if (PackageDependencyMetadata.TryGetMetadata(
-                        changedItem,
-                        resolved,
-                        properties: projectChange.After.GetProjectItemProperties(changedItem) ?? ImmutableDictionary<string, string>.Empty,
-                        unresolvedChanges,
-                        targetFramework,
-                        _targetFrameworkProvider,
-                        out PackageDependencyMetadata metadata))
+                    foreach (string changedItem in projectChange.Difference.ChangedItems)
                     {
-                        changesBuilder.Removed(targetFramework, ProviderTypeString, metadata.OriginalItemSpec);
-                        changesBuilder.Added(targetFramework, metadata.CreateDependencyModel());
+                        if (PackageDependencyMetadata.TryGetMetadata(
+                            changedItem,
+                            resolved,
+                            properties: projectChange.After.GetProjectItemProperties(changedItem) ?? ImmutableDictionary<string, string>.Empty,
+                            unresolvedChanges,
+                            targetFramework,
+                            _targetFrameworkProvider,
+                            out PackageDependencyMetadata metadata))
+                        {
+                            changesBuilder.Removed(targetFramework, ProviderTypeString, metadata.OriginalItemSpec);
+                            changesBuilder.Added(targetFramework, metadata.CreateDependencyModel());
+                        }
                     }
                 }
 
-                foreach (string addedItem in projectChange.Difference.AddedItems)
+                if (projectChange.Difference.AddedItems.Count != 0)
                 {
-                    if (PackageDependencyMetadata.TryGetMetadata(
-                        addedItem,
-                        resolved,
-                        properties: projectChange.After.GetProjectItemProperties(addedItem) ?? ImmutableDictionary<string, string>.Empty,
-                        unresolvedChanges,
-                        targetFramework,
-                        _targetFrameworkProvider,
-                        out PackageDependencyMetadata metadata))
+                    foreach (string addedItem in projectChange.Difference.AddedItems)
                     {
-                        changesBuilder.Added(targetFramework, metadata.CreateDependencyModel());
+                        if (PackageDependencyMetadata.TryGetMetadata(
+                            addedItem,
+                            resolved,
+                            properties: projectChange.After.GetProjectItemProperties(addedItem) ?? ImmutableDictionary<string, string>.Empty,
+                            unresolvedChanges,
+                            targetFramework,
+                            _targetFrameworkProvider,
+                            out PackageDependencyMetadata metadata))
+                        {
+                            changesBuilder.Added(targetFramework, metadata.CreateDependencyModel());
+                        }
                     }
                 }
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
@@ -42,7 +42,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
         public override ImageMoniker ImplicitIcon => ManagedImageMonikers.NuGetGreyPrivate;
 
         public override void Handle(
+            IImmutableDictionary<NamedIdentity, IComparable> versions,
             IImmutableDictionary<string, IProjectChangeDescription> changesByRuleName,
+            RuleSource source,
             ITargetFramework targetFramework,
             CrossTargetDependenciesChangesBuilder changesBuilder)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 
@@ -47,16 +46,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             ITargetFramework targetFramework,
             CrossTargetDependenciesChangesBuilder changesBuilder)
         {
-            var evaluatedItemSpecs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
             if (changesByRuleName.TryGetValue(EvaluatedRuleName, out IProjectChangeDescription unresolvedChanges))
             {
-                evaluatedItemSpecs.AddRange(unresolvedChanges.After.Items.Keys);
-
                 HandleChangesForRule(
                     resolved: false,
                     projectChange: unresolvedChanges,
-                    evaluatedItemSpecs: null);
+                    isEvaluatedItemSpec: null);
             }
 
             if (changesByRuleName.TryGetValue(ResolvedRuleName, out IProjectChangeDescription resolvedChanges))
@@ -64,7 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 HandleChangesForRule(
                     resolved: true,
                     projectChange: resolvedChanges,
-                    evaluatedItemSpecs: evaluatedItemSpecs);
+                    isEvaluatedItemSpec: unresolvedChanges!.After.Items.ContainsKey);
             }
 
             return;
@@ -72,7 +67,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             void HandleChangesForRule(
                 bool resolved,
                 IProjectChangeDescription projectChange,
-                HashSet<string>? evaluatedItemSpecs)
+                Func<string, bool>? isEvaluatedItemSpec)
             {
                 Requires.NotNull(targetFramework, nameof(targetFramework));
 
@@ -84,7 +79,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                             removedItem,
                             resolved,
                             properties: projectChange.Before.GetProjectItemProperties(removedItem) ?? ImmutableDictionary<string, string>.Empty,
-                            evaluatedItemSpecs,
+                            isEvaluatedItemSpec,
                             targetFramework,
                             _targetFrameworkProvider,
                             out PackageDependencyMetadata metadata))
@@ -102,7 +97,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                             changedItem,
                             resolved,
                             properties: projectChange.After.GetProjectItemProperties(changedItem) ?? ImmutableDictionary<string, string>.Empty,
-                            evaluatedItemSpecs,
+                            isEvaluatedItemSpec,
                             targetFramework,
                             _targetFrameworkProvider,
                             out PackageDependencyMetadata metadata))
@@ -121,7 +116,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                             addedItem,
                             resolved,
                             properties: projectChange.After.GetProjectItemProperties(addedItem) ?? ImmutableDictionary<string, string>.Empty,
-                            evaluatedItemSpecs,
+                            isEvaluatedItemSpec,
                             targetFramework,
                             _targetFrameworkProvider,
                             out PackageDependencyMetadata metadata))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
@@ -46,20 +46,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             ITargetFramework targetFramework,
             CrossTargetDependenciesChangesBuilder changesBuilder)
         {
-            if (changesByRuleName.TryGetValue(EvaluatedRuleName, out IProjectChangeDescription unresolvedChanges))
-            {
-                HandleChangesForRule(
-                    resolved: false,
-                    projectChange: unresolvedChanges,
-                    isEvaluatedItemSpec: null);
-            }
+            IProjectChangeDescription unresolvedChanges = changesByRuleName[EvaluatedRuleName];
+
+            HandleChangesForRule(
+                resolved: false,
+                projectChange: unresolvedChanges,
+                isEvaluatedItemSpec: null);
 
             if (changesByRuleName.TryGetValue(ResolvedRuleName, out IProjectChangeDescription resolvedChanges))
             {
                 HandleChangesForRule(
                     resolved: true,
                     projectChange: resolvedChanges,
-                    isEvaluatedItemSpec: unresolvedChanges!.After.Items.ContainsKey);
+                    isEvaluatedItemSpec: unresolvedChanges.After.Items.ContainsKey);
             }
 
             return;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
@@ -53,17 +53,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             {
                 caseInsensitiveUnresolvedChanges.AddRange(unresolvedChanges.After.Items.Keys);
 
-                if (unresolvedChanges.Difference.AnyChanges)
-                {
-                    HandleChangesForRule(
-                        resolved: false,
-                        projectChange: unresolvedChanges,
-                        unresolvedChanges: null);
-                }
+                HandleChangesForRule(
+                    resolved: false,
+                    projectChange: unresolvedChanges,
+                    unresolvedChanges: null);
             }
 
-            if (changesByRuleName.TryGetValue(ResolvedRuleName, out IProjectChangeDescription resolvedChanges)
-                && resolvedChanges.Difference.AnyChanges)
+            if (changesByRuleName.TryGetValue(ResolvedRuleName, out IProjectChangeDescription resolvedChanges))
             {
                 HandleChangesForRule(
                     resolved: true,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
@@ -119,6 +119,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                         }
                     }
                 }
+
+                System.Diagnostics.Debug.Assert(evaluatedChanges.Difference.RenamedItems.Count == 0, "Project rule diff should not contain renamed items");
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                         if (PackageDependencyMetadata.TryGetMetadata(
                             removedItem,
                             resolved,
-                            properties: projectChange.Before.GetProjectItemProperties(removedItem) ?? ImmutableDictionary<string, string>.Empty,
+                            properties: projectChange.Before.GetProjectItemProperties(removedItem)!,
                             isEvaluatedItemSpec,
                             targetFramework,
                             _targetFrameworkProvider,
@@ -90,7 +90,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                         if (PackageDependencyMetadata.TryGetMetadata(
                             changedItem,
                             resolved,
-                            properties: projectChange.After.GetProjectItemProperties(changedItem) ?? ImmutableDictionary<string, string>.Empty,
+                            properties: projectChange.After.GetProjectItemProperties(changedItem)!,
                             isEvaluatedItemSpec,
                             targetFramework,
                             _targetFrameworkProvider,
@@ -109,7 +109,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                         if (PackageDependencyMetadata.TryGetMetadata(
                             addedItem,
                             resolved,
-                            properties: projectChange.After.GetProjectItemProperties(addedItem) ?? ImmutableDictionary<string, string>.Empty,
+                            properties: projectChange.After.GetProjectItemProperties(addedItem)!,
                             isEvaluatedItemSpec,
                             targetFramework,
                             _targetFrameworkProvider,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
@@ -46,11 +46,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             ITargetFramework targetFramework,
             CrossTargetDependenciesChangesBuilder changesBuilder)
         {
-            IProjectChangeDescription unresolvedChanges = changesByRuleName[EvaluatedRuleName];
+            IProjectChangeDescription evaluatedChanges = changesByRuleName[EvaluatedRuleName];
 
             HandleChangesForRule(
                 resolved: false,
-                projectChange: unresolvedChanges,
+                projectChange: evaluatedChanges,
                 isEvaluatedItemSpec: null);
 
             if (changesByRuleName.TryGetValue(ResolvedRuleName, out IProjectChangeDescription resolvedChanges))
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 HandleChangesForRule(
                     resolved: true,
                     projectChange: resolvedChanges,
-                    isEvaluatedItemSpec: unresolvedChanges.After.Items.ContainsKey);
+                    isEvaluatedItemSpec: evaluatedChanges.After.Items.ContainsKey);
             }
 
             return;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Utilities/InternPool.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Utilities/InternPool.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+using System.Threading;
+
+namespace Microsoft.VisualStudio.Utilities
+{
+    /// <summary>
+    /// A thread-safe object pool, backed by <see cref="ImmutableHashSet{T}"/> and using interlocked
+    /// operations for optimistic, lock-free concurrent access.
+    /// </summary>
+    /// <remarks>
+    /// Objects added to this pool will never be released.
+    /// </remarks>
+    /// <typeparam name="T"></typeparam>
+    internal sealed class InternPool<T> where T : class
+    {
+        private ImmutableHashSet<T> _set;
+
+        public int Count => _set.Count;
+
+        public InternPool(IEqualityComparer<T>? comparer = null)
+        {
+            _set = ImmutableHashSet.Create(comparer);
+        }
+
+        public T Intern(T value)
+        {
+            // Would be nice if this was on ImmutableInterlocked as
+            // requested in https://github.com/dotnet/corefx/issues/33653
+
+            ImmutableHashSet<T> priorCollection = Volatile.Read(ref _set);
+
+            bool successful;
+            do
+            {
+                if (priorCollection.TryGetValue(value, out T existingValue))
+                {
+                    // The value already exists in the set. Return it.
+                    return existingValue;
+                }
+
+                ImmutableHashSet<T> updatedCollection = priorCollection.Add(value);
+                ImmutableHashSet<T> interlockedResult = Interlocked.CompareExchange(ref _set, updatedCollection, priorCollection);
+                successful = ReferenceEquals(priorCollection, interlockedResult);
+                priorCollection = interlockedResult; // We already have a volatile read that we can reuse for the next loop
+            }
+            while (!successful);
+
+            // We won the race-condition and have updated the collection.
+            // Return the value that is in the collection (as of the Interlocked operation).
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
Part of #5044. For that issue we'll need to update how evaluation and design-time build data flows through the first stages of the dependency node pipeline.

Previously the code that handled this was implemented in `DependenciesRuleHandlerBase` for most types of dependencies, however `PackageRuleHandler` overrode this with largely copy/paste logic.

This PR allows the logic in the base class to be reused by `PackageRuleHandler` without duplication.

It also starts to unpick complexity in `PackageRuleHandler`, making a clearer division between the handling of evaluation data and design-time data.