### PR TITLE
Use string.Equals over string.Compare

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerView.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ApplicationDesignerView.vb
@@ -743,7 +743,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                         Dim FileName As String = DirectCast(AppDesignerItems(Index - PropertyPages.Length), String)
 
                         .EditFlags = CUInt(_VSRDTFLAGS.RDT_DontAddToMRU)
-                        If String.Compare(VisualBasic.Right(FileName, 5), ".resx", StringComparison.OrdinalIgnoreCase) = 0 Then
+                        If String.Equals(VisualBasic.Right(FileName, 5), ".resx", StringComparison.OrdinalIgnoreCase) Then
                             'Add .resx file with a known editor so user config cannot change
                             .EditorGuid = New Guid(My.Resources.Designer.ResourceEditorFactory_GUID)
                             .EditorCaption = My.Resources.Designer.APPDES_ResourceTabTitle
@@ -760,7 +760,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
                             Else
                                 .CustomViewProvider = New SpecialFileCustomViewProvider(Me, DesignerPanel, __PSFFILEID2.PSFFILEID_AssemblyResource, My.Resources.Designer.APPDES_ClickHereCreateResx)
                             End If
-                        ElseIf String.Compare(VisualBasic.Right(FileName, 9), ".settings", StringComparison.OrdinalIgnoreCase) = 0 Then
+                        ElseIf String.Equals(VisualBasic.Right(FileName, 9), ".settings", StringComparison.OrdinalIgnoreCase) Then
                             'Add .settings file with a known editor so user config cannot change
                             .EditorGuid = New Guid(My.Resources.Designer.SettingsDesignerEditorFactory_GUID)
                             .EditorCaption = My.Resources.Designer.APPDES_SettingsTabTitle

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb
@@ -3387,7 +3387,7 @@ NextControl:
             End If
 
             ' Remove the project directory path
-            If String.Compare(BasePath, Strings.Left(DirectoryPath, Len(BasePath)), StringComparison.OrdinalIgnoreCase) = 0 Then
+            If String.Equals(BasePath, Strings.Left(DirectoryPath, Len(BasePath)), StringComparison.OrdinalIgnoreCase) Then
                 Dim ch As Char = CChar(Mid(DirectoryPath, Len(BasePath), 1))
                 If ch = Path.DirectorySeparatorChar OrElse ch = Path.AltDirectorySeparatorChar Then
                     RelativePath = Mid(DirectoryPath, Len(BasePath) + 1)
@@ -3473,7 +3473,7 @@ NextControl:
         ''' <returns></returns>
         ''' <remarks></remarks>
         Public Function IsVBProject() As Boolean
