### PR TITLE
Create a special file provider for C#, for the AssemblyInfo file

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/CSharp/CSharpAssemblyInfoSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/CSharp/CSharpAssemblyInfoSpecialFileProvider.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+
+using Microsoft.VisualStudio.IO;
+
+namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders.CSharp
+{
+    [ExportSpecialFileProvider(SpecialFiles.AssemblyInfo)]
+    [AppliesTo(ProjectCapability.CSharp)]
+    internal class CSharpAssemblyInfoSpecialFileProvider : AbstractFindByNameSpecialFileProvider
+    {
+        [ImportingConstructor]
+        public CSharpAssemblyInfoSpecialFileProvider(
+            IPhysicalProjectTree projectTree,
+            [Import(ExportContractNames.ProjectItemProviders.SourceFiles)] IProjectItemProvider sourceItemsProvider,
+            [Import(AllowDefault = true)] Lazy<ICreateFileFromTemplateService>? templateFileCreationService,
+            IFileSystem fileSystem,
+            ISpecialFilesManager specialFilesManager)
+            : base(projectTree, sourceItemsProvider, templateFileCreationService, fileSystem, specialFilesManager)
+        {
+        }
+
+        protected override string Name => "AssemblyInfo.cs";
+
+        protected override string TemplateName => "AssemblyInfoInternal.zip";
+    }
+}


### PR DESCRIPTION
This creates a special file provider for C#. This currently points to AssemblyInfoInternal, which I've verified works, though produces a file that doesn't compile in most SDK-style projects, because of duplicate attributes.

That will be fixed in #5347