### PR TITLE
Do not non-fatal watson on main path

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
@@ -5228,7 +5228,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                         If cultureInfo IsNot Nothing Then
                             isLocalizedFileName = True
                         End If
-                    Catch ex As Exception When ReportWithoutCrash(ex, NameOf(IsLocalizedResXFile), NameOf(ResourceEditorView))
+                    Catch ex As Exception
                     End Try
                 End If
             End If


### PR DESCRIPTION
We were sending non-fatal watsons when opening resource files that were not language-specific.