-            Return String.Compare(ProjectLanguage, EnvDTE.CodeModelLanguageConstants.vsCMLanguageVB, StringComparison.OrdinalIgnoreCase) = 0
+            Return String.Equals(ProjectLanguage, EnvDTE.CodeModelLanguageConstants.vsCMLanguageVB, StringComparison.OrdinalIgnoreCase)
         End Function
 
         ''' <summary>
@@ -3482,7 +3482,7 @@ NextControl:
         ''' <returns></returns>
         ''' <remarks></remarks>
         Public Function IsCSProject() As Boolean
-            Return String.Compare(ProjectLanguage, EnvDTE.CodeModelLanguageConstants.vsCMLanguageCSharp, StringComparison.OrdinalIgnoreCase) = 0
+            Return String.Equals(ProjectLanguage, EnvDTE.CodeModelLanguageConstants.vsCMLanguageCSharp, StringComparison.OrdinalIgnoreCase)
         End Function
 
 #End Region

--- a/src/Microsoft.VisualStudio.Editors/Common/DTEUtils.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/DTEUtils.vb
@@ -231,7 +231,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
                     projectItem.FileCount > 0 Then
 
                     Dim itemFileName As String = Path.GetFileName(projectItem.FileNames(1))
-                    If String.Compare(fileName, itemFileName, StringComparison.OrdinalIgnoreCase) = 0 Then
+                    If String.Equals(fileName, itemFileName, StringComparison.OrdinalIgnoreCase) Then
                         Return projectItem
                     End If
                 End If

--- a/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
@@ -927,8 +927,8 @@ Namespace Microsoft.VisualStudio.Editors.Common
 
             ' If the 2 paths have different root paths, return Path. 
             ' It's harder to deal with UNC root path in the algorithm.
-            If String.Compare(IO.Path.GetPathRoot(BaseDirectory), IO.Path.GetPathRoot(Path),
-                    StringComparison.OrdinalIgnoreCase) <> 0 Then
+            If Not String.Equals(IO.Path.GetPathRoot(BaseDirectory), IO.Path.GetPathRoot(Path),
+                    StringComparison.OrdinalIgnoreCase) Then
                 Return RemoveEndingSeparator(Path)
             End If
 
@@ -1574,7 +1574,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
             Dim frameworkName As FrameworkName = Nothing
             If TryGetTargetFrameworkMoniker(hierarchy, frameworkName) Then
                 ' Verify that we are targeting .NET
-                If String.Compare(frameworkName.Identifier, ".NETFramework", StringComparison.OrdinalIgnoreCase) <> 0 Then
+                If Not String.Equals(frameworkName.Identifier, ".NETFramework", StringComparison.OrdinalIgnoreCase) Then
                     Return False
                 End If
 
@@ -1610,7 +1610,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <returns>Value indicating whether the specified framework is .Net Core</returns>
         Friend Function IsTargetingDotNetCore(frameworkIdentifier As String) As Boolean
 
-            Return String.Compare(frameworkIdentifier, ".NETCoreApp", StringComparison.OrdinalIgnoreCase) = 0
+            Return String.Equals(frameworkIdentifier, ".NETCoreApp", StringComparison.OrdinalIgnoreCase)
 
         End Function
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/AdvBuildSettingsPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AdvBuildSettingsPropPage.vb
@@ -211,7 +211,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Dim StringValue As String = Trim(control.Text)
 
             'DLL Baseaddress must be 0xNNNNNNNN format
-            If String.Compare(VBStrings.Left(StringValue, 2), "0x", StringComparison.OrdinalIgnoreCase) = 0 Then
+            If String.Equals(VBStrings.Left(StringValue, 2), "0x", StringComparison.OrdinalIgnoreCase) Then
                 StringValue = "&h" + Mid(StringValue, 3)
                 If IsNumeric(StringValue) Then
                     Dim LongValue As ULong

--- a/src/Microsoft.VisualStudio.Editors/PropPages/AdvCompilerSettingsPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/AdvCompilerSettingsPropPage.vb
@@ -128,7 +128,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Dim StringValue As String = Trim(control.Text)
 
             'DLL Baseaddress must be &Hxxxxxxxx format
-            If String.Compare(VBStrings.Left(StringValue, 2), "&H", StringComparison.OrdinalIgnoreCase) = 0 AndAlso IsNumeric(StringValue) Then
+            If String.Equals(VBStrings.Left(StringValue, 2), "&H", StringComparison.OrdinalIgnoreCase) AndAlso IsNumeric(StringValue) Then
                 Try
                     Dim LongValue As ULong = CULng(StringValue)
                     If LongValue < UInteger.MaxValue Then
@@ -179,7 +179,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     '// Need to special case pdb-only because it's stored in the property without the dash but it's
                     '// displayed in the dialog with a dash.
 
-                    If (String.Compare(stValue, "pdbonly", StringComparison.OrdinalIgnoreCase) <> 0) Then
+                    If Not String.Equals(stValue, "pdbonly", StringComparison.OrdinalIgnoreCase) Then
                         DebugInfoComboBox.Text = stValue
                     Else
                         DebugInfoComboBox.Text = "pdb-only"
@@ -234,7 +234,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             If StringValue = "" Then
                 DllBaseTextbox.Text = DEFAULT_DLLBASEADDRESS
 
-            ElseIf String.Compare(VBStrings.Left(StringValue, 2), "&H", StringComparison.OrdinalIgnoreCase) = 0 AndAlso IsNumeric(StringValue) Then
+            ElseIf String.Equals(VBStrings.Left(StringValue, 2), "&H", StringComparison.OrdinalIgnoreCase) AndAlso IsNumeric(StringValue) Then
                 Dim LongValue As ULong = CULng(StringValue)
                 If LongValue < UInteger.MaxValue Then
                     'Reformat into clean

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageInternalBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageInternalBase.vb
@@ -246,7 +246,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Else
                 Dim frameworkName As New FrameworkName(currentTarget.Moniker)
 
-                If String.Compare(frameworkName.Identifier, ".NETFramework", StringComparison.Ordinal) = 0 Then
+                If String.Equals(frameworkName.Identifier, ".NETFramework", StringComparison.Ordinal) Then
                     bindingRedirectsCheckBox.Visible = True
                 Else
                     bindingRedirectsCheckBox.Visible = False

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.vb
@@ -472,7 +472,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     '// convert to the one with the space for this specific case
 
                     '// Convert the no-space to one with a space
-                    If (String.Compare(strPlatform, "AnyCPU", StringComparison.Ordinal) = 0) Then
+                    If (String.Equals(strPlatform, "AnyCPU", StringComparison.Ordinal)) Then
                         strPlatform = "Any CPU"
                     End If
 
@@ -486,7 +486,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                             '// platform target to the user.
 
                             Dim stValue As String = TryCast(value, String)
-                            If (String.Compare(Trim(stValue), "Itanium", StringComparison.Ordinal) = 0) Then
+                            If (String.Equals(Trim(stValue), "Itanium", StringComparison.Ordinal)) Then
                                 cboPlatformTarget.Items.Add("Itanium")
                                 cboPlatformTarget.SelectedItem = stValue
                             Else
@@ -581,9 +581,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                                 If (Path.IsPathRooted(stOutputPath)) Then
                                     '// stOutputPath is an Absolute path so check to see if its within the project path
 
-                                    If (String.Compare(Path.GetFullPath(stProjectDirectory),
-                                                       VisualBasic.Left(Path.GetFullPath(stOutputPath), Len(stProjectDirectory)),
-                                                       StringComparison.Ordinal) = 0) Then
+                                    If (String.Equals(Path.GetFullPath(stProjectDirectory),
+                                                      VisualBasic.Left(Path.GetFullPath(stOutputPath), Len(stProjectDirectory)),
+                                                      StringComparison.Ordinal)) Then
 
                                         '// The output path is within the project so suggest the output directory (or suggest just the filename
                                         '// which will put it in the default location
@@ -971,7 +971,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
                 If (Not (IsNothing(rgConstants))) Then
                     For Each stTemp In rgConstants
-                        If (String.Compare(Trim(stTemp), stSymbol, StringComparison.Ordinal) = 0) Then
+                        If (String.Equals(Trim(stTemp), stSymbol, StringComparison.Ordinal)) Then
                             bFound = True
                             Exit For
                         End If
@@ -1009,7 +1009,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
                 If (Not (IsNothing(rgConstants))) Then
                     For Each stTemp In rgConstants
-                        If (String.Compare(Trim(stTemp), stSymbol, StringComparison.Ordinal) = 0) Then
+                        If (String.Equals(Trim(stTemp), stSymbol, StringComparison.Ordinal)) Then
                             Return True
                         End If
                     Next
@@ -1035,7 +1035,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
                 If (Not (IsNothing(rgConstants))) Then
                     For Each stTemp In rgConstants
-                        If (String.Compare(Trim(stTemp), stSymbol, StringComparison.Ordinal) <> 0) Then
+                        If (String.Equals(Trim(stTemp), stSymbol, StringComparison.Ordinal)) Then
                             If (stNewConstants <> "") Then
                                 stNewConstants += ";"
                             End If

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPageBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPageBase.vb
@@ -44,7 +44,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                 Return True
             End If
 
-            Return String.Compare(stringValue, "AnyCPU", StringComparison.Ordinal) = 0
+            Return String.Equals(stringValue, "AnyCPU", StringComparison.Ordinal)
 
         End Function
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePathsPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePathsPropPage.vb
@@ -265,7 +265,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             'Enable/Disable Add/UpdateFolder buttons
             Dim HasFolderEntry As Boolean = (Len(FolderText) > 0)
             AddFolder.Enabled = HasFolderEntry
-            UpdateFolder.Enabled = HasFolderEntry AndAlso (SelectedCount = 1) AndAlso String.Compare(FolderText, DirectCast(ReferencePath.SelectedItem, String), StringComparison.OrdinalIgnoreCase) <> 0
+            UpdateFolder.Enabled = HasFolderEntry AndAlso (SelectedCount = 1) AndAlso Not String.Equals(FolderText, DirectCast(ReferencePath.SelectedItem, String), StringComparison.OrdinalIgnoreCase)
 
             'Enable/Disable MoveUp/MoveDown buttons
             MoveUp.Enabled = (SelectedCount = 1) AndAlso (ItemIndices.Item(0) > 0)

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePropPage.vb
@@ -1077,7 +1077,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     'CONSIDER: Shouldn't this be cached and applied by 'Apply' button?
                     Dim theVSProject As VSLangProj.VSProject = CType(DTEProject.Object, VSLangProj.VSProject)
                     Dim item As EnvDTE.ProjectItem = theVSProject.AddWebReference(url)
-                    If String.Compare(item.Name, newName, StringComparison.Ordinal) <> 0 Then
+                    If Not String.Equals(item.Name, newName, StringComparison.Ordinal) Then
                         item.Name = newName
                     End If
                     PopulateReferenceList()

--- a/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworkMoniker.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworkMoniker.vb
@@ -1,4 +1,4 @@
-' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.ComponentModel
 Imports System.Runtime.Versioning
@@ -110,7 +110,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     Dim frameworkName As New FrameworkName(moniker)
 
                     ' Filter out frameworks with a different identifier since they are not applicable to the current project type
-                    If String.Compare(frameworkName.Identifier, currentFrameworkName.Identifier, StringComparison.OrdinalIgnoreCase) = 0 Then
+                    If String.Equals(frameworkName.Identifier, currentFrameworkName.Identifier, StringComparison.OrdinalIgnoreCase) Then
 
                         If isWebProject Then
 
@@ -133,8 +133,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
                         ' Use DTAR to get the display name corresponding to the moniker
                         Dim displayName As String = ""
-                        If String.Compare(frameworkName.Identifier, ".NETStandard", StringComparison.Ordinal) = 0 OrElse
-                           String.Compare(frameworkName.Identifier, ".NETCoreApp", StringComparison.Ordinal) = 0 Then
+                        If String.Equals(frameworkName.Identifier, ".NETStandard", StringComparison.Ordinal) OrElse
+                           String.Equals(frameworkName.Identifier, ".NETCoreApp", StringComparison.Ordinal) Then
                             displayName = CStr(supportedTargetFrameworksDescriptor.Converter?.ConvertTo(moniker, GetType(String)))
                         Else
                             VSErrorHandler.ThrowOnFailure(vsFrameworkMultiTargeting.GetDisplayNameForTargetFx(moniker, displayName))

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/FileWatcher.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/FileWatcher.vb
@@ -386,7 +386,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             ''' <remarks></remarks>
             Private Sub OnFileChanged(FullDirectoryPath As String, FileName As String)
                 Debug.Assert(Not String.IsNullOrEmpty(FileName))
