### PR TITLE
Add licenses.licx special file provider

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectItemsSchema.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectItemsSchema.xaml
@@ -81,6 +81,7 @@
   <FileExtension Name=".asp" ContentType="AspPage" />
   <FileExtension Name=".txt" ContentType="Text" />
   <FileExtension Name=".resx" ContentType="EmbeddedResource" />
+  <FileExtension Name=".licx" ContentType="EmbeddedResource" />
   <FileExtension Name=".html" ContentType="HTML" />
   <FileExtension Name=".htm" ContentType="HTML" />
   <FileExtension Name=".css" ContentType="CSS" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractFindByNameSpecialFileProvider2.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractFindByNameSpecialFileProvider2.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
+{
+    /// <summary>
+    ///     Provides <see langword="abstract"/> base class for <see cref="ISpecialFileProvider"/> instances
+    ///     that find their special file by file name in the root of the project.
+    /// </summary>
+    internal abstract class AbstractFindByNameSpecialFileProvider2 : AbstractSpecialFileProvider
+    {
+        private readonly string _fileName;
+
+        protected AbstractFindByNameSpecialFileProvider2(string fileName, IPhysicalProjectTree projectTree)
+            : base(projectTree)
+        {
+            _fileName = fileName;
+        }
+
+        protected override Task<IProjectTree?> FindFileAsync(IProjectTreeProvider provider, IProjectTree root)
+        {
+            root.TryFindImmediateChild(_fileName, out IProjectTree? node);
+
+            return Task.FromResult<IProjectTree?>(node);
+        }
+
+        protected override Task<string?> GetDefaultFileAsync(IProjectTreeProvider provider, IProjectTree root)
+        {
+            string? projectPath = provider.GetRootedAddNewItemDirectory(root);
+            if (projectPath == null)  // Root has DisableAddItem
+                return Task.FromResult<string?>(null);
+
+            string path = Path.Combine(projectPath, _fileName);
+
+            return Task.FromResult<string?>(path);
+        }
+
+        protected string? GetDefaultFileAsync(string rootPath)
+        {
+            return Path.Combine(rootPath, _fileName);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractFindByNameUnderAppDesignerSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractFindByNameUnderAppDesignerSpecialFileProvider.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
+{
+    /// <summary>
+    ///     Provides <see langword="abstract"/> base class for <see cref="ISpecialFileProvider"/> instances 
+    ///     that find their special file by file name under the AppDesigner folder, falling back 
+    ///     to the root folder if it doesn't exist.
+    /// </summary>
+    internal class AbstractFindByNameUnderAppDesignerSpecialFileProvider : AbstractFindByNameSpecialFileProvider2
+    {
+        private readonly ISpecialFilesManager _specialFilesManager;
+
+        protected AbstractFindByNameUnderAppDesignerSpecialFileProvider(string fileName, ISpecialFilesManager specialFilesManager, IPhysicalProjectTree projectTree)
+            : base(fileName, projectTree)
+        {
+            _specialFilesManager = specialFilesManager;
+        }
+
+        protected override async Task<IProjectTree?> FindFileAsync(IProjectTreeProvider provider, IProjectTree root)
+        {
+            // Search AppDesigner folder first if it exists
+            IProjectTree? appDesignerFolder = await GetAppDesignerFolderAsync(provider, root);
+            if (appDesignerFolder != null)
+            {
+                IProjectTree? node = await base.FindFileAsync(provider, appDesignerFolder);
+                if (node != null)
+                    return node;
+            }
+
+            // Then fallback to project root
+            return await base.FindFileAsync(provider, root);
+        }
+
+        protected override async Task<string?> GetDefaultFileAsync(IProjectTreeProvider provider, IProjectTree root)
+        {
+            // AppDesigner folder first if it exists
+            string? appDesignerPath = await GetAppDesignerFolderPathAsync();
+            if (appDesignerPath != null)
+            {
+                return GetDefaultFileAsync(appDesignerPath);
+            }
+
+            // Then fallback to project root
+            return await base.GetDefaultFileAsync(provider, root);
+        }
+
+        private async Task<IProjectTree?> GetAppDesignerFolderAsync(IProjectTreeProvider provider, IProjectTree root)
+        {
+            string? appDesignerPath = await GetAppDesignerFolderPathAsync();
+            if (appDesignerPath == null)
+                return null;
+
+            return provider.FindByPath(root, appDesignerPath);
+        }
+
+        private Task<string?> GetAppDesignerFolderPathAsync(bool createIfNotExists = false)
+        {
+            SpecialFileFlags flags = SpecialFileFlags.FullPath;
+            if (createIfNotExists)
+                flags |= SpecialFileFlags.CreateIfNotExist;
+
+            return _specialFilesManager.GetFileAsync(SpecialFiles.AppDesigner, flags);
+        }
+
+        protected override async Task CreateFileAsync(string path)
+        {
+            await EnsureAppDesignerFolder();
+
+            await base.CreateFileAsync(path);
+        }
+
+        private Task EnsureAppDesignerFolder()
+        {
+            return GetAppDesignerFolderPathAsync(createIfNotExists: true);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/LicensesSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/LicensesSpecialFileProvider.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+
+namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
+{
+    /// <summary>
+    ///     Provides a <see cref="ISpecialFileProvider"/> that handles the 'licenses.licx' file; 
+    ///     a file that contains a list of licensed (typically Windows Forms) components used by
+    ///     a project.  
+    /// </summary>
+    [ExportSpecialFileProvider(SpecialFiles.Licenses)]
+    [AppliesTo(ProjectCapability.DotNet)]
+    internal class LicensesSpecialFileProvider : AbstractFindByNameUnderAppDesignerSpecialFileProvider
+    {
+        [ImportingConstructor]
+        public LicensesSpecialFileProvider(ISpecialFilesManager specialFilesManager, IPhysicalProjectTree projectTree) 
+            : base("licenses.licx", specialFilesManager, projectTree)
+        {
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IPhysicalProjectTreeStorageFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IPhysicalProjectTreeStorageFactory.cs
@@ -13,6 +13,24 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return Mock.Of<IPhysicalProjectTreeStorage>();
         }
 
+        public static IPhysicalProjectTreeStorage ImplementCreateEmptyFileAsync(Action<string> action)
+        {
+            var mock = new Mock<IPhysicalProjectTreeStorage>();
+            mock.Setup(p => p.CreateEmptyFileAsync(It.IsAny<string>()))
+                .ReturnsAsync(action);
+
+            return mock.Object;
+        }
+
+        public static IPhysicalProjectTreeStorage ImplementAddFileAsync(Action<string> action)
+        {
+            var mock = new Mock<IPhysicalProjectTreeStorage>();
+            mock.Setup(p => p.AddFileAsync(It.IsAny<string>()))
+                .ReturnsAsync(action);
+
+            return mock.Object;
+        }
+
         public static IPhysicalProjectTreeStorage ImplementAddFolderAsync(Action<string> action)
         {
             var mock = new Mock<IPhysicalProjectTreeStorage>();

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AbstractFindByNameUnderAppDesignerSpecialFileProviderTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AbstractFindByNameUnderAppDesignerSpecialFileProviderTestBase.cs
@@ -1,0 +1,223 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
+{
+    public abstract class AbstractFindByNameUnderAppDesignerSpecialFileProviderTestBase
+    {
+        private readonly string _fileName;
+
+        protected AbstractFindByNameUnderAppDesignerSpecialFileProviderTestBase(string fileName)
+        {
+            _fileName = fileName;
+        }
+
+        [Fact]
+        public async Task GetFileAsync_WhenNoAppDesigner_ReturnsPathUnderAppDesigner()
+        {
+            var tree = ProjectTreeParser.Parse($@"
+Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
+");
+            var specialFilesManager = ISpecialFilesManagerFactory.ImplementGetFile(@"C:\Project\Properties");
+            var provider = CreateInstance(specialFilesManager, tree);
+
+            var result = await provider.GetFileAsync(0, SpecialFileFlags.FullPath);
+
+            Assert.Equal($@"C:\Project\Properties\{_fileName}", result);
+        }
+
+        [Fact]
+        public async Task GetFileAsync_WhenAppDesigner_ReturnsPathUnderAppDesigner()
+        {
+            var tree = ProjectTreeParser.Parse($@"
+Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
+    Properties (flags: {{FileSystemEntity Folder AppDesignerFolder}}), FilePath: ""C:\Project\Properties""
+");
+            var specialFilesManager = ISpecialFilesManagerFactory.ImplementGetFile(@"C:\Project\Properties");
+            var provider = CreateInstance(specialFilesManager, tree);
+
+            var result = await provider.GetFileAsync(0, SpecialFileFlags.FullPath);
+
+            Assert.Equal($@"C:\Project\Properties\{_fileName}", result);
+        }
+
+        [Fact]
+        public async Task GetFileAsync_WhenAppDesignerNotSupported_ReturnsPathUnderProjectRoot()
+        {   // AppDesigner is turned off
+
+            var tree = ProjectTreeParser.Parse($@"
+Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
+");
+            var specialFilesManager = ISpecialFilesManagerFactory.ImplementGetFile(null);
+
+            var provider = CreateInstance(specialFilesManager, tree);
+
+            var result = await provider.GetFileAsync(0, SpecialFileFlags.FullPath);
+
+            Assert.Equal($@"C:\Project\{_fileName}", result);
+        }
+
+        [Fact]
+        public async Task GetFileAsync_WhenAppDesignerWithFile_ReturnsPath()
+        {
+            var tree = ProjectTreeParser.Parse($@"
+Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
+    Properties (flags: {{FileSystemEntity Folder AppDesignerFolder}}), FilePath: ""C:\Project\Properties""
+        {_fileName} (flags: {{FileSystemEntity FileOnDisk}}), FilePath: ""C:\Project\Properties\{_fileName}""
+");
+            var specialFilesManager = ISpecialFilesManagerFactory.ImplementGetFile(@"C:\Project\Properties");
+            var provider = CreateInstance(specialFilesManager, tree);
+
+            var result = await provider.GetFileAsync(0, SpecialFileFlags.FullPath);
+
+            Assert.Equal($@"C:\Project\Properties\{_fileName}", result);
+        }
+
+        [Fact]
+        public async Task GetFileAsync_WhenAppDesignerButRootWithFile_ReturnsPath()
+        {
+            var tree = ProjectTreeParser.Parse($@"
+Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
+    Properties (flags: {{FileSystemEntity Folder AppDesignerFolder}}), FilePath: ""C:\Project\Properties""
+    {_fileName} (flags: {{FileSystemEntity FileOnDisk}}), FilePath: ""C:\Project\{_fileName}""
+");
+            var specialFilesManager = ISpecialFilesManagerFactory.ImplementGetFile(@"C:\Project\Properties");
+            var provider = CreateInstance(specialFilesManager, tree);
+
+            var result = await provider.GetFileAsync(0, SpecialFileFlags.FullPath);
+
+            Assert.Equal($@"C:\Project\{_fileName}", result);
+        }
+
+        [Fact]
+        public async Task GetFileAsync_WhenRootWithFile_ReturnsPath()
+        {
+            var tree = ProjectTreeParser.Parse($@"
+Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
+    {_fileName} (flags: {{FileSystemEntity FileOnDisk}}), FilePath: ""C:\Project\{_fileName}""
+");
+            var specialFilesManager = ISpecialFilesManagerFactory.ImplementGetFile(null);
+
+            var provider = CreateInstance(specialFilesManager, tree);
+
+            var result = await provider.GetFileAsync(0, SpecialFileFlags.FullPath);
+
+            Assert.Equal($@"C:\Project\{_fileName}", result);
+        }
+
+        [Fact]
+        public async Task GetFileAsync_WhenTreeWithFolderSameName_ReturnsPath()
+        {
+            var tree = ProjectTreeParser.Parse($@"
+Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
+    {_fileName} (flags: {{FileSystemEntity Folder}}), FilePath: ""C:\Project\{_fileName}""
+");
+
+            var specialFilesManager = ISpecialFilesManagerFactory.ImplementGetFile(null);
+            var provider = CreateInstance(specialFilesManager, tree);
+
+            var result = await provider.GetFileAsync(0, SpecialFileFlags.FullPath);
+
+            Assert.Equal($@"C:\Project\{_fileName}", result);
+        }
+
+        [Fact]
+        public async Task GetFileAsync_WhenTreeWithFolderSameName_ThrowsIfCreateIfNotExist()
+        {
+            var tree = ProjectTreeParser.Parse($@"
+Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
+    {_fileName} (flags: {{FileSystemEntity Folder}}), FilePath: ""C:\Project\{_fileName}""
+");
+
+            var specialFilesManager = ISpecialFilesManagerFactory.ImplementGetFile(null);
+            var provider = CreateInstance(specialFilesManager, tree);
+
+            await Assert.ThrowsAsync<IOException>(() =>
+            {
+                return provider.GetFileAsync(0, SpecialFileFlags.CreateIfNotExist);
+            });
+        }
+
+        [Fact]
+        public async Task GetFileAsync_WhenTreeWithExcludedFile_IsAddedToProjectIfCreateIfNotExist()
+        {
+            var tree = ProjectTreeParser.Parse($@"
+Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
+    {_fileName} (flags: {{FileSystemEntity FileOnDisk IncludeInProjectCandidate}}), FilePath: ""C:\Project\{_fileName}""
+");
+            int callCount = 0;
+            var storage = IPhysicalProjectTreeStorageFactory.ImplementAddFileAsync(path => callCount++);
+            var specialFilesManager = ISpecialFilesManagerFactory.ImplementGetFile(null);
+            var physicalProjectTree = IPhysicalProjectTreeFactory.Create(currentTree: tree, storage: storage);
+            var provider = CreateInstance(specialFilesManager, physicalProjectTree);
+
+            await provider.GetFileAsync(0, SpecialFileFlags.CreateIfNotExist);
+
+            Assert.Equal(1, callCount);
+        }
+
+        [Fact]
+        public async Task GetFileAsync_WhenTreeWithExistentFile_ReturnsPathIfCreateIfNotExist()
+        {
+            var tree = ProjectTreeParser.Parse($@"
+Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
+    {_fileName} (flags: {{FileSystemEntity FileOnDisk}}), FilePath: ""C:\Project\{_fileName}""
+");
+            var physicalProjectTree = IPhysicalProjectTreeFactory.Create(currentTree: tree);
+            var specialFilesManager = ISpecialFilesManagerFactory.ImplementGetFile(null);
+            var provider = CreateInstance(specialFilesManager, physicalProjectTree);
+
+            string? result = await provider.GetFileAsync(0, SpecialFileFlags.CreateIfNotExist);
+
+            Assert.Equal($@"C:\Project\{_fileName}", result);
+        }
+
+        [Fact]
+        public async Task GetFileAsync_WhenTreeWithNoFile_IsCreatedIfCreateIfNotExist()
+        {
+            var tree = ProjectTreeParser.Parse($@"
+Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
+");
+
+            int callCount = 0;
+            var storage = IPhysicalProjectTreeStorageFactory.ImplementCreateEmptyFileAsync(path => callCount++);
+            var specialFilesManager = ISpecialFilesManagerFactory.ImplementGetFile(null);
+            var physicalProjectTree = IPhysicalProjectTreeFactory.Create(currentTree: tree, storage: storage);
+            var provider = CreateInstance(specialFilesManager, physicalProjectTree);
+
+            await provider.GetFileAsync(0, SpecialFileFlags.CreateIfNotExist);
+
+            Assert.Equal(1, callCount);
+        }
+
+        [Fact]
+        public async Task GetFileAsync_WhenTreeWithMissingFile_IsCreatedIfCreateIfNotExist()
+        {
+            var tree = ProjectTreeParser.Parse($@"
+Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
+    {_fileName} (flags: {{}}), FilePath: ""C:\Project\{_fileName}""
+");
+            int callCount = 0;
+            var storage = IPhysicalProjectTreeStorageFactory.ImplementCreateEmptyFileAsync(path => callCount++);
+            var specialFilesManager = ISpecialFilesManagerFactory.ImplementGetFile(null);
+            var physicalProjectTree = IPhysicalProjectTreeFactory.Create(currentTree: tree, storage: storage);
+            var provider = CreateInstance(specialFilesManager, physicalProjectTree);
+
+            await provider.GetFileAsync(0, SpecialFileFlags.CreateIfNotExist);
+
+            Assert.Equal(1, callCount);
+        }
+
+        private AbstractFindByNameUnderAppDesignerSpecialFileProvider CreateInstance(ISpecialFilesManager specialFilesManager, IProjectTree projectTree)
+        {
+            var physicalProjectTree = IPhysicalProjectTreeFactory.Create(currentTree: projectTree);
+
+            return CreateInstance(specialFilesManager, physicalProjectTree);
+        }
+
+        internal abstract AbstractFindByNameUnderAppDesignerSpecialFileProvider CreateInstance(ISpecialFilesManager specialFilesManager, IPhysicalProjectTree projectTree);
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/LicensesSpecialFileProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/LicensesSpecialFileProviderTests.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
+{
+    public class LicensesSpecialFileProviderTests : AbstractFindByNameUnderAppDesignerSpecialFileProviderTestBase
+    {
+        public LicensesSpecialFileProviderTests() 
+            : base("licenses.licx")
+        {
+        }
+
+        internal override AbstractFindByNameUnderAppDesignerSpecialFileProvider CreateInstance(ISpecialFilesManager specialFilesManager, IPhysicalProjectTree projectTree)
+        {
+            return new LicensesSpecialFileProvider(specialFilesManager, projectTree);
+        }
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/dotnet/project-system/issues/4938.

This adds a new implementation of AbstractFindByNameSpecialFileProvider called AbstractFindByNameSpecialFileProvider2 that derives from the new AbstractSpecialFileProvider. The original will be removed & replaced in a later PR