### PR TITLE
Use full paths for design time inputs

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsBuildManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsBuildManager.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
         internal OrderPrecedenceImportCollection<VSLangProj.VSProject> Project { get; }
 
         [Import]
-        internal Lazy<IDesignTimeInputsBuildManagerBridge, IAppliesToMetadataView>? DesignTimeInputsBuildManagerBridge { get; }
+        internal Lazy<IDesignTimeInputsBuildManagerBridge, IAppliesToMetadataView>? DesignTimeInputsBuildManagerBridge { get; private set; }
 
         /// <summary>
         /// Occurs when a design time output moniker is deleted.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputFileChange.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputFileChange.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Diagnostics;
+
 namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 {
+    [DebuggerDisplay("{File}, ignore: {IgnoreFileWriteTime}")]
     internal class DesignTimeInputFileChange
     {
         public string File { get; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTracker.cs
@@ -116,10 +116,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             var changedInputs = new List<DesignTimeInputFileChange>();
             foreach (string changedFile in arg.Value)
             {
-                string relativeFilePath = _project.MakeRelative(changedFile);
-
                 // if a shared input changes, we recompile everything
-                if (state.SharedInputs.Contains(relativeFilePath))
+                if (state.SharedInputs.Contains(changedFile))
                 {
                     foreach (string file in state.Inputs)
                     {
@@ -130,7 +128,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                 }
                 else
                 {
-                    changedInputs.Add(new DesignTimeInputFileChange(relativeFilePath, ignoreFileWriteTime: false));
+                    changedInputs.Add(new DesignTimeInputFileChange(changedFile, ignoreFileWriteTime: false));
                 }
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsCompiler.QueueItem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsCompiler.QueueItem.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 {
     internal partial class DesignTimeInputsCompiler
     {
+        [DebuggerDisplay("{FileName}")]
         public class QueueItem
         {
             public string FileName { get; }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
-using System.Linq;
 using System.Threading.Tasks.Dataflow;
 
 using Microsoft.VisualStudio.Shell;
@@ -22,7 +21,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
     [AppliesTo(ProjectCapability.CSharpOrVisualBasicLanguageService)]
     internal class DesignTimeInputsFileWatcher : ProjectValueDataSourceBase<string[]>, IVsFreeThreadedFileChangeEvents2, IDesignTimeInputsFileWatcher
     {
-        private readonly UnconfiguredProject _project;
         private readonly IProjectThreadingService _threadingService;
         private readonly IDesignTimeInputsDataSource _designTimeInputsDataSource;
         private readonly IVsService<IVsAsyncFileChangeEx> _fileChangeService;
@@ -54,7 +52,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                                            IVsService<SVsFileChangeEx, IVsAsyncFileChangeEx> fileChangeService)
              : base(unconfiguredProjectServices, synchronousDisposal: true, registerDataSource: false)
         {
-            _project = project;
             _threadingService = threadingService;
             _designTimeInputsDataSource = designTimeInputsDataSource;
             _fileChangeService = fileChangeService;
@@ -101,8 +98,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 
             // we don't care about the difference between types of inputs, so we just construct one hashset for fast comparisons later
             var allFiles = new HashSet<string>(StringComparers.Paths);
-            allFiles.AddRange(designTimeInputs.Inputs.Select(_project.MakeRooted));
-            allFiles.AddRange(designTimeInputs.SharedInputs.Select(_project.MakeRooted));
+            allFiles.AddRange(designTimeInputs.Inputs);
+            allFiles.AddRange(designTimeInputs.SharedInputs);
 
             // Remove any files we're watching that we don't care about any more
             var removedFiles = new List<string>();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/IDesignTimeInputsBuildManagerBridge.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/IDesignTimeInputsBuildManagerBridge.cs
@@ -20,6 +20,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         /// <summary>
         /// Gets the XML that describes a TempPE DLL, including building it if necessary
         /// </summary>
-        Task<string> GetDesignTimeInputXmlAsync(string file);
+        Task<string> GetDesignTimeInputXmlAsync(string relativeFileName);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/IDesignTimeInputsCompiler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/IDesignTimeInputsCompiler.cs
@@ -12,10 +12,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         /// <summary>
         /// Gets the XML that describes a TempPE DLL, including building it if necessary
         /// </summary>
-        /// <param name="fileName">A project relative path to a source file that is a design time input</param>
+        /// <param name="relativeFileName">A project relative path to a source file that is a design time input</param>
         /// <param name="tempPEOutputPath">The path in which to place the TempPE DLL if one is created</param>
         /// <param name="sharedInputs">The list of shared inputs to be included in the TempPE DLL</param>
         /// <returns>An XML description of the TempPE DLL for the specified file</returns>
-        Task<string> GetDesignTimeInputXmlAsync(string fileName, string tempPEOutputPath, System.Collections.Immutable.ImmutableHashSet<string> sharedInputs);
+        Task<string> GetDesignTimeInputXmlAsync(string relativeFileName, string tempPEOutputPath, System.Collections.Immutable.ImmutableHashSet<string> sharedInputs);
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsBuildManagerBridgeTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsBuildManagerBridgeTests.cs
@@ -89,10 +89,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                     _lastSharedInputs = sharedInputs;
                 });
 
+            var project = UnconfiguredProjectFactory.Create(filePath: @"C:\MyProject\MyProject.csproj");
 
             _buildManager = new TestBuildManager();
 
-            _bridge = new TestDesignTimeInputsBuildManagerBridge(threadingService, changeTracker, compilerMock.Object, _buildManager);
+            _bridge = new TestDesignTimeInputsBuildManagerBridge(project, threadingService, changeTracker, compilerMock.Object, _buildManager);
             _bridge.SkipInitialization = true;
         }
 
@@ -103,8 +104,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 
         internal class TestDesignTimeInputsBuildManagerBridge : DesignTimeInputsBuildManagerBridge
         {
-            public TestDesignTimeInputsBuildManagerBridge(IProjectThreadingService threadingService, IDesignTimeInputsChangeTracker designTimeInputsChangeTracker, IDesignTimeInputsCompiler designTimeInputsCompiler, VSBuildManager buildManager)
-                : base(threadingService, designTimeInputsChangeTracker, designTimeInputsCompiler, buildManager)
+            public TestDesignTimeInputsBuildManagerBridge(UnconfiguredProject project, IProjectThreadingService threadingService, IDesignTimeInputsChangeTracker designTimeInputsChangeTracker, IDesignTimeInputsCompiler designTimeInputsCompiler, VSBuildManager buildManager)
+                : base(project, threadingService, designTimeInputsChangeTracker, designTimeInputsCompiler, buildManager)
             {
             }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsCompilerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsCompilerTests.cs
@@ -350,22 +350,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 
         private void SendDesignTimeInputs(DesignTimeInputs? inputs = null, string[]? changedFiles = null)
         {
+            // Make everything full paths here, to allow for easier test authoring
+            if (inputs != null)
+            {
+                inputs = new DesignTimeInputs(inputs.Inputs.Select(f => Path.Combine(_projectFolder, f)), inputs.SharedInputs.Select(f => Path.Combine(_projectFolder, f)));
+            }
+
             _designTimeInputs = inputs ?? _designTimeInputs!;
 
             // Ensure our input files are in the mock file system
             foreach (string file in _designTimeInputs.Inputs.Concat(_designTimeInputs.SharedInputs))
             {
-                var fullFilePath = Path.Combine(_projectFolder, file);
-                if (!_fileSystem.FileExists(fullFilePath))
+                if (!_fileSystem.FileExists(file))
                 {
-                    _fileSystem.AddFile(fullFilePath);
+                    _fileSystem.AddFile(file);
                 }
             }
 
             IEnumerable<DesignTimeInputFileChange> changes;
             if (changedFiles != null)
             {
-                changes = changedFiles.Select(f => new DesignTimeInputFileChange(f, false));
+                changes = changedFiles.Select(f => new DesignTimeInputFileChange(Path.Combine(_projectFolder, f), false));
             }
             else
             {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsDataSourceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsDataSourceTests.cs
@@ -24,12 +24,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                         ""Compile"": {
                             ""Items"": { 
                                 ""File1.cs"": {
-                                    ""DesignTime"": true
+                                    ""DesignTime"": true,
+                                    ""FullPath"": ""C:\\Project\\File1.cs""
                                 }
                             }
                         }
                     }",
-                    new string[] { "File1.cs" },
+                    new string[] { "C:\\Project\\File1.cs" },
                     new string[] { }
                 },
 
@@ -40,13 +41,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                         ""Compile"": {
                             ""Items"": { 
                                 ""File1.cs"": {
-                                    ""DesignTime"": true
+                                    ""DesignTime"": true,
+                                    ""FullPath"": ""C:\\Project\\File1.cs""
                                 },
-                                ""File2.cs"": { }
+                                ""File2.cs"": {
+                                    ""FullPath"": ""C:\\Project\\File2.cs""
+                                }
                             }
                         }
                     }",
-                    new string[] { "File1.cs" },
+                    new string[] { "C:\\Project\\File1.cs" },
                     new string[] { }
                 },
 
@@ -57,16 +61,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                         ""Compile"": {
                             ""Items"": { 
                                 ""File1.cs"": {
-                                    ""DesignTime"": true
+                                    ""DesignTime"": true,
+                                    ""FullPath"": ""C:\\Project\\File1.cs""
                                 },
                                 ""File2.cs"": {
-                                    ""DesignTimeSharedInput"": true
+                                    ""DesignTimeSharedInput"": true,
+                                    ""FullPath"": ""C:\\Project\\File2.cs""
                                 }
                             }
                         }
                     }",
-                    new string[] { "File1.cs" },
-                    new string[] { "File2.cs" }
+                    new string[] { "C:\\Project\\File1.cs" },
+                    new string[] { "C:\\Project\\File2.cs" }
                 },
 
                 // A file that is both a design time and shared design time input
@@ -77,13 +83,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                             ""Items"": { 
                                 ""File1.cs"": {
                                     ""DesignTime"": true,
-                                    ""DesignTimeSharedInput"": true
+                                    ""DesignTimeSharedInput"": true,
+                                    ""FullPath"": ""C:\\Project\\File1.cs""
                                 }
                             }
                         }
                     }",
-                    new string[] { "File1.cs" },
-                    new string[] { "File1.cs" }
+                    new string[] { "C:\\Project\\File1.cs" },
+                    new string[] { "C:\\Project\\File1.cs" }
                 },
 
                 // A design time input that is a linked file, and hence ignored