-                Debug.Assert(0 = String.Compare(Path.GetDirectoryName(FullDirectoryPath), _directoryPath, StringComparison.OrdinalIgnoreCase))
+                Debug.Assert(String.Equals(Path.GetDirectoryName(FullDirectoryPath), _directoryPath, StringComparison.OrdinalIgnoreCase))
                 Debug.Assert(Path.IsPathRooted(FullDirectoryPath))
 
                 Dim FileNameThatChanged As String = NormalizeFileName(FileName)

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/Resource.vb
@@ -117,9 +117,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Public Overrides Function ConvertFrom(context As ITypeDescriptorContext, culture As CultureInfo, value As Object) As Object
                 If TypeOf (value) Is String Then
                     Dim strValue As String = CStr(value)
-                    If String.Compare(strValue, _linkedDisplayValue, StringComparison.OrdinalIgnoreCase) = 0 Then
+                    If String.Equals(strValue, _linkedDisplayValue, StringComparison.OrdinalIgnoreCase) Then
                         Return ResourcePersistenceMode.Linked
-                    ElseIf String.Compare(strValue, _embeddedDisplayValue, StringComparison.OrdinalIgnoreCase) = 0 Then
+                    ElseIf String.Equals(strValue, _embeddedDisplayValue, StringComparison.OrdinalIgnoreCase) Then
                         Return ResourcePersistenceMode.Embedded
                     End If
                 End If
