### PR TITLE
Keep version number in line with Visual Studio

### DIFF
--- a/build/import/Versions.props
+++ b/build/import/Versions.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ProjectSystemVersion>16.3.0</ProjectSystemVersion>
+    <ProjectSystemVersion>16.4.0</ProjectSystemVersion>
     <VersionBase>$(ProjectSystemVersion)</VersionBase>
     <PreReleaseVersionLabel>beta1</PreReleaseVersionLabel>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>


### PR DESCRIPTION
I'm guessing the intention when changing version numbers to 16.3.0 was to keep them in line with VS, so...