### PR TITLE
Extract base class for rules subscribers

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/CrossTarget/IDependenciesRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/CrossTarget/IDependenciesRuleHandler.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Immutable;
 
 using Microsoft.VisualStudio.Composition;
@@ -37,9 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
         /// to the given <see cref="CrossTargetDependenciesChangesBuilder"/>.
         /// </summary>
         void Handle(
-            IImmutableDictionary<NamedIdentity, IComparable> versions,
             IImmutableDictionary<string, IProjectChangeDescription> changesByRuleName,
-            RuleSource source,
             ITargetFramework targetFramework,
             CrossTargetDependenciesChangesBuilder changesBuilder);
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
@@ -98,7 +98,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                     dataSource.SourceBlock.LinkTo(
                         intermediateBlock,
                         ruleNames: ruleNames,
-                        suppressVersionOnlyUpdates: true,
+                        suppressVersionOnlyUpdates: false,
                         linkOptions: DataflowOption.PropagateCompletion));
 
                 Subscriptions.Add(ProjectDataSources.SyncLinkTo(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriber.cs
@@ -5,178 +5,111 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Linq;
-using System.Threading.Tasks;
 using System.Threading.Tasks.Dataflow;
 
 using Microsoft.VisualStudio.ProjectSystem.Properties;
-using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
+
+using EventData = System.Tuple<
+    Microsoft.VisualStudio.ProjectSystem.IProjectSubscriptionUpdate,
+    Microsoft.VisualStudio.ProjectSystem.Properties.IProjectCatalogSnapshot,
+    Microsoft.VisualStudio.ProjectSystem.IProjectCapabilitiesSnapshot>;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions
 {
     [Export(typeof(IDependencyCrossTargetSubscriber))]
     [AppliesTo(ProjectCapability.DependenciesTree)]
-    internal sealed class DependencyRulesSubscriber : DependencyRulesSubscriberBase
+    internal sealed class DependencyRulesSubscriber : DependencyRulesSubscriberBase<EventData>
     {
         public const string DependencyRulesSubscriberContract = "DependencyRulesSubscriberContract";
 
-        private readonly IUnconfiguredProjectCommonServices _commonServices;
         private readonly IDependencyTreeTelemetryService _treeTelemetryService;
 
         [ImportMany(DependencyRulesSubscriberContract)]
         private readonly OrderPrecedenceImportCollection<IDependenciesRuleHandler> _handlers;
+
+        private readonly Lazy<string[]> _watchedEvaluationRules;
+        private readonly Lazy<string[]> _watchedJointRules;
 
         [ImportingConstructor]
         public DependencyRulesSubscriber(
             IUnconfiguredProjectCommonServices commonServices,
             IUnconfiguredProjectTasksService tasksService,
             IDependencyTreeTelemetryService treeTelemetryService)
-            : base(tasksService, commonServices.ThreadingService.JoinableTaskContext)
+            : base(commonServices, tasksService)
         {
             _handlers = new OrderPrecedenceImportCollection<IDependenciesRuleHandler>(
                 projectCapabilityCheckProvider: commonServices.Project);
 
-            _commonServices = commonServices;
             _treeTelemetryService = treeTelemetryService;
-        }
 
-        protected override void InitializeSubscriber(IProjectSubscriptionService subscriptionService)
-        {
-            IReadOnlyCollection<string> watchedEvaluationRules = GetRuleNames(RuleSource.Evaluation);
-            IReadOnlyCollection<string> watchedJointRules = GetRuleNames(RuleSource.Joint);
+            _watchedJointRules = new Lazy<string[]>(() => GetRuleNames(RuleSource.Joint));
+            _watchedEvaluationRules = new Lazy<string[]>(() => GetRuleNames(RuleSource.Evaluation));
 
-            SubscribeToConfiguredProject(
-                _commonServices.ActiveConfiguredProject, subscriptionService, watchedEvaluationRules, watchedJointRules);
-        }
-
-        protected override void AddSubscriptionsInternal(AggregateCrossTargetProjectContext projectContext)
-        {
-            IReadOnlyCollection<string> watchedEvaluationRules = GetRuleNames(RuleSource.Evaluation);
-            IReadOnlyCollection<string> watchedJointRules = GetRuleNames(RuleSource.Joint);
-
-            _treeTelemetryService.InitializeTargetFrameworkRules(projectContext.TargetFrameworks, watchedJointRules);
-
-            foreach (ConfiguredProject configuredProject in projectContext.InnerConfiguredProjects)
+            string[] GetRuleNames(RuleSource source)
             {
-                SubscribeToConfiguredProject(
-                    configuredProject, configuredProject.Services.ProjectSubscription, watchedEvaluationRules, watchedJointRules);
+                var rules = new HashSet<string>(StringComparers.RuleNames);
+
+                foreach (Lazy<IDependenciesRuleHandler, IOrderPrecedenceMetadataView> item in _handlers)
+                {
+                    rules.Add(item.Value.EvaluatedRuleName);
+
+                    if (source == RuleSource.Joint)
+                    {
+                        rules.Add(item.Value.ResolvedRuleName);
+                    }
+                }
+
+                return rules.ToArray();
             }
         }
 
-        private void SubscribeToConfiguredProject(
-            ConfiguredProject configuredProject,
-            IProjectSubscriptionService subscriptionService,
-            IReadOnlyCollection<string> watchedEvaluationRules,
-            IReadOnlyCollection<string> watchedJointRules)
+        public override void AddSubscriptions(AggregateCrossTargetProjectContext projectContext)
         {
-            Subscribe(RuleSource.Evaluation, subscriptionService.ProjectRuleSource, watchedEvaluationRules);
-            Subscribe(RuleSource.Joint, subscriptionService.JointRuleSource, watchedJointRules);
+            _treeTelemetryService.InitializeTargetFrameworkRules(projectContext.TargetFrameworks, _watchedJointRules.Value);
 
-            void Subscribe(RuleSource source, IProjectValueDataSource<IProjectSubscriptionUpdate> dataSource, IReadOnlyCollection<string> ruleNames)
+            base.AddSubscriptions(projectContext);
+        }
+
+        protected override void SubscribeToConfiguredProject(
+            ConfiguredProject configuredProject,
+            IProjectSubscriptionService subscriptionService)
+        {
+            Subscribe(
+                configuredProject,
+                subscriptionService.ProjectRuleSource,
+                _watchedEvaluationRules.Value,
+                "CrossTarget Evaluation Input: {1}",
+                SyncLink);
+
+            Subscribe(
+                configuredProject,
+                subscriptionService.JointRuleSource,
+                _watchedJointRules.Value,
+                "CrossTarget Joint Input: {1}",
+                SyncLink);
+
+            IDisposable SyncLink((BufferBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>> Intermediate, ITargetBlock<IProjectVersionedValue<EventData>> Action) blocks)
             {
-                // Use intermediate buffer blocks for project rule data to allow subsequent blocks
-                // to only observe specific rule name(s).
-
-                var intermediateBlock =
-                    new BufferBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(
-                        new ExecutionDataflowBlockOptions
-                        {
-                            NameFormat = string.Intern($"CrossTarget Intermediate {source} Input: {{1}}")
-                        });
-
-                ITargetBlock<IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectCatalogSnapshot, IProjectCapabilitiesSnapshot>>> actionBlock =
-                    DataflowBlockSlim.CreateActionBlock<IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectCatalogSnapshot, IProjectCapabilitiesSnapshot>>>(
-                        e => OnProjectChangedAsync(e.DataSourceVersions, e.Value.Item1, e.Value.Item2, e.Value.Item3, configuredProject, source),
-                        new ExecutionDataflowBlockOptions
-                        {
-                            NameFormat = string.Intern($"CrossTarget {source} Input: {{1}}")
-                        });
-
-                Subscriptions ??= new DisposableBag();
-
-                Subscriptions.Add(
-                    dataSource.SourceBlock.LinkTo(
-                        intermediateBlock,
-                        ruleNames: ruleNames,
-                        suppressVersionOnlyUpdates: false,
-                        linkOptions: DataflowOption.PropagateCompletion));
-
-                Subscriptions.Add(ProjectDataSources.SyncLinkTo(
-                    intermediateBlock.SyncLinkOptions(),
+                return ProjectDataSources.SyncLinkTo(
+                    blocks.Intermediate.SyncLinkOptions(),
                     subscriptionService.ProjectCatalogSource.SourceBlock.SyncLinkOptions(),
                     configuredProject.Capabilities.SourceBlock.SyncLinkOptions(),
-                    actionBlock,
-                    linkOptions: DataflowOption.PropagateCompletion));
+                    blocks.Action,
+                    linkOptions: DataflowOption.PropagateCompletion);
             }
         }
 
-        private IReadOnlyCollection<string> GetRuleNames(RuleSource source)
+        protected override IProjectCapabilitiesSnapshot GetCapabilitiesSnapshot(EventData e) => e.Item3;
+        protected override IProjectSubscriptionUpdate GetProjectSubscriptionUpdate(EventData e) => e.Item1;
+
+        protected override void Handle(
+            AggregateCrossTargetProjectContext currentAggregateContext,
+            ITargetFramework targetFrameworkToUpdate,
+            EventData e)
         {
-            var rules = new HashSet<string>(StringComparers.RuleNames);
-
-            foreach (Lazy<IDependenciesRuleHandler, IOrderPrecedenceMetadataView> item in _handlers)
-            {
-                rules.Add(item.Value.EvaluatedRuleName);
-
-                if (source == RuleSource.Joint)
-                {
-                    rules.Add(item.Value.ResolvedRuleName);
-                }
-            }
-
-            return rules;
-        }
-
-        private async Task OnProjectChangedAsync(
-            IImmutableDictionary<NamedIdentity, IComparable> versions,
-            IProjectSubscriptionUpdate projectUpdate,
-            IProjectCatalogSnapshot catalogSnapshot,
-            IProjectCapabilitiesSnapshot capabilities,
-            ConfiguredProject configuredProject,
-            RuleSource source)
-        {
-            if (IsDisposing || IsDisposed)
-            {
-                return;
-            }
-
-            // Ensure updates don't overlap and that we aren't disposed during the update without cleaning up properly
-            await ExecuteUnderLockAsync(async token =>
-            {
-                // Ensure the project doesn't unload during the update
-                await TasksService.LoadedProjectAsync(async () =>
-                {
-                    // TODO pass _tasksService.UnloadCancellationToken into HandleAsync to reduce redundant work on unload
-
-                    // Ensure the project's capabilities don't change during the update
-                    using (ProjectCapabilitiesContext.CreateIsolatedContext(configuredProject, capabilities))
-                    {
-                        await HandleAsync(versions, projectUpdate, catalogSnapshot, source);
-                    }
-                });
-            });
-        }
-
-        private async Task HandleAsync(
-            IImmutableDictionary<NamedIdentity, IComparable> versions,
-            IProjectSubscriptionUpdate projectUpdate,
-            IProjectCatalogSnapshot catalogSnapshot,
-            RuleSource source)
-        {
-            AggregateCrossTargetProjectContext? currentAggregateContext = await Host!.GetCurrentAggregateProjectContextAsync();
-
-            if (currentAggregateContext == null || CurrentProjectContext != currentAggregateContext)
-            {
-                return;
-            }
-
-            // Get the inner workspace project context to update for this change.
-            ITargetFramework? targetFrameworkToUpdate = currentAggregateContext.GetProjectFramework(projectUpdate.ProjectConfiguration);
-
-            if (targetFrameworkToUpdate == null)
-            {
-                return;
-            }
+            IProjectSubscriptionUpdate projectUpdate = e.Item1;
+            IProjectCatalogSnapshot catalogSnapshot = e.Item2;
 
             // Broken design time builds sometimes cause updates with no project changes and sometimes
             // cause updates with a project change that has no difference.
@@ -197,7 +130,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             // Give each handler a chance to register dependency changes.
             foreach (Lazy<IDependenciesRuleHandler, IOrderPrecedenceMetadataView> handler in _handlers)
             {
-                handler.Value.Handle(versions, projectUpdate.ProjectChanges, source, targetFrameworkToUpdate, changesBuilder);
+                handler.Value.Handle(projectUpdate.ProjectChanges, targetFrameworkToUpdate, changesBuilder);
             }
 
             ImmutableDictionary<ITargetFramework, IDependenciesChanges>? changes = changesBuilder.TryBuildChanges();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriberBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriberBase.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.Utilities;
+using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions
+{
+    /// <summary>
+    /// Base class for <see cref="IDependencyCrossTargetSubscriber"/> implementations.
+    /// </summary>
+    internal abstract class DependencyRulesSubscriberBase : OnceInitializedOnceDisposedUnderLockAsync, IDependencyCrossTargetSubscriber
+    {
+        protected IUnconfiguredProjectTasksService TasksService { get; }
+
+        protected DisposableBag? Subscriptions { get; set; }
+
+        protected ICrossTargetSubscriptionsHost? Host { get; private set; }
+
+        protected AggregateCrossTargetProjectContext? CurrentProjectContext { get; private set; }
+
+        public event EventHandler<DependencySubscriptionChangedEventArgs>? DependenciesChanged;
+
+        protected DependencyRulesSubscriberBase(
+            IUnconfiguredProjectTasksService tasksService,
+            JoinableTaskContextNode joinableTaskContextNode)
+            : base(joinableTaskContextNode)
+        {
+            TasksService = tasksService;
+        }
+
+        protected abstract void InitializeSubscriber(IProjectSubscriptionService subscriptionService);
+
+        protected abstract void AddSubscriptionsInternal(AggregateCrossTargetProjectContext projectContext);
+
+        public async Task InitializeSubscriberAsync(ICrossTargetSubscriptionsHost host, IProjectSubscriptionService subscriptionService)
+        {
+            Host = host;
+
+            await InitializeAsync();
+
+            InitializeSubscriber(subscriptionService);
+        }
+
+        public void AddSubscriptions(AggregateCrossTargetProjectContext projectContext)
+        {
+            Requires.NotNull(projectContext, nameof(projectContext));
+
+            CurrentProjectContext = projectContext;
+
+            AddSubscriptionsInternal(projectContext);
+        }
+
+        public void ReleaseSubscriptions()
+        {
+            CurrentProjectContext = null;
+
+            // We can't re-use the DisposableBag after disposing it, so null it out
+            // to ensure we create a new one the next time we go to add subscriptions.
+            Subscriptions?.Dispose();
+            Subscriptions = null;
+        }
+
+        protected override Task InitializeCoreAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        protected override Task DisposeCoreUnderLockAsync(bool initialized)
+        {
+            ReleaseSubscriptions();
+
+            return Task.CompletedTask;
+        }
+
+        protected void RaiseDependenciesChanged(ImmutableDictionary<ITargetFramework, IDependenciesChanges> changes, AggregateCrossTargetProjectContext currentAggregateContext, IProjectCatalogSnapshot catalogSnapshot)
+        {
+            DependenciesChanged?.Invoke(
+                this,
+                new DependencySubscriptionChangedEventArgs(
+                    currentAggregateContext.TargetFrameworks,
+                    currentAggregateContext.ActiveTargetFramework,
+                    catalogSnapshot,
+                    changes));
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriberBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriberBase.cs
@@ -4,68 +4,149 @@ using System;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
 
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget;
-using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions
 {
     /// <summary>
     /// Base class for <see cref="IDependencyCrossTargetSubscriber"/> implementations.
     /// </summary>
-    internal abstract class DependencyRulesSubscriberBase : OnceInitializedOnceDisposedUnderLockAsync, IDependencyCrossTargetSubscriber
+    internal abstract class DependencyRulesSubscriberBase<T> : OnceInitializedOnceDisposedUnderLockAsync, IDependencyCrossTargetSubscriber
     {
-        protected IUnconfiguredProjectTasksService TasksService { get; }
+        private readonly IUnconfiguredProjectCommonServices _commonServices;
+        private readonly IUnconfiguredProjectTasksService _tasksService;
 
-        protected DisposableBag? Subscriptions { get; set; }
-
-        protected ICrossTargetSubscriptionsHost? Host { get; private set; }
-
-        protected AggregateCrossTargetProjectContext? CurrentProjectContext { get; private set; }
+        private ICrossTargetSubscriptionsHost? _host;
+        private DisposableBag? _subscriptions;
 
         public event EventHandler<DependencySubscriptionChangedEventArgs>? DependenciesChanged;
 
         protected DependencyRulesSubscriberBase(
-            IUnconfiguredProjectTasksService tasksService,
-            JoinableTaskContextNode joinableTaskContextNode)
-            : base(joinableTaskContextNode)
+            IUnconfiguredProjectCommonServices commonServices,
+            IUnconfiguredProjectTasksService tasksService)
+            : base(commonServices.ThreadingService.JoinableTaskContext)
         {
-            TasksService = tasksService;
+            _commonServices = commonServices;
+            _tasksService = tasksService;
         }
-
-        protected abstract void InitializeSubscriber(IProjectSubscriptionService subscriptionService);
-
-        protected abstract void AddSubscriptionsInternal(AggregateCrossTargetProjectContext projectContext);
 
         public async Task InitializeSubscriberAsync(ICrossTargetSubscriptionsHost host, IProjectSubscriptionService subscriptionService)
         {
-            Host = host;
+            _host = host;
 
             await InitializeAsync();
 
-            InitializeSubscriber(subscriptionService);
+            SubscribeToConfiguredProject(_commonServices.ActiveConfiguredProject, subscriptionService);
         }
 
-        public void AddSubscriptions(AggregateCrossTargetProjectContext projectContext)
+        public virtual void AddSubscriptions(AggregateCrossTargetProjectContext projectContext)
         {
             Requires.NotNull(projectContext, nameof(projectContext));
 
-            CurrentProjectContext = projectContext;
-
-            AddSubscriptionsInternal(projectContext);
+            foreach (ConfiguredProject configuredProject in projectContext.InnerConfiguredProjects)
+            {
+                SubscribeToConfiguredProject(configuredProject, configuredProject.Services.ProjectSubscription);
+            }
         }
 
         public void ReleaseSubscriptions()
         {
-            CurrentProjectContext = null;
-
             // We can't re-use the DisposableBag after disposing it, so null it out
             // to ensure we create a new one the next time we go to add subscriptions.
-            Subscriptions?.Dispose();
-            Subscriptions = null;
+            _subscriptions?.Dispose();
+            _subscriptions = null;
         }
+
+        protected abstract void SubscribeToConfiguredProject(
+            ConfiguredProject configuredProject,
+            IProjectSubscriptionService subscriptionService);
+
+        protected void Subscribe(
+            ConfiguredProject configuredProject,
+            IProjectValueDataSource<IProjectSubscriptionUpdate> dataSource,
+            string[] ruleNames,
+            string nameFormat,
+            Func<(BufferBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>> Intermediate, ITargetBlock<IProjectVersionedValue<T>> Action), IDisposable> syncLink)
+        {
+            // Use an intermediate buffer block for project rule data to allow subsequent blocks
+            // to only observe specific rule name(s).
+
+            var intermediateBlock =
+                new BufferBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(
+                    new ExecutionDataflowBlockOptions
+                    {
+                        NameFormat = nameFormat
+                    });
+
+            ITargetBlock<IProjectVersionedValue<T>> actionBlock =
+                DataflowBlockSlim.CreateActionBlock<IProjectVersionedValue<T>>(
+                    e => OnProjectChangedAsync(configuredProject, e.Value),
+                    new ExecutionDataflowBlockOptions
+                    {
+                        NameFormat = nameFormat
+                    });
+
+            _subscriptions ??= new DisposableBag();
+
+            _subscriptions.Add(
+                dataSource.SourceBlock.LinkTo(
+                    intermediateBlock,
+                    ruleNames: ruleNames,
+                    suppressVersionOnlyUpdates: false,
+                    linkOptions: DataflowOption.PropagateCompletion));
+
+            _subscriptions.Add(syncLink((intermediateBlock, actionBlock)));
+        }
+
+        private async Task OnProjectChangedAsync(ConfiguredProject configuredProject, T e)
+        {
+            if (IsDisposing || IsDisposed)
+            {
+                return;
+            }
+
+            await InitializeAsync();
+
+            // Ensure updates don't overlap and that we aren't disposed during the update without cleaning up properly
+            await ExecuteUnderLockAsync(async token =>
+            {
+                // Ensure the project doesn't unload during the update
+                await _tasksService.LoadedProjectAsync(async () =>
+                {
+                    // TODO pass TasksService.UnloadCancellationToken into Handle to reduce redundant work on unload
+
+                    // Ensure the project's capabilities don't change during the update
+                    using (ProjectCapabilitiesContext.CreateIsolatedContext(configuredProject, capabilities: GetCapabilitiesSnapshot(e)))
+                    {
+                        AggregateCrossTargetProjectContext? currentAggregateContext = await _host!.GetCurrentAggregateProjectContextAsync();
+
+                        if (currentAggregateContext == null)
+                        {
+                            return;
+                        }
+
+                        // Get the target framework to update for this change.
+                        ITargetFramework? targetFrameworkToUpdate = currentAggregateContext.GetProjectFramework(GetProjectSubscriptionUpdate(e).ProjectConfiguration);
+
+                        if (targetFrameworkToUpdate == null)
+                        {
+                            return;
+                        }
+
+                        Handle(currentAggregateContext, targetFrameworkToUpdate, e);
+                    }
+                });
+            });
+        }
+
+        protected abstract void Handle(AggregateCrossTargetProjectContext currentAggregateContext, ITargetFramework targetFrameworkToUpdate, T e);
+
+        protected abstract IProjectCapabilitiesSnapshot GetCapabilitiesSnapshot(T e);
+        protected abstract IProjectSubscriptionUpdate GetProjectSubscriptionUpdate(T e);
 
         protected override Task InitializeCoreAsync(CancellationToken cancellationToken)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
@@ -1,25 +1,27 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Linq;
-using System.Threading.Tasks;
-using System.Threading.Tasks.Dataflow;
 
 using Microsoft.VisualStudio.ProjectSystem.Properties;
-using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Models;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Snapshot;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscriptions.RuleHandlers;
 
+using EventData = System.Tuple<
+    Microsoft.VisualStudio.ProjectSystem.IProjectSubscriptionUpdate,
+    Microsoft.VisualStudio.ProjectSystem.IProjectSharedFoldersSnapshot,
+    Microsoft.VisualStudio.ProjectSystem.Properties.IProjectCatalogSnapshot,
+    Microsoft.VisualStudio.ProjectSystem.IProjectCapabilitiesSnapshot>;
+
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
 {
     [Export(typeof(IDependencyCrossTargetSubscriber))]
     [AppliesTo(ProjectCapability.DependenciesTree)]
-    internal sealed class DependencySharedProjectsSubscriber : DependencyRulesSubscriberBase
+    internal sealed class DependencySharedProjectsSubscriber : DependencyRulesSubscriberBase<EventData>
     {
         private readonly IDependenciesSnapshotProvider _dependenciesSnapshotProvider;
 
@@ -28,90 +30,39 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.CrossTarget
             IUnconfiguredProjectCommonServices commonServices,
             IUnconfiguredProjectTasksService tasksService,
             IDependenciesSnapshotProvider dependenciesSnapshotProvider)
-            : base(tasksService, commonServices.ThreadingService.JoinableTaskContext)
+            : base(commonServices, tasksService)
         {
             _dependenciesSnapshotProvider = dependenciesSnapshotProvider;
         }
 
-        protected override void AddSubscriptionsInternal(AggregateCrossTargetProjectContext projectContext)
+        protected override void SubscribeToConfiguredProject(
+            ConfiguredProject configuredProject,
+            IProjectSubscriptionService subscriptionService)
         {
-            foreach (ConfiguredProject configuredProject in projectContext.InnerConfiguredProjects)
-            {
-                InitializeSubscriber(configuredProject.Services.ProjectSubscription);
-            }
-        }
-
-        protected override void InitializeSubscriber(IProjectSubscriptionService subscriptionService)
-        {
-            // Use an intermediate buffer block for project rule data to allow subsequent blocks
-            // to only observe specific rule name(s).
-
-            var intermediateBlock =
-                new BufferBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(
-                    new ExecutionDataflowBlockOptions
-                    {
-                        NameFormat = "Dependencies Shared Projects Input: {1}"
-                    });
-
-            ITargetBlock<IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectSharedFoldersSnapshot, IProjectCatalogSnapshot>>> actionBlock =
-                DataflowBlockSlim.CreateActionBlock<IProjectVersionedValue<Tuple<IProjectSubscriptionUpdate, IProjectSharedFoldersSnapshot, IProjectCatalogSnapshot>>>(
-                    e => OnProjectChangedAsync(e.Value),
-                    new ExecutionDataflowBlockOptions
-                    {
-                        NameFormat = "Dependencies Shared Projects Input: {1}"
-                    });
-
-            Subscriptions ??= new DisposableBag();
-
-            Subscriptions!.Add(
-                subscriptionService.ProjectRuleSource.SourceBlock.LinkTo(
-                    intermediateBlock,
-                    ruleNames: ConfigurationGeneral.SchemaName,
-                    suppressVersionOnlyUpdates: false,
+            Subscribe(
+                configuredProject,
+                subscriptionService.ProjectRuleSource,
+                ruleNames: new [] { ConfigurationGeneral.SchemaName },
+                "Dependencies Shared Projects Input: {1}",
+                blocks => ProjectDataSources.SyncLinkTo(
+                    blocks.Intermediate.SyncLinkOptions(),
+                    subscriptionService.SharedFoldersSource.SourceBlock.SyncLinkOptions(),
+                    subscriptionService.ProjectCatalogSource.SourceBlock.SyncLinkOptions(),
+                    configuredProject.Capabilities.SourceBlock.SyncLinkOptions(),
+                    blocks.Action,
                     linkOptions: DataflowOption.PropagateCompletion));
-
-            Subscriptions.Add(ProjectDataSources.SyncLinkTo(
-                intermediateBlock.SyncLinkOptions(),
-                subscriptionService.SharedFoldersSource.SourceBlock.SyncLinkOptions(),
-                subscriptionService.ProjectCatalogSource.SourceBlock.SyncLinkOptions(),
-                actionBlock,
-                linkOptions: DataflowOption.PropagateCompletion));
         }
 
-        private async Task OnProjectChangedAsync(Tuple<IProjectSubscriptionUpdate, IProjectSharedFoldersSnapshot, IProjectCatalogSnapshot> e)
+        protected override IProjectCapabilitiesSnapshot GetCapabilitiesSnapshot(EventData e) => e.Item4;
+        protected override IProjectSubscriptionUpdate GetProjectSubscriptionUpdate(EventData e) => e.Item1;
+
+        protected override void Handle(
+            AggregateCrossTargetProjectContext currentAggregateContext,
+            ITargetFramework targetFrameworkToUpdate,
+            EventData e)
         {
-            if (IsDisposing || IsDisposed)
-            {
-                return;
-            }
-
-            await InitializeAsync();
-
-            await TasksService.LoadedProjectAsync(() =>
-            {
-                return HandleAsync(e);
-            });
-        }
-
-        private async Task HandleAsync(Tuple<IProjectSubscriptionUpdate, IProjectSharedFoldersSnapshot, IProjectCatalogSnapshot> e)
-        {
-            AggregateCrossTargetProjectContext? currentAggregateContext = await Host!.GetCurrentAggregateProjectContextAsync();
-            if (currentAggregateContext == null)
-            {
-                return;
-            }
-
-            IProjectSubscriptionUpdate projectUpdate = e.Item1;
             IProjectSharedFoldersSnapshot sharedProjectsUpdate = e.Item2;
             IProjectCatalogSnapshot catalogs = e.Item3;
-
-            // Get the target framework to update for this change.
-            ITargetFramework? targetFrameworkToUpdate = currentAggregateContext.GetProjectFramework(projectUpdate.ProjectConfiguration);
-
-            if (targetFrameworkToUpdate == null)
-            {
-                return;
-            }
 
             var changesBuilder = new CrossTargetDependenciesChangesBuilder();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
@@ -32,9 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
         public abstract ImageMoniker ImplicitIcon { get; }
 
         public void Handle(
-            IImmutableDictionary<NamedIdentity, IComparable> versions,
             IImmutableDictionary<string, IProjectChangeDescription> changesByRuleName,
-            RuleSource source,
             ITargetFramework targetFramework,
             CrossTargetDependenciesChangesBuilder changesBuilder)
         {
@@ -98,6 +96,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             Func<string, bool>? isEvaluatedItemSpec)
         {
             IDependencyModel model = CreateDependencyModelForRule(addedItem, projectChange.After, resolved);
+
             if (isEvaluatedItemSpec == null || isEvaluatedItemSpec(model.Id))
             {
                 changesBuilder.Added(targetFramework, model);
@@ -166,8 +165,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
             bool isImplicit,
             IImmutableDictionary<string, string> properties)
         {
-            // Should be overridden by subclasses, unless they override and replace 'Handle'.
-            // Not 'abstract' because a subclass could replace 'Handle', in which case they don't need this method.
+            // Should be overridden by subclasses, unless they override 'HandleAddedItem', 'HandleRemovedItem'
+            // and 'HandleChangedItem' to not use this method.
             throw new NotImplementedException();
         }
 


### PR DESCRIPTION
The dependencies node defines interface `IDependencyCrossTargetSubscriber`, implementations of which subscribe to project Dataflow sources and emit events when data changes.

There are currently two implementations of this interface, `DependencyRulesSubscriber` and `DependencySharedProjectsSubscriber`. Both of these shared a considerable amount of code yet differed in various ways.

For example:
- They used different base classes (`OnceInitializedOnceDisposedUnderLockAsync` vs. `OnceInitializedOnceDisposed` respectively).
- The former protected against project unload and capabilities changes while processing updates, while the latter did not.
- The former suppressed version-only updates while the latter did not.

This PR extracts a new common base class `DependencyRulesSubscriberBase<T>` to standardise the handling of Dataflow subscriptions, updates and instance lifecycle events.