### PR TITLE
Suppress version only updates

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriberBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Tree/Dependencies/Subscriptions/DependencyRulesSubscriberBase.cs
@@ -93,7 +93,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Subscription
                 dataSource.SourceBlock.LinkTo(
                     intermediateBlock,
                     ruleNames: ruleNames,
-                    suppressVersionOnlyUpdates: false,
+                    suppressVersionOnlyUpdates: true,
                     linkOptions: DataflowOption.PropagateCompletion));
 
             _subscriptions.Add(syncLink((intermediateBlock, actionBlock)));


### PR DESCRIPTION
As the output of this block is not sync-linked to anything, it's safe to skip version-only changes.

As this is on the base class it applies to all rule handlers, including shared projects.