### PR TITLE
Check for invalid characters in resource file 

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.vb
@@ -611,6 +611,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                         If Trim(Win32ResourceFile.Text).Length = 0 Then
                             message = My.Resources.Microsoft_VisualStudio_Editors_Designer.PropPage_NeedResFile
                             Return ValidationResult.Warning
+                        ElseIf Not Win32ResourceFile.Text.IndexOfAny(Path.GetInvalidPathChars()) = -1 Then
+                            message = My.Resources.Microsoft_VisualStudio_Editors_Designer.PropPage_InvalidCharactersInFilePath
+                            Return ValidationResult.Failed
                         ElseIf Not File.Exists(Win32ResourceFile.Text) Then
                             message = My.Resources.Microsoft_VisualStudio_Editors_Designer.PropPage_ResourceFileNotExist
                             Return ValidationResult.Warning

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.vb
@@ -608,12 +608,12 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                     End If
                 Case VsProjPropId80.VBPROJPROPID_Win32ResourceFile
                     If Win32ResourceRadioButton.Checked Then
+                        Dim FirstInvalidCharacter As Integer = Win32ResourceFile.Text.IndexOfAny(Path.GetInvalidPathChars())
                         If Trim(Win32ResourceFile.Text).Length = 0 Then
                             message = My.Resources.Microsoft_VisualStudio_Editors_Designer.PropPage_NeedResFile
                             Return ValidationResult.Warning
-                        ElseIf Not Win32ResourceFile.Text.IndexOfAny(Path.GetInvalidPathChars()) = -1 Then
-                            Dim FirstInvalidCharacter As String = Path.GetInvalidPathChars().First
-                            message = My.Resources.Microsoft_VisualStudio_Editors_Designer.PropPage_InvalidCharactersInFilePath & vbCrLf & "Please remove the following character: " & FirstInvalidCharacter
+                        ElseIf Not FirstInvalidCharacter = -1 Then
+                            message = My.Resources.Microsoft_VisualStudio_Editors_Designer.PropPage_InvalidCharactersInFilePath & vbCrLf & "Remove the following character: " & Win32ResourceFile.Text.Substring(FirstInvalidCharacter, 1)
                             Return ValidationResult.Failed
                         ElseIf Not File.Exists(Win32ResourceFile.Text) Then
                             message = My.Resources.Microsoft_VisualStudio_Editors_Designer.PropPage_ResourceFileNotExist

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPage.vb
@@ -612,7 +612,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
                             message = My.Resources.Microsoft_VisualStudio_Editors_Designer.PropPage_NeedResFile
                             Return ValidationResult.Warning
                         ElseIf Not Win32ResourceFile.Text.IndexOfAny(Path.GetInvalidPathChars()) = -1 Then
-                            message = My.Resources.Microsoft_VisualStudio_Editors_Designer.PropPage_InvalidCharactersInFilePath
+                            Dim FirstInvalidCharacter As String = Path.GetInvalidPathChars().First
+                            message = My.Resources.Microsoft_VisualStudio_Editors_Designer.PropPage_InvalidCharactersInFilePath & vbCrLf & "Please remove the following character: " & FirstInvalidCharacter
                             Return ValidationResult.Failed
                         ElseIf Not File.Exists(Win32ResourceFile.Text) Then
                             message = My.Resources.Microsoft_VisualStudio_Editors_Designer.PropPage_ResourceFileNotExist

--- a/src/Microsoft.VisualStudio.Editors/Resources/Microsoft.VisualStudio.Editors.Designer.Designer.vb
+++ b/src/Microsoft.VisualStudio.Editors/Resources/Microsoft.VisualStudio.Editors.Designer.Designer.vb
@@ -2835,7 +2835,16 @@ Namespace My.Resources
                 Return ResourceManager.GetString("PropPage_ImportedNamespacesTitle", resourceCulture)
             End Get
         End Property
-        
+
+        '''<summary>
+        '''  Looks up a localized string similar to &quot;Invalid characters in file path.&quot;.
+        '''</summary>
+        Friend Shared ReadOnly Property PropPage_InvalidCharactersInFilePath() As String
+            Get
+                Return ResourceManager.GetString("PropPage_InvalidCharactersInFilePath", resourceCulture)
+            End Get
+        End Property
+
         '''<summary>
         '''  Looks up a localized string similar to The URL is invalid. Please enter a valid URL like &quot;http://www.microsoft.com/&quot;.
         '''</summary>