@@ -2630,7 +2630,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             'Note that we compare against the original NewName, not the trimmed version (so that if there are actually
             '  blanks in the Name in the file, just moving through the cells will not cause validation to occur, and so that
             '  we will notice if the original Name had blanks and the user now removes them).
-            If OldName <> "" AndAlso 0 = String.Compare(NewName, OldName, StringComparison.OrdinalIgnoreCase) Then
+            If OldName <> "" AndAlso String.Equals(NewName, OldName, StringComparison.OrdinalIgnoreCase) Then
                 'No change in Name - nothing to do
                 NewFormattedName = NewName
                 Return True

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
@@ -1697,7 +1697,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                                     'The file have been copied into the project.  We should check whether there is an old item linking to it
                                     If File.Exists(FinalPathAndFileName) Then
                                         Resource.SetLink(FinalPathAndFileName)
-                                        If String.Compare(Resource.AbsoluteLinkPathAndFileName, currentPath, StringComparison.Ordinal) = 0 Then
+                                        If String.Equals(Resource.AbsoluteLinkPathAndFileName, currentPath, StringComparison.Ordinal) Then
                                             ' It was the file which was already in the project ... we always add a new item...
                                             ResourcesReadyToAdd.Add(Resource)
                                         Else
@@ -5425,7 +5425,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
                 Dim codeModel As CodeModel = Project.CodeModel
                 ' NOTE: VB will append the custom setting after the RootNamespace (which is done by compiler), but other language does not...
