### PR TITLE
Hide broken windows forms templates

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsAddItemFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsAddItemFilter.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
+{
+    /// <summary>
+    /// A filter for the Add New Item dialog that filters out Windows Forms items from non-Windows Forms projects.
+    /// </summary>
+    [ExportProjectNodeComService(typeof(IVsFilterAddProjectItemDlg))]
+    [AppliesTo("!" + ProjectCapability.WindowsForms)]
+    internal class WindowsFormsAddItemFilter : IVsFilterAddProjectItemDlg
+    {
+        public int FilterTreeItemByLocalizedName(ref Guid rguidProjectItemTemplates, string pszLocalizedName, out int pfFilter)
+        {
+            pfFilter = 0;
+            return HResult.NotImplemented;
+        }
+
+        public int FilterTreeItemByTemplateDir(ref Guid rguidProjectItemTemplates, string pszTemplateDir, out int pfFilter)
+        {
+            pfFilter = 0;
+            // Most of the templates for Windows Forms items are filtered by capabilities in the .vstemplate but there are a couple
+            // that use an older .vsz tmeplate format that doesn't support capabilities, so we filter them out here.
+            // The AppliesTo on this class ensures this code only runs for Windows Forms projects
+            if (pszTemplateDir.EndsWith("\\Windows Forms", StringComparisons.Paths))
+            {
+                pfFilter = 1;
+            }
+            return HResult.OK;
+        }
+
+        public int FilterListItemByLocalizedName(ref Guid rguidProjectItemTemplates, string pszLocalizedName, out int pfFilter)
+        {
+            pfFilter = 0;
+            return HResult.NotImplemented;
+        }
+
+        public int FilterListItemByTemplateFile(ref Guid rguidProjectItemTemplates, string pszTemplateFile, out int pfFilter)
+        {
+            pfFilter = 0;
+            return HResult.NotImplemented;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsAddItemFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsAddItemFilter.cs
@@ -30,9 +30,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
         public int FilterTreeItemByTemplateDir(ref Guid rguidProjectItemTemplates, string pszTemplateDir, out int pfFilter)
         {
             pfFilter = 0;
+
+            var project = _project;
+            if (project == null)
+            {
+                return HResult.Unexpected;
+            }
+
             // Most of the templates for Windows Forms items are filtered by capabilities in the .vstemplate but there are a couple
             // that use an older .vsz tmeplate format that doesn't support capabilities, so we filter them all out here.
-            if (pszTemplateDir.EndsWith("\\Windows Forms", StringComparisons.Paths) && !_project!.Capabilities.AppliesTo(ProjectCapability.WindowsForms))
+            if (pszTemplateDir.EndsWith("\\Windows Forms", StringComparisons.Paths) && !project.Capabilities.AppliesTo(ProjectCapability.WindowsForms))
             {
                 pfFilter = 1;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsAddItemFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsAddItemFilter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
@@ -9,9 +10,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
     /// A filter for the Add New Item dialog that filters out Windows Forms items from non-Windows Forms projects.
     /// </summary>
     [ExportProjectNodeComService(typeof(IVsFilterAddProjectItemDlg))]
-    [AppliesTo("!" + ProjectCapability.WindowsForms)]
-    internal class WindowsFormsAddItemFilter : IVsFilterAddProjectItemDlg
+    [AppliesTo(ProjectCapability.DotNet)]
+    internal class WindowsFormsAddItemFilter : IVsFilterAddProjectItemDlg, IDisposable
     {
+        private  UnconfiguredProject? _project;
+
+        [ImportingConstructor]
+        public WindowsFormsAddItemFilter(UnconfiguredProject project)
+        {
+            _project = project;
+        }
+
         public int FilterTreeItemByLocalizedName(ref Guid rguidProjectItemTemplates, string pszLocalizedName, out int pfFilter)
         {
             pfFilter = 0;
@@ -22,9 +31,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
         {
             pfFilter = 0;
             // Most of the templates for Windows Forms items are filtered by capabilities in the .vstemplate but there are a couple
-            // that use an older .vsz tmeplate format that doesn't support capabilities, so we filter them out here.
-            // The AppliesTo on this class ensures this code only runs for Windows Forms projects
-            if (pszTemplateDir.EndsWith("\\Windows Forms", StringComparisons.Paths))
+            // that use an older .vsz tmeplate format that doesn't support capabilities, so we filter them all out here.
+            if (pszTemplateDir.EndsWith("\\Windows Forms", StringComparisons.Paths) && !_project!.Capabilities.AppliesTo(ProjectCapability.WindowsForms))
             {
                 pfFilter = 1;
             }
@@ -40,7 +48,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
         public int FilterListItemByTemplateFile(ref Guid rguidProjectItemTemplates, string pszTemplateFile, out int pfFilter)
         {
             pfFilter = 0;
-            return HResult.NotImplemented;
+
+            // These item templates are an older style that can't be filtered by capabilities, and use a Wizard that is broken for .NET Core
+            if (pszTemplateFile.EndsWith("\\CSControlInheritanceWizard.vsz", StringComparisons.Paths) ||
+                pszTemplateFile.EndsWith("\\CSFormInheritanceWizard.vsz", StringComparisons.Paths))
+            {
+                pfFilter = 1;
+            }
+            return HResult.OK;
+        }
+
+        public void Dispose()
+        {
+            // Important for ProjectNodeComServices to null out fields to reduce the amount 
+            // of data we leak when extensions incorrectly holds onto the IVsHierarchy.
+            _project = null;
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/WindowsForms/WindowsFormsAddItemFilterTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/WindowsForms/WindowsFormsAddItemFilterTests.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Xunit;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
+{
+    public class WindowsFormsAddItemFilterTests
+    {
+        [Theory]
+        [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\Non-Windows Forms", false })]
+        [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\General", false })]
+        [InlineData(new object[] { @"C:\Program Files\Visual Studio\Extensions\dh64yf.343\ProjectTemplates\CSharp", false })]
+        [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\Windows Forms", true })]
+        public void FiltersItemTemplateFolders(string templateDir, bool shouldBeFiltered)
+        {
+            var filter = new WindowsFormsAddItemFilter();
+
+            Guid guid = Guid.Empty;
+            var result = filter.FilterTreeItemByTemplateDir(ref guid, templateDir, out int filterResult);
+
+            Assert.Equal(0, result);
+            Assert.Equal(shouldBeFiltered, (filterResult == 1));
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/WindowsForms/WindowsFormsAddItemFilterTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/WindowsForms/WindowsFormsAddItemFilterTests.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using Xunit;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/WindowsForms/WindowsFormsAddItemFilterTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/WindowsForms/WindowsFormsAddItemFilterTests.cs
@@ -12,12 +12,44 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
         [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\General", false })]
         [InlineData(new object[] { @"C:\Program Files\Visual Studio\Extensions\dh64yf.343\ProjectTemplates\CSharp", false })]
         [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\Windows Forms", true })]
-        public void FiltersItemTemplateFolders(string templateDir, bool shouldBeFiltered)
+        public void FiltersItemTemplateFolders_NonWindowsForms(string templateDir, bool shouldBeFiltered)
         {
-            var filter = new WindowsFormsAddItemFilter();
+            var filter = new WindowsFormsAddItemFilter(UnconfiguredProjectFactory.Create(scope: IProjectCapabilitiesScopeFactory.Create()));
 
             Guid guid = Guid.Empty;
             var result = filter.FilterTreeItemByTemplateDir(ref guid, templateDir, out int filterResult);
+
+            Assert.Equal(0, result);
+            Assert.Equal(shouldBeFiltered, (filterResult == 1));
+        }
+
+        [Theory]
+        [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\Non-Windows Forms", false })]
+        [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\General", false })]
+        [InlineData(new object[] { @"C:\Program Files\Visual Studio\Extensions\dh64yf.343\ProjectTemplates\CSharp", false })]
+        [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\Windows Forms", false })]
+        public void FiltersItemTemplateFolders_WindowsForms(string templateDir, bool shouldBeFiltered)
+        {
+            var filter = new WindowsFormsAddItemFilter(UnconfiguredProjectFactory.Create(scope: IProjectCapabilitiesScopeFactory.Create(new string[] { "WindowsForms" })));
+
+            Guid guid = Guid.Empty;
+            var result = filter.FilterTreeItemByTemplateDir(ref guid, templateDir, out int filterResult);
+
+            Assert.Equal(0, result);
+            Assert.Equal(shouldBeFiltered, (filterResult == 1));
+        }
+
+        [Theory]
+        [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\CSControlInheritanceWizard.vsz", true })]
+        [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\CSFormInheritanceWizard.vsz", true })]
+        [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\Class.vsz", false })]
+        [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\ControlLibrary.vsz", false })]
+        public void FiltersItemTemplateFiles(string templateDir, bool shouldBeFiltered)
+        {
+            var filter = new WindowsFormsAddItemFilter(UnconfiguredProjectFactory.Create());
+
+            Guid guid = Guid.Empty;
+            var result = filter.FilterListItemByTemplateFile(ref guid, templateDir, out int filterResult);
 
             Assert.Equal(0, result);
             Assert.Equal(shouldBeFiltered, (filterResult == 1));


### PR DESCRIPTION
Fixes #5398 

We filter Windows Forms templates by capabilities but there are two that don't support that, so this hides them too.