@@ -94,7 +101,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                             ""Items"": { 
                                 ""File1.cs"": {
                                     ""DesignTime"": true,
-                                    ""Link"": ""foo""
+                                    ""Link"": ""foo"",
+                                    ""FullPath"": ""C:\\Project\\File1.cs""
                                 }
                             }
                         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
@@ -89,8 +89,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 
             watcher.AllowSourceBlockCompletion = true;
 
-            // Send our input
-            await source.SendAsync(new DesignTimeInputs(designTimeInputs, sharedDesignTimeInputs));
+            // Send our input. DesignTimeInputs expects full file paths
+            await source.SendAsync(new DesignTimeInputs(designTimeInputs.Select(f => f), sharedDesignTimeInputs.Select(f => f)));
 
             // The TaskCompletionSource is the thing we use to wait for the test to finish
             var finished = new TaskCompletionSource<bool>();
@@ -136,7 +136,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             watcher.Dispose();
 
             // Make sure we watched all of the files we should
-            Assert.Equal(watchedFiles, fileChangeService.UniqueFilesWatched.Select(f => Path.GetFileName(f)).ToArray());
+            Assert.Equal(watchedFiles, fileChangeService.UniqueFilesWatched);
 
             // Should clean up and unwatch everything
             Assert.Empty(fileChangeService.WatchedFiles.ToArray());

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 


### PR DESCRIPTION
On balance most of the bits of the TempPE infrastructure either needs full paths, or doesn't care. Given that using full paths means we get de-duping of inputs for free, it makes sense to use them throughout.

I left the public API bits using relative paths for backwards compatibility reasons.

For #4163