### PR TITLE
Removes invalid Assumes.NotNull

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/DependenciesTreeViewProvider.cs
@@ -370,8 +370,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
 
             ProjectTreeFlags filteredFlags = FilterFlags(viewModel.Flags);
 
-            Assumes.NotNull(filePath);
-
             return isProjectItem
                 ? CreateProjectItemTreeNode()
                 : CreateProjectTreeNode();


### PR DESCRIPTION
This was added in 8f558fe5d4f6891164601017b48d15a7bdb83ea6 in an attempt to suppress NRT warnings. The filePath variable may be null for non-project items, and so this was triggering errors in VS, such as that reported in #5454.

Removing this line does not seem to introduce any new warnings, and fixes the error.