--- a/src/Microsoft.VisualStudio.Editors/Resources/Microsoft.VisualStudio.Editors.Designer.resx
+++ b/src/Microsoft.VisualStudio.Editors/Resources/Microsoft.VisualStudio.Editors.Designer.resx
@@ -742,6 +742,9 @@ Error:</value>
   <data name="PropPage_ResourceFileNotExist" xml:space="preserve">
     <value>"The resource file entered does not exist."</value>
   </data>
+  <data name="PropPage_InvalidCharactersInFilePath" xml:space="preserve">
+    <value>"Invalid characters in file path."</value>
+  </data>
   <data name="APPDES_Title" xml:space="preserve">
     <value>Project Designer</value>
   </data>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.cs.xlf
@@ -918,6 +918,11 @@ Chyba:</target>
         <target state="translated">Vlastnosti odkazu</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropPage_InvalidCharactersInFilePath">
+        <source>"Invalid characters in file path."</source>
+        <target state="new">"Invalid characters in file path."</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropPage_RemoteMachineBlankError">
         <source>The remote machine name cannot be blank.  Please specify the name of the machine to debug remotely.</source>
         <target state="translated">Název vzdáleného počítače nesmí být prázdný.  Zadejte prosím název vzdáleně laděného počítače.</target>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.de.xlf
@@ -918,6 +918,11 @@ Fehler:</target>
         <target state="translated">Verweiseigenschaften</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropPage_InvalidCharactersInFilePath">
+        <source>"Invalid characters in file path."</source>
+        <target state="new">"Invalid characters in file path."</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropPage_RemoteMachineBlankError">
         <source>The remote machine name cannot be blank.  Please specify the name of the machine to debug remotely.</source>
         <target state="translated">Der Name des Remotecomputers darf nicht leer sein.  Geben Sie den Namen des Computers für das Remotedebuggen ein.</target>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.es.xlf
@@ -918,6 +918,11 @@ Error:</target>
         <target state="translated">Propiedades de la referencia</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropPage_InvalidCharactersInFilePath">
+        <source>"Invalid characters in file path."</source>
+        <target state="new">"Invalid characters in file path."</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropPage_RemoteMachineBlankError">
         <source>The remote machine name cannot be blank.  Please specify the name of the machine to debug remotely.</source>
         <target state="translated">El nombre de la máquina remota no puede estar en blanco.  Especifique el nombre de la máquina para la depuración remota.</target>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.fr.xlf
@@ -918,6 +918,11 @@ Erreur :</target>
         <target state="translated">Propriétés de la référence</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropPage_InvalidCharactersInFilePath">
+        <source>"Invalid characters in file path."</source>
+        <target state="new">"Invalid characters in file path."</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropPage_RemoteMachineBlankError">
         <source>The remote machine name cannot be blank.  Please specify the name of the machine to debug remotely.</source>
         <target state="translated">Le nom de l'ordinateur distant ne peut pas être vide.  Spécifiez le nom de l'ordinateur à déboguer à distance.</target>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.it.xlf
@@ -918,6 +918,11 @@ Errore:</target>
         <target state="translated">Proprietà del riferimento</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropPage_InvalidCharactersInFilePath">
+        <source>"Invalid characters in file path."</source>
+        <target state="new">"Invalid characters in file path."</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropPage_RemoteMachineBlankError">
         <source>The remote machine name cannot be blank.  Please specify the name of the machine to debug remotely.</source>
         <target state="translated">Il nome del computer remoto non può essere vuoto. Specificare il nome del computer di cui eseguire il debug remoto.</target>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ja.xlf
@@ -918,6 +918,11 @@ Error:</source>
         <target state="translated">参照プロパティ</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropPage_InvalidCharactersInFilePath">
+        <source>"Invalid characters in file path."</source>
+        <target state="new">"Invalid characters in file path."</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropPage_RemoteMachineBlankError">
         <source>The remote machine name cannot be blank.  Please specify the name of the machine to debug remotely.</source>
         <target state="translated">リモート コンピューター名を空白にすることはできません。リモートでデバッグするコンピューターの名前を指定してください。</target>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ko.xlf