-                If codeModel IsNot Nothing AndAlso String.Compare(codeModel.Language, CodeModelLanguageConstants.vsCMLanguageVB, StringComparison.OrdinalIgnoreCase) = 0 Then
+                If codeModel IsNot Nothing AndAlso String.Equals(codeModel.Language, CodeModelLanguageConstants.vsCMLanguageVB, StringComparison.OrdinalIgnoreCase) Then
                     'Build up the qualified name
                     Return CombineNamespaces(CombineNamespaces(RootNamespace, CustomToolNamespace), ClassName)
                 Else

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceFile.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceFile.vb
@@ -465,7 +465,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             For Each Resource As Resource In _resourcesHash.Values
                 If Resource.IsLink Then
                     Dim linkFileInfo As New FileInfo(Resource.AbsoluteLinkPathAndFileName)
-                    If String.Compare(FileFullPath, linkFileInfo.FullName, StringComparison.OrdinalIgnoreCase) = 0 Then
+                    If String.Equals(FileFullPath, linkFileInfo.FullName, StringComparison.OrdinalIgnoreCase) Then
                         Return Resource
                     End If
                 End If

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceStringTable.vb
@@ -541,7 +541,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Dim Exception As Exception = Nothing
 
             ' we should ignore the problem if it is the original value, or the cursor will be locked inside such cell
