### PR TITLE
Avoid NGEN'ing resource dlls

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -37,7 +37,7 @@
     <PackageReference Update="Microsoft.DevDiv.Validation.MediaRecorder"                              Version="15.0.199" />
 
     <!-- VS SDK -->
-    <PackageReference Update="Microsoft.VSSDK.BuildTools"                                             Version="16.2.3073" />
+    <PackageReference Update="Microsoft.VSSDK.BuildTools"                                             Version="16.3.2099" />
     <PackageReference Update="Microsoft.VisualStudio.ComponentModelHost"                              Version="16.0.198-g52de9c2988"/>
     <PackageReference Update="Microsoft.VisualStudio.Composition"                                     Version="16.1.8"/>
     <PackageReference Update="Microsoft.VisualStudio.Data.Core"                                       Version="9.0.21022" />


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/980771. This SDK has a fix to avoid NGEN'ing resource dlls for Editors and AppDesigner.