### PR TITLE
Add GenerateAssemblyInfo property

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/GeneralBrowseObject.xaml
@@ -160,6 +160,9 @@
     </StringProperty.DataSource>
   </StringProperty>
 
+  <BoolProperty Name="GenerateAssemblyInfo"
+                Visible="False" />
+
   <BoolProperty Name="GeneratePackageOnBuild"
                 Default="False"
                 Visible="False" />


### PR DESCRIPTION
For #5347

This allows the AssemblyInfo wizard to know which type of file to create.