### PR TITLE
Be resilent when AppDesigner folder is missing or a file

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Interop/Win32Interop.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Interop/Win32Interop.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.Interop
+{
+    internal class Win32Interop
+    {
+        /// <summary>
+        ///     Represents the Win32 error code for ERROR_FILE_EXISTS.
+        /// </summary>
+        public const int ERROR_FILE_EXISTS = 80;
+
+        /// <summary>
+        ///     Returns a HRESULT representing the specified Win32 error code.
+        /// </summary>
+        internal static int HResultFromWin32(int errorCode)
+        {
+            const int FACILITY_WIN32 = 7;
+            uint hr = errorCode <= 0 ? (uint)errorCode : ((uint)(errorCode & 0x0000FFFF) | (FACILITY_WIN32 << 16) | 0x80000000);
+            return (int)hr;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectTreeFlagsExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectTreeFlagsExtensions.cs
@@ -34,6 +34,15 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         /// <summary>
         ///     Returns a value indicating whether the specified flags indicates that 
+        ///     the file or folder is missing on disk.
+        /// </summary>
+        public static bool IsMissingOnDisk(this ProjectTreeFlags flags)
+        {
+            return !flags.HasFlag(ProjectTreeFlags.Common.FileSystemEntity);
+        }
+
+        /// <summary>
+        ///     Returns a value indicating whether the specified flags indicates that 
         ///     the node is a folder.
         /// </summary>
         public static bool IsFolder(this ProjectTreeFlags flags)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractSpecialFileProvider.cs
@@ -1,7 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Globalization;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.Interop;
 
 namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
 {
@@ -11,10 +15,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
     internal abstract class AbstractSpecialFileProvider : ISpecialFileProvider
     {
         private readonly IProjectTreeService _treeService;
+        private readonly IPhysicalProjectTreeStorage _storage;
+        private readonly bool _isFolder;
 
-        protected AbstractSpecialFileProvider(IProjectTreeService treeService)
+        protected AbstractSpecialFileProvider(IPhysicalProjectTree projectTree, bool isFolder)
         {
-            _treeService = treeService;
+            _treeService = projectTree.TreeService;
+            _storage = projectTree.TreeStorage;
+            _isFolder = isFolder;
         }
 
         public virtual async Task<string?> GetFileAsync(SpecialFiles fileId, SpecialFileFlags flags, CancellationToken cancellationToken = default)
@@ -22,26 +30,82 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
             // Make sure at least have a tree before we start searching it
             IProjectTreeServiceState state = await _treeService.PublishAnyNonLoadingTreeAsync(cancellationToken);
 
-            string? path = await FindFileAsync(state.TreeProvider, state.Tree);
+            // Attempt to find an existing file/folder first
+            string? path = await FindFileAsync(state.TreeProvider, state.Tree, flags);
             if (path == null)
             {
-                // Not found, let's find the default path, and then create it if needed
-                path = await GetDefaultFileAsync(state.TreeProvider, state.Tree);
+                // Otherwise, fall back and create it
+                path = await CreateDefaultFileAsync(state.TreeProvider, state.Tree, flags);
+            }
 
-                if (path != null && (flags & SpecialFileFlags.CreateIfNotExist) == SpecialFileFlags.CreateIfNotExist)
-                {
-                    await CreateFileAsync(path);
-                }
+            return path;
+        }
+        private async Task<string?> FindFileAsync(IProjectTreeProvider provider, IProjectTree root, SpecialFileFlags flags)
+        {
+            IProjectTree? node = await FindFileAsync(provider, root);
+            if (node == null)
+                return null;
+
+            string? path = GetFilePath(provider, node);
+            if (path != null && flags.HasFlag(SpecialFileFlags.CreateIfNotExist))
+            {
+                // Similar to legacy, we only verify state if we've been asked to create it
+                await VerifyStateAsync(node, path);
+            }
+
+            return path;
+        }
+
+        private async Task<string?> CreateDefaultFileAsync(IProjectTreeProvider provider, IProjectTree root, SpecialFileFlags flags)
+        {
+            string? path = await GetDefaultFileAsync(provider, root);
+
+            if (path != null && flags.HasFlag(SpecialFileFlags.CreateIfNotExist))
+            {
+                await CreateFileAsync(path);
             }
 
             // We always return the default path, regardless of whether we created it or it exists, as per contract
             return path;
         }
 
-        protected abstract Task<string?> FindFileAsync(IProjectTreeProvider provider, IProjectTree root);
+        protected abstract Task<IProjectTree?> FindFileAsync(IProjectTreeProvider provider, IProjectTree root);
+
+        protected string? GetFilePath(IProjectTreeProvider provider, IProjectTree node)
+        {
+            return _isFolder ? provider.GetRootedAddNewItemDirectory(node) : provider.GetPath(node);
+        }
 
         protected abstract Task<string?> GetDefaultFileAsync(IProjectTreeProvider provider, IProjectTree root);
 
-        protected abstract Task CreateFileAsync(string path);
+        protected virtual Task CreateFileAsync(string path)
+        {
+            return _isFolder ? _storage.CreateFolderAsync(path) : _storage.CreateEmptyFileAsync(path);
+        }
+
+        private Task AddFileAsync(string path)
+        {
+            return _isFolder ? _storage.AddFolderAsync(path) : _storage.AddFileAsync(path);
+        }
+
+        private Task VerifyStateAsync(IProjectTree node, string path)
+        {
+            if (_isFolder != node.IsFolder)
+                throw new IOException(string.Format(CultureInfo.CurrentCulture, Resources.SpecialFileProvider_FileOrFolderAlreadyExists, node.Caption), Win32Interop.HResultFromWin32(Win32Interop.ERROR_FILE_EXISTS));
+
+            if (!node.Flags.IsIncludedInProject())
+            {   // Excluded from project
+
+                return AddFileAsync(path);
+            } 
+            
+            if (node.Flags.IsMissingOnDisk())
+            {   // Project includes it, but missing from disk
+
+                return CreateFileAsync(path);
+            }
+
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProvider.cs
@@ -16,43 +16,39 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
     [AppliesTo(ProjectCapability.AppDesigner)]
     internal class AppDesignerFolderSpecialFileProvider : AbstractSpecialFileProvider, IAppDesignerFolderSpecialFileProvider
     {
-        private readonly IPhysicalProjectTree _projectTree;
         private readonly ProjectProperties _properties;
 
         [ImportingConstructor]
         public AppDesignerFolderSpecialFileProvider(IPhysicalProjectTree projectTree, ProjectProperties properties)
-            : base(projectTree.TreeService)
+            : base(projectTree, isFolder: true)
         {
-            _projectTree = projectTree;
             _properties = properties;
         }
 
-        protected override Task<string?> FindFileAsync(IProjectTreeProvider provider, IProjectTree root)
+        protected override async Task<IProjectTree?> FindFileAsync(IProjectTreeProvider provider, IProjectTree root)
         {
-            IProjectTree? folder = root?.GetSelfAndDescendentsBreadthFirst().FirstOrDefault(child => child.Flags.HasFlag(ProjectTreeFlags.Common.AppDesignerFolder));
-
+            // First look for the actual AppDesigner folder
+            IProjectTree? folder = FindAppDesignerFolder(root);
             if (folder == null)
-                return Task.FromResult<string?>(null);
+            {
+                // Otherwise, find a location that is a candidate
+                folder = await FindAppDesignerFolderCandidateAsync(provider, root);
+            }
 
-            return Task.FromResult(provider.GetRootedAddNewItemDirectory(folder));
-        }
-
-        protected override Task CreateFileAsync(string path)
-        {
-            return _projectTree.TreeStorage.CreateFolderAsync(path);
+            return folder;
         }
 
         protected override async Task<string?> GetDefaultFileAsync(IProjectTreeProvider provider, IProjectTree root)
         {
-            string? rootPath = provider.GetRootedAddNewItemDirectory(root);
-
-            Assumes.NotNull(rootPath);
+            string? projectFolder = GetFilePath(provider, root);
+            if (projectFolder == null)  // Root has DisableAddItem
+                return null;
 
             string folderName = await GetDefaultAppDesignerFolderNameAsync();
             if (string.IsNullOrEmpty(folderName))
                 return null; // Developer has set the AppDesigner path to empty
 
-            return Path.Combine(rootPath, folderName);
+            return Path.Combine(projectFolder, folderName);
         }
 
         private async Task<string> GetDefaultAppDesignerFolderNameAsync()
@@ -60,6 +56,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
             AppDesigner general = await _properties.GetAppDesignerPropertiesAsync();
 
             return (string)await general.FolderName.GetValueAsync();
+        }
+
+        private IProjectTree? FindAppDesignerFolder(IProjectTree root)
+        {
+            return root.GetSelfAndDescendentsBreadthFirst()
+                       .FirstOrDefault(child => child.Flags.HasFlag(ProjectTreeFlags.Common.AppDesignerFolder));
+        }
+
+        private async Task<IProjectTree?> FindAppDesignerFolderCandidateAsync(IProjectTreeProvider provider, IProjectTree root)
+        {
+            string? path = await GetDefaultFileAsync(provider, root);
+            if (path == null)
+                return null;
+
+            return provider.FindByPath(root, path);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.Designer.cs
@@ -176,5 +176,16 @@ namespace Microsoft.VisualStudio {
                 return ResourceManager.GetString("SdkNodeName", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A file or folder with the name &apos;{0}&apos; already exists on disk at this location. Please choose another name.
+        ///
+        ///If this file or folder does not appear in Solution Explorer, then it is not currently part of your project. To view files which exist on disk, but are not in the project, select Show All Files from the Project menu..
+        /// </summary>
+        internal static string SpecialFileProvider_FileOrFolderAlreadyExists {
+            get {
+                return ResourceManager.GetString("SpecialFileProvider_FileOrFolderAlreadyExists", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.resx
@@ -158,4 +158,9 @@
   <data name="FrameworkNodeName" xml:space="preserve">
     <value>Frameworks</value>
   </data>
+  <data name="SpecialFileProvider_FileOrFolderAlreadyExists" xml:space="preserve">
+    <value>A file or folder with the name '{0}' already exists on disk at this location. Please choose another name.
+
+If this file or folder does not appear in Solution Explorer, then it is not currently part of your project. To view files which exist on disk, but are not in the project, select Show All Files from the Project menu.</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
@@ -67,6 +67,15 @@
         <target state="new">Packages</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpecialFileProvider_FileOrFolderAlreadyExists">
+        <source>A file or folder with the name '{0}' already exists on disk at this location. Please choose another name.
+
+If this file or folder does not appear in Solution Explorer, then it is not currently part of your project. To view files which exist on disk, but are not in the project, select Show All Files from the Project menu.</source>
+        <target state="new">A file or folder with the name '{0}' already exists on disk at this location. Please choose another name.
+
+If this file or folder does not appear in Solution Explorer, then it is not currently part of your project. To view files which exist on disk, but are not in the project, select Show All Files from the Project menu.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
@@ -67,6 +67,15 @@
         <target state="new">Packages</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpecialFileProvider_FileOrFolderAlreadyExists">
+        <source>A file or folder with the name '{0}' already exists on disk at this location. Please choose another name.
+
+If this file or folder does not appear in Solution Explorer, then it is not currently part of your project. To view files which exist on disk, but are not in the project, select Show All Files from the Project menu.</source>
+        <target state="new">A file or folder with the name '{0}' already exists on disk at this location. Please choose another name.
+
+If this file or folder does not appear in Solution Explorer, then it is not currently part of your project. To view files which exist on disk, but are not in the project, select Show All Files from the Project menu.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
@@ -67,6 +67,15 @@
         <target state="new">Packages</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpecialFileProvider_FileOrFolderAlreadyExists">
+        <source>A file or folder with the name '{0}' already exists on disk at this location. Please choose another name.
+
+If this file or folder does not appear in Solution Explorer, then it is not currently part of your project. To view files which exist on disk, but are not in the project, select Show All Files from the Project menu.</source>
+        <target state="new">A file or folder with the name '{0}' already exists on disk at this location. Please choose another name.
+
+If this file or folder does not appear in Solution Explorer, then it is not currently part of your project. To view files which exist on disk, but are not in the project, select Show All Files from the Project menu.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
@@ -67,6 +67,15 @@
         <target state="new">Packages</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpecialFileProvider_FileOrFolderAlreadyExists">
+        <source>A file or folder with the name '{0}' already exists on disk at this location. Please choose another name.
+
+If this file or folder does not appear in Solution Explorer, then it is not currently part of your project. To view files which exist on disk, but are not in the project, select Show All Files from the Project menu.</source>
+        <target state="new">A file or folder with the name '{0}' already exists on disk at this location. Please choose another name.
+
+If this file or folder does not appear in Solution Explorer, then it is not currently part of your project. To view files which exist on disk, but are not in the project, select Show All Files from the Project menu.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
@@ -67,6 +67,15 @@
         <target state="new">Packages</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpecialFileProvider_FileOrFolderAlreadyExists">
+        <source>A file or folder with the name '{0}' already exists on disk at this location. Please choose another name.
+
+If this file or folder does not appear in Solution Explorer, then it is not currently part of your project. To view files which exist on disk, but are not in the project, select Show All Files from the Project menu.</source>
+        <target state="new">A file or folder with the name '{0}' already exists on disk at this location. Please choose another name.
+
+If this file or folder does not appear in Solution Explorer, then it is not currently part of your project. To view files which exist on disk, but are not in the project, select Show All Files from the Project menu.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
@@ -67,6 +67,15 @@
         <target state="new">Packages</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpecialFileProvider_FileOrFolderAlreadyExists">
+        <source>A file or folder with the name '{0}' already exists on disk at this location. Please choose another name.
+
+If this file or folder does not appear in Solution Explorer, then it is not currently part of your project. To view files which exist on disk, but are not in the project, select Show All Files from the Project menu.</source>
+        <target state="new">A file or folder with the name '{0}' already exists on disk at this location. Please choose another name.
+
+If this file or folder does not appear in Solution Explorer, then it is not currently part of your project. To view files which exist on disk, but are not in the project, select Show All Files from the Project menu.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
@@ -67,6 +67,15 @@
         <target state="new">Packages</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpecialFileProvider_FileOrFolderAlreadyExists">
+        <source>A file or folder with the name '{0}' already exists on disk at this location. Please choose another name.
+
+If this file or folder does not appear in Solution Explorer, then it is not currently part of your project. To view files which exist on disk, but are not in the project, select Show All Files from the Project menu.</source>
+        <target state="new">A file or folder with the name '{0}' already exists on disk at this location. Please choose another name.
+
+If this file or folder does not appear in Solution Explorer, then it is not currently part of your project. To view files which exist on disk, but are not in the project, select Show All Files from the Project menu.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
@@ -67,6 +67,15 @@
         <target state="new">Packages</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpecialFileProvider_FileOrFolderAlreadyExists">
+        <source>A file or folder with the name '{0}' already exists on disk at this location. Please choose another name.
+
+If this file or folder does not appear in Solution Explorer, then it is not currently part of your project. To view files which exist on disk, but are not in the project, select Show All Files from the Project menu.</source>
+        <target state="new">A file or folder with the name '{0}' already exists on disk at this location. Please choose another name.
+
+If this file or folder does not appear in Solution Explorer, then it is not currently part of your project. To view files which exist on disk, but are not in the project, select Show All Files from the Project menu.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
@@ -67,6 +67,15 @@
         <target state="new">Packages</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpecialFileProvider_FileOrFolderAlreadyExists">
+        <source>A file or folder with the name '{0}' already exists on disk at this location. Please choose another name.
+
+If this file or folder does not appear in Solution Explorer, then it is not currently part of your project. To view files which exist on disk, but are not in the project, select Show All Files from the Project menu.</source>
+        <target state="new">A file or folder with the name '{0}' already exists on disk at this location. Please choose another name.
+
+If this file or folder does not appear in Solution Explorer, then it is not currently part of your project. To view files which exist on disk, but are not in the project, select Show All Files from the Project menu.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
@@ -67,6 +67,15 @@
         <target state="new">Packages</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpecialFileProvider_FileOrFolderAlreadyExists">
+        <source>A file or folder with the name '{0}' already exists on disk at this location. Please choose another name.
+
+If this file or folder does not appear in Solution Explorer, then it is not currently part of your project. To view files which exist on disk, but are not in the project, select Show All Files from the Project menu.</source>
+        <target state="new">A file or folder with the name '{0}' already exists on disk at this location. Please choose another name.
+
+If this file or folder does not appear in Solution Explorer, then it is not currently part of your project. To view files which exist on disk, but are not in the project, select Show All Files from the Project menu.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
@@ -67,6 +67,15 @@
         <target state="new">Packages</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpecialFileProvider_FileOrFolderAlreadyExists">
+        <source>A file or folder with the name '{0}' already exists on disk at this location. Please choose another name.
+
+If this file or folder does not appear in Solution Explorer, then it is not currently part of your project. To view files which exist on disk, but are not in the project, select Show All Files from the Project menu.</source>
+        <target state="new">A file or folder with the name '{0}' already exists on disk at this location. Please choose another name.
+
+If this file or folder does not appear in Solution Explorer, then it is not currently part of your project. To view files which exist on disk, but are not in the project, select Show All Files from the Project menu.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
@@ -67,6 +67,15 @@
         <target state="new">Packages</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpecialFileProvider_FileOrFolderAlreadyExists">
+        <source>A file or folder with the name '{0}' already exists on disk at this location. Please choose another name.
+
+If this file or folder does not appear in Solution Explorer, then it is not currently part of your project. To view files which exist on disk, but are not in the project, select Show All Files from the Project menu.</source>
+        <target state="new">A file or folder with the name '{0}' already exists on disk at this location. Please choose another name.
+
+If this file or folder does not appear in Solution Explorer, then it is not currently part of your project. To view files which exist on disk, but are not in the project, select Show All Files from the Project menu.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
@@ -67,6 +67,15 @@
         <target state="new">Packages</target>
         <note />
       </trans-unit>
+      <trans-unit id="SpecialFileProvider_FileOrFolderAlreadyExists">
+        <source>A file or folder with the name '{0}' already exists on disk at this location. Please choose another name.
+
+If this file or folder does not appear in Solution Explorer, then it is not currently part of your project. To view files which exist on disk, but are not in the project, select Show All Files from the Project menu.</source>
+        <target state="new">A file or folder with the name '{0}' already exists on disk at this location. Please choose another name.
+
+If this file or folder does not appear in Solution Explorer, then it is not currently part of your project. To view files which exist on disk, but are not in the project, select Show All Files from the Project menu.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IPhysicalProjectTreeFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IPhysicalProjectTreeFactory.cs
@@ -6,10 +6,12 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal static class IPhysicalProjectTreeFactory
     {
-        public static IPhysicalProjectTree Create(IProjectTreeProvider? provider = null, IProjectTree? currentTree = null, IProjectTreeService? service = null)
+        public static IPhysicalProjectTree Create(IProjectTreeProvider? provider = null, IProjectTree? currentTree = null, IProjectTreeService? service = null, IPhysicalProjectTreeStorage? storage = null)
         {
             currentTree ??= ProjectTreeParser.Parse("Project");
             provider ??= new ProjectTreeProvider();
+            storage ??= IPhysicalProjectTreeStorageFactory.Create();
+            service ??= IProjectTreeServiceFactory.Create(currentTree, provider);
 
             var mock = new Mock<IPhysicalProjectTree>();
             mock.Setup(t => t.TreeProvider)
@@ -19,7 +21,10 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 .Returns(currentTree);
 
             mock.Setup(t => t.TreeService)
-                .Returns(service ?? IProjectTreeServiceFactory.Create(currentTree, provider));
+                .Returns(service);
+
+            mock.Setup(t => t.TreeStorage)
+           .    Returns(storage);
 
             return mock.Object;
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IPhysicalProjectTreeStorageFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IPhysicalProjectTreeStorageFactory.cs
@@ -2,6 +2,8 @@
 
 using Moq;
 
+using System;
+
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal static class IPhysicalProjectTreeStorageFactory
@@ -9,6 +11,24 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public static IPhysicalProjectTreeStorage Create()
         {
             return Mock.Of<IPhysicalProjectTreeStorage>();
+        }
+
+        public static IPhysicalProjectTreeStorage ImplementAddFolderAsync(Action<string> action)
+        {
+            var mock = new Mock<IPhysicalProjectTreeStorage>();
+            mock.Setup(p => p.AddFolderAsync(It.IsAny<string>()))
+                .ReturnsAsync(action);
+
+            return mock.Object;
+        }
+
+        public static IPhysicalProjectTreeStorage ImplementCreateFolderAsync(Action<string> action)
+        {
+            var mock = new Mock<IPhysicalProjectTreeStorage>();
+            mock.Setup(p => p.CreateFolderAsync(It.IsAny<string>()))
+                .ReturnsAsync(action);
+
+            return mock.Object;
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProviderTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.IO;
 using System.Threading.Tasks;
 
 using Xunit;
@@ -85,6 +86,23 @@ Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
             Assert.Equal(expected, result);
         }
 
+        [Fact]
+        public async Task GetFile_WhenTreeWithAppDesignerFolder_ReturnsPathIfCreateIfNotExist()
+        {
+            var tree = ProjectTreeParser.Parse(@"
+Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
+    My Project (flags: {Folder AppDesignerFolder BubbleUp})");
+
+            var treeProvider = new ProjectTreeProvider();
+            var physicalProjectTree = IPhysicalProjectTreeFactory.Create(provider: treeProvider, currentTree: tree);
+
+            var provider = CreateInstance(physicalProjectTree);
+
+            var result = await provider.GetFileAsync(SpecialFiles.AppDesigner, SpecialFileFlags.CreateIfNotExist);
+
+            Assert.Equal(@"C:\Project\My Project", result);
+        }
+
         [Theory]    // AppDesignerFolder        // Expected return
         [InlineData(@"Properties",              @"C:\Project\Properties")]
         [InlineData(@"My Project",              @"C:\Project\My Project")]
@@ -94,7 +112,7 @@ Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
         {
             var tree = ProjectTreeParser.Parse(@"
 Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
-    Properties (flags: {Folder})
+    Properties (flags: {FileSystemEntity Folder})
 ");
 
             var treeProvider = new ProjectTreeProvider();
@@ -109,6 +127,137 @@ Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
             Assert.Equal(expected, result);
         }
 
+        [Fact]
+        public async Task GetFileAsync_WhenTreeWithFileSameName_ReturnsDefaultAppDesignerFolder()
+        {
+            var tree = ProjectTreeParser.Parse(@"
+Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
+    Properties (flags: {FileSystemEntity FileOnDisk})
+");
+
+            var treeProvider = new ProjectTreeProvider();
+            var physicalProjectTree = IPhysicalProjectTreeFactory.Create(provider: treeProvider, currentTree: tree);
+
+            var projectProperties = CreateProperties(appDesignerFolderName: "Properties");
+
+            var provider = CreateInstance(physicalProjectTree, projectProperties);
+
+            var result = await provider.GetFileAsync(SpecialFiles.AppDesigner, SpecialFileFlags.FullPath);
+
+            Assert.Equal(@"C:\Project\Properties", result);
+        }
+
+        [Fact]
+        public async Task GetFileAsync_WhenTreeWithFileSameName_ThrowsIfCreateIfNotExist()
+        {
+            var tree = ProjectTreeParser.Parse(@"
+Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
+    Properties (flags: {FileSystemEntity FileOnDisk}), FilePath: ""C:\Project\Properties""
+");
+
+            var treeProvider = new ProjectTreeProvider();
+            var physicalProjectTree = IPhysicalProjectTreeFactory.Create(provider: treeProvider, currentTree: tree);
+
+            var projectProperties = CreateProperties(appDesignerFolderName: "Properties");
+
+            var provider = CreateInstance(physicalProjectTree, projectProperties);
+
+            await Assert.ThrowsAsync<IOException>(() =>
+            {
+                return provider.GetFileAsync(SpecialFiles.AppDesigner, SpecialFileFlags.CreateIfNotExist);
+            });
+        }
+
+        [Fact]
+        public async Task GetFileAsync_WhenTreeWithExcludedFolder_IsAddedToProjectIfCreateIfNotExist()
+        {
+            var tree = ProjectTreeParser.Parse(@"
+Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
+    Properties (flags: {FileSystemEntity Folder IncludeInProjectCandidate}), FilePath: ""C:\Project\Properties""
+");
+            int callCount = 0;
+            var storage = IPhysicalProjectTreeStorageFactory.ImplementAddFolderAsync(path => callCount++);
+            var physicalProjectTree = IPhysicalProjectTreeFactory.Create(currentTree: tree, storage: storage);
+
+            var provider = CreateInstance(physicalProjectTree);
+
+            await provider.GetFileAsync(SpecialFiles.AppDesigner, SpecialFileFlags.CreateIfNotExist);
+
+            Assert.Equal(1, callCount);
+        }
+
+        [Fact]
+        public async Task GetFileAsync_WhenTreeWithExistentAppDesignerFolder_ReturnsPathIfCreateIfNotExist()
+        {
+            var tree = ProjectTreeParser.Parse(@"
+Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
+    Properties (flags: {FileSystemEntity Folder AppDesignerFolder})
+");
+
+            var physicalProjectTree = IPhysicalProjectTreeFactory.Create(currentTree: tree);
+
+            var provider = CreateInstance(physicalProjectTree);
+
+            string? result = await provider.GetFileAsync(SpecialFiles.AppDesigner, SpecialFileFlags.CreateIfNotExist);
+
+            Assert.Equal(@"C:\Project\Properties", result);
+        }
+
+        [Fact]
+        public async Task GetFileAsync_WhenTreeWithNoAppDesignerFolder_IsCreatedIfCreateIfNotExist()
+        {
+            var tree = ProjectTreeParser.Parse(@"
+Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""");
+
+            int callCount = 0;
+            var storage = IPhysicalProjectTreeStorageFactory.ImplementCreateFolderAsync(path => callCount++);
+            var physicalProjectTree = IPhysicalProjectTreeFactory.Create(currentTree: tree, storage: storage);
+
+            var projectProperties = CreateProperties(appDesignerFolderName: "Properties");
+
+            var provider = CreateInstance(physicalProjectTree, projectProperties);
+
+            await provider.GetFileAsync(SpecialFiles.AppDesigner, SpecialFileFlags.CreateIfNotExist);
+
+            Assert.Equal(1, callCount);
+        }
+
+        [Fact]
+        public async Task GetFileAsync_WhenTreeWithMissingAppDesignerFolder_IsCreatedIfCreateIfNotExist()
+        {
+            var tree = ProjectTreeParser.Parse(@"
+Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
+    Properties (flags: {Folder AppDesignerFolder})
+");
+            int callCount = 0;
+            var storage = IPhysicalProjectTreeStorageFactory.ImplementCreateFolderAsync(path => callCount++);
+            var physicalProjectTree = IPhysicalProjectTreeFactory.Create(currentTree: tree, storage: storage);
+
+            var provider = CreateInstance(physicalProjectTree);
+
+            await provider.GetFileAsync(SpecialFiles.AppDesigner, SpecialFileFlags.CreateIfNotExist);
+
+            Assert.Equal(1, callCount);
+        }
+
+        [Fact]
+        public async Task GetFileAsync_WhenGetAddNewItemDirectoryNull_ReturnsNull()
+        {   // Mimics an extension turning on DisableAddItem flag for our parent
+
+            var tree = ProjectTreeParser.Parse(@"
+Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
+    Properties (flags: {Folder AppDesignerFolder})
+");
+            var treeProvider = IProjectTreeProviderFactory.ImplementGetAddNewItemDirectory(node => null!);
+            var physicalProjectTree = IPhysicalProjectTreeFactory.Create(provider: treeProvider, currentTree: tree);
+
+            var provider = CreateInstance(physicalProjectTree);
+
+            var result = await provider.GetFileAsync(SpecialFiles.AppDesigner, SpecialFileFlags.CreateIfNotExist);
+
+            Assert.Null(result);
+        }
+
         private static ProjectProperties CreateProperties(string appDesignerFolderName)
         {
             return ProjectPropertiesFactory.Create(UnconfiguredProjectFactory.Create(), new[] {
@@ -119,7 +268,7 @@ Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
         private static AppDesignerFolderSpecialFileProvider CreateInstance(IPhysicalProjectTree? physicalProjectTree = null, ProjectProperties? properties = null)
         {
             physicalProjectTree ??= IPhysicalProjectTreeFactory.Create();
-            properties ??= ProjectPropertiesFactory.CreateEmpty();
+            properties ??= CreateProperties(appDesignerFolderName: "Properties");
 
             return new AppDesignerFolderSpecialFileProvider(physicalProjectTree, properties);
         }


### PR DESCRIPTION
This makes the special file provider for AppDesigner folder (and hence AbstractSpecialFileProvider) more resilent against being:

- Excluded from the project
- Included in the project, but missing on disk
- An actual file on disk

This mimics legacy extremely closely - except that CPS has a bug where it silently ignores failures from special file handlers, which will be fixed later.