### PR TITLE
Make sure AppDesigner exists before adding template

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractFindByNameUnderAppDesignerSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractFindByNameUnderAppDesignerSpecialFileProvider.cs
@@ -65,11 +65,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
             return _specialFilesManager.GetFileAsync(SpecialFiles.AppDesigner, flags);
         }
 
-        protected override async Task CreateFileAsync(string path)
+        protected override sealed async Task CreateFileAsync(string path)
         {
             await EnsureAppDesignerFolder();
 
-            await base.CreateFileAsync(path);
+            await CreateFileCoreAsync(path);
+        }
+
+        protected virtual Task CreateFileCoreAsync(string path)
+        {
+            return base.CreateFileAsync(path);
         }
 
         private Task EnsureAppDesignerFolder()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppManifestSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppManifestSpecialFileProvider.cs
@@ -24,9 +24,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
             _properties = properties;
         }
 
-        protected override Task CreateFileAsync(string path)
+        protected override async Task CreateFileCoreAsync(string path)
         {
-            return _templateFileCreationService.CreateFileAsync("ResourceInternal.zip", path);
+            await _templateFileCreationService.CreateFileAsync("ResourceInternal.zip", path);
         }
 
         protected override async Task<IProjectTree?> FindFileAsync(IProjectTreeProvider provider, IProjectTree root)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppSettingsSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppSettingsSpecialFileProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
             _templateFileCreationService = templateFileCreationService;
         }
 
-        protected override Task CreateFileAsync(string path)
+        protected override Task CreateFileCoreAsync(string path)
         {
             return _templateFileCreationService.CreateFileAsync("SettingsInternal.zip", path);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AssemblyResourcesSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AssemblyResourcesSpecialFileProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
             _templateFileCreationService = templateFileCreationService;
         }
 
-        protected override Task CreateFileAsync(string path)
+        protected override Task CreateFileCoreAsync(string path)
         {
             return _templateFileCreationService.CreateFileAsync("ResourceInternal.zip", path);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/CSharp/CSharpAssemblyInfoSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/CSharp/CSharpAssemblyInfoSpecialFileProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders.CSharp
             _templateFileCreationService = templateFileCreationService;
         }
 
-        protected override Task CreateFileAsync(string path)
+        protected override Task CreateFileCoreAsync(string path)
         {
             return _templateFileCreationService.CreateFileAsync("AssemblyInfoInternal.zip", path);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/VisualBasic/VisualBasicAssemblyInfoSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/VisualBasic/VisualBasicAssemblyInfoSpecialFileProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders.VisualBasic
             _templateFileCreationService = templateFileCreationService;
         }
 
-        protected override Task CreateFileAsync(string path)
+        protected override Task CreateFileCoreAsync(string path)
         {
             return _templateFileCreationService.CreateFileAsync("AssemblyInfoInternal.zip", path);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ISpecialFilesManagerFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ISpecialFilesManagerFactory.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using Moq;
 
 namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AbstractFindByNameUnderAppDesignerSpecialFileProviderTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AbstractFindByNameUnderAppDesignerSpecialFileProviderTestBase.cs
@@ -233,7 +233,7 @@ Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
 
             // We override CreateFileAsync to call the CreateEmptyFileAsync which makes writting tests in the base easier
             var mock = new Mock<T>(arguments);
-            mock.Protected().Setup<Task>("CreateFileAsync", ItExpr.IsAny<string>())
+            mock.Protected().Setup<Task>("CreateFileCoreAsync", ItExpr.IsAny<string>())
                 .Returns<string>(path => projectTree.TreeStorage.CreateEmptyFileAsync(path));
 
             mock.CallBase = true;


### PR DESCRIPTION
After we moved the template-based special file providers over to AbstractFindByNameUnderAppDesignerSpecialFileProvider, we stopped ensuring that the AppDesigner existed before we added the template, this caused template creation to fail.