@@ -918,6 +918,11 @@ Error:</source>
         <target state="translated">참조 속성</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropPage_InvalidCharactersInFilePath">
+        <source>"Invalid characters in file path."</source>
+        <target state="new">"Invalid characters in file path."</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropPage_RemoteMachineBlankError">
         <source>The remote machine name cannot be blank.  Please specify the name of the machine to debug remotely.</source>
         <target state="translated">원격 컴퓨터 이름은 비워 둘 수 없습니다.  원격으로 디버그할 컴퓨터의 이름을 지정하세요.</target>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.pl.xlf
@@ -918,6 +918,11 @@ Błąd:</target>
         <target state="translated">Właściwości odwołania</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropPage_InvalidCharactersInFilePath">
+        <source>"Invalid characters in file path."</source>
+        <target state="new">"Invalid characters in file path."</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropPage_RemoteMachineBlankError">
         <source>The remote machine name cannot be blank.  Please specify the name of the machine to debug remotely.</source>
         <target state="translated">Nazwa zdalnego komputera nie może być pusta.  Podaj nazwę komputera do zdalnego debugowania.</target>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.pt-BR.xlf
@@ -918,6 +918,11 @@ Erro:</target>
         <target state="translated">Propriedades de Referência</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropPage_InvalidCharactersInFilePath">
+        <source>"Invalid characters in file path."</source>
+        <target state="new">"Invalid characters in file path."</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropPage_RemoteMachineBlankError">
         <source>The remote machine name cannot be blank.  Please specify the name of the machine to debug remotely.</source>
         <target state="translated">O nome do computador remoto não pode ficar em branco.  Especifique o nome do computador a ser depurado remotamente.</target>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.ru.xlf
@@ -918,6 +918,11 @@ Error:</source>
         <target state="translated">Свойства ссылки</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropPage_InvalidCharactersInFilePath">
+        <source>"Invalid characters in file path."</source>
+        <target state="new">"Invalid characters in file path."</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropPage_RemoteMachineBlankError">
         <source>The remote machine name cannot be blank.  Please specify the name of the machine to debug remotely.</source>
         <target state="translated">Имя удаленного компьютера не может быть пустым.  Укажите имя компьютера для удаленной отладки.</target>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.tr.xlf
@@ -918,6 +918,11 @@ Hata:</target>
         <target state="translated">Başvuru Özellikleri</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropPage_InvalidCharactersInFilePath">
+        <source>"Invalid characters in file path."</source>
+        <target state="new">"Invalid characters in file path."</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropPage_RemoteMachineBlankError">
         <source>The remote machine name cannot be blank.  Please specify the name of the machine to debug remotely.</source>
         <target state="translated">Uzak makine adı boş olamaz.  Lütfen uzaktan hata ayıklama işleminin yapılacağı makinenin adını belirtin.</target>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.zh-Hans.xlf
@@ -918,6 +918,11 @@ Error:</source>
         <target state="translated">引用属性</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropPage_InvalidCharactersInFilePath">
+        <source>"Invalid characters in file path."</source>
+        <target state="new">"Invalid characters in file path."</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropPage_RemoteMachineBlankError">
         <source>The remote machine name cannot be blank.  Please specify the name of the machine to debug remotely.</source>
         <target state="translated">远程计算机名称不能为空。请指定要远程调试的计算机的名称。</target>

--- a/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/Resources/xlf/Microsoft.VisualStudio.Editors.Designer.zh-Hant.xlf
@@ -918,6 +918,11 @@ Error:</source>
         <target state="translated">參考屬性</target>
         <note />
       </trans-unit>
+      <trans-unit id="PropPage_InvalidCharactersInFilePath">
+        <source>"Invalid characters in file path."</source>
+        <target state="new">"Invalid characters in file path."</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PropPage_RemoteMachineBlankError">
         <source>The remote machine name cannot be blank.  Please specify the name of the machine to debug remotely.</source>
         <target state="translated">遠端電腦名稱不能為空白。請指定電腦名稱以進行遠端偵錯。</target>


### PR DESCRIPTION
Adds a check for invalid characters in the name of the resource file on the Application property page. It fails validation instead of a warning because the file cannot exist.