-            If String.Compare(CStr(e.FormattedValue), originalValue, StringComparison.Ordinal) = 0 OrElse
+            If String.Equals(CStr(e.FormattedValue), originalValue, StringComparison.Ordinal) OrElse
                 ValidateCell(e.RowIndex, e.ColumnIndex, CStr(e.FormattedValue), Exception) Then
                 'Validation succeeded
                 e.Cancel = False

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorImageBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceTypeEditorImageBase.vb
@@ -196,8 +196,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                     Extension = GetResourceFileExtension(NewResource)
                 End If
 
-                If String.Compare(Extension, EXT_TIF, StringComparison.OrdinalIgnoreCase) = 0 OrElse
-                    String.Compare(Extension, EXT_TIFF, StringComparison.OrdinalIgnoreCase) = 0 Then
+                If String.Equals(Extension, EXT_TIF, StringComparison.OrdinalIgnoreCase) OrElse
+                   String.Equals(Extension, EXT_TIFF, StringComparison.OrdinalIgnoreCase) Then
 
                     Message = My.Resources.Microsoft_VisualStudio_Editors_Designer.GetString(My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_Err_CantAddFileToDeviceProject_1Arg, Extension)
                     HelpID = HelpIDs.Err_CantAddFileToDeviceProject

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/AppConfigSerializer.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/AppConfigSerializer.vb
@@ -112,7 +112,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                     ' (by comparing the serialized values of the corresponding SerializedConnectionStrings)
                     Dim serializedValueInSettings As String = ExistingSettings.Item(cs.Name).SerializedValue
                     Dim serializedValueInAppConfig As String = SettingsValueSerializer.Serialize(scs, Globalization.CultureInfo.InvariantCulture)
-                    Dim valueChanged As Boolean = String.Compare(serializedValueInSettings, serializedValueInAppConfig, StringComparison.Ordinal) <> 0
+                    Dim valueChanged As Boolean = Not String.Equals(serializedValueInSettings, serializedValueInAppConfig, StringComparison.Ordinal)
                     If valueChanged Then
                         ' Yep! Ask the user what (s)he wants to do...
                         Dim Instance As DesignTimeSettingInstance = ExistingSettings.Item(cs.Name)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VisualBasic/VisualBasicNamespaceImportsList.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VisualBasic/VisualBasicNamespaceImportsList.cs
