### PR TITLE
Remove test-only constructor

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/Renamer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/Renamer.cs
@@ -36,20 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
         [ImportingConstructor]
         internal Renamer(IUnconfiguredProjectVsServices projectVsServices,
                          IUnconfiguredProjectTasksService unconfiguredProjectTasksService,
-                         VisualStudioWorkspace workspace,
-                         IVsUIService<Shell.Interop.SDTE, DTE> dte,
-                         IEnvironmentOptions environmentOptions,
-                         IUserNotificationServices userNotificationServices,
-                         IRoslynServices roslynServices,
-                         IWaitIndicator waitService,
-                         IRefactorNotifyService refactorNotifyService)
-            : this(projectVsServices, unconfiguredProjectTasksService, workspace as Workspace, dte, environmentOptions, userNotificationServices, roslynServices, waitService, refactorNotifyService)
-        {
-        }
-
-        internal Renamer(IUnconfiguredProjectVsServices projectVsServices,
-                         IUnconfiguredProjectTasksService unconfiguredProjectTasksService,
-                         Workspace workspace,
+                         [Import(typeof(VisualStudioWorkspace))]Workspace workspace,
                          IVsUIService<Shell.Interop.SDTE, DTE> dte,
                          IEnvironmentOptions environmentOptions,
                          IUserNotificationServices userNotificationServices,


### PR DESCRIPTION
MEF lets you import something by type that is different to the type of the parameter.