@@ -89,7 +89,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
                     while (trackingIndex < oldListCount && trackingIndex < newListCount)
                     {
                         string incomingItem = sortedItems.ElementAt(trackingIndex);
-                        if (string.Compare(_list[trackingIndex], incomingItem, StringComparison.OrdinalIgnoreCase) == 0)
+                        if (string.Equals(_list[trackingIndex], incomingItem, StringComparison.OrdinalIgnoreCase))
                         {
                             trackingIndex++;
                             continue;
@@ -161,7 +161,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
 
             lock (_lock)
             {
-                return _list.Any(l => string.Compare(bstrImport, l, StringComparison.OrdinalIgnoreCase) == 0);
+                return _list.Any(l => string.Equals(bstrImport, l, StringComparison.OrdinalIgnoreCase));
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VisualBasic/VisualBasicVSImports.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VisualBasic/VisualBasicVSImports.cs
@@ -96,7 +96,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
                         if (index is string removeImport1)
                         {
                             importProjectItem = project.GetItems(ImportItemTypeName)
-                                                       .First(i => string.Compare(removeImport1, i.EvaluatedInclude, StringComparison.OrdinalIgnoreCase) == 0);
+                                                       .First(i => string.Equals(removeImport1, i.EvaluatedInclude, StringComparison.OrdinalIgnoreCase));
                         }
                         else if (index is int indexInt1)
                         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/NameValuePair.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/NameValuePair.cs
@@ -115,7 +115,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
                 {
                     if (!ReferenceEquals(this, nvp))
                     {
-                        if (string.Compare(nvp.Name, Name, StringComparison.OrdinalIgnoreCase) == 0)
+                        if (string.Equals(nvp.Name, Name, StringComparison.OrdinalIgnoreCase))
                         {
                             return true;
                         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildUtilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildUtilities.cs
@@ -142,7 +142,7 @@ namespace Microsoft.VisualStudio.Build
             bool valueFound = false;
             foreach (string value in GetPropertyValues(evaluatedPropertyValue, delimiter))
             {
-                if (string.Compare(value, valueToRemove, StringComparison.Ordinal) != 0)
+                if (!string.Equals(value, valueToRemove, StringComparison.Ordinal))
                 {
                     if (newValue.Length != 0)
                     {
@@ -194,7 +194,7 @@ namespace Microsoft.VisualStudio.Build
                     value.Append(delimiter);
                 }
 
-                if (string.Compare(propertyValue, oldValue, StringComparison.Ordinal) == 0)
+                if (string.Equals(propertyValue, oldValue, StringComparison.Ordinal))
                 {
                     value.Append(newValue);
                     valueFound = true;


### PR DESCRIPTION
The former is clearer in code, and is faster in execution.

```
BenchmarkDotNet=v0.11.1, OS=Windows 10.0.18362
Intel Xeon Silver 4110 CPU 2.10GHz, 2 CPU, 32 logical and 16 physical cores
  [Host] : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.8.3815.0
  Clr    : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.8.3815.0

Job=Clr  Runtime=Clr
```

|        Method | SameLength |      Mean |     Error |    StdDev |    Median |
|-------------- |----------- |----------:|----------:|----------:|----------:|
|      Comparer |      False |  3.520 ns | 0.1193 ns | 0.3441 ns |  3.421 ns |
|  StaticEquals |      False |  2.661 ns | 0.1319 ns | 0.3890 ns |  2.447 ns |
|  MemberEquals |      False |  2.805 ns | 0.0251 ns | 0.0222 ns |  2.800 ns |
| StaticCompare |      False | 24.074 ns | 0.5388 ns | 1.1483 ns | 23.970 ns |
|      Comparer |       True | 27.444 ns | 0.6542 ns | 1.9288 ns | 27.454 ns |
|  StaticEquals |       True | 16.903 ns | 0.4885 ns | 1.4328 ns | 16.442 ns |
|  MemberEquals |       True | 17.859 ns | 0.6551 ns | 1.9315 ns | 17.567 ns |
| StaticCompare |       True | 23.432 ns | 0.6640 ns | 1.9263 ns | 23.744 ns |


```c#
[ClrJob]
public class StringEqualityBenchmarks
{
    private string x;
    private string y;

    [Params(true, false)]
    public bool SameLength;

    [GlobalSetup]
    public void Setup()
    {
        x = "FrobbleBoo";
        y = SameLength ? "FrobbleBar" : "FrobbleBa";
    }

    [Benchmark]
    public bool Comparer()
    {
        return StringComparer.OrdinalIgnoreCase.Equals(x, y);
    }

    [Benchmark]
    public bool StaticEquals()
    {
        return string.Equals(x, y, StringComparison.OrdinalIgnoreCase);
    }

    [Benchmark]
    public bool MemberEquals()
    {
        return x != null && x.Equals(y, StringComparison.OrdinalIgnoreCase);
    }

    [Benchmark]
    public bool StaticCompare()
    {
        return String.Compare(x, y, StringComparison.OrdinalIgnoreCase) == 0;
